### PR TITLE
HdfInfiltration: fix multipart region polygons

### DIFF
--- a/examples/211_final_mannings_and_infiltration.ipynb
+++ b/examples/211_final_mannings_and_infiltration.ipynb
@@ -1,6 +1,627 @@
 {
- "nbformat": 4,
- "nbformat_minor": 4,
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "e65a0853",
+   "metadata": {},
+   "source": [
+    "# Final Manning's N and Infiltration Analysis\n",
+    "\n",
+    "This notebook demonstrates how to extract final Manning's N and preprocessed infiltration values from a reproducible example project. It also includes a regression check for multi-ring infiltration override polygons."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "7f85657c",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-03-27T17:19:37.722320Z",
+     "iopub.status.busy": "2026-03-27T17:19:37.721386Z",
+     "iopub.status.idle": "2026-03-27T17:19:38.742816Z",
+     "shell.execute_reply": "2026-03-27T17:19:38.742816Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Imports successful\n"
+     ]
+    }
+   ],
+   "source": [
+    "from pathlib import Path\n",
+    "import logging\n",
+    "import importlib\n",
+    "import sys\n",
+    "import types\n",
+    "\n",
+    "repo_root = (\n",
+    "    Path.cwd().resolve().parent\n",
+    "    if Path.cwd().resolve().name == 'examples'\n",
+    "    else Path.cwd().resolve()\n",
+    ")\n",
+    "\n",
+    "package = types.ModuleType('ras_commander')\n",
+    "package.__path__ = [str(repo_root / 'ras_commander')]\n",
+    "sys.modules.pop('ras_commander', None)\n",
+    "sys.modules['ras_commander'] = package\n",
+    "logging_config = importlib.import_module('ras_commander.LoggingConfig')\n",
+    "package.get_logger = logging_config.get_logger\n",
+    "package.setup_logging = logging_config.setup_logging\n",
+    "decorators = importlib.import_module('ras_commander.Decorators')\n",
+    "package.log_call = decorators.log_call\n",
+    "package.standardize_input = decorators.standardize_input\n",
+    "\n",
+    "for logger_name in [\n",
+    "    'ras_commander.RasExamples',\n",
+    "    'ras_commander.hdf.HdfLandCover',\n",
+    "    'ras_commander.hdf.HdfInfiltration',\n",
+    "    'ras_commander.hdf.HdfBase',\n",
+    "]:\n",
+    "    logging.getLogger(logger_name).setLevel(logging.CRITICAL + 1)\n",
+    "\n",
+    "import h5py\n",
+    "import matplotlib.pyplot as plt\n",
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "\n",
+    "RasExamples = importlib.import_module('ras_commander.RasExamples').RasExamples\n",
+    "HdfLandCover = importlib.import_module('ras_commander.hdf.HdfLandCover').HdfLandCover\n",
+    "HdfInfiltration = importlib.import_module('ras_commander.hdf.HdfInfiltration').HdfInfiltration\n",
+    "\n",
+    "print('Imports successful')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "75593b02",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-03-27T17:19:38.759113Z",
+     "iopub.status.busy": "2026-03-27T17:19:38.759113Z",
+     "iopub.status.idle": "2026-03-27T17:19:40.137737Z",
+     "shell.execute_reply": "2026-03-27T17:19:40.137737Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Project: BaldEagleCrkMulti2D\n",
+      "Geometry HDF: BaldEagleDamBrk.g09.hdf\n",
+      "Meshes with infiltration data: ['BaldEagleCr']\n"
+     ]
+    }
+   ],
+   "source": [
+    "project_path = RasExamples.extract_project('BaldEagleCrkMulti2D')\n",
+    "\n",
+    "geom_hdf = None\n",
+    "mesh_names = []\n",
+    "for candidate in sorted(project_path.glob('*.g*.hdf')):\n",
+    "    with h5py.File(candidate, 'r') as hdf_file:\n",
+    "        areas_group = hdf_file.get('Geometry/2D Flow Areas')\n",
+    "        if areas_group is None:\n",
+    "            continue\n",
+    "        current_mesh_names = [\n",
+    "            area_name\n",
+    "            for area_name, area in areas_group.items()\n",
+    "            if isinstance(area, h5py.Group) and 'Infiltration' in area\n",
+    "        ]\n",
+    "        if current_mesh_names:\n",
+    "            geom_hdf = candidate\n",
+    "            mesh_names = current_mesh_names\n",
+    "            break\n",
+    "\n",
+    "assert geom_hdf is not None, 'No geometry HDF with preprocessed infiltration data found.'\n",
+    "print(f'Project: {project_path.name}')\n",
+    "print(f'Geometry HDF: {geom_hdf.name}')\n",
+    "print(f'Meshes with infiltration data: {mesh_names}')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0b47cf8d",
+   "metadata": {},
+   "source": [
+    "## Preprocessed Per-Cell Manning's N"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "41980821",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-03-27T17:19:40.141966Z",
+     "iopub.status.busy": "2026-03-27T17:19:40.141966Z",
+     "iopub.status.idle": "2026-03-27T17:19:40.176615Z",
+     "shell.execute_reply": "2026-03-27T17:19:40.176615Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Cells: 19,597\n",
+      "N range: 0.0300 to 0.1500\n",
+      "Mean: 0.0674\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>mesh_name</th>\n",
+       "      <th>n_cells</th>\n",
+       "      <th>min_n</th>\n",
+       "      <th>max_n</th>\n",
+       "      <th>mean_n</th>\n",
+       "      <th>median_n</th>\n",
+       "      <th>std_n</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>BaldEagleCr</td>\n",
+       "      <td>19597</td>\n",
+       "      <td>0.03</td>\n",
+       "      <td>0.15</td>\n",
+       "      <td>0.067352</td>\n",
+       "      <td>0.06</td>\n",
+       "      <td>0.025607</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "     mesh_name  n_cells  min_n  max_n    mean_n  median_n     std_n\n",
+       "0  BaldEagleCr    19597   0.03   0.15  0.067352      0.06  0.025607"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "mann_df = HdfLandCover.get_preprocessed_mannings_n(geom_hdf)\n",
+    "assert len(mann_df) > 0, \"Expected preprocessed Manning's n values.\"\n",
+    "print(f'Cells: {len(mann_df):,}')\n",
+    "print(\n",
+    "    f\"N range: {mann_df['mannings_n'].min():.4f} to {mann_df['mannings_n'].max():.4f}\"\n",
+    ")\n",
+    "print(f\"Mean: {mann_df['mannings_n'].mean():.4f}\")\n",
+    "stats = HdfLandCover.get_preprocessed_mannings_stats(geom_hdf)\n",
+    "stats"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "e83e99cc",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-03-27T17:19:40.176615Z",
+     "iopub.status.busy": "2026-03-27T17:19:40.176615Z",
+     "iopub.status.idle": "2026-03-27T17:19:40.296804Z",
+     "shell.execute_reply": "2026-03-27T17:19:40.296804Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA90AAAHqCAYAAAAZLi26AAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjgsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvwVt1zgAAAAlwSFlzAAAPYQAAD2EBqD+naQAAVj9JREFUeJzt3Ql4U1X6x/G3+wYFKaXsiIhssgi4oI6gIqiMGzg6/pUdVAaUZQRE2R1EQRREFBUFHXUU3EZBBQRZBBREUQRERBYdtoJCW7pBm//znpKQtGlpS2+Tm3w/zxN6k9zcniSnIb97thCHw+EQAAAAAABQ5kLL/pAAAAAAAIDQDQAAAACAhWjpBgAAAADAIoRuAAAAAAAsQugGAAAAAMAihG4AAAAAACxC6AYAAAAAwCKEbgAAAAAALELoBgAAAADAIoRuAECJjR8/XkJCQsrllevQoYO5OK1YscL87nfffbdcfn+vXr3k3HPPFX+WlpYm/fr1k+rVq5vXZsiQIRJI5s2bZ57X7t27fV0UW9PXT19HfT0BAOWH0A0AQc4ZaJyX6OhoqVmzpnTu3FmeffZZSU1NLZPfs2/fPhPWN23aJP7Gn8tWHI8//rh5HwcMGCD//ve/pXv37oXuqycQ9H3u2LGj1/tffvllV1345ptvJJjoyR09yVJW4VYv7733XqEnrQ4fPlzoMW6++WaJjY0t8u/v7rvvlsjISDly5MhZlxkAYB1CNwDAmDhxoglsL7zwgjzwwAPmNm0xbd68ufzwww8er9Lo0aMlIyOjxMF2woQJJQ62S5YsMRcrFVU2DaHbt28Xf7Z8+XK57LLLZNy4cXLPPfdImzZtitxfT6x88cUXcuDAgQL3vfnmm+Z+f6InEbS+1atXT+z4d+VwOEr8OA3U+pw/+OADr/enp6fLf//7X7n++uslISGhDEoKALAKoRsAYNxwww0msPXu3VtGjRolixcvls8//1wOHTpkWt3cQ3Z4eLjlwUxDhdKWPL34SkREhERFRYk/0/eocuXKxd7/iiuukAoVKsg777zjcfvvv/8uq1evli5duog/CQsLM/WtvIY0lJVWrVqZE1aFBeei6N9cxYoV5a233vJ6vwbu48ePm3AOAPBvhG4AQKGuueYaGTNmjOzZs0feeOONIsd0L126VK688koT/jTQNWrUSB555BHXOOyLL77YbGuod3a9dY4t1W69F154oWzcuFGuuuoq063W+dj8Y7qdcnJyzD46jjkuLs6ElN9++61AV2pv3YXdj3mmsnkb061h55///KfUqVPHBHJ9rk899VSBFk09zqBBg+TDDz80z0/3bdasmXz22WfFDtN9+/aVpKQkEzpbtmwpr732WoHx7bt27ZJFixa5yn6msc96rK5duxYIdP/5z3/knHPOMUML8tPwqK/FeeedZx6vr3ufPn0KdG121o1ffvnF7K/1oVKlSua1dZ5IKenr421Mt74nf/3rX+XLL7+USy65xJRJy/b66697LXv79u0lJiZGateuLf/6179k7ty5xXqtZs6cacqkdVJfm7Zt2xYahPP7+9//LhdccEGpWru1rPoeLVu2zNSD/LQMGsq13v/xxx/y0EMPmV4p+rcXHx9vTqJ9//33Z/w9hf19eav3ubm5Mn36dPN66Out9fK+++6TP//802M/HZagdahq1armedSvX9/UFQAIVoRuAECRnOODi+rivWXLFhOAsrKyTMCYNm2aCQNr1qwx9zdp0sTcru69917TjV0vGrCdNLxpUNDWQf1if/XVVxdZrkmTJpmgOXLkSHnwwQdN6NdxyiXt9l6csrnT8KTP7ZlnnjFde59++mkTuocPHy7Dhg0rsL+Gwn/84x8mgE2ZMkUyMzOlW7duZxyHq89Dw5CWRVszp06dasKrhqEZM2a4yq73a7jR181Z9sTExDM+7//7v/+T9evXy86dOz2C3O23325a9/PT1/fXX3814VmDqD6ft99+W2688UavgfKOO+4w45EnT55stjU4axf+snp9lAZ7Le91111n6pyGYn19tD46/e9//zN1SW/THhxDhw41Xeidr2FRdGiB1q2mTZuaOqnl19f566+/luK20OtQDA2/pWnt1vf95MmTMn/+fI/bNWRrT5TbbrvNhFp9X/TEhf4Nan3Uurh582ZzokGHTpQVDdh6bO0poa+f1gV9LTVgnzhxwuyjJwg6depkTmY8/PDDpq7o8/jqq6/KrBwAYDsOAEBQmzt3riYmx4YNGwrdp1KlSo6LLrrIdX3cuHHmMU7PPPOMuZ6cnFzoMfT4uo/+vvzat29v7ps9e7bX+/Ti9MUXX5h9a9Wq5UhJSXHdPn/+fHP7jBkzXLfVq1fP0bNnzzMes6iy6eP1OE4ffvih2fdf//qXx3633367IyQkxPHLL7+4btP9IiMjPW77/vvvze0zZ850FGX69OlmvzfeeMN1W3Z2tqNdu3aOChUqeDx3LV+XLl2KPF7+fU+ePOmoXr2647HHHjO3b9261fy+lStXeq0T6enpBY71n//8x+y3atWqAnWjT58+HvvedtttjoSEBI/bivv6OMuza9cuj+eR/3cfOnTIERUV5fjnP//puu2BBx4w78t3333nuu3IkSOOKlWqFDhmfrfccoujWbNmjpLSY+qxp06dal7nhg0bOlq2bOnIzc31eI2K+ntR+tgaNWqY99yd/p3o4xcvXmyuZ2ZmOnJycgqUQV+LiRMnFiiXez3P/7dQWL1fvXq1eeybb77psd9nn33mcfsHH3xwxs8TAAg2tHQDAM5Iu6wWNYuyczyxjjPVLqiloV2LteWsuHr06GG61zppi2eNGjXkk08+ESvp8bUFU1tA3Wl3c82Rn376qcft2vreoEED1/UWLVqY7r/aOnmm36NduO+66y7XbdoCrb9XlwhbuXLlWT0PfQ7aAq1dypW2WGp3+b/85S9e99cWVSdtjdaZt3XyNvXtt98W2P/+++/3uK7H1dbrlJSUMnl9lLZAu5dXW/i114H7Y7Wrert27UwLtVOVKlWKNRZa67WOc9+wYYOUlntrt7ZGl/Sx2gNg3bp1Ht3gtUeCdu2+9tprXX87oaGhrmEX+jo7h3h4e29KY8GCBaanhfYq0PfeedFJ+/R36cR87p8FCxcudLV+A0CwI3QDAM5IQ557wM3vzjvvNF1Oda1oDQMaFLRLbEkCeK1atUo0YVrDhg09ruv43PPPP9/ytZx1fLsuqZb/9dCu3s773dWtW7fAMbQbdP5xsN5+jz5HZ5g60+8pDe1ivnXrVhMINcjp+1bYZGXapXnw4MHm/dUArgFXx+qqY8eOFdg///PW56zyP+/Svj7Ffay+Tlov8vN2W346dEEDpY4Z1/di4MCBriETJaEBX39facZ2O08OOMeROye70/dKQ7nSvzMd7qBl1ACuww30/dGx7N7em9LYsWOHOVa1atXMsd0v+vngHHeuXdp1eIB2xddy3HLLLWb8vA49AYBgRegGABRJv+Trl+2iQoqGsFWrVpnZznUMuH7Z1yCurWLa8lYc7i2pZaWwAFncMpUFZzDKrzTLSJW1Sy+91LQy69JwOhmbhvDCaKu4jnHWFuz333/fjPF3Tnjm7eRKcZ/32bw+Vr+2eoJDl4vTses6SaCuua0/dWm20rR265J02hukJLQluXHjxq4eCfpTn597S72u067zCeg8BDrhoY731jH4OuHZmU58FfdvRI+jgVuP6+3inBdBj/fuu++a1nmdJE/H1Oskavo8NJwDQDAidAMAiqQTcylvM1p7/IcSGmq6u+pETtp6qhOd6frRzm6nZb3ck7a8udMgohNruc+4rK2eR48eLfDY/K3EJSmbrhWtk1Pl727/008/ue4vC3ocfY75Q1NZ/x7tvq6zoGvAdO+C7U5bjnUWbZ0YS1swdQIvPaGis4X7O32dtF7k5+02b3RmfD2BpK21e/fuNcupad3WLvYlocvx6Ykrff1K09r9448/mpNZ2uKtLdrOGfeVhlydLO6VV14xLeA6kZl22/dW9/Mr7t+InpzRbuvao0WPnf+iM+u706EH+jrpTOY6dEEnstOTFwAQjAjdAIBCaWh+7LHHTDfiosbAatfj/JwBztmtVMOLKk4QKA5dGso9+Grw2L9/v5kB3T0o6KzJ2dnZrtt0rGn+pcVKUjadrVtbAZ977jmP27V7r4Z3999/NvT3HDhwwGMtbZ3JWmeD1i7P2o23LOiQAG251dm/z9SinD8s6oze/k5PFmmrq7Yyu9dXDYJnkn8GdR3+oOPI9XUo6Xhl99bujz76qESPdf7tjR071jw+/9+iHjv/e6NjsLWV+Uz0b0RP5CQnJ7tu0+EG+bvRa08Hrff6eZCf1kvn346eoMlflvyfBQAQbMJ9XQAAgH/QCcD0y7d+gT548KAJ3NptVFsKNSTouryF0a6l2r1cWwF1fx3f+fzzz5s1kbU7rvPLvU6yNHv2bDMeWoOudm92jgsuKZ0MS4+tk69peTUAakti//79PQKlhnFd2ktDgy6Ppd1v3SfuKmnZbrrpJtOq+Oijj5rx49rCp12ttduwdtPOf+zS0uXLXnzxRbMElq5fri34+lw0DOlzLWqMfUno+6VraxdFJzbTrsu6pJeGTR1/r89Zu6T7uxEjRpj3XFvmH3jgAfPezpkzx4wH1/BdVC8HbTHWyey0dVfHsm/bts2cbNF6XprXX8Oyhlb3EwDFofXw8ssvd3VNzx+6dakw/RvUvwXdT5cL05MKxemJoF2/tXeKnpzQNeH1b1f/DrRruvukd3qSR5cM0yXgtPz62ujEftobQwO+LiGmkxnqOvL6t6+9IfRvQU+M6bAErUN6IgkAghGhGwDgakVztuZpoG3evLkJd/pF/kwBQ9et1gD66quvmhmNdQIl/ZKuXWl1xmOlX9D1C7mulazjgjXca5fd0obuRx55xHS31RCgX+y1a7t+2Y+NjXXto0FCW3A1VGggbtu2rWnp1pnG3ZWkbNqNXk9C6OulrdC6nwZiXUc7/3HPho5x127f2qVby6YBSGej1t+nQby8abdmDa2zZs0yLZkauvREjU4q5890RnYd4qCzvuvYZ534SydE0/CttxV1MklDpoZXrT86HllPIuljtMW6NMLDw81jSzJLv5MG7bVr15pJ3fLPr6B/C8ePHzfvkdbJ1q1bmzXste6ciQ4r0F4jWp91XLi25OuQEj2W1j93GsZ1bLaeDNLfqc9H6752ndcTE0r/7nX9d+1KrifD9O9fy6yvY2n/1gHA7kJ03TBfFwIAAKA86UkYDY8apgubkA0AgLLAmG4AABDQMjIyCozV1tZcHZ5A4AYAWI3u5QAAIKC1a9dOOnToYLpSa5dnneVbu+uPGTPG10UDAAQBQjcAAAhoOoGXTkL30ksvmYnTdMyzBm+dHA4AAKsxphsAAAAAAIswphsAAAAAgEAM3bouqHbzcr80btzYdX9mZqZZ1iMhIUEqVKgg3bp1M2Ox3O3du9esl6lLxFSrVk2GDx9ulnpxp0teaFeyqKgos8zGvHnzyu05AgAAAACCl8/HdDdr1kw+//xz13Vd89Fp6NChZp3JBQsWmHUeBw0aJF27dpU1a9aY+3Nyckzgrl69ulm7cv/+/dKjRw+z3qquxal27dpl9tF1V3WNyGXLlkm/fv2kRo0aZv3W4sjNzZV9+/aZdWr1xAAAAAAAILg5HA5JTU2VmjVrSmhoEe3ZDh8aN26co2XLll7vO3r0qCMiIsKxYMEC123btm3TNcUd69atM9c/+eQTR2hoqOPAgQOufV544QVHfHy8Iysry1wfMWKEo1mzZh7HvvPOOx2dO3cudjl/++0383u58BpQB6gD1AHqAHWAOkAdoA5QB6gD1AHqgLi9BpoXi+Lzlu4dO3aYMwPR0dFmSY/JkydL3bp1ZePGjXLixAnp2LGja1/teq73rVu3Ti677DLzs3nz5pKUlOTaR1uvBwwYIFu2bJGLLrrI7ON+DOc+Q4YMKbRMWVlZ5uJ+BkPt2bNH4uPjy/gVgFW0h8Lhw4elatWqRZ95QtAKmDpy/LiE1q5tNnN//10kLs7XJQooAVNPYBnqCKgj4HMkOKWkpEi9evVMj+ii+DR0X3rppWZ8daNGjUzX8AkTJshf/vIX+fHHH+XAgQMSGRkplStX9niMBmy9T+lP98DtvN95X1H76AuUkZEhMTExBcqlwV/Lkp8GcR1nDvt8CdIhCPqe8UUZgVxHQrKyxPkpdzArSxxhYT4uUWAJlHoC61BHQB0BnyPBKetUQ+2ZhiD7NHTfcMMNru0WLVqYEK5nCubPn+81DJeXUaNGybBhw1zXNaDXqVNHEhMTaem22Zcg/QPQ940vygjoOnL8uGtTnwst3WUrYOoJLEMdAXUEfI4Ep+jo6GLt5/Pu5e60VfuCCy6QX375Ra677jrJzs6Wo0ePerR26+zlOnGa0p/r16/3OIZzdnP3ffLPeK7XtZt4YcFeZznXS376ZYsvXPaiX5R53xDwdcSt7OZ52Pm5+KmAqCewFHUE1BHwORJ8Qov5vcCvvj2kpaXJzp07zczibdq0MbOQ62zjTtu3bzdLhOnYb6U/N2/eLIcOHXLts3TpUhOomzZt6trH/RjOfZzHAAAAAADAKj5t6X7ooYfkpptuMl3KdUmucePGSVhYmNx1111mibC+ffuabt5VqlQxQfqBBx4wYVknUVOdOnUy4bp79+4yZcoUM3579OjRZm1vZ0u1LhX23HPPyYgRI6RPnz6yfPly031dlyIDAAAAELh0Tg6dnNkOw1S0nMwf4l+0EVjzqa1D9++//24C9pEjR8xYuSuvvFK++uqrvDGJIvLMM8+YJvtu3bqZQeo66/jzzz/very+AAsXLjSzlWsYj4uLk549e8rEiRNd+9SvX98EbF3ze8aMGVK7dm2ZM2dOsdfoBgC/FxEhMm7c6W0AAIKcrj6kDXI6VNUu5dXgrWs+n2lSLpQvHeqsQ5bP5n0J0XXDyrRUAUgnUtOW92PHjjGRmo3oB5cOPahWrRrjMEEdAZ8l4P8b+AzfScqfroykgVu/B8bGxvp9kNVIdvLkSQkPD/f7sgYLh8Mh6enpJk9o8NYh0KXNiX41kRoAAAAAnG2XcmfgTkhIsMWLSej2T86Jt50NeaXtau5XE6kBAEohN1dky5a8i24DABDEnGO4tYUbOFvOenQ2cwPQ0g0AdpeRIXLhhXnbaWms0w0AwKml/AB/qEe0dAMAAAAAYBFCNwAAAAAAFiF0AwAAAIAf6N27t+nOfP/99xe4b+DAgea+Xr16iT/bu3evdOnSxYyF1snHhg8fbmZmL8off/whd999t5kBXGcK79u3r6TpkLl8k8099dRTcsEFF0hUVJTUqlVLJk2a5LpfXxd9ffJfmjVr5vV3PvHEE+b+IUOGiNUI3QAAAADgJ+rUqSNvv/22ZOicLadkZmbKW2+9JXXr1hV/nzleA3d2drasXbtWXnvtNZk3b56MHTu2yMdp4N6yZYssXbpUFi5cKKtWrZJ7773XY5/BgwfLnDlzTPD+6aef5KOPPpJLLrnEdf+MGTPMUnHOy2+//SZVqlSRv/3tbwV+34YNG+TFF1+UFi1aSHkgdAMAAACAn2jdurUJ3u+//77rNt3WwH3RRRd5rP8+efJkqV+/vlnaqmXLlvLuu+96BGBtMXbe36hRIxNM3Wnr8K233mqCrK5DrUusaYt6aWfqXrJkiWzdulXeeOMNadWqldxwww3y2GOPyaxZs0wQ92bbtm3y2WefmUB96aWXypVXXikzZ840Jx727dvn2ueFF16Q//73v3LzzTeb59SmTRu57rrrXMfR9bKrV6/uunzzzTfy559/mt4D7rQFXUP+yy+/LOecc46UB0I3AAAAgOBw/Hjhl8zM4u/r1gpd5L6l1KdPH5k7d67r+quvvlogPGrgfv3112X27NmmlXjo0KFyzz33yMqVK12hvHbt2rJgwQIThLW1+ZFHHpH58+d7HOeLL76QnTt3mp/Olmm9OGlX9woVKhR5cVq3bp00b95ckpKSXLd17txZUlJSTBm90cdol/K2bdu6buvYsaOEhobK119/ba5//PHHct5555lWcA3c5557rvTr1890Sy/MK6+8Yo5Tr149j9v1pIK2xut95YUlwwDA7iIiRB566PQ2AADwzi0gFnDjjSKLFp2+Xq2aSHq6933btxdZseL09XPPFTl8uOB+Dkep3gkNz6NGjZI9e/aY62vWrDEtvytO/c6srCx5/PHH5fPPP5d27dqZ2zSUfvnll6bbdPv27SUiIkImTJjgOqaGVQ24GrrvuOMO1+3a2vvcc89JWFiYNG7c2ATSZcuWSf/+/c39EydOlIec3zPO4MCBAx6BWyWduq73FfYYHfvtLjw83HQNdz7m119/Na+FnkDQEw3aiq8nGW6//XZZvnx5gWNqC/mnn35quuS709fw22+/Nd3LyxOhGwDsLjJSZOpUX5fCFpKTk83Z9pLQiVtSU1NNdzTtupaYmGhZ+QAAUPp/jYZfbXHW/4d0u2rVqq4X55dffpH09HSP7tVKu3C7d0HXbt3aSq6Tm+kYcb1fu32704nGNHA7aTfzzZs3u65rIM4fistbbm6uOdGggVsnUnO2ZGsX8+3bt5uu8+60xV5bz7XrvJOO8dZx4TpuPDo6ulzLT+gGAARN4O7Ru58cTS2k1aIQOrNpg/r1ZOeuPVKpQoy8PncOwRsA7CrfjNge3IKncehQ4fuG5hulu3u3lDXtYj5o0CBXeHbnnNl70aJFZhZvdzqzt7NVV1uop02bZlrDK1asKFOnTnV12XbSFvH8/+9pyHXvXq5jtIviLI+OpV6/fr3HfQcPHnTd543efijfa62znWvXcedj9ESAtn47A7dq0qSJ+aknFNxDt56k0BMN3bt3l0htmDhl48aN5vfomHknbTHXSdu0pV9DvfvJh7JE6AYAu9P/GPfuzdvWWU3zfxGAoS3cGrgbtu8m8QmeXd+KEiIiCTEioXUOys8r3zPHobUbAGwqLs73+xbT9ddfb1qmNQTruGh3TZs2NeFaA6d2JfdGu6Rffvnl8o9//MN1m47dLqmSdC/XcK/LeGm4dbaOL1261CwFpmUu7DFHjx41oVhbrpV2GdfgrxOrqSuuuMIEcS1/gwYNzG0///yz+Zl/zLaOadeeADqJnLtrr73WowVf6Th57VI/cuRIywK3InQDgN3pZC716+dt65lmC/7jDyQauKsk1S7BIxxSMTRL4vPNmQMAgJU0BOqs3c5td9pqrUFYxzVrONUZv48dO2aCtgbcnj17SsOGDU137MWLF5vx3P/+97/NWGbdLomSdC/v1KmTCdfayjxlyhQzJnv06NFm8jJnC7y2hPfo0cOMG9dWem2x1hMMOoZcJ4XTmdO1hf/vf/+71KxZ0zxGJz3TFmpt/Z8+fbp5znpM7V7v3vrt7HauYf3CCy8s8Jrlvy0uLs7M2J7/9rJGcwgAAAAA+CEN0HrxRpfiGjNmjJnF3Blctbu5M1Tfd9990rVrV7nzzjtNCD1y5IhHq7cV9OSAzjCuP7UFWyeE69Gjh2ktd9Kx6DoO231ZsjfffNO0OGtr9I033mhOIrz00kuu+3Umc53BXMe1X3XVVWaMuz5n7ULvTk88vPfeewVauX0txKGd3lEk7Uqok+fom1hYpYf/0TNgzq4t+ocKBGwd0SVJnLOx0tJdKO2Sdk+f+6VN13+UuKW7UmiW7N5/WL55/3l549XZrq5tQEB9lsAy1JHylZmZKbt27TLhs7wnzCotjWTafVrHLWt3ctijPhU3J/I/AwAAAAAAFiF0AwAAAABgEUI3AAAAAAAWIXQDAAAAAGARlgwDALsLDxdxzkaq2wAAAPAbfDsDALvTdS9nzfJ1KQAA8LtZ4wF/qEeEbgAAAAABIzIy0izft2/fPklMTDTX/X0ZLpYM88/3JDs7W5KTk0190npUWoRuALA7h0Pk8OG87apVRfz8iwUAAFbSgKRrKu/fv98Eb7sEPG1R1bL7+wmCYBMbGyt169Y1701pEboBwO7S00WqVcvbTksTiYvzdYkAAPApbZXUoHTy5EnJycnx+3dDA/eRI0ckISHhrMIdylZYWJiEh4ef9YkQQjcAAACAgKNBKSIiwlzsELq1nNHR0YTuAMRpFAAAAAAALELoBgAAAADAIoRuAAAAAAAsQugGAAAAAMAihG4AAAAAACzC7OUAYHfh4SI9e57eBgAAgN/g2xkA2F1UlMi8eb4uBQAAALygezkAAAAAABahpRsA7M7hEElPz9uOjRUJCfF1iQAAAHAKLd0AYHcauCtUyLs4wzcAAAD8AqEbAAAAAACLELoBAAAAALAIoRsAAAAAAIsQugEAAAAAsAihGwAAAAAAixC6AQAAAACwCOt0A4DdhYWJ3H776W0AAAD4DUI3ANhddLTIggW+LgUAAAC8oHs5AAAAAAAWIXQDAAAAAGARQjcA2N3x4yIhIXkX3QYAAIDfIHQDAAAAAGARQjcAAAAAABYhdAMAAAAAYBFCNwAAAAAAFiF0AwAAAABgEUI3AAAAAAAWCbfqwACAchIWJnLjjae3AQAA4DcI3QBgd9HRIosW+boUAAAA8ILu5QAAAAAAWITQDQAAAACARQjdAGB3x4+LxMXlXXQbAAAAfoMx3QAQCNLTfV0CAAAAeEFLNwAAAAAAFiF0AwAAAABgEUI3AAAAAAAWIXQDAAAAAGARQjcAAAAAABZh9nIAsLvQUJH27U9vAwAAwG8QugHA7mJiRFas8HUpAAAA4AVNIgAAAAAAWITQDQAAAACARQjdAGB3x4+LJCbmXXQbAAAAfsNvQvcTTzwhISEhMmTIENdtmZmZMnDgQElISJAKFSpIt27d5ODBgx6P27t3r3Tp0kViY2OlWrVqMnz4cDl58qTHPitWrJDWrVtLVFSUnH/++TJv3rxye14AUC4OH867AAAAwK/4RejesGGDvPjii9KiRQuP24cOHSoff/yxLFiwQFauXCn79u2Trl27uu7PyckxgTs7O1vWrl0rr732mgnUY8eOde2za9cus8/VV18tmzZtMqG+X79+snjx4nJ9jgAAAACA4OPz0J2WliZ33323vPzyy3LOOee4bj927Ji88sor8vTTT8s111wjbdq0kblz55pw/dVXX5l9lixZIlu3bpU33nhDWrVqJTfccIM89thjMmvWLBPE1ezZs6V+/foybdo0adKkiQwaNEhuv/12eeaZZ3z2nAEAAAAAwcHnoVu7j2tLdMeOHT1u37hxo5w4ccLj9saNG0vdunVl3bp15rr+bN68uSQlJbn26dy5s6SkpMiWLVtc++Q/tu7jPAYAAAAAAAG5Tvfbb78t3377relent+BAwckMjJSKleu7HG7Bmy9z7mPe+B23u+8r6h9NJhnZGRIjK5vm09WVpa5OOm+Kjc311xgD/peORwO3jMEfh3JzXWdQTXPxe7PxyL6XuvcISF510rySHPRx+njA6LOoEwFzGcJLEMdAXUkMBX3c99nofu3336TwYMHy9KlSyU6Olr8yeTJk2XChAkFbk9OTjaTu8E+fwQ6TEG/CIWG+rxTB/xQoNSRkPR0SXL7nHIwg7lXqamp0qB+PUmIEakYevrE6pk5JDb0hHmcPl6Pc+jQobJ46xAgAuWzBNahjoA6Epj0O4Ffh27tPq5fWnRWcfeJ0VatWiXPPfecmehMx2UfPXrUo7VbZy+vXr262daf69ev9ziuc3Zz933yz3iu1+Pj4722cqtRo0bJsGHDPFq669SpI4mJieZxsM9/cNoqpe8bX4IQ0HUkI0McbduazUTt2VPIZ1uw0zlEdu7aI5VbieTGR5XgkXmt4kcyxDy+YsWKZrUMIOA+S2AZ6gioI4GpuI3HPgvd1157rWzevNnjtt69e5tx2yNHjjQhNyIiQpYtW2aWClPbt283S4S1a9fOXNefkyZNMuHd+QVIW841GDdt2tS1zyeffOLxe3Qf5zG80aXF9JKf/kfKf6b2ol+CeN8Q8HUkLk6XgTCbeV2n4Y2za7ijVK9USF4n81Nd1G1dX2CJgPgsgaWoI6COBJ7ifub7LHRrS8GFF17ocVtcXJxZk9t5e9++fU2Lc5UqVUyQfuCBB0xYvuyyy8z9nTp1MuG6e/fuMmXKFDN+e/To0WZyNmdovv/++03L+YgRI6RPnz6yfPlymT9/vixatMgHzxoAAAAAEEx8OpHameiyXnr2QFu6dWIznXX8+eefd90fFhYmCxculAEDBpgwrqG9Z8+eMnHiRNc+ulyYBmxd83vGjBlSu3ZtmTNnjjkWAAAAAABBE7pXrFhRoI+8rrmtl8LUq1evQPfx/Dp06CDfffddmZUTAPxKerrIqSE1snWrSGysr0sEAAAAfwzdAIBScDhE9uw5vQ0AAAC/wWwfAAAAAABYhNANAAAAAIBFCN0AAAAAAFiE0A0AAAAAgEUI3QAAAAAAWITZywHA7kJCTi8ZptsAAADwG4RuALA7XZd7yxZflwIAAABe0L0cAAAAAACL0NINIKAlJydLSkqK1/scDoekpqZKWlqahBTRLTs+Pl4SExMtLCUAAAACFaEbQEAH7h69+8nR1HSv92vQblC/nuzctccE8MJUrhgrr8+d47/BOz1d5OKL87Y3bMjrbg4AAAC/QOgGELC0hVsDd8P23SQ+IanA/dq2nRAjUrmVSGGRO+XIQdmx8j1zLL8N3XrCYOvW09sAAADwG4RuAAFPA3eVpNpe7nFIxdAsyY2POhXBAQAAgLLFRGoAAAAAAFiE0A0AAAAAgEUI3QAAAAAAWITQDQAAAACARZhIDQDsTtcYr1fv9DYAAAD8BqEbAOxO1+XevdvXpQAAAIAXdC8HAAAAAMAihG4AAAAAACxC6AYAu8vIELn44ryLbgMAAMBvMKYbAOwuN1fkm29ObwMAAMBv0NINAAAAAIBFCN0AAAAAAFiE0A0AAAAAgEUY0w0AAFAKycnJkpKSIg6HQ1JTUyUtLU1CQkJKdIz4+HhJTEzk9QeAAEboBgAAKEXg7tG7nxxNTTdBu0H9erJz1x4TwEuicsVYeX3uHII3AAQwQjcABIKqVX1dAiCoaAu3Bu6G7btJpYQkSYgRqdxKpCSRO+XIQdmx8j1zLFq7ASBwEboBwO7i4rTZzdelAIJSfEKSnJNUSyqGZklufJSIlKx7OQAg8DGRGgAAAAAAFiF0AwAAAABgEUI3ANhdRoZIhw55F90GAACA32BMNwDYXW6uyMqVp7cBAADgN2jpBgAAAADAIoRuAAAAAAAsQugGAAAAAMAihG4AAAAAACxC6AYAAAAAwCLMXg4AgSA21tclAAAAgBeEbgCwu7g4kePHfV0KAAAAeEH3cgAAAAAALELoBgAAAADAIoRuALC7zEyRLl3yLroNAAAAv8GYbgCwu5wckU8+Ob0NAAAAv0FLNwAAAAAAFiF0AwAAAABgEUI3AAAAAAAWIXQDAAAAAGARQjcAAAAAABYhdAMAAAAAYBGWDAMAu4uLE3E4fF0KAAAAeEFLNwAAAAAAFiF0AwAAAABgEUI3ANhdZqbI3/6Wd9FtAAAA+A1CNwDYXU6OyLvv5l10GwAAAH6D0A0AAAAAgEUI3QAAAAAAWITQDQAAAACARQjdAAAAAABYhNANAAAAAIBFCN0AAAAAAFgk3KoDAwDKSWysSFra6W0AAAD4DUI3ANhdSIhIXJyvSwEAAAAv6F4OAAAAAIBFCN0AYHdZWSK9euVddBsAAAB+g9ANAHZ38qTIa6/lXXQbAAAAfoPQDQAAAACARQjdAAAAAABYhNANAAAAAEAghu4XXnhBWrRoIfHx8ebSrl07+fTTT133Z2ZmysCBAyUhIUEqVKgg3bp1k4MHD3ocY+/evdKlSxeJjY2VatWqyfDhw+VkvjGNK1askNatW0tUVJScf/75Mm/evHJ7jgAAAACA4OXT0F27dm154oknZOPGjfLNN9/INddcI7fccots2bLF3D906FD5+OOPZcGCBbJy5UrZt2+fdO3a1fX4nJwcE7izs7Nl7dq18tprr5lAPXbsWNc+u3btMvtcffXVsmnTJhkyZIj069dPFi9e7JPnDAAAAAAIHuG+/OU33XSTx/VJkyaZ1u+vvvrKBPJXXnlF3nrrLRPG1dy5c6VJkybm/ssuu0yWLFkiW7dulc8//1ySkpKkVatW8thjj8nIkSNl/PjxEhkZKbNnz5b69evLtGnTzDH08V9++aU888wz0rlzZ588bwAAAABAcPBp6Hanrdbaon38+HHTzVxbv0+cOCEdO3Z07dO4cWOpW7eurFu3zoRu/dm8eXMTuJ00SA8YMMC0ll900UVmH/djOPfRFu/CZGVlmYtTSkqK+Zmbm2susAd9rxwOB+9ZENP3PyQkRELyrnnbw+3inT5Wj+HXdSk6WuTAgdPb/lpOv68PhT7SXGxRF+DD+lT0Z4k31KngwXcSUEcCU3G/D/g8dG/evNmEbB2/reO2P/jgA2natKnpCq4t1ZUrV/bYXwP2gVNfLvWne+B23u+8r6h9NEhnZGRITExMgTJNnjxZJkyYUOD25ORkU07Y54/g2LFj5otRaChzBgaj1NRUaVC/niTEiFQMPX0i7TSHxIaeOLWd99U5v9AYMcfQYx06dEj8XnKyr0tg4/pQmLx6kmC3uoByrU9n+iwJiM8XlBrfSUAdCUz6+W2L0N2oUSMTsDUcvfvuu9KzZ08zftuXRo0aJcOGDXNd14Bep04dSUxMNBO+wT7/wWkrhL5vhO7glJaWJjt37ZHKrURy46O87JHXKnUsN6rQL8p/Zog5RsWKFc1kjQjk+lCYvHpyhLqAM9Snoj5LvOHzJXjwnQTUkcAUrT0M7RC6tTVbZxRXbdq0kQ0bNsiMGTPkzjvvNBOkHT161KO1W2cvr169utnWn+vXr/c4nnN2c/d98s94rtc1PHtr5VY6y7le8tPgRnizFw3dvG/By9kVOC8yhRTVwbPQ+x1u3Uj99u9fh8M4TxQ+/bR+iPm6RDauD4U+2h51AT6sT0V/lnhDnQoufCcBdSTwFPf7QKg/ngnU8dQawCMiImTZsmWu+7Zv326WCNPu6Ep/avd09y5ZS5cuNYFau6g793E/hnMf5zEAwPZ0mcTnn8+75FsyEQAAAL5V4tC9atWqAutgK71N7ytpN259zO7du0141uu6pvbdd98tlSpVkr59+5pu3l988YWZWK13794mLOskaqpTp04mXHfv3l2+//57swzY6NGjzdrezpbq+++/X3799VcZMWKE/PTTT/L888/L/PnzzXJkAAAAAABYqcTdy3W96/379xcY26hjsvU+nYW8uLSFukePHuZ4GrJbtGhhgvN1111n7tdlvbTJvlu3bqb1W2cd19DsFBYWJgsXLjSzlWsYj4uLM2PCJ06c6NpHlwtbtGiRCdnabV2XIpszZw7LhQEAAAAA/C90O8ez5XfkyBETektC1+E+08D0WbNmmUth6tWrJ5988kmRx+nQoYN89913JSobAAAAAADlFrq7du1qfmrg7tWrl8dEY9q6/cMPP8jll19+1gUCAAAAACDoQrd2/3a2dOvSOe4zf+sM5DrOun///taUEgAAAACAQA7dc+fONT/PPfdceeihh0rclRwAAAAAgGBT4jHd48aNs6YkAIDS0Z5Hu3ad3gYAAIB9lww7ePCgWaKrZs2aEh4ebmYQd78AAMpZaKh2Q8q76DYAAADs29Ktk6jt3btXxowZIzVq1PA6kzkAAAAAAChF6P7yyy9l9erV0qpVK14/APAH2dkijz6atz1pks5u6esSAQAA4JQS90OsU6eOmcEcAOAnTpwQeeqpvItuAwAAwL6he/r06fLwww/L7t27rSkRAAAAAADB2r38zjvvlPT0dGnQoIHExsZKRESEx/1//PFHWZYPAAAAAIDgCd3a0g0AAAAAACwI3T179izpQwAAAAAACEolDt26XFhR6tatezblAQAAAAAgeEP3ueeeW+Ta3Dk5OWdbJgAAAAAAgjN0f/fddx7XT5w4YW57+umnZZKuDwsAKF8xMSI//nh6GwAAAPYN3S1btixwW9u2baVmzZoydepU6dq1a1mVDQBQHKGhIs2a8VoBAAAEwjrdhWnUqJFs2LChrA4HAAAAAEDwtXSnpKR4XHc4HLJ//34ZP368NGzYsCzLBgAojuxskccfz9t+5BGRyEheNwAAALuG7sqVKxeYSE2Dd506deTtt98uy7IBAIrjxAmRCRPytocPJ3QDAADYOXR/8cUXHtdDQ0MlMTFRzj//fAkPL/HhAAAAAAAIWCVOye3bt7emJAAAAAAABJhSNU3v3LlTpk+fLtu2bTPXmzZtKoMHD5YGDRqUdfkAAAAAAAie2csXL15sQvb69eulRYsW5vL1119Ls2bNZOnSpdaUEgAAAACAYGjpfvjhh2Xo0KHyxBNPFLh95MiRct1115Vl+QAAAAAACJ6Wbu1S3rdv3wK39+nTR7Zu3VpW5QIAAAAAIPhCt85UvmnTpgK3623VqlUrq3IBAIorOlpk/fq8i24DAADAvt3L+/fvL/fee6/8+uuvcvnll5vb1qxZI08++aQMGzbMijICAIoSFiZy8cW8RgAAAIEQuseMGSMVK1aUadOmyahRo8xtNWvWlPHjx8uDDz5oRRkBAAAAAAiO0B0SEmImUtNLamqquU1DOADAR7KzRWbMyNsePFgkMpK3AgAAwG5jujMyMuSjjz5yBW1n2NZLSkqKuS8rK8uqcgIACnPihMiIEXkX3QYAAID9QvdLL70kM2bM8NqqHR8fL88++6zMmTOnrMsHAAAAAEDgh+4333xThgwZUuj9et9rr71WVuUCAAAAACB4QveOHTukZcuWhd7fokULsw8AAAAAAChh6D558qQkJycXer/ep/sAAAAAAIAShu5mzZrJ559/Xuj9S5YsMfsAAAAAAIAShu4+ffrIY489JgsXLixw38cffyyTJk0y+wAAAAAAgBKu033vvffKqlWr5Oabb5bGjRtLo0aNzO0//fST/Pzzz3LHHXeYfQAA5Sw6WuSLL05vAwAAwH6hW73xxhsmdL/11lsmaDscDhO+J0yYYEI3AMAHwsJEOnTgpQcAALB76FYargnYAAAAAABYELoBAH7mxAmRl17K29ZhPhERvi4RAAAATiF0o0zp0nEpKSlndYz4+HhJTEwsszIBAS87W2TQoLztXr0I3QAAAH6E0I0yDdw9eveTo6npZ3WcyhVj5fW5cwjeAAAAAGyP0I0yoy3cGrgbtu8m8QlJpTvGkYOyY+V75li0dgMAAACwO0I3ypwG7ipJtX3exV1n109NTZW0tDQJCQkp0THo4g4AAACg3EJ3165di33A999//2zKA5RZF3cN2g3q15Odu/aYAF4SdHEHAAAAUG6hu1KlSmXyy4Dy7OJeKSFJEmJEKrcSKUnkpos7AAAAgHIN3XPnzi2zXwiUVxf3c5JqScXQLMmNjxKRknUvBwAAAICywJhuALC7qCiRhQtPbwMAAMBeofuiiy4q9kRU33777dmWCQBQEuHhIl268JoBAADYNXTfeuut1pcEAAAAAIBgDN3jxo2zviQAgNI5cULkzTfztu++WyQiglcSAADAT4SW5kFHjx6VOXPmyKhRo+SPP/5wdSv/3//+V9blAwCcSXa2SO/eeRfdBgAAgH0nUvvhhx+kY8eOZhmx3bt3S//+/aVKlSpmfe69e/fK66+/bk1JAQAAAAAI9JbuYcOGSa9evWTHjh0SHR3tuv3GG2+UVatWlXX5AAAAAAAIntC9YcMGue+++wrcXqtWLTlw4EBZlQsAAAAAgOAL3VFRUZKSklLg9p9//lkSExPLqlwAAAAAAARf6L755ptl4sSJckJnyxUx63frWO6RI0dKt27drCgjAAAAAADBEbqnTZsmaWlpUq1aNcnIyJD27dvL+eefLxUrVpRJkyZZU0oAAAAAAIJh9nKdtXzp0qWyZs0a+f77700Ab926tZnRHADgA1FRIvPnn94GAACAfUO30xVXXGEuAAAfCw8X+dvffF0KAAAAnE338uXLl0vTpk29TqJ27Ngxadasmaxevbq4hwMAAAAAIOAVO3RPnz5d+vfvL/Hx8V67nOsyYk8//XRZlw8AcCYnT4osWJB30W0AAADYL3Tr+O3rr7++0Ps7deokGzduLKtyAQCKKytL5I478i66DQAAAPuF7oMHD0pERESh94eHh0tycnJZlQsAAAAAgOAJ3bVq1ZIff/yx0Pt/+OEHqVGjRlmVCwAAAACA4AndN954o4wZM0YyMzML3KfrdY8bN07++te/lnX5AAAAAAAI/CXDRo8eLe+//75ccMEFMmjQIGnUqJG5/aeffpJZs2ZJTk6OPProo1aWFQAAAACAwAzdSUlJsnbtWhkwYICMGjVKHA6HuT0kJEQ6d+5sgrfuAwAAAAAAShi6Vb169eSTTz6RP//8U3755RcTvBs2bCjnnHNOSQ4DAAAAAEBQKPaYbncasi+++GK55JJLzipwT5482RynYsWKUq1aNbn11ltl+/btHvvoGPKBAwdKQkKCVKhQQbp162ZmUne3d+9e6dKli8TGxprjDB8+XE7mW6t2xYoV0rp1a4mKipLzzz9f5s2bV+pyA4BfiYwUmTs376LbAAAAsHfoLisrV640gfqrr76SpUuXyokTJ8x638ePH3ftM3ToUPn4449lwYIFZv99+/ZJ165dXffrWHIN3NnZ2ab7+2uvvWYC9dixY1377Nq1y+xz9dVXy6ZNm2TIkCHSr18/Wbx4cbk/ZwAoc7qcY69eeZcilnYEAACAn3cvL2ufffaZx3UNy9pSvXHjRrnqqqvk2LFj8sorr8hbb70l11xzjdln7ty50qRJExPUL7vsMlmyZIls3bpVPv/8czOmvFWrVvLYY4/JyJEjZfz48RIZGSmzZ8+W+vXry7Rp08wx9PFffvmlPPPMM2Y8OgAAAAAAAdfSnZ+GbFWlShXzU8O3tn537NjRtU/jxo2lbt26sm7dOnNdfzZv3txjEjcN0ikpKbJlyxbXPu7HcO7jPAYA2JoOp1m0KO+Sb2gNAAAAgril211ubq7p9n3FFVfIhRdeaG47cOCAaamuXLmyx74asPU+5z75Z013Xj/TPhrMdY3xmJgYj/uysrLMxUn3c5ZRL/BOJ9bT2exD8q6V6mXSx+ox9Filea0LlsF5Kb8ywE518sx1xBb1ISNDQv/6V7OZq59XcXG+LlGAfUbl1RFb1AWUG/6/QUnoZwafHaCOBJ7ifh/wm9CtY7t//PFH0+3b13SCtwkTJhS4PTk52UzsBu9SU1OlQf16khAjUjH09EmLkgiNEXMMPdahQ4fOugyxoSdO3RNSbmWAneqk44x1xA71ISQ9XZLcPqccbvNioCw+o/LqSYIN6gLKD//foKRfzLVHpwbv0FC/6mgKP0Edse//BbYJ3YMGDZKFCxfKqlWrpHbt2q7bq1evbiZIO3r0qEdrt85ervc591m/fr3H8Zyzm7vvk3/Gc70eHx9foJVb6Trkw4YN82jprlOnjiQmJprHwLu0tDTZuWuPVG4lkhsfVaqX6c8MMcdwzmhfFmU4lhtVotB9tmVQhw8fdvWQKC2ta1WrVj2rYwS7M9dJxxnrSFnUB8u5hWz9nKKlu6w/o/LqyRE71AWUG3/5/wb2CVTaU0Y/owndoI4EjujoaP8P3Xq274EHHpAPPvjALOmlk525a9OmjURERMiyZcvMUmFKlxTTJcLatWtnruvPSZMmmVYH539YOhO6BpamTZu69tH1xd3pPs5j5KfLiuklP/2Q5IOycM5ul3lfT4v/paNAJ85TXUBL81oXLIP7pXzKoC2NPfv0l6Op6XI2KleMldfnzskLUbCwThZdR862PpQLt3KZMvprOW39GRVij7qAcuMP/9/AXpzvM+81qCOBo7h/z+G+7lKuM5P/97//NWd5nWOwK1WqZFqg9Wffvn1Nq7NOrqZBWkO6hmWduVzpEmMarrt37y5Tpkwxxxg9erQ5tjM433///fLcc8/JiBEjpE+fPrJ8+XKZP3++LNJJh4Aypi3cGrgbtu8m8QlJpTvGkYOyY+V75liEbgAAAMC+fBq6X3jhBfOzQ4cOHrfrsmC9dL1ZEbOsl55B0JZundxMZx1//vnnXfuGhYWZrukDBgwwYTwuLk569uwpEydOdO2jLegasHXN7xkzZpgu7HPmzGG5MFhKA3eVpNPDJQAAAAAEH593Ly9OP/lZs2aZS2Hq1atXoPt4fhrsv/vuu1KVEwAAAACA0vCLidQAAGchMlLkuedObwMAAMBvELoBwO4iInSSDF+XAgAAAF4wVSYAAAAAABahpRsA7C4nR2T16rztv/xFZ5j0dYkAAABwCqEbAOwuM1Pk6qvzttPSROLifF0iAAAAnEL3cgAAAAAALELoBgAAAADAIoRuAAAAAAAsQugGAAAAAMAihG4AAAAAACxC6AYAAAAAwCIsGQYAdhcRITJlyultAAAA+A1CNwDYXWSkyPDhvi4FAAAAvKB7OQAAAAAAFqGlGwDsLidH5Ntv87ZbtxYJC/N1iQAAAHAKoRsA7C4zU+SSS/K209JE4uJ8XSIAAACcQvdyAAAAAAAsQugGAAAAAMAihG4AAAAAACxC6AYAAAAAwCKEbgAAAAAALELoBgAAAADAIiwZBgB2FxEhMm7c6W0AAAD4DUI3ANhdZKTI+PG+LgUAAAC8oHs5AAAAAAAWoaUbAOwuN1dk27a87SZNREI5nwoAAOAvCN0AYHcZGSIXXpi3nZYmEhfn6xIBAADgFJpDAAAAAACwCKEbAAAAAACLELoBAAAAALAIoRsAAAAAAIsQugEAAAAAsAihGwAAAAAAi7BkGADYXUSEyEMPnd4GAACA3yB0A4DdRUaKTJ3q61IAAADAC7qXAwAAAABgEVq6AcDucnNF9u7N265bVySU86kAAAD+gtANAHaXkSFSv37edlqaSFycr0sEAACAU2gOAQAAAADAIoRuAAAAAAAsQugGAAAAAMAihG4AAAAAACxC6AYAAAAAwCKEbgAAAAAALMKSYQBgd+HhIv/4x+ltAAAA+A2+nQGA3UVFicya5etSAAAAwAu6lwMAAAAAYBFaugHA7hwOkcOH87arVhUJCfF1iQAAAHAKoRsA7C49XaRatbzttDSRuDhflwgAAACn0L0cAAAAAACLELoBAAAAALAIoRsAAAAAAIsQugEAAAAAsAihGwAAAAAAixC6AQAAAACwCEuGAYDdhYeL9Ox5ehsAAAB+g29nAGB3UVEi8+b5uhQAAADwgu7lAAAAAABYhJZuALA7h0MkPT1vOzZWJCTE1yUCAADAKbR0A4DdaeCuUCHv4gzfAAAA8AuEbgAAAAAALELoBgAAAADAIoRuAAAAAAAsQugGAAAAAMAihG4AAAAAACxC6AYAAAAAwCKs0w0AdhcWJnL77ae3AQAA4DcI3QBgd9HRIgsW+LoUAAAA8ILu5QAAAAAAWITQDQAAAABAIIbuVatWyU033SQ1a9aUkJAQ+fDDDz3udzgcMnbsWKlRo4bExMRIx44dZceOHR77/PHHH3L33XdLfHy8VK5cWfr27StpaWke+/zwww/yl7/8RaKjo6VOnToyZcqUcnl+AFAujh8XCQnJu+g2AAAA/IZPQ/fx48elZcuWMmvWLK/3azh+9tlnZfbs2fL1119LXFycdO7cWTIzM137aODesmWLLF26VBYuXGiC/L333uu6PyUlRTp16iT16tWTjRs3ytSpU2X8+PHy0ksvlctzBAAAAAAEL59OpHbDDTeYizfayj19+nQZPXq03HLLLea2119/XZKSkkyL+N///nfZtm2bfPbZZ7JhwwZp27at2WfmzJly4403ylNPPWVa0N98803Jzs6WV199VSIjI6VZs2ayadMmefrppz3COQAAAAAAQTN7+a5du+TAgQOmS7lTpUqV5NJLL5V169aZ0K0/tUu5M3Ar3T80NNS0jN92221mn6uuusoEbidtLX/yySflzz//lHPOOafA787KyjIX99ZylZubay6QQk+U6DCBkLxrpXqZ9LF6DD1WaV7rgmVwXnxZhpI72zKguO/FmeuILd6L3FxXtyVTRn8tp4+V/m8zr47Yoi6g3PjD/zewD31/eZ9BHQk8xf3s9tvQrYFbacu2O73uvE9/VqtWzeP+8PBwqVKlisc+9evXL3AM533eQvfkyZNlwoQJBW5PTk726NoOT6mpqdKgfj1JiBGpGHr6pEVJhMaIOYYe69ChQ2ddhtjQE6fuCfFZGUrjbMuA4r4XjjPWETu8FyHp6ZLk9jnlYFx3Gf9t5tWTBBvUBZQff/j/Bvb6Yn7s2DETvLVxCKCOBAb9/LZ16PalUaNGybBhwzxaunUCtsTERDNhG7zTCex27tojlVuJ5MZHlepl+jNDzDEqVqxY4IRKactwLDeqRF+CrChDSZ1tGVDc98Jxxjpii/fCLWTr55TExfm0OP6q9H+befXkiB3qAsqNP/x/A3uFbu3VoJ/RhG5QRwKHTtRt69BdvXp18/PgwYNm9nInvd6qVSvXPvnPDJ88edLMaO58vP7Ux7hzXnfuk19UVJS55KcfknxQFs7ZRS7v62nxv3S4c7h12SvNa12wDO4XX5Wh5M62DCjJe1F0HbHFe+FWLlNGfy2nj53d32aIPeoCyo0//H8De3G+z7zXoI4EjuL+PfvtJ7x2CddQvGzZMo8WZx2r3a5dO3Ndfx49etTMSu60fPlyczZRx34799EZzU+ccHb7EjPTeaNGjbx2LQcA2wkLE7nxxryLbgMAAMBvhPq6a5bOJK4X5+Rpur13715zNnDIkCHyr3/9Sz766CPZvHmz9OjRw8xIfuutt5r9mzRpItdff730799f1q9fL2vWrJFBgwaZSdZ0P/V///d/ZhI1Xb9blxZ75513ZMaMGR7dxwHA1rRr06JFeZdidnMCAABA+fBp9/JvvvlGrr76atd1ZxDu2bOnzJs3T0aMGGHW8talvbRF+8orrzRLhLn3ndclwTRoX3vttaZ5v1u3bmZtb/cZz5csWSIDBw6UNm3aSNWqVWXs2LEsFwYAAAAACOzQ3aFDBzOWqTDa2j1x4kRzKYzOVP7WW28V+XtatGghq1evPquyAgAAAABQUn47phsAUILZy3XGcr2wXBgAAIBf8dvZywEAJZCezssFAADgh2jpBgAAAADAIoRuAAAAAAAsQugGAAAAAMAihG4AAAAAACxC6AYAAAAAwCLMXg4AdhcaKtK+/eltAAAA+A1CNwDYXUyMyIoVvi4FAAAAvKBJBAAAAAAAixC6AQAAAACwCKEbAOzu+HGRxMS8i24DAADAbzCmGwACweHDvi4BAAAAvKClGwAAAAAAixC6AQAAAACwCKEbAAAAAACLELoBAAAAALAIoRsAAAAAAIswezkA2F1oqEjbtqe3AQAA4DcI3QBgdzExIhs2+LoUAAAA8IImEQAAAAAALELoBgAAAADAIoRuALC79HSRc8/Nu+g2AAAA/AZjugHA7hwOkT17Tm8DAADAb9DSDQAAAACARQjdAAAAAABYhNANAAAAAIBFCN0AAAAAAFiE0A0AAAAAgEWYvRwA7C4kRKRp09PbAAAA8BuEbgCwu9hYkS1bfF0KAAAAeEH3cgAAAAAALELoBgAAAADAIoRuALC79HSRZs3yLroNAAAAv8GYbgCwO4dDZOvW09sAAADwG7R0AwAAAABgEUI3AAAAAAAWIXQDAAAAAGARQjcAAAAAABYhdAMAAAAAYBFmLwcAuwsJEalX7/Q2AAAA/AahGwDsLjZWZPduX5cCAAAAXtC9HAAAAAAAi9DSDQAAAJyl5ORkSUlJ8Xqfw+GQ1NRUSUtLk5BChgHFx8dLYmIi7wMQgAjdAGB3GRkiV12Vt71qlUhMjK9LBABBF7h79O4nR1PTvd6vQbtB/Xqyc9ceE8C9qVwxVl6fO4fgDQQgQjcA2F1ursg335zeBgCUK23h1sDdsH03iU9IKnC/tm0nxIhUbiXiLXKnHDkoO1a+Z45DazcQeAjdAAAAQBnQwF0lqbaXexxSMTRLcuOjTkVwAMGEidQAAAAAALAIoRsAAAAAAIsQugEAAAAAsAihGwAAAAAAizCRGgAEgqpVfV0CAAAAeEHoBgC7i4vTRWJ9XQoAAAB4QegGAAAAAJSp5ORks/b82YiPjw+ItesJ3QAAAACAMg3cPXr3k6Op6Wd1nMoVY+X1uXNsH7wJ3QBgdxkZIjfckLf96aciMTG+LhEAAAhi2sKtgbth+24Sn5BUumMcOSg7Vr5njkXoBgD4Vm6uyMqVp7cBAAD8gAbuKkm1JdixZBgAAAAAABYhdAMAAAAAYBFCNwAAAAAAFiF0AwAAAABgEUI3AAAAAAAWYckwAAgEsbG+LgEAAAC8IHQDgN3FxYkcP+7rUgAAAMALupcDAAAAAGARQjcAAAAAABYhdAOA3WVminTpknfRbQAAAPgNxnQDgN3l5Ih88snpbQAAAPgNQneASU5OlpSUlFI/Pj4+XhITE8u0TAAAAAAQrIIqdM+aNUumTp0qBw4ckJYtW8rMmTPlkksukUAK3D1695OjqemlPkblirHy+tw5BG8AAAAAKANBE7rfeecdGTZsmMyePVsuvfRSmT59unTu3Fm2b98u1apVk0CgLdwauBu27ybxCUklf/yRg7Jj5XvmOLR2AwAAAMDZC5rQ/fTTT0v//v2ld+/e5rqG70WLFsmrr74qDz/8sAQSDdxVkmr7uhiw+VADxXADAAAA4OwERejOzs6WjRs3yqhRo1y3hYaGSseOHWXdunU+LRvgr0MNFMMNAAAAgLMTFKH78OHDkpOTI0lJnl2u9fpPP/1UYP+srCxzcTp27Jj5efToUcnNzRV/pa2a+jyP7NstJzJLHrZS/jgk2ZmZsmXLllK1kP72229yIjur1L+/rMtwMjNdTkSL/Jkp4gjC1yH5yJ9SvfmVElexcqnKcDz1qOz/frU5MVWnTh2xozO9FyEiZ6wjZ/telIeQjAw579T2r99/L46YGB+XyD+V9m/TWU+O7PP/uoDy4w//3yBw/r+hLkClpqbK/v37A+LFKKvvwzk5OXlDaI8eFX/k/Ox2OIr+9A9xnGmPALBv3z6pVauWrF27Vtq1a+e6fcSIEbJy5Ur5+uuvPfYfP368TJgwwQclBQAAAADY7SRD7dq1g7ulu2rVqhIWFiYHDx70uF2vV69evcD+2g1dJ11z0tbtP/74QxISEiQkRM9Vwg70zJO20OofgY5NBqgj4LME/H8DX+A7CagjgUnbr7WHQs2aNYvcLyhCd2RkpLRp00aWLVsmt956qytI6/VBgwYV2D8qKspc3FWuXLouuvA9DdyEblBHwGcJ+P8GvsZ3ElBHAk+lSpXOuE9QhG6lLdc9e/aUtm3bmrW5dcmw48ePu2YzBwAAAACgrAVN6L7zzjvNjM5jx46VAwcOSKtWreSzzz4rMLkaAAAAAABlJWhCt9Ku5N66kyMw6RCBcePGFRgqAFBHwGcJ+P8G5YnvJKCOBLegmL0cAAAAAABfCPXJbwUAAAAAIAgQugEAAAAAsAihGwAAAAAAixC6YSuzZs2Sc889V6Kjo+XSSy+V9evXF7n/ggULpHHjxmb/5s2byyeffFLovvfff7+EhISY5eRgX1bUkW3btsnNN99s1mGMi4uTiy++WPbu3Wvhs4Cd6khaWpqZpLN27doSExMjTZs2ldmzZ/MmBkkd2bJli3Tr1s3sX9T/ISWtdwi+ejJ58mTz/0vFihWlWrVqcuutt8r27dstfhaw22eJ0xNPPGH2GzJkiAUlR1kjdMM23nnnHbPeus5I/u2330rLli2lc+fOcujQIa/7r127Vu666y7p27evfPfdd+Y/L738+OOPBfb94IMP5KuvvpKaNWuWwzOBnerIzp075corrzSha8WKFfLDDz/ImDFjzH+gsB8r6ogeT5egfOONN8wJGv0CpCH8o48+KsdnBl/VkfT0dDnvvPPMF+Dq1auXyTERnPVk5cqVMnDgQPN9ZOnSpXLixAnp1KmTHD9+3OJnA7vUEacNGzbIiy++KC1atODNswudvRywg0suucQxcOBA1/WcnBxHzZo1HZMnT/a6/x133OHo0qWLx22XXnqp47777vO47ffff3fUqlXL8eOPPzrq1avneOaZZyx6BrBjHbnzzjsd99xzj4Wlht3rSLNmzRwTJ0702Kd169aORx99tMzLD/+rI+4K+z/kbI6J4Kkn+R06dEhXGHKsXLnyrMuLwKkjqampjoYNGzqWLl3qaN++vWPw4MFlWm5Yg5Zu2EJ2drZs3LhROnbs6LotNDTUXF+3bp3Xx+jt7vsrPcPovn9ubq50795dhg8fLs2aNbPwGcCOdUTrx6JFi+SCCy4wt2t3P+0e9uGHH1r8bGCnz5HLL7/ctGr/73//0xPZ8sUXX8jPP/9sWqgQ+HXEF8eEb5XXe3rs2DHzs0qVKmV2TNi/jmhviC5duhT4vwn+jdANWzh8+LDk5ORIUlKSx+16/cCBA14fo7efaf8nn3xSwsPD5cEHH7So5LBzHdEuYDpeV7t6XX/99bJkyRK57bbbpGvXrqYbIOzFqs+RmTNnmnHcOqY7MjLS1BUdx3fVVVdZ9EzgT3XEF8eEb5XHe6onfXWoyhVXXCEXXnhhmRwT9q8jb7/9tumqruP/YS/hvi4A4Ct6BnLGjBnmw0snogC8felRt9xyiwwdOtRst2rVyozz1Ymy2rdvz4sGE7p1DKa2dterV09WrVplWiJ0jghaIgCUhn6G6NwRX375JS8gjN9++00GDx5sxvszr4z9ELphC1WrVpWwsDA5ePCgx+16vbDJJvT2ovZfvXq1acmsW7eu6349K/nPf/7TzBi5e/duS54L7FNH9JjaE0JbMd01adKEL0I2ZEUdycjIkEceecRMxqjd/ZRObLNp0yZ56qmnCN1BUEd8cUz4ltXvqU7EuHDhQnMCT3vQwH6sqCPaWKTfW1u3bu3xvVXryXPPPSdZWVnmd8I/0b0ctqBdNtu0aSPLli3zaIXU6+3atfP6GL3dfX+lZwed++tYbp2JWr8cOy/aMqXjuxcvXmzxM4Id6ogeU5dvyb9ki47X1RZN2IsVdURnF9aLjtVzp198nD0lENh1xBfHhG9Z9Z7qnBAauPUk3vLly6V+/fplVGIEQh259tprZfPmzR7fW9u2bSt333232SZw+zmLJmgDytzbb7/tiIqKcsybN8+xdetWx7333uuoXLmy48CBA+b+7t27Ox5++GHX/mvWrHGEh4c7nnrqKce2bdsc48aNc0RERDg2b95c6O9g9nJ7s6KOvP/+++a2l156ybFjxw7HzJkzHWFhYY7Vq1f75DnC/+qIzh6rM5h/8cUXjl9//dUxd+5cR3R0tOP555/n7QqCOpKVleX47rvvzKVGjRqOhx56yGzr50Vxjwn7saKeDBgwwFGpUiXHihUrHPv373dd0tPTffIc4X91JD9mL7cPQjdsRQNP3bp1HZGRkWYphq+++srjg6dnz54e+8+fP99xwQUXmP31S/GiRYuKPD6h2/6sqCOvvPKK4/zzzzdBqmXLlo4PP/ywXJ4L7FFH9Etxr169zFIwWkcaNWrkmDZtmiM3N5e3MAjqyK5du8yyTvkvul9xjwl7Kut64u1+veiJPNiTFZ8l7gjd9hGi//i6tR0AAAAAgEDEmG4AAAAAACxC6AYAAAAAwCKEbgAAAAAALELoBgAAAADAIoRuAAAAAAAsQugGAAAAAMAihG4AAAAAACxC6AYAAAAAwCKEbgAAcEa9evWSW2+9lVcKAIASInQDAOBn4TYkJETuv//+AvcNHDjQ3Kf7lLcZM2bIvHnzyvy4+nx27959Vq/VE0884XH7hx9+aG4HAMAfELoBAPAzderUkbffflsyMjJct2VmZspbb70ldevW9UmZKlWqJJUrVxZ/Ex0dLU8++aT8+eefvi4KAABeEboBAPAzrVu3NsH7/fffd92m2xq4L7roIo99P/vsM7nyyitNIE5ISJC//vWvsnPnTtf92oqsrb76+KuvvlpiY2OlZcuWsm7dOtc+2oKtj1+8eLE0adJEKlSoINdff73s37+/0O7lHTp0kAcffFBGjBghVapUkerVq8v48eM9yvbTTz+Zsmkwbtq0qXz++eemLNoS7Y0G57vvvlsSExMlJiZGGjZsKHPnzi3yterYsaP53ZMnTy7WawsAQHkjdAMA4If69OnjEThfffVV6d27d4H9jh8/LsOGDZNvvvlGli1bJqGhoXLbbbdJbm6ux36PPvqoPPTQQ7Jp0ya54IIL5K677pKTJ0+67k9PT5ennnpK/v3vf8uqVatk7969Zv+ivPbaaxIXFydff/21TJkyRSZOnChLly419+Xk5JiQriFf73/ppZdMGYoyZswY2bp1q3z66aeybds2eeGFF6Rq1apFPiYsLEwef/xxmTlzpvz+++9F7gsAgC+E++S3AgCAIt1zzz0yatQo2bNnj7m+Zs0a0+V8xYoVHvt169bN47qGc20p1vB64YUXum7XAN2lSxezPWHCBGnWrJn88ssv0rhxY3PbiRMnZPbs2dKgQQNzfdCgQSZEF6VFixYybtw4s62t0s8995wJ/tddd50J39riruXVlmg1adIkc587h8Ph2tagry35bdu2NdfPPffcYtUSPcnQqlUrU5ZXXnmlWI8BAKC80NINAIAf0uCsIVm7fmuLt257a/XdsWOHabU+77zzJD4+3hVUNcDmD8hONWrUMD8PHTrkuk1bpJ2B27mP+/3euB8z/2O2b99uusg7A7e65JJLijzegAEDzIkFDdDabX3t2rVSXDquW1vetYUcAAB/QugGAMCPu5hr6NYwqdve3HTTTfLHH3/Iyy+/bLpx60VlZ2d77BcREeHads7s7d4F3f1+5z7urdDeeHtM/m7tJXHDDTeYlv2hQ4fKvn375Nprrz1jF3enq666Sjp37mx6BwAA4E8I3QAA+CmdzEzDs3b91kCZ35EjR0yL8ujRo01A1UnQ/GUW70aNGslvv/0mBw8edN22YcOGYrXw9+zZU9544w2ZPn26GQteXLp02Mcff+wxSRwAAL7GmG4AAPyUThLm7C6t2/mdc845ZsZyDabatVu7lD/88MPiD3TstnZX1wCtk6ylpqaakwOqsDW0x44dK23atDHjzbOysmThwoXmREJxNW/e3Mx+/uyzz5bZ8wAA4GzR0g0AgB/Tcdp68UZnKtcx0Bs3bjSTpmm37KlTp4o/0JMEujRYWlqaXHzxxdKvXz/X7OW6hJg3kZGRpnu4jhXX7uJ6DH1+JaGTv51NF3cAAMpaiONMA7YAAADKgM7Arut266zp7pO2AQAQyAjdAADAEh988IFUqFDBLCemQXvw4MGmS/yXX37JKw4ACBqM6QYAAJbQcdwjR440Y811ubOOHTvKtGnTeLUBAEGFlm4AAAAAACzCRGoAAAAAAFiE0A0AAAAAgEUI3QAAAAAAWITQDQAAAACARQjdAAAAAABYhNANAAAAAIBFCN0AAAAAAFiE0A0AAAAAgEUI3QAAAAAAiDX+HxlzZzNBEaHqAAAAAElFTkSuQmCC",
+      "text/plain": [
+       "<Figure size 1000x500 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "fig, ax = plt.subplots(figsize=(10, 5))\n",
+    "ax.hist(\n",
+    "    mann_df['mannings_n'],\n",
+    "    bins=50,\n",
+    "    edgecolor='black',\n",
+    "    alpha=0.7,\n",
+    "    color='steelblue',\n",
+    ")\n",
+    "ax.set_xlabel(\"Manning's N\")\n",
+    "ax.set_ylabel('Cell Count')\n",
+    "ax.set_title(\"Distribution of Manning's N Values\")\n",
+    "ax.axvline(\n",
+    "    mann_df['mannings_n'].mean(),\n",
+    "    color='red',\n",
+    "    linestyle='--',\n",
+    "    label=f\"Mean={mann_df['mannings_n'].mean():.4f}\",\n",
+    ")\n",
+    "ax.legend()\n",
+    "ax.grid(True, alpha=0.3)\n",
+    "plt.tight_layout()\n",
+    "plt.show()\n",
+    "plt.close(fig)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bdb13300",
+   "metadata": {},
+   "source": [
+    "## Calibration Table and Base vs Calibrated Comparison"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "3d661f8c",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-03-27T17:19:40.296804Z",
+     "iopub.status.busy": "2026-03-27T17:19:40.296804Z",
+     "iopub.status.idle": "2026-03-27T17:19:40.303965Z",
+     "shell.execute_reply": "2026-03-27T17:19:40.303965Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Land cover classes: 17, Calibration regions: 1\n",
+      "\n",
+      "Base values:\n",
+      "             Land Cover Name  Base Manning's n Value\n",
+      "                                                 NaN\n",
+      "                      NoData                   0.060\n",
+      "  Barren Land Rock/Sand/Clay                   0.040\n",
+      "            Cultivated Crops                   0.060\n",
+      "            Deciduous Forest                   0.100\n",
+      "   Developed, High Intensity                   0.150\n",
+      "    Developed, Low Intensity                   0.100\n",
+      " Developed, Medium Intensity                   0.080\n",
+      "       Developed, Open Space                   0.040\n",
+      "Emergent Herbaceous Wetlands                   0.080\n",
+      "            Evergreen Forest                   0.120\n",
+      "        Grassland/Herbaceous                   0.045\n",
+      "                Mixed Forest                   0.080\n",
+      "                  Open Water                   0.035\n",
+      "                 Pasture/Hay                   0.060\n",
+      "                 Shrub/Scrub                   0.080\n",
+      "              Woody Wetlands                   0.120\n"
+     ]
+    }
+   ],
+   "source": [
+    "cal = HdfLandCover.get_mannings_calibration_table(geom_hdf)\n",
+    "assert cal is not None and len(cal) > 0, \"Expected Manning's calibration data.\"\n",
+    "print(f'Land cover classes: {len(cal)}, Calibration regions: {len(cal.columns) - 2}')\n",
+    "print()\n",
+    "print('Base values:')\n",
+    "print(cal.iloc[:, :2].to_string(index=False))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "c991292a",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-03-27T17:19:40.305969Z",
+     "iopub.status.busy": "2026-03-27T17:19:40.305969Z",
+     "iopub.status.idle": "2026-03-27T17:19:40.313132Z",
+     "shell.execute_reply": "2026-03-27T17:19:40.312905Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Override entries: 14, Classes: 14, Regions: 1\n",
+      "\n",
+      "Largest N increases:\n",
+      "land_cover_class  region_name  base_n  calibrated_n  delta_n\n",
+      "      Open Water Main Channel   0.035          0.04    0.005\n"
+     ]
+    }
+   ],
+   "source": [
+    "comp = HdfLandCover.compare_base_vs_calibrated(geom_hdf)\n",
+    "if comp is not None and len(comp) > 0:\n",
+    "    print(\n",
+    "        f\"Override entries: {len(comp)}, Classes: {comp['land_cover_class'].nunique()}, Regions: {comp['region_name'].nunique()}\"\n",
+    "    )\n",
+    "    print()\n",
+    "    print('Largest N increases:')\n",
+    "    print(\n",
+    "        comp[comp['delta_n'] > 0]\n",
+    "        .nlargest(5, 'delta_n')[['land_cover_class', 'region_name', 'base_n', 'calibrated_n', 'delta_n']]\n",
+    "        .to_string(index=False)\n",
+    "    )\n",
+    "else:\n",
+    "    print('No calibrated overrides found.')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0bc01935",
+   "metadata": {},
+   "source": [
+    "## Preprocessed Infiltration Parameters"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "6c097bfa",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-03-27T17:19:40.315136Z",
+     "iopub.status.busy": "2026-03-27T17:19:40.314136Z",
+     "iopub.status.idle": "2026-03-27T17:19:40.325239Z",
+     "shell.execute_reply": "2026-03-27T17:19:40.325239Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Curve Number: 18,066 cells, range 36.000-100.000, mean 73.645\n",
+      "Abstraction Ratio: 18,066 cells, range 0.000-0.200, mean 0.137\n",
+      "Minimum Infiltration Rate: 18,066 cells, range 0.000-0.120, mean 0.115\n"
+     ]
+    }
+   ],
+   "source": [
+    "for var in ['Curve Number', 'Abstraction Ratio', 'Minimum Infiltration Rate']:\n",
+    "    df = HdfInfiltration.get_preprocessed_infiltration(geom_hdf, variable=var)\n",
+    "    if len(df) > 0:\n",
+    "        print(\n",
+    "            f\"{var}: {len(df):,} cells, range {df['value'].min():.3f}-{df['value'].max():.3f}, mean {df['value'].mean():.3f}\"\n",
+    "        )\n",
+    "    else:\n",
+    "        print(f'{var}: No data')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "f4bd3dfa",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-03-27T17:19:40.327242Z",
+     "iopub.status.busy": "2026-03-27T17:19:40.327242Z",
+     "iopub.status.idle": "2026-03-27T17:19:40.438904Z",
+     "shell.execute_reply": "2026-03-27T17:19:40.438904Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA90AAAHqCAYAAAAZLi26AAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjgsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvwVt1zgAAAAlwSFlzAAAPYQAAD2EBqD+naQAAW8BJREFUeJzt3Qd8FNXax/EnCWkkhBpCL4LSpAhYuHoFFUXECpbrFQUpXhVU4AqKF6UoFryIKCgqCiqgwn2toAJSFVAQG4KiIEVFIEgJCQlp836eE2fZTWM37JBk5/flM+zs7Oxkdma2/OecOSfMsixLAAAAAABA0IUHf5EAAAAAAIDQDQAAAACAgyjpBgAAAADAIYRuAAAAAAAcQugGAAAAAMAhhG4AAAAAABxC6AYAAAAAwCGEbgAAAAAAHELoBgAAAADAIYRuAIDHmDFjJCws7KRskS5dupjBtnz5cvO3//e//52Uv9+3b19p1KiRlGWpqakyYMAAqVWrltk2Q4YMKe1VQiHvl3379oXMdrHfh3oLAAgOQjcAhKiZM2eaH8/2EBMTI3Xq1JFu3brJM888I4cPHw7K39m1a5cJH998842UNWV53fzx6KOPmv14xx13yOuvvy4333xzsfPn5OTIjBkzzMmMatWqSXR0tDmxcOutt8qXX34p5ZGeHNHjt02bNmJZVoHH9bHBgweLG+k2adCgQaHbxXbuuedKUlKSZGdnn9R1AwAcQ+gGgBA3btw4E9ief/55ueuuu8w0LTFt3bq1fPfddz7zjho1StLT0wMOtmPHjg042C5atMgMTipu3V566SXZvHmzlGVLly6Vc845R0aPHi29e/eWDh06FDmv7rfLL79c+vXrZ0LYAw88YPb5LbfcImvWrJGzzjpLfvvtNymvNmzYIG+//XZpr0aZctNNN8mvv/4qn376aaGPb9++3ez7G264QSpUqHDS1w8AkIdPYAAIcd27d5eOHTt67o8cOdKEOQ1oV155pfzwww8SGxtrHtMf5k7/OD9y5IhUrFhRoqKipDRFRkZKWbd3715p2bKlX/MOHz5cPv74Y5k0aVKBauga2nV6MOTm5kpmZqapOXGy6PFZv359cwKpZ8+eJ+0SiLLCfs/k989//tO8n+fMmSPnn39+gcffeOMNcwJGwzkAoPRQ0g0ALnThhRfKgw8+KDt27JBZs2YVe0334sWL5bzzzpMqVapIfHy8NGvWzJSiKr3u88wzzzTjWoXZrsquVaKVVnM+/fTTZf369SYUaHCwn5v/mm7vKtI6j17HHBcXZ04MaGmeN60yrdWO8/Ne5vHWrbBrutPS0uTf//63CXhaNVtf63//+98C1XftKs3vvvuueX06b6tWrUzo9TdM9+/f31T71fDatm1befXVVwtcV7tt2zZZsGCBZ9215LIwWoL9wgsvyMUXX1zodd8RERFy7733Sr169Yp87UXtf/u1zp4927xGfa0ffPCBqb6u2zW/lJQU85r079mOHj1qgn/Tpk3N83X7jhgxwkz3R3h4uKmFoTUz3nnnHb8uq8i/rQq7Vtk+PnW5nTt3NsenrqPdrsCKFSvk7LPPNqFfj4VPPvmk0L+p13Rff/31kpCQINWrV5d77rlHMjIyCsyn7zWtraDL0+33j3/8o8CxXdx7Jj/djjqPrm9WVlaBxzWMN2nSxLwGfa/feeed5nXo39f1vO6664o8pgJ9vwW6r4v7XAGAUEPoBgCXsq8PLq6K98aNG02JuP5g1lLGiRMnmhC8atUq83iLFi3MdHXbbbeZauw6eJe6/fnnn6a0vV27dvL000/LBRdcUOx6jR8/3gTN++67T+6++27z47xr164BV3v3Z928abDW16Ylwpdeeqk89dRTJghoCfKwYcMKzP/ZZ5+ZEKPBacKECSZk9erVy7ze4ujr0KCi66IlkE8++aRUrlzZhJrJkyd71l0fr1Gjhtlu9ronJiYWusyPPvrIXLN7vGu+S0prRgwdOtRUU9Z1PPXUU+Waa64xJx201NubTtPjRbeLXTKu21VPXlxxxRXy7LPPytVXX222sy7PX1qqq39X92lx1zAH6sCBA+YY12Cq+1GDoq77W2+9ZW4vu+wyefzxx80JmWuvvbbQthA0cOv+f+yxx8z82maCHnP5j2ut6q+vQY8tPTmyZMkSczwePHjQZ95A3jN6DOn8CxcuLFAd//vvv/eUcq9bt05Wr15tXpOu3+23327+vh6LWpIeDP7u6+N9rgBAyLEAACFpxowZmkysdevWFTlP5cqVrTPOOMNzf/To0eY5tkmTJpn7ycnJRS5Dl6/z6N/Lr3PnzuaxadOmFfqYDrZly5aZeevWrWulpKR4ps+dO9dMnzx5smdaw4YNrT59+hx3mcWtmz5fl2N79913zbyPPPKIz3zXXnutFRYWZm3ZssUzTeeLiorymfbtt9+a6c8++6xVnKefftrMN2vWLM+0zMxMq1OnTlZ8fLzPa9f169Gjh3U8Q4cONcv8+uuvLX/kf+1F7X+l98PDw62NGzf6TF+4cKF57IMPPvCZftlll1mnnHKK5/7rr79unv/pp5/6zKfHhD5/1apVx13XuLg4M/7qq6+a57z99ts+6zdo0KACx/22bdt8lmMfX3qb//icM2eOZ9qPP/7oec2ff/55gdfrfSzZ2+vKK6/0+Vt33nmnma7HhNq+fbsVERFhjR8/3me+DRs2WBUqVPCZXtx7pjD79++3oqOjrRtvvNFn+v3332+Ws3nzZnP/yJEjBZ67Zs0aM89rr71W7Hby9/3m777253MFAEIJJd0A4GJarbO4Vsy16qd67733TClWSWjJYWHVkIuipYGVKlXy3NfSxdq1a8uHH34oTtLlazVsLV33ptXNNdtpabI3LX3XqrveLUlr9eJffvnluH9Hq87feOONPteX69/VLsK0SnOgtEq38t5uwaRVr/NfW66XKGhJvJYIe5caa80E71LNefPmmZL75s2bm2rY9qDPV8uWLfN7PbTUNtil3foesEvlldZu0ONe11lLv232eGH7d9CgQT737QYL7WNWG4DT94+WiHtvAz0O9PXk3waBvGeqVq1qStfff/99UxqvdNu8+eabpi2H0047zUyz221QWhVdS8e1Cri+1q+++kqCwd99HYzPFQAoTwjdAOBiGvKKC2oanrTLIe0rWq8/1nAyd+7cgH4o161bN6BG0zSEeNPrcDUc+HPt6YnQa161S7X820NDhP24N+2qqbAApMHzeH9HX6Nep+zP3/GHhn0VrG7g8mvcuHGBadrgnlan1+BkX6+r4VIDnXfo/vnnn011Yq0a7z3YYVCvb/eXnhTRa7u1NXqtxh4Mep17/uvYtbq/Xoucf5oqbP/mP2b1ZIzuX/uY1W2gQVjny78dtCHD/Nsg0PeMnozQwK37Qmk1cv3b3g2o6WUNDz30kKe9Aj1hon9fq7YfOnRIgsHffR2MzxUAKE9ovRwAXEob39If2xpoi6KlYytXrjQlVHqdtTYUpiWbWnKl14JrCDoe7xK2YCmq9WpthM2fdQqGov5OMK839peWLNrX8ep1wCey/QLZhxqWtAE3rQWg1+5qcNJ10YbhbBqktHs6vY65MPnD7fFokHz44YdNabf+zRN9bUXtxxPZv/nXQbeBTtPtVNhytbT9RN4zen20nhTQhtP02ne91b/jXYKvpe/ah7teS96pUyczv66TznO8sOvv+83ffR2MzxUAKE8I3QDgUtowl+rWrVux82mJ3UUXXWQG/TH96KOPyn/+8x/zg1mrWAe7+yYtLcsfcrZs2WKqb3uXKOdvfMouJT7llFM89wNZt4YNG5rWqbW02Lu0+8cff/Q8Hgy6HG0tWwOKd2n3ifwdbXRLg4q2ju1PY2rFbb9AaCNgWvVfA5O2RK0Nrumxkb/U99tvvzXHTzCOFbu0Wxues0t28782lf/1laQGQSDHrHdtAD1edf/aLcTrNtDjWOexS32DSUuu9TKM1157Tfbs2WOqeWuA1errNm3hvE+fPqbRMps2/lbYcZCfv++3QPb18T5XACCUUL0cAFxIw5GWFmoIKK4P3/379xeYZpek2lWKtVsv5c+Pd39ocPCuJq1h4Y8//jDB0vvH/eeff+7Tcvb8+fMLdL8UyLrpdbFacjdlyhSf6drysgYI779/IvTv7N692+daaG15XFt61hJPvX46UFqCOHDgQFNKqMvJTwOghi2t3WBvP63loOHfptv4eN1xFRacNOxpF2J6EkdfR/4WyfU65t9//11eeumlAs/XKs/2dciB6N27t6mhMXbs2AKP2dfZa0mqTffriy++KE6ZOnWqz317H9jHjPYtricLdH3zl5Tr/eO1eO8PfR9r1f5//etfkpycXOB9rX8//9/W9SyqBoA3f99v/u5rfz5XACCUUNINACFOq7RqKaoGIi0F08CtjV1piao2vqR9KhdFq/BqeOnRo4eZX6/JfO6558x1sFqyaf8g14aRpk2bZkqINehqo1OFXQfsD+2/WJetDUnp+mqXSRqwNFTa9FpQDePatZf+0N+6dasp5fVu2CzQddMujrRrJi1t0+thtYq0hlgtTdUqufmXXVLalZRWydaSWu2LWUtD9bVod0n6WkvaGJqGat0O2iCbXlutVY61hHLnzp2m5FOPAbu6sd5ql2za7ZfOr11GPf/886YUNtBGtTRka3jTvpm1arF9bbpNS9612rl2UaWlmHotrwY9XR+drl1daYNfgdAAqfupsMbGtC/xc845R0aOHGnCnR5P2qiYHv9O0f7UtcsrPR7XrFljjkWt5m1Xs9dj55FHHjHrpMeWVovX/azP0xMdekx492teEnqyRt+Xerxq9W0N+t70eNATI1qtXBvF0/XUmh3aX/fx+Pt+83df+/O5AgAhpbSbTwcAOMPuOsketIurWrVqWRdffLHpfsu7a6qiuoxasmSJddVVV1l16tQxz9db7Zrop59+8nnee++9Z7Vs2dJ0f+TdrZJ2J9SqVatC16+oLsPeeOMNa+TIkVbNmjWt2NhY02XWjh07Cjx/4sSJpnsx7S7p3HPPtb788ssCyyxu3QrrNuvw4cOm+y19nZGRkdapp55qPfnkk1Zubq7PfPm7qTpe10r57dmzx7r11lutGjVqmO3aunXrQrs187fLMFt2drY1ffp06+9//7vpDk5fgy5D/1b+7sQWLVpknX766ebvN2vWzHRhVlSXYYW9Vptum/r16xfa3Zp3l2hPPPGEORZ0f1WtWtXq0KGDNXbsWOvQoUN+dxnmLSsry2rSpEmh67d161ara9eu5m8lJSVZDzzwgLV48eJCuwwr7Pgsarvn/1v29tq0aZPpWq5SpUrmtQ0ePNhKT08v8Pz/+7//s8477zzzenRo3ry5WZ7drVdx6+SP4cOHm/W5/vrrCzx24MABzzGnXdN169bNdI+W/5gtrMuwQN5v/uxrfz9XACBUhOl/pR38AQAAAAAIRVzTDQAAAACAQwjdAAAAAAA4hNANAAAAAIBDCN0AAAAAADiE0A0AAAAAgEMI3QAAAAAAOKSCUwsOJbm5ubJr1y6pVKmShIWFlfbqAAAAAABKmfa+ffjwYalTp46Ehxddnk3o9oMG7vr16wdz/wAAAAAAQsCvv/4q9erVK/JxQrcftITb3pgJCQnB2zsotnZBcnKyJCYmFnvWCKGLY8Dd2P8ot8dAWppInTp547t2icTFlfYalVvl9hhAULD/kVsOPgNSUlJM4aydF4tC6PaDXaVcAzeh++S9yTIyMsz2LqtvMjiLY8Dd2P8ot8dARMSxcT1RT+h23zGAoGD/I7ccfQYc7xLksr32AAAAAACUY4RuAAAAAAAcQugGAAAAAMAhXNMNAAAAAMXIycmRrKwsttFJvqY7KyvLXNddWtd0R0ZGSoR3Wx0lROgGAAAIlshIkdGjj40DKPf9MO/evVsOHjxY2qviym2fm5tr+sE+XkNlTqpSpYrUqlXrhNaB0A0AABAsUVEiY8awPYEQYQfumjVrSsWKFUs1/LkxdGdnZ0uFChVKZbvr3z9y5Ijs3bvX3K9du3aJl0XoBgAAAIBCqpTbgbt69epsH5eFbhUbG2tuNXjrcVDSquY0pAYAABAsubkiGzfmDToOoNyyr+HWEm64V8W/9v+JXNNPSTcAAECwpKeLnH563nhqqkhcHNsWKOeoUu5uYUEoZaekGwAAAAAAhxC6AQAAAABwCKEbAAAAAEJI3759TbXo22+/vcBjgwYNMo/pPGXVzJkzTd/cUVFR5lbX1x7s1sQ/++wzOffcc00jd9rgWfPmzWXSpEl+NdD23//+V0477TSJjo6WunXryvjx4x19PVzTDQAAAAAhpn79+vLmm2+aIGq3wp2RkSFz5syRBg0aSFl2ww03SLdu3XxaL9eTBLr+2oq4iouLk8GDB0ubNm3MuIbwf/3rX2b8tttuK3LZ99xzjyxatMgE79atW8v+/fvN4CRKugEAAAAgxLRv394E77ffftszTcc1cJ9xxhmeabm5ufLYY49J48aNTThv27at/O9///PpOq1///6ex5s1ayaTJ0/2+VsaiK+++moTZLU/ay191hL1krb4HRsbK7Vq1fIM2lXX0qVLzXrY9DXceOON0qpVK2nUqJH07t3bBPVPP/20yOX+8MMP8vzzz8t7770nV155pXlNHTp0kIsvvlicROgGAAAAAH+lpRU9ZGT4P6/2duDPvCegX79+MmPGDM/9V155RW699VafeTRwv/baazJt2jTZuHGjDB061ATYFStWeEJ5vXr1ZN68ebJp0yZ56KGH5IEHHpC5c+f6LGfZsmWydetWc/vqq6+aKuI62LSqe3x8fLFDUXT9tOuua6+9tsh5vv76a1m9erV07ty5yHk++OADOeWUU2T+/PkmcGtYHzBggOMl3VQvBwAACJbISJF77z02DiD0FBMO5bLLRBYsOHZfq0IfOVL4vBoOly8/dr9RI5F9+wrOZ1klXlUNzyNHjpQdO3aY+6tWrTJVzpf/9XePHj0qjz76qHzyySfSqVMnM01DqVbVfuGFF0yAjYyMlLFjx3qWqWF1zZo1JnRff/31nulVq1aVKVOmmFJpvb66R48esmTJEhk4cKB5fNy4cXKv/fkYoJdffln++c9/eqrJe9MTAsnJyaYq+pgxY0yILsovv/xitoWeQNAgr6X4epJBw7yWpDuF0A0AAFxJf6SlpKSU+PkJCQmSmJjoOzEqSuTJJ0985QAgCPQzSsOvljhrA2I6XqNGDc/jW7ZskSNHjhSoXp2ZmelTBX3q1KmmlHznzp2Snp5uHm/Xrp3Pc7SatwZum1Yz37Bhg+e+XottX48dCA34Wi389ddfL/RxrU6empoqn3/+udx///3StGlTU+28MFpqrycaNHBrQ2p2oNcq5ps3bzZV551A6AYAAK4M3L379ZYDqQdKvIyq8VVl1iuzCgZvAKEtNbXox7xCp/FXS9uFCs93pe/27eIErWKuDY7Z4dmbhlW1YMEC04q3N23ZW2nJuJZQT5w40ZSGV6pUSZ588kn54osvfObXEnFv2viZhlzv6uWzZs2S4tjr42369Okm4GswLoyWvCttFG3Pnj2mtLuo0K0nArRhNjtwqxYtWphbPaFA6AYAAAgSLeHWwJ14QaLE1yimqmgRUvelSvKyvJJyn9CtPzB37swb19aB8/+oBlD+xcWV/rwBuPTSS03JtIZgbWjMW8uWLU241sBZ1LXQWiX9b3/7m9x5552eaXrtdqDGlaB6uYZwrQqu1537wy7JLop2MabV0HX9mzRpYqb99NNP5rZhw4biFEq6AQCAa2ngTqiVUKLnJktywYnaMNJfpS6mNMyhH9EA4C+t8q3Vs+1xb1pqrUFYr2vWwHreeefJoUOHTNDWS2j69Okjp556qqmOvXDhQlOqrNW8161b5ylh9lfNElQv18CtIVmvTc9PS+21JXa9flytXLnStJ5+9913e+bRa8zfeecdc2256tq1q2nVXUv/n376afOatZV1rV7vXfodbIRuAAAAAAhhGqCL8vDDD5saO1qarA2NValSxQRTbaFcad/X2jK49p2tpeVadVtLvT/66CPH13vGjBnSs2dPs075aWDWRuK2bdtmqoxryfUTTzxh1te2b98+n1L58PBw04L5XXfdJeeff77p07t79+6m6ryTwiy9oh7F0qpjlStXNmd9ijtgETz6Jtq7d685G6ZvDrgPx4C7sf/h9DGgP8JuHHCjNL6ucYlKulN2p8i2edvkjelveKooGtq9j92yMSXdJ4TPAXcrC/s/IyPDBDot0Y2JiSmVdXAzy7JMKbcGag37paW448DfnEiaAQAAAADAIYRuAAAAAAAcQugGAAAAAMAhhG4AAAAAABxC6+UAAABB+2VVQcTuy1bHAQCux7cBAABAsERHa+exbE8gxFpSh3vlBmH/E7oBAAAAIJ+oqCjTXdmuXbtMP9Z6vzS7rnIbq5S7DNO/n5mZKcnJyeY40P1fLkP3mDFjZOzYsT7TmjVrJj/++KOnT7R///vf8uabb8rRo0elW7du8txzz0lSUpJn/p07d8odd9why5Ytk/j4eOnTp4/p2F13jm358uUybNgw2bhxo9SvX19GjRolffv2PYmvFAAAuIJliezblzdeo4YIP9CBckuDlvbN/Mcff5jgjZMfenNzc81+KM2THRUrVpQGDRqcUH/xpV7S3apVK/nkk088973D8tChQ2XBggUyb9480+n44MGDpWfPnrJq1SrzeE5OjvTo0UNq1aolq1evNm+IW265RSIjI+XRRx8182hH5jrP7bffLrNnz5YlS5bIgAEDpHbt2ibEAwAABM2RIyI1a+aNp6aKxMWxcYFyTEs3NXBpiatmD5w8ubm58ueff0r16tVPKPCeiIiIiKCUtJd66NYXoaE5v0OHDsnLL78sc+bMkQsvvNBMmzFjhrRo0UI+//xzOeecc2TRokWyadMmE9q19Ltdu3by8MMPy3333WdK0fVNMm3aNHOGauLEiWYZ+vzPPvtMJk2aROgGAAAAUCwNXFqopwNObuiOjIyUmJiYUgvdwVLqa//zzz9LnTp15JRTTpGbbrrJVBdX69evl6ysLOnatatn3ubNm5szTWvWrDH39bZ169Y+1c219DolJcVUJbfn8V6GPY+9DAAAAAAAnFKqJd1nn322zJw501zHrVXD9fruv//97/L999/L7t27TUl1lSpVfJ6jAVsfU3rrHbjtx+3HiptHg3l6errExsYWWC+9flwHm85rn22h9cKTQ7ezfR0H3IljwN3Y/3D6GNBla+mV/S9Q5llhYQXXUa8/9IzmmvsoGT4H3I39j9xykAf8XbdSDd3du3f3jLdp08aE8IYNG8rcuXMLDcMnizbElr+BN6Ut12njbjg5B7BeYqBvtPJenQQlwzHgbux/OH0MHD58WJo2aipJMUkSK4H/5oiPiZeIRhFmOXv37vVMDztyRJK8fjdYaWlBXGt34XPA3dj/yC0HeUC/A8rFNd3etFT7tNNOky1btsjFF19smmg/ePCgT2n3nj17PNeA6+3atWt9lqGP24/Zt/Y073kSEhKKDPYjR440rZ17l3Rrq+faVYA+DyfnTaYlCLrNy+qbDM7iGHA39j+cPgZSU1Nly/YtktMxRxIk8O/2lIwU2bZ9m1SqVElq2g2nKa+QretOQ2olx+eAu7H/kVsO8oBeb17uQrd+AW7dulVuvvlm6dChg7lwXlsb79Wrl3l88+bN5prvTp06mft6O378eHOG2f7CW7x4sQnGLVu29Mzz4Ycf+vwdncdeRmGio6PNkJ/u7LK6w0ORvsnY5u7GMeBu7H84eQzYVcPtf4Eyz/qrirrP+nmNm+n8bjjh/cRvAfdi/yOsjH8G+LtepRq67733XrniiitMlXLt+2706NGmWfYbb7zRdBHWv39/U+JcrVo1E6TvuusuE5a15XJ1ySWXmHCtIX3ChAnm+m3tg3vQoEGe0KxdhU2ZMkVGjBgh/fr1k6VLl5rq69oVGQAAQFBp16d9+hwbBwC4Xql+G/z2228mYGv/a1pt4LzzzjPdgZnqWCKmWy89e6Al3dqwmbY6/txzz3merwF9/vz5cscdd5gwHhcXJ3369JFx48Z55tHuwjRga5/fkydPlnr16sn06dPpLgwAAASfnvSfOZMtCwAoG6H7zTffPG4d+alTp5qhKFpKnr/6eH5dunSRr7/+usTrCQAAAABASVDvCQAAIFgsS+TIkbzxihX1olS2LQC4XNm8Ih0AAKA80sAdH5832OEbAOBqhG4AAAAAABxC6AYAAAAAwCGEbgAAAAAAHELoBgAAAADAIYRuAAAAAAAcQugGAAAAAMAh9NMNAAAQLBERItdee2wcAOB6hG4AAIBgiYkRmTeP7QkA8KB6OQAAAAAADiF0AwAAAADgEEI3AABAsKSliYSF5Q06DgBwPUI3AAAAAAAOIXQDAAAAAOAQQjcAAAAAAA4hdAMAAAAA4BBCNwAAAAAADiF0AwAAAADgkApOLRgAAMB1IiJELrvs2DgAwPUI3QAAAMESEyOyYAHbEwDgQfVyAAAAAAAcQugGAAAAAMAhhG4AAIBgSUsTiYvLG3QcAOB6XNMNAAAQTEeOsD0BAB6UdAMAAAAA4BBCNwAAAAAADiF0AwAAAADgEEI3AAAAAAAOIXQDAAAAAOAQWi8HAAAIlvBwkc6dj40DAFyP0A0AABAssbEiy5ezPQEAHpyCBQAAAADAIYRuAAAAAAAcQugGAAAIlrQ0kcTEvEHHAQCuxzXdAAAAwbRvH9sTAOBBSTcAAAAAAA4hdAMAAAAA4BBCNwAAAAAADiF0AwAAAADgEEI3AAAAAAAOofVyAACAYAkPF+nY8dg4AMD1CN0AAADBEhsrsm4d2xMA4MEpWAAAAAAAHELoBgAAAADAIYRuAACAYDlyRKRRo7xBxwEArsc13QAAAMFiWSI7dhwbBwC4HiXdAAAAAAA4hNANAAAAAIBDCN0AAAAAADiE0A0AAAAAgEMI3QAAAAAAOITWywEAAIIlLEykZctj4wAA1yN0AwAABEvFiiIbN7I9AQAeVC8HAAAAAMAhhG4AAAAAABxC6AYAAAiWI0dEWrXKG3QcAOB6XNMNAAAQLJYlsmnTsXEAgOtR0g0AAAAAgEMI3QAAAAAAOITQDQAAAACAQwjdAAAAAAA4hNANAAAAAECoh+7HH39cwsLCZMiQIZ5pGRkZMmjQIKlevbrEx8dLr169ZM+ePT7P27lzp/To0UMqVqwoNWvWlOHDh0t2drbPPMuXL5f27dtLdHS0NG3aVGbOnHnSXhcAAHCRsDCRhg3zBh0HALhemQjd69atkxdeeEHatGnjM33o0KHywQcfyLx582TFihWya9cu6dmzp+fxnJwcE7gzMzNl9erV8uqrr5pA/dBDD3nm2bZtm5nnggsukG+++caE+gEDBsjChQtP6msEAAAuULGiyPbteYOOAwBcr9RDd2pqqtx0003y0ksvSdWqVT3TDx06JC+//LI89dRTcuGFF0qHDh1kxowZJlx//vnnZp5FixbJpk2bZNasWdKuXTvp3r27PPzwwzJ16lQTxNW0adOkcePGMnHiRGnRooUMHjxYrr32Wpk0aVKpvWYAAAAAgDtUKO0V0OrjWhLdtWtXeeSRRzzT169fL1lZWWa6rXnz5tKgQQNZs2aNnHPOOea2devWkpSU5JmnW7ducscdd8jGjRvljDPOMPN4L8Oex7sae35Hjx41gy0lJcXc5ubmmgHO0+1sWRbb28U4BtyN/Q+njwFdtl7WZv8LlHlWWBjfVQ7ic8Dd2P/ILQd5wN91K9XQ/eabb8pXX31lqpfnt3v3bomKipIqVar4TNeArY/Z83gHbvtx+7Hi5tEgnZ6eLrGxsQX+9mOPPSZjx44tMD05OdlcZ46TcwBrbQd9o4WHl3qFDJQCjgF3Y//D6WPg8OHD0rRRU0mKSZJYKfhb4HjiY+IlolGEWc7evXuPPZCeLtWvucaM/vnOOyKF/M6Af/gccDf2P3LLQR7Q74AyHbp//fVXueeee2Tx4sUSExMjZcnIkSNl2LBhnvsa0OvXry+JiYmSkJBQquvmpjeZliDoNi+rbzI4i2PA3dj/cPoY0MvbtmzfIjkdcyRBAv9uT8lIkW3bt0mlSpVMQ64eaWkS/u23ZrRmjRoicXHBXG1X4XPA3dj/yC0HecDfHFtqoVurj+uZYW1V3LthtJUrV8qUKVNMQ2d6XfbBgwd9Sru19fJatWqZcb1du3atz3Lt1s2958nf4rne1/BcWCm30lbOdchPd3ZZ3eGhSN9kbHN34xhwN/Y/nDwG7Krh9r9AmWf9VUXdZ/28xs10fjec8H7it4B7sf8RVsY/A/xdr1Jb+4suukg2bNhgWhS3h44dO5pG1ezxyMhIWbJkiec5mzdvNl2EderUydzXW12Gd7UuLTnXQN2yZUvPPN7LsOexlwEAAAAAgFNKraRbq2OdfvrpPtPi4uJMn9z29P79+5tq3tWqVTNB+q677jJhWRtRU5dccokJ1zfffLNMmDDBXL89atQo0zibXVJ9++23m5LzESNGSL9+/WTp0qUyd+5cWbBgQSm8agAAAACAm5R66+XF0W69tMi+V69epjVxbXX8ueee8zweEREh8+fPN62VaxjX0N6nTx8ZN26cZx7tLkwDtvb5PXnyZKlXr55Mnz7dLAsAAAAAANeE7uXLlxe4MF373NahKA0bNpQPP/yw2OV26dJFvv7666CtJwAAAAAA/ihToRsAAKDc01bLAQD4C6EbAAAgWLSLsORkticAwKNstr0OAAAAAEAIIHQDAAAAAOAQQjcAAECwpKdrC655g44DAFyPa7oBAACCJTdXZMWKY+MAANejpBsAAAAAAIcQugEAAAAAcAihGwAAAAAAhxC6AQAAAABwCKEbAAAAAACH0Ho5AABAMFWsyPYEAHgQugEAAIIlLk4kLY3tCQDwoHo5AAAAAAAOIXQDAAAAAOAQQjcAAECwZGSI9OiRN+g4AMD1uKYbAAAgWHJyRD788Ng4AMD1KOkGAAAAAMAhhG4AAAAAABxC6AYAAAAAwCGEbgAAAAAAHELoBgAAAADAIYRuAAAAAAAcQpdhAAAAwRIXJ2JZbE8AgAcl3QAAAAAAOITQDQAAAACAQwjdAAAAwZKRIXLddXmDjgMAXI/QDQAAECw5OSL/+1/eoOMAANcjdAMAAAAA4BBCNwAAAAAADiF0AwAAAADgEEI3AAAAAAAOIXQDAAAAAOAQQjcAAAAAAA6p4NSCAQAAXKdiRZHU1GPjAADXI3QDAAAES1iYSFwc2xMA4EH1cgAAAAAAHELoBgAACJajR0X69s0bdBwA4HqEbgAAgGDJzhZ59dW8QccBAK5H6AYAAAAAwCGEbgAAAAAAHELoBgAAAADAIYRuAAAAAAAcQugGAAAAAMAhhG4AAAAAABxSwakFAwAAuE7FiiJ79x4bBwC4HqEbAAAgWMLCRBIT2Z4AAA+qlwMAAAAA4BBCNwAAQLAcPSoyaFDeoOMAANcjdAMAAARLdrbIc8/lDToOAHC9gEP3ypUrJbuQLxGdpo8BAAAAAIAShu4LLrhA9u/fX2D6oUOHzGMAAAAAAKCEoduyLAnTljnz+fPPPyUuLi7QxQEAAAAAELL87jKsZ8+e5lYDd9++fSU6OtrzWE5Ojnz33Xfyt7/9zZm1BAAAAAAglEN35cqVPSXdlSpVktjYWM9jUVFRcs4558jAgQOdWUsAAAAAAEI5dM+YMcPcNmrUSO69916qkgMAAAAAEKzQbRs9enSgTwEAAHAHrQm4bduxcQCA6wXckNqePXvk5ptvljp16kiFChUkIiLCZwAAAHCt8HCtFpg36DgAwPUCLunWRtR27twpDz74oNSuXbvQlswBAAAAAEAJqpd/9tln8umnn0q7du3YfgAAAN4yM0X+85+88fHjtbVZtg8AuFzA9Z7q169vWjAHAABAPllZIv/9b96g4wAA1ws4dD/99NNy//33y/bt212/8QAAAAAACGrovuGGG2T58uXSpEkT0193tWrVfIZAPP/889KmTRtJSEgwQ6dOneSjjz7yPJ6RkSGDBg2S6tWrS3x8vPTq1cs05OZNry/v0aOHVKxYUWrWrCnDhw+X7Oxsn3l0fdu3by/R0dHStGlTmTlzZqAvGwAAAAAA56/p1pLuYKlXr548/vjjcuqpp5oq66+++qpcddVV8vXXX0urVq1k6NChsmDBApk3b55UrlxZBg8eLD179pRVq1aZ5+fk5JjAXatWLVm9erX88ccfcsstt0hkZKQ8+uijZp5t27aZeW6//XaZPXu2LFmyRAYMGGAagevWrVvQXgsAAAAAACccuvv06SPBcsUVV/jcHz9+vCn9/vzzz00gf/nll2XOnDly4YUXmsdnzJghLVq0MI+fc845smjRItm0aZN88sknkpSUZBp3e/jhh+W+++6TMWPGSFRUlEybNk0aN24sEydONMvQ52tjcJMmTSJ0AwAAAADKVvVyrc5d3FBSWmr95ptvSlpamqlmvn79esnKypKuXbt65mnevLk0aNBA1qxZY+7rbevWrU3gtmnpdUpKimzcuNEzj/cy7HnsZQAAAAAAUGZKuhs1alRs39wangOxYcMGE7L1+m29bvudd96Rli1byjfffGNKqqtUqeIzvwbs3bt3m3G99Q7c9uP2Y8XNo8E8PT1dYmNjC6zT0aNHzWDTeVVubq4Z4DzdznrJAdvbvTgG3I39D6ePAV22/p6x/wXKPCssrOA65uZ6SjTMdH43lBifA+7G/kduOcgD/q5bwKFbr7f2pqXROu2pp54y1cMD1axZMxOwDx06JP/73/9M9fUVK1ZIaXrsscdk7NixBaYnJyebkwM4OQewHhP6RgsPD7hCBkIAx4C7sf/h9DFw+PBhadqoqSTFJEmsFDwBfzzxMfES0SjCLGfv3r3HHsjNlQrLl5vR7MOHRdLSgrnarsLngLux/5FbDvKAfgc4Errbtm1bYFrHjh2lTp068uSTT5qGzgKhpdnaorjq0KGDrFu3TiZPnmxaSc/MzJSDBw/6lHZr6+XacJrS27Vr1/osz27d3Hue/C2e631tLb2wUm41cuRIGTZsmE9Jt/ZPnpiYaJ6Hk/Mm0xIE3eZl9U0GZ3EMuBv7H04fA6mpqbJl+xbJ6ZgjCRL4d3tKRops277N9OSivaf4+Os3CE4MnwPuxv5HbjnIAzExMc6E7uJKrDUwB2PjatVuDeDaCrm2Nq5dhanNmzeb68a1OrrSWy1d1zPM9hfe4sWLTTDWKur2PB9++KHP39B57GUURrsW0yE/3dlldYeHIn2Tsc3djWPA3dj/cPIYsKuG2/8CZZ71VxV1fhs4h88Bd2P/I6yM5wF/1yvg0G1f32zTLxztqktbC9euvwKhJcrdu3c3jaNp0by2VK59ai9cuNB0Eda/f39T4qz9f2uQvuuuu0xY1pbL1SWXXGLC9c033ywTJkww12+PGjXK9O1th2btKmzKlCkyYsQI6devnyxdulTmzp1ruiIDAAAIqsxMkb+6LZUHHtAqfWxgAHC5gEO3VvXO35CaBm+tfq2tjwdCS6i1X20N7Rqy27RpYwL3xRdfbB7Xbr307IGWdGvpt7Y6/txzz3meHxERIfPnz5c77rjDhPG4uDhzTfi4ceM882h3YRqwtc9vrbauXZFNnz6d7sIAAEDwZWWJ2O3CDB9O6AYABB66ly1b5nNfQ7HWs9frsitUCGxx2g/38erIT5061QxFadiwYYHq4/l16dKlQANwAAAAAACUudDduXNnZ9YEAAAAAIAQU6KG1LZu3SpPP/20/PDDD+a+Xld9zz33SJMmTYK9fgAAAAAAlFsBNwOn11xryNauuvQabB2++OILadWqlWkVHAAAAAAAlLCk+/777zeNkj3++OMFpt93332eRtAAAAAAAHC7gEu6tUq5duWVn3bHtWnTpmCtFwAAAAAA7gvd2lL5N998U2C6TqtZs2aw1gsAAKD8iYkRWbs2b9BxAIDrBVy9fODAgXLbbbfJL7/8In/729/MtFWrVskTTzwhw4YNc/0GBQAALhYRIXLmmaW9FgCA8hy6H3zwQalUqZJMnDhRRo4caabVqVNHxowZI3fffbcT6wgAAAAAgDtCd1hYmGlITYfDhw+baRrCAQAAXC8zU2Ty5LzNcM89IlFRrt8kAOB2fl/TnZ6eLu+//74naNthW4eUlBTz2NGjR51aTwAAgLIvK0tkxIi8QccBAK7nd+h+8cUXZfLkyYWWaickJMgzzzwj06dPd/0GBQAAAAAg4NA9e/ZsGTJkSJGP62Ovvvqqv4sDAAAAACDk+R26f/75Z2nbtm2Rj7dp08bMAwAAAAAAAgzd2dnZkpycXOTj+pjOAwAAAAAAAgzdrVq1kk8++aTIxxctWmTmAQAAAAAAAYbufv36ycMPPyzz588v8NgHH3wg48ePN/MAAAAAAIAA++m+7bbbZOXKlXLllVdK8+bNpVmzZmb6jz/+KD/99JNcf/31Zh4AAADXiokRWbbs2DgAwPX8Dt1q1qxZJnTPmTPHBG3Lskz4Hjt2rAndAAAArhYRIdKlS2mvBQCgvIZupeGagA0AAAAAgAOhGwAAAEXIyhJ58cW8cb3sLjKSTQUALkfoBgAACJbMTJHBg/PG+/YldAMA/G+9HAAAAAAABIbQDQAAAACAQwjdAAAAAACU5jXdPXv29HuBb7/99omsDwAAAAAA7grdlStXdn5NAAAAAABwY+ieMWOG82sCAAAAAECIocswAACAYImOFpk//9g4AMD1/ArdZ5xxhoSFhfm1sb766ivXb1QAAOBSFSqI9OhR2msBAChvofvqq692fk0AAAAAAHBj6B49erTzawIAAFDeZWWJzJ6dN37TTSKRkaW9RgCA8thP98GDB2X69OkycuRI2b9/v6da+e+//x7s9QMAACg/MjNFbr01b9BxAIDrBdyQ2nfffSddu3Y13Yht375dBg4cKNWqVTP9c+/cuVNee+01129UAAAAAABKVNI9bNgw6du3r/z8888SExPjmX7ZZZfJypUr2aoAAAAAAJQ0dK9bt07+9a9/FZhet25d2b17d6CLAwAAAAAgZAUcuqOjoyUlJaXA9J9++kkSExODtV4AAAAAALgvdF955ZUybtw4ydLWOUVM/916Lfd9990nvXr1cmIdAQAAAABwR0NqEydOlGuvvVZq1qwp6enp0rlzZ1OtvFOnTjJ+/Hhn1hIAAAAAUG4kJycXWkPaX5ZlSU5Ojsmdrgvd2mr54sWLZdWqVfLtt99KamqqtG/f3rRoDgAA4GrR0SJz5x4bBwCXBu7e/XrLgdQDJV6G1qhu26KtPDL6kXIfvAMO3bZzzz3XDAAAALB/WVUQue46NgcAV9MSbg3ciRckSnyN+BItI21fmqRtTzPLKu+h2+9rupcuXSotW7YstIrAoUOHpFWrVvLpp58Ge/0AAAAAAOWQBu6EWgklGkoa1st16H766adl4MCBkpCQUGiVc+1G7Kmnngr2+gEAAJQf2dki8+blDToOAHA9v0O3Xr996aWXFvn4JZdcIuvXr3f9BgUAAC529KjI9dfnDToOAHA9v0P3nj17JDIyssjHK1SoYC6YBwAAAAAAAYbuunXryvfff1/k4999953Url3b38UBAAAAABDy/A7dl112mTz44IOSkZFR4DHtr3v06NFy+eWXB3v9AAAAAAAI/S7DRo0aJW+//bacdtppMnjwYGnWrJmZ/uOPP8rUqVNNx+X/+c9/nFxXAAAAAABCM3QnJSXJ6tWr5Y477pCRI0eKZVmeTsu7detmgrfOAwAAAAAAAgzdqmHDhvLhhx/KgQMHZMuWLSZ4n3rqqVK1atVAFgMAAAAAgCsEFLptGrLPPPPM4K8NAABAeRYVJTJjxrFxAIDrlSh0AwAAoBDavWrfvmwaAEDgrZcDAAAAAIDAUNINAAAQLNnZIgsX5o136yZSgZ9aAOB2fBMAAAAEy9GjIpdfnjeemkroBgBQvRwAAAAAAKdwTTcAAAAAAA4hdAMAAAAA4BBCNwAAAAAADiF0AwAAAADgEEI3AAAAAAAOocswAACAYImKEpky5dg4AMD1CN0AAADBEhkpMmgQ2xMA4EH1cgAAAAAAQjF0P/bYY3LmmWdKpUqVpGbNmnL11VfL5s2bfebJyMiQQYMGSfXq1SU+Pl569eole/bs8Zln586d0qNHD6lYsaJZzvDhwyU7O9tnnuXLl0v79u0lOjpamjZtKjNnzjwprxEAkCc5OVm2bt3q1/DLL7/IH3/8YW7tafp8oMzLydEfHXmDjgMAXK9Uq5evWLHCBGoN3hqSH3jgAbnkkktk06ZNEhcXZ+YZOnSoLFiwQObNmyeVK1eWwYMHS8+ePWXVqlXm8ZycHBO4a9WqJatXrzY/0m655RaJjIyURx991Myzbds2M8/tt98us2fPliVLlsiAAQOkdu3a0q1bN9cfBADgNA3Mvfv1lgOpB/yaPywsTJo2aipbtm8Ry7LMtKrxVWXWK7MkMTHR4bUFTkBGhsgFF+SNp6aK/PV7BgDgXqUauj/++GOf+1r6rCXV69evl/PPP18OHTokL7/8ssyZM0cuvPBCM8+MGTOkRYsW8vnnn8s555wjixYtMiH9k08+kaSkJGnXrp08/PDDct9998mYMWMkKipKpk2bJo0bN5aJEyeaZejzP/vsM5k0aRKhGwBOgpSUFBO4Ey9IlPga8cedP0zCJCkmSXI65ogllqTuS5XkZclmOYRuAABQnpSphtQ0ZKtq1aqZWw3fWVlZ0rVrV888zZs3lwYNGsiaNWtM6Nbb1q1bm8Bt09LrO+64QzZu3ChnnHGGmcd7GfY8Q4YMKXQ9jh49agab/shTubm5ZoDzdDtr6Rbb2704BkKLvp+19LpSjUqSUCvBr9AdK7FSWSqb0K3394Xt43PBRZz+DLCPSftfoMyzwsIKrmNurufaPTOd3w0lxveAu7H/y7cT/Ywt9nO2DPF3vSqUpRXWEHzuuefK6aefbqbt3r3blFRXqVLFZ14N2PqYPY934LYftx8rbh4N0+np6RIbG1vgWvOxY8cWWj1SrzHHyTke9CSMvsnCw2nvz404BkLL4cOHTXVxLb3WMO3PF60Gbr3V0B0fEy8RjSLMcvbu3XtS1hmh/RkQ6DGZX1HHZNiRI5Lk9bvBSksL4lq7C98D7sb+L99O9DPW/pwNrxkuqampZfa7X19nuQrdem33999/b6p9l7aRI0fKsGHDPPc1nNevX99UaUxIOH4JDYLzQatntnSbE7rdiWMgtOgXpl6frdXFE8S/km4N2/tkn7lNyUiRbdu3eRreROhz+jMg0GMyvyKPSa+QbS6F4JruEuN7wN3Y/+XbiX7GqsMZhyVib4RpTLusfvfHxMSUn9CtjaPNnz9fVq5cKfXq1fNM18bRMjMz5eDBgz6l3dp6uT5mz7N27Vqf5dmtm3vPk7/Fc72vATp/KbfSFs51yE+/9AmAJ4/+2GKbuxvHQOiwq4fZ//x17BmWp6oan8Pu4eRnQEmPSVuRx6TXuJlOba0T3k/8FnAv9n/5daKfsao8fPf7u16luva6ETVwv/POO7J06VLT2Jm3Dh06mFbItbVxm3Yppl2EderUydzX2w0bNvhUOVi8eLEJ1C1btvTM470Mex57GQAAAAAAOKFCaVcp15bJ33vvPVM9y74GW7sG0xJove3fv7+p6q2Nq2mQvuuuu0xY1kbUlHYxpuH65ptvlgkTJphljBo1yizbLq3WrsKmTJkiI0aMkH79+pmAP3fuXNMVGQAAQNBERopMmHBsHADgeqUaup9//nlz26VLF5/p2i1Y3759zbh266XF9r169TItimur488995xn3oiICFM1XVsr1zCu/Xv36dNHxo0b55lHS9A1YGuf35MnTzZV2KdPn053YQAAILiiokSGD2erAgDKRujW6uX+XJw+depUMxSlYcOG8uGHHxa7HA32X3/9dYnWEwAAAACAkigTDakBAACEhJwcka++yhtv316r5JX2GgEAShmhGwAAIFgyMkTOOitvPDWVLsMAAKXbejkAAAAAAKGM0A0AAAAAgEMI3QAAAAAAOITQDQAAAACAQwjdAAAAAAA4hNANAAAAAIBD6DIMAAAgWCIjRUaPPjYOAHA9QjcAAECwREWJjBnD9gQAeFC9HAAAAAAAh1DSDQAAECy5uSI//JA33qKFSDjlGwDgdoRuAACAYElPFzn99Lzx1FSRuDi2LQC4HKdfAQAAAABwCKEbAAAAAACHELoBAAAAAHAIoRsAAAAAAIcQugEAAAAAcAihGwAAAAAAh9BlGAAAQLBERorce++xcRdITk6WlJSUEj8/ISFBEhMTg7pOAFCWELoBAACCJSpK5MknXbM9NXD37tdbDqQeKPEyqsZXlVmvzCJ4AwhZhG4AAACUiJZwa+BOvCBR4mvEB/z81H2pkrwsr6Sc0m4AoYrQDQAAECy5uSI7d+aNN2ggEu6O5nM0cCfUSijRc5MlOejrAwBlCaEbAAAgWNLTRRo3zhtPTRWJi2PbAoDLueP0KwAAAAAApYCSbgAAcFJbq1a0WA0AcAtCNwAAOKmtVStarAYAuAWhGwAAnLTWqhUtVgMA3ITQDQAATmpr1YoWqwEAbkFDagAAAAAAOISSbgAAgKD9sqogcuedx8YBAK7HtwEAAECwREeLTJ3K9gQAeFC9HAAAAAAAh1DSDQAAECyWJbJvX954jRoiYWFsWwBwOUI3AABAsBw5IlKzZt54aqpIXBzbFgBcjurlAAAAAAA4hNANAAAAAIBDCN0AAAAAADiE0A0AAAAAgEMI3QAAAAAAOITQDQAAAACAQ+gyDAAAIGi/rCqI9OlzbBwA4Hp8GwAAAARLdLTIzJlsTwCAB9XLAQAAAABwCCXdAAAAwWJZIkeO5I1XrCgSFsa2BQCXo6QbAAAgWDRwx8fnDXb4BgC4GqEbAAAAAACHELoBAAAAAHAIoRsAAAAAAIcQugEAAAAAcAihGwAAAAAAh9BlGADHJCcnS0pKSomea1mWHD58WMLDw6VmzZpBXzcAAADgZCB0A3AscPfu11sOpB4o0fPDwsKkaaOm8ue+P+X1l1+XxMTEoK8jAARdRITItdceGwcAuB6hG4AjtIRbA3fiBYkSXyM+4OeHSZgkZCbIlve3mGURugGUCzExIvPmlfZaAADKEEI3AEdp4E6olVCi0B17MNaRdQIAAABOFhpSAwAAAADAIYRuAACAYElL00Yp8gYdBwC4HqEbAAAAAACHELoBAAAAAHAIoRsAAAAAAIcQugEAAAAAcAihGwAAAAAAhxC6AQAAAAAIxdC9cuVKueKKK6ROnToSFhYm7777rs/jlmXJQw89JLVr15bY2Fjp2rWr/Pzzzz7z7N+/X2666SZJSEiQKlWqSP/+/SU1NdVnnu+++07+/ve/S0xMjNSvX18mTJhwUl4fAABwmYgIkcsuyxt0HADgeqUautPS0qRt27YyderUQh/XcPzMM8/ItGnT5IsvvpC4uDjp1q2bZGRkeObRwL1x40ZZvHixzJ8/3wT52267zfN4SkqKXHLJJdKwYUNZv369PPnkkzJmzBh58cUXT8prBAAALhITI7JgQd6g4wAA16tQmluge/fuZiiMlnI//fTTMmrUKLnqqqvMtNdee02SkpJMifg//vEP+eGHH+Tjjz+WdevWSceOHc08zz77rFx22WXy3//+15Sgz549WzIzM+WVV16RqKgoadWqlXzzzTfy1FNP+YRzAAAAAABCKnQXZ9u2bbJ7925TpdxWuXJlOfvss2XNmjUmdOutVim3A7fS+cPDw03J+DXXXGPmOf/8803gtmlp+RNPPCEHDhyQqlWrFvjbR48eNYN3abnKzc01A5yn21lPvLC9yy/df3rZiP0vUPZzdBkcC+47Hjz73+uWYyE03tv+7k+nvweC8RnFMensduS3gLux/8u3k/VdUdr8Xa8yG7o1cCst2fam9+3H9LZmzZo+j1eoUEGqVavmM0/jxo0LLMN+rLDQ/dhjj8nYsWMLTE9OTvap2g5nD+BDhw6ZN5meREH5c/jwYWnaqKkkxSRJrMSW6IM2NjJWmjRqYpa1d+9eR9YTZfN40P1fWSqbW0ssiY+Jl4hGERwLIfDeVv7sT6e/B070dRT1GsKOHJHE008348nffy9WxYoSypzajorfAu7G/i/fgvVdEV4z3LTXVVZ/B+rrLNehuzSNHDlShg0b5lPSrQ2wJSYmmgbbcHI+aPXMlm5zQnf5pB+QW7ZvkZyOOZIggb9vNGzFZcXJ1u1bpVKlSgVOsCG0jwc7bO+TfeY2JSNFtm3fxrEQAu9t5c/+dPp74ERfR5GvIS1NwtPTzaiuu8TFSShzbDvyW8D1+C1YvgXju+JwxmGJ2Bsh8fHxZfZ3oDbUXa5Dd61atcztnj17TOvlNr3frl07zzz5z3pkZ2ebFs3t5+utPsebfd+eJ7/o6Ggz5Kdf+gTAk0d/bLHNyy+7OpD970SrJ/Hec+fxcOwZFsdCCL23/d2fTn4PnOjrKPI1eI2b6SFeW8ux7ei1fH4LuBf7v/w6md8Vpcnf9Sqbay9iqoRrKF6yZIlPibNeq92pUydzX28PHjxoWiW3LV261JwZ02u/7Xm0RfOsrCzPPNrSebNmzQqtWg4AAAAAQLCEl3a1A21JXAe78TQd37lzpzmjMWTIEHnkkUfk/ffflw0bNsgtt9xiWiS/+uqrzfwtWrSQSy+9VAYOHChr166VVatWyeDBg00jazqf+uc//2kaUdP+u7VrsbfeeksmT57sU30cAAAAAAAnlGr18i+//FIuuOACz307CPfp00dmzpwpI0aMMH15a9deWqJ93nnnmS7CvOvOa5dgGrQvuugiU7zfq1cv07e3d4vnixYtkkGDBkmHDh2kRo0a8tBDD9FdGAAAAAAgtEN3ly5dTD39omhp97hx48xQFG2pfM6cOcX+nTZt2sinn356QusKAAAAAECgymxDagAAAOWONqrTufOxcQCA6xG6AQAAgiU2VmT5crYnAMCDU7AAAAAAADiE0A0AAAAAgEMI3QAAAMGSliaSmJg36DgAwPW4phsAACCY9u1je55kycnJkpKSUuLnJyQkSKKeKAEABxC6AQAAUK4Dd+9+veVA6oESL6NqfFWZ9cosgjcARxC6AQAAUG5pCbcG7sQLEiW+RnzAz0/dlyrJy/JKyintBuAEQjcAAADKPQ3cCbUSSvTcZEkO+voAgI2G1AAAAAAAcAihGwAAAAAAh1C9HAAAIFjCw0U6djw2DgBwPUI3AAAu6hpJ0T2Sg2JjRdatc/IvAADKGUI3AAAu6hpJ0T0SAAAnD6EbAACXdI2k6B4JAICTi9ANAICLukZSdI/koCNHRFq2zBvftEmkYkUn/xoAoBwgdAMAAASLZYns2HFsHADgejSrCQAAAACAQwjdAAAAAAA4hNANAAAAAIBDCN0AAAAAADiE0A0AAAAAgENovRwAACBYwsKOdRmm4wAA1yN0AwAABIv2y71xI9sTAOBB9XIAAAAAABxC6AYAAAAAwCGEbgAAgGA5ckSkVau8QccBAK7HNd0AAADBYlkimzYdGwcAuB4l3QAAAAAAOITQDQAAAACAQwjdAAAAAAA4hNANAAAAAIBDaEgtxCQnJ0tKSkqJn5+QkCCJiYlBXScAAIBQx28wAEUhdIfYh33vfr3lQOqBEi+janxVmfXKLII3AAAlERYm0rDhsXG4Ar/BABSH0B1CtIRbA3fiBYkSXyM+4Oen7kuV5GV5JeWUdgMAUAIVK4ps386mcxl+gwEoDqE7BGngTqiVUKLnJkty0NcHAADADfgNBqAwNKQGAAAAAIBDCN0AAADBkp4ucuaZeYOOAwBcj+rlAAAAwZKbK/Lll8fGAQCuR+gGAACAq2VlZsmOHTtK/Hx9blZWVlDXCUDoIHQDAADAtTIOZ8j2bdtl6KihEh0dXbJlpGfIb7t+k0ZZjYK+fgDKP0I3AAAAXCs7I1tywnKkxgU1pEbdGiVaxp6f9sj2edslOzs76OsHoPwjdAMAAMD1KlarWOIuV1OTU12//QAUjdANAAAAQJKTkyUlJeWEtkRCQoIkJiayNQFCNwAAgENqlKyKMlDagbt3v95yIPXACS2nanxVmfXKLII34IWSbgAAgGCJi9P0wvZEuaMl3Bq4Ey9IlPga8SVaRuq+VElelldaTmk3cAyhGwAAAIChgbuk17arZOGkE5BfeIEpAAAAAAAgKCjpBgAACJb0dJHu3fPGP/pIJDY2pBvO2rFjh2RlZQV1nQAg1BC6AQAAgiU3V2TFimPjId5wVkZ6hvy26zdplNUoqOsGAKGE0A0AAOBCwWg4a89Pe2T7vO2SnZ0d9PUDgFBB6AYAAHCxE2k4KzU5NejrAwChhobUAAAAAABwCKEbAAAAAACHELoBAAAAAHAI13QDIdqNS0JCgiQmJgZ1nQAAfqhY0e/NxGc9AIQ+QjcQot24VI2vKrNemUXwBoCTKS5OJC3Nr1n5rAeKLnSwLEsOHz4sqampEhYWFtCmouABZQ2hGwjBblxS96VK8rK8Ly1KuwGgbOKzHij6RJQG7aaNmsqW7VtMAA8EBQ8oawjdQIh245IsyUFfHwBA8PFZDxQ8EVWpRiVJikmSnI45YonluoIHLj0JLYRuAACAYMnIEOnVK2/8//5PJCaGbQuU8ERUrMRKgiQEFLpDoeCBS09CD6EbAAAgWHJyRD788Ng4AASIS09CD6EbAAAAAMoYLj0JHa7qp3vq1KnSqFEjiYmJkbPPPlvWrl1b2qsEAAAAAAhhrinpfuutt2TYsGEybdo0E7iffvpp6datm2zevFlq1qxZ2qsHAICrZGVmyY4dO4p8/HjdBdElEACgvHBN6H7qqadk4MCBcuutt5r7Gr4XLFggr7zyitx///2lvXoAALhGxuEM2b5tuwwdNVSio6MLned43QXRJRDcdiLKH5yMAsomV4TuzMxMWb9+vYwcOdIzLTw8XLp27Spr1qwp1XUDAMBtsjOyJScsR2pcUENq1K1R6DxhElZkd0Gh0iUQig+bx6vtYNPnZmVlhfyJKH9wMgoom1wRuvft2yc5OTmSlJTkM13v//jjjwXmP3r0qBlshw4dMrcHDx6U3NxcKav0x0duTq4c/O2gZKdnB/z81D9TJTMjUzZu3GiWVdr0i/aPP/4QN/r1118l82hmud6XJ/oa9Ad3blZuqb8OlM7xoPs/MiZS9mfsN4GrLBzTZcGJvq/UiW7LYKxDyp4Us49zjuYUuQx9/Kh11AT0/KFbp53o8eDU52xYerqc8tf4L99+K1Zs7Elfh9LYl4f/OCxREhXw8/f/ul92bNshQ0YOkajofM8PE2nSoIls3blViusx6mj6Ufl9z+9SbUe1Er2OE30NwVjG/h37JTcsV6JbRkvl6pVLtA4ZKRmy55s9pkCpfv365f7zJSc9x+d74GStQ1lQ2p8NwRCM4yntzzSpnFXZZALNYWWRvX0Lq5HlLcw63hwhYNeuXVK3bl1ZvXq1dOrUyTN9xIgRsmLFCvniiy985h8zZoyMHTu2FNYUAAAAAFCe6EmGevXqubuku0aNGhIRESF79uzxma73a9WqVWB+rYauja7ZtHR7//79Ur169WKrNyG4Z430LK0ewHp9EtyHY8Dd2P/gGADHgLux/5FSDvKAfRlMnTp1ip3PFaE7KipKOnToIEuWLJGrr77aE6T1/uDBgwvMr9fS5L+epkqVKidtfXGMvsHK6psMJwfHgLux/8ExAI4Bd2P/I6GM54HKlY9/SYgrQrfSkus+ffpIx44d5ayzzjJdhqWlpXlaMwcAAAAAINhcE7pvuOEGSU5Oloceekh2794t7dq1k48//rhA42oAAAAAAASLa0K30qrkhVUnR9mj1ftHjx59Qt1moHzjGHA39j84BsAx4G7sf0SHUB5wRevlAAAAAACUhvBS+asAAAAAALgAoRsAAAAAAIcQugEAAAAAcAihG2XG448/LmFhYTJkyBDPtIyMDBk0aJBUr15d4uPjpVevXrJnz55SXU8Ez5gxY8w+9x6aN2/ueZz9H/p+//136d27t3mPx8bGSuvWreXLL7/0PK7NjmivE7Vr1zaPd+3aVX7++edSXWcET6NGjQp8Buign/uKz4DQl5OTIw8++KA0btzYvMebNGkiDz/8sHnv2/gcCG2HDx82v/0aNmxojoG//e1vsm7dOs/j7P/QsnLlSrniiiukTp065vP+3Xff9Xncn/29f/9+uemmm0zf3VWqVJH+/ftLamqqlGWEbpQJ+uH6wgsvSJs2bXymDx06VD744AOZN2+erFixQnbt2iU9e/YstfVE8LVq1Ur++OMPz/DZZ595HmP/h7YDBw7IueeeK5GRkfLRRx/Jpk2bZOLEiVK1alXPPBMmTJBnnnlGpk2bJl988YXExcVJt27dTBhDaHz2e7//Fy9ebKZfd9115pbPgND3xBNPyPPPPy9TpkyRH374wdzX9/2zzz7rmYfPgdA2YMAA895//fXXZcOGDXLJJZeYoKUnZRX7P7SkpaVJ27ZtZerUqYU+7s/+1sC9ceNGc9zMnz/fBPnbbrtNyjRtvRwoTYcPH7ZOPfVUa/HixVbnzp2te+65x0w/ePCgFRkZac2bN88z7w8//KCnvq01a9aU4hojWEaPHm21bdu20MfY/6Hvvvvus84777wiH8/NzbVq1aplPfnkkz7HRXR0tPXGG2+cpLXEyaSf/02aNDH7ns8Ad+jRo4fVr18/n2k9e/a0brrpJjPO50BoO3LkiBUREWHNnz/fZ3r79u2t//znP+z/ECci1jvvvOO578/7fdOmTeZ569at88zz0UcfWWFhYdbvv/9ulVWUdKPUaTXCHj16mLOa3tavXy9ZWVk+07XqcYMGDWTNmjWlsKZwglYZ0ipGp5xyijlzuXPnTjOd/R/63n//fenYsaMp1axZs6acccYZ8tJLL3ke37Ztm+zevdvnM6By5cpy9tln8xkQgjIzM2XWrFnSr18/U+WQzwB30KrES5YskZ9++snc//bbb02Np+7du5v7fA6EtuzsbHOJQUxMjM90rVasxwH73122+fG9r7dapVx/P9h0/vDwcFMyXlZVKO0VgLu9+eab8tVXX/lcu2PTN11UVJR5Y3lLSkoyj6H80w/RmTNnSrNmzUzV0rFjx8rf//53+f7779n/LvDLL7+YaqXDhg2TBx54wHwO3H333eZ936dPH8/7XN/z3vgMCE16Xd/Bgwelb9++5j7fAe5w//33S0pKijmpHhERYQLY+PHjzUlYxedAaKtUqZJ06tTJXMffokUL8/n+xhtvmGDVtGlT9r/L7Pbje19v9US9twoVKki1atXKdD4gdKPU/Prrr3LPPfeY6zHyn+GEO9glGUqv59cQrg2pzJ0715zlRmjLzc01Z6offfRRc19LuvWEi17HpaEb7vLyyy+bzwSt+QL30M/72bNny5w5c0wbH998841pVEuPAz4H3EGv5dYaLnXr1jUnXtq3by833nijqe0ChAqql6PU6Ifp3r17zYernqHSQRtL08YTdFzPaml1Qy358Katl9eqVavU1hvO0VoNp512mmzZssXsY/Z/aNOWSVu2bOkzTUs67EsM7Pd5/h4L+AwIPTt27JBPPvnENKhk4zPAHYYPH25Ku//xj3+Y3gtuvvlm04DeY489Zh7ncyD0aYv1+vtPW5/WApm1a9eaywv1sjP2v7vU8uN7X281P+S/TEFbNC/L+YDQjVJz0UUXmVYq9ay2PWipl1Yps8e1VWO91su2efNm84NcqyIh9OgX7tatW00Y69ChA/s/xGnL5fqe9qbXdWptB6VdCOkXqPdngFZD1Wu2+AwILTNmzDDVBbV9DxufAe5w5MgRcy2mNy3t1Jowis8B99BWqvX7X3u2WLhwoVx11VXsf5dp7Mf3vt5qgZx3TYilS5eazwytMVlmlXZLboA379bL1e233241aNDAWrp0qfXll19anTp1MgNCw7///W9r+fLl1rZt26xVq1ZZXbt2tWrUqGHt3bvXPM7+D21r1661KlSoYI0fP976+eefrdmzZ1sVK1a0Zs2a5Znn8ccft6pUqWK999571nfffWddddVVVuPGja309PRSXXcET05Ojvmc19bs8+MzIPT16dPHqlu3rmm9Wr8L3n77bfM9MGLECM88fA6Eto8//ti0Pv3LL79YixYtMr2anH322VZmZqZ5nP0fer0Wff3112bQKPrUU0+Z8R07dvi9vy+99FLrjDPOsL744gvrs88+M70g3XjjjVZZRuhGmQ7d+ga78847rapVq5of49dcc431xx9/lOo6InhuuOEGq3bt2lZUVJT50aX3t2zZ4nmc/R/6PvjgA+v000833YE0b97cevHFF30e1+5DHnzwQSspKcnMc9FFF1mbN28utfVF8C1cuND88Cpsv/IZEPpSUlLM976eeImJibFOOeUU01XU0aNHPfPwORDa3nrrLbPf9beAdhc1aNAg002Ujf0fWpYtW2Y+8/MPegLO3/39559/mpAdHx9vJSQkWLfeeqsJ82VZmP5X2qXtAAAAAACEIq7pBgAAAADAIYRuAAAAAAAcQugGAAAAAMAhhG4AAAAAABxC6AYAAAAAwCGEbgAAAAAAHELoBgAAAADAIYRuAAAAAAAcQugGAAAhbfv27RIWFibffPNNaa8KAMCFCN0AAAQgOTlZ7rjjDmnQoIFER0dLrVq1pFu3brJq1Sqf+b7++mu57rrrJCkpSWJiYuTUU0+VgQMHyk8//eSZ55133pFzzjlHKleuLJUqVZJWrVrJkCFDjrsOy5Ytk8suu0yqV68uFStWlJYtW8q///1v+f3338vkvuzbt68JvY8//rjP9HfffddMBwAglBG6AQAIQK9evUygfvXVV02Afv/996VLly7y559/euaZP3++CdNHjx6V2bNnyw8//CCzZs0y4frBBx808yxZskRuuOEGs7y1a9fK+vXrZfz48ZKVlVXs33/hhReka9euJuz/3//9n2zatEmmTZsmhw4dkokTJ5Z4X2ZmZoqT9MTDE088IQcOHJBQ4fQ2AwCECAsAAPjlwIEDln51Ll++vMh50tLSrBo1alhXX311kctQ99xzj9WlS5eAtvyvv/5qRUVFWUOGDCl22aNHj7batm3r89ikSZOshg0beu736dPHuuqqq6xHHnnEql27ttWoUSNr5MiR1llnnVVguW3atLHGjh3ruf/SSy9ZzZs3t6Kjo61mzZpZU6dOLXa99W9dfvnl5jnDhw/3TH/nnXfM9rQFst7jx4+3atasaVWuXNmsW1ZWlnXvvfdaVatWterWrWu98sornuds27bN/J033njD6tSpk1nvVq1aFdiPGzZssC699FIrLi7OLLt3795WcnKy5/HOnTtbgwYNMvuuevXqAe8/AIA7UdINAICf4uPjzaDVorUUuzALFy6Uffv2yYgRIwp9vEqVKuZWS6o3btwo33//vd/bf968eaZ09XjL9peWtm/evFkWL15sSudvuukmU+q+detWzzy6jt99953885//NPe15P6hhx4ypfJagv/oo4+a0nst+S9ORESEmffZZ5+V3377TU7E0qVLZdeuXbJy5Up56qmnZPTo0XL55ZdL1apV5YsvvpDbb79d/vWvfxX4O8OHDzfV8LWmQqdOneSKK67w1FA4ePCgXHjhhXLGGWfIl19+KR9//LHs2bNHrr/+ep9l6OuMiooylxNoDQMAAI6H0A0AgJ8qVKggM2fONMFLA+65554rDzzwgAmltp9//tncNm/evNhl3XXXXXLmmWdK69atpVGjRvKPf/xDXnnllSLDvL3shIQEqV27dlD2WVxcnEyfPt1cS24Pbdu2lTlz5njm0ZB99tlnS9OmTc19Dbhajb1nz57SuHFjczt06FBT7f14rrnmGmnXrp1ZxomoVq2aPPPMM9KsWTPp16+fuT1y5IjZF3rt/MiRI00w/uyzz3yeN3jwYFOdv0WLFvL888+b6v4vv/yyeWzKlCkmcOuJAd13Oq77Q6+f974OX5c/YcIE8zd1AADgeAjdAAAEQEOblrLqtdyXXnqpLF++XNq3b2/CuLIsrcnsX+BdsGCBbNmyRUaNGmVK0LUU9qyzzjIBsjC67GA2PKaBX8OpNy3ttkO3/r033njDTFNpaWmmFLx///6eUn8dHnnkEZ/S8eLodd160kJLyUtKTw6Ehx/7CaON1elr8S5V10bm9u7d6/M8Ld32PoHSsWNHz3p8++23JmB7vy77xIn3a+vQoUOJ1xsA4E6EbgAAStAo2MUXX2yqVa9evdq0zm2X3p522mnm9scff/RrWU2aNJEBAwaYEuevvvrKNIz21ltvFTqvLlsbTPvjjz+KXaYG0vzhv7AG2jT453fjjTeaKue6Lvrafv31V9Pgm0pNTTW3L730kul+yx60ivznn3/u1+s9//zzTWvvWhpd0vWOjIz0ua8nIgqblpubK/7S16bVzb1flw5au0DXubhtBgBAcQjdAACcIO2yS0uB1SWXXCI1atQwVZALo9cOF0WrmWsXYPay8rv22mtNyfTxlp2YmCi7d+/2CbD+9lFdr1496dy5s6lWroOeXKhZs6anRLlOnTryyy+/mOrm3oNWNfeXdh32wQcfyJo1a3ymn8h6+8P7xEB2drZpMV6rmiutraDXr+s+yP/aCNoAgBNR4YSeDQCAi2ijW9r3tl5H3KZNG9O3tja6pSH4qquu8rlOWue78sor5e677zbBTRtXmzt3ruzcuVPefPNNGTNmjKlGrv1tN2zY0ARmvU5ZS3Y16Bamfv36MmnSJHNtckpKitxyyy0mJGqDYa+99pqpEq3XW2sXZtqfuK6XBnVtFOyjjz4y14P7Q6uTa8m9Ntqmf8/b2LFjzWvS66G1er1eg67bQLsCGzZsmF/L16rg+jf09Xo70fU+nqlTp5prsjVo6+vSddZ9qQYNGmRK8LWkXxuq0+vGteq/7ivdn1plHQCAkqCkGwAAP2mo1UbFNLBplePTTz/dVDEfOHCgaYjLpgFcq2ZrlWdt9VuvDdYwp1XD9fpnpaXJWmKswVkf7969uynlXbRoUbENdN15551mnt9//900TKbP1erpGkzvvfdeM4+Gyueee86ETG0YTVsktx/zhwZePcGgJwWuvvpqn8fsqvAzZsww4Vlfh17PHkhJtxo3blyB6t8nut7+lLDroMvWRtb0unytlaC0BF9bJM/JyTG1FfS1DRkyxDSY5339OAAAgQrTfsMCfhYAAAAAADguTt0CAAAAAOAQQjcAAAAAAA4hdAMAAAAA4BBCNwAAAAAADiF0AwAAAADgEEI3AAAAAAAOIXQDAAAAAOAQQjcAAAAAAA4hdAMAAAAA4BBCNwAAAAAADiF0AwAAAADgEEI3AAAAAADijP8HXd0x4fbt2/kAAAAASUVORK5CYII=",
+      "text/plain": [
+       "<Figure size 1000x500 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "cn = HdfInfiltration.get_preprocessed_infiltration(geom_hdf, variable='Curve Number')\n",
+    "assert len(cn) > 0, 'Expected preprocessed Curve Number values.'\n",
+    "fig, ax = plt.subplots(figsize=(10, 5))\n",
+    "ax.hist(\n",
+    "    cn['value'],\n",
+    "    bins=50,\n",
+    "    edgecolor='black',\n",
+    "    alpha=0.7,\n",
+    "    color='forestgreen',\n",
+    ")\n",
+    "ax.set_xlabel('SCS Curve Number')\n",
+    "ax.set_ylabel('Cell Count')\n",
+    "ax.set_title('Distribution of Curve Number Values')\n",
+    "ax.axvline(\n",
+    "    cn['value'].mean(),\n",
+    "    color='red',\n",
+    "    linestyle='--',\n",
+    "    label=f\"Mean={cn['value'].mean():.1f}\",\n",
+    ")\n",
+    "ax.legend()\n",
+    "ax.grid(True, alpha=0.3)\n",
+    "plt.tight_layout()\n",
+    "plt.show()\n",
+    "plt.close(fig)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7fdea9fc",
+   "metadata": {},
+   "source": [
+    "## Infiltration Region Polygon Regression\n",
+    "\n",
+    "The bundled example project exposes preprocessed infiltration cell values, but it does not contain geometry-level infiltration override polygons. This regression cell builds a minimal geometry HDF fixture with one exterior ring and one interior ring so the notebook exercises `HdfInfiltration.get_infiltration_region_polygons()` on the multi-ring path."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "0e90d0a0",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-03-27T17:19:40.438904Z",
+     "iopub.status.busy": "2026-03-27T17:19:40.438904Z",
+     "iopub.status.idle": "2026-03-27T17:19:40.461548Z",
+     "shell.execute_reply": "2026-03-27T17:19:40.460685Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Regression fixture: 211_infiltration_multipart_fixture.g01.hdf\n",
+      "Geometry type: Polygon\n",
+      "Interior rings: 1\n",
+      "Area: 12.00\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>region_id</th>\n",
+       "      <th>Name</th>\n",
+       "      <th>geometry</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>0</td>\n",
+       "      <td>MultiRingRegion</td>\n",
+       "      <td>POLYGON ((0 0, 4 0, 4 4, 0 4, 0 0), (1 1, 1 3,...</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   region_id             Name  \\\n",
+       "0          0  MultiRingRegion   \n",
+       "\n",
+       "                                            geometry  \n",
+       "0  POLYGON ((0 0, 4 0, 4 4, 0 4, 0 0), (1 1, 1 3,...  "
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "fixture_dir = repo_root / 'working' / 'notebook_runs'\n",
+    "fixture_dir.mkdir(parents=True, exist_ok=True)\n",
+    "fixture_hdf = fixture_dir / '211_infiltration_multipart_fixture.g01.hdf'\n",
+    "\n",
+    "outer_ring = np.array(\n",
+    "    [\n",
+    "        [0.0, 0.0],\n",
+    "        [4.0, 0.0],\n",
+    "        [4.0, 4.0],\n",
+    "        [0.0, 4.0],\n",
+    "        [0.0, 0.0],\n",
+    "    ],\n",
+    "    dtype=float,\n",
+    ")\n",
+    "inner_ring = np.array(\n",
+    "    [\n",
+    "        [1.0, 1.0],\n",
+    "        [1.0, 3.0],\n",
+    "        [3.0, 3.0],\n",
+    "        [3.0, 1.0],\n",
+    "        [1.0, 1.0],\n",
+    "    ],\n",
+    "    dtype=float,\n",
+    ")\n",
+    "polygon_points = np.vstack([outer_ring, inner_ring])\n",
+    "polygon_parts = np.array(\n",
+    "    [\n",
+    "        [0, len(outer_ring)],\n",
+    "        [len(outer_ring), len(inner_ring)],\n",
+    "    ],\n",
+    "    dtype=np.int32,\n",
+    ")\n",
+    "polygon_info = np.array(\n",
+    "    [[0, len(polygon_points), 0, len(polygon_parts)]],\n",
+    "    dtype=np.int32,\n",
+    ")\n",
+    "attributes = np.array(\n",
+    "    [(b'MultiRingRegion',)],\n",
+    "    dtype=np.dtype([('Name', 'S32')]),\n",
+    ")\n",
+    "\n",
+    "with h5py.File(fixture_hdf, 'w') as hdf_file:\n",
+    "    geometry = hdf_file.create_group('Geometry')\n",
+    "    infiltration = geometry.create_group('Infiltration')\n",
+    "    infiltration.create_dataset('Attributes', data=attributes)\n",
+    "    infiltration.create_dataset('Polygon Info', data=polygon_info)\n",
+    "    infiltration.create_dataset('Polygon Parts', data=polygon_parts)\n",
+    "    infiltration.create_dataset('Polygon Points', data=polygon_points)\n",
+    "\n",
+    "regions_gdf = HdfInfiltration.get_infiltration_region_polygons(fixture_hdf)\n",
+    "assert len(regions_gdf) == 1, 'Expected one infiltration region from regression fixture.'\n",
+    "fixture_geom = regions_gdf.geometry.iloc[0]\n",
+    "assert fixture_geom.geom_type == 'Polygon'\n",
+    "assert len(fixture_geom.interiors) == 1, 'Expected one interior ring.'\n",
+    "assert np.isclose(fixture_geom.area, 12.0), f'Unexpected polygon area: {fixture_geom.area}'\n",
+    "print(f'Regression fixture: {fixture_hdf.name}')\n",
+    "print(f'Geometry type: {fixture_geom.geom_type}')\n",
+    "print(f'Interior rings: {len(fixture_geom.interiors)}')\n",
+    "print(f'Area: {fixture_geom.area:.2f}')\n",
+    "regions_gdf[['region_id', 'Name', 'geometry']]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f22ea9fb",
+   "metadata": {},
+   "source": [
+    "## Key Takeaways\n",
+    "\n",
+    "- `BaldEagleCrkMulti2D` provides a reproducible real-project source for preprocessed Manning's N and infiltration values.\n",
+    "- The notebook now includes an executable regression for multi-ring infiltration override polygons.\n",
+    "- Running this notebook end to end validates both the example workflow and the polygon-construction fix."
+   ]
+  }
+ ],
  "metadata": {
   "kernelspec": {
    "display_name": "Python 3",
@@ -8,91 +629,18 @@
    "name": "python3"
   },
   "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
    "name": "python",
-   "version": "3.12.0"
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.13"
   }
  },
