### PR TITLE
fix(RasProcess): honor configured wine executable

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -135,6 +135,9 @@ winetricks -q corefonts     # Arial, Times New Roman, etc.
 !!! tip "Detailed Setup Instructions"
     Run `RasProcess.setup_wine_environment()` in Python to print the complete list of required DLLs and step-by-step instructions.
 
+!!! info "Validated Environment"
+    Verified on the CLB07 Proxmox container `ras2cng-wine` (Debian 13, Wine 11.0). Custom `wine_executable` paths or wrappers are supported; helper tools such as `winepath` are resolved automatically.
+
 !!! note "Scope"
     Wine support covers `RasProcess.exe` (stored map generation) only. Full HEC-RAS simulation (`Ras.exe`) still requires Windows. HDF analysis works natively on Linux without Wine.
 

--- a/ras_commander/RasProcess.py
+++ b/ras_commander/RasProcess.py
@@ -38,7 +38,7 @@ import tempfile
 import xml.etree.ElementTree as ET
 from dataclasses import dataclass
 from pathlib import Path, PurePosixPath, PureWindowsPath
-from typing import Union, Optional, List, Dict, Any
+from typing import Union, Optional, List, Dict, Any, Tuple
 from datetime import datetime
 import shutil
 import platform
@@ -193,7 +193,9 @@ class RasProcess:
 
         Args:
             wine_prefix: Path to WINEPREFIX (default: auto-detect from WINE_PREFIX_PATHS)
-            wine_executable: Wine binary name or path (default: "wine")
+            wine_executable: Wine binary name or path used to launch
+                            Windows executables under Wine. Auxiliary tools
+                            such as ``winepath`` are resolved automatically.
             ras_install_dir: Path to directory containing RasProcess.exe and DLLs.
                            Can be a Linux path (under drive_c/) or left None for auto-detect.
 
@@ -266,6 +268,51 @@ class RasProcess:
         return config
 
     @staticmethod
+    def _build_wine_env(
+        wine_config: WineConfig = None,
+        include_winedebug: bool = True,
+    ) -> Dict[str, str]:
+        """Build environment variables for Wine subprocess execution."""
+        config = wine_config or RasProcess._get_wine_config()
+
+        env = {**os.environ, "DISPLAY": ""}
+        if config and config.wine_prefix:
+            env["WINEPREFIX"] = str(config.wine_prefix)
+        if include_winedebug:
+            env["WINEDEBUG"] = "-all"
+
+        return env
+
+    @staticmethod
+    def _resolve_wine_tool_executable(
+        tool_name: str,
+        wine_config: WineConfig = None,
+    ) -> str:
+        """
+        Resolve an auxiliary Wine tool for the configured Wine install.
+
+        For the main Wine runner, returns the configured ``wine_executable``.
+        For tools like ``winepath``, prefer a sibling binary next to a
+        path-based executable (for example ``/opt/wine/bin/wine64`` ->
+        ``/opt/wine/bin/winepath``). Otherwise fall back to the generic tool
+        name on ``PATH``.
+        """
+        config = wine_config or RasProcess._get_wine_config()
+        if config is None:
+            return tool_name
+
+        if tool_name == "wine":
+            return str(config.wine_executable)
+
+        wine_executable = Path(str(config.wine_executable))
+        if wine_executable.parent != Path(".") or wine_executable.is_absolute():
+            sibling_tool = wine_executable.with_name(tool_name)
+            if sibling_tool.exists():
+                return str(sibling_tool)
+
+        return tool_name
+
+    @staticmethod
     def _linux_to_wine_path(linux_path: Union[str, Path]) -> str:
         """
         Convert a Linux filesystem path to a Wine/Windows path.
@@ -291,14 +338,25 @@ class RasProcess:
             wine_config = RasProcess._get_wine_config()
             if wine_config:
                 try:
+                    winepath_executable = (
+                        RasProcess._resolve_wine_tool_executable(
+                            "winepath",
+                            wine_config,
+                        )
+                    )
                     result = subprocess.run(
-                        [wine_config.wine_executable + "path", "-w", str(linux_path)],
-                        capture_output=True, text=True, timeout=10,
-                        env={**os.environ, "WINEPREFIX": str(wine_config.wine_prefix), "DISPLAY": ""}
+                        [winepath_executable, "-w", str(linux_path)],
+                        capture_output=True,
+                        text=True,
+                        timeout=10,
+                        env=RasProcess._build_wine_env(
+                            wine_config,
+                            include_winedebug=False,
+                        ),
                     )
                     if result.returncode == 0:
                         return result.stdout.strip()
-                except Exception:
+                except (OSError, subprocess.TimeoutExpired):
                     pass
             # Fallback: return as-is (Wine can sometimes handle Unix paths)
             logger.warning(f"Cannot convert to Wine path (no drive_c/ found): {linux_path}")
@@ -348,7 +406,7 @@ class RasProcess:
         args: List[str],
         wine_config: WineConfig = None,
         working_dir: Path = None,
-    ) -> tuple:
+    ) -> Tuple[List[str], Dict[str, str], Optional[str]]:
         """
         Build a Wine-wrapped command line.
 
