### PR TITLE
Fix GitHub Actions build by making pywin32 Windows-only

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ setup(
         'shapely',
         'rasterstats',
         'rtree',
-        'pywin32>=227',    # Required for RasControl COM interface
+        'pywin32>=227; sys_platform == "win32"',    # Required for RasControl COM interface (Windows only)
         'psutil>=5.6.6',   # Required for RasControl process management
     ],
     extras_require={


### PR DESCRIPTION
The pywin32 package is Windows-only but was listed as a hard dependency
in setup.py. This caused the documentation build to fail on Ubuntu when
running `pip install -e .`.

Added platform marker `sys_platform == "win32"` to only install pywin32
on Windows systems.