- "cells": [
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": "# Final Manning's N and Infiltration Analysis\n\nThis notebook demonstrates how to extract and analyze the **final resolved** Manning's N and infiltration parameters from HEC-RAS geometry HDF files.\n\n## What You'll Learn\n- Read preprocessed per-cell Manning's N and infiltration values\n- Analyze the Manning's N calibration table (base + region overrides)\n- Compare base vs calibrated Manning's N values\n- Compute statistics on final parameter layers"
-  },
-  {
-   "cell_type": "code",
-   "metadata": {},
-   "source": "# Setup\nfrom pathlib import Path\nimport numpy as np\nimport pandas as pd\nimport matplotlib.pyplot as plt\nfrom ras_commander.hdf.HdfLandCover import HdfLandCover\nfrom ras_commander.hdf.HdfInfiltration import HdfInfiltration\nprint(\"Imports successful\")",
-   "outputs": [],
-   "execution_count": null
-  },
-  {
-   "cell_type": "code",
-   "metadata": {},
-   "source": "# Set geometry HDF path\ngeom_hdf = Path(r\"G:\\BayouConway_A14_03202026\\BayouConway_Update_250731.g17.hdf\")\nassert geom_hdf.exists()\nprint(f\"Geometry: {geom_hdf.name}\")",
-   "outputs": [],
-   "execution_count": null
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": "## Preprocessed Per-Cell Manning's N\nThe exact per-cell values HEC-RAS uses in computation."
-  },
-  {
-   "cell_type": "code",
-   "metadata": {},
-   "source": "mann_df = HdfLandCover.get_preprocessed_mannings_n(geom_hdf)\nprint(f\"Cells: {len(mann_df):,}\")\nprint(f\"N range: {mann_df[\"mannings_n\"].min():.4f} to {mann_df[\"mannings_n\"].max():.4f}\")\nprint(f\"Mean: {mann_df[\"mannings_n\"].mean():.4f}\")\nstats = HdfLandCover.get_preprocessed_mannings_stats(geom_hdf)\nstats",
-   "outputs": [],
-   "execution_count": null
-  },
-  {
-   "cell_type": "code",
-   "metadata": {},
-   "source": "fig, ax = plt.subplots(figsize=(10, 5))\nax.hist(mann_df[\"mannings_n\"], bins=50, edgecolor=\"black\", alpha=0.7, color=\"steelblue\")\nax.set_xlabel(\"Manning's N\")\nax.set_ylabel(\"Cell Count\")\nax.set_title(\"Distribution of Manning's N Values\")\nax.axvline(mann_df[\"mannings_n\"].mean(), color=\"red\", linestyle=\"--\", label=f\"Mean={mann_df[\"mannings_n\"].mean():.4f}\")\nax.legend()\nax.grid(True, alpha=0.3)\nplt.tight_layout()\nplt.show()",
-   "outputs": [],
-   "execution_count": null
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": "## Calibration Table and Base vs Calibrated Comparison"
-  },
-  {
-   "cell_type": "code",
-   "metadata": {},
-   "source": "cal = HdfLandCover.get_mannings_calibration_table(geom_hdf)\nprint(f\"Land cover classes: {len(cal)}, Calibration regions: {len(cal.columns) - 2}\")\nprint()\nprint(\"Base values:\")\nprint(cal.iloc[:, :2].to_string(index=False))",
-   "outputs": [],
-   "execution_count": null
-  },
-  {
-   "cell_type": "code",
-   "metadata": {},
-   "source": "comp = HdfLandCover.compare_base_vs_calibrated(geom_hdf)\nif comp is not None and len(comp) > 0:\n    print(f\"Override entries: {len(comp)}, Classes: {comp[\"land_cover_class\"].nunique()}, Regions: {comp[\"region_name\"].nunique()}\")\n    print()\n    print(\"Largest N increases:\")\n    print(comp[comp[\"delta_n\"] > 0].nlargest(5, \"delta_n\")[[\"land_cover_class\", \"region_name\", \"base_n\", \"calibrated_n\", \"delta_n\"]].to_string(index=False))",
-   "outputs": [],
-   "execution_count": null
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": "## Preprocessed Infiltration Parameters"
-  },
-  {
-   "cell_type": "code",
-   "metadata": {},
-   "source": "for var in [\"Curve Number\", \"Abstraction Ratio\", \"Minimum Infiltration Rate\"]:\n    df = HdfInfiltration.get_preprocessed_infiltration(geom_hdf, variable=var)\n    if len(df) > 0:\n        print(f\"{var}: {len(df):,} cells, range {df[\"value\"].min():.3f}-{df[\"value\"].max():.3f}, mean {df[\"value\"].mean():.3f}\")\n    else:\n        print(f\"{var}: No data\")",
-   "outputs": [],
-   "execution_count": null
-  },
-  {
-   "cell_type": "code",
-   "metadata": {},
-   "source": "cn = HdfInfiltration.get_preprocessed_infiltration(geom_hdf, variable=\"Curve Number\")\nif len(cn) > 0:\n    fig, ax = plt.subplots(figsize=(10, 5))\n    ax.hist(cn[\"value\"], bins=50, edgecolor=\"black\", alpha=0.7, color=\"forestgreen\")\n    ax.set_xlabel(\"SCS Curve Number\")\n    ax.set_ylabel(\"Cell Count\")\n    ax.set_title(\"Distribution of Curve Number Values\")\n    ax.axvline(cn[\"value\"].mean(), color=\"red\", linestyle=\"--\", label=f\"Mean={cn[\"value\"].mean():.1f}\")\n    ax.legend()\n    ax.grid(True, alpha=0.3)\n    plt.tight_layout()\n    plt.show()",
-   "outputs": [],
-   "execution_count": null
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": "## Key Takeaways\n\n-  reads the exact per-cell N values from geometry HDF\n-  reads per-cell infiltration parameters\n-  shows the full base + override matrix\n-  highlights calibration changes\n- For raster export:  produces a GeoTIFF"
-  }
- ]
+ "nbformat": 4,
+ "nbformat_minor": 4
 }

