### PR TITLE
Framework/governance: rules, skills, agents updates

### DIFF
--- a/.claude/MANIFEST.md
+++ b/.claude/MANIFEST.md
@@ -72,6 +72,7 @@ When adding a new component, add it to the appropriate domain group AND the rela
 | Component | Type | Path |
 |-----------|------|------|
 | `terrain.md` | rule | `.claude/rules/hec-ras/terrain.md` |
+| `terrain-modification.md` | rule | `.claude/rules/hec-ras/terrain-modification.md` |
 | `RasTerrainMod` | module | `ras_commander/terrain/RasTerrainMod.py` |
 | `HdfLandCover` | module | `ras_commander/hdf/HdfLandCover.py` |
 | `930_terrain_modification_analysis` | notebook | `examples/930_terrain_modification_analysis.ipynb` |
@@ -81,6 +82,7 @@ When adding a new component, add it to the appropriate domain group AND the rela
 
 | Component | Type | Path |
 |-----------|------|------|
+| `ebfe_crawl_s3-catalog` | skill | `.claude/skills/ebfe_crawl_s3-catalog/SKILL.md` |
 | `ebfe_organize_models` | skill | `.claude/skills/ebfe_organize_models/SKILL.md` |
 | `ebfe_validate_models` | skill | `.claude/skills/ebfe_validate_models/SKILL.md` |
 | `ebfe-organizer` | agent | `.claude/agents/ebfe-organizer/SUBAGENT.md` |
@@ -99,6 +101,7 @@ When adding a new component, add it to the appropriate domain group AND the rela
 | Component | Type | Path |
 |-----------|------|------|
 | `hecras_explore_gui` | skill | `.claude/skills/hecras_explore_gui/SKILL.md` |
+| `hecras_screenshot` | skill | `.claude/skills/hecras_screenshot/SKILL.md` |
 | `hecras_export_cloud-native` | skill | `.claude/skills/hecras_export_cloud-native/SKILL.md` |
 | `win32com-automation-expert` | agent | `.claude/agents/win32com-automation-expert.md` |
 | `hecras-code-archaeologist` | agent | `.claude/agents/hecras-code-archaeologist.md` |
@@ -109,6 +112,14 @@ When adding a new component, add it to the appropriate domain group AND the rela
 |-----------|------|------|
 | `hecras-project-inspector` | agent | `.claude/agents/hecras-project-inspector.md` |
 | `hecras-notebook-qaqc` | agent | `.claude/agents/hecras-notebook-qaqc.md` |
+
+### Calibration
+
+| Component | Type | Path |
+|-----------|------|------|
+| `calibration.md` | rule | `.claude/rules/hec-ras/calibration.md` |
+| `RasCalibrate` | module | `ras_commander/RasCalibrate.py` |
+| `ras-commander-first.md` | rule | `.claude/rules/hec-ras/ras-commander-first.md` |
 
 ### Python Patterns
 
@@ -163,6 +174,7 @@ When adding a new component, add it to the appropriate domain group AND the rela
 | `dev_invoke_gemini-cli` | skill | `.claude/skills/dev_invoke_gemini-cli/SKILL.md` |
 | `dev_invoke_kimi-cli` | skill | `.claude/skills/dev_invoke_kimi-cli/SKILL.md` |
 | `dev_manage_git-worktrees` | skill | `.claude/skills/dev_manage_git-worktrees/SKILL.md` |
+| `dev_gate_merge-to-main` | skill | `.claude/skills/dev_gate_merge-to-main/SKILL.md` |
 | `code-oracle-codex` | agent | `.claude/agents/code-oracle-codex.md` |
 | `code-oracle-gemini` | agent | `.claude/agents/code-oracle-gemini.md` |
 | `git-operations` | agent | `.claude/agents/git-operations/SUBAGENT.md` |
@@ -175,6 +187,7 @@ When adding a new component, add it to the appropriate domain group AND the rela
 | `subagent-output-pattern.md` | rule | `.claude/rules/subagent-output-pattern.md` |
 | `primitive-extraction-workflow.md` | rule | `.claude/rules/workflow/primitive-extraction-workflow.md` |
 | `clb-engineering-recommendation.md` | rule | `.claude/rules/clb-engineering-recommendation.md` |
+| `agents-md-bridge.md` | rule | `.claude/rules/agents-md-bridge.md` |
 | `hec-hms-documentation-scout` | agent | `.claude/agents/hec-hms-documentation-scout.md` |
 | `claude-code-guide` | agent | `.claude/agents/claude-code-guide.md` |
 
@@ -200,6 +213,15 @@ When adding a new component, add it to the appropriate domain group AND the rela
 | `agent-crossrepo` | command | `.claude/commands/agent-crossrepo.md` |
 | `agents-start-gitworktree` | command | `.claude/commands/agents-start-gitworktree.md` |
 | `agents-close-gitworktree` | command | `.claude/commands/agents-close-gitworktree.md` |
+
+### Cross-Validation & QAQC
+
+| Component | Type | Path |
+|-----------|------|------|
+| `dual-qaqc` | command | `.claude/commands/dual-qaqc.md` |
+| `qa_review_triple-model` | skill | `.claude/skills/qa_review_triple-model/SKILL.md` |
+| `code-oracle-codex` | agent | `.claude/agents/code-oracle-codex.md` |
+| `code-oracle-gemini` | agent | `.claude/agents/code-oracle-gemini.md` |
 
 ---
 
@@ -286,7 +308,12 @@ When adding a new component, add it to the appropriate domain group AND the rela
 
 ### eBFE/BLE Domain
 
+**`ebfe_crawl_s3-catalog`** (skill) -- public BLE/eBFE catalog discovery
+- Downstream: `ebfe_organize_models` skill
+- Agents: `ebfe-organizer`
+
 **`ebfe_organize_models`** (skill) -- model organization
+- Upstream: `ebfe_crawl_s3-catalog` skill
 - Downstream: `ebfe_validate_models` skill
 - Agents: `ebfe-organizer`
 
@@ -307,6 +334,10 @@ When adding a new component, add it to the appropriate domain group AND the rela
 
 ### Dev Tooling Domain
 
+**`dev_gate_merge-to-main`** (skill) -- feature-branch guardrail
+- Agents: `git-operations`
+- Commands: `agent-taskupdate`, `agent-engagesubagents`
+
 **`dev_invoke_codex-cli`** (skill) -- Codex CLI delegation
 - Agents: `code-oracle-codex`
 
@@ -318,6 +349,16 @@ When adding a new component, add it to the appropriate domain group AND the rela
 **`dev_manage_git-worktrees`** (skill) -- worktree management
 - Agents: `git-operations`
 - Commands: `agents-start-gitworktree`, `agents-close-gitworktree`
+
+### HEC-RAS GUI & Documentation Domain
+
+**`hecras_explore_gui`** (skill) -- GUI exploration
+- Agents: `win32com-automation-expert`, `hecras-code-archaeologist`
+- Related skills: `hecras_screenshot`
+
+**`hecras_screenshot`** (skill) -- GUI screenshot capture
+- Agents: `win32com-automation-expert`, `hecras-code-archaeologist`
+- Related skills: `hecras_explore_gui`
 
 ### Notebook Operations Domain
 

--- a/.claude/agents/notebook-runner.md
+++ b/.claude/agents/notebook-runner.md
@@ -6,12 +6,12 @@ working_directory: .
 skills: []
 description: |
   Runs and troubleshoots Jupyter notebooks (.ipynb) as repeatable tests and
-  executable documentation. Specializes in nbmake/pytest execution, nbconvert
-  fallbacks, capturing run artifacts (logs, executed notebooks), and producing
-  small “output digests” for downstream review.
+  executable documentation. Uses papermill as primary execution engine for
+  parameterization, progress reporting, and robust error handling. Falls back
+  to nbconvert or pytest+nbmake for specific scenarios.
 
-  Use when users say: run notebook, execute ipynb, nbmake, nbconvert, notebook
-  test, notebook CI, failing notebook, traceback in notebook, stderr in notebook.
+  Use when users say: run notebook, execute ipynb, papermill, nbmake, nbconvert,
+  notebook test, notebook CI, failing notebook, traceback in notebook, stderr in notebook.
 
   For ras-commander-specific examples and conventions, delegate to:
   example-notebook-librarian.
@@ -40,42 +40,80 @@ Always produce these minimum artifacts:
 
 ## Execution Modes
 
-### Mode A: nbconvert with allow-errors (preferred)
+### Mode A: Papermill (preferred)
 
-Run a COPY of the notebook via nbconvert. This approach captures all cell outputs even when errors occur, enabling complete post-mortem analysis.
+Run a COPY of the notebook via papermill. Papermill is purpose-built for notebook execution with parameterization, progress reporting, and structured error capture.
 
 1. **Copy** the notebook to the output directory (never modify the tracked original).
-2. **Inject an `os.chdir()` cell** at position 0 so the kernel CWD matches the expected working directory (e.g., `examples/` for RasExamples.projects_dir):
-   ```python
-   import os; os.chdir(r'C:\GH\ras-commander\examples')
-   ```
-3. **Execute** with:
+2. **Execute** with:
    ```bash
-   jupyter nbconvert --to notebook --execute \
-     --ExecutePreprocessor.timeout=600 \
-     --ExecutePreprocessor.kernel_name=<kernel> \
-     --ExecutePreprocessor.allow_errors=True \
-     --output <stem>_executed.ipynb \
-     <copied_notebook>.ipynb
+   papermill <input_notebook>.ipynb <output_notebook>_executed.ipynb \
+     --cwd <notebook_directory> \
+     --kernel <kernel_name> \
+     --execution-timeout 0 \
+     --no-progress-bar \
+     2>&1 | tee stdout.txt
    ```
-4. **Analyze** the executed notebook for errors (cell `output_type == 'error'`), warnings (stderr containing `Warning`/`WARNING`), and anomalies (empty outputs where content expected).
+3. **Analyze** the executed notebook for errors (cell `output_type == 'error'`), warnings (stderr containing `Warning`/`WARNING`), and anomalies (empty outputs where content expected).
 
