### PR TITLE
ebfe: use forward slashes in DSS path docs

### DIFF
--- a/ras_commander/sources/federal/ebfe_models.py
+++ b/ras_commander/sources/federal/ebfe_models.py
@@ -1594,8 +1594,8 @@ Generated: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}
         This finds where DSS files actually exist and corrects all references.
 
         Handles:
-        - Absolute paths: C:\\eBFE\\... → relative path to actual file
-        - Wrong relative paths: DSS\Input\file.dss → file.dss (if file is in same folder)
+        - Absolute paths: C:/eBFE/... → relative path to actual file
+        - Wrong relative paths: DSS/Input/file.dss → file.dss (if file is in same folder)
 
         Args:
             ras_model_folder: Path to RAS Model/ folder
@@ -2150,7 +2150,7 @@ print(ras.plan_df)
 - WA3 has breakline shapefiles for mesh refinement
 - WA4 has non-standard plan numbering (p08-p13 instead of p01-p07)
 - WA5 originally referenced WA4's Terrain and LandCover (cross-model refs corrected)
-- All DSS boundary conditions use relative paths (.\\Input_DSS\\...)
+- All DSS boundary conditions use relative paths (./Input_DSS/...)
 
 ## Usage
 


### PR DESCRIPTION
## Summary

Use forward slashes in `RasEbfeModels` DSS path examples so the docstrings do not emit Python `SyntaxWarning` messages for invalid backslash escape sequences.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)
- [ ] Example notebook

---

## Motivation

The eBFE helper code was clean at runtime, but two Windows-style path examples inside `ebfe_models.py` docstrings used backslashes like `DSS\Input\file.dss` in plain Python strings. On Python 3.14 this produces a `SyntaxWarning` for invalid escape sequences such as `\I` during import/compile, which creates avoidable noise in verification runs.

## Linked Issues

- None

## Reproduction Steps

Before:
1. Run `python -m py_compile ras_commander/sources/federal/ebfe_models.py`
2. Observe a `SyntaxWarning` about an invalid escape sequence in the docstring path examples

After:
1. Run `python -m py_compile ras_commander/sources/federal/ebfe_models.py`
2. No warning is emitted

## Before/After Notes

Before:
- Docstring examples used backslashes in plain string literals
- Import/compile emitted a warning unrelated to runtime behavior

After:
- Docstring examples use forward slashes
- Import/compile is clean

---

## LLM Self-Review

> **ras-commander encourages LLM-assisted contributions.** If your agent prepared this code, confirm it reviewed the style guide. See [CONTRIBUTING.md](../CONTRIBUTING.md) for details.

### Style Compliance

- [x] Static class pattern followed (`.claude/rules/python/static-classes.md`)
- [x] `@staticmethod` + `@log_call` on public methods (`.claude/rules/python/decorators.md`)
- [x] Naming conventions followed (`.claude/rules/python/naming-conventions.md`)
- [x] `pathlib.Path` used, accepts both `str` and `Path` (`.claude/rules/python/path-handling.md`)
- [x] DataFrames used for project metadata, not glob (`.claude/rules/python/dataframe-first-principle.md`)

### Code Quality

- [x] Google-style docstrings with Args, Returns, Raises
- [ ] Tested with real HEC-RAS project (`RasExamples.extract_project()`)
- [x] No hardcoded file paths
- [x] Uses logging, not `print()`
- [x] Proper error handling with informative messages

Note: this PR only updates docstring examples and does not change executable logic, so a HEC-RAS project run was not needed.

### API Changes (if applicable)

- [ ] `ras_object=None` parameter included for multi-project support
- [ ] Standard parameter names (`plan_number`, `geom_file`)
- [ ] API consistency auditor 5 rules followed (`.claude/agents/api-consistency-auditor.md`)
- [ ] Return types consistent (DataFrames for tabular data)

### Notebooks (if applicable)

- [ ] First cell is markdown with H1 title
- [ ] Uses `RasExamples.extract_project()` for data
- [ ] Development toggle cell included (`USE_LOCAL_SOURCE`)

---

## Test Plan

- Ran `python -m py_compile ras_commander/sources/federal/ebfe_models.py`
- Confirmed the prior `SyntaxWarning` no longer appears

## LLM Attribution

**Model/Tool used**: OpenAI Codex (GPT-5-based coding agent)