@@ -374,14 +432,12 @@ class RasProcess:
         else:
             exe_wine_path = exe_str  # Bare filename, let Wine find it
 
-        cmd = [config.wine_executable, exe_wine_path] + args
+        cmd = [
+            RasProcess._resolve_wine_tool_executable("wine", config),
+            exe_wine_path,
+        ] + args
 
-        env = {
-            **os.environ,
-            "WINEPREFIX": str(config.wine_prefix),
-            "DISPLAY": "",  # Headless — no X11 needed
-            "WINEDEBUG": "-all",  # Suppress Wine debug output
-        }
+        env = RasProcess._build_wine_env(config)
 
         cwd = str(working_dir) if working_dir else None
 
@@ -392,6 +448,9 @@ class RasProcess:
     def check_wine_environment() -> Dict[str, Any]:
         """
         Verify the Wine environment is properly configured for RasProcess.
+
+        Uses the configured ``wine_executable`` when one was provided via
+        ``configure_wine()``.
 
         Returns a dict with status of each component:
         - wine_found: bool
@@ -421,12 +480,23 @@ class RasProcess:
             "hdf5_found": False,
         }
 
+        config = RasProcess._get_wine_config()
+        wine_executable = RasProcess._resolve_wine_tool_executable(
+            "wine",
+            config,
+        )
+
         # Check wine binary
         try:
             proc = subprocess.run(
-                ["wine", "--version"],
-                capture_output=True, text=True, timeout=10,
-                env={**os.environ, "DISPLAY": ""}
+                [wine_executable, "--version"],
+                capture_output=True,
+                text=True,
+                timeout=10,
+                env=RasProcess._build_wine_env(
+                    config,
+                    include_winedebug=False,
+                ),
             )
             if proc.returncode == 0:
                 result["wine_found"] = True
@@ -435,7 +505,6 @@ class RasProcess:
             pass
 
         # Check Wine prefix
-        config = RasProcess._get_wine_config()
         if config and config.wine_prefix:
             result["wine_prefix"] = str(config.wine_prefix)
             result["prefix_exists"] = config.wine_prefix.exists()

--- a/tests/test_rasprocess_wine_config.py
+++ b/tests/test_rasprocess_wine_config.py
@@ -1,0 +1,158 @@
+from importlib import import_module
+import subprocess
+
+import pytest
+
+
+ras_process_module = import_module("ras_commander.RasProcess")
+RasProcess = ras_process_module.RasProcess
+
+
+@pytest.fixture(autouse=True)
+def restore_wine_config():
+    original = RasProcess._wine_config
+    yield
+    RasProcess._wine_config = original
+
+
+def _make_wine_prefix(tmp_path):
+    prefix = tmp_path / "wineprefix"
+    (prefix / "drive_c").mkdir(parents=True)
+    return prefix
+
+
+def test_linux_to_wine_path_uses_winepath_for_wine64(
+    monkeypatch,
+    tmp_path,
+):
+    prefix = _make_wine_prefix(tmp_path)
+    RasProcess.configure_wine(wine_prefix=prefix, wine_executable="wine64")
+
+    calls = []
+
+    def fake_run(cmd, *args, **kwargs):
+        calls.append((cmd, kwargs))
+        return subprocess.CompletedProcess(
+            cmd,
+            0,
+            stdout="Z:\\converted\n",
+            stderr="",
+        )
+
+    monkeypatch.setattr(ras_process_module.subprocess, "run", fake_run)
+
+    converted = RasProcess._linux_to_wine_path(
+        tmp_path / "outside-drive-c" / "example.txt"
+    )
+
+    assert converted == "Z:\\converted"
+    assert calls[0][0][0] == "winepath"
+    assert calls[0][0][0] != "wine64path"
+    assert calls[0][1]["env"]["WINEPREFIX"] == str(prefix)
+
+
+def test_linux_to_wine_path_prefers_sibling_winepath(
+    monkeypatch,
+    tmp_path,
+):
+    prefix = _make_wine_prefix(tmp_path)
+    wine_dir = tmp_path / "custom-wine" / "bin"
+    wine_dir.mkdir(parents=True)
+    wine_executable = wine_dir / "wine64"
+    winepath_executable = wine_dir / "winepath"
+    wine_executable.write_text("", encoding="utf-8")
+    winepath_executable.write_text("", encoding="utf-8")
+    RasProcess.configure_wine(
+        wine_prefix=prefix,
+        wine_executable=str(wine_executable),
+    )
+
+    calls = []
+
+    def fake_run(cmd, *args, **kwargs):
+        calls.append((cmd, kwargs))
+        return subprocess.CompletedProcess(
+            cmd,
+            0,
+            stdout="Z:\\converted\n",
+            stderr="",
+        )
+
+    monkeypatch.setattr(ras_process_module.subprocess, "run", fake_run)
+
+    RasProcess._linux_to_wine_path(tmp_path / "outside-drive-c" / "example.txt")
+
+    assert calls[0][0][0] == str(winepath_executable)
+
+
+def test_check_wine_environment_uses_configured_wine_executable(
+    monkeypatch,
+    tmp_path,
+):
+    prefix = _make_wine_prefix(tmp_path)
+    wine_dir = tmp_path / "custom-wine" / "bin"
+    wine_dir.mkdir(parents=True)
+    wine_executable = wine_dir / "wine64"
+    wine_executable.write_text("", encoding="utf-8")
+    RasProcess.configure_wine(
+        wine_prefix=prefix,
+        wine_executable=str(wine_executable),
+    )
+
+    calls = []
+
+    def fake_run(cmd, *args, **kwargs):
+        calls.append((cmd, kwargs))
+        return subprocess.CompletedProcess(
+            cmd,
+            0,
+            stdout="wine-10.0\n",
+            stderr="",
+        )
+
+    monkeypatch.setattr(ras_process_module.subprocess, "run", fake_run)
+    monkeypatch.setattr(
+        RasProcess,
+        "find_rasprocess",
+        staticmethod(lambda ras_version=None: None),
+    )
+
+    status = RasProcess.check_wine_environment()
+
+    assert status["wine_found"] is True
+    assert status["wine_version"] == "wine-10.0"
+    assert calls[0][0] == [str(wine_executable), "--version"]
+    assert calls[0][1]["env"]["WINEPREFIX"] == str(prefix)
+
+
+def test_check_wine_environment_defaults_to_plain_wine(
+    monkeypatch,
+):
+    calls = []
+
+    def fake_run(cmd, *args, **kwargs):
+        calls.append((cmd, kwargs))
+        return subprocess.CompletedProcess(
+            cmd,
+            0,
+            stdout="wine-9.0\n",
+            stderr="",
+        )
+
+    monkeypatch.setattr(ras_process_module.subprocess, "run", fake_run)
+    monkeypatch.setattr(
+        RasProcess,
+        "_get_wine_config",
+        staticmethod(lambda: None),
+    )
+    monkeypatch.setattr(
+        RasProcess,
+        "find_rasprocess",
+        staticmethod(lambda ras_version=None: None),
+    )
+
+    status = RasProcess.check_wine_environment()
+
+    assert status["wine_found"] is True
+    assert calls[0][0] == ["wine", "--version"]
+    assert "WINEPREFIX" not in calls[0][1]["env"]


### PR DESCRIPTION
## Summary
- Fixes Wine executable resolution for custom installations (e.g. `/opt/wine/bin/wine64`)
- Previous code produced `wine64path` instead of `winepath` due to string concatenation bug
- Adds `_build_wine_env()` and `_resolve_wine_tool_executable()` for centralized Wine config handling
- Fixes `check_wine_environment()` to respect configured executable instead of hardcoded `wine`

## Changes
- `RasProcess.py`: New helper methods, fixed winepath resolution, narrowed exception handling
- `installation.md`: Added validated environment info box
- `test_rasprocess_wine_config.py`: 4 new pytest tests covering all fix scenarios

## Test plan
- [x] 4 unit tests with monkeypatch covering: winepath for wine64, sibling binary resolution, configured executable in check, default fallback
- [x] Zero merge conflicts verified via merge-tree
- [x] Changes isolated to Wine/Linux path — no impact on Windows HEC-RAS execution

🤖 Generated with [Claude Code](https://claude.com/claude-code)