### PR TITLE
feat: Terrain modification analysis and final Manning's N / infiltration APIs

### DIFF
--- a/.claude/MANIFEST.md
+++ b/.claude/MANIFEST.md
@@ -67,11 +67,15 @@ When adding a new component, add it to the appropriate domain group AND the rela
 | `precipitation-notebook-debugging-patterns.md` | rule | `.claude/rules/documentation/precipitation-notebook-debugging-patterns.md` |
 | `precipitation-specialist` | agent | `.claude/agents/precipitation-specialist/SUBAGENT.md` |
 
-### Terrain
+### Terrain & Land Cover
 
 | Component | Type | Path |
 |-----------|------|------|
 | `terrain.md` | rule | `.claude/rules/hec-ras/terrain.md` |
+| `RasTerrainMod` | module | `ras_commander/terrain/RasTerrainMod.py` |
+| `HdfLandCover` | module | `ras_commander/hdf/HdfLandCover.py` |
+| `930_terrain_modification_analysis` | notebook | `examples/930_terrain_modification_analysis.ipynb` |
+| `211_final_mannings_and_infiltration` | notebook | `examples/211_final_mannings_and_infiltration.ipynb` |
 
 ### eBFE/BLE Models
 

--- a/.claude/rules/hec-ras/terrain.md
+++ b/.claude/rules/hec-ras/terrain.md
@@ -19,11 +19,13 @@ paths: ras_commander/**
 
 Create HEC-RAS terrain files (`.hdf`) programmatically. These files store multi-resolution elevation data with pyramid levels and multi-source stitching. Use CLI-based terrain creation via `RasProcess.exe` (HEC-RAS 6.6+).
 
-## Key Class
+## Key Classes
 
 | Class | Purpose |
 |-------|---------|
-| `RasTerrain` | Terrain HDF creation, VRT conversion, USGS download (future) |
+| `RasTerrain` | Terrain HDF creation, VRT conversion via RasProcess.exe CLI |
+| `Usgs3depAws` | USGS 3DEP elevation tile download from AWS S3 |
+| `RasTerrainMod` | Terrain modification analysis via pythonnet (cut/fill, no-net-fill) |
 
 ## RasProcess.exe CreateTerrain Command
 
@@ -165,11 +167,47 @@ subprocess.run(cmd_str, shell=True)
 3. TerrainDestinationFolder set in .rasmap?
 4. Projection file referenced in .rasmap?
 
+## Terrain Modification Analysis (RasTerrainMod)
+
+**New**: Sample terrain WITH modifications applied via pythonnet + RasMapperLib.dll. No GUI required.
+
+```python
+from ras_commander.terrain import RasTerrainMod
+
+# One-time setup (creates GDAL junction)
+RasTerrainMod.setup_gdal_bridge()
+
+# Sample terrain profile with channels/levees/polygon overrides applied
+profile = RasTerrainMod.get_terrain_profile(
+    "project.rasmap", "project.g01.hdf",
+    x_coords=[3400000, 3410000], y_coords=[612000, 612000]
+)
+
+# Elevation-volume curve for a polygon (for pond sizing / no-net-fill)
+ev = RasTerrainMod.get_terrain_volume_elevation(
+    "project.rasmap", "project.g01.hdf",
+    x_coords=pond_polygon_x, y_coords=pond_polygon_y,
+    volume_factor=43560.0  # acre-feet
+)
+```
+
+**Requirements**: pythonnet (`pip install pythonnet`), HEC-RAS 6.6+, Windows.
+
+**How it works**: Loads `RasMapperLib.dll` via pythonnet and calls `RASMapperCom` methods directly. Terrain modifications (channels, levees, polygon overrides stored in `/Modifications/` within terrain HDF) are applied on-the-fly by the .NET code, identical to RASMapper.
+
+**See**: `examples/930_terrain_modification_analysis.ipynb` for complete cut/fill workflow.
+
 ## Cross-References
 
 **Primary sources**:
 - `ras_commander/terrain/` -- Terrain module implementation
+- `ras_commander/terrain/RasTerrainMod.py` -- Terrain modification analysis via pythonnet
+- `examples/920_terrain_creation.ipynb` -- Terrain creation workflow
+- `examples/930_terrain_modification_analysis.ipynb` -- Cut/fill analysis workflow
+
+**Research**:
+- `feature_dev_notes/Terrain_Modifications/` -- HDF format research, API design, rasterization path
 
 ---
 
-**Key Takeaway**: Use `RasTerrain.create_terrain_hdf()` to create terrain HDF files via `RasProcess.exe CreateTerrain`. Register in RasMapper with `RasMap.add_terrain_layer()`. Input files are processed in priority order (first = highest).
+**Key Takeaway**: Use `RasTerrain.create_terrain_hdf()` for terrain creation, `RasTerrainMod.get_terrain_profile()` for sampling terrain with modifications. Register terrains with `RasMap.add_terrain_layer()`. For cut/fill: use `RasTerrainMod.compare_terrain_volumes()`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -528,6 +528,51 @@ result = GeomHtab.optimize_all_htab_from_results("model.g01", "model.p01.hdf")
 # See ras_commander/geom/AGENTS.md for complete HTAB documentation
 ```
 
+**Terrain modification analysis** (cut/fill, no-net-fill via pythonnet):
+```python
+from ras_commander.terrain import RasTerrainMod
+
+# One-time setup (creates GDAL junction for pythonnet)
+RasTerrainMod.setup_gdal_bridge()
+
+# Sample terrain profile WITH modifications applied (no GUI!)
+profile = RasTerrainMod.get_terrain_profile(
+    "project.rasmap", "project.g01.hdf",
+    x_coords=[3400000, 3410000], y_coords=[612000, 612000]
+)
+
+# Elevation-volume curve for pond sizing / no-net-fill
+ev = RasTerrainMod.get_terrain_volume_elevation(
+    "project.rasmap", "project.g01.hdf",
+    x_coords=pond_x, y_coords=pond_y,
+    volume_factor=43560.0  # acre-feet
+)
+
+# See examples/930_terrain_modification_analysis.ipynb for complete workflow
+```
+
+**Final Manning's N and infiltration** (preprocessed per-cell values + calibration analysis):
+```python
+from ras_commander.hdf import HdfLandCover, HdfInfiltration
+
+# Read preprocessed Manning's N (what HEC-RAS actually uses) - accepts plan number
+mann = HdfLandCover.get_preprocessed_mannings_n("01")
+
+# Calibration table: base + all region overrides
+cal = HdfLandCover.get_mannings_calibration_table("01")
+
+# Compare base vs calibrated (which regions change which classes)
+comp = HdfLandCover.compare_base_vs_calibrated("01")
+
+# Read preprocessed infiltration (Curve Number, Abstraction Ratio, etc.)
+cn = HdfInfiltration.get_preprocessed_infiltration("01", variable='Curve Number')
+
+# Full-resolution raster with overrides applied (auto-resolves land cover association)
+arr = HdfLandCover.compute_final_mannings_raster("01", output_tif_path="final_n.tif")
+
+# See examples/211_final_mannings_and_infiltration.ipynb for complete workflow
+```
+
 ### Common Pitfalls
 
 - ❌ Don't instantiate static classes: `RasCmdr()` is wrong

--- a/examples/211_final_mannings_and_infiltration.ipynb
+++ b/examples/211_final_mannings_and_infiltration.ipynb
@@ -1,0 +1,98 @@
+{
+ "nbformat": 4,
+ "nbformat_minor": 4,
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.12.0"
+  }
+ },
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "# Final Manning's N and Infiltration Analysis\n\nThis notebook demonstrates how to extract and analyze the **final resolved** Manning's N and infiltration parameters from HEC-RAS geometry HDF files.\n\n## What You'll Learn\n- Read preprocessed per-cell Manning's N and infiltration values\n- Analyze the Manning's N calibration table (base + region overrides)\n- Compare base vs calibrated Manning's N values\n- Compute statistics on final parameter layers"
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": "# Setup\nfrom pathlib import Path\nimport numpy as np\nimport pandas as pd\nimport matplotlib.pyplot as plt\nfrom ras_commander.hdf.HdfLandCover import HdfLandCover\nfrom ras_commander.hdf.HdfInfiltration import HdfInfiltration\nprint(\"Imports successful\")",
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": "# Set geometry HDF path\ngeom_hdf = Path(r\"G:\\BayouConway_A14_03202026\\BayouConway_Update_250731.g17.hdf\")\nassert geom_hdf.exists()\nprint(f\"Geometry: {geom_hdf.name}\")",
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Preprocessed Per-Cell Manning's N\nThe exact per-cell values HEC-RAS uses in computation."
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": "mann_df = HdfLandCover.get_preprocessed_mannings_n(geom_hdf)\nprint(f\"Cells: {len(mann_df):,}\")\nprint(f\"N range: {mann_df[\"mannings_n\"].min():.4f} to {mann_df[\"mannings_n\"].max():.4f}\")\nprint(f\"Mean: {mann_df[\"mannings_n\"].mean():.4f}\")\nstats = HdfLandCover.get_preprocessed_mannings_stats(geom_hdf)\nstats",
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": "fig, ax = plt.subplots(figsize=(10, 5))\nax.hist(mann_df[\"mannings_n\"], bins=50, edgecolor=\"black\", alpha=0.7, color=\"steelblue\")\nax.set_xlabel(\"Manning's N\")\nax.set_ylabel(\"Cell Count\")\nax.set_title(\"Distribution of Manning's N Values\")\nax.axvline(mann_df[\"mannings_n\"].mean(), color=\"red\", linestyle=\"--\", label=f\"Mean={mann_df[\"mannings_n\"].mean():.4f}\")\nax.legend()\nax.grid(True, alpha=0.3)\nplt.tight_layout()\nplt.show()",
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Calibration Table and Base vs Calibrated Comparison"
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": "cal = HdfLandCover.get_mannings_calibration_table(geom_hdf)\nprint(f\"Land cover classes: {len(cal)}, Calibration regions: {len(cal.columns) - 2}\")\nprint()\nprint(\"Base values:\")\nprint(cal.iloc[:, :2].to_string(index=False))",
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": "comp = HdfLandCover.compare_base_vs_calibrated(geom_hdf)\nif comp is not None and len(comp) > 0:\n    print(f\"Override entries: {len(comp)}, Classes: {comp[\"land_cover_class\"].nunique()}, Regions: {comp[\"region_name\"].nunique()}\")\n    print()\n    print(\"Largest N increases:\")\n    print(comp[comp[\"delta_n\"] > 0].nlargest(5, \"delta_n\")[[\"land_cover_class\", \"region_name\", \"base_n\", \"calibrated_n\", \"delta_n\"]].to_string(index=False))",
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Preprocessed Infiltration Parameters"
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": "for var in [\"Curve Number\", \"Abstraction Ratio\", \"Minimum Infiltration Rate\"]:\n    df = HdfInfiltration.get_preprocessed_infiltration(geom_hdf, variable=var)\n    if len(df) > 0:\n        print(f\"{var}: {len(df):,} cells, range {df[\"value\"].min():.3f}-{df[\"value\"].max():.3f}, mean {df[\"value\"].mean():.3f}\")\n    else:\n        print(f\"{var}: No data\")",
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": "cn = HdfInfiltration.get_preprocessed_infiltration(geom_hdf, variable=\"Curve Number\")\nif len(cn) > 0:\n    fig, ax = plt.subplots(figsize=(10, 5))\n    ax.hist(cn[\"value\"], bins=50, edgecolor=\"black\", alpha=0.7, color=\"forestgreen\")\n    ax.set_xlabel(\"SCS Curve Number\")\n    ax.set_ylabel(\"Cell Count\")\n    ax.set_title(\"Distribution of Curve Number Values\")\n    ax.axvline(cn[\"value\"].mean(), color=\"red\", linestyle=\"--\", label=f\"Mean={cn[\"value\"].mean():.1f}\")\n    ax.legend()\n    ax.grid(True, alpha=0.3)\n    plt.tight_layout()\n    plt.show()",
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Key Takeaways\n\n-  reads the exact per-cell N values from geometry HDF\n-  reads per-cell infiltration parameters\n-  shows the full base + override matrix\n-  highlights calibration changes\n- For raster export:  produces a GeoTIFF"
+  }
+ ]
+}

--- a/examples/930_terrain_modification_analysis.ipynb
+++ b/examples/930_terrain_modification_analysis.ipynb
@@ -1,0 +1,266 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": "# Setup and imports\nfrom pathlib import Path\nimport sys\nimport numpy as np\nimport pandas as pd\nimport matplotlib.pyplot as plt\n\n# Use local development version of ras-commander\n# (ensures RasTerrainMod is available even if not in pip-installed version)\ndev_path = str(Path('.').resolve().parent)\nif dev_path not in sys.path:\n    sys.path.insert(0, dev_path)\n\n# Force reimport from local source\nimport importlib\nimport ras_commander.terrain\nimportlib.reload(ras_commander.terrain)\n\nfrom ras_commander.terrain import RasTerrainMod\n\nprint('RasTerrainMod imported successfully')",
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 1: One-Time GDAL Bridge Setup\n",
+    "\n",
+    "RasMapperLib.dll requires GDAL to be available relative to the Python executable. This creates a directory junction (symbolic link) from the Python installation to the HEC-RAS GDAL folder. Only needs to be run once per Python environment."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# One-time setup - creates GDAL junction if it doesn't exist\n",
+    "bridge_ok = RasTerrainMod.setup_gdal_bridge()\n",
+    "print(f'GDAL bridge ready: {bridge_ok}')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 2: Define Project Paths\n",
+    "\n",
+    "Point to a HEC-RAS project that has terrain modifications. You need:\n",
+    "- The `.rasmap` file (references terrain layers and their modifications)\n",
+    "- A geometry `.g##.hdf` file (provides spatial reference)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# === USER: Set your project paths here ===\n",
+    "project_folder = Path(r'G:\\BayouConway_A14_03202026')\n",
+    "rasmap_path = project_folder / 'BayouConway_Update_250731.rasmap'\n",
+    "geom_hdf = project_folder / 'BayouConway_Update_250731.g17.hdf'\n",
+    "\n",
+    "# Verify files exist\n",
+    "assert rasmap_path.exists(), f'rasmap not found: {rasmap_path}'\n",
+    "assert geom_hdf.exists(), f'geometry HDF not found: {geom_hdf}'\n",
+    "print(f'Project: {project_folder.name}')\n",
+    "print(f'Rasmap: {rasmap_path.name}')\n",
+    "print(f'Geometry: {geom_hdf.name}')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 3: Get Terrain Extent\n",
+    "\n",
+    "Query the terrain bounding box to understand the project domain."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "extent = RasTerrainMod.get_terrain_extent(rasmap_path, geom_hdf)\n",
+    "print(f\"Success: {extent['success']}\")\n",
+    "print(f\"X range: {extent['min_x']:,.0f} to {extent['max_x']:,.0f}\")\n",
+    "print(f\"Y range: {extent['min_y']:,.0f} to {extent['max_y']:,.0f}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 4: Sample Terrain Profile with Modifications\n",
+    "\n",
+    "Sample terrain along a polyline. The returned elevations include ALL terrain modifications (channels, levees, polygon overrides) that are defined in the terrain HDF referenced by the .rasmap file.\n",
+    "\n",
+    "This is equivalent to cutting a cross-section through the terrain in RASMapper \u00e2\u20ac\u201d but without opening the GUI."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Define a profile line across the project area\n",
+    "# (coordinates in project CRS - LA State Plane South, US feet)\n",
+    "x_profile = [3400000, 3402000, 3404000, 3406000, 3408000, 3410000]\n",
+    "y_profile = [612000, 612000, 612000, 612000, 612000, 612000]\n",
+    "\n",
+    "# Sample terrain WITH modifications\n",
+    "profile = RasTerrainMod.get_terrain_profile(\n",
+    "    rasmap_path, geom_hdf,\n",
+    "    x_coords=x_profile,\n",
+    "    y_coords=y_profile\n",
+    ")\n",
+    "\n",
+    "print(f'Profile points: {len(profile)}')\n",
+    "print(f'Station range: {profile[\"station\"].min():.0f} to {profile[\"station\"].max():.0f} ft')\n",
+    "print(f'Elevation range: {profile[\"elevation\"].min():.2f} to {profile[\"elevation\"].max():.2f} ft')\n",
+    "profile.head(10)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Plot the terrain profile\n",
+    "fig, ax = plt.subplots(figsize=(14, 5))\n",
+    "ax.plot(profile['station'], profile['elevation'], 'b-', linewidth=0.8)\n",
+    "ax.fill_between(profile['station'], profile['elevation'].min() - 0.5,\n",
+    "                profile['elevation'], alpha=0.2, color='sienna')\n",
+    "ax.set_xlabel('Station (ft)')\n",
+    "ax.set_ylabel('Elevation (ft)')\n",
+    "ax.set_title('Terrain Profile with Modifications Applied')\n",
+    "ax.grid(True, alpha=0.3)\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 5: Elevation-Volume Curve for a Polygon\n",
+    "\n",
+    "Compute the elevation-volume relationship within a polygon area. This is essential for:\n",
+    "- Detention pond sizing\n",
+    "- Storage volume calculations\n",
+    "- No-net-fill compliance\n",
+    "\n",
+    "The volumes reflect the terrain WITH modifications \u00e2\u20ac\u201d so if you've modeled a pond with terrain modifications, the volume curve includes the pond excavation."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Define an analysis polygon (1000 x 1000 ft area)\n",
+    "# Must close (first point == last point)\n",
+    "cx, cy = 3405000.0, 612000.0  # Center of analysis area\n",
+    "hw = 500.0  # Half-width\n",
+    "\n",
+    "poly_x = [cx-hw, cx+hw, cx+hw, cx-hw, cx-hw]\n",
+    "poly_y = [cy-hw, cy-hw, cy+hw, cy+hw, cy-hw]\n",
+    "\n",
+    "# Compute elevation-volume curve (in cubic feet)\n",
+    "ev_cuft = RasTerrainMod.get_terrain_volume_elevation(\n",
+    "    rasmap_path, geom_hdf,\n",
+    "    x_coords=poly_x, y_coords=poly_y,\n",
+    "    volume_factor=1.0  # cubic feet\n",
+    ")\n",
+    "\n",
+    "# Also compute in acre-feet\n",
+    "ev_acft = RasTerrainMod.get_terrain_volume_elevation(\n",
+    "    rasmap_path, geom_hdf,\n",
+    "    x_coords=poly_x, y_coords=poly_y,\n",
+    "    volume_factor=43560.0  # acre-feet\n",
+    ")\n",
+    "\n",
+    "print(f'Elevation-Volume table: {len(ev_cuft)} rows')\n",
+    "print(f'Elevation range: {ev_cuft[\"elevation\"].min():.2f} to {ev_cuft[\"elevation\"].max():.2f} ft')\n",
+    "print(f'Max volume: {ev_cuft[\"volume\"].max():,.0f} cu ft = {ev_acft[\"volume\"].max():.1f} ac-ft')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Plot elevation-volume curve\n",
+    "fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(14, 5))\n",
+    "\n",
+    "ax1.plot(ev_cuft['volume'], ev_cuft['elevation'], 'b-o', markersize=3)\n",
+    "ax1.set_xlabel('Volume (cubic feet)')\n",
+    "ax1.set_ylabel('Elevation (ft)')\n",
+    "ax1.set_title('Elevation-Volume Curve')\n",
+    "ax1.grid(True, alpha=0.3)\n",
+    "ax1.ticklabel_format(style='scientific', axis='x', scilimits=(0,0))\n",
+    "\n",
+    "ax2.plot(ev_acft['volume'], ev_acft['elevation'], 'r-o', markersize=3)\n",
+    "ax2.set_xlabel('Volume (acre-feet)')\n",
+    "ax2.set_ylabel('Elevation (ft)')\n",
+    "ax2.set_title('Elevation-Volume Curve (acre-feet)')\n",
+    "ax2.grid(True, alpha=0.3)\n",
+    "\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 6: Elevation-Volume Table\n",
+    "\n",
+    "Display the full elevation-volume table for engineering review."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Combine into a summary table\n",
+    "summary = ev_acft.copy()\n",
+    "summary.columns = ['Elevation (ft)', 'Volume (ac-ft)']\n",
+    "summary['Volume (cu ft)'] = ev_cuft['volume'].values[:len(summary)]\n",
+    "print(summary.to_string(index=False, float_format=lambda x: f'{x:,.2f}'))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Key Takeaways\n",
+    "\n",
+    "- **`RasTerrainMod`** provides headless access to HEC-RAS terrain sampling with modifications applied\n",
+    "- **No GUI required** \u00e2\u20ac\u201d all operations use RasMapperLib.dll directly via pythonnet\n",
+    "- **Terrain modifications are automatically applied** \u00e2\u20ac\u201d channels, levees, polygon overrides all included\n",
+    "- **One-time setup** \u00e2\u20ac\u201d `setup_gdal_bridge()` creates a GDAL junction (only once per Python environment)\n",
+    "- **Cut/fill analysis** \u00e2\u20ac\u201d compare profiles from existing vs proposed .rasmap files\n",
+    "- **No-net-fill compliance** \u00e2\u20ac\u201d compare elevation-volume curves to verify excavation balances fill\n",
+    "\n",
+    "## Adapting for Your Project\n",
+    "\n",
+    "1. Update the project paths in Step 2\n",
+    "2. Adjust profile coordinates to match your project CRS and area of interest\n",
+    "3. Define analysis polygons around ponds, channels, or development areas\n",
+    "4. For no-net-fill: create two .rasmap files referencing existing and proposed terrain HDFs,\n",
+    "   then use `compare_terrain_volumes()` to compute the net fill at each elevation"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.12.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/examples/AGENTS.md
+++ b/examples/AGENTS.md
@@ -118,6 +118,11 @@ How agents should use notebooks
 - Functions: RasFixit.check_blocked_obstructions (ras_commander/RasFixit.py), RasFixit.fix_blocked_obstructions (ras_commander/RasFixit.py).
 - Pattern: Use 0.02-unit gap constant for HEC-RAS compatibility; inspect FixResults for before/after.
 
+211_final_mannings_and_infiltration.ipynb
+- Focus: Extract and analyze final resolved Manning's N and infiltration parameters from geometry HDF, including base values and calibration region overrides.
+- Functions: HdfLandCover.get_preprocessed_mannings_n (ras_commander/hdf/HdfLandCover.py), HdfLandCover.get_mannings_calibration_table (ras_commander/hdf/HdfLandCover.py), HdfLandCover.compare_base_vs_calibrated (ras_commander/hdf/HdfLandCover.py), HdfLandCover.get_preprocessed_mannings_stats (ras_commander/hdf/HdfLandCover.py), HdfInfiltration.get_preprocessed_infiltration (ras_commander/hdf/HdfInfiltration.py), HdfInfiltration.get_preprocessed_infiltration_stats (ras_commander/hdf/HdfInfiltration.py).
+- Pattern: Read preprocessed per-cell values from geometry HDF → compute statistics → analyze calibration table for override inventory → compare base vs calibrated → visualize distributions; for raster export use compute_final_mannings_raster().
+
 ---
 
 ## 300s: Boundary Condition Parsing & Operations
@@ -380,6 +385,11 @@ How agents should use notebooks
 - Focus: Download USGS 3DEP elevation tiles and create HEC-RAS terrain HDF files programmatically.
 - Functions: Usgs3depAws.find_tiles_for_bbox (ras_commander/terrain/Usgs3depAws.py), Usgs3depAws.download_tiles (ras_commander/terrain/Usgs3depAws.py), Usgs3depAws.create_vrt (ras_commander/terrain/Usgs3depAws.py), RasTerrain.vrt_to_tiff (ras_commander/terrain/RasTerrain.py), RasTerrain.create_terrain_hdf (ras_commander/terrain/RasTerrain.py), RasMap.add_terrain_layer (ras_commander/RasMap.py).
 - Pattern: Query 3DEP tiles for project bbox → download GeoTIFF tiles → build VRT mosaic → convert to single GeoTIFF → create terrain HDF via RasProcess.exe → register layer in .rasmap; uses BaldEagleCrkMulti2D as example project.
+
+930_terrain_modification_analysis.ipynb
+- Focus: Analyze terrain modifications (channels, levees, polygon overrides) for cut/fill and no-net-fill analysis without the RASMapper GUI.
+- Functions: RasTerrainMod.setup_gdal_bridge (ras_commander/terrain/RasTerrainMod.py), RasTerrainMod.get_terrain_extent (ras_commander/terrain/RasTerrainMod.py), RasTerrainMod.get_terrain_profile (ras_commander/terrain/RasTerrainMod.py), RasTerrainMod.get_terrain_volume_elevation (ras_commander/terrain/RasTerrainMod.py), RasTerrainMod.compare_terrain_profiles (ras_commander/terrain/RasTerrainMod.py), RasTerrainMod.compare_terrain_volumes (ras_commander/terrain/RasTerrainMod.py).
+- Pattern: Setup GDAL bridge (one-time) → sample terrain profiles with modifications → compute elevation-volume curves → compare existing vs proposed for cut/fill; uses pythonnet to call RasMapperLib.dll directly (no GUI); requires HEC-RAS 6.6+ and pythonnet.
 
 ---
 

--- a/ras_commander/CLAUDE.md
+++ b/ras_commander/CLAUDE.md
@@ -38,6 +38,8 @@ The ras_commander library is organized into core modules and specialized subpack
 - `HdfResultsMesh`, `HdfResultsPlan`, `HdfResultsXsec` - Results time series extraction
 - `HdfResultsBreach` - Breach results extraction
 - `HdfPipe`, `HdfPump` - Infrastructure analysis (HEC-RAS 6.6+)
+- `HdfLandCover` - Final Manning's N (base + calibration overrides, raster composition)
+- `HdfInfiltration` - Infiltration parameters (base overrides, preprocessed per-cell values)
 - `HdfPlot`, `HdfResultsPlot` - Visualization helpers
 - `HdfBenefitAreas`, `HdfFluvialPluvial`, `HdfChannelCapacity` - Analysis tools
 - `HdfResultsAnalysis` - Results analysis utilities
@@ -77,6 +79,12 @@ Each subpackage has its own CLAUDE.md or AGENTS.md file with detailed guidance:
 **dss/** (3 modules):
 - DSS file operations for boundary conditions
 - See `ras_commander/dss/AGENTS.md`
+
+**terrain/** (3 modules):
+- Terrain creation (RasTerrain via RasProcess.exe), USGS 3DEP download (Usgs3depAws)
+- Terrain modification analysis (RasTerrainMod via pythonnet/RasMapperLib.dll)
+- Cut/fill analysis, elevation-volume curves, no-net-fill compliance
+- See `.claude/rules/hec-ras/terrain.md`
 
 **fixit/** (6 modules):
 - Automated geometry repair (RasFixit framework)

--- a/ras_commander/hdf/HdfInfiltration.py
+++ b/ras_commander/hdf/HdfInfiltration.py
@@ -59,13 +59,6 @@ from ..Decorators import standardize_input, log_call
 from ..LoggingConfig import setup_logging, get_logger
 
 logger = get_logger(__name__)
-        
-from pathlib import Path
-import pandas as pd
-import geopandas as gpd
-import h5py
-
-from ..Decorators import log_call, standardize_input
 
 class HdfInfiltration:
         
@@ -80,8 +73,135 @@ class HdfInfiltration:
     SQM_TO_ACRE = 0.000247105
     SQM_TO_SQMILE = 3.861e-7
 
+    # Valid infiltration variables for preprocessed cell-level data
+    INFILTRATION_VARIABLES = [
+        'Curve Number', 'Abstraction Ratio', 'Minimum Infiltration Rate',
+        'Maximum Deficit', 'Initial Deficit', 'Potential Percolation Rate',
+        'Wetting Front Suction', 'Saturated Hydraulic Conductivity',
+        'Initial Soil Water Content', 'Saturated Soil Water Content',
+    ]
+
     @staticmethod
-    @log_call 
+    @log_call
+    @standardize_input(file_type='geom_hdf')
+    def get_preprocessed_infiltration(
+        hdf_path: Path,
+        mesh_name: Optional[str] = None,
+        variable: str = 'Curve Number',
+        ras_object=None
+    ) -> pd.DataFrame:
+        """
+        Read preprocessed per-cell infiltration values from geometry HDF.
+
+        Returns the exact per-cell infiltration parameter values that HEC-RAS
+        uses in computation, from
+        ``/Geometry/2D Flow Areas/{mesh}/Infiltration/{variable}``.
+        These reflect all overrides (base + calibration regions) as resolved
+        during geometry preprocessing.
+
+        Args:
+            hdf_path: Geometry HDF path, plan number ("01"), or geometry number ("g01").
+            mesh_name: Specific 2D flow area. If None, reads all.
+            variable: Infiltration variable name. Common values:
+                'Curve Number', 'Abstraction Ratio', 'Minimum Infiltration Rate'
+            ras_object: Optional RasPrj object for path resolution.
+
+        Returns:
+            DataFrame with columns: mesh_name, cell_id, value
+
+        Example:
+            >>> cn = HdfInfiltration.get_preprocessed_infiltration("01", variable='Curve Number')
+        """
+        results = []
+
+        try:
+            with h5py.File(hdf_path, 'r') as hdf_file:
+                areas_path = "Geometry/2D Flow Areas"
+                if areas_path not in hdf_file:
+                    logger.warning(f"No 2D Flow Areas found in {hdf_path}")
+                    return pd.DataFrame(columns=['mesh_name', 'cell_id', 'value'])
+
+                areas_group = hdf_file[areas_path]
+
+                for area_name in areas_group:
+                    # Skip datasets - only process groups (mesh perimeters)
+                    if not isinstance(areas_group[area_name], h5py.Group):
+                        continue
+                    if mesh_name is not None and area_name != mesh_name:
+                        continue
+
+                    area = areas_group[area_name]
+                    var_path = f"Infiltration/{variable}"
+
+                    if var_path not in area:
+                        logger.debug(f"No '{variable}' data for mesh '{area_name}'")
+                        continue
+
+                    values = area[var_path][()]
+                    n_cells = len(values)
+
+                    area_df = pd.DataFrame({
+                        'mesh_name': [area_name] * n_cells,
+                        'cell_id': range(n_cells),
+                        'value': values.astype(float),
+                    })
+                    results.append(area_df)
+
+        except Exception as e:
+            logger.error(f"Error reading preprocessed infiltration from {hdf_path}: {e}")
+            return pd.DataFrame(columns=['mesh_name', 'cell_id', 'value'])
+
+        if not results:
+            return pd.DataFrame(columns=['mesh_name', 'cell_id', 'value'])
+
+        return pd.concat(results, ignore_index=True)
+
+    @staticmethod
+    @log_call
+    @standardize_input(file_type='geom_hdf')
+    def get_preprocessed_infiltration_stats(
+        hdf_path: Path,
+        mesh_name: Optional[str] = None,
+        variable: str = 'Curve Number',
+        ras_object=None
+    ) -> pd.DataFrame:
+        """
+        Compute statistics on preprocessed per-cell infiltration values.
+
+        Args:
+            hdf_path: Geometry HDF path, plan number ("01"), or geometry number ("g01").
+            mesh_name: Specific 2D flow area. If None, computes for all.
+            variable: Infiltration variable name.
+            ras_object: Optional RasPrj object.
+
+        Returns:
+            DataFrame with columns: mesh_name, variable, n_cells,
+            min_val, max_val, mean_val, median_val, std_val
+        """
+        df = HdfInfiltration.get_preprocessed_infiltration(
+            hdf_path, mesh_name, variable, ras_object
+        )
+
+        if len(df) == 0:
+            return pd.DataFrame(columns=[
+                'mesh_name', 'variable', 'n_cells',
+                'min_val', 'max_val', 'mean_val', 'median_val', 'std_val'
+            ])
+
+        stats = df.groupby('mesh_name').agg(
+            n_cells=('value', 'count'),
+            min_val=('value', 'min'),
+            max_val=('value', 'max'),
+            mean_val=('value', 'mean'),
+            median_val=('value', 'median'),
+            std_val=('value', 'std'),
+        ).reset_index()
+        stats['variable'] = variable
+
+        return stats
+
+    @staticmethod
+    @log_call
     def get_infiltration_baseoverrides(hdf_path: Path) -> Optional[pd.DataFrame]:
         """
         Retrieve current infiltration parameters from a HEC-RAS geometry HDF file.
@@ -130,9 +250,173 @@ class HdfInfiltration:
         
 
 
-    # set_infiltration_baseoverrides goes here, once finalized tested and fixed. 
+    @staticmethod
+    @log_call
+    @standardize_input(file_type='geom_hdf')
+    def get_infiltration_region_names(hdf_path: Path) -> Optional[List[str]]:
+        """Retrieve infiltration region names from a HEC-RAS geometry HDF file.
 
+        Reads the ``Name`` field from the structured array at
+        ``Geometry/Infiltration/Attributes``.
 
+        Args:
+            hdf_path: Path to the HEC-RAS geometry HDF file.
+
+        Returns:
+            A list of infiltration region name strings, or ``None`` if the
+            dataset does not exist.
+
+        Example
+        -------
+        >>> names = HdfInfiltration.get_infiltration_region_names("model.g01.hdf")
+        >>> print(names)
+        ['Grass', 'Paving - Concrete', 'Detention Pond']
+        """
+        try:
+            with h5py.File(hdf_path, 'r') as hdf_file:
+                attrs_path = "Geometry/Infiltration/Attributes"
+                if attrs_path not in hdf_file:
+                    logger.warning(f"No infiltration attributes found in {hdf_path}")
+                    return None
+
+                data = hdf_file[attrs_path][()]
+                names = list(np.vectorize(HdfUtils.convert_ras_string)(data['Name']))
+                return names
+
+        except Exception as e:
+            logger.error(f"Error reading infiltration region names from {hdf_path}: {str(e)}")
+            return None
+
+    @staticmethod
+    @log_call
+    @standardize_input(file_type='geom_hdf')
+    def get_infiltration_calibration_regions(hdf_path: Path) -> Optional[Dict[str, pd.DataFrame]]:
+        """Retrieve infiltration calibration region data from a HEC-RAS geometry HDF file.
+
+        Reads compound datasets from ``Geometry/Infiltration/Variables`` (e.g.
+        Curve Number, Abstraction Ratio, Minimum Infiltration Rate) and builds
+        a DataFrame for each, indexed by the infiltration region names from
+        ``Geometry/Infiltration/Attributes``.
+
+        Args:
+            hdf_path: Path to the HEC-RAS geometry HDF file.
+
+        Returns:
+            A dictionary mapping variable names (e.g. ``"Curve Number"``) to
+            DataFrames where rows are regions and columns are land cover / soil
+            combinations, or ``None`` if the required paths do not exist.
+
+        Example
+        -------
+        >>> regions = HdfInfiltration.get_infiltration_calibration_regions("model.g01.hdf")
+        >>> print(regions.keys())
+        dict_keys(['Curve Number', 'Abstraction Ratio', 'Minimum Infiltration Rate'])
+        """
+        try:
+            with h5py.File(hdf_path, 'r') as hdf_file:
+                variables_path = "Geometry/Infiltration/Variables"
+                attrs_path = "Geometry/Infiltration/Attributes"
+
+                if variables_path not in hdf_file or attrs_path not in hdf_file:
+                    logger.warning(f"No infiltration variables or attributes found in {hdf_path}")
+                    return None
+
+                # Read region names
+                attrs_data = hdf_file[attrs_path][()]
+                region_names = list(np.vectorize(HdfUtils.convert_ras_string)(attrs_data['Name']))
+
+                result = {}
+                variables_group = hdf_file[variables_path]
+
+                for ds_name in variables_group:
+                    data = variables_group[ds_name][()]
+                    df_dict = {}
+                    for field_name in data.dtype.names:
+                        values = data[field_name]
+                        if values.dtype.kind == 'S':
+                            values = [v.decode('utf-8').strip() for v in values]
+                        df_dict[field_name] = values
+
+                    df = pd.DataFrame(df_dict)
+                    if len(df) == len(region_names):
+                        df.index = region_names
+                    result[ds_name] = df
+
+                return result
+
+        except Exception as e:
+            logger.error(f"Error reading infiltration calibration regions from {hdf_path}: {str(e)}")
+            return None
+
+    @staticmethod
+    @log_call
+    @standardize_input(file_type='geom_hdf')
+    def get_infiltration_region_polygons(hdf_path: Path) -> 'gpd.GeoDataFrame':
+        """Retrieve infiltration region polygons from a HEC-RAS geometry HDF file.
+
+        Reads polygon geometry from ``Geometry/Infiltration/Polygon Info``,
+        ``Polygon Parts``, ``Polygon Points``, and region names from
+        ``Geometry/Infiltration/Attributes``.
+
+        Args:
+            hdf_path: Path to the HEC-RAS geometry HDF file.
+
+        Returns:
+            A GeoDataFrame with columns ``region_id``, ``Name``, and
+            ``geometry``. Returns an empty GeoDataFrame if the required
+            datasets do not exist.
+
+        Example
+        -------
+        >>> gdf = HdfInfiltration.get_infiltration_region_polygons("model.g01.hdf")
+        >>> print(gdf[['Name', 'geometry']].head())
+        """
+        import geopandas as gpd
+        from shapely.geometry import Polygon, MultiPolygon
+
+        try:
+            with h5py.File(hdf_path, 'r') as hdf_file:
+                infiltration_path = "Geometry/Infiltration"
+                if infiltration_path not in hdf_file:
+                    return gpd.GeoDataFrame()
+
+                infil_data = hdf_file[infiltration_path]
+
+                if ("Polygon Info" not in infil_data or
+                    "Attributes" not in infil_data or
+                    "Polygon Points" not in infil_data):
+                    return gpd.GeoDataFrame()
+
+                region_ids = range(infil_data["Attributes"][()].shape[0])
+                names = np.vectorize(HdfUtils.convert_ras_string)(infil_data["Attributes"][()]["Name"])
+
+                geoms = list()
+                for pnt_start, pnt_cnt, part_start, part_cnt in infil_data["Polygon Info"][()]:
+                    points = infil_data["Polygon Points"][()][pnt_start : pnt_start + pnt_cnt]
+                    if part_cnt == 1:
+                        geoms.append(Polygon(points))
+                    else:
+                        parts = infil_data["Polygon Parts"][()][part_start : part_start + part_cnt]
+                        geoms.append(
+                            MultiPolygon(
+                                list(
+                                    points[part_pnt_start : part_pnt_start + part_pnt_cnt]
+                                    for part_pnt_start, part_pnt_cnt in parts
+                                )
+                            )
+                        )
+
+                return gpd.GeoDataFrame(
+                    {"region_id": region_ids, "Name": names, "geometry": geoms},
+                    geometry="geometry",
+                    crs=HdfBase.get_projection(hdf_file),
+                )
+
+        except Exception as e:
+            logger.error(f"Error reading infiltration region polygons from {hdf_path}: {str(e)}")
+            return gpd.GeoDataFrame()
+
+    # set_infiltration_baseoverrides goes here, once finalized tested and fixed.
 
     # Since the infiltration base overrides are in the geometry file, the above functions work on the geometry files
     # The below functions work on the infiltration layer HDF files.  Changes only take effect if no base overrides are present. 

--- a/ras_commander/hdf/HdfLandCover.py
+++ b/ras_commander/hdf/HdfLandCover.py
@@ -1,0 +1,780 @@
+"""
+HdfLandCover - Final Manning's N Computation from Land Cover and Calibration Regions
+
+This module computes the resolved per-pixel or per-cell Manning's n values
+accounting for all override layers:
+1. Base land cover table (from land cover .hdf file)
+2. Calibration region overrides (from geometry HDF)
+3. Preprocessed per-cell values (from geometry HDF after preprocessing)
+
+Two approaches are provided:
+- Cell-based: Read preprocessed per-cell values from geometry HDF (fast, authoritative)
+- Raster-based: Compute from source layers with full rasterization (exportable, no preprocessing needed)
+
+All methods are static. Do not instantiate.
+
+Platform:
+    Cross-platform for HDF reading; raster export requires rasterio.
+
+Example:
+    from ras_commander.hdf import HdfLandCover
+
+    # Read preprocessed per-cell Manning's n (what HEC-RAS uses)
+    df = HdfLandCover.get_preprocessed_mannings_n("project.g01.hdf")
+
+    # Read the calibration table (base + all region overrides)
+    cal = HdfLandCover.get_mannings_calibration_table("project.g01.hdf")
+"""
+
+import logging
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Union
+
+import h5py
+import numpy as np
+import pandas as pd
+
+from ..Decorators import log_call, standardize_input
+from ..LoggingConfig import get_logger
+from .HdfBase import HdfBase
+from .HdfUtils import HdfUtils
+
+logger = get_logger(__name__)
+
+
+class HdfLandCover:
+    """
+    Final Manning's n computation from land cover, base values, and calibration regions.
+
+    Provides two access patterns:
+    - **Preprocessed cell values**: Read the exact per-cell n-values that HEC-RAS
+      computed during geometry preprocessing (fast, authoritative).
+    - **Raster composition**: Combine base land cover raster + calibration table +
+      region polygons to produce the full-resolution Final Manning's N raster
+      (exportable, enables before/after comparison).
+
+    All methods are static - call directly without instantiation:
+        HdfLandCover.get_preprocessed_mannings_n("project.g01.hdf")
+    """
+
+    # ---- Phase 1: Cell-Level Readers (preprocessed values) ----
+
+    @staticmethod
+    @log_call
+    @standardize_input(file_type='geom_hdf')
+    def get_preprocessed_mannings_n(
+        hdf_path: Path,
+        mesh_name: Optional[str] = None,
+        ras_object: Any = None
+    ) -> pd.DataFrame:
+        """
+        Read preprocessed per-cell Manning's n from geometry HDF.
+
+        Returns the exact per-cell n-values that HEC-RAS uses in computation,
+        from ``/Geometry/2D Flow Areas/{mesh}/Cells Center Manning's n``.
+        These values reflect the full override chain (base + calibration regions)
+        as resolved during geometry preprocessing.
+
+        Args:
+            hdf_path: Geometry HDF path, plan number ("01"), or geometry number ("g01").
+                Resolved via @standardize_input to the geometry HDF file.
+            mesh_name: Specific 2D flow area name. If None, reads all areas.
+            ras_object: Optional RasPrj object for path resolution.
+
+        Returns:
+            DataFrame with columns: mesh_name, cell_id, mannings_n
+
+        Example:
+            >>> df = HdfLandCover.get_preprocessed_mannings_n("01")  # by plan number
+            >>> df = HdfLandCover.get_preprocessed_mannings_n("project.g01.hdf")  # by path
+        """
+        results = []
+
+        try:
+            with h5py.File(hdf_path, 'r') as hdf_file:
+                areas_path = "Geometry/2D Flow Areas"
+                if areas_path not in hdf_file:
+                    logger.warning(f"No 2D Flow Areas found in {hdf_path}")
+                    return pd.DataFrame(columns=['mesh_name', 'cell_id', 'mannings_n'])
+
+                areas_group = hdf_file[areas_path]
+
+                for area_name in areas_group:
+                    # Skip datasets (Attributes, Cell Info, etc.) - only process groups (mesh perimeters)
+                    if not isinstance(areas_group[area_name], h5py.Group):
+                        continue
+                    if mesh_name is not None and area_name != mesh_name:
+                        continue
+
+                    area = areas_group[area_name]
+                    mann_path = "Cells Center Manning's n"
+
+                    if mann_path not in area:
+                        logger.debug(f"No Manning's n data for mesh '{area_name}'")
+                        continue
+
+                    n_values = area[mann_path][()]
+                    n_cells = len(n_values)
+
+                    area_df = pd.DataFrame({
+                        'mesh_name': [area_name] * n_cells,
+                        'cell_id': range(n_cells),
+                        'mannings_n': n_values.astype(float),
+                    })
+                    results.append(area_df)
+
+        except Exception as e:
+            logger.error(f"Error reading preprocessed Manning's n from {hdf_path}: {e}")
+            return pd.DataFrame(columns=['mesh_name', 'cell_id', 'mannings_n'])
+
+        if not results:
+            return pd.DataFrame(columns=['mesh_name', 'cell_id', 'mannings_n'])
+
+        return pd.concat(results, ignore_index=True)
+
+    @staticmethod
+    @log_call
+    @standardize_input(file_type='geom_hdf')
+    def get_mannings_calibration_table(
+        hdf_path: Path,
+        ras_object: Any = None
+    ) -> Optional[pd.DataFrame]:
+        """
+        Read the Manning's n calibration table from geometry HDF.
+
+        Returns the full calibration table showing base n-values and per-region
+        overrides. Each row is a land cover class, each column after the first
+        two is a calibration region. Values > 0 indicate an override; 0 means
+        use the base value.
+
+        Args:
+            hdf_path: Geometry HDF path, plan number ("01"), or geometry number ("g01").
+            ras_object: Optional RasPrj object for path resolution.
+
+        Returns:
+            DataFrame with columns: Land Cover Name, Base Manning's n Value,
+            plus one column per calibration region. None if not found.
+
+        Example:
+            >>> cal = HdfLandCover.get_mannings_calibration_table("01")
+        """
+
+        try:
+            with h5py.File(hdf_path, 'r') as hdf_file:
+                table_path = "Geometry/Land Cover (Manning's n)/Calibration Table"
+                if table_path not in hdf_file:
+                    logger.warning(f"No Manning's n calibration table in {hdf_path}")
+                    return None
+
+                data = hdf_file[table_path][()]
+
+                df_dict = {}
+                for field_name in data.dtype.names:
+                    values = data[field_name]
+                    if values.dtype.kind == 'S':
+                        values = [v.decode('utf-8').strip() for v in values]
+                    df_dict[field_name] = values
+
+                return pd.DataFrame(df_dict)
+
+        except Exception as e:
+            logger.error(f"Error reading calibration table from {hdf_path}: {e}")
+            return None
+
+    # ---- Phase 2: Component Readers ----
+
+    @staticmethod
+    @log_call
+    @standardize_input(file_type='geom_hdf')
+    def get_mannings_region_polygons(
+        hdf_path: Path,
+        ras_object: Any = None
+    ) -> 'gpd.GeoDataFrame':
+        """
+        Read Manning's n calibration region polygons from geometry HDF.
+
+        Returns the polygon geometries used for spatial override of Manning's n
+        values. Each polygon defines a calibration region that can override
+        base n-values for specific land cover classes.
+
+        Args:
+            hdf_path: Geometry HDF path, plan number ("01"), or geometry number ("g01").
+            ras_object: Optional RasPrj object for path resolution.
+
+        Returns:
+            GeoDataFrame with columns: region_id, Name, 2D_Area_Name, geometry
+
+        Example:
+            >>> regions = HdfLandCover.get_mannings_region_polygons("01")
+        """
+        import geopandas as gpd
+        from shapely.geometry import Polygon, MultiPolygon
+
+        try:
+            with h5py.File(hdf_path, 'r') as hdf_file:
+                lc_path = "Geometry/Land Cover (Manning's n)"
+                if lc_path not in hdf_file:
+                    logger.warning(f"No Land Cover (Manning's n) group in {hdf_path}")
+                    return gpd.GeoDataFrame()
+
+                lc_group = hdf_file[lc_path]
+
+                if ("Polygon Info" not in lc_group or
+                    "Attributes" not in lc_group or
+                    "Polygon Points" not in lc_group):
+                    logger.warning(f"Missing polygon datasets in {lc_path}")
+                    return gpd.GeoDataFrame()
+
+                attrs = lc_group["Attributes"][()]
+                names = np.vectorize(HdfUtils.convert_ras_string)(attrs["Name"])
+
+                area_names = None
+                if "2D Area Name" in attrs.dtype.names:
+                    area_names = np.vectorize(HdfUtils.convert_ras_string)(attrs["2D Area Name"])
+
+                geoms = []
+                for pnt_start, pnt_cnt, part_start, part_cnt in lc_group["Polygon Info"][()]:
+                    points = lc_group["Polygon Points"][()][pnt_start:pnt_start + pnt_cnt]
+                    if part_cnt == 1:
+                        geoms.append(Polygon(points))
+                    elif "Polygon Parts" not in lc_group:
+                        logger.warning("Multi-part polygon but 'Polygon Parts' dataset missing")
+                        geoms.append(Polygon(points))
+                    else:
+                        parts = lc_group["Polygon Parts"][()][part_start:part_start + part_cnt]
+                        rings = [points[ps:ps + pc] for ps, pc in parts]
+                        if len(rings) == 1:
+                            geoms.append(Polygon(rings[0]))
+                        else:
+                            # First ring is exterior, rest are holes
+                            geoms.append(Polygon(rings[0], rings[1:]))
+
+                data = {
+                    "region_id": range(len(names)),
+                    "Name": names,
+                    "geometry": geoms,
+                }
+                if area_names is not None:
+                    data["2D_Area_Name"] = area_names
+
+                return gpd.GeoDataFrame(
+                    data,
+                    geometry="geometry",
+                    crs=HdfBase.get_projection(hdf_file),
+                )
+
+        except Exception as e:
+            logger.error(f"Error reading Manning's region polygons from {hdf_path}: {e}")
+            return gpd.GeoDataFrame()
+
+    @staticmethod
+    @log_call
+    @standardize_input(file_type='geom_hdf')
+    def get_mannings_region_cell_mapping(
+        hdf_path: Path,
+        ras_object: Any = None
+    ) -> Optional[pd.DataFrame]:
+        """
+        Read the cell-to-region mapping for Manning's n calibration regions.
+
+        Returns which cells fall within which calibration regions, from the
+        preprocessed datasets in the geometry HDF.
+
+        Args:
+            hdf_path: Geometry HDF path, plan number ("01"), or geometry number ("g01").
+            ras_object: Optional RasPrj object for path resolution.
+
+        Returns:
+            DataFrame with columns: region_id, cell_index.
+            None if datasets not found.
+        """
+
+        try:
+            with h5py.File(hdf_path, 'r') as hdf_file:
+                cells_path = "Geometry/Land Cover (Manning's n)/Internal Cells"
+                if cells_path not in hdf_file:
+                    return None
+
+                data = hdf_file[cells_path][()]
+                return pd.DataFrame({
+                    'region_id': data['Region ID'],
+                    'cell_index': data['Cell Index'],
+                })
+
+        except Exception as e:
+            logger.error(f"Error reading region cell mapping from {hdf_path}: {e}")
+            return None
+
+    @staticmethod
+    @log_call
+    def get_landcover_raster_map(
+        landcover_hdf_path: Union[str, Path],
+        ras_object: Any = None
+    ) -> Optional[pd.DataFrame]:
+        """
+        Read the raster classification map from a land cover .hdf file.
+
+        Returns the mapping of integer pixel values to land cover class names
+        and their associated Manning's n values.
+
+        Reads ``//Raster Map`` and ``//Variables`` from the land cover HDF.
+
+        Args:
+            landcover_hdf_path: Path to land cover HDF file
+                (from rasmap_df['landcover_hdf_path'])
+            ras_object: Optional RasPrj object for path resolution.
+
+        Returns:
+            DataFrame with columns: pixel_value, class_name, mannings_n.
+            None if file cannot be read.
+
+        Example:
+            >>> rmap = HdfLandCover.get_landcover_raster_map("LandCover.hdf")
+            >>> print(rmap[['class_name', 'mannings_n']].head())
+        """
+        landcover_hdf_path = Path(landcover_hdf_path)
+
+        try:
+            with h5py.File(landcover_hdf_path, 'r') as hdf_file:
+                # Read raster map: pixel_value -> class_name
+                # HDF path may be "Raster Map" or "//Raster Map" depending on version
+                rmap_path = None
+                for candidate in ["Raster Map", "//Raster Map"]:
+                    if candidate in hdf_file:
+                        rmap_path = candidate
+                        break
+                if rmap_path is None:
+                    logger.warning(f"No Raster Map found in {landcover_hdf_path}")
+                    return None
+
+                rmap_data = hdf_file[rmap_path][()]
+                class_names = [HdfUtils.convert_ras_string(n) for n in rmap_data['Name']]
+                pixel_ids = rmap_data['ID'].tolist()
+
+                # Read variables: class_name -> ManningsN
+                vars_path = None
+                for candidate in ["Variables", "//Variables"]:
+                    if candidate in hdf_file:
+                        vars_path = candidate
+                        break
+                if vars_path is None:
+                    logger.warning(f"No Variables found in {landcover_hdf_path}")
+                    return None
+
+                vars_data = hdf_file[vars_path][()]
+                var_names = [HdfUtils.convert_ras_string(n) for n in vars_data['Name']]
+
+                mannings_n = {}
+                if 'ManningsN' in vars_data.dtype.names:
+                    for i, name in enumerate(var_names):
+                        mannings_n[name] = float(vars_data['ManningsN'][i])
+
+                # Build mapping
+                rows = []
+                for pid, cname in zip(pixel_ids, class_names):
+                    rows.append({
+                        'pixel_value': int(pid),
+                        'class_name': cname,
+                        'mannings_n': mannings_n.get(cname, np.nan),
+                    })
+
+                return pd.DataFrame(rows)
+
+        except Exception as e:
+            logger.error(f"Error reading land cover raster map from {landcover_hdf_path}: {e}")
+            return None
+
+    # ---- Phase 3: Comparison and Statistics ----
+
+    @staticmethod
+    @log_call
+    @standardize_input(file_type='geom_hdf')
+    def compare_base_vs_calibrated(
+        hdf_path: Path,
+        ras_object: Any = None
+    ) -> Optional[pd.DataFrame]:
+        """
+        Compare base Manning's n vs calibrated values per land cover class per region.
+
+        Shows the effect of calibration: which regions override which classes,
+        and by how much. Only includes entries where the region has a non-zero
+        override (actual calibration changes).
+
+        Args:
+            hdf_path: Geometry HDF path, plan number ("01"), or geometry number ("g01").
+            ras_object: Optional RasPrj object for path resolution.
+
+        Returns:
+            DataFrame with columns: land_cover_class, base_n, region_name,
+            calibrated_n, delta_n, pct_change.
+            None if calibration table not found.
+
+        Example:
+            >>> comp = HdfLandCover.compare_base_vs_calibrated("project.g01.hdf")
+            >>> biggest = comp.nlargest(5, 'pct_change')
+            >>> print(biggest[['land_cover_class', 'region_name', 'base_n', 'calibrated_n', 'pct_change']])
+        """
+        cal_table = HdfLandCover.get_mannings_calibration_table(hdf_path)
+        if cal_table is None or len(cal_table) == 0:
+            return None
+
+        lc_col = "Land Cover Name"
+        base_col = "Base Manning's n Value"
+
+        if lc_col not in cal_table.columns or base_col not in cal_table.columns:
+            logger.warning("Calibration table missing expected columns")
+            return None
+
+        region_cols = [c for c in cal_table.columns if c not in (lc_col, base_col)]
+
+        rows = []
+        for _, row in cal_table.iterrows():
+            class_name = row[lc_col]
+            base_n = float(row[base_col])
+
+            for region_name in region_cols:
+                cal_n = float(row[region_name])
+                if cal_n > 0 and cal_n != base_n:
+                    delta = cal_n - base_n
+                    pct = (delta / base_n * 100) if base_n > 0 else float('inf')
+                    rows.append({
+                        'land_cover_class': class_name,
+                        'base_n': base_n,
+                        'region_name': region_name,
+                        'calibrated_n': cal_n,
+                        'delta_n': delta,
+                        'pct_change': pct,
+                    })
+
+        if not rows:
+            logger.info("No calibration overrides found (all regions use base values)")
+            return pd.DataFrame(columns=[
+                'land_cover_class', 'base_n', 'region_name',
+                'calibrated_n', 'delta_n', 'pct_change'
+            ])
+
+        return pd.DataFrame(rows)
+
+    @staticmethod
+    @log_call
+    @standardize_input(file_type='geom_hdf')
+    def get_preprocessed_mannings_stats(
+        hdf_path: Path,
+        mesh_name: Optional[str] = None,
+        ras_object: Any = None
+    ) -> pd.DataFrame:
+        """
+        Compute statistics on preprocessed per-cell Manning's n values.
+
+        Args:
+            hdf_path: Geometry HDF path, plan number ("01"), or geometry number ("g01").
+            mesh_name: Specific 2D flow area. If None, computes for all.
+            ras_object: Optional RasPrj object.
+
+        Returns:
+            DataFrame with columns: mesh_name, n_cells, min_n, max_n,
+            mean_n, median_n, std_n
+
+        Example:
+            >>> stats = HdfLandCover.get_preprocessed_mannings_stats("project.g01.hdf")
+            >>> print(stats)
+        """
+        df = HdfLandCover.get_preprocessed_mannings_n(hdf_path, mesh_name, ras_object)
+
+        if len(df) == 0:
+            return pd.DataFrame(columns=[
+                'mesh_name', 'n_cells', 'min_n', 'max_n', 'mean_n', 'median_n', 'std_n'
+            ])
+
+        stats = df.groupby('mesh_name').agg(
+            n_cells=('mannings_n', 'count'),
+            min_n=('mannings_n', 'min'),
+            max_n=('mannings_n', 'max'),
+            mean_n=('mannings_n', 'mean'),
+            median_n=('mannings_n', 'median'),
+            std_n=('mannings_n', 'std'),
+        ).reset_index()
+
+        return stats
+
+    # ---- Phase 3: Raster Composition ----
+
+    @staticmethod
+    @log_call
+    @standardize_input(file_type='geom_hdf')
+    def get_landcover_association(
+        hdf_path: Path,
+        ras_object: Any = None
+    ) -> Optional[Path]:
+        """
+        Get the land cover HDF path associated with a geometry.
+
+        Reads the ``Land Cover Filename`` attribute from the geometry HDF
+        and resolves it to an absolute path. This is set via RASMapper's
+        "Manage Associations" menu.
+
+        Args:
+            hdf_path: Geometry HDF path, plan number ("01"), or geometry number ("g01").
+            ras_object: Optional RasPrj object.
+
+        Returns:
+            Absolute path to the land cover HDF file, or None if not found.
+        """
+
+        try:
+            with h5py.File(hdf_path, 'r') as hdf_file:
+                geom_group = hdf_file.get('Geometry')
+                if geom_group is None:
+                    return None
+
+                lc_attr = geom_group.attrs.get('Land Cover Filename')
+                if lc_attr is None:
+                    return None
+
+                if isinstance(lc_attr, bytes):
+                    lc_attr = lc_attr.decode('utf-8')
+
+                lc_path = Path(lc_attr)
+                if not lc_path.is_absolute():
+                    lc_path = (hdf_path.parent / lc_path).resolve()
+
+                if lc_path.exists():
+                    return lc_path
+                else:
+                    logger.warning(f"Land cover file not found: {lc_path}")
+                    return None
+
+        except Exception as e:
+            logger.error(f"Error reading land cover association from {hdf_path}: {e}")
+            return None
+
+    @staticmethod
+    @log_call
+    @standardize_input(file_type='geom_hdf')
+    def compute_final_mannings_raster(
+        hdf_path: Path,
+        landcover_hdf_path: Optional[Union[str, Path]] = None,
+        output_tif_path: Optional[Union[str, Path]] = None,
+        ras_object: Any = None
+    ) -> Optional[np.ndarray]:
+        """
+        Compute final Manning's n raster accounting for base + calibration overrides.
+
+        Combines the base land cover raster with the calibration table and
+        region polygons to produce the full-resolution Final Manning's N raster.
+        This replicates what RASMapper's FinalNValueLayer computes internally.
+
+        The land cover HDF is auto-resolved from the geometry's ``Land Cover Filename``
+        attribute (set via RASMapper's Manage Associations menu), or can be overridden.
+
+        Args:
+            hdf_path: Geometry HDF path, plan number ("01"), or geometry number ("g01").
+            landcover_hdf_path: Path to land cover HDF file. If None (default),
+                auto-resolves from the geometry HDF's association attribute.
+            ras_object: Optional RasPrj object for path resolution.
+            output_tif_path: If provided, writes result to GeoTIFF.
+
+        Returns:
+            2D numpy array of final Manning's n values (same shape as land cover raster).
+            None if inputs cannot be resolved.
+
+        Example:
+            >>> arr = HdfLandCover.compute_final_mannings_raster("01")  # auto-resolves LC
+            >>> arr = HdfLandCover.compute_final_mannings_raster(
+            ...     "project.g01.hdf",
+            ...     landcover_hdf_path="custom_landcover.hdf",  # override
+            ...     output_tif_path="final_mannings_n.tif"
+            ... )
+        """
+        import rasterio
+        from rasterio.features import rasterize as rio_rasterize
+
+        # Resolve land cover HDF path from geometry association if not provided
+        if landcover_hdf_path is None:
+            landcover_hdf_path = HdfLandCover.get_landcover_association(hdf_path)
+            if landcover_hdf_path is None:
+                logger.error("Cannot resolve land cover HDF path")
+                return None
+        landcover_hdf_path = Path(landcover_hdf_path)
+
+        # Find sidecar TIF
+        lc_tif_path = landcover_hdf_path.with_suffix('.tif')
+        if not lc_tif_path.exists():
+            # Try matching the naming pattern: base.classname.tif
+            candidates = list(landcover_hdf_path.parent.glob(
+                f"{landcover_hdf_path.stem}*.tif"
+            ))
+            if candidates:
+                lc_tif_path = candidates[0]
+            else:
+                logger.error(f"Land cover TIF not found for {landcover_hdf_path}")
+                return None
+
+        logger.info(f"Reading land cover TIF: {lc_tif_path.name} ({lc_tif_path.stat().st_size / 1024 / 1024:.0f} MB)")
+
+        # Step 1: Read the raster map (pixel_id → class_name → base_n)
+        raster_map = HdfLandCover.get_landcover_raster_map(landcover_hdf_path)
+        if raster_map is None or len(raster_map) == 0:
+            logger.error("Cannot read land cover raster map")
+            return None
+
+        # Build pixel_value → base_n lookup
+        pixel_to_base_n = {}
+        pixel_to_class_name = {}
+        for _, row in raster_map.iterrows():
+            pv = int(row['pixel_value'])
+            pixel_to_base_n[pv] = float(row['mannings_n']) if not np.isnan(row['mannings_n']) else 0.0
+            pixel_to_class_name[pv] = row['class_name']
+
+        # Step 2: Read calibration table
+        cal_table = HdfLandCover.get_mannings_calibration_table(hdf_path)
+        has_calibration = cal_table is not None and len(cal_table) > 0
+
+        # Build (class_name, region_name) → override_n lookup
+        cal_lookup = {}
+        region_names_ordered = []
+        if has_calibration:
+            lc_col = "Land Cover Name"
+            base_col = "Base Manning's n Value"
+            region_names_ordered = [c for c in cal_table.columns if c not in (lc_col, base_col)]
+
+            for _, row in cal_table.iterrows():
+                class_name = row[lc_col]
+                for i, region_name in enumerate(region_names_ordered):
+                    val = float(row[region_name])
+                    if val > 0:
+                        cal_lookup[(class_name, i)] = val
+
+        # Step 3: Read region polygons and prepare for rasterization
+        region_shapes = []
+        if has_calibration and len(region_names_ordered) > 0:
+            regions_gdf = HdfLandCover.get_mannings_region_polygons(hdf_path)
+            if len(regions_gdf) > 0:
+                for _, rgn in regions_gdf.iterrows():
+                    region_name = rgn['Name']
+                    if region_name in region_names_ordered:
+                        region_idx = region_names_ordered.index(region_name)
+                        region_shapes.append((rgn['geometry'], region_idx + 1))  # 1-indexed
+
+        # Step 4: Determine clip extent from 2D flow area perimeter (tight bounds)
+        # The full geometry extent can be much larger than the 2D flow area
+        clip_bounds = None
+        try:
+            with h5py.File(hdf_path, 'r') as hf:
+                # Try 2D flow area perimeter first (tightest bounds)
+                perim_pts_path = "Geometry/2D Flow Areas/Polygon Points"
+                if perim_pts_path in hf:
+                    pts = hf[perim_pts_path][()]
+                    buffer = 500.0  # 500 ft buffer around perimeter
+                    clip_bounds = (
+                        float(pts[:, 0].min()) - buffer,
+                        float(pts[:, 1].min()) - buffer,
+                        float(pts[:, 0].max()) + buffer,
+                        float(pts[:, 1].max()) + buffer,
+                    )
+                    logger.info(f"Clipping to 2D flow area perimeter (+ {buffer:.0f} ft buffer)")
+                else:
+                    # Fall back to full geometry extents
+                    extents = hf['Geometry'].attrs.get('Extents')
+                    if extents is not None:
+                        clip_bounds = (
+                            float(extents[0]), float(extents[2]),
+                            float(extents[1]), float(extents[3]),
+                        )
+                        logger.info("Clipping to geometry extent (no 2D perimeter found)")
+        except Exception as e:
+            logger.debug(f"Could not read clip bounds from geometry HDF: {e}")
+
+        # Step 5: Read land cover TIF (clipped to geometry extent) and compute
+        from rasterio.windows import from_bounds
+
+        with rasterio.open(lc_tif_path) as src:
+            if clip_bounds is not None:
+                # Compute the window that covers the geometry extent
+                try:
+                    window = from_bounds(*clip_bounds, transform=src.transform)
+                    # Round to integer pixel boundaries
+                    window = window.round_offsets().round_lengths()
+                    lc_raster = src.read(1, window=window)
+                    transform = src.window_transform(window)
+                    # Build a profile for the clipped extent
+                    profile = src.profile.copy()
+                    profile.update(
+                        width=lc_raster.shape[1],
+                        height=lc_raster.shape[0],
+                        transform=transform,
+                    )
+                except Exception as e:
+                    logger.warning(f"Window clipping failed ({e}), reading full raster")
+                    lc_raster = src.read(1)
+                    profile = src.profile.copy()
+                    transform = src.transform
+            else:
+                lc_raster = src.read(1)
+                profile = src.profile.copy()
+                transform = src.transform
+
+            logger.info(f"Land cover raster: {lc_raster.shape} ({lc_raster.nbytes / 1024 / 1024:.0f} MB)")
+
+            if lc_raster.size == 0:
+                logger.error("Land cover raster is empty after clipping — check clip bounds vs raster extent")
+                return None
+
+            # Rasterize calibration regions onto same grid
+            if region_shapes:
+                logger.info(f"Rasterizing {len(region_shapes)} calibration regions")
+                region_raster = rio_rasterize(
+                    region_shapes,
+                    out_shape=lc_raster.shape,
+                    transform=transform,
+                    fill=0,
+                    dtype=np.int32
+                )
+            else:
+                region_raster = np.zeros(lc_raster.shape, dtype=np.int32)
+
+            # Step 6: Vectorized lookup
+            max_pixel_val = max(int(lc_raster.max()) + 1, max(pixel_to_base_n.keys(), default=0) + 1)
+            base_n_lut = np.zeros(max_pixel_val, dtype=np.float32)
+            for pv, n in pixel_to_base_n.items():
+                if 0 <= pv < max_pixel_val:
+                    base_n_lut[pv] = n
+
+            # Apply base lookup
+            final_raster = base_n_lut[np.clip(lc_raster, 0, max_pixel_val - 1)]
+
+            # Apply calibration overrides where regions exist
+            if cal_lookup and region_shapes:
+                for (class_name, region_idx), override_n in cal_lookup.items():
+                    for pv, cn in pixel_to_class_name.items():
+                        if cn == class_name and 0 <= pv < max_pixel_val:
+                            mask = (lc_raster == pv) & (region_raster == (region_idx + 1))
+                            if mask.any():
+                                final_raster[mask] = override_n
+
+            valid = final_raster[final_raster > 0]
+            if len(valid) > 0:
+                logger.info(
+                    f"Final Manning's n: shape={final_raster.shape}, "
+                    f"range={valid.min():.4f}-{valid.max():.4f}, mean={valid.mean():.4f}"
+                )
+            else:
+                logger.warning("No valid Manning's n values in output")
+
+            # Step 7: Optionally write to GeoTIFF
+            if output_tif_path is not None:
+                output_tif_path = Path(output_tif_path)
+                output_profile = profile.copy()
+                output_profile.update(
+                    dtype='float32',
+                    count=1,
+                    nodata=-9999.0,
+                    compress='deflate'
+                )
+                with rasterio.open(output_tif_path, 'w', **output_profile) as dst:
+                    out = final_raster.copy()
+                    out[out == 0] = -9999.0
+                    dst.write(out, 1)
+                logger.info(f"Wrote final Manning's n raster to {output_tif_path}")
+
+        return final_raster

--- a/ras_commander/hdf/HdfMesh.py
+++ b/ras_commander/hdf/HdfMesh.py
@@ -1059,3 +1059,50 @@ class HdfMesh:
         except Exception as e:
             logger.error(f"Error reading sloped topology from {hdf_path}: {e}")
             return {}
+
+    @staticmethod
+    @log_call
+    @standardize_input(file_type='geom_hdf')
+    def get_mannings_calibration_table(hdf_path: Path) -> Optional[pd.DataFrame]:
+        """Retrieve the Manning's n calibration table from a HEC-RAS geometry HDF file.
+
+        Reads the compound dataset at
+        ``Geometry/Land Cover (Manning's n)/Calibration Table`` which contains
+        land cover names, base Manning's n values, and per-region calibration
+        factors.
+
+        Args:
+            hdf_path: Path to the HEC-RAS geometry HDF file.
+
+        Returns:
+            A DataFrame with columns for each field in the calibration table
+            (land cover name, base Manning's n, and one column per calibration
+            region), or ``None`` if the dataset does not exist.
+
+        Example
+        -------
+        >>> df = HdfMesh.get_mannings_calibration_table("model.g01.hdf")
+        >>> print(df.columns.tolist()[:3])
+        ['Land Cover Name', "Base Manning's n Value", ...]
+        """
+        try:
+            with h5py.File(hdf_path, 'r') as hdf_file:
+                table_path = "Geometry/Land Cover (Manning's n)/Calibration Table"
+                if table_path not in hdf_file:
+                    logger.warning(f"No Manning's n calibration table found in {hdf_path}")
+                    return None
+
+                data = hdf_file[table_path][()]
+
+                df_dict = {}
+                for field_name in data.dtype.names:
+                    values = data[field_name]
+                    if values.dtype.kind == 'S':
+                        values = [v.decode('utf-8').strip() for v in values]
+                    df_dict[field_name] = values
+
+                return pd.DataFrame(df_dict)
+
+        except Exception as e:
+            logger.error(f"Error reading Manning's n calibration table from {hdf_path}: {str(e)}")
+            return None

--- a/ras_commander/hdf/__init__.py
+++ b/ras_commander/hdf/__init__.py
@@ -27,7 +27,8 @@ Results:
 Infrastructure:
     - HdfPipe: Pipe network geometry and results
     - HdfPump: Pump station geometry and results
-    - HdfInfiltration: Infiltration parameters
+    - HdfInfiltration: Infiltration parameters and preprocessed per-cell values
+    - HdfLandCover: Final Manning's N (base + calibration overrides, raster composition)
 
 Visualization:
     - HdfPlot: General HDF plotting
@@ -77,6 +78,7 @@ from .HdfResultsBreach import HdfResultsBreach
 from .HdfPipe import HdfPipe
 from .HdfPump import HdfPump
 from .HdfInfiltration import HdfInfiltration
+from .HdfLandCover import HdfLandCover
 
 # Visualization classes
 from .HdfPlot import HdfPlot
@@ -99,7 +101,7 @@ __all__ = [
     # Results
     'HdfResultsPlan', 'HdfResultsMesh', 'HdfResultsXsec', 'HdfResultsBreach',
     # Infrastructure
-    'HdfPipe', 'HdfPump', 'HdfInfiltration',
+    'HdfPipe', 'HdfPump', 'HdfInfiltration', 'HdfLandCover',
     # Visualization
     'HdfPlot', 'HdfResultsPlot',
     # Analysis

--- a/ras_commander/terrain/RasTerrainMod.py
+++ b/ras_commander/terrain/RasTerrainMod.py
@@ -1,0 +1,667 @@
+"""
+RasTerrainMod - Terrain Modification Analysis via RasMapperLib.dll
+
+This module provides static methods for sampling HEC-RAS terrain WITH terrain
+modifications applied, enabling cut/fill analysis and no-net-fill calculations
+without requiring the RASMapper GUI.
+
+Uses pythonnet to call RasMapperLib.dll's RASMapperCom class directly from Python.
+Terrain modifications (channels, levees, polygons, etc.) are automatically applied
+to all terrain sampling operations.
+
+Summary:
+    Wraps RASMapperCom methods (TerrainExtent, TerrainProfile, TerrainVolumeElevation)
+    for headless terrain analysis with modifications. No HEC-RAS GUI required.
+
+Key Functions:
+    setup_gdal_bridge():
+        One-time setup to create GDAL junction for pythonnet loading.
+
+    get_terrain_extent():
+        Get terrain layer bounding box (with modifications).
+
+    get_terrain_profile():
+        Sample terrain along a polyline (with modifications applied).
+
+    get_terrain_volume_elevation():
+        Compute elevation-volume curve for a polygon (with modifications).
+
+    compare_terrain_profiles():
+        Compare two terrain profiles for cut/fill analysis.
+
+    compare_terrain_volumes():
+        Compare elevation-volume curves for no-net-fill analysis.
+
+Platform:
+    Windows only (requires HEC-RAS 6.6+ and .NET Framework)
+
+Requirements:
+    - HEC-RAS 6.6+ installed
+    - pythonnet (pip install pythonnet)
+    - GDAL junction created (call setup_gdal_bridge() once)
+
+Example:
+    from ras_commander.terrain import RasTerrainMod
+
+    # One-time setup
+    RasTerrainMod.setup_gdal_bridge()
+
+    # Sample terrain profile with modifications
+    profile = RasTerrainMod.get_terrain_profile(
+        rasmap_path="project.rasmap",
+        geom_hdf_path="project.g01.hdf",
+        x_coords=[3400000, 3405000, 3410000],
+        y_coords=[612000, 612000, 612000]
+    )
+"""
+
+import logging
+import os
+import sys
+import platform
+import subprocess
+import threading
+from pathlib import Path
+from typing import List, Optional, Tuple, Union
+
+import numpy as np
+import pandas as pd
+
+from ..Decorators import log_call
+from ..LoggingConfig import get_logger
+
+logger = get_logger(__name__)
+
+_RAS_INSTALL_PATHS = [
+    Path("C:/Program Files (x86)/HEC/HEC-RAS/6.6"),
+    Path("C:/Program Files (x86)/HEC/HEC-RAS/6.5"),
+    Path("C:/Program Files/HEC/HEC-RAS/6.6"),
+    Path("C:/Program Files/HEC/HEC-RAS/6.5"),
+]
+
+
+class RasTerrainMod:
+    """
+    Static class for terrain modification analysis via RasMapperLib.dll.
+
+    Provides headless terrain sampling with modifications applied, enabling
+    cut/fill analysis and no-net-fill calculations without the RASMapper GUI.
+
+    All methods are static - call directly without instantiation:
+        RasTerrainMod.get_terrain_profile(rasmap, geom_hdf, x, y)
+
+    Prerequisites:
+        1. HEC-RAS 6.6+ installed
+        2. pythonnet installed (pip install pythonnet)
+        3. GDAL bridge set up (call setup_gdal_bridge() once)
+
+    Thread Safety:
+        NOT thread-safe. The .NET RASMapperCom instance is shared and COM
+        objects follow single-threaded apartment (STA) rules. Do not call
+        methods concurrently from multiple threads.
+    """
+
+    _com_instance = None
+    _ras_path = None
+    _initialized = False
+    _lock = threading.Lock()
+
+    @staticmethod
+    def _find_hecras_path() -> Path:
+        """Find HEC-RAS installation directory."""
+        for path in _RAS_INSTALL_PATHS:
+            if (path / "RasMapperLib.dll").exists():
+                return path
+        raise FileNotFoundError(
+            "HEC-RAS 6.5+ installation not found. "
+            "Searched: " + ", ".join(str(p) for p in _RAS_INSTALL_PATHS)
+        )
+
+    @staticmethod
+    @log_call
+    def setup_gdal_bridge(
+        hecras_version: str = "6.6",
+        python_dir: Optional[Union[str, Path]] = None
+    ) -> bool:
+        """
+        One-time setup: create GDAL junction for pythonnet/RasMapperLib.
+
+        RasMapperLib.dll expects a GDAL/ subfolder next to the entry assembly.
+        When loaded from Python, this means GDAL/ must exist next to python.exe.
+        This method creates a directory junction to satisfy that requirement.
+
+        Args:
+            hecras_version: HEC-RAS version to use (default "6.6")
+            python_dir: Python installation directory (auto-detected if None)
+
+        Returns:
+            True if junction exists or was created, False if creation failed
+
+        Note:
+            Only needs to be called once per Python environment.
+            Requires write permission to the Python directory.
+        """
+        if python_dir is None:
+            python_dir = Path(sys.executable).parent
+        else:
+            python_dir = Path(python_dir)
+
+        gdal_junction = python_dir / "GDAL"
+
+        # Check if junction already exists and works
+        if gdal_junction.exists() and (gdal_junction / "bin64").exists():
+            logger.info(f"GDAL junction already exists at {gdal_junction}")
+            return True
+
+        # Find HEC-RAS GDAL source
+        ras_path = RasTerrainMod._find_hecras_path()
+        gdal_source = ras_path / "GDAL"
+
+        if not gdal_source.exists():
+            logger.error(f"GDAL not found in HEC-RAS installation: {gdal_source}")
+            return False
+
+        # Create junction via PowerShell
+        try:
+            result = subprocess.run(
+                [
+                    "powershell", "-Command",
+                    f'New-Item -ItemType Junction -Path "{gdal_junction}" '
+                    f'-Target "{gdal_source}" -Force'
+                ],
+                capture_output=True, text=True, timeout=10
+            )
+            if result.returncode == 0:
+                logger.info(f"Created GDAL junction: {gdal_junction} -> {gdal_source}")
+                return True
+            else:
+                logger.error(f"Failed to create junction: {result.stderr}")
+                return False
+        except Exception as e:
+            logger.error(f"Junction creation failed: {e}")
+            return False
+
+    @staticmethod
+    def _ensure_initialized():
+        """Initialize pythonnet and RasMapperLib if not already done."""
+        if RasTerrainMod._initialized:
+            return
+
+        if platform.system() != "Windows":
+            raise RuntimeError("RasTerrainMod requires Windows (HEC-RAS is Windows-only)")
+
+        try:
+            import clr
+        except ImportError:
+            raise ImportError(
+                "pythonnet is required for RasTerrainMod. "
+                "Install with: pip install pythonnet"
+            )
+
+        ras_path = RasTerrainMod._find_hecras_path()
+        RasTerrainMod._ras_path = ras_path
+
+        # Add HEC-RAS to sys.path and PATH for DLL resolution
+        if str(ras_path) not in sys.path:
+            sys.path.append(str(ras_path))
+
+        gdal_bin = str(Path(sys.executable).parent / "GDAL" / "bin64")
+        if os.path.exists(gdal_bin):
+            os.environ['PATH'] = gdal_bin + ';' + str(ras_path) + ';' + os.environ.get('PATH', '')
+        else:
+            os.environ['PATH'] = str(ras_path) + ';' + os.environ.get('PATH', '')
+            logger.warning(
+                f"GDAL junction not found at {gdal_bin}. "
+                "Call RasTerrainMod.setup_gdal_bridge() first."
+            )
+
+        # Load RasMapperLib.dll
+        try:
+            clr.AddReference('RasMapperLib')
+            logger.info(f"RasMapperLib.dll loaded from {ras_path}")
+        except Exception as e:
+            raise RuntimeError(
+                f"Failed to load RasMapperLib.dll from {ras_path}: {e}"
+            )
+
+        RasTerrainMod._initialized = True
+
+    @staticmethod
+    def _get_com():
+        """Get or create the RASMapperCom instance (thread-safe)."""
+        with RasTerrainMod._lock:
+            RasTerrainMod._ensure_initialized()
+
+            if RasTerrainMod._com_instance is None:
+                from RasMapperLib import RASMapperCom
+                RasTerrainMod._com_instance = RASMapperCom()
+                logger.debug("Created RASMapperCom instance")
+
+            return RasTerrainMod._com_instance
+
+    @staticmethod
+    def _validate_paths(rasmap_path: Union[str, Path], geom_hdf_path: Union[str, Path]):
+        """Validate that rasmap and geometry HDF paths exist."""
+        rasmap_path = Path(rasmap_path)
+        geom_hdf_path = Path(geom_hdf_path)
+        if not rasmap_path.exists():
+            raise FileNotFoundError(f"rasmap file not found: {rasmap_path}")
+        if not geom_hdf_path.exists():
+            raise FileNotFoundError(f"Geometry HDF not found: {geom_hdf_path}")
+        return rasmap_path, geom_hdf_path
+
+    @staticmethod
+    def _validate_coords(x_coords: List[float], y_coords: List[float]):
+        """Validate coordinate arrays are finite and matching length."""
+        if len(x_coords) != len(y_coords):
+            raise ValueError("x_coords and y_coords must have the same length")
+        arr = np.array(x_coords + y_coords, dtype=float)
+        if not np.all(np.isfinite(arr)):
+            raise ValueError("Coordinate values must be finite (no NaN or inf)")
+
+    @staticmethod
+    @log_call
+    def get_terrain_extent(
+        rasmap_path: Union[str, Path],
+        geom_hdf_path: Union[str, Path],
+        ras_object=None
+    ) -> dict:
+        """
+        Get the terrain bounding box with modifications applied.
+
+        Args:
+            rasmap_path: Path to .rasmap project file
+            geom_hdf_path: Path to geometry HDF file (.g##.hdf)
+
+        Returns:
+            dict with keys: success, min_x, max_x, min_y, max_y
+
+        Example:
+            >>> extent = RasTerrainMod.get_terrain_extent(
+            ...     "project.rasmap", "project.g01.hdf"
+            ... )
+            >>> print(f"Extent: {extent['min_x']:.0f} to {extent['max_x']:.0f}")
+        """
+        rasmap_path, geom_hdf_path = RasTerrainMod._validate_paths(rasmap_path, geom_hdf_path)
+        com = RasTerrainMod._get_com()
+
+        try:
+            result = com.TerrainExtent(
+                str(rasmap_path), str(geom_hdf_path),
+                0.0, 0.0, 0.0, 0.0
+            )
+        except Exception as e:
+            raise RuntimeError(
+                f"TerrainExtent failed for rasmap='{rasmap_path}': {e}"
+            ) from e
+
+        # pythonnet returns all ref params: (success, rasmap, geom, minX, maxX, minY, maxY)
+        return {
+            'success': result[0],
+            'min_x': result[3],
+            'max_x': result[4],
+            'min_y': result[5],
+            'max_y': result[6],
+        }
+
+    @staticmethod
+    @log_call
+    def get_terrain_profile(
+        rasmap_path: Union[str, Path],
+        geom_hdf_path: Union[str, Path],
+        x_coords: List[float],
+        y_coords: List[float],
+        filter_tolerance: float = 0.01,
+        ras_object=None
+    ) -> pd.DataFrame:
+        """
+        Sample terrain elevation along a polyline with modifications applied.
+
+        The terrain profile includes ALL terrain modifications (channels, levees,
+        polygon overrides, etc.) that exist in the terrain HDF referenced by
+        the .rasmap file.
+
+        Args:
+            rasmap_path: Path to .rasmap project file
+            geom_hdf_path: Path to geometry HDF file (.g##.hdf)
+            x_coords: X coordinates defining the profile polyline
+            y_coords: Y coordinates defining the profile polyline
+            filter_tolerance: Douglas-Peucker vertical filter tolerance (default 0.01)
+
+        Returns:
+            DataFrame with columns:
+            - station: float - distance along polyline (project units)
+            - elevation: float - terrain elevation with modifications
+
+        Example:
+            >>> profile = RasTerrainMod.get_terrain_profile(
+            ...     "project.rasmap", "project.g01.hdf",
+            ...     x_coords=[3400000, 3410000],
+            ...     y_coords=[612000, 612000]
+            ... )
+            >>> profile.plot(x='station', y='elevation')
+        """
+        rasmap_path, geom_hdf_path = RasTerrainMod._validate_paths(rasmap_path, geom_hdf_path)
+        RasTerrainMod._validate_coords(x_coords, y_coords)
+        com = RasTerrainMod._get_com()
+
+        from System import Array, Double, Single
+
+        n = len(x_coords)
+        if n < 2:
+            raise ValueError("Need at least 2 points to define a profile line")
+
+        x = Array.CreateInstance(Double, n)
+        y = Array.CreateInstance(Double, n)
+        for i in range(n):
+            x[i] = float(x_coords[i])
+            y[i] = float(y_coords[i])
+
+        sta = Array.CreateInstance(Single, 0)
+        elev = Array.CreateInstance(Single, 0)
+
+        try:
+            # All 10 params are ref - pythonnet returns all in tuple:
+            # (rasmap, geom, count, x, y, tol, profileCount, station, elevation, err)
+            result = com.TerrainProfile(
+                str(rasmap_path), str(geom_hdf_path),
+                n, x, y, filter_tolerance,
+                0, sta, elev, ''
+            )
+        except Exception as e:
+            raise RuntimeError(
+                f"TerrainProfile failed for rasmap='{rasmap_path}': {e}"
+            ) from e
+
+        prof_count = result[6]
+        sta_out = result[7]
+        elev_out = result[8]
+        err_out = result[9]
+
+        if err_out:
+            logger.warning(f"TerrainProfile warning: {err_out}")
+
+        if prof_count == 0:
+            logger.warning("TerrainProfile returned 0 points")
+            return pd.DataFrame(columns=['station', 'elevation'])
+
+        return pd.DataFrame({
+            'station': [float(sta_out[i]) for i in range(prof_count)],
+            'elevation': [float(elev_out[i]) for i in range(prof_count)],
+        })
+
+    @staticmethod
+    @log_call
+    def get_terrain_volume_elevation(
+        rasmap_path: Union[str, Path],
+        geom_hdf_path: Union[str, Path],
+        x_coords: List[float],
+        y_coords: List[float],
+        filter_tolerance: float = 0.01,
+        volume_factor: float = 1.0,
+        ras_object=None
+    ) -> pd.DataFrame:
+        """
+        Compute elevation-volume curve for a polygon with modifications applied.
+
+        Returns the volume of space below each elevation within the polygon,
+        computed from the modified terrain surface (including channels, ponds, etc.).
+
+        Args:
+            rasmap_path: Path to .rasmap project file
+            geom_hdf_path: Path to geometry HDF file (.g##.hdf)
+            x_coords: X coordinates of polygon vertices (must close - first == last)
+            y_coords: Y coordinates of polygon vertices (must close - first == last)
+            filter_tolerance: Terrain sampling tolerance (default 0.01)
+            volume_factor: Volume conversion factor:
+                - 1.0 = cubic feet (if project units are feet)
+                - 43560.0 = acre-feet
+                - 0.0283168 = cubic meters (from cubic feet)
+
+        Returns:
+            DataFrame with columns:
+            - elevation: float - terrain elevation
+            - volume: float - cumulative volume below that elevation
+
+        Example:
+            >>> # Define a pond polygon (must close)
+            >>> x = [3400000, 3400500, 3400500, 3400000, 3400000]
+            >>> y = [612000, 612000, 612500, 612500, 612000]
+            >>> ev = RasTerrainMod.get_terrain_volume_elevation(
+            ...     "project.rasmap", "project.g01.hdf", x, y
+            ... )
+            >>> ev.plot(x='elevation', y='volume', title='Elev-Volume Curve')
+        """
+        rasmap_path, geom_hdf_path = RasTerrainMod._validate_paths(rasmap_path, geom_hdf_path)
+        RasTerrainMod._validate_coords(x_coords, y_coords)
+        com = RasTerrainMod._get_com()
+
+        from System import Array, Double, Single
+
+        n = len(x_coords)
+        if n < 4:
+            raise ValueError("Need at least 4 points (3 vertices + closing point)")
+
+        x = Array.CreateInstance(Double, n)
+        y = Array.CreateInstance(Double, n)
+        for i in range(n):
+            x[i] = float(x_coords[i])
+            y[i] = float(y_coords[i])
+
+        elev = Array.CreateInstance(Single, 0)
+        vol = Array.CreateInstance(Single, 0)
+
+        try:
+            # All 11 params are ref - pythonnet returns all in tuple:
+            # (rasmap, geom, count, x, y, tol, volFactor, tableCount, elev, vol, err)
+            result = com.TerrainVolumeElevation(
+                str(rasmap_path), str(geom_hdf_path),
+                n, x, y, filter_tolerance, volume_factor,
+                0, elev, vol, ''
+            )
+        except Exception as e:
+            raise RuntimeError(
+                f"TerrainVolumeElevation failed for rasmap='{rasmap_path}': {e}"
+            ) from e
+
+        table_count = result[7]
+        elev_out = result[8]
+        vol_out = result[9]
+        err_out = result[10]
+
+        if err_out:
+            logger.warning(f"TerrainVolumeElevation warning: {err_out}")
+
+        if table_count == 0:
+            logger.warning("TerrainVolumeElevation returned 0 rows")
+            return pd.DataFrame(columns=['elevation', 'volume'])
+
+        return pd.DataFrame({
+            'elevation': [float(elev_out[i]) for i in range(table_count)],
+            'volume': [float(vol_out[i]) for i in range(table_count)],
+        })
+
+    @staticmethod
+    @log_call
+    def compare_terrain_profiles(
+        rasmap_existing: Union[str, Path],
+        rasmap_proposed: Union[str, Path],
+        geom_hdf_path: Union[str, Path],
+        x_coords: List[float],
+        y_coords: List[float],
+        filter_tolerance: float = 0.01,
+        ras_object=None
+    ) -> pd.DataFrame:
+        """
+        Compare terrain profiles between existing and proposed conditions.
+
+        Computes cut/fill along a profile line by differencing terrain elevations
+        from two .rasmap files (each referencing different terrain HDFs with
+        different terrain modifications).
+
+        Args:
+            rasmap_existing: Path to .rasmap with existing terrain
+            rasmap_proposed: Path to .rasmap with proposed terrain (with modifications)
+            geom_hdf_path: Path to geometry HDF (shared between both)
+            x_coords: X coordinates of profile line
+            y_coords: Y coordinates of profile line
+            filter_tolerance: Terrain sampling tolerance
+
+        Returns:
+            DataFrame with columns:
+            - station: float - distance along profile
+            - existing_elevation: float - existing terrain elevation
+            - proposed_elevation: float - proposed terrain elevation
+            - difference: float - proposed - existing (positive = fill, negative = cut)
+
+        Example:
+            >>> df = RasTerrainMod.compare_terrain_profiles(
+            ...     "existing.rasmap", "proposed.rasmap", "project.g01.hdf",
+            ...     x_coords=[3400000, 3410000], y_coords=[612000, 612000]
+            ... )
+            >>> cut_volume = df[df['difference'] < 0]['difference'].sum()
+            >>> fill_volume = df[df['difference'] > 0]['difference'].sum()
+        """
+        existing = RasTerrainMod.get_terrain_profile(
+            rasmap_existing, geom_hdf_path, x_coords, y_coords, filter_tolerance
+        )
+        proposed = RasTerrainMod.get_terrain_profile(
+            rasmap_proposed, geom_hdf_path, x_coords, y_coords, filter_tolerance
+        )
+
+        if len(existing) == 0 or len(proposed) == 0:
+            logger.warning("One or both profiles are empty")
+            return pd.DataFrame(columns=[
+                'station', 'existing_elevation', 'proposed_elevation', 'difference'
+            ])
+
+        # Clip to overlapping station range to avoid extrapolation
+        sta_min = max(existing['station'].iloc[0], proposed['station'].iloc[0])
+        sta_max = min(existing['station'].iloc[-1], proposed['station'].iloc[-1])
+        mask = (existing['station'] >= sta_min) & (existing['station'] <= sta_max)
+        existing_clipped = existing[mask]
+
+        if len(existing_clipped) == 0:
+            logger.warning("No overlapping station range between profiles")
+            return pd.DataFrame(columns=[
+                'station', 'existing_elevation', 'proposed_elevation', 'difference'
+            ])
+
+        proposed_interp = np.interp(
+            existing_clipped['station'].values,
+            proposed['station'].values,
+            proposed['elevation'].values
+        )
+
+        return pd.DataFrame({
+            'station': existing_clipped['station'].values,
+            'existing_elevation': existing_clipped['elevation'].values,
+            'proposed_elevation': proposed_interp,
+            'difference': proposed_interp - existing_clipped['elevation'].values,
+        })
+
+    @staticmethod
+    @log_call
+    def compare_terrain_volumes(
+        rasmap_existing: Union[str, Path],
+        rasmap_proposed: Union[str, Path],
+        geom_hdf_path: Union[str, Path],
+        x_coords: List[float],
+        y_coords: List[float],
+        filter_tolerance: float = 0.01,
+        volume_factor: float = 1.0,
+        ras_object=None
+    ) -> pd.DataFrame:
+        """
+        Compare elevation-volume curves for no-net-fill analysis.
+
+        Computes volume differences between existing and proposed terrain
+        within a polygon, enabling no-net-fill compliance checking.
+
+        At each elevation:
+        - net_volume = proposed_volume - existing_volume
+        - Positive net_volume = net fill added
+        - Negative net_volume = net cut (excavation exceeds fill)
+        - Zero net_volume = no-net-fill condition met
+
+        Args:
+            rasmap_existing: Path to .rasmap with existing terrain
+            rasmap_proposed: Path to .rasmap with proposed terrain
+            geom_hdf_path: Path to geometry HDF (shared)
+            x_coords: Polygon X coordinates (must close)
+            y_coords: Polygon Y coordinates (must close)
+            filter_tolerance: Terrain sampling tolerance
+            volume_factor: Volume unit conversion (1.0 = cubic feet)
+
+        Returns:
+            DataFrame with columns:
+            - elevation: float - terrain elevation
+            - existing_volume: float - volume below elevation (existing)
+            - proposed_volume: float - volume below elevation (proposed)
+            - net_volume: float - proposed - existing (positive = net fill)
+
+        Example:
+            >>> df = RasTerrainMod.compare_terrain_volumes(
+            ...     "existing.rasmap", "proposed.rasmap", "project.g01.hdf",
+            ...     x_coords=pond_x, y_coords=pond_y,
+            ...     volume_factor=43560.0  # acre-feet
+            ... )
+            >>> # Check no-net-fill at 100-year flood elevation
+            >>> flood_elev = 10.0
+            >>> row = df[df['elevation'] >= flood_elev].iloc[0]
+            >>> print(f"Net volume at {flood_elev} ft: {row['net_volume']:.1f} ac-ft")
+        """
+        existing = RasTerrainMod.get_terrain_volume_elevation(
+            rasmap_existing, geom_hdf_path, x_coords, y_coords,
+            filter_tolerance, volume_factor
+        )
+        proposed = RasTerrainMod.get_terrain_volume_elevation(
+            rasmap_proposed, geom_hdf_path, x_coords, y_coords,
+            filter_tolerance, volume_factor
+        )
+
+        if len(existing) == 0 or len(proposed) == 0:
+            logger.warning("One or both volume curves are empty")
+            return pd.DataFrame(columns=[
+                'elevation', 'existing_volume', 'proposed_volume', 'net_volume'
+            ])
+
+        # Create common elevation grid spanning both curves
+        all_elevations = np.unique(np.concatenate([
+            existing['elevation'].values,
+            proposed['elevation'].values
+        ]))
+
+        # Clip to overlapping elevation range for reliable comparison
+        elev_min = max(existing['elevation'].min(), proposed['elevation'].min())
+        elev_max = min(existing['elevation'].max(), proposed['elevation'].max())
+        all_elevations = all_elevations[
+            (all_elevations >= elev_min) & (all_elevations <= elev_max)
+        ]
+
+        if len(all_elevations) == 0:
+            logger.warning("No overlapping elevation range between volume curves")
+            return pd.DataFrame(columns=[
+                'elevation', 'existing_volume', 'proposed_volume', 'net_volume'
+            ])
+
+        # Interpolate both curves onto common grid
+        existing_interp = np.interp(
+            all_elevations,
+            existing['elevation'].values,
+            existing['volume'].values,
+            left=0.0
+        )
+        proposed_interp = np.interp(
+            all_elevations,
+            proposed['elevation'].values,
+            proposed['volume'].values,
+            left=0.0
+        )
+
+        return pd.DataFrame({
+            'elevation': all_elevations,
+            'existing_volume': existing_interp,
+            'proposed_volume': proposed_interp,
+            'net_volume': proposed_interp - existing_interp,
+        })

--- a/ras_commander/terrain/__init__.py
+++ b/ras_commander/terrain/__init__.py
@@ -1,51 +1,61 @@
 """
-ras-commander terrain subpackage: HEC-RAS terrain creation and manipulation.
+ras-commander terrain subpackage: HEC-RAS terrain creation, manipulation, and analysis.
 
-This subpackage provides terrain creation capabilities for HEC-RAS projects,
-including HDF terrain creation via RasProcess.exe and VRT to TIFF conversion.
+This subpackage provides terrain capabilities for HEC-RAS projects:
+- Terrain HDF creation from rasters via RasProcess.exe CreateTerrain
+- VRT mosaic to single TIFF conversion via HEC-RAS GDAL tools
+- USGS 3DEP elevation data download from AWS
+- Terrain modification analysis (cut/fill, no-net-fill) via RasMapperLib.dll
 
-Key Capabilities:
-    - Create HEC-RAS terrain HDF from input rasters using RasProcess.exe CreateTerrain
-    - Convert VRT mosaics to single optimized TIFF files using HEC-RAS GDAL tools
-    - Generate ESRI PRJ files from raster coordinate reference systems
-    - Support for multiple HEC-RAS versions (6.3+)
+Main Classes:
+    RasTerrain: Terrain HDF creation and VRT conversion (RasProcess.exe CLI)
+        - create_terrain_hdf(): Create terrain HDF from input rasters
+        - vrt_to_tiff(): Convert VRT to single TIFF with overviews
 
-Main Class:
-    RasTerrain: Static methods for terrain operations
-        - create_terrain_hdf(): Create HEC-RAS terrain HDF from input rasters
-        - vrt_to_tiff(): Convert VRT to single TIFF with optional overviews
+    Usgs3depAws: USGS 3DEP elevation tile download from AWS S3
+        - find_tiles_for_bbox(): Find tiles covering a bounding box
+        - download_tiles(): Download tiles with concurrent threads
+
+    RasTerrainMod: Terrain modification analysis via pythonnet (Windows only)
+        - get_terrain_profile(): Sample terrain with modifications applied
+        - get_terrain_volume_elevation(): Elevation-volume curve for polygons
+        - compare_terrain_profiles(): Cut/fill analysis between terrains
+        - compare_terrain_volumes(): No-net-fill compliance checking
+        Requires: pythonnet, HEC-RAS 6.6+, one-time setup_gdal_bridge() call
 
 Requirements:
     - HEC-RAS 6.3+ installed (for RasProcess.exe and GDAL tools)
-    - No additional Python packages required for core functionality
+    - Optional: pythonnet for RasTerrainMod (terrain modification analysis)
     - Optional: rasterio for advanced raster analysis
 
 Usage:
-    from ras_commander.terrain import RasTerrain
-    from pathlib import Path
+    from ras_commander.terrain import RasTerrain, RasTerrainMod
 
     # Create terrain HDF from TIFF files
     terrain_hdf = RasTerrain.create_terrain_hdf(
         input_rasters=[Path("dem.tif")],
         output_hdf=Path("Terrain/Terrain.hdf"),
         projection_prj=Path("Terrain/Projection.prj"),
-        units="Feet",
-        hecras_version="6.6"
     )
 
-    # Convert VRT mosaic to single TIFF
-    output_tiff = RasTerrain.vrt_to_tiff(
-        vrt_path=Path("combined.vrt"),
-        output_path=Path("combined.tif"),
-        compression="LZW"
+    # Sample terrain with modifications (no GUI required)
+    RasTerrainMod.setup_gdal_bridge()  # one-time setup
+    profile = RasTerrainMod.get_terrain_profile(
+        "project.rasmap", "project.g01.hdf",
+        x_coords=[3400000, 3410000], y_coords=[612000, 612000]
     )
 
 See Also:
-    - feature_dev_notes/HEC-RAS_Terrain_CLI/CLAUDE.md for design documentation
-    - examples/800_terrain_creation.ipynb for complete workflow
+    - examples/920_terrain_creation.ipynb for terrain creation workflow
+    - examples/930_terrain_modification_analysis.ipynb for cut/fill analysis
 """
 
 from .RasTerrain import RasTerrain
 from .Usgs3depAws import Usgs3depAws
 
-__all__ = ['RasTerrain', 'Usgs3depAws']
+# Conditional import - RasTerrainMod requires pythonnet (Windows only)
+try:
+    from .RasTerrainMod import RasTerrainMod
+    __all__ = ['RasTerrain', 'Usgs3depAws', 'RasTerrainMod']
+except ImportError:
+    __all__ = ['RasTerrain', 'Usgs3depAws']


### PR DESCRIPTION
## Summary

- **RasTerrainMod**: Headless terrain sampling with modifications applied via pythonnet + RasMapperLib.dll (no GUI required). Enables cut/fill and no-net-fill analysis.
- **HdfLandCover**: Final Manning's N computation from land cover + calibration regions. Reads preprocessed per-cell values, calibration tables, region polygons, and computes full-resolution rasters.
- **HdfInfiltration additions**: Preprocessed per-cell infiltration (Curve Number, Abstraction Ratio, Min Infiltration Rate) with statistics.
- All methods accept plan numbers via `@standardize_input` ("01", "g01", or direct path)
- Land cover HDF auto-resolved from geometry association (RASMapper Manage Associations)

## New Files
- `ras_commander/terrain/RasTerrainMod.py` — 6 methods for terrain mod analysis
- `ras_commander/hdf/HdfLandCover.py` — 10 methods for Manning's N composition
- `examples/930_terrain_modification_analysis.ipynb` — Cut/fill notebook
- `examples/211_final_mannings_and_infiltration.ipynb` — Manning's N + infiltration notebook

## Test plan
- [x] Tested all methods against BayouConway production project (g16 vs g17)
- [x] Detected 10 extra calibration regions in Proposed vs Existing
- [x] Detected CN differences within Pond Drainage Area (mean 86.6 vs 73.5)
- [x] Terrain profile and volume-elevation working
- [x] Raster composition produces final Manning's N GeoTIFF
- [x] QAQC'd by code-reviewer and api-consistency-auditor
- [x] Both notebooks execute end-to-end with 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)