### PR TITLE
RasCmdr: normalize list plan selectors

### DIFF
--- a/ras_commander/RasCmdr.py
+++ b/ras_commander/RasCmdr.py
@@ -107,6 +107,62 @@ class RasCmdr:
         return Path(ras_object.project_folder) / f"{ras_object.project_name}.p{plan_num_str}.hdf"
 
     @staticmethod
+    def _normalize_requested_plan_numbers(
+        plan_number: Union[str, Number, List[Union[str, Number]], None]
+    ) -> Optional[List[str]]:
+        """
+        Normalize user-supplied plan selectors to two-digit plan numbers.
+        """
+        if plan_number is None:
+            return None
+
+        if isinstance(plan_number, (str, Number)):
+            requested_plan_numbers = [plan_number]
+        else:
+            requested_plan_numbers = list(plan_number)
+
+        return [
+            RasUtils.normalize_ras_number(requested_plan)
+            for requested_plan in requested_plan_numbers
+        ]
+
+    @staticmethod
+    def _filter_plan_entries(
+        plan_entries: pd.DataFrame,
+        plan_number: Union[str, Number, List[Union[str, Number]], None]
+    ) -> pd.DataFrame:
+        """
+        Filter plan entries using normalized two-digit plan numbers.
+        """
+        if not plan_number:
+            return plan_entries
+
+        requested_plan_numbers = RasCmdr._normalize_requested_plan_numbers(
+            plan_number
+        )
+        filtered_plan_entries = plan_entries[
+            plan_entries["plan_number"].isin(requested_plan_numbers)
+        ].copy()
+        available_plan_numbers = set(filtered_plan_entries["plan_number"])
+        missing_plan_numbers = [
+            requested_plan
+            for requested_plan in requested_plan_numbers
+            if requested_plan not in available_plan_numbers
+        ]
+
+        if missing_plan_numbers:
+            logger.warning(
+                "Requested plan numbers not found in plan_df after "
+                f"normalization: {missing_plan_numbers}"
+            )
+
+        logger.info(
+            "Filtered plans to execute: "
+            f"{list(filtered_plan_entries['plan_number'])}"
+        )
+        return filtered_plan_entries
+
+    @staticmethod
     def _verify_completion(hdf_path: Path, check_errors: bool = False) -> bool:
         """
         Verify that a HEC-RAS computation completed successfully (HDF-only).
@@ -629,16 +685,11 @@ class RasCmdr:
                 project_folder = dest_folder_path
 
             # Store filtered plan numbers separately to ensure only these are executed
-            filtered_plan_numbers = []
-
-            if plan_number:
-                if isinstance(plan_number, (str, Number)):
-                    plan_number = [plan_number]
-                ras_obj.plan_df = ras_obj.plan_df[ras_obj.plan_df['plan_number'].isin(plan_number)]
-                filtered_plan_numbers = list(ras_obj.plan_df['plan_number'])
-                logger.info(f"Filtered plans to execute: {filtered_plan_numbers}")
-            else:
-                filtered_plan_numbers = list(ras_obj.plan_df['plan_number'])
+            filtered_plan_entries = RasCmdr._filter_plan_entries(
+                ras_obj.plan_df,
+                plan_number
+            )
+            filtered_plan_numbers = list(filtered_plan_entries["plan_number"])
 
             # Initialize execution_results dict
             execution_results: Dict[str, bool] = {}
@@ -662,7 +713,10 @@ class RasCmdr:
 
             # If all plans were skipped, return early
             if num_plans == 0:
-                logger.info("All plans skipped (existing results found). No computation needed.")
+                if execution_results:
+                    logger.info("All plans skipped (existing results found). No computation needed.")
+                else:
+                    logger.warning("No plans matched the requested plan filter. No computation needed.")
                 # Try to populate results_df from existing results
                 _results_df = pd.DataFrame()
                 try:
@@ -1002,13 +1056,10 @@ class RasCmdr:
                 logger.critical(f"Error retrieving plan entries: {str(e)}")
                 return ComputeParallelResult()
 
-            if plan_number:
-                if isinstance(plan_number, (str, Number)):
-                    plan_number = [plan_number]
-                ras_compute_plan_entries = ras_compute_plan_entries[
-                    ras_compute_plan_entries['plan_number'].isin(plan_number)
-                ]
-                logger.info(f"Filtered plans to execute: {plan_number}")
+            ras_compute_plan_entries = RasCmdr._filter_plan_entries(
+                ras_compute_plan_entries,
+                plan_number
+            )
 
             execution_results = {}
             logger.info("Running selected plans sequentially...")

--- a/tests/test_rascmdr_plan_number_normalization.py
+++ b/tests/test_rascmdr_plan_number_normalization.py
@@ -1,0 +1,137 @@
+from pathlib import Path
+import importlib
+
+import pandas as pd
+
+from ras_commander.ComputeResults import ComputeResult
+
+
+rascmdr_module = importlib.import_module("ras_commander.RasCmdr")
+RasCmdr = rascmdr_module.RasCmdr
+
+
+class FakeRasProject:
+    DEFAULT_PLAN_NUMBERS = ["01", "02", "03"]
+
+    def __init__(self, project_folder=None, plan_numbers=None):
+        self.project_name = "TestProject"
+        self.ras_exe_path = Path("C:/HEC-RAS/6.6/Ras.exe")
+        self._plan_numbers = list(plan_numbers or self.DEFAULT_PLAN_NUMBERS)
+        self.project_folder = (
+            Path(project_folder) if project_folder is not None else Path.cwd()
+        )
+        self.prj_file = self.project_folder / f"{self.project_name}.prj"
+        self.plan_df = self.get_plan_entries()
+        self.geom_df = pd.DataFrame(columns=["geom_number"])
+        self.flow_df = pd.DataFrame(columns=["flow_number"])
+        self.unsteady_df = pd.DataFrame(columns=["unsteady_number"])
+        self.results_df = pd.DataFrame(columns=["plan_number", "status"])
+
+    def check_initialized(self):
+        return None
+
+    def initialize(self, project_folder, ras_exe_path):
+        self.project_folder = Path(project_folder)
+        self.ras_exe_path = ras_exe_path
+        self.prj_file = self.project_folder / f"{self.project_name}.prj"
+        self.plan_df = self.get_plan_entries()
+
+    def get_plan_entries(self):
+        return pd.DataFrame({"plan_number": self._plan_numbers})
+
+    def get_geom_entries(self):
+        return pd.DataFrame(columns=["geom_number"])
+
+    def get_flow_entries(self):
+        return pd.DataFrame(columns=["flow_number"])
+
+    def get_unsteady_entries(self):
+        return pd.DataFrame(columns=["unsteady_number"])
+
+    def update_results_df(self, plan_numbers=None):
+        plan_numbers = [] if plan_numbers is None else list(plan_numbers)
+        self.results_df = pd.DataFrame(
+            {
+                "plan_number": plan_numbers,
+                "status": ["done"] * len(plan_numbers),
+            }
+        )
+
+    def close(self):
+        return None
+
+
+def fake_init_ras_project(ras_project_folder, ras_version, ras_object):
+    ras_object.initialize(ras_project_folder, ras_version)
+    return ras_object
+
+
+def test_normalize_requested_plan_numbers_returns_two_digit_strings():
+    assert RasCmdr._normalize_requested_plan_numbers([1, "2", 3.0]) == [
+        "01",
+        "02",
+        "03",
+    ]
+    assert RasCmdr._normalize_requested_plan_numbers("4") == ["04"]
+
+
+def test_compute_parallel_normalizes_list_plan_numbers_before_filtering(
+    monkeypatch, tmp_path
+):
+    project_folder = tmp_path / "parallel-project"
+    project_folder.mkdir()
+    (project_folder / "TestProject.prj").write_text(
+        "Proj Title=TestProject\n",
+        encoding="utf-8",
+    )
+    ras_object = FakeRasProject(project_folder=project_folder)
+    executed_plans = []
+
+    def fake_compute_plan(plan_number, **kwargs):
+        executed_plans.append(plan_number)
+        return ComputeResult(success=True)
+
+    monkeypatch.setattr(rascmdr_module, "RasPrj", FakeRasProject)
+    monkeypatch.setattr(rascmdr_module, "init_ras_project", fake_init_ras_project)
+    monkeypatch.setattr(RasCmdr, "compute_plan", staticmethod(fake_compute_plan))
+
+    result = RasCmdr.compute_parallel(
+        plan_number=[1, 2],
+        max_workers=1,
+        ras_object=ras_object,
+    )
+
+    assert executed_plans == ["01", "02"]
+    assert result.execution_results == {"01": True, "02": True}
+    assert result.results_df["plan_number"].tolist() == ["01", "02"]
+    assert ras_object.plan_df["plan_number"].tolist() == ["01", "02", "03"]
+
+
+def test_compute_test_mode_normalizes_list_plan_numbers_before_filtering(
+    monkeypatch, tmp_path
+):
+    project_folder = tmp_path / "test-mode-project"
+    project_folder.mkdir()
+    (project_folder / "TestProject.prj").write_text(
+        "Proj Title=TestProject\n",
+        encoding="utf-8",
+    )
+    ras_object = FakeRasProject(project_folder=project_folder)
+    executed_plans = []
+
+    def fake_compute_plan(plan_number, **kwargs):
+        executed_plans.append(plan_number)
+        return ComputeResult(success=True)
+
+    monkeypatch.setattr(rascmdr_module, "RasPrj", FakeRasProject)
+    monkeypatch.setattr(RasCmdr, "compute_plan", staticmethod(fake_compute_plan))
+
+    result = RasCmdr.compute_test_mode(
+        plan_number=[1, "2"],
+        dest_folder_suffix="[Normalized]",
+        ras_object=ras_object,
+    )
+
+    assert executed_plans == ["01", "02"]
+    assert result.execution_results == {"01": True, "02": True}
+    assert result.results_df["plan_number"].tolist() == ["01", "02"]


### PR DESCRIPTION
## Summary

Normalize list-valued `plan_number` inputs in `RasCmdr.compute_parallel()` and `RasCmdr.compute_test_mode()` before filtering `plan_df`, so numeric selectors like `[1, 2]` resolve to `['01', '02']` instead of being silently dropped. Add focused regression coverage for the normalized filtering path.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)
- [ ] Example notebook

---

## LLM Self-Review

> **ras-commander encourages LLM-assisted contributions.** If your agent prepared this code, confirm it reviewed the style guide. See [CONTRIBUTING.md](../CONTRIBUTING.md) for details.

### Style Compliance

- [x] Static class pattern followed (`.claude/rules/python/static-classes.md`)
- [x] `@staticmethod` + `@log_call` on public methods (`.claude/rules/python/decorators.md`)
- [x] Naming conventions followed (`.claude/rules/python/naming-conventions.md`)
- [x] `pathlib.Path` used, accepts both `str` and `Path` (`.claude/rules/python/path-handling.md`)
- [x] DataFrames used for project metadata, not glob (`.claude/rules/python/dataframe-first-principle.md`)

### Code Quality

- [ ] Google-style docstrings with Args, Returns, Raises
- [x] Tested with real HEC-RAS project (`RasExamples.extract_project()`)
- [x] No hardcoded file paths
- [x] Uses logging, not `print()`
- [x] Proper error handling with informative messages

### API Changes (if applicable)

- [ ] `ras_object=None` parameter included for multi-project support
- [x] Standard parameter names (`plan_number`, `geom_file`)
- [ ] API consistency auditor 5 rules followed (`.claude/agents/api-consistency-auditor.md`)
- [x] Return types consistent (DataFrames for tabular data)

### Notebooks (if applicable)

- [ ] First cell is markdown with H1 title
- [ ] Uses `RasExamples.extract_project()` for data
- [ ] Development toggle cell included (`USE_LOCAL_SOURCE`)

---

## Test Plan

- Added `tests/test_rascmdr_plan_number_normalization.py` to cover direct normalization plus stubbed `compute_parallel()` and `compute_test_mode()` regression cases for numeric list selectors.
- Direct Python verification passed for both methods with numeric inputs `[1, 2]` and `[1, "2"]`.
- Ran a notebook-runner-style regression on a copy of `examples/111_executing_plan_sets.ipynb` using `RasExamples.extract_project("Balde Eagle Creek")`; the executed notebook confirmed both `compute_test_mode()` and `compute_parallel()` returned `['01', '02']` when called with `[1, 2]`.
- Environment note: the machine does not have a usable installed `Ras.exe`, so the notebook validation monkeypatched `RasCmdr.compute_plan()` to avoid an actual HEC-RAS execution while still exercising the real list-filtering logic against a real extracted project.

## LLM Attribution

**Model/Tool used**: Codex desktop (GPT-5)