--- a/ras_commander/hdf/HdfInfiltration.py
+++ b/ras_commander/hdf/HdfInfiltration.py
@@ -372,7 +372,7 @@ class HdfInfiltration:
         >>> print(gdf[['Name', 'geometry']].head())
         """
         import geopandas as gpd
-        from shapely.geometry import Polygon, MultiPolygon
+        from shapely.geometry import Polygon
 
         try:
             with h5py.File(hdf_path, 'r') as hdf_file:
@@ -390,21 +390,38 @@ class HdfInfiltration:
                 region_ids = range(infil_data["Attributes"][()].shape[0])
                 names = np.vectorize(HdfUtils.convert_ras_string)(infil_data["Attributes"][()]["Name"])
 
-                geoms = list()
+                geoms = []
                 for pnt_start, pnt_cnt, part_start, part_cnt in infil_data["Polygon Info"][()]:
-                    points = infil_data["Polygon Points"][()][pnt_start : pnt_start + pnt_cnt]
-                    if part_cnt == 1:
+                    points = infil_data["Polygon Points"][()][
+                        pnt_start : pnt_start + pnt_cnt
+                    ]
+
+                    if part_cnt <= 1:
                         geoms.append(Polygon(points))
-                    else:
-                        parts = infil_data["Polygon Parts"][()][part_start : part_start + part_cnt]
-                        geoms.append(
-                            MultiPolygon(
-                                list(
-                                    points[part_pnt_start : part_pnt_start + part_pnt_cnt]
-                                    for part_pnt_start, part_pnt_cnt in parts
-                                )
-                            )
+                        continue
+
+                    if "Polygon Parts" not in infil_data:
+                        logger.warning(
+                            "Multi-part infiltration polygon but "
+                            "'Polygon Parts' dataset missing"
                         )
+                        geoms.append(Polygon(points))
+                        continue
+
+                    parts = infil_data["Polygon Parts"][()][
+                        part_start : part_start + part_cnt
+                    ]
+                    rings = [
+                        points[part_pnt_start : part_pnt_start + part_pnt_cnt]
+                        for part_pnt_start, part_pnt_cnt in parts
+                    ]
+
+                    if len(rings) == 1:
+                        geoms.append(Polygon(rings[0]))
+                    else:
+                        # HEC-RAS stores polygon parts as rings:
+                        # first ring exterior, remaining rings interiors.
+                        geoms.append(Polygon(rings[0], rings[1:]))
 
                 return gpd.GeoDataFrame(
                     {"region_id": region_ids, "Name": names, "geometry": geoms},


### PR DESCRIPTION
## Summary
- fix `HdfInfiltration.get_infiltration_region_polygons()` so multi-part infiltration regions are built from polygon rings instead of raw coordinate arrays
- update `examples/211_final_mannings_and_infiltration.ipynb` to use a reproducible example project and add an executable regression cell for the multi-ring infiltration path
- keep the notebook executable from a clean `main`-based checkout without relying on the package `__init__` import path

## Motivation
- the `2026-03-24` QAQC pass flagged this as a `P1` defect: real multi-part infiltration regions could fail to load because Shapely was being given raw NumPy coordinate arrays
- the contribution guidelines call for testing with example notebooks, so the notebook now exercises the regression path directly

## Linked Review Context
- `feature_dev_notes/QAQC_2026-03-24/04_linux_terrain/review.md`
- `feature_dev_notes/QAQC_2026-03-24/consolidated_findings.md`

## Reproduction Steps
1. Open `examples/211_final_mannings_and_infiltration.ipynb`.
2. Run the notebook in the repo `.venv`.
3. Let the notebook extract `BaldEagleCrkMulti2D` via `RasExamples.extract_project()`.
4. Observe the regression cell that writes `working/notebook_runs/211_infiltration_multipart_fixture.g01.hdf`.
5. Confirm the returned geometry is one polygon with one interior ring and area `12.0`.

## Before / After
- Before: multi-part infiltration regions were assembled by passing raw point-array slices into `MultiPolygon(...)`, which failed on the multi-ring path.
- After: polygon parts are interpreted as rings, producing a valid Shapely polygon, and the notebook now captures that path as a saved regression.

## Testing
- executed `examples/211_final_mannings_and_infiltration.ipynb`
- real-project notebook path uses `RasExamples.extract_project("BaldEagleCrkMulti2D")`
- regression cell validates a multi-ring infiltration override fixture