-Key advantages over pytest+nbmake:
-- `allow_errors=True` ensures ALL cells execute, not just up to the first failure
-- Full output capture enables comprehensive QAQC review
-- Executed notebook is a reviewable artifact with inline outputs
+Key parameters:
+- `--execution-timeout 0` disables hard kill (HEC-RAS runs can exceed 10+ minutes)
+- `--cwd` sets working directory so relative paths resolve correctly
+- `--kernel` selects the execution environment
+- `-p KEY VALUE` injects parameters into tagged cells (papermill's killer feature)
 
-### Mode B: Pytest + nbmake (for CI / pass-fail gating)
+Key advantages over nbconvert:
+- Purpose-built for execution (not conversion)
+- Built-in parameterization via tagged cells
+- Better error reporting with per-cell exception capture
+- No hard timeout kill -- use `--execution-timeout 0`
+- Python API available for programmatic control
+
+### Mode B: nbconvert with allow-errors (for full post-mortem)
+
+Use when you need ALL cells to execute even after failures (papermill stops at first error by default):
+
+```bash
+jupyter nbconvert --to notebook --execute \
+  --ExecutePreprocessor.timeout=0 \
+  --ExecutePreprocessor.kernel_name=<kernel> \
+  --ExecutePreprocessor.allow_errors=True \
+  --output <stem>_executed.ipynb \
+  <copied_notebook>.ipynb
+```
+
+Note: `timeout=0` means no timeout (not "instant kill").
+
+### Mode C: Pytest + nbmake (for CI / pass-fail gating)
 
 Run a single notebook:
-- `pytest --nbmake examples/101_project_initialization.ipynb -vv --nbmake-timeout=300`
+- `pytest --nbmake examples/101_project_initialization.ipynb -vv --nbmake-timeout=0`
 
 Run all example notebooks:
 - `pytest --nbmake examples/*.ipynb -vv`
 
-Note: nbmake stops at the first cell failure per notebook and does not capture subsequent cell outputs. Use Mode A for development testing and QAQC; use Mode B for CI gates where pass/fail is sufficient.
+Note: nbmake stops at the first cell failure per notebook. Use Mode A or B for development testing; use Mode C for CI gates where pass/fail is sufficient.
 
-Note that many notebooks require HEC-RAS installed and a valid `Ras.exe` path. Record intentionally “manual” (GUI automation) notebooks as such.
+Note that many notebooks require HEC-RAS installed and a valid `Ras.exe` path. Record intentionally "manual" (GUI automation) notebooks as such.
+
+## Kernel Selection
+
+**Default**: Use the `rascommander` kernel (pip-installed package) to validate end-user experience.
+
+**Switch to `rascmdr` kernel** only when testing unpublished library changes.
+
+**If neither kernel is available**: Report the issue and suggest the user set up an environment.
+
+Check available kernels with: `jupyter kernelspec list`
+
+## GUI Automation Cells
+
+Some notebooks contain cells that launch HEC-RAS GUI and block waiting for user interaction (e.g., `RasGuiAutomation.open_rasmapper(wait_for_user=True)`). These cells will block indefinitely during automated execution.
+
+**Handling**: 
+- Warn about GUI-blocking cells before execution starts
+- Grep for `wait_for_user`, `open_rasmapper`, `open_and_compute`, `run_multiple_plans` in the notebook source
+- Note them in the execution report as expected blocks, not failures
 
 ## Output Digest Workflow (for large notebooks)
 
@@ -104,7 +142,7 @@ For `hecras-notebook-qaqc`, also pass a source-only extract:
 ## Delegation Rules
 
 ### Delegate to example-notebook-librarian when:
-- The user asks “how should ras-commander notebooks be structured?”
+- The user asks "how should ras-commander notebooks be structured?"
 - You need to find the best existing example notebook for a workflow.
 - You need repo-specific conventions (import cells, RasExamples usage, mkdocs).
 
@@ -120,7 +158,7 @@ For `hecras-notebook-qaqc`, also pass a source-only extract:
 
 ## Success Criteria
 
-Mark a notebook run as “complete” when:
+Mark a notebook run as "complete" when:
 - No unhandled exceptions remain (or failures are clearly isolated and reproducible)
 - Artifacts exist in `working/notebook_runs/<run>/`
 - Digest identifies exact cell indices and error summaries
@@ -131,6 +169,7 @@ Mark a notebook run as “complete” when:
 - `notebook-output-auditor` -- Delegate for output review after execution
 - `notebook-anomaly-spotter` -- Delegate for anomaly detection in results
 - `example-notebook-librarian` -- Coordinates notebook management
+- `hecras-notebook-qaqc` -- HEC-RAS project linkage verification
 
 **Rules** (follow these):
 - `.claude/rules/documentation/notebook-standards.md` -- Notebook conventions

--- a/.claude/agents/notebook-runner.md
+++ b/.claude/agents/notebook-runner.md
@@ -27,7 +27,7 @@ Read these first for ras-commander conventions:
 - `examples/AGENTS.md` -- example notebook index and conventions
 - `.claude/rules/documentation/notebook-standards.md` -- required notebook format
 - `.claude/rules/testing/tdd-approach.md` -- example notebooks as tests
-- `.claude/rules/testing/environment-management.md` -- preferred environments
+- `.claude/rules/testing/environment-management.md` -- canonical kernel names and environments
 
 ## What You Produce (Always)
 
@@ -38,11 +38,20 @@ Always produce these minimum artifacts:
 - `stdout.txt` / `stderr.txt` -- captured output
 - `audit.json` / `audit.md` -- condensed digest (see script below)
 
+## Preflight: GUI Automation Scan
+
+Before executing any notebook, grep its source for GUI-blocking markers:
+- `wait_for_user`, `open_rasmapper`, `open_and_compute`, `run_multiple_plans`
+
+If found, warn the caller which cells will block and note them in the execution report as expected blocks (not failures). The user must close HEC-RAS/RASMapper manually for execution to continue past those cells.
+
 ## Execution Modes
 
-### Mode A: Papermill (preferred)
+Choose the mode based on the caller's goal:
 
-Run a COPY of the notebook via papermill. Papermill is purpose-built for notebook execution with parameterization, progress reporting, and structured error capture.
+### Mode A: Papermill (default for quick validation)
+
+Best for: quick pass/fail validation, parameterized runs, single-error diagnosis. Stops at first error.
 
 1. **Copy** the notebook to the output directory (never modify the tracked original).
 2. **Execute** with:
@@ -60,34 +69,29 @@ Key parameters:
 - `--execution-timeout 0` disables hard kill (HEC-RAS runs can exceed 10+ minutes)
 - `--cwd` sets working directory so relative paths resolve correctly
 - `--kernel` selects the execution environment
-- `-p KEY VALUE` injects parameters into tagged cells (papermill's killer feature)
+- `-p KEY VALUE` injects parameters into tagged cells (papermill's key feature)
 
-Key advantages over nbconvert:
-- Purpose-built for execution (not conversion)
-- Built-in parameterization via tagged cells
-- Better error reporting with per-cell exception capture
-- No hard timeout kill -- use `--execution-timeout 0`
-- Python API available for programmatic control
+Note: Papermill stops at the first cell error. Use Mode B when you need all cells to execute.
 
 ### Mode B: nbconvert with allow-errors (for full post-mortem)
 
-Use when you need ALL cells to execute even after failures (papermill stops at first error by default):
+Best for: comprehensive development QA, "hide nothing" testing. Executes ALL cells regardless of errors.
 
 ```bash
 jupyter nbconvert --to notebook --execute \
-  --ExecutePreprocessor.timeout=0 \
+  --ExecutePreprocessor.timeout=-1 \
   --ExecutePreprocessor.kernel_name=<kernel> \
   --ExecutePreprocessor.allow_errors=True \
   --output <stem>_executed.ipynb \
   <copied_notebook>.ipynb
 ```
 
-Note: `timeout=0` means no timeout (not "instant kill").
+Note: `timeout=-1` disables the per-cell timeout. Use this mode when the caller requests complete error reporting (e.g., `/test-notebook`).
 
 ### Mode C: Pytest + nbmake (for CI / pass-fail gating)
 
 Run a single notebook:
-- `pytest --nbmake examples/101_project_initialization.ipynb -vv --nbmake-timeout=0`
+- `pytest --nbmake examples/101_project_initialization.ipynb -vv --nbmake-timeout=600`
 
 Run all example notebooks:
 - `pytest --nbmake examples/*.ipynb -vv`
@@ -98,22 +102,15 @@ Note that many notebooks require HEC-RAS installed and a valid `Ras.exe` path. R
 
 ## Kernel Selection
 
-**Default**: Use the `rascommander` kernel (pip-installed package) to validate end-user experience.
+Resolve the kernel by running `jupyter kernelspec list` and selecting:
 
-**Switch to `rascmdr` kernel** only when testing unpublished library changes.
+**Default**: `RasCommander` kernel (pip-installed package) to validate end-user experience.
 
-**If neither kernel is available**: Report the issue and suggest the user set up an environment.
+**Switch to `rascmdr_local`** only when testing unpublished library changes.
 
-Check available kernels with: `jupyter kernelspec list`
+**Fallback**: If neither canonical kernel exists, check for close matches (`rascommander`, `rascmdr`, `python3`). Report the available kernels and ask the caller to confirm.
 
-## GUI Automation Cells
-
-Some notebooks contain cells that launch HEC-RAS GUI and block waiting for user interaction (e.g., `RasGuiAutomation.open_rasmapper(wait_for_user=True)`). These cells will block indefinitely during automated execution.
-
-**Handling**: 
-- Warn about GUI-blocking cells before execution starts
-- Grep for `wait_for_user`, `open_rasmapper`, `open_and_compute`, `run_multiple_plans` in the notebook source
-- Note them in the execution report as expected blocks, not failures
+See `.claude/rules/testing/environment-management.md` for canonical kernel setup.
 
 ## Output Digest Workflow (for large notebooks)
 
@@ -147,7 +144,6 @@ For `hecras-notebook-qaqc`, also pass a source-only extract:
 - You need repo-specific conventions (import cells, RasExamples usage, mkdocs).
 
 ### Delegate to HEC documentation scouts when:
-- You need to confirm workflow constraints in official HEC-RAS docs: `hec-ras-documentation-scout`
 - You need to confirm HMS-related assumptions in official HEC-HMS docs: `hec-hms-documentation-scout`
 
 ### Delegate to domain specialists when failures are domain-specific:
@@ -173,6 +169,7 @@ Mark a notebook run as "complete" when:
 
 **Rules** (follow these):
 - `.claude/rules/documentation/notebook-standards.md` -- Notebook conventions
+- `.claude/rules/testing/environment-management.md` -- Canonical kernel names
 
 **Commands** (user triggers):
 - `/test-notebook` -- Triggers notebook testing workflow

--- a/.claude/agents/remote-executor/SUBAGENT.md
+++ b/.claude/agents/remote-executor/SUBAGENT.md
@@ -7,6 +7,7 @@ description: >
   Primary sources: ras_commander/remote/AGENTS.md (patterns), examples/500_remote_execution_psexec.ipynb (workflow),
   .claude/rules/hec-ras/remote.md (critical setup requirements).
 model: sonnet
+tools: [Bash, Read, Write, Glob, Grep]
 working_directory: ras_commander/remote
 ---
 
@@ -23,7 +24,7 @@ working_directory: ras_commander/remote
 This subagent acts as a **lightweight navigator**. Consult these primary sources for detailed information:
 
 ### 1. Implementation Guide
-**File**: `C:\GH\ras-commander\ras_commander\remote\AGENTS.md` (156 lines)
+**File**: `G:\GH\ras-commander\ras_commander\remote\AGENTS.md` (156 lines)
 
 **Contains**:
 - Module structure and naming conventions
@@ -37,7 +38,7 @@ This subagent acts as a **lightweight navigator**. Consult these primary sources
 **Use for**: Coding patterns, module architecture, worker development
 
 ### 2. Complete Workflow Example
-**File**: `C:\GH\ras-commander\examples\500_remote_execution_psexec.ipynb`
+**File**: `G:\GH\ras-commander\examples\500_remote_execution_psexec.ipynb`
 
 **Contains**:
 - Part 1: Setup and imports
@@ -329,7 +330,7 @@ def init_ssh_worker(**kwargs) -> SshWorker:
 
 ## Testing
 
-**Notebook**: `C:\GH\ras-commander\examples\500_remote_execution_psexec.ipynb`
+**Notebook**: `G:\GH\ras-commander\examples\500_remote_execution_psexec.ipynb`
 
 **Test sequence**:
 1. Part 2: Local parallel (baseline, no remote setup needed)

--- a/.claude/commands/agent-engagesubagents.md
+++ b/.claude/commands/agent-engagesubagents.md
@@ -1,3 +1,97 @@
 Search through your agents and skills and make a detailed plan to execute the user's query. Use the agents to save context and use shared documents in agent_tasks as a form of memory and passive coordination layer.
 
 First, list the proposed agents for the user's review and approval. Then, ultrathink and write a detailed execution plan that can be expanded and progress summaries noted by multiple agents, as well as a place to provide references to external files that document their individual work product and findings.
+
+## Subagent Engagement Protocol
+
+### 1. Plan and List Proposed Agents
+
+Before dispatching, present the user with:
+- Which subagents will be used
+- What each subagent will do
+- Expected output files and locations
+- Estimated complexity (Haiku / Sonnet / Opus)
+
+Wait for user approval before proceeding.
+
+### 2. Model Selection Guidance
+
+| Complexity | Model | Use When |
+|------------|-------|----------|
+| Simple, focused, fast | Haiku | Documentation lookup, file reads, scanning, summarization |
+| Moderate, multi-step | Sonnet | Analysis, code generation, multi-file coordination |
+| Complex, deep reasoning | Opus | Architecture decisions, cross-domain synthesis, hard problems |
+
+Default to Sonnet unless there is clear reason to go up or down.
+
+### 3. Context Handoff Pattern (Critical)
+
+**Always pass context via file paths, never raw text.**
+
+Correct pattern:
+- Pass relative file paths in the subagent prompt
+- Subagent reads those files for context
+- Subagent writes output to .claude/outputs/{subagent}/{date}-{task}.md
+- Subagent returns the output file path (not raw text)
+
+Wrong pattern:
+- Embedding large text blobs directly in the prompt
+- Subagent returning large text instead of writing a file
+
+Path format: Always use relative paths from repository root.
+  CORRECT: agent_tasks/.agent/STATE.md
+  CORRECT: .claude/outputs/hdf-analyst/analysis.md
+  WRONG: C:/GH/ras-commander/agent_tasks/.agent/STATE.md (absolute)
+
+### 4. Execution Plan File
+
+Before dispatching agents, write an execution plan to agent_tasks:
+
+Write to: agent_tasks/.agent/STATE.md or a task-specific folder.
+
+Include:
+- Task name and date
+- List of agents with model, task, and expected output file
+- Coordination notes (which agent feeds which)
+- Progress checklist
+
+### 5. Dispatch Pattern
+
+Dispatch independent agents in the first wave.
+After first wave completes, read output file paths and dispatch dependent agents.
+Pass first-wave output file paths to second-wave agents via their prompt.
+
+### 6. Collecting and Presenting Results
+
+After all agents complete:
+1. Read each output file
+2. Synthesize key findings
+3. Update agent_tasks/.agent/PROGRESS.md
+4. Present summary to user with links to detailed output files
+
+## Available Agent Roster
+
+Consult .claude/agents/README.md for the full list. Key agents by domain:
+
+| Domain | Agent |
+|--------|-------|
+| HEC-RAS execution | hecras-general-agent, remote-executor |
+| HDF results | hdf-analyst, hecras-results-analyst |
+| Geometry | geometry-parser |
+| USGS integration | usgs-integrator |
+| Quality assurance | quality-assurance |
+| Documentation | documentation-generator, hec-hms-documentation-scout |
+| Dev tooling | code-oracle-codex, code-oracle-gemini |
+| Notebooks | notebook-runner, notebook-output-auditor, notebook-anomaly-spotter |
+
+## Cross-References
+
+**Rules** (follow these):
+- .claude/rules/subagent-output-pattern.md -- Subagent output conventions (write files, return paths)
+
+**Agents** (available for dispatch):
+- .claude/agents/README.md -- Full agent registry with model assignments
+
+**Commands** (related):
+- /agent-taskupdate -- Update task state after agent runs
+- /agent-taskclose -- Close out when all agents complete

--- a/.claude/commands/agent-taskupdate.md
+++ b/.claude/commands/agent-taskupdate.md
@@ -1,6 +1,129 @@
 Look at your task list and memory, assess your current progress, and make a detailed plan to continue making progress on your task list.
 
+## Task Update Protocol
+
+### 1. Read Current State (Do This First)
+
+Read the following files to understand the current situation:
+
+```
+agent_tasks/.agent/STATE.md      -- Current project state, what's in progress
+agent_tasks/.agent/PROGRESS.md   -- Recent session history (last 2-3 entries)
+agent_tasks/.agent/BACKLOG.md    -- All tasks and their status
+```
+
+If these files don't exist, look for task planning documents in `agent_tasks/` root or `agent_tasks/tasks/`.
+
+### 2. Assess Current Progress
+
+For the currently in-progress task:
+- What was accomplished in the last session?
+- Are there blockers?
+- What is the next concrete action?
+
+For the backlog:
+- Are any "Blocked" tasks now unblocked?
+- Have new tasks emerged from the current work?
+
+### 3. Update STATE.md
+
+Update `agent_tasks/.agent/STATE.md` with:
+- Current timestamp
+- What is currently in progress
+- Health status (Green / Yellow / Red)
+- Any blockers discovered
+- Next priorities
+
+STATE.md format:
+```markdown
+# Project State
+
+**Last Updated**: {YYYY-MM-DD HH:MM}
+**Session**: {N}
+**Health**: Green | Yellow | Red
+
+## Current Focus
+{What task is actively being worked on}
+
+## Next Priorities
+1. {Priority 1}
+2. {Priority 2}
+
+## Blockers
+- {Any blockers, or "None"}
+
+## Recent Accomplishments
+- {What was done recently}
+```
+
+### 4. Append to PROGRESS.md
+
+Append a new session entry to `agent_tasks/.agent/PROGRESS.md`:
+
+```markdown
+## Session {N} — {YYYY-MM-DD}
+
+### Accomplished
+- {What was done}
+
+### Decisions Made
+- {Any key decisions and rationale}
+
+### Files Modified
+- {List of files}
+
+### Handoff Notes
+{Context the next session needs to know immediately}
+
+### Next Session Should Start With
+1. {First action}
+2. {Second action}
+```
+
+PROGRESS.md is append-only — never edit previous entries.
+
+### 5. Update BACKLOG.md
+
+Update task status:
+- Mark completed tasks with `[x]`
+- Add any new tasks discovered
+- Move newly-unblocked tasks from Blocked to Ready
+- Add notes to tasks based on current findings
+
+BACKLOG.md task format:
+```markdown
+## Ready
+- [ ] task-id: Task description (estimated complexity: S/M/L)
+
+## In Progress
+- [ ] task-id: Task description — Started {date}
+
+## Blocked
+- [ ] task-id: Task description — Blocked: {reason}
+
+## Completed
+- [x] task-id: Task description — Completed {date}
+```
+
+### 6. Plan Next Steps
+
+Based on the updated state, propose a concrete plan for continuing:
+- Which task to work on next (from Backlog Ready)
+- What specific actions to take
+- Which agents or skills to engage
+
+## When to Use This Command
+
+- At the start of a new session (update state, plan the session)
+- When switching from one task to another
+- When a task completes (update BACKLOG before starting next)
+- When discovering a blocker (update STATE and BACKLOG)
+- After a subagent completes (incorporate findings into state)
+- Periodically during long tasks (keep state current)
+
 ## Cross-References
 
 **Commands** (related):
-- `/agent-taskclose` -- End-of-task variant
+- `/agent-taskclose` -- End-of-task variant (more aggressive cleanup and knowledge extraction)
+- `/agent-engagesubagents` -- When task requires delegating to multiple agents
+- `/agent-cleanfiles` -- Periodic cleanup of completed task artifacts

--- a/.claude/commands/dual-qaqc.md
+++ b/.claude/commands/dual-qaqc.md
@@ -1,0 +1,123 @@
+# /dual-qaqc — Dual-Oracle Cross-Validation
+
+**Trigger**: `/dual-qaqc [topic or target]`
+
+Run the same analysis through two independent AI oracles (Codex CLI at xhigh thinking + Claude Opus) and reconcile findings. Items where both agree are high-confidence. Divergences require human review.
+
+**Use for**: API consistency audits, algorithmic correctness checks, security reviews, QAQC of complex outputs, design decisions with non-obvious tradeoffs.
+
+---
+
+## Workflow
+
+### Step 1: Frame the Question
+
+Formulate a precise, answerable question. Vague questions produce useless divergence.
+
+```
+Good: "Does HdfResultsPlan.get_compute_messages() handle the case where the HDF 
+       exists but the compute messages group is missing? Check lines 720-830."
+
+Bad: "Is this code good?"
+```
+
+### Step 2: Write Context to a File
+
+Save the code/question to a temp file so both oracles get identical input:
+
+```bash
+cat > /tmp/dual-qaqc-context.md << 'EOF'
+# Dual-QAQC Context — [topic]
+
+## Question
+[Precise question]
+
+## Code Under Review
+[Paste relevant code or file path]
+
+## What to Check
+- [Specific concern 1]
+- [Specific concern 2]
+EOF
+```
+
+### Step 3: Invoke Codex Oracle
+
+Dispatch to `code-oracle-codex` agent (see `.claude/agents/code-oracle-codex.md`):
+
+```
+@code-oracle-codex: Review /tmp/dual-qaqc-context.md
+- Answer the question in the context file
+- Flag any issues you find that weren't asked about
+- Assign confidence: High / Medium / Low to each finding
+- Write findings to: .claude/outputs/dual-qaqc/{date}-codex.md
+```
+
+### Step 4: Invoke Opus Oracle
+
+Run the same context through Claude Opus (max thinking if available):
+
+```
+@opus: Review /tmp/dual-qaqc-context.md
+- Same instructions as Codex oracle above
+- Write findings to: .claude/outputs/dual-qaqc/{date}-opus.md
+```
+
+### Step 5: Reconcile
+
+Compare the two outputs:
+
+```
+Agreement     → High confidence finding → act on it
+Disagreement  → Flag for human review → do NOT resolve automatically
+One found, one missed → Medium confidence → investigate further
+```
+
+### Step 6: Write Reconciled Report
+
+```markdown
+# Dual-QAQC: [Topic] — {date}
+
+## High-Confidence Findings (Both Agree)
+- [Finding]: [Action required]
+
+## Divergences (Human Review Required)
+- [Topic]: Codex says X, Opus says Y — [why this matters]
+
+## One-Sided Findings (Investigate Further)
+- [Finding from Codex only]: [Codex confidence]
+- [Finding from Opus only]: [Opus confidence]
+
+## Verdict
+[Overall assessment and recommended action]
+```
+
+Save to: `.claude/outputs/dual-qaqc/{date}-{topic}-reconciled.md`
+
+---
+
+## Model Guidance
+
+| Oracle | Strengths | Run when |
+|--------|-----------|----------|
+| Codex CLI (xhigh) | Code logic, security, edge cases | Always |
+| Claude Opus (extended thinking) | Architecture, tradeoffs, broader context | Always |
+| Claude Sonnet | Speed, iteration | Skip for dual-qaqc (use for drafts) |
+
+**xhigh thinking** = Codex CLI's maximum reasoning budget. Use `--thinking xhigh` flag.
+
+---
+
+## Output Location
+
+`.claude/outputs/dual-qaqc/`
+
+```
+{date}-{topic}-codex.md      ← Codex oracle findings
+{date}-{topic}-opus.md       ← Opus oracle findings
+{date}-{topic}-reconciled.md ← Final reconciled report
+```
+
+---
+
+*Cross-references*: `code-oracle-codex` agent, `code-oracle-gemini` agent, `/agent-oracle-codex` command

--- a/.claude/commands/test-notebook.md
+++ b/.claude/commands/test-notebook.md
@@ -22,45 +22,54 @@ Look at the current conversation to determine which notebook is being worked on:
 
 If unclear, ask the user which notebook to test.
 
-### 2. Determine the Kernel
+### 2. Preflight: Scan for GUI-Blocking Cells
 
-**Default**: Use the `rascommander` kernel (pip-installed package). This validates the end-user experience.
+Before delegating, grep the notebook for GUI automation markers:
+- `wait_for_user`, `open_rasmapper`, `open_and_compute`, `run_multiple_plans`
 
-**Switch to local dev kernel** (`rascmdr` or `rascmdr_local`) only when:
-- The current work involves unpublished library changes being tested
-- The user explicitly requests local dev testing
+If found, warn the user: "This notebook contains GUI automation cells that will block waiting for you to close HEC-RAS. The run will pause at those cells."
 
-**If neither kernel is available**: Ask the user which environment to use and offer to set one up.
+### 3. Resolve the Kernel
 
-### 3. Delegate to notebook-runner Subagent
+Run `jupyter kernelspec list` to discover available kernels. Select based on context:
 
-**You MUST use the Agent tool** to delegate this work:
+**Default**: Use `RasCommander` kernel (pip-installed package) to validate end-user experience.
+
+**Switch to `rascmdr_local`** only when the current work involves unpublished library changes.
+
+**If neither canonical kernel exists**: Check for close matches (`rascommander`, `rascmdr`, `python3`). Ask the user which to use if ambiguous, and offer to set one up per `.claude/rules/testing/environment-management.md`.
+
+### 4. Delegate to notebook-runner Subagent
+
+**You MUST use the Agent tool** to delegate this work. The subagent chooses the appropriate execution mode (papermill, nbconvert, or nbmake) based on the goal.
+
+Since `/test-notebook` is for **comprehensive development QA** (hide nothing, report all errors), the subagent should use **Mode B (nbconvert with allow-errors)** to ensure ALL cells execute even after failures. Mode A (papermill) stops at the first error, which misses downstream issues.
 
 ```python
 Agent(
     subagent_type="notebook-runner",
     model="sonnet",
     prompt=f"""
-    Execute and test this notebook using **papermill**: {notebook_path}
-    Use kernel: {kernel_name}
+    Execute and test this notebook: {notebook_path}
+    Use kernel: {resolved_kernel_name}
 
     **DEVELOPMENT TEST MODE - Report ALL issues back to main agent.**
 
-    Run via papermill (NOT nbconvert):
-    ```
-    papermill {notebook_path} working/notebook_runs/{stem}_executed.ipynb \
-      --cwd {notebook_dir} \
-      --kernel {kernel_name} \
-      --no-progress-bar
-    ```
+    Goal: comprehensive post-mortem — every cell must execute, even after errors.
+    Use Mode B (nbconvert with allow-errors) for full coverage.
+    If Mode B is unavailable, fall back to Mode A (papermill).
 
-    Use `--execution-timeout 0` (no hard kill) — let cells run to completion.
-    If execution seems stuck, report which cell is blocking and why, but do NOT kill it.
+    Follow the standard artifact contract:
+    - Create a timestamped folder under working/notebook_runs/
+    - Produce: run_command.txt, stdout.txt, stderr.txt, audit.json, audit.md
+    - Save the executed notebook as {stem}_executed.ipynb
+
+    Use --execution-timeout 0 / --ExecutePreprocessor.timeout=-1 (no hard kill).
 
     Return:
 
     1. EXECUTION STATUS
-       - Pass/Fail
+       - Pass/Fail per cell
        - Which cells succeeded/failed
        - Total execution time
 
@@ -86,14 +95,12 @@ Agent(
        - Print statements suggesting issues
        - GUI automation cells (will block waiting for user)
 
-    Write artifacts to: working/notebook_runs/
-
     Return a complete summary - the main agent needs full details to help the developer.
     """
 )
 ```
 
-### 4. Report Results Back to User
+### 5. Report Results Back to User
 
 After receiving the subagent's response, present ALL findings to the user:
 
@@ -113,7 +120,7 @@ User is editing `examples/725_atlas14_spatial_variance.ipynb`:
 User: /test-notebook
 ```
 
-Agent identifies notebook from context, delegates to notebook-runner, receives results, and reports back with complete error details.
+Agent identifies notebook from context, runs preflight scan, resolves kernel, delegates to notebook-runner, receives results, and reports back with complete error details.
 
 ## Key Principle
 
@@ -123,20 +130,14 @@ Agent identifies notebook from context, delegates to notebook-runner, receives r
 - All stderr output
 - Anything that indicates the notebook isn't working perfectly
 
-## GUI Automation Cells
-
-Some notebooks (e.g., 120, 320, 600) contain cells that launch HEC-RAS GUI and wait for user interaction. These cells will **block indefinitely** during automated execution. The subagent should:
-- Warn about GUI-blocking cells before execution
-- Note them in the execution report
-- Not treat them as failures
-
 ## Cross-References
 
 **Agents** (delegate to):
-- `notebook-runner` -- Notebook execution via papermill
+- `notebook-runner` -- Notebook execution (chooses mode based on goal)
 - `notebook-output-auditor` -- Output review (downstream)
 - `notebook-anomaly-spotter` -- Anomaly detection (downstream)
 - `hecras-notebook-qaqc` -- HEC-RAS project linkage verification (downstream)
 
 **Rules** (follow these):
 - `.claude/rules/documentation/notebook-standards.md` -- Notebook conventions
+- `.claude/rules/testing/environment-management.md` -- Canonical kernel names

--- a/.claude/commands/test-notebook.md
+++ b/.claude/commands/test-notebook.md
@@ -22,20 +22,42 @@ Look at the current conversation to determine which notebook is being worked on:
 
 If unclear, ask the user which notebook to test.
 
-### 2. Delegate to notebook-runner Subagent
+### 2. Determine the Kernel
 
-**You MUST use the Task tool** to delegate this work:
+**Default**: Use the `rascommander` kernel (pip-installed package). This validates the end-user experience.
+
+**Switch to local dev kernel** (`rascmdr` or `rascmdr_local`) only when:
+- The current work involves unpublished library changes being tested
+- The user explicitly requests local dev testing
+
+**If neither kernel is available**: Ask the user which environment to use and offer to set one up.
+
+### 3. Delegate to notebook-runner Subagent
+
+**You MUST use the Agent tool** to delegate this work:
 
 ```python
-Task(
+Agent(
     subagent_type="notebook-runner",
     model="sonnet",
     prompt=f"""
-    Execute and test this notebook: {notebook_path}
+    Execute and test this notebook using **papermill**: {notebook_path}
+    Use kernel: {kernel_name}
 
     **DEVELOPMENT TEST MODE - Report ALL issues back to main agent.**
 
-    Execute the notebook and return:
+    Run via papermill (NOT nbconvert):
+    ```
+    papermill {notebook_path} working/notebook_runs/{stem}_executed.ipynb \
+      --cwd {notebook_dir} \
+      --kernel {kernel_name} \
+      --no-progress-bar
+    ```
+
+    Use `--execution-timeout 0` (no hard kill) — let cells run to completion.
+    If execution seems stuck, report which cell is blocking and why, but do NOT kill it.
+
+    Return:
 
     1. EXECUTION STATUS
        - Pass/Fail
@@ -62,6 +84,7 @@ Task(
        - Import failures (even partial)
        - Slow cells (>30 seconds)
        - Print statements suggesting issues
+       - GUI automation cells (will block waiting for user)
 
     Write artifacts to: working/notebook_runs/
 
@@ -70,7 +93,7 @@ Task(
 )
 ```
 
-### 3. Report Results Back to User
+### 4. Report Results Back to User
 
 After receiving the subagent's response, present ALL findings to the user:
 
@@ -100,11 +123,20 @@ Agent identifies notebook from context, delegates to notebook-runner, receives r
 - All stderr output
 - Anything that indicates the notebook isn't working perfectly
 
+## GUI Automation Cells
+
+Some notebooks (e.g., 120, 320, 600) contain cells that launch HEC-RAS GUI and wait for user interaction. These cells will **block indefinitely** during automated execution. The subagent should:
+- Warn about GUI-blocking cells before execution
+- Note them in the execution report
+- Not treat them as failures
+
 ## Cross-References
 
 **Agents** (delegate to):
-- `notebook-runner` -- Notebook execution
-- `notebook-output-auditor` -- Output review
+- `notebook-runner` -- Notebook execution via papermill
+- `notebook-output-auditor` -- Output review (downstream)
+- `notebook-anomaly-spotter` -- Anomaly detection (downstream)
+- `hecras-notebook-qaqc` -- HEC-RAS project linkage verification (downstream)
 
 **Rules** (follow these):
 - `.claude/rules/documentation/notebook-standards.md` -- Notebook conventions

--- a/.claude/rules/README.md
+++ b/.claude/rules/README.md
@@ -15,18 +15,21 @@ Language-specific patterns for ras-commander development:
 
 ### hec-ras/
 Domain-specific knowledge:
+- `calibration.md` - RasCalibrate workflows, CalibrationPoint setup, metric selection
 - `execution.md` - compute_plan(), parallel modes, stream_callback
 - `geometry.md` - Fixed-width parsing, bank station interpolation, 450-point limit
 - `hdf-files.md` - Result extraction, steady vs unsteady detection
 - `dss-files.md` - Boundary conditions, Java bridge, lazy loading
 - `remote.md` - Worker patterns, Session ID=2, Group Policy requirements
+- `ras-commander-first.md` - Check existing ras-commander APIs before reimplementing logic
+- `terrain-modification.md` - RasTerrainMod Windows/pythonnet workflow rules
+- `terrain.md` - Terrain creation and terrain-file guidance
 - `usgs.md` - Gauge workflows, NWIS access, validation metrics
 - `precipitation.md` - AORC workflows, Atlas 14 integration
 
 ### testing/
 Testing approaches:
 - `tdd-approach.md` - Test with real HEC-RAS examples, not mocks
-- `example-projects.md` - RasExamples.extract_project() workflows
 - `environment-management.md` - Virtual environment setup: uv for agents, Anaconda for notebooks (rascmdr_local/RasCommander)
 
 ### documentation/
@@ -34,6 +37,10 @@ Documentation standards:
 - `hierarchical-knowledge-best-practices.md` - Subagent/skill patterns, avoiding duplication
 - `mkdocs-config.md` - Notebook integration, symlink handling
 - `notebook-standards.md` - Title requirements, execution policy
+
+### bridge rules
+Repository bridge rules:
+- `agents-md-bridge.md` - Standard thin-wrapper pattern for `AGENTS.md` compatibility files
 
 ## How Rules Work
 
@@ -61,9 +68,13 @@ These files have **no** `paths:` frontmatter and load in all sessions:
 | Rule File | Loads When Working In |
 |-----------|----------------------|
 | `python/*.md` (14 files) | `ras_commander/**` |
+| `agents-md-bridge.md` | `AGENTS.md`, `**/AGENTS.md` |
+| `hec-ras/calibration.md` | `ras_commander/RasCalibrate.py`, `ras_commander/usgs/metrics.py` |
 | `hec-ras/execution.md` | `ras_commander/**` |
 | `hec-ras/precipitation.md` | `ras_commander/**` |
+| `hec-ras/ras-commander-first.md` | `**/*.py`, `**/*.ipynb` |
 | `hec-ras/terrain.md` | `ras_commander/**` |
+| `hec-ras/terrain-modification.md` | `ras_commander/terrain/RasTerrainMod.py`, `examples/930_terrain_modification_analysis.ipynb` |
 | `hec-ras/remote.md` | `ras_commander/remote/**` |
 | `validation/validation-patterns.md` | `ras_commander/**` |
 | `testing/tdd-approach.md` | `tests/**` |

--- a/.claude/rules/agents-md-bridge.md
+++ b/.claude/rules/agents-md-bridge.md
@@ -1,0 +1,86 @@
+---
+description: Standard pattern for creating thin-wrapper AGENTS.md files that bridge Claude Code .claude/ infrastructure with Codex and other agents
+paths:
+  - "AGENTS.md"
+  - "**/AGENTS.md"
+---
+
+# AGENTS.md Bridge Standard
+
+## Purpose
+
+- `AGENTS.md` is the compatibility layer for non-Claude agents such as Codex, Gemini CLI, and similar tools.
+- Canonical repository guidance stays in `CLAUDE.md` and the canonical agent framework stays under `.claude/`.
+- Use `AGENTS.md` to help other agents discover the Claude-managed framework quickly, not to create a second framework.
+
+## Standard Thin-Wrapper Structure
+
+1. Start with a one-line purpose statement.
+2. Point to `CLAUDE.md` as the canonical top-level instruction file.
+3. Point to `.claude/MANIFEST.md` as the component registry when it exists.
+4. List the key framework paths: `.claude/rules/`, `.claude/agents/`, `.claude/skills/`, `.claude/commands/`.
+5. Add a short project-specific quick-start: environment setup, key entry points, working directory conventions.
+6. Include a `Cross-Loading Contract` that says: read `AGENTS.md`, then `CLAUDE.md`, then `MANIFEST.md`, then only the relevant `.claude/` files.
+
+## What Not To Put In AGENTS.md
+
+- Do not duplicate `.claude/rules/` content.
+- Do not create tool-specific parallel frameworks such as separate Codex-only instruction hierarchies unless explicitly requested.
+- Do not turn `AGENTS.md` into a long tutorial or operations manual.
+- Do not maintain competing top-level instructions that can drift away from `CLAUDE.md`.
+
+## Subdirectory AGENTS.md Files
+
+- Subdirectory `AGENTS.md` files should also be thin wrappers.
+- They should point to the nearest relevant `CLAUDE.md` file for that subtree.
+- They may add only local entry points, local workflows, or local directory conventions that a sub-agent needs immediately.
+
+## Worktree Pattern
+
+- Git worktrees inherit the parent repository `AGENTS.md` by default.
+- A worktree may add a small local wrapper if it needs branch-specific paths, outputs, or temporary context.
+- Worktree wrappers should still point back to the parent `CLAUDE.md` and `.claude/` sources rather than copying framework content.
+
+## When To Create AGENTS.md
+
+- Any project with active Claude Code sessions should also have `AGENTS.md`.
+- Add it when bootstrapping `.claude/` in a new repository.
+- Add it when creating a Claude-managed analysis workspace or sub-workspace that non-Claude agents will also enter.
+
+## Template: Thin-Wrapper AGENTS.md for CLB Projects
+
+```markdown
+## Template: Thin-Wrapper AGENTS.md for CLB Projects
+
+---
+**Purpose**: Thin compatibility wrapper - canonical guidance lives in `CLAUDE.md` and `.claude/`.
+
+**Read First**
+- `CLAUDE.md` - canonical top-level instructions
+- `.claude/MANIFEST.md` - component registry (rules, agents, skills, commands)
+
+**Claude Infrastructure** (load only what's relevant to current task)
+- `.claude/rules/` - auto-loaded topic rules
+- `.claude/agents/` - specialist subagent definitions
+- `.claude/skills/` - domain workflow skills
+- `.claude/commands/` - slash command definitions
+
+**[Project-Specific Quick Start]**
+- [Environment setup]
+- [Key entry points]
+- [Working directory conventions]
+
+**Cross-Loading Contract**
+1. Read this AGENTS.md
+2. Read CLAUDE.md
+3. Consult .claude/MANIFEST.md for component discovery
+4. Load only relevant .claude/ files for the current task
+---
+```
+
+## Maintenance Rules
+
+- Keep new project `AGENTS.md` files short; thin wrappers should usually stay under 100 lines.
+- If a project does not yet have `.claude/MANIFEST.md`, point to the existing `.claude/` paths directly and say so explicitly.
+- When framework paths change, update `AGENTS.md` pointers instead of copying content into the wrapper.
+- The compatibility contract is stable: `AGENTS.md` redirects, `CLAUDE.md` instructs, `.claude/` provides the detailed components.

--- a/.claude/rules/commit-policy.md
+++ b/.claude/rules/commit-policy.md
@@ -1,0 +1,49 @@
+---
+paths: ras_commander/**, examples/**
+---
+
+# Commit Policy: Library Code Requires Notebook Coverage
+
+**Context**: Ensures every new library function ships with test coverage and documentation
+**Priority**: Critical - applies to all commits adding new public API
+**Auto-loads**: Yes (library and examples code)
+
+## Core Rule
+
+Every commit that adds **new public library functions** to `ras_commander/` MUST include:
+
+1. **Example notebook coverage** in `examples/` exercising the new function with real-world data (RasExamples, eBFE, USGS, or other production sources — never mocks)
+2. **Documentation update** in the relevant subpackage `CLAUDE.md` listing the new method
+3. **Evidence the function was tested** (notebook executed successfully or verified)
+
+All three elements ship in the **same commit** so every commit is self-contained.
+
+## Exemptions
+
+| Category | Notebook Required? | CLAUDE.md Required? |
+|----------|--------------------|---------------------|
+| New public library function | Yes | Yes |
+| Bug fix to existing function with existing coverage | No | No |
+| Framework/governance files (`.claude/` rules, skills, commands) | No | No |
+| Documentation-only changes (docs/, mkdocs.yml) | No | No |
+| Refactoring with no public API change | No | No |
+
+## .py Test Files
+
+Files in `tests/` are **temporary development scaffolding**:
+
+- Useful during implementation for quick iteration
+- May inform later notebook creation
+- Must NOT be included in library commits
+- Clean up when the corresponding notebook exists
+
+## Blocking Commits
+
+If notebook coverage or CLAUDE.md docs are missing, the commit is **BLOCKED** until prerequisites are met. Track blocked commits explicitly in the plan with unblocking steps.
+
+## Rationale
+
+- Notebooks serve as both documentation and functional tests
+- Real-world data catches integration issues mocks would miss
+- CLAUDE.md updates keep subpackage API docs current
+- Self-contained commits enable clean git bisect and cherry-pick

--- a/.claude/rules/hec-ras/calibration.md
+++ b/.claude/rules/hec-ras/calibration.md
@@ -1,0 +1,116 @@
+---
+description: RasCalibrate patterns — CalibrationPoint setup, metric selection, extraction methods, and optimization workflow
+paths:
+  - ras_commander/RasCalibrate.py
+  - ras_commander/usgs/metrics.py
+---
+
+# HEC-RAS Calibration Rules
+
+## CalibrationPoint Construction
+
+Always use the `CalibrationPoint` dataclass directly — do not build dicts and pass to `RasCalibrate` unless you prefer the dict-coercion path.
+
+```python
+from ras_commander import CalibrationPoint
+
+pt = CalibrationPoint(
+    name="Gauge_12040104",
+    variable="wse",                    # wse | flow | depth | velocity
+    extraction_method="ref_point",     # 1d_xs | 2d_cell | ref_line | ref_point
+    observed=42.3,                     # scalar → time_index required; Series → full-series mode
+    ref_feature_name="Gauge_12040104",
+    metric="nse",                      # nse | kge | rmse | mae | pbias
+    weight=1.0,
+    time_index="max",                  # "max" = peak value; None/"all" = full time series
+)
+```
+
+**Extraction method requirements**:
+
+| Method | Required fields |
+|--------|----------------|
+| `1d_xs` | `river`, `reach`, `station` |
+| `2d_cell` | `x`, `y` (projected CRS matching model) |
+| `ref_line` | `ref_feature_name` |
+| `ref_point` | `ref_feature_name` |
+
+## Metric Selection
+
+| Metric | Direction | Use when |
+|--------|-----------|----------|
+| `nse` | higher is better | Peak discharge / WSE time series — primary calibration metric |
+| `kge` | higher is better | Balanced bias + timing — use alongside NSE for USGS gauge matching |
+| `rmse` | lower is better | Absolute error in physical units — use for WSE vs. survey data |
+| `mae` | lower is better | Outlier-robust error |
+| `pbias` | lower is better | Volume bias check |
+
+**Default**: use `nse` for first-pass calibration. Add `kge` as a secondary metric (weight = 0.5) when timing matters as well as magnitude.
+
+## time_index Rules
+
+- `time_index="max"` — extracts the peak (scalar) value. Use with scalar `observed`.
+- `time_index=None` (or `"all"` / `"series"`) — extracts full time series. Use with `pd.Series` `observed`.
+- Integer: extracts a specific time step index. Rarely used outside unit tests.
+- **Mismatch error**: scalar `observed` + full-series `time_index` → raises `ValueError`. Always pair correctly.
+
+## Scipy Optimization
+
+`RasCalibrate` supports these `scipy.optimize.minimize` methods:
+
+```python
+from ras_commander import RasCalibrate
+
+result = RasCalibrate.optimize(
+    calibration_points=points,
+    param_bounds={"mannings_n": (0.025, 0.06), "infiltration_rate": (0.01, 0.10)},
+    method="nelder-mead",    # Start with nelder-mead; switch to l-bfgs-b for many params
+    max_iter=50,
+    plan_number="01",
+)
+```
+
+**Method guidance**:
+- `nelder-mead`: good for 1–5 parameters, no gradient required. Default starting point.
+- `powell`: good for separable objectives.
+- `l-bfgs-b`: efficient for 5+ parameters; requires well-behaved objective.
+- `slsqp`: use when you have inequality constraints (e.g., Manning's n ≥ 0.025).
+
+## Batch Calibration Pattern
+
+RasCalibrate composes `RasPermutation` internally. Each optimizer iteration runs a full HEC-RAS compute. For expensive calibration runs:
+
+1. Start with a coarse Nelder-Mead pass (10–20 iterations) to identify the basin
+2. Use the best result as the starting point for a refinement pass
+3. Always read compute messages after each run — calibration errors often manifest as convergence failures, not Python exceptions
+
+```python
+# After calibration, always inspect messages
+from ras_commander import HdfResultsPlan
+msgs = HdfResultsPlan.get_compute_messages(plan_number="01")
+errors = [l for l in msgs if "ERROR" in l.upper()]
+if errors:
+    raise RuntimeError(f"Model errors during calibration: {errors[:5]}")
+```
+
+## Composite Objectives
+
+When using multiple calibration points, each point's metric is computed separately and then weighted:
+
+```python
+points = [
+    CalibrationPoint(name="Q_upstream", variable="flow", ..., weight=2.0, metric="nse"),
+    CalibrationPoint(name="WSE_mid",    variable="wse",  ..., weight=1.0, metric="rmse"),
+    CalibrationPoint(name="WSE_down",   variable="wse",  ..., weight=1.0, metric="rmse"),
+]
+```
+
+Higher weight = more influence on the objective. Normalize weights when in doubt (sum to 1).
+
+## Cross-References
+
+- `ras_commander/RasCalibrate.py` — CalibrationPoint, RasCalibrate class, _SCIPY_METHODS
+- `ras_commander/usgs/metrics.py` — calculate_all_metrics, nash_sutcliffe_efficiency, kling_gupta_efficiency
+- `ras_commander/RasPermutation.py` — underlying batch execution engine
+- `.claude/rules/hec-ras/execution.md` — mandatory Post-Execution Protocol for compute messages
+- `.claude/rules/hec-ras/usgs.md` — USGS gauge integration for observed data sourcing

--- a/.claude/rules/hec-ras/execution.md
+++ b/.claude/rules/hec-ras/execution.md
@@ -694,6 +694,108 @@ RasCmdr.compute_plan("01", force_geompre=True)
 
 **Manual override**: Not currently supported (flag always enabled)
 
+## Post-Execution Protocol (Required)
+
+**After every compute operation, always:**
+
+### 1. Enable Verbose Streaming During Execution
+
+Always pass `stream_callback` with verbose output — never run silent:
+
+```python
+from ras_commander.callbacks import ConsoleCallback, FileLoggerCallback
+
+# ✅ Standard: stream to console
+RasCmdr.compute_plan("01", stream_callback=ConsoleCallback(verbose=True))
+
+# ✅ Better for notebooks/CI: stream to file + console
+RasCmdr.compute_plan("01", stream_callback=FileLoggerCallback("logs/plan_01.log", verbose=True))
+
+# ❌ Never run without a callback — silent failures are invisible
+RasCmdr.compute_plan("01")  # Don't do this
+```
+
+### 2. Read Compute Messages After Every Run
+
+Always call `get_compute_messages()` after execution and review the output:
+
+```python
+from ras_commander.hdf import HdfResultsPlan
+
+# Read messages (HDF primary, .computeMsgs.txt fallback, .comp_msgs.txt fallback)
+messages = HdfResultsPlan.get_compute_messages("01")
+print(messages)  # Always print — don't silently discard
+```
+
+### 3. Check for Warnings and Errors
+
+Scan messages for these patterns and report them — do not silently pass:
+
+```python
+# Standard message review
+messages = HdfResultsPlan.get_compute_messages("01")
+lines = messages.splitlines()
+
+errors   = [l for l in lines if "ERROR"    in l.upper()]
+warnings = [l for l in lines if "WARNING"  in l.upper()]
+unstable = [l for l in lines if "UNSTABLE" in l.upper() or "NEGATIVE DEPTH" in l.upper()]
+converge = [l for l in lines if "COURANT"  in l.upper() or "NOT CONVERGE" in l.upper()]
+
+if errors:
+    raise RuntimeError(f"HEC-RAS errors:\n" + "\n".join(errors))
+if unstable:
+    print(f"⚠️  Instability warnings ({len(unstable)}):\n" + "\n".join(unstable[:5]))
+if warnings:
+    print(f"⚠️  Warnings ({len(warnings)}):\n" + "\n".join(warnings[:10]))
+if not errors and not unstable:
+    runtime = HdfResultsPlan.get_runtime_data("01")
+    if runtime is not None:
+        hrs = runtime['Complete Process (hr)'].values[0]
+        print(f"✅  Plan 01 complete in {hrs:.2f} hr")
+```
+
+### 4. Report Findings to User
+
+Always summarize what was found in compute messages — even for successful runs:
+- **Success**: Report runtime duration and confirm no warnings
+- **Warnings**: List all warnings; let user decide if they're acceptable
+- **Errors**: Always surface errors immediately — never continue past an error
+
+### Default Pattern (Copy-Paste Template)
+
+```python
+from ras_commander import init_ras_project, RasCmdr
+from ras_commander.hdf import HdfResultsPlan
+from ras_commander.callbacks import ConsoleCallback
+
+init_ras_project("/path/to/project", "6.6")
+
+# Execute with verbose streaming
+RasCmdr.compute_plan("01", stream_callback=ConsoleCallback(verbose=True))
+
+# Review messages
+messages = HdfResultsPlan.get_compute_messages("01")
+lines = messages.splitlines()
+errors   = [l for l in lines if "ERROR"    in l.upper()]
+warnings = [l for l in lines if "WARNING"  in l.upper()]
+unstable = [l for l in lines if "UNSTABLE" in l.upper() or "NEGATIVE DEPTH" in l.upper()]
+
+if errors:
+    raise RuntimeError("HEC-RAS errors:\n" + "\n".join(errors))
+if unstable or warnings:
+    print(f"⚠️  {len(warnings)} warnings, {len(unstable)} instability notices")
+    for w in (unstable + warnings)[:10]:
+        print(f"   {w}")
+else:
+    runtime = HdfResultsPlan.get_runtime_data("01")
+    hrs = runtime['Complete Process (hr)'].values[0] if runtime is not None else "?"
+    print(f"✅  Plan 01 complete in {hrs} hr — no warnings")
+```
+
+**Note**: `Write Detailed= 1` is automatically set by all compute functions — detailed messages are always generated. The only question is whether you read them.
+
+---
+
 ## Cross-References
 
 **Skills** (invoke these):

--- a/.claude/rules/hec-ras/ras-commander-first.md
+++ b/.claude/rules/hec-ras/ras-commander-first.md
@@ -1,0 +1,78 @@
+---
+description: Check ras-commander's existing API before writing new HEC-RAS automation code. Prevents duplicate implementation of functionality that already exists.
+paths:
+  - "**/*.py"
+  - "**/*.ipynb"
+---
+
+# ras-commander First Principle
+
+Before writing any new HEC-RAS automation code, always check whether ras-commander already provides the functionality.
+
+## Why This Rule Exists
+
+ras-commander is the canonical Python library for HEC-RAS automation in this codebase. New code that reimplements existing ras-commander methods:
+- Creates maintenance debt (two places to fix bugs)
+- Misses edge cases already handled by the library (Unicode paths, HDF locking, plan number normalization, etc.)
+- Diverges from the static-class API pattern used everywhere
+
+## What to Check First
+
+Before writing file parsing, HDF reads, plan manipulation, or geometry ops, check:
+
+```
+ras_commander/
+├── RasCmdr.py          ← plan execution (compute_plan, compute_plans)
+├── RasCalibrate.py     ← calibration workflows (CalibrationPoint, RasCalibrate)
+├── RasPermutation.py   ← batch permutation / parameter sweeps
+├── RasPlan.py          ← plan file read/write
+├── RasGeometry.py      ← geometry file operations
+├── RasUtils.py         ← normalize_ras_number, path helpers
+├── hdf/
+│   ├── HdfResultsPlan.py     ← compute messages, plan results
+│   ├── HdfResultsMesh.py     ← 2D mesh results (depth, WSE, velocity)
+│   ├── HdfResultsXsec.py     ← 1D cross-section results
+│   └── HdfLandCover.py       ← land cover / Manning's n
+├── usgs/
+│   ├── core.py               ← USGS gauge data retrieval
+│   └── metrics.py            ← NSE, KGE, RMSE, MAE, pbias
+├── terrain/
+│   └── RasTerrainMod.py      ← terrain sampling with modifications
+└── precip/
+    ├── PrecipAorc.py         ← AORC historical precipitation
+    └── Atlas14Grid.py        ← Atlas 14 design storms
+```
+
+## How to Apply This
+
+1. **Describe what you need** — e.g., "read maximum WSE from 2D mesh at coordinates (x, y)"
+2. **Grep ras-commander first**: `Grep pattern="def.*wse|get.*wse" path="G:/GH/ras-commander/ras_commander/"`
+3. **Read the method signature** before assuming it doesn't exist
+4. **Use it** — call ras-commander directly rather than writing equivalent logic
+
+## What to Do When ras-commander Doesn't Have It
+
+If functionality is genuinely missing:
+1. Implement it using ras-commander's internal helpers (`RasUtils`, `HdfUtils`, `Decorators`)
+2. Follow the static-class pattern: `class MyClass:` with `@staticmethod` methods
+3. Use `@log_call` decorator from `Decorators.py`
+4. Consider contributing it back to ras-commander via a feature branch
+
+## Applied to RASAlphaCLI
+
+This rule was written partly because RASAlphaCLI scripts (`notebooks/`, `tools/`) have repeatedly reimplemented HDF reads, plan manipulation, and path handling that already exist in ras-commander. When working in RASAlphaCLI:
+
+```python
+# BAD — reimplemented path normalization
+plan_num = str(plan_number).zfill(2)
+
+# GOOD — use ras-commander
+from ras_commander import RasUtils
+plan_num = RasUtils.normalize_ras_number(plan_number)
+```
+
+## Cross-References
+
+- `.claude/rules/python/api-first-principle.md` — broader API-first guidance
+- `.claude/rules/python/static-classes.md` — static class pattern
+- `G:/GH/RASAlphaCLI/.claude/rules/ras-commander-first.md` — mirror rule in RASAlphaCLI

--- a/.claude/rules/hec-ras/terrain-modification.md
+++ b/.claude/rules/hec-ras/terrain-modification.md
@@ -1,0 +1,111 @@
+---
+description: RasTerrainMod rules — Windows-only, pythonnet setup, GDAL junction, thread safety, no-net-fill workflow
+paths:
+  - ras_commander/terrain/RasTerrainMod.py
+  - examples/930_terrain_modification_analysis.ipynb
+---
+
+# Terrain Modification Rules (RasTerrainMod)
+
+## Platform Constraint: Windows Only
+
+`RasTerrainMod` wraps `RasMapperLib.dll` via pythonnet. It **will not run on Linux or macOS**, even in containers. All terrain modification sampling must run on a Windows machine with HEC-RAS 6.5+ installed.
+
+```python
+# This raises RuntimeError on non-Windows:
+RasTerrainMod.get_terrain_profile(...)
+```
+
+## Prerequisites (in order)
+
+1. **HEC-RAS 6.5 or 6.6** installed at one of:
+   - `C:/Program Files (x86)/HEC/HEC-RAS/6.6/`
+   - `C:/Program Files (x86)/HEC/HEC-RAS/6.5/`
+   - `C:/Program Files/HEC/HEC-RAS/6.6/`
+
+2. **pythonnet** installed: `pip install pythonnet`
+
+3. **GDAL bridge** set up once per Python environment:
+   ```python
+   from ras_commander.terrain import RasTerrainMod
+   RasTerrainMod.setup_gdal_bridge()  # Creates GDAL junction next to python.exe
+   ```
+   This creates a directory junction at `<python.exe dir>/GDAL/` pointing to HEC-RAS's GDAL. Only needs to run once. Requires write permission to the Python directory (run as admin if needed).
+
+## Thread Safety
+
+`RasTerrainMod` is **NOT thread-safe**. The internal `RASMapperCom` instance uses COM STA rules. Do not call methods from multiple threads simultaneously. Use a `threading.Lock()` if calling from a multi-threaded context.
+
+```python
+# BAD — concurrent calls will corrupt the COM state
+with ThreadPoolExecutor() as ex:
+    futures = [ex.submit(RasTerrainMod.get_terrain_profile, ...) for ...]
+
+# GOOD — sequential calls only
+for profile_args in profiles:
+    result = RasTerrainMod.get_terrain_profile(**profile_args)
+```
+
+## Core Methods
+
+| Method | Purpose | Key args |
+|--------|---------|----------|
+| `setup_gdal_bridge()` | One-time GDAL junction creation | `hecras_version`, `python_dir` |
+| `get_terrain_extent()` | Bounding box with modifications | `rasmap_path`, `geom_hdf_path` |
+| `get_terrain_profile()` | Sample terrain along polyline | + `x_coords`, `y_coords` |
+| `get_terrain_volume_elevation()` | Elevation-volume curve for polygon | + polygon coordinates |
+| `compare_terrain_profiles()` | Cut/fill analysis (2 profiles) | two profile dicts |
+| `compare_terrain_volumes()` | No-net-fill comparison (2 E-V curves) | two volume dicts |
+
+## Terrain Modifications Are Automatic
+
+Modifications stored in the `.rasmap` file (channels, levees, terrain polygons) are automatically applied by `RASMapperCom`. You do not need to apply them manually. This is the entire reason to use `RasTerrainMod` rather than direct raster sampling.
+
+```python
+# Both calls sample WITH modifications applied:
+profile = RasTerrainMod.get_terrain_profile(
+    rasmap_path="project.rasmap",
+    geom_hdf_path="project.g01.hdf",
+    x_coords=[...],
+    y_coords=[...]
+)
+```
+
+## No-Net-Fill Workflow
+
+```python
+# 1. Sample existing terrain (pre-modification)
+pre_volume = RasTerrainMod.get_terrain_volume_elevation(
+    rasmap_path="project_pre.rasmap",
+    geom_hdf_path="project.g01.hdf",
+    polygon_x=[...], polygon_y=[...]
+)
+
+# 2. Sample with modifications (post)
+post_volume = RasTerrainMod.get_terrain_volume_elevation(
+    rasmap_path="project_post.rasmap",
+    geom_hdf_path="project.g01.hdf",
+    polygon_x=[...], polygon_y=[...]
+)
+
+# 3. Compare
+comparison = RasTerrainMod.compare_terrain_volumes(pre_volume, post_volume)
+# Returns: cut_volume, fill_volume, net_fill, net_fill_pct
+```
+
+## Common Errors
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| `RuntimeError: HEC-RAS not found` | HEC-RAS not installed or wrong version | Install HEC-RAS 6.5+ at expected path |
+| `ImportError: pythonnet required` | pythonnet not installed | `pip install pythonnet` |
+| `GDAL junction not found` warning | `setup_gdal_bridge()` not called | Call once before any sampling |
+| Junction creation fails | No write permission to Python dir | Run as Administrator once |
+| COM object errors after concurrent calls | Thread safety violation | Serialize all calls |
+
+## Cross-References
+
+- `ras_commander/terrain/RasTerrainMod.py` — full implementation
+- `ras_commander/terrain/RasTerrain.py` — terrain layer operations (no modifications)
+- `.claude/MANIFEST.md` — Terrain & Land Cover domain
+- `examples/930_terrain_modification_analysis.ipynb` — worked example with no-net-fill

--- a/.claude/skills/README.md
+++ b/.claude/skills/README.md
@@ -47,6 +47,7 @@ Both use Claude Skills framework - the distinction is **scope and distribution**
 
 ### HEC-RAS GUI (`hecras_explore_*`)
 - **hecras_explore_gui** - HEC-RAS GUI exploration and documentation
+- **hecras_screenshot** - Screenshot capture workflow for HEC-RAS GUI documentation/debugging
 
 ### DSS Operations (`dss_*`)
 - **dss_read_boundary-data** - RasDss API, HEC-DSS V6/V7 files
@@ -57,6 +58,7 @@ Both use Claude Skills framework - the distinction is **scope and distribution**
 - **precip_analyze_atlas14-variance** - Atlas 14 precipitation spatial analysis
 
 ### eBFE/BLE Models (`ebfe_*`)
+- **ebfe_crawl_s3-catalog** - Crawl/cache FEMA public BLE/eBFE catalog availability
 - **ebfe_organize_models** - FEMA eBFE/BLE model organization
 - **ebfe_validate_models** - Validate organized eBFE models
 
@@ -65,6 +67,7 @@ Both use Claude Skills framework - the distinction is **scope and distribution**
 - **qa_review_triple-model** - Multi-LLM code review (Opus, Gemini, Codex)
 
 ### Development Tools (`dev_*`)
+- **dev_gate_merge-to-main** - Feature-branch guardrail for merge/push operations targeting `main`
 - **dev_manage_git-worktrees** - Git worktree management for feature isolation
 
 ### CLI Invocation Skills (`dev_invoke_*`)

--- a/.claude/skills/dev_gate_merge-to-main/SKILL.md
+++ b/.claude/skills/dev_gate_merge-to-main/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: dev_gate_merge-to-main
+description: Enforce the feature branch workflow — intercept any attempt to merge, push, or commit directly to main and redirect to the correct feature branch process. Triggers on "merge to main", "push to main", "PR to main", or any operation targeting the main branch.
+---
+
+# Development Gate: Merge-to-Main Policy
+
+**Policy**: ALL development happens on feature branches. `main` is production-only. Direct pushes to `main` are never allowed.
+
+This policy was established to prevent incomplete work from reaching the production branch. It applies universally — no exceptions without explicit user confirmation.
+
+## Trigger Conditions
+
+Activate this skill when you detect any of:
+- User says "merge", "push to main", "commit to main", "PR to main"
+- Current branch appears to be `main` and user wants to commit
+- `git push origin main` is about to be run
+- A PR target is set to `main` without a feature branch in the chain
+
+## Workflow
+
+### Step 1: Check Current Branch
+
+```bash
+git branch --show-current
+```
+
+**If on `main`**: Stop immediately — explain the policy and offer to create a feature branch.
+
+**If on a feature branch**: Verify the merge direction (feature → main via PR, not direct push).
+
+### Step 2: If on Main — Recover
+
+```bash
+# Create feature branch from current state
+git checkout -b feature/[descriptive-name]
+
+# Verify uncommitted changes moved with you
+git status
+
+# Optionally stash and reapply if needed
+git stash
+git checkout -b feature/[descriptive-name]
+git stash pop
+```
+
+### Step 3: Gate Check Before Any Push to Main
+
+Before running `git push origin main` or creating a PR to main, verify:
+
+| Check | Command | Pass Condition |
+|-------|---------|----------------|
+| Not on main | `git branch --show-current` | Output ≠ "main" |
+| Tests pass | `pytest` or project test command | 0 failures |
+| No uncommitted changes | `git status` | "nothing to commit" |
+| Feature branch exists | `git log --oneline main..HEAD` | At least 1 commit ahead |
+
+### Step 4: Correct Merge Path
+
+```
+feature/my-work → PR → main    ✅ Correct
+feature/my-work → direct push to main  ❌ Blocked
+main → direct commit  ❌ Blocked
+```
+
+**Creating the PR**:
+```bash
+git push origin feature/my-work
+gh pr create --base main --head feature/my-work --title "..." --body "..."
+```
+
+### Step 5: Hotfix Exception
+
+Hotfixes may go directly to main **only** with:
+1. Explicit user statement: "this is a hotfix"
+2. User confirmation: "I understand this bypasses the feature branch policy"
+3. A same-day revert plan if needed
+
+Even then: prefer `hotfix/[name]` branch → PR → main.
+
+## Branch Naming Convention
+
+```
+feature/[ticket-or-description]    ← new features
+bugfix/[description]               ← bug fixes
+hotfix/[description]               ← production emergencies only
+refactor/[description]             ← refactoring passes
+experiment/[description]           ← exploratory work
+```
+
+## What to Say When Intercepting
+
+If user attempts a direct-to-main operation:
+
+> "⚠️ You're about to [operation] directly to `main`. The ras-commander workflow requires all changes go through feature branches → PR → main.
+>
+> Want me to:
+> 1. Create a feature branch from your current state?
+> 2. Help you open a PR from your existing feature branch?
+> 3. Proceed anyway (hotfix only — requires your confirmation)?"
+
+---
+
+**Source**: Policy re-declared 4× in conversation history (2026-03-20 to 2026-04-12). Codified to prevent future re-statements.

--- a/.claude/skills/ebfe_crawl_s3-catalog/SKILL.md
+++ b/.claude/skills/ebfe_crawl_s3-catalog/SKILL.md
@@ -1,0 +1,186 @@
+---
+name: ebfe_crawl_s3-catalog
+description: Crawl FEMA's public BLE/eBFE S3 bucket to build a catalog of available Base Level Engineering datasets by state, HUC, and watershed. Cache results locally. Use when discovering what BLE models are available for a region before download.
+---
+
+# eBFE / BLE S3 Catalog Crawl Skill
+
+Crawl FEMA's public BLE S3 bucket and build a local catalog of available Base Level Engineering datasets. Cache results so repeated sessions don't re-crawl.
+
+## When to Use
+
+- "What BLE models are available for [state/watershed]?"
+- "Get the eBFE catalog for Texas"
+- Before any BLE model download or eBFE workflow
+- When `RasCatalog` / `RasSources` needs to be populated
+
+## S3 Source
+
+**Bucket**: `s3://fim-public-availability-data/` (FEMA public, no auth required)
+
+**Structure**:
+```
+fim-public-availability-data/
+└── ble/
+    └── {state}/
+        └── {huc8}/
+            ├── Hydraulics/
+            │   └── {project}.zip   ← HEC-RAS model
+            ├── Terrain/
+            └── Mapping/
+```
+
+**Alternative bucket** (check both):
+```
+s3://ras2fim-dev/
+s3://fim-dev-outputs/
+```
+
+## Crawl Workflow
+
+### Step 1: Check Local Cache First
+
+```python
+from pathlib import Path
+import json
+
+cache_path = Path(".claude/outputs/ble-catalog-cache.json")
+if cache_path.exists():
+    import time
+    age_days = (time.time() - cache_path.stat().st_mtime) / 86400
+    if age_days < 30:
+        with open(cache_path) as f:
+            catalog = json.load(f)
+        print(f"Using cached catalog ({age_days:.0f} days old, {len(catalog)} entries)")
+        # Skip crawl, use catalog
+```
+
+### Step 2: Crawl S3 (if cache miss or stale)
+
+```python
+import boto3
+from botocore import UNSIGNED
+from botocore.config import Config
+
+# Public bucket — no credentials needed
+s3 = boto3.client('s3', config=Config(signature_version=UNSIGNED))
+
+bucket = "fim-public-availability-data"
+prefix = "ble/"
+
+# Optional: filter by state
+state_filter = "TX"  # or None for all states
+if state_filter:
+    prefix = f"ble/{state_filter}/"
+
+paginator = s3.get_paginator('list_objects_v2')
+catalog = []
+
+for page in paginator.paginate(Bucket=bucket, Prefix=prefix, Delimiter='/'):
+    for obj in page.get('Contents', []):
+        key = obj['Key']
+        size = obj['Size']
+        # Filter to hydraulics .zip files
+        if 'Hydraulics' in key and key.endswith('.zip'):
+            parts = key.split('/')
+            # parts: ['ble', state, huc8, 'Hydraulics', filename]
+            if len(parts) >= 5:
+                catalog.append({
+                    'state': parts[1],
+                    'huc8': parts[2],
+                    'filename': parts[-1],
+                    's3_path': f"s3://{bucket}/{key}",
+                    'size_mb': round(size / 1e6, 1),
+                })
+
+print(f"Found {len(catalog)} BLE hydraulic models")
+```
+
+### Step 3: Save Cache
+
+```python
+import json
+from pathlib import Path
+
+cache_path = Path(".claude/outputs/ble-catalog-cache.json")
+cache_path.parent.mkdir(parents=True, exist_ok=True)
+
+with open(cache_path, 'w') as f:
+    json.dump(catalog, f, indent=2)
+
+print(f"Catalog cached: {cache_path}")
+```
+
+### Step 4: Build DataFrame for Filtering
+
+```python
+import pandas as pd
+
+df = pd.DataFrame(catalog)
+df['huc2'] = df['huc8'].str[:2]
+df['huc4'] = df['huc8'].str[:4]
+df['huc6'] = df['huc8'].str[:6]
+
+# Filter examples
+tx_models = df[df['state'] == 'TX']
+huc_models = df[df['huc8'].str.startswith('12040')]  # Harris County HUC8s
+print(f"Texas BLE models: {len(tx_models)}")
+print(tx_models[['huc8', 'filename', 'size_mb']].to_string())
+```
+
+### Step 5: Write Catalog Report
+
+```python
+output_path = f".claude/outputs/ebfe-catalog/{date}-{state_filter or 'all'}-catalog.md"
+
+content = f"""# BLE/eBFE S3 Catalog
+**Date**: {date}
+**State filter**: {state_filter or 'All states'}
+**Total models**: {len(df)}
+
+## Summary by State
+{df.groupby('state').size().to_string()}
+
+## Available HUC8s
+{df[['huc8', 'state', 'filename', 'size_mb']].to_string()}
+"""
+Path(output_path).parent.mkdir(parents=True, exist_ok=True)
+Path(output_path).write_text(content)
+print(f"Report: {output_path}")
+```
+
+## Integration with ras-commander
+
+After crawling, use the catalog with ras-commander's eBFE tools:
+
+```python
+from ras_commander import RasCatalog  # if available
+
+# Or use S3 paths directly
+s3_path = df[df['huc8'] == '12040104']['s3_path'].iloc[0]
+# Download and process
+```
+
+See `.claude/rules/hec-ras/` for eBFE-specific rules.
+
+## Output Location
+
+```
+.claude/outputs/
+├── ble-catalog-cache.json         ← persistent cache (30-day TTL)
+└── ebfe-catalog/
+    └── {date}-{state}-catalog.md  ← crawl reports
+```
+
+## Troubleshooting
+
+| Error | Fix |
+|-------|-----|
+| `NoCredentialsError` | Use `signature_version=UNSIGNED` for public bucket |
+| `403 Forbidden` | Bucket name changed; check FEMA's current BLE data portal |
+| Empty results | Try `prefix="ble/"` without state filter first |
+| Very slow | Use Delimiter and paginate; avoid listing all objects at once |
+
+---
+
+**Source**: BLE S3 crawl rebuilt from scratch multiple times in ras-commander conversation history (2026-03-20 to 2026-04-12). Codified to eliminate repeated reconstruction.

--- a/.claude/skills/hecras_screenshot/SKILL.md
+++ b/.claude/skills/hecras_screenshot/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: hecras_screenshot
+description: Capture screenshots of HEC-RAS GUI for documentation and debugging.
+---
+
+# HEC-RAS Screenshot Skill
+
+[Content to be populated - see RASDecomp project for current implementation]
+
+## Trigger
+
+Use when: capturing HEC-RAS GUI state for documentation, debugging, or QAQC reports.
+
+## Status
+
+Stub - implementation pending. The screenshot capability exists in the RASDecomp project at G:/GH/RASDecomp/screenshot/ras_screenshot.py, which provides:
+
+- Window capture via Win32 PrintWindow + GDI (works even when obscured)
+- Click control by name/best-match
+- Menu navigation via menu_select
+- Window detection by polling for new windows after interaction
+- Change detection via pixel-diff monitoring (>0.5% threshold)
+
+## Usage (from RASDecomp implementation)
+
+See G:/GH/RASDecomp/screenshot/ras_screenshot.py for full implementation (~900 lines).
+
+Common flags:
+  --list --json         List available windows
+  --output-dir DIR      Capture all windows to directory
+  --title PATTERN       Capture specific window by title
+  --click CONTROL       Click named control and capture
+  --menu PATH           Navigate menu and capture
+  --watch               Auto-capture on change detection
+
+## Cross-References
+
+**Related agents**:
+- win32com-automation-expert -- .claude/agents/win32com-automation-expert.md
+- hecras-code-archaeologist -- .claude/agents/hecras-code-archaeologist.md
+
+**External implementation**:
+- G:/GH/RASDecomp/screenshot/ras_screenshot.py -- Full screenshot tool (~900 lines)

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -9,6 +9,14 @@ labels: enhancement
 
 <!-- What problem does this solve? What workflow does it enable? -->
 
+## Source Workflow
+
+<!-- Which repo or workflow exposed this gap? Example: ras-agent watershed-to-geometry integration -->
+
+## Why This Belongs In `ras-commander`
+
+<!-- Explain the reusable HEC-RAS project/geometry/execution value of landing this here -->
+
 ## Proposed Solution
 
 <!-- How should it work? Include API design if you have ideas -->
@@ -23,6 +31,10 @@ result = NewFeature.do_something(plan_number="01", ras_object=ras)
 ## Alternatives Considered
 
 <!-- Other approaches you've thought about -->
+
+## Downstream Impact
+
+<!-- Which repos or workflows are blocked or enabled by this? Include issue links when relevant -->
 
 ## Additional Context
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,11 +40,12 @@
 **Repository Layout**
 - `ras_commander/` — core library (e.g., `RasCmdr`, `RasPrj`, `RasPlan`, `RasMap`, `Hdf*`, `Ras*`). One class per module is typical (e.g., `HdfMesh.py`). See `ras_commander/AGENTS.md` for coding-level details.
 - `examples/` — Jupyter notebooks and sample data for scenario validation. See `examples/AGENTS.md` for a detailed, agent-friendly index.
-- Top-level docs: `README.md`, `STYLE_GUIDE.md`, `Comprehensive_Library_Guide.md`, `api.md`.
+- Top-level docs: `README.md`, `CONTRIBUTING.md`, `ROADMAP.md`, `INTEGRATION.md`, `COMMIT_READY.md`.
+- Site docs: `docs/` with navigation in `mkdocs.yml`.
 - Packaging: `setup.py`, `pyproject.toml`.
 
 **Coding Style**
-- Follow `STYLE_GUIDE.md` (PEP 8, 4-space indents, ≤79-char lines, imports: stdlib → third-party → local).
+- Follow PEP 8 and existing repository patterns (4-space indents, imports ordered stdlib → third-party → local, keep lines reasonably short).
 - Names: `snake_case` for functions/variables; `PascalCase` for classes; `UPPER_CASE` for constants.
 - Logging pattern:
   - `from ras_commander import get_logger, log_call`
@@ -70,6 +71,12 @@
   - Update `agent_tasks/.agent/PROGRESS.md` at session end with detailed handoff notes
   - See `CLAUDE.md` § "Agent Coordination for Long-Running Tasks" for complete lifecycle
 - Not every session needs coordination—only use for complex, multi-file features that require planning and tracking across sessions.
+
+**Stale TASK.md Path Fallback**
+- If a TASK.md references a file path that does not exist, treat the path as stale (likely from a pre-migration era using `C:\GH\` or `\GH\`).
+- Remap: `C:\GH\` → `G:\GH\`, `C:\GH\ras-commander` → `G:\GH\ras-commander`.
+- If the remapped path also does not exist, search by filename under `G:\GH\ras-commander\` before asking the user.
+- Always resolve paths before failing — do not abort a task solely because an input path in TASK.md is stale.
 
 **Discovering HEC-RAS Projects**
 - Before initializing a project, agents often need to find valid HEC-RAS folders in a directory tree.
@@ -100,6 +107,16 @@
 - Commits: imperative mood, concise subject, optional scope. Example: `HdfXsec: fix ineffective-flow handling`.
 - PRs: include summary, motivation, linked issues, reproduction steps, and before/after notes.
 - Update documentation when APIs change; keep diffs focused and consistent.
+
+**Cross-Repo Feature Requests**
+- Reusable feature gaps discovered in sibling repos such as `ras-agent` or `hms-commander` should be tracked as GitHub issues in this repository when the work belongs here.
+- Prefer the existing GitHub feature request template for these requests.
+- A good cross-repo issue should include:
+  - source repo and workflow exposing the gap
+  - why the capability belongs in `ras-commander`
+  - proposed API or behavior
+  - downstream integration impact and blocking status
+  - acceptance criteria, example projects, and validation notes
 
 **HEC Commander (companion repo)**
 - Apply this `AGENTS.md` standard there as well. Remove outdated custom GPT files. Republishing as standardized CLB agents can follow separately. This repo's `AGENTS.md` is self-sufficient for Ras Commander.


### PR DESCRIPTION
## Summary
- Switch notebook-runner to papermill execution engine
- Add commit policy, calibration, ras-commander-first, terrain-modification rules
- Add Post-Execution Protocol rule
- Update MANIFEST, commands, agents, issue template
- Add merge-gate, eBFE S3 crawler, HEC-RAS screenshot skills
- Fix Codex QAQC findings in notebook-runner and test-notebook agents

## Notes
Cherry-picked from `feat/ras-calibrate`. No library code changes — framework/governance only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)