### PR TITLE
Migrate remaining HDF selectors to shared assets

### DIFF
--- a/ras_commander/Decorators.py
+++ b/ras_commander/Decorators.py
@@ -1,11 +1,10 @@
 from functools import wraps
 from pathlib import Path
-from typing import Union
-import logging
-import h5py
+from typing import Callable
 import inspect
-import pandas as pd
-from numbers import Number
+import logging
+
+import h5py
 
 
 def log_call(func):
@@ -18,278 +17,128 @@ def log_call(func):
         return result
     return wrapper
 
-def standardize_input(file_type: str = 'plan_hdf'):
+
+def standardize_input(_func: Callable = None, file_type: str = 'plan_hdf'):
     """
-    Decorator to standardize input for HDF file operations.
+    Decorator to standardize HDF path inputs.
 
-    This decorator processes various input types and converts them to a Path object
-    pointing to the correct HDF file. It handles the following input types:
-    - h5py.File objects
-    - pathlib.Path objects
-    - Strings (file paths or plan/geom numbers)
-    - Integers (interpreted as plan/geom numbers)
-
-    The decorator also manages RAS object references and logging.
-
-    Args:
-        file_type (str): Specifies whether to look for 'plan_hdf' or 'geom_hdf' files.
-
-    Returns:
-        A decorator that wraps the function to standardize its input to a Path object.
+    Supports direct HDF paths, h5py.File objects, plan selectors, and geometry
+    selectors. Path resolution is delegated to RasPrjAssets so HDF-facing
+    APIs share one selector policy.
     """
+    if callable(_func):
+        return standardize_input(file_type=file_type)(_func)
+
     def decorator(func):
         @wraps(func)
         def wrapper(*args, **kwargs):
             logger = logging.getLogger(func.__module__)
-            
-            # Check if the function expects an hdf_path parameter
             sig = inspect.signature(func)
             param_names = list(sig.parameters.keys())
-            
-            # If first parameter is 'hdf_file', pass an h5py object
-            if param_names and param_names[0] == 'hdf_file':
-                if isinstance(args[0], h5py.File):
-                    return func(*args, **kwargs)
-                elif isinstance(args[0], (str, Path)):
-                    with h5py.File(args[0], 'r') as hdf:
-                        return func(hdf, *args[1:], **kwargs)
-                else:
-                    raise ValueError(f"Expected h5py.File or path, got {type(args[0])}")
-                
-            # Handle both static method calls and regular function calls
-            if args and isinstance(args[0], type):
-                # Static method call, remove the class argument
-                args = args[1:]
-            
-            # Get hdf_input from kwargs if provided with hdf_path key, or take first positional arg
-            hdf_input = kwargs.pop('hdf_path', None) if 'hdf_path' in kwargs else (args[0] if args else None)
-            
-            # Import ras here to ensure we get the most current instance
-            from .RasPrj import ras as ras
-            # ras_object is always keyword-only, never in args
-            ras_object = kwargs.pop('ras_object', None)
-            ras_obj = ras_object or ras
 
-            # If no hdf_input provided, return the function unmodified
+            if args and isinstance(args[0], type):
+                args = args[1:]
+
+            ras_object_provided = 'ras_object' in kwargs
+            ras_object = kwargs.pop('ras_object', None)
+
+            if param_names and param_names[0] == 'hdf_file':
+                if not args:
+                    raise ValueError("Expected h5py.File or path input")
+                if isinstance(args[0], h5py.File):
+                    if ras_object_provided and 'ras_object' in param_names:
+                        kwargs['ras_object'] = ras_object
+                    return func(*args, **kwargs)
+
+                hdf_path = _resolve_hdf_input(args[0], file_type, ras_object, logger)
+                with h5py.File(hdf_path, 'r') as hdf:
+                    new_args = (hdf,) + args[1:]
+                    if ras_object_provided and 'ras_object' in param_names:
+                        kwargs['ras_object'] = ras_object
+                    return func(*new_args, **kwargs)
+
+            hdf_input_from_kwargs = 'hdf_path' in kwargs
+            hdf_input = kwargs.pop('hdf_path', None) if hdf_input_from_kwargs else (
+                args[0] if args else None
+            )
+
             if hdf_input is None:
+                if ras_object_provided and 'ras_object' in param_names:
+                    kwargs['ras_object'] = ras_object
                 return func(*args, **kwargs)
 
-            hdf_path = None
+            hdf_path = _resolve_hdf_input(hdf_input, file_type, ras_object, logger)
 
-            # Clean and normalize string inputs
-            if isinstance(hdf_input, str):
-                # Clean the string (remove extra whitespace, normalize path separators)
-                hdf_input = hdf_input.strip()
-                
-                # Check if it's a raw file path that exists
-                try:
-                    test_path = Path(hdf_input)
-                    if test_path.is_file():
-                        hdf_path = test_path
-                        logger.info(f"Using HDF file from direct string path: {hdf_path}")
-                except Exception as e:
-                    logger.debug(f"Error converting string to path: {str(e)}")
-
-            # If a valid path wasn't created from string processing, continue with normal flow
-            if hdf_path is None:
-                # If hdf_input is already a Path and exists, use it directly
-                if isinstance(hdf_input, Path) and hdf_input.is_file():
-                    hdf_path = hdf_input
-                    logger.info(f"Using existing Path object HDF file: {hdf_path}")
-                # If hdf_input is an h5py.File object, use its filename
-                elif isinstance(hdf_input, h5py.File):
-                    hdf_path = Path(hdf_input.filename)
-                    logger.info(f"Using HDF file from h5py.File object: {hdf_path}")
-                # Handle Path objects that might not be verified yet
-                elif isinstance(hdf_input, Path):
-                    if hdf_input.is_file():
-                        hdf_path = hdf_input
-                        logger.info(f"Using verified Path object HDF file: {hdf_path}")
-                # Handle string inputs that are plan/geom numbers
-                elif isinstance(hdf_input, str) and (hdf_input.isdigit() or (len(hdf_input) > 1 and hdf_input[0] == 'p' and hdf_input[1:].isdigit())):
-                    try:
-                        ras_obj.check_initialized()
-                    except Exception as e:
-                        raise ValueError(f"RAS object is not initialized: {str(e)}")
-
-                    # Extract the number part and strip leading zeros
-                    number_str = hdf_input if hdf_input.isdigit() else hdf_input[1:]
-                    stripped_number = number_str.lstrip('0')
-                    if stripped_number == '':  # Handle case where input was '0' or '00'
-                        stripped_number = '0'
-
-                    # Convert to integer and validate range
-                    try:
-                        number_int = int(stripped_number)
-                        if not (1 <= number_int <= 99):
-                            raise ValueError(f"Plan/geometry number must be between 1 and 99, got {number_int}")
-                    except (ValueError, TypeError) as e:
-                        raise ValueError(f"Cannot convert plan/geometry number '{hdf_input}' to integer") from e
-                    
-                    if file_type == 'plan_hdf':
-                        try:
-                            # Convert plan_number column to integers for comparison after stripping zeros
-                            plan_info = ras_obj.plan_df[ras_obj.plan_df['plan_number'].str.lstrip('0').astype(int) == number_int]
-                            if not plan_info.empty:
-                                # Make sure HDF_Results_Path is a string and not None
-                                hdf_path_str = plan_info.iloc[0]['HDF_Results_Path']
-                                if pd.notna(hdf_path_str):
-                                    hdf_path = Path(str(hdf_path_str))
-                        except Exception as e:
-                            logger.warning(f"Error retrieving plan HDF path: {str(e)}")
-
-                    elif file_type == 'plan':
-                        try:
-                            # Get plan file path (.p##)
-                            from .RasUtils import RasUtils
-                            plan_number_str = RasUtils.normalize_ras_number(number_int)
-                            hdf_path = ras_obj.project_folder / f"{ras_obj.project_name}.p{plan_number_str}"
-                            if not hdf_path.exists():
-                                raise FileNotFoundError(f"Plan file not found: {hdf_path}")
-                        except Exception as e:
-                            logger.warning(f"Error retrieving plan file path: {str(e)}")
-
-                    elif file_type == 'geom_hdf':
-                        try:
-                            # First try to get the geometry number from the plan
-                            from ras_commander import RasPlan
-                            plan_info = ras_obj.plan_df[ras_obj.plan_df['plan_number'].astype(int) == number_int]
-                            if not plan_info.empty:
-                                # Extract the geometry number from the plan
-                                geom_number = plan_info.iloc[0]['geometry_number']
-                                if pd.notna(geom_number) and geom_number is not None:
-                                    # Handle different types of geom_number (string or int)
-                                    try:
-                                        # Get the geometry path using RasPlan
-                                        geom_path = RasPlan.get_geom_path(str(geom_number), ras_obj)
-
-                                        if geom_path is not None:
-                                            # Create the HDF path by adding .hdf to the geometry path
-                                            hdf_path = Path(str(geom_path) + ".hdf")
-                                            if hdf_path.exists():
-                                                logger.info(f"Found geometry HDF file for plan {number_int}: {hdf_path}")
-                                            else:
-                                                # Try to find it in the geom_df if direct path doesn't exist
-                                                geom_info = ras_obj.geom_df[ras_obj.geom_df['full_path'] == str(geom_path)]
-                                                if not geom_info.empty and 'hdf_path' in geom_info.columns:
-                                                    hdf_path_str = geom_info.iloc[0]['hdf_path']
-                                                    if pd.notna(hdf_path_str):
-                                                        hdf_path = Path(str(hdf_path_str))
-                                                        logger.info(f"Found geometry HDF file from geom_df for plan {number_int}: {hdf_path}")
-                                    except (TypeError, ValueError) as e:
-                                        logger.warning(f"Error processing geometry number {geom_number}: {str(e)}")
-                                else:
-                                    logger.warning(f"No valid geometry number found for plan {number_int}")
-                        except Exception as e:
-                            logger.warning(f"Error retrieving geometry HDF path: {str(e)}")
-                    else:
-                        raise ValueError(f"Invalid file type: {file_type}")
-                    
-
-
-
-                # Handle numeric inputs (int, float, numpy types, etc. - assuming they're plan or geom numbers)
-                elif isinstance(hdf_input, Number):
-                    try:
-                        ras_obj.check_initialized()
-                    except Exception as e:
-                        raise ValueError(f"RAS object is not initialized: {str(e)}")
-
-                    # Convert to integer and validate range
-                    try:
-                        number_int = int(hdf_input)
-                        if not (1 <= number_int <= 99):
-                            raise ValueError(f"Plan/geometry number must be between 1 and 99, got {number_int}")
-                    except (ValueError, TypeError) as e:
-                        raise ValueError(f"Cannot convert plan/geometry number to integer: {hdf_input}") from e
-
-                    if file_type == 'plan_hdf':
-                        try:
-                            # Convert plan_number column to integers for comparison after stripping zeros
-                            plan_info = ras_obj.plan_df[ras_obj.plan_df['plan_number'].str.lstrip('0').astype(int) == number_int]
-                            if not plan_info.empty:
-                                # Make sure HDF_Results_Path is a string and not None
-                                hdf_path_str = plan_info.iloc[0]['HDF_Results_Path']
-                                if pd.notna(hdf_path_str):
-                                    hdf_path = Path(str(hdf_path_str))
-                        except Exception as e:
-                            logger.warning(f"Error retrieving plan HDF path: {str(e)}")
-
-                    elif file_type == 'plan':
-                        try:
-                            # Get plan file path (.p##)
-                            from .RasUtils import RasUtils
-                            plan_number_str = RasUtils.normalize_ras_number(number_int)
-                            hdf_path = ras_obj.project_folder / f"{ras_obj.project_name}.p{plan_number_str}"
-                            if not hdf_path.exists():
-                                raise FileNotFoundError(f"Plan file not found: {hdf_path}")
-                        except Exception as e:
-                            logger.warning(f"Error retrieving plan file path: {str(e)}")
-
-                    elif file_type == 'geom_hdf':
-                        try:
-                            # First try finding plan info to get geometry number
-                            plan_info = ras_obj.plan_df[ras_obj.plan_df['plan_number'].astype(int) == number_int]
-                            if not plan_info.empty:
-                                # Extract the geometry number from the plan
-                                geom_number = plan_info.iloc[0]['geometry_number']
-                                if pd.notna(geom_number) and geom_number is not None:
-                                    # Handle different types of geom_number (string or int)
-                                    try:
-                                        # Get the geometry path using RasPlan
-                                        from ras_commander import RasPlan
-                                        geom_path = RasPlan.get_geom_path(str(geom_number), ras_obj)
-
-                                        if geom_path is not None:
-                                            # Create the HDF path by adding .hdf to the geometry path
-                                            hdf_path = Path(str(geom_path) + ".hdf")
-                                            if hdf_path.exists():
-                                                logger.info(f"Found geometry HDF file for plan {number_int}: {hdf_path}")
-                                            else:
-                                                # Try to find it in the geom_df if direct path doesn't exist
-                                                geom_info = ras_obj.geom_df[ras_obj.geom_df['full_path'] == str(geom_path)]
-                                                if not geom_info.empty and 'hdf_path' in geom_info.columns:
-                                                    hdf_path_str = geom_info.iloc[0]['hdf_path']
-                                                    if pd.notna(hdf_path_str):
-                                                        hdf_path = Path(str(hdf_path_str))
-                                                        logger.info(f"Found geometry HDF file from geom_df for plan {number_int}: {hdf_path}")
-                                    except (TypeError, ValueError) as e:
-                                        logger.warning(f"Error processing geometry number {geom_number}: {str(e)}")
-                                else:
-                                    logger.warning(f"No valid geometry number found for plan {number_int}")
-                        except Exception as e:
-                            logger.warning(f"Error retrieving geometry HDF path: {str(e)}")
-                    else:
-                        raise ValueError(f"Invalid file type: {file_type}")
-
-            # Final verification that the path exists
-            if hdf_path is None or not hdf_path.exists():
-                file_type_name = "HDF file" if 'hdf' in file_type else "file"
-                error_msg = f"{file_type_name} not found: {hdf_input}"
-                logger.error(error_msg)
-                raise FileNotFoundError(error_msg)
-
-            logger.info(f"Final validated file path: {hdf_path}")
-
-            # Validate HDF file structure (only for HDF types)
             if 'hdf' in file_type:
                 try:
                     with h5py.File(hdf_path, 'r') as test_file:
-                        # Just open to verify it's a valid HDF5 file
-                        logger.debug(f"Successfully opened HDF file for validation: {hdf_path}")
+                        logger.debug(f"Successfully opened HDF file for validation: {test_file.filename}")
                 except Exception as e:
                     logger.warning(f"Warning: Could not validate HDF file: {str(e)}")
-                    # Continue anyway, let the function handle detailed validation
-            
-            # Pass all original arguments and keywords, replacing hdf_input with standardized hdf_path
-            # If the original input was positional, replace the first argument
-            if args and 'hdf_path' not in kwargs:
-                new_args = (hdf_path,) + args[1:]
-            else:
-                new_args = args
+
+            if hdf_input_from_kwargs or not args:
                 kwargs['hdf_path'] = hdf_path
-                
+                new_args = args
+            else:
+                new_args = (hdf_path,) + args[1:]
+
+            if ras_object_provided and 'ras_object' in param_names:
+                kwargs['ras_object'] = ras_object
+
+            logger.info(f"Final validated file path: {hdf_path}")
             return func(*new_args, **kwargs)
 
         return wrapper
     return decorator
+
+
+def _resolve_hdf_input(hdf_input, file_type: str, ras_object, logger) -> Path:
+    from .RasPrj import ras as default_ras
+    from .RasPrjAssets import RasPrjAssets
+
+    ras_obj = ras_object or default_ras
+
+    if isinstance(hdf_input, h5py.File):
+        return Path(hdf_input.filename)
+
+    if isinstance(hdf_input, (str, Path)):
+        candidate = Path(str(hdf_input).strip())
+        if candidate.is_file():
+            logger.info(f"Using direct file path: {candidate}")
+            return candidate
+
+    try:
+        if hasattr(ras_obj, 'check_initialized'):
+            ras_obj.check_initialized()
+    except Exception as e:
+        raise ValueError(f"RAS object is not initialized: {str(e)}") from e
+
+    if file_type == 'plan_hdf':
+        resolved = RasPrjAssets.plan_results_hdf(
+            hdf_input,
+            ras_object=ras_obj,
+            must_exist=True,
+        )
+    elif file_type == 'geom_hdf':
+        resolved = RasPrjAssets.geometry_hdf(
+            hdf_input,
+            ras_object=ras_obj,
+            selector_kind="auto",
+            must_exist=True,
+        )
+    elif file_type == 'plan':
+        resolved = RasPrjAssets.plan_path(
+            hdf_input,
+            ras_object=ras_obj,
+            must_exist=True,
+        )
+    else:
+        raise ValueError(f"Invalid file type: {file_type}")
+
+    if resolved is None or not Path(resolved).exists():
+        file_type_name = "HDF file" if 'hdf' in file_type else "file"
+        error_msg = f"{file_type_name} not found: {hdf_input}"
+        logger.error(error_msg)
+        raise FileNotFoundError(error_msg)
+
+    return Path(resolved)

--- a/ras_commander/RasCmdr.py
+++ b/ras_commander/RasCmdr.py
@@ -66,6 +66,7 @@ from .LoggingConfig import get_logger
 from .Decorators import log_call
 from .RasBco import BcoMonitor
 from .ComputeResults import ComputeResult, ComputeParallelResult
+from .RasPrjAssets import RasPrjAssets
 import pandas as pd
 from typing import Callable
 
@@ -99,13 +100,11 @@ class RasCmdr:
         Returns:
             Path to the expected HDF file
         """
-        # Normalize plan number to 2-digit string
-        if isinstance(plan_number, Number):
-            plan_num_str = f"{int(plan_number):02d}"
-        else:
-            plan_num_str = str(plan_number).zfill(2)
-
-        return Path(ras_object.project_folder) / f"{ras_object.project_name}.p{plan_num_str}.hdf"
+        return RasPrjAssets.plan_results_hdf(
+            plan_number,
+            ras_object=ras_object,
+            must_exist=False,
+        )
 
     @staticmethod
     def _normalize_requested_plan_numbers(
@@ -184,9 +183,9 @@ class RasCmdr:
             if pd.isna(value):
                 continue
 
-            digits = "".join(ch for ch in str(value) if ch.isdigit())
-            if digits:
-                return digits.zfill(2)
+            geometry_number = RasPrjAssets.extract_number(value, prefix="g")
+            if geometry_number is not None:
+                return geometry_number
 
         return None
 
@@ -523,8 +522,8 @@ class RasCmdr:
             # Smart skip: check file modification times (unless force_rerun or skip_existing)
             # Note: Smart skip is bypassed when skip_existing=True since that provides explicit skip logic
             if not force_rerun and not skip_existing:
-                from .RasCurrency import RasCurrency
-                is_current, reason = RasCurrency.are_plan_results_current(plan_number, compute_ras)
+                from .RasComputeState import RasComputeState
+                is_current, reason = RasComputeState.are_plan_results_current(plan_number, compute_ras)
                 if is_current:
                     logger.info(f"Skipping plan {plan_number}: {reason}")
                     _success = True
@@ -543,7 +542,7 @@ class RasCmdr:
                 # Create monitor with callback wrapper
                 bco_monitor = BcoMonitor(
                     project_path=Path(compute_ras.project_folder),
-                    plan_number=str(plan_number).zfill(2) if isinstance(plan_number, (int, Number)) else str(plan_number),
+                    plan_number=RasPrjAssets.normalize_number(plan_number, prefix="p"),
                     project_name=compute_ras.project_name,
                     message_callback=lambda msg: (
                         stream_callback.on_exec_message(str(plan_number), msg)
@@ -559,9 +558,9 @@ class RasCmdr:
             # Handle geometry preprocessor clearing
             if force_geompre:
                 # Force full geometry reprocessing (clears both .g##.hdf AND .c## files)
-                from .RasCurrency import RasCurrency
+                from .RasComputeState import RasComputeState
                 try:
-                    RasCurrency.clear_geom_hdf(plan_number, compute_ras)
+                    RasComputeState.clear_geom_hdf(plan_number, compute_ras)
                     RasGeo.clear_geompre_files(compute_plan_path, ras_object=compute_ras)
                     logger.info(f"Force-cleared all geometry preprocessor files for plan: {plan_number}")
                 except Exception as e:
@@ -663,7 +662,7 @@ class RasCmdr:
                 logger.info(f"Total run time for plan {plan_number}: {run_time:.2f} seconds")
 
                 # Read compute message files (.bco## for 5.x, .computeMsgs.txt/.comp_msgs.txt for 6.x+)
-                plan_num_str = f"{int(plan_number):02d}" if isinstance(plan_number, Number) else str(plan_number).zfill(2)
+                plan_num_str = RasPrjAssets.normalize_number(plan_number, prefix="p")
                 try:
                     bco_path = Path(compute_ras.project_folder) / f"{compute_ras.project_name}.bco{plan_num_str}"
                     if bco_path.exists():
@@ -1416,7 +1415,7 @@ class RasCmdr:
         ras_obj = ras_object if ras_object is not None else ras
         ras_obj.check_initialized()
 
-        plan_num_str = str(plan_number).zfill(2) if isinstance(plan_number, Number) else str(plan_number).zfill(2)
+        plan_num_str = RasPrjAssets.normalize_number(plan_number, prefix="p")
 
         ras_exe_dir = Path(ras_exe_dir)
         ras_exe = ras_exe_dir / "RasUnsteady"

--- a/ras_commander/RasComputeState.py
+++ b/ras_commander/RasComputeState.py
@@ -94,42 +94,17 @@ class RasComputeState:
         Returns:
             Dictionary with keys: 'plan', 'geom', 'flow' (values are Path or None)
         """
-        plan_num = RasComputeState._normalize_plan_number(plan_number)
+        assets = RasPrjAssets.plan_assets(
+            plan_number,
+            ras_object=ras_object,
+            must_exist=False,
+        )
 
-        result = {
-            'plan': None,
-            'geom': None,
-            'flow': None
+        return {
+            'plan': assets.plan_path,
+            'geom': assets.geometry_path,
+            'flow': assets.flow_path,
         }
-
-        # Get plan file path from plan_df
-        if hasattr(ras_object, 'plan_df') and ras_object.plan_df is not None:
-            plan_df = ras_object.plan_df
-
-            # Find matching plan row
-            plan_mask = plan_df['plan_number'].astype(str).str.zfill(2) == plan_num
-            if plan_mask.any():
-                plan_row = plan_df[plan_mask].iloc[0]
-
-                # Get plan file path
-                if 'full_path' in plan_row.index and plan_row['full_path']:
-                    result['plan'] = Path(plan_row['full_path'])
-
-                # Get geometry file path
-                if 'Geom Path' in plan_row.index and plan_row['Geom Path']:
-                    result['geom'] = Path(plan_row['Geom Path'])
-                elif 'geom_file' in plan_row.index and plan_row['geom_file']:
-                    result['geom'] = Path(ras_object.project_folder) / plan_row['geom_file']
-
-                # Get flow file path (unsteady or steady)
-                if 'Flow Path' in plan_row.index and plan_row['Flow Path']:
-                    result['flow'] = Path(plan_row['Flow Path'])
-                elif 'unsteady_file' in plan_row.index and plan_row['unsteady_file']:
-                    result['flow'] = Path(ras_object.project_folder) / plan_row['unsteady_file']
-                elif 'steady_file' in plan_row.index and plan_row['steady_file']:
-                    result['flow'] = Path(ras_object.project_folder) / plan_row['steady_file']
-
-        return result
 
     @staticmethod
     def get_plan_hdf_path(plan_number: Union[str, Number], ras_object) -> Path:

--- a/ras_commander/RasComputeState.py
+++ b/ras_commander/RasComputeState.py
@@ -1,12 +1,12 @@
 """
-RasCurrency - Execution currency checking for HEC-RAS simulations
+RasComputeState - execution state checks for HEC-RAS simulations
 
 This module provides utilities for determining whether HEC-RAS plan results
-are current (up-to-date) based on file modification times. This enables
-smart execution skip - avoiding unnecessary re-runs when results already
-exist and input files haven't changed.
+are current based on file modification times and completion messages. This
+enables smart execution skip, avoiding unnecessary re-runs when results
+already exist and input files haven't changed.
 
-Currency Logic:
+State Logic:
 - Results are CURRENT if plan HDF exists AND is newer than all input files
 - Input files checked: plan file (.p##), geometry file (.g##), flow file (.u##/.f##)
 - For older HEC-RAS versions (no HDF): uses .O output file instead
@@ -22,13 +22,14 @@ from numbers import Number
 
 from .LoggingConfig import get_logger
 from .Decorators import log_call
+from .RasPrjAssets import RasPrjAssets
 
 logger = get_logger(__name__)
 
 
-class RasCurrency:
+class RasComputeState:
     """
-    Static class for HEC-RAS execution currency checking.
+    Static class for HEC-RAS execution state checking.
 
     Determines whether plan results are current based on file modification times,
     enabling smart execution skip to avoid unnecessary re-runs.
@@ -78,19 +79,7 @@ class RasCurrency:
         Returns:
             Two-digit string (e.g., "01", "02")
         """
-        if isinstance(plan_number, Path):
-            # Extract plan number from path like "project.p01"
-            stem = plan_number.stem
-            if '.p' in stem:
-                plan_num = stem.split('.p')[-1]
-            else:
-                plan_num = stem[-2:] if len(stem) >= 2 else stem
-        elif isinstance(plan_number, Number):
-            plan_num = f"{int(plan_number):02d}"
-        else:
-            plan_num = str(plan_number).lstrip('p').zfill(2)
-
-        return plan_num
+        return RasPrjAssets.normalize_number(plan_number, prefix="p")
 
     @staticmethod
     @log_call
@@ -105,7 +94,7 @@ class RasCurrency:
         Returns:
             Dictionary with keys: 'plan', 'geom', 'flow' (values are Path or None)
         """
-        plan_num = RasCurrency._normalize_plan_number(plan_number)
+        plan_num = RasComputeState._normalize_plan_number(plan_number)
 
         result = {
             'plan': None,
@@ -154,8 +143,11 @@ class RasCurrency:
         Returns:
             Path to the expected HDF file
         """
-        plan_num = RasCurrency._normalize_plan_number(plan_number)
-        return Path(ras_object.project_folder) / f"{ras_object.project_name}.p{plan_num}.hdf"
+        return RasPrjAssets.plan_results_hdf(
+            plan_number,
+            ras_object=ras_object,
+            must_exist=False,
+        )
 
     @staticmethod
     def get_geom_hdf_path(plan_number: Union[str, Number], ras_object) -> Optional[Path]:
@@ -169,31 +161,12 @@ class RasCurrency:
         Returns:
             Path to geometry HDF file or None if not found
         """
-        plan_num = RasCurrency._normalize_plan_number(plan_number)
-
-        # Get geometry number from plan
-        if hasattr(ras_object, 'plan_df') and ras_object.plan_df is not None:
-            plan_df = ras_object.plan_df
-            plan_mask = plan_df['plan_number'].astype(str).str.zfill(2) == plan_num
-
-            if plan_mask.any():
-                plan_row = plan_df[plan_mask].iloc[0]
-
-                # Get geometry number
-                geom_num = None
-                if 'geometry_number' in plan_row.index:
-                    geom_num = str(plan_row['geometry_number']).zfill(2)
-                elif 'geom_file' in plan_row.index and plan_row['geom_file']:
-                    # Extract from filename like "project.g01"
-                    geom_file = str(plan_row['geom_file'])
-                    if '.g' in geom_file:
-                        geom_num = geom_file.split('.g')[-1].split('.')[0].zfill(2)
-
-                if geom_num:
-                    geom_hdf = Path(ras_object.project_folder) / f"{ras_object.project_name}.g{geom_num}.hdf"
-                    return geom_hdf
-
-        return None
+        return RasPrjAssets.geometry_hdf(
+            plan_number,
+            ras_object=ras_object,
+            selector_kind="plan",
+            must_exist=False,
+        )
 
     @staticmethod
     def get_output_file_path(plan_number: Union[str, Number], ras_object) -> Optional[Path]:
@@ -207,7 +180,7 @@ class RasCurrency:
         Returns:
             Path to .O output file or None if not found
         """
-        plan_num = RasCurrency._normalize_plan_number(plan_number)
+        plan_num = RasComputeState._normalize_plan_number(plan_number)
         output_file = Path(ras_object.project_folder) / f"{ras_object.project_name}.O{plan_num}"
 
         if output_file.exists():
@@ -267,25 +240,25 @@ class RasCurrency:
             - is_current: True if results are current, False if execution needed
             - reason: Human-readable explanation
         """
-        plan_num = RasCurrency._normalize_plan_number(plan_number)
+        plan_num = RasComputeState._normalize_plan_number(plan_number)
 
         # Check for HDF file first
-        hdf_path = RasCurrency.get_plan_hdf_path(plan_number, ras_object)
+        hdf_path = RasComputeState.get_plan_hdf_path(plan_number, ras_object)
         output_path = None
         result_mtime = None
 
         if hdf_path.exists():
-            result_mtime = RasCurrency.get_file_mtime(hdf_path)
+            result_mtime = RasComputeState.get_file_mtime(hdf_path)
             result_file = hdf_path
 
             # Check for Complete Process
-            if check_complete and not RasCurrency.check_plan_hdf_complete(hdf_path):
+            if check_complete and not RasComputeState.check_plan_hdf_complete(hdf_path):
                 return (False, f"Plan {plan_num} HDF exists but incomplete (no 'Complete Process')")
         else:
             # Try .O file for older versions
-            output_path = RasCurrency.get_output_file_path(plan_number, ras_object)
+            output_path = RasComputeState.get_output_file_path(plan_number, ras_object)
             if output_path and output_path.exists():
-                result_mtime = RasCurrency.get_file_mtime(output_path)
+                result_mtime = RasComputeState.get_file_mtime(output_path)
                 result_file = output_path
             else:
                 return (False, f"Plan {plan_num} has no results (HDF or .O file not found)")
@@ -294,7 +267,7 @@ class RasCurrency:
             return (False, f"Plan {plan_num} cannot determine results file modification time")
 
         # Get input files
-        input_files = RasCurrency.get_plan_input_files(plan_number, ras_object)
+        input_files = RasComputeState.get_plan_input_files(plan_number, ras_object)
 
         # Check each input file modification time
         stale_files = []
@@ -307,7 +280,7 @@ class RasCurrency:
                 logger.debug(f"Input file not found: {file_path}")
                 continue
 
-            input_mtime = RasCurrency.get_file_mtime(file_path)
+            input_mtime = RasComputeState.get_file_mtime(file_path)
             if input_mtime is None:
                 logger.warning(f"Cannot get mtime for {file_path}, assuming stale")
                 stale_files.append(file_path.name)
@@ -340,10 +313,10 @@ class RasCurrency:
         Returns:
             Tuple of (is_current: bool, reason: str)
         """
-        plan_num = RasCurrency._normalize_plan_number(plan_number)
+        plan_num = RasComputeState._normalize_plan_number(plan_number)
 
         # Get geometry HDF path
-        geom_hdf_path = RasCurrency.get_geom_hdf_path(plan_number, ras_object)
+        geom_hdf_path = RasComputeState.get_geom_hdf_path(plan_number, ras_object)
 
         if geom_hdf_path is None:
             return (False, f"Plan {plan_num} geometry HDF path cannot be determined")
@@ -351,19 +324,19 @@ class RasCurrency:
         if not geom_hdf_path.exists():
             return (False, f"Plan {plan_num} geometry HDF does not exist: {geom_hdf_path.name}")
 
-        geom_hdf_mtime = RasCurrency.get_file_mtime(geom_hdf_path)
+        geom_hdf_mtime = RasComputeState.get_file_mtime(geom_hdf_path)
         if geom_hdf_mtime is None:
             return (False, f"Plan {plan_num} cannot determine geometry HDF modification time")
 
         # Get geometry text file path
-        input_files = RasCurrency.get_plan_input_files(plan_number, ras_object)
+        input_files = RasComputeState.get_plan_input_files(plan_number, ras_object)
         geom_path = input_files.get('geom')
 
         if geom_path is None or not geom_path.exists():
             # If we can't find geometry file, assume preprocessing is OK
             return (True, f"Plan {plan_num} geometry preprocessing assumed current (geometry file not found)")
 
-        geom_mtime = RasCurrency.get_file_mtime(geom_path)
+        geom_mtime = RasComputeState.get_file_mtime(geom_path)
         if geom_mtime is None:
             return (False, f"Plan {plan_num} cannot determine geometry file modification time")
 
@@ -385,7 +358,7 @@ class RasCurrency:
         Returns:
             True if file was deleted or didn't exist, False on error
         """
-        geom_hdf_path = RasCurrency.get_geom_hdf_path(plan_number, ras_object)
+        geom_hdf_path = RasComputeState.get_geom_hdf_path(plan_number, ras_object)
 
         if geom_hdf_path is None:
             logger.debug(f"No geometry HDF path found for plan {plan_number}")

--- a/ras_commander/RasModPuls.py
+++ b/ras_commander/RasModPuls.py
@@ -593,15 +593,17 @@ class RasModPuls:
         """Resolve plan HDF path from plan number via ras_object."""
         try:
             from . import ras as global_ras
+            from .RasPrjAssets import RasPrjAssets
+
             _ras = ras_object if ras_object is not None else global_ras
-            plan_num = plan_number.lstrip('p')
-            plan_row = _ras.plan_df[_ras.plan_df['plan_number'] == plan_num]
-            if len(plan_row) == 0:
-                raise ValueError(f"Plan {plan_number} not found in project")
-            hdf_path = plan_row['HDF_Results_Path'].iloc[0]
-            if hdf_path is None or (hasattr(hdf_path, '__class__') and hdf_path != hdf_path):
+            hdf_path = RasPrjAssets.plan_results_hdf(
+                plan_number,
+                ras_object=_ras,
+                must_exist=False,
+            )
+            if hdf_path is None:
                 raise ValueError(f"Plan {plan_number} has not been executed (no HDF file)")
-            return Path(str(hdf_path))
+            return Path(hdf_path)
         except Exception as e:
             raise ValueError(f"Cannot resolve HDF path for plan {plan_number}: {e}") from e
 
@@ -617,18 +619,26 @@ class RasModPuls:
         """
         try:
             from . import ras as global_ras
+            from .RasPrjAssets import RasPrjAssets
+
             _ras = ras_object if ras_object is not None else global_ras
-            plan_num = plan_number.lstrip('p') if plan_number else None
-            if plan_num:
-                plan_row = _ras.plan_df[_ras.plan_df['plan_number'] == plan_num]
-                if len(plan_row) > 0:
-                    geom_num = plan_row['Geom File'].iloc[0]
-                    geom_row = _ras.geom_df[_ras.geom_df['geom_number'] == geom_num]
-                    if len(geom_row) > 0:
-                        geom_file = Path(str(geom_row['full_path'].iloc[0]))
-                        geom_hdf = Path(str(geom_file) + '.hdf')
-                        if geom_hdf.exists():
-                            return geom_hdf
+            if plan_number:
+                geom_hdf = RasPrjAssets.geometry_hdf(
+                    plan_number,
+                    ras_object=_ras,
+                    selector_kind="plan",
+                    must_exist=True,
+                )
+                if geom_hdf is not None:
+                    return geom_hdf
+            geom_hdf = RasPrjAssets.geometry_hdf(
+                plan_hdf_path,
+                ras_object=_ras,
+                selector_kind="plan_hdf",
+                must_exist=True,
+            )
+            if geom_hdf is not None:
+                return geom_hdf
         except Exception:
             pass
         return None

--- a/ras_commander/RasPlan.py
+++ b/ras_commander/RasPlan.py
@@ -87,6 +87,7 @@ import logging
 import re
 from .LoggingConfig import get_logger
 from .Decorators import log_call
+from .RasPrjAssets import RasPrjAssets
 
 logger = get_logger(__name__)
 
@@ -570,18 +571,11 @@ class RasPlan:
         # Update the plan dataframe in the ras instance to ensure it is current
         ras_obj.plan_df = ras_obj.get_plan_entries()
 
-        # Normalize plan number to two-digit format
-        plan_number = RasUtils.normalize_ras_number(plan_number)
-        
-        plan_entry = ras_obj.plan_df[ras_obj.plan_df['plan_number'] == plan_number]
-        if not plan_entry.empty:
-            results_path = plan_entry['HDF_Results_Path'].iloc[0]
-            if results_path and Path(results_path).exists():
-                return Path(results_path)
-            else:
-                return None
-        else:
-            return None
+        return RasPrjAssets.plan_results_hdf(
+            plan_number,
+            ras_object=ras_obj,
+            must_exist=True,
+        )
 
     @staticmethod
     @log_call
@@ -615,20 +609,12 @@ class RasPlan:
         ras_obj = ras_object or ras
         ras_obj.check_initialized()
 
-        # Normalize plan number to two-digit format
-        plan_number = RasUtils.normalize_ras_number(plan_number)
-        
-        plan_df = ras_obj.get_plan_entries()
-        
-        plan_path = plan_df[plan_df['plan_number'] == plan_number]
-
-        if not plan_path.empty:
-            if 'full_path' in plan_path.columns and not pd.isna(plan_path['full_path'].iloc[0]):
-                return Path(plan_path['full_path'].iloc[0])
-            else:
-                # Fallback to constructing path
-                return ras_obj.project_folder / f"{ras_obj.project_name}.p{plan_number}"
-        return None
+        ras_obj.plan_df = ras_obj.get_plan_entries()
+        return RasPrjAssets.plan_path(
+            plan_number,
+            ras_object=ras_obj,
+            must_exist=False,
+        )
 
     @staticmethod
     @log_call
@@ -733,13 +719,13 @@ class RasPlan:
             return None
 
         try:
-            result = RasPlan._get_component_path(
-                component_number=geom_number,
-                df_attr='geom_df',
-                number_column='geom_number',
-                prj_entry_type='Geom',
-                file_prefix='g',
-                ras_object=ras_object,
+            ras_obj = ras_object or ras
+            ras_obj.check_initialized()
+            ras_obj.geom_df = ras_obj.get_prj_entries('Geom')
+            result = RasPrjAssets.geometry_path(
+                geom_number,
+                ras_object=ras_obj,
+                must_exist=False,
             )
             if result is not None:
                 _logger.info(f"Found geometry path: {result}")

--- a/ras_commander/RasPreprocess.py
+++ b/ras_commander/RasPreprocess.py
@@ -32,6 +32,7 @@ from .Decorators import log_call
 from .LoggingConfig import get_logger
 from .RasBco import BcoMonitor
 from .RasPlan import RasPlan
+from .RasPrjAssets import RasPrjAssets
 from .RasPrj import ras
 
 logger = get_logger(__name__)
@@ -98,11 +99,7 @@ class RasPreprocess:
         start_time = time.time()
         ras_obj = ras_object if ras_object is not None else ras
 
-        # Normalize plan number
-        if isinstance(plan_number, Number):
-            plan_num = f"{int(plan_number):02d}"
-        else:
-            plan_num = str(plan_number).zfill(2)
+        plan_num = RasPrjAssets.normalize_number(plan_number, prefix="p")
 
         try:
             ras_obj.check_initialized()
@@ -291,10 +288,7 @@ class RasPreprocess:
         """
         ras_obj = ras_object if ras_object is not None else ras
 
-        if isinstance(plan_number, Number):
-            plan_num = f"{int(plan_number):02d}"
-        else:
-            plan_num = str(plan_number).zfill(2)
+        plan_num = RasPrjAssets.normalize_number(plan_number, prefix="p")
 
         try:
             ras_obj.check_initialized()

--- a/ras_commander/RasPreprocess.py
+++ b/ras_commander/RasPreprocess.py
@@ -18,7 +18,6 @@ Classes:
     RasPreprocess - Static class for Windows preprocessing operations.
 """
 
-import re
 import shutil
 import subprocess
 import time
@@ -113,20 +112,12 @@ class RasPreprocess:
         project_folder = Path(ras_obj.project_folder)
         project_name = ras_obj.project_name
 
-        # Get geometry number from plan_df (DataFrame-first), fallback to file parsing
-        geometry_number = None
-        try:
-            plan_row = ras_obj.plan_df[ras_obj.plan_df['plan_number'] == plan_num]
-            if not plan_row.empty and 'Geom File' in plan_row.columns:
-                geom_ref = str(plan_row['Geom File'].iloc[0])
-                m = re.search(r'(\d+)', geom_ref)
-                if m:
-                    geometry_number = m.group(1)
-        except Exception:
-            pass
+        # Get geometry number from project metadata, fallback to plan file parsing.
+        assets = RasPrjAssets.plan_assets(plan_num, ras_object=ras_obj, must_exist=False)
+        geometry_number = assets.geometry_number
 
         if geometry_number is None:
-            plan_path = RasPlan.get_plan_path(plan_num, ras_obj)
+            plan_path = assets.plan_path or RasPlan.get_plan_path(plan_num, ras_obj)
             if plan_path:
                 geometry_number = RasPreprocess._extract_geometry_number(Path(plan_path))
             if geometry_number is None:
@@ -298,20 +289,11 @@ class RasPreprocess:
         project_folder = Path(ras_obj.project_folder)
         project_name = ras_obj.project_name
 
-        # Determine geometry number
-        geometry_number = None
-        try:
-            plan_row = ras_obj.plan_df[ras_obj.plan_df['plan_number'] == plan_num]
-            if not plan_row.empty and 'Geom File' in plan_row.columns:
-                geom_ref = str(plan_row['Geom File'].iloc[0])
-                m = re.search(r'(\d+)', geom_ref)
-                if m:
-                    geometry_number = m.group(1)
-        except Exception:
-            pass
+        assets = RasPrjAssets.plan_assets(plan_num, ras_object=ras_obj, must_exist=False)
+        geometry_number = assets.geometry_number
 
         if geometry_number is None:
-            plan_path = RasPlan.get_plan_path(plan_num, ras_obj)
+            plan_path = assets.plan_path or RasPlan.get_plan_path(plan_num, ras_obj)
             if plan_path:
                 geometry_number = RasPreprocess._extract_geometry_number(Path(plan_path))
             if geometry_number is None:
@@ -347,9 +329,7 @@ class RasPreprocess:
             for line in content.splitlines():
                 if line.strip().startswith("Geom File="):
                     geom_ref = line.split('=', 1)[1].strip()
-                    m = re.search(r'(\d+)', geom_ref)
-                    if m:
-                        return m.group(1)
+                    return RasPrjAssets.extract_number(geom_ref, prefix="g")
         except Exception as e:
             logger.debug(f"Could not read geometry number from {plan_path}: {e}")
         return None

--- a/ras_commander/RasPrj.py
+++ b/ras_commander/RasPrj.py
@@ -1809,18 +1809,22 @@ class RasPrj:
         """
         self.check_initialized()
 
-        matching = self.plan_df[self.plan_df['plan_number'] == plan_number]
+        from .RasPrjAssets import RasPrjAssets
+
+        normalized_plan_number = RasPrjAssets.normalize_number(plan_number, prefix="p")
+        matching = self.plan_df[self.plan_df['plan_number'] == normalized_plan_number]
         if matching.empty:
             raise ValueError(f"Plan '{plan_number}' not found. Available: {self.plan_df['plan_number'].tolist()}")
 
-        row = matching.iloc[0]
-
-        results_path = row.get('HDF_Results_Path')
-        geom_path = row.get('Geom Path')
+        assets = RasPrjAssets.plan_assets(
+            normalized_plan_number,
+            ras_object=self,
+            must_exist=False,
+        )
 
         return {
-            'results': Path(results_path) if pd.notna(results_path) else None,
-            'geometry': Path(str(geom_path) + '.hdf') if pd.notna(geom_path) else None,
+            'results': assets.results_hdf_path,
+            'geometry': assets.geometry_hdf_path,
         }
 
     # =========================================================================

--- a/ras_commander/RasPrjAssets.py
+++ b/ras_commander/RasPrjAssets.py
@@ -1,0 +1,583 @@
+"""
+Project asset resolution helpers for ras-commander.
+
+This module centralizes plan, geometry, flow, and HDF artifact lookup while
+preserving the public APIs that currently expose those paths.
+"""
+
+from dataclasses import dataclass
+from numbers import Number
+from pathlib import Path
+from typing import Any, Optional, Union
+import re
+
+import pandas as pd
+
+from .Decorators import log_call
+
+
+@dataclass(frozen=True)
+class PlanAssets:
+    """Resolved file paths associated with one HEC-RAS plan."""
+
+    plan_number: str
+    plan_path: Optional[Path] = None
+    results_hdf_path: Optional[Path] = None
+    geometry_number: Optional[str] = None
+    geometry_path: Optional[Path] = None
+    geometry_hdf_path: Optional[Path] = None
+    flow_path: Optional[Path] = None
+    output_path: Optional[Path] = None
+    compute_messages_path: Optional[Path] = None
+
+
+class RasPrjAssets:
+    """Static namespace for resolving project asset paths."""
+
+    @staticmethod
+    @log_call
+    def normalize_number(value: Union[str, Number, Path], prefix: Optional[str] = None) -> str:
+        """
+        Normalize a RAS component selector to a two-digit number.
+
+        Args:
+            value: Number, prefixed selector, or path-like selector.
+            prefix: Optional expected prefix such as ``"p"`` or ``"g"``.
+
+        Returns:
+            Two-digit number string.
+        """
+        if value is None:
+            raise ValueError("RAS component number cannot be None")
+
+        if isinstance(value, Path):
+            text = value.name
+        elif isinstance(value, Number):
+            number_int = int(value)
+            if float(value) != float(number_int):
+                raise ValueError(f"RAS component number must be whole: {value}")
+            return RasPrjAssets._validate_number_int(number_int)
+        else:
+            text = str(value).strip()
+
+        expected_prefix = prefix.lower().lstrip(".") if prefix else None
+
+        if expected_prefix:
+            match = re.search(rf"\.{expected_prefix}(\d{{1,2}})$", text, re.IGNORECASE)
+            if match:
+                text = match.group(1)
+            elif text.lower().startswith(expected_prefix):
+                text = text[1:]
+        else:
+            match = re.search(r"\.[pguf](\d{1,2})$", text, re.IGNORECASE)
+            if match:
+                text = match.group(1)
+            elif len(text) > 1 and text[0].lower() in {"p", "g", "u", "f"} and text[1:].isdigit():
+                text = text[1:]
+
+        if not str(text).isdigit():
+            raise ValueError(f"Cannot normalize RAS component number: {value}")
+
+        return RasPrjAssets._validate_number_int(int(text))
+
+    @staticmethod
+    @log_call
+    def extract_number(value: Any, prefix: Optional[str] = None) -> Optional[str]:
+        """
+        Extract a normalized RAS component number from loose metadata.
+
+        Unlike :meth:`normalize_number`, this helper returns ``None`` when the
+        value is empty or not recognizable. It is intended for optional
+        DataFrame/HDF metadata fields where missing values are valid.
+        """
+        if not RasPrjAssets._is_present(value):
+            return None
+
+        try:
+            return RasPrjAssets.normalize_number(value, prefix=prefix)
+        except ValueError:
+            pass
+
+        text = str(value).strip()
+        expected_prefix = prefix.lower().lstrip(".") if prefix else None
+        candidates = [text]
+        try:
+            path = Path(text)
+            candidates.extend([path.name, path.stem])
+        except (OSError, ValueError):
+            pass
+
+        if expected_prefix:
+            patterns = [
+                rf"\.{expected_prefix}(\d{{1,2}})(?:\.|$)",
+                rf"^{expected_prefix}(\d{{1,2}})$",
+            ]
+        else:
+            patterns = [
+                r"\.[pguf](\d{1,2})(?:\.|$)",
+                r"^[pguf](\d{1,2})$",
+                r"^(\d{1,2})$",
+            ]
+
+        for candidate in candidates:
+            for pattern in patterns:
+                match = re.search(pattern, candidate, flags=re.IGNORECASE)
+                if match:
+                    return RasPrjAssets.normalize_number(match.group(1), prefix=prefix)
+        return None
+
+    @staticmethod
+    @log_call
+    def plan_path(
+        plan_number_or_path: Union[str, Number, Path],
+        ras_object=None,
+        must_exist: bool = True,
+    ) -> Optional[Path]:
+        """Resolve a plan selector or path to a ``.p##`` file path."""
+        direct_path = RasPrjAssets._direct_path(plan_number_or_path)
+        if direct_path is not None:
+            return RasPrjAssets._existing_or_optional(direct_path, must_exist)
+
+        ras_obj = RasPrjAssets._ras_object(ras_object)
+        plan_number = RasPrjAssets.normalize_number(plan_number_or_path, prefix="p")
+        row = RasPrjAssets._matching_plan_row(ras_obj, plan_number)
+        if row is None and RasPrjAssets._has_dataframe(ras_obj, "plan_df", "plan_number"):
+            return None
+
+        if row is not None:
+            path = RasPrjAssets._path_from_row(row, "full_path")
+            if path is not None:
+                return RasPrjAssets._existing_or_optional(path, must_exist)
+
+        path = RasPrjAssets._project_path(ras_obj, f"p{plan_number}")
+        return RasPrjAssets._existing_or_optional(path, must_exist)
+
+    @staticmethod
+    @log_call
+    def plan_results_hdf(
+        plan_number_or_path: Union[str, Number, Path],
+        ras_object=None,
+        must_exist: bool = True,
+    ) -> Optional[Path]:
+        """Resolve a plan selector or path to a plan results HDF path."""
+        direct_path = RasPrjAssets._direct_path(plan_number_or_path)
+        if direct_path is not None:
+            if direct_path.suffix.lower() == ".hdf":
+                return RasPrjAssets._existing_or_optional(direct_path, must_exist)
+            if re.search(r"\.p\d{1,2}$", direct_path.name, flags=re.IGNORECASE):
+                return RasPrjAssets._existing_or_optional(
+                    Path(str(direct_path) + ".hdf"),
+                    must_exist,
+                )
+
+        ras_obj = RasPrjAssets._ras_object(ras_object)
+        plan_number = RasPrjAssets.normalize_number(plan_number_or_path, prefix="p")
+        row = RasPrjAssets._matching_plan_row(ras_obj, plan_number)
+        if (
+            row is None
+            and must_exist
+            and RasPrjAssets._has_dataframe(ras_obj, "plan_df", "plan_number")
+        ):
+            return None
+
+        if row is not None:
+            path = RasPrjAssets._path_from_row(row, "HDF_Results_Path")
+            if path is not None:
+                return RasPrjAssets._existing_or_optional(path, must_exist)
+
+        path = RasPrjAssets._project_path(ras_obj, f"p{plan_number}.hdf")
+        return RasPrjAssets._existing_or_optional(path, must_exist)
+
+    @staticmethod
+    @log_call
+    def geometry_path(
+        geom_number_or_path: Union[str, Number, Path],
+        ras_object=None,
+        must_exist: bool = True,
+    ) -> Optional[Path]:
+        """Resolve a geometry selector or path to a ``.g##`` file path."""
+        direct_path = RasPrjAssets._direct_path(geom_number_or_path)
+        if direct_path is not None:
+            if direct_path.suffix.lower() == ".hdf":
+                direct_path = Path(str(direct_path)[:-4])
+            return RasPrjAssets._existing_or_optional(direct_path, must_exist)
+
+        ras_obj = RasPrjAssets._ras_object(ras_object)
+        geom_number = RasPrjAssets.normalize_number(geom_number_or_path, prefix="g")
+        row = RasPrjAssets._matching_geom_row(ras_obj, geom_number)
+        if row is None and RasPrjAssets._has_dataframe(ras_obj, "geom_df", "geom_number"):
+            return None
+
+        if row is not None:
+            path = RasPrjAssets._path_from_row(row, "full_path")
+            if path is not None:
+                return RasPrjAssets._existing_or_optional(path, must_exist)
+
+        path = RasPrjAssets._project_path(ras_obj, f"g{geom_number}")
+        return RasPrjAssets._existing_or_optional(path, must_exist)
+
+    @staticmethod
+    @log_call
+    def geometry_hdf(
+        selector: Union[str, Number, Path],
+        ras_object=None,
+        selector_kind: str = "auto",
+        must_exist: bool = True,
+    ) -> Optional[Path]:
+        """
+        Resolve a geometry HDF path.
+
+        Bare numeric selectors keep legacy behavior and resolve through the plan's
+        geometry. Explicit ``g##`` selectors resolve geometry files directly.
+        """
+        direct_path = RasPrjAssets._direct_path(selector)
+        if direct_path is not None:
+            if direct_path.suffix.lower() == ".hdf" and re.search(
+                r"\.g\d{1,2}\.hdf$",
+                direct_path.name,
+                flags=re.IGNORECASE,
+            ):
+                return RasPrjAssets._existing_or_optional(direct_path, must_exist)
+            if direct_path.suffix.lower() == ".hdf" and re.search(
+                r"\.p\d{1,2}\.hdf$",
+                direct_path.name,
+                flags=re.IGNORECASE,
+            ):
+                return RasPrjAssets._geometry_hdf_from_plan_hdf(
+                    direct_path,
+                    ras_object=ras_object,
+                    must_exist=must_exist,
+                )
+            if re.search(r"\.g\d{1,2}$", direct_path.name, flags=re.IGNORECASE):
+                return RasPrjAssets._existing_or_optional(
+                    Path(str(direct_path) + ".hdf"),
+                    must_exist,
+                )
+
+        kind = selector_kind.lower()
+        text = str(selector).strip() if not isinstance(selector, Number) else ""
+        direct_geom = kind == "geom" or (
+            kind == "auto" and text.lower().startswith("g") and text[1:].isdigit()
+        )
+
+        if direct_geom:
+            geom_path = RasPrjAssets.geometry_path(
+                selector,
+                ras_object=ras_object,
+                must_exist=False,
+            )
+            if geom_path is None:
+                return None
+            return RasPrjAssets._existing_or_optional(
+                Path(str(geom_path) + ".hdf"),
+                must_exist,
+            )
+
+        if kind == "plan_hdf":
+            direct_plan_hdf = RasPrjAssets.plan_results_hdf(
+                selector,
+                ras_object=ras_object,
+                must_exist=must_exist,
+            )
+            if direct_plan_hdf is None:
+                return None
+            return RasPrjAssets._geometry_hdf_from_plan_hdf(
+                direct_plan_hdf,
+                ras_object=ras_object,
+                must_exist=must_exist,
+            )
+
+        assets = RasPrjAssets.plan_assets(
+            selector,
+            ras_object=ras_object,
+            must_exist=False,
+        )
+        if assets.geometry_hdf_path is None:
+            return None
+        return RasPrjAssets._existing_or_optional(
+            assets.geometry_hdf_path,
+            must_exist,
+        )
+
+    @staticmethod
+    @log_call
+    def plan_assets(
+        plan_number: Union[str, Number, Path],
+        ras_object=None,
+        must_exist: bool = False,
+    ) -> PlanAssets:
+        """Resolve the core file assets associated with a plan."""
+        ras_obj = RasPrjAssets._ras_object(ras_object)
+        normalized_plan_number = RasPrjAssets.normalize_number(plan_number, prefix="p")
+        row = RasPrjAssets._matching_plan_row(ras_obj, normalized_plan_number)
+
+        plan_path = RasPrjAssets.plan_path(
+            normalized_plan_number,
+            ras_object=ras_obj,
+            must_exist=must_exist,
+        )
+        results_hdf_path = RasPrjAssets.plan_results_hdf(
+            normalized_plan_number,
+            ras_object=ras_obj,
+            must_exist=must_exist,
+        )
+
+        geometry_number = None
+        geometry_path = None
+        geometry_hdf_path = None
+        flow_path = None
+
+        if row is not None:
+            geometry_number = RasPrjAssets._geometry_number_from_plan_row(row)
+            flow_path = (
+                RasPrjAssets._path_from_row(row, "Flow Path")
+                or RasPrjAssets._project_path_from_value(ras_obj, row.get("unsteady_file"))
+                or RasPrjAssets._project_path_from_value(ras_obj, row.get("steady_file"))
+            )
+
+        if geometry_number is not None:
+            geometry_path = RasPrjAssets.geometry_path(
+                geometry_number,
+                ras_object=ras_obj,
+                must_exist=must_exist,
+            )
+            if geometry_path is None and row is not None:
+                geometry_path = RasPrjAssets._path_from_row(row, "Geom Path")
+                geometry_path = RasPrjAssets._existing_or_optional(
+                    geometry_path,
+                    must_exist,
+                )
+            geometry_hdf_path = RasPrjAssets.geometry_hdf(
+                f"g{geometry_number}",
+                ras_object=ras_obj,
+                selector_kind="geom",
+                must_exist=must_exist,
+            )
+            if geometry_hdf_path is None and geometry_path is not None:
+                geometry_hdf_path = RasPrjAssets._existing_or_optional(
+                    Path(str(geometry_path) + ".hdf"),
+                    must_exist,
+                )
+
+        output_path = RasPrjAssets._project_path(ras_obj, f"O{normalized_plan_number}")
+        output_path = RasPrjAssets._existing_or_optional(output_path, must_exist)
+
+        compute_messages_path = RasPrjAssets._project_path(
+            ras_obj,
+            f"p{normalized_plan_number}.computeMsgs.txt",
+        )
+        compute_messages_path = RasPrjAssets._existing_or_optional(
+            compute_messages_path,
+            must_exist,
+        )
+
+        return PlanAssets(
+            plan_number=normalized_plan_number,
+            plan_path=plan_path,
+            results_hdf_path=results_hdf_path,
+            geometry_number=geometry_number,
+            geometry_path=geometry_path,
+            geometry_hdf_path=geometry_hdf_path,
+            flow_path=RasPrjAssets._existing_or_optional(flow_path, must_exist)
+            if flow_path is not None
+            else None,
+            output_path=output_path,
+            compute_messages_path=compute_messages_path,
+        )
+
+    @staticmethod
+    def _validate_number_int(number_int: int) -> str:
+        if not (1 <= number_int <= 99):
+            raise ValueError(f"RAS component number must be between 1 and 99, got {number_int}")
+        return f"{number_int:02d}"
+
+    @staticmethod
+    def _ras_object(ras_object=None):
+        if ras_object is not None:
+            return ras_object
+        from .RasPrj import ras
+
+        return ras
+
+    @staticmethod
+    def _direct_path(value: Union[str, Number, Path]) -> Optional[Path]:
+        if isinstance(value, Path):
+            return value
+        if isinstance(value, Number) or value is None:
+            return None
+
+        text = str(value).strip()
+        if not text:
+            return None
+
+        path = Path(text)
+        if path.exists():
+            return path
+
+        if any(sep in text for sep in ("/", "\\")):
+            return path
+
+        if re.search(r"\.[pguf]\d{1,2}(\.hdf)?$", path.name, flags=re.IGNORECASE):
+            return path
+
+        return None
+
+    @staticmethod
+    def _existing_or_optional(path: Optional[Path], must_exist: bool) -> Optional[Path]:
+        if path is None:
+            return None
+        path = Path(path)
+        if must_exist and not path.exists():
+            return None
+        return path
+
+    @staticmethod
+    def _project_path(ras_obj, suffix: str) -> Optional[Path]:
+        project_folder = getattr(ras_obj, "project_folder", None)
+        project_name = getattr(ras_obj, "project_name", None)
+        if project_folder is None or not project_name:
+            return None
+        return Path(project_folder) / f"{project_name}.{suffix}"
+
+    @staticmethod
+    def _project_path_from_value(ras_obj, value: Any) -> Optional[Path]:
+        if not RasPrjAssets._is_present(value):
+            return None
+        path = Path(str(value))
+        if path.is_absolute() or any(sep in str(value) for sep in ("/", "\\")):
+            return path
+        project_folder = getattr(ras_obj, "project_folder", None)
+        if project_folder is None:
+            return path
+        return Path(project_folder) / path
+
+    @staticmethod
+    def _path_from_row(row, column: str) -> Optional[Path]:
+        if row is None or column not in row.index:
+            return None
+        value = row.get(column)
+        if not RasPrjAssets._is_present(value):
+            return None
+        return Path(str(value))
+
+    @staticmethod
+    def _is_present(value: Any) -> bool:
+        if value is None:
+            return False
+        try:
+            if pd.isna(value):
+                return False
+        except (TypeError, ValueError):
+            pass
+        return str(value) != ""
+
+    @staticmethod
+    def _matching_plan_row(ras_obj, plan_number: str):
+        plan_df = getattr(ras_obj, "plan_df", None)
+        if plan_df is None or len(plan_df) == 0 or "plan_number" not in plan_df.columns:
+            return None
+        mask = plan_df["plan_number"].astype(str).str.zfill(2).eq(plan_number)
+        matches = plan_df[mask]
+        return None if matches.empty else matches.iloc[0]
+
+    @staticmethod
+    def _matching_geom_row(ras_obj, geom_number: str):
+        geom_df = getattr(ras_obj, "geom_df", None)
+        if geom_df is None or len(geom_df) == 0 or "geom_number" not in geom_df.columns:
+            return None
+        mask = geom_df["geom_number"].astype(str).str.zfill(2).eq(geom_number)
+        matches = geom_df[mask]
+        return None if matches.empty else matches.iloc[0]
+
+    @staticmethod
+    def _has_dataframe(ras_obj, attr_name: str, required_column: str) -> bool:
+        frame = getattr(ras_obj, attr_name, None)
+        return frame is not None and required_column in getattr(frame, "columns", [])
+
+    @staticmethod
+    def _geometry_number_from_plan_row(row) -> Optional[str]:
+        for column in ("geometry_number", "Geom File", "geom_file"):
+            if column in row.index and RasPrjAssets._is_present(row.get(column)):
+                geometry_number = RasPrjAssets.extract_number(row.get(column), prefix="g")
+                if geometry_number is not None:
+                    return geometry_number
+        geom_path = RasPrjAssets._path_from_row(row, "Geom Path")
+        if geom_path is not None:
+            return RasPrjAssets.extract_number(geom_path, prefix="g")
+        return None
+
+    @staticmethod
+    def _geometry_hdf_from_plan_hdf(
+        plan_hdf_path: Path,
+        ras_object=None,
+        must_exist: bool = True,
+    ) -> Optional[Path]:
+        plan_hdf_path = Path(plan_hdf_path)
+        geom_number = None
+
+        try:
+            from .hdf.HdfPlan import HdfPlan
+
+            plan_info = HdfPlan.get_plan_information(plan_hdf_path)
+            for key in ("Geometry File", "Geom File"):
+                if key in plan_info:
+                    try:
+                        geom_number = RasPrjAssets.normalize_number(plan_info.get(key), prefix="g")
+                        break
+                    except ValueError:
+                        continue
+        except Exception:
+            geom_number = None
+
+        if geom_number:
+            project_name = RasPrjAssets._project_name_from_plan_hdf(plan_hdf_path)
+            hdf_path = plan_hdf_path.parent / f"{project_name}.g{geom_number}.hdf"
+            found = RasPrjAssets._existing_or_optional(hdf_path, must_exist)
+            if found is not None:
+                return found
+
+        ras_obj = ras_object
+        if ras_obj is not None:
+            plan_number_match = re.search(r"\.p(\d{1,2})\.hdf$", plan_hdf_path.name, flags=re.IGNORECASE)
+            if plan_number_match:
+                assets = RasPrjAssets.plan_assets(
+                    plan_number_match.group(1),
+                    ras_object=ras_obj,
+                    must_exist=False,
+                )
+                if assets.geometry_hdf_path is not None:
+                    return RasPrjAssets._existing_or_optional(
+                        assets.geometry_hdf_path,
+                        must_exist,
+                    )
+
+            plan_df = getattr(ras_obj, "plan_df", None)
+            if plan_df is not None and "HDF_Results_Path" in plan_df.columns:
+                mask = plan_df["HDF_Results_Path"].notna() & plan_df[
+                    "HDF_Results_Path"
+                ].map(lambda value: RasPrjAssets._paths_match(value, plan_hdf_path))
+                matches = plan_df[mask]
+                if not matches.empty:
+                    geometry_number = RasPrjAssets._geometry_number_from_plan_row(matches.iloc[0])
+                    if geometry_number:
+                        return RasPrjAssets.geometry_hdf(
+                            f"g{geometry_number}",
+                            ras_object=ras_obj,
+                            selector_kind="geom",
+                            must_exist=must_exist,
+                        )
+
+        return None
+
+    @staticmethod
+    def _project_name_from_plan_hdf(plan_hdf_path: Path) -> str:
+        stem = Path(plan_hdf_path).stem
+        match = re.match(r"(.+)\.p\d{1,2}$", stem, flags=re.IGNORECASE)
+        return match.group(1) if match else stem
+
+    @staticmethod
+    def _paths_match(path_a: Any, path_b: Any) -> bool:
+        try:
+            return Path(str(path_a)).absolute() == Path(str(path_b)).absolute()
+        except Exception:
+            return False

--- a/ras_commander/__init__.py
+++ b/ras_commander/__init__.py
@@ -31,7 +31,7 @@ from .RasExamples import RasExamples
 from .sources.federal import RasEbfeModels
 from .sources.county import M3Model
 from .RasCmdr import RasCmdr
-from .RasCurrency import RasCurrency
+from .RasComputeState import RasComputeState
 from .RasControl import RasControl
 from .ComputeResults import ComputeResult, ComputeParallelResult, RasControlResult, PreprocessResult
 from .RasPreprocess import RasPreprocess
@@ -152,7 +152,7 @@ __all__ = [
     'RasPlan', 'RasUnsteady', 'RasUtils',
     'ComputeResult', 'ComputeParallelResult', 'RasControlResult', 'PreprocessResult',
     'RasPreprocess',
-    'RasExamples', 'RasEbfeModels', 'M3Model', 'RasCmdr', 'RasControl', 'RasMap', 'RasProcess', 'ProjectionInfo', 'RasGuiAutomation', 'RasScreenshot', 'HdfFluvialPluvial',
+    'RasExamples', 'RasEbfeModels', 'M3Model', 'RasCmdr', 'RasComputeState', 'RasControl', 'RasMap', 'RasProcess', 'ProjectionInfo', 'RasGuiAutomation', 'RasScreenshot', 'HdfFluvialPluvial',
     'RasModPuls', 'RasPermutation', 'RangeSpec',
     'CalibrationPoint', 'RasCalibrate',
 

--- a/ras_commander/check/_utils.py
+++ b/ras_commander/check/_utils.py
@@ -32,32 +32,39 @@ def resolve_hdf_paths(
         Tuple of (plan_hdf_path, geom_hdf_path)
         Note: geom_hdf_path may equal plan_hdf_path if no separate geometry HDF exists
     """
-    if isinstance(plan, str) and len(plan) <= 3:
-        # Plan number format (e.g., "01")
-        matching = ras_obj.plan_df[ras_obj.plan_df['plan_number'] == plan]
-        if matching.empty:
-            raise ValueError(f"Plan '{plan}' not found. Available: {ras_obj.plan_df['plan_number'].tolist()}")
-        plan_row = matching.iloc[0]
-        plan_hdf = Path(plan_row['HDF_Results_Path'])
-        geom_path = plan_row['Geom Path']
-        # Get geometry HDF from geometry file path
-        # Pattern: Muncie.g01 -> Muncie.g01.hdf (append .hdf, don't replace suffix)
-        geom_base = Path(str(geom_path))
-        geom_hdf = geom_base.parent / f"{geom_base.name}.hdf"
-    else:
+    from ..RasPrjAssets import RasPrjAssets
+
+    plan_hdf: Optional[Path]
+    geom_hdf: Optional[Path]
+
+    if isinstance(plan, (str, Path)) and Path(str(plan)).suffix.lower() == ".hdf":
         plan_hdf = Path(plan)
-        # Derive geometry HDF from plan HDF name
-        # Pattern: project.p01.hdf -> project.g01.hdf
-        plan_stem = plan_hdf.stem  # e.g., "project.p01"
-        if '.p' in plan_stem:
-            geom_stem = plan_stem.replace('.p', '.g', 1)
-        else:
-            geom_stem = plan_stem
-        geom_hdf = plan_hdf.parent / f"{geom_stem}.hdf"
+        geom_hdf = RasPrjAssets.geometry_hdf(
+            plan_hdf,
+            ras_object=ras_obj,
+            selector_kind="plan_hdf",
+            must_exist=True,
+        )
+    else:
+        plan_hdf = RasPrjAssets.plan_results_hdf(
+            plan,
+            ras_object=ras_obj,
+            must_exist=True,
+        )
+        geom_hdf = RasPrjAssets.geometry_hdf(
+            plan,
+            ras_object=ras_obj,
+            selector_kind="plan",
+            must_exist=True,
+        )
+
+    if plan_hdf is None:
+        available = getattr(getattr(ras_obj, "plan_df", None), "plan_number", [])
+        raise ValueError(f"Plan '{plan}' not found. Available: {list(available)}")
 
     # Fall back to plan HDF if geometry HDF doesn't exist
     # HEC-RAS 6.x plan HDF files contain geometry data
-    if not geom_hdf.exists():
+    if geom_hdf is None or not geom_hdf.exists():
         logger.debug(f"Geometry HDF not found at {geom_hdf}, using plan HDF for geometry data")
         geom_hdf = plan_hdf
 

--- a/ras_commander/geom/GeomBridge.py
+++ b/ras_commander/geom/GeomBridge.py
@@ -42,6 +42,7 @@ import numpy as np
 from ..LoggingConfig import get_logger
 from ..Decorators import log_call
 from .GeomParser import GeomParser
+from .GeomIndex import GeomIndex
 
 logger = get_logger(__name__)
 
@@ -62,30 +63,17 @@ class GeomBridge:
     @staticmethod
     def _find_bridge(lines: List[str], river: str, reach: str, rs: str) -> Optional[int]:
         """Find bridge/culvert section and return line index of 'Bridge Culvert-' marker."""
-        current_river = None
-        current_reach = None
-        last_rs = None
-
-        for i, line in enumerate(lines):
-            if line.startswith("River Reach="):
-                values = GeomParser.extract_comma_list(line, "River Reach")
-                if len(values) >= 2:
-                    current_river = values[0]
-                    current_reach = values[1]
-
-            elif line.startswith("Type RM Length L Ch R ="):
-                value_str = GeomParser.extract_keyword_value(line, "Type RM Length L Ch R")
-                values = [v.strip() for v in value_str.split(',')]
-                if len(values) > 1:
-                    last_rs = values[1]
-
-            elif line.startswith("Bridge Culvert-"):
-                if (current_river == river and
-                    current_reach == reach and
-                    last_rs == rs):
-                    logger.debug(f"Found bridge at line {i}: {river}/{reach}/RS {rs}")
-                    return i
-
+        index = GeomIndex.from_lines(lines)
+        record = GeomIndex.find(
+            index,
+            "bridge_culvert",
+            river=river,
+            reach=reach,
+            rs=rs,
+        )
+        if record is not None:
+            logger.debug(f"Found bridge at line {record.marker_idx}: {river}/{reach}/RS {rs}")
+            return record.marker_idx
         logger.debug(f"Bridge not found: {river}/{reach}/RS {rs}")
         return None
 

--- a/ras_commander/geom/GeomCrossSection.py
+++ b/ras_commander/geom/GeomCrossSection.py
@@ -54,6 +54,7 @@ import math
 from ..LoggingConfig import get_logger
 from ..Decorators import log_call
 from .GeomParser import GeomParser
+from .GeomIndex import GeomIndex
 
 logger = get_logger(__name__)
 
@@ -90,32 +91,17 @@ class GeomCrossSection:
             Line index where "Type RM Length L Ch R =" for matching XS starts,
             or None if not found
         """
-        current_river = None
-        current_reach = None
-
-        for i, line in enumerate(lines):
-            # Track current river/reach
-            if line.startswith("River Reach="):
-                values = GeomParser.extract_comma_list(line, "River Reach")
-                if len(values) >= 2:
-                    current_river = values[0]
-                    current_reach = values[1]
-
-            # Find matching cross section
-            elif line.startswith("Type RM Length L Ch R ="):
-                value_str = GeomParser.extract_keyword_value(line, "Type RM Length L Ch R")
-                values = [v.strip() for v in value_str.split(',')]
-
-                if len(values) > 1:
-                    # Format: Type, RS, Length_L, Length_Ch, Length_R
-                    xs_rs = values[1]  # RS is second value
-
-                    if (current_river == river and
-                        current_reach == reach and
-                        xs_rs == rs):
-                        logger.debug(f"Found XS at line {i}: {river}/{reach}/RS {rs}")
-                        return i
-
+        index = GeomIndex.from_lines(lines)
+        record = GeomIndex.find(
+            index,
+            "cross_section",
+            river=river,
+            reach=reach,
+            rs=rs,
+        )
+        if record is not None:
+            logger.debug(f"Found XS at line {record.start_idx}: {river}/{reach}/RS {rs}")
+            return record.start_idx
         logger.debug(f"XS not found: {river}/{reach}/RS {rs}")
         return None
 
@@ -137,13 +123,9 @@ class GeomCrossSection:
             Line index of the first line PAST the current XS section
             (i.e., the start of the next section, or len(lines) if at end)
         """
-        for i in range(xs_idx + 1, len(lines)):
-            line = lines[i]
-            if line.startswith("Type RM Length L Ch R ="):
-                return i
-            if line.startswith("River Reach="):
-                return i
-        return len(lines)
+        index = GeomIndex.from_lines(lines)
+        record = GeomIndex.record_at(index, kind="cross_section", start_idx=xs_idx)
+        return record.end_idx if record is not None else len(lines)
 
     @staticmethod
     def _read_bank_stations(lines: List[str], start_idx: int) -> Optional[Tuple[float, float]]:

--- a/ras_commander/geom/GeomCulvert.py
+++ b/ras_commander/geom/GeomCulvert.py
@@ -35,6 +35,7 @@ import pandas as pd
 from ..LoggingConfig import get_logger
 from ..Decorators import log_call
 from .GeomParser import GeomParser
+from .GeomIndex import GeomIndex
 
 logger = get_logger(__name__)
 
@@ -66,30 +67,15 @@ class GeomCulvert:
     @staticmethod
     def _find_bridge(lines: List[str], river: str, reach: str, rs: str) -> Optional[int]:
         """Find bridge/culvert section and return line index."""
-        current_river = None
-        current_reach = None
-        last_rs = None
-
-        for i, line in enumerate(lines):
-            if line.startswith("River Reach="):
-                values = GeomParser.extract_comma_list(line, "River Reach")
-                if len(values) >= 2:
-                    current_river = values[0]
-                    current_reach = values[1]
-
-            elif line.startswith("Type RM Length L Ch R ="):
-                value_str = GeomParser.extract_keyword_value(line, "Type RM Length L Ch R")
-                values = [v.strip() for v in value_str.split(',')]
-                if len(values) > 1:
-                    last_rs = values[1]
-
-            elif line.startswith("Bridge Culvert-"):
-                if (current_river == river and
-                    current_reach == reach and
-                    last_rs == rs):
-                    return i
-
-        return None
+        index = GeomIndex.from_lines(lines)
+        record = GeomIndex.find(
+            index,
+            "bridge_culvert",
+            river=river,
+            reach=reach,
+            rs=rs,
+        )
+        return record.marker_idx if record is not None else None
 
     @staticmethod
     @log_call

--- a/ras_commander/geom/GeomIndex.py
+++ b/ras_commander/geom/GeomIndex.py
@@ -1,0 +1,282 @@
+"""
+Read-only index for plain-text HEC-RAS geometry records.
+
+GeomParser remains responsible for fixed-width parsing. This module owns record
+boundaries and selector lookup so geometry modules do not each rediscover the
+same blocks independently.
+"""
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Mapping, Optional, Union, List
+
+from ..Decorators import log_call
+from .GeomParser import GeomParser
+
+
+@dataclass(frozen=True)
+class GeomRecord:
+    """A located record block in a HEC-RAS geometry file."""
+
+    kind: str
+    start_idx: int
+    end_idx: int
+    marker_idx: Optional[int]
+    river: Optional[str] = None
+    reach: Optional[str] = None
+    rs: Optional[str] = None
+    name: Optional[str] = None
+    type_code: Optional[int] = None
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class GeomIndexData:
+    """Index over geometry file lines and their discovered records."""
+
+    geom_file: Optional[Path]
+    lines: List[str]
+    line_ending: str
+    records: List[GeomRecord]
+
+
+class GeomIndex:
+    """Static namespace for geometry record indexing and lookup."""
+
+    @staticmethod
+    @log_call
+    def build(geom_file: Union[str, Path]) -> GeomIndexData:
+        """Build an index from a geometry file."""
+        geom_path = Path(geom_file)
+        text = geom_path.read_text(encoding="utf-8", errors="replace")
+        lines = text.splitlines(keepends=True)
+        line_ending = "\r\n" if "\r\n" in text else "\n"
+        return GeomIndex.from_lines(lines, geom_file=geom_path, line_ending=line_ending)
+
+    @staticmethod
+    @log_call
+    def from_lines(
+        lines: List[str],
+        geom_file: Union[str, Path, None] = None,
+        line_ending: Optional[str] = None,
+    ) -> GeomIndexData:
+        """Build an index from existing geometry file lines."""
+        records: List[GeomRecord] = []
+        current_river = None
+        current_reach = None
+        last_type_idx = None
+        last_type_code = None
+        last_rs = None
+
+        for idx, line in enumerate(lines):
+            if line.startswith("River Reach="):
+                values = GeomParser.extract_comma_list(line, "River Reach")
+                if len(values) >= 2:
+                    current_river = values[0]
+                    current_reach = values[1]
+                continue
+
+            if line.startswith("Type RM Length L Ch R ="):
+                values = GeomIndex._type_rm_values(line)
+                if len(values) > 1:
+                    last_type_idx = idx
+                    last_rs = values[1]
+                    last_type_code = GeomIndex._safe_int(values[0])
+                    records.append(
+                        GeomRecord(
+                            kind="cross_section",
+                            start_idx=idx,
+                            end_idx=GeomIndex._section_end(lines, idx),
+                            marker_idx=idx,
+                            river=current_river,
+                            reach=current_reach,
+                            rs=last_rs,
+                            type_code=last_type_code,
+                        )
+                    )
+                continue
+
+            if line.startswith("Bridge Culvert-"):
+                records.append(
+                    GeomRecord(
+                        kind="bridge_culvert",
+                        start_idx=last_type_idx if last_type_idx is not None else idx,
+                        end_idx=GeomIndex._section_end(lines, idx),
+                        marker_idx=idx,
+                        river=current_river,
+                        reach=current_reach,
+                        rs=last_rs,
+                        type_code=last_type_code,
+                    )
+                )
+                continue
+
+            if line.startswith("IW Pilot Flow="):
+                records.append(
+                    GeomRecord(
+                        kind="inline_weir",
+                        start_idx=last_type_idx if last_type_idx is not None else idx,
+                        end_idx=GeomIndex._section_end(lines, idx),
+                        marker_idx=idx,
+                        river=current_river,
+                        reach=current_reach,
+                        rs=last_rs,
+                        type_code=last_type_code,
+                    )
+                )
+                continue
+
+            if line.startswith("Lat Struct="):
+                values = GeomParser.extract_comma_list(line, "Lat Struct")
+                records.append(
+                    GeomRecord(
+                        kind="lateral_structure",
+                        start_idx=idx,
+                        end_idx=GeomIndex._section_end(
+                            lines,
+                            idx,
+                            peer_markers=("Lat Struct=", "River Reach="),
+                        ),
+                        marker_idx=idx,
+                        river=current_river,
+                        reach=current_reach,
+                        name=values[0] if values else None,
+                    )
+                )
+                continue
+
+            if line.startswith("SA/2D Area Conn="):
+                values = GeomParser.extract_comma_list(line, "SA/2D Area Conn")
+                records.append(
+                    GeomRecord(
+                        kind="sa_2d_connection",
+                        start_idx=idx,
+                        end_idx=GeomIndex._section_end(
+                            lines,
+                            idx,
+                            peer_markers=("SA/2D Area Conn=", "Storage Area=", "River Reach="),
+                        ),
+                        marker_idx=idx,
+                        name=values[0] if values else None,
+                    )
+                )
+                continue
+
+            if line.startswith("Storage Area="):
+                values = GeomParser.extract_comma_list(line, "Storage Area")
+                records.append(
+                    GeomRecord(
+                        kind="storage_area",
+                        start_idx=idx,
+                        end_idx=GeomIndex._section_end(
+                            lines,
+                            idx,
+                            peer_markers=("Storage Area=", "River Reach="),
+                        ),
+                        marker_idx=idx,
+                        name=values[0] if values else None,
+                    )
+                )
+
+        if line_ending is None:
+            line_ending = "\r\n" if any(line.endswith("\r\n") for line in lines) else "\n"
+
+        return GeomIndexData(
+            geom_file=Path(geom_file) if geom_file is not None else None,
+            lines=lines,
+            line_ending=line_ending,
+            records=records,
+        )
+
+    @staticmethod
+    @log_call
+    def find(index: GeomIndexData, kind: str, **selectors) -> Optional[GeomRecord]:
+        """Return the first record matching kind and selectors."""
+        matches = GeomIndex.find_all(index, kind=kind, **selectors)
+        return matches[0] if matches else None
+
+    @staticmethod
+    @log_call
+    def find_all(index: GeomIndexData, kind: Optional[str] = None, **selectors) -> List[GeomRecord]:
+        """Return all records matching kind and selectors."""
+        records = index.records
+        if kind is not None:
+            records = [record for record in records if record.kind == kind]
+
+        for key, expected in selectors.items():
+            records = [
+                record for record in records
+                if GeomIndex._selector_matches(getattr(record, key), expected)
+            ]
+
+        return records
+
+    @staticmethod
+    @log_call
+    def find_keyword(index: GeomIndexData, record: GeomRecord, keyword: str) -> Optional[int]:
+        """Find a keyword line inside a record block."""
+        for idx in range(record.start_idx, min(record.end_idx, len(index.lines))):
+            line = index.lines[idx]
+            if line.startswith(keyword) or line.startswith(f"{keyword}="):
+                return idx
+        return None
+
+    @staticmethod
+    @log_call
+    def data_section(index: GeomIndexData, keyword_idx: int) -> tuple[int, int]:
+        """Return the line range after a keyword until the next keyword-like line."""
+        start_idx = keyword_idx + 1
+        end_idx = start_idx
+        while end_idx < len(index.lines):
+            stripped = index.lines[end_idx].strip()
+            if "=" in stripped and not stripped.startswith("-"):
+                break
+            end_idx += 1
+        return start_idx, end_idx
+
+    @staticmethod
+    @log_call
+    def record_at(
+        index: GeomIndexData,
+        kind: Optional[str] = None,
+        start_idx: Optional[int] = None,
+        marker_idx: Optional[int] = None,
+    ) -> Optional[GeomRecord]:
+        """Return a record at a known start or marker index."""
+        for record in index.records:
+            if kind is not None and record.kind != kind:
+                continue
+            if start_idx is not None and record.start_idx == start_idx:
+                return record
+            if marker_idx is not None and record.marker_idx == marker_idx:
+                return record
+        return None
+
+    @staticmethod
+    def _type_rm_values(line: str) -> List[str]:
+        value_str = GeomParser.extract_keyword_value(line, "Type RM Length L Ch R")
+        return [value.strip() for value in value_str.split(",")]
+
+    @staticmethod
+    def _section_end(
+        lines: List[str],
+        start_idx: int,
+        peer_markers: tuple[str, ...] = ("Type RM Length L Ch R =", "River Reach="),
+    ) -> int:
+        for idx in range(start_idx + 1, len(lines)):
+            if any(lines[idx].startswith(marker) for marker in peer_markers):
+                return idx
+        return len(lines)
+
+    @staticmethod
+    def _selector_matches(actual, expected) -> bool:
+        if expected is None:
+            return actual is None
+        return str(actual) == str(expected)
+
+    @staticmethod
+    def _safe_int(value: str) -> Optional[int]:
+        try:
+            return int(str(value).strip())
+        except (TypeError, ValueError):
+            return None

--- a/ras_commander/geom/GeomInlineWeir.py
+++ b/ras_commander/geom/GeomInlineWeir.py
@@ -38,6 +38,7 @@ import pandas as pd
 from ..LoggingConfig import get_logger
 from ..Decorators import log_call
 from .GeomParser import GeomParser
+from .GeomIndex import GeomIndex
 
 logger = get_logger(__name__)
 
@@ -69,33 +70,17 @@ class GeomInlineWeir:
             Line index where "IW Pilot Flow=" appears for matching inline weir,
             or None if not found
         """
-        current_river = None
-        current_reach = None
-        last_rs = None
-
-        for i, line in enumerate(lines):
-            # Track current river/reach
-            if line.startswith("River Reach="):
-                values = GeomParser.extract_comma_list(line, "River Reach")
-                if len(values) >= 2:
-                    current_river = values[0]
-                    current_reach = values[1]
-
-            # Track most recent Type RM Length line (contains RS)
-            elif line.startswith("Type RM Length L Ch R ="):
-                value_str = GeomParser.extract_keyword_value(line, "Type RM Length L Ch R")
-                values = [v.strip() for v in value_str.split(',')]
-                if len(values) > 1:
-                    last_rs = values[1]  # RS is second value
-
-            # Find IW Pilot Flow marker (start of inline weir)
-            elif line.startswith("IW Pilot Flow="):
-                if (current_river == river and
-                    current_reach == reach and
-                    last_rs == rs):
-                    logger.debug(f"Found inline weir at line {i}: {river}/{reach}/RS {rs}")
-                    return i
-
+        index = GeomIndex.from_lines(lines)
+        record = GeomIndex.find(
+            index,
+            "inline_weir",
+            river=river,
+            reach=reach,
+            rs=rs,
+        )
+        if record is not None:
+            logger.debug(f"Found inline weir at line {record.marker_idx}: {river}/{reach}/RS {rs}")
+            return record.marker_idx
         logger.debug(f"Inline weir not found: {river}/{reach}/RS {rs}")
         return None
 

--- a/ras_commander/gui/workflows/open_compute.py
+++ b/ras_commander/gui/workflows/open_compute.py
@@ -210,8 +210,8 @@ class OpenAndComputeWorkflow:
                 # Only check HDF if it was modified since we started
                 try:
                     if hdf_path.exists() and hdf_path.stat().st_mtime > hdf_mtime_before:
-                        from ...RasCurrency import RasCurrency
-                        if RasCurrency.check_plan_hdf_complete(hdf_path):
+                        from ...RasComputeState import RasComputeState
+                        if RasComputeState.check_plan_hdf_complete(hdf_path):
                             logger.info("Detected 'Complete Process' in HDF — computation complete")
                             completion_detected = True
                             break

--- a/ras_commander/hdf/HdfBenefitAreas.py
+++ b/ras_commander/hdf/HdfBenefitAreas.py
@@ -296,6 +296,7 @@ class HdfBenefitAreas:
             ValueError: If input cannot be resolved to HDF path
         """
         from ras_commander.hdf import HdfUtils
+        from ras_commander.RasPrjAssets import RasPrjAssets
 
         # Convert to string for pattern matching
         input_str = str(hdf_input)
@@ -314,8 +315,7 @@ class HdfBenefitAreas:
             return Path(ras_object.folder) / input_str
 
         # Case 3: Plan number (assume anything else is a plan number)
-        # Remove 'p' prefix if present (e.g., "p01" -> "01")
-        plan_number = input_str.lstrip('p')
+        plan_number = RasPrjAssets.normalize_number(input_str, prefix="p")
 
         if ras_object is None:
             raise ValueError(

--- a/ras_commander/hdf/HdfChannelCapacity.py
+++ b/ras_commander/hdf/HdfChannelCapacity.py
@@ -124,7 +124,7 @@ class HdfChannelCapacity:
         Raises:
             ValueError: If input cannot be resolved
         """
-        from ras_commander.hdf import HdfUtils
+        from ras_commander.RasPrjAssets import RasPrjAssets
 
         input_str = str(hdf_input)
 
@@ -140,28 +140,37 @@ class HdfChannelCapacity:
                 )
             return Path(ras_object.folder) / input_str
 
-        # Case 3: Plan/geometry number
-        plan_number = input_str.lstrip('pgPG')
-
         if ras_object is None:
             raise ValueError(
-                f"Cannot resolve number '{plan_number}' without initialized project."
+                f"Cannot resolve number '{input_str}' without initialized project."
             )
 
         try:
             project_folder = ras_object.folder
-            hdfs = HdfUtils.resolve_hdf_paths(
-                project_folder, plan_number, ras_object=ras_object
-            )
-            # Try plan HDF first, fall back to geometry HDF
-            hdf_path = hdfs.get('plan') or hdfs.get('geom')
+            if label.lower().startswith("geometry"):
+                hdf_path = RasPrjAssets.geometry_hdf(
+                    input_str,
+                    ras_object=ras_object,
+                    selector_kind="geom",
+                    must_exist=False,
+                )
+            else:
+                hdf_path = RasPrjAssets.plan_results_hdf(
+                    input_str,
+                    ras_object=ras_object,
+                    must_exist=False,
+                )
             if hdf_path is not None:
                 return Path(hdf_path)
-            return Path(project_folder) / f"unknown.p{plan_number}.hdf"
+            selector_number = RasPrjAssets.extract_number(input_str)
+            suffix = f".p{selector_number}.hdf" if selector_number else f".{input_str}.hdf"
+            return Path(project_folder) / f"unknown{suffix}"
         except Exception as e:
             logger.warning(f"Could not resolve {label} '{input_str}': {e}")
             if hasattr(ras_object, 'folder') and ras_object.folder:
-                return Path(ras_object.folder) / f"unknown.p{plan_number}.hdf"
+                selector_number = RasPrjAssets.extract_number(input_str)
+                suffix = f".p{selector_number}.hdf" if selector_number else f".{input_str}.hdf"
+                return Path(ras_object.folder) / f"unknown{suffix}"
             raise ValueError(f"Failed to resolve {label} '{input_str}': {e}")
 
     # -----------------------------------------------------------------
@@ -201,17 +210,6 @@ class HdfChannelCapacity:
         geom_path = HdfChannelCapacity._standardize_hdf_input(
             geom_hdf, "geometry", _ras
         )
-
-        # If the input looks like a plan number, try to find the geometry HDF
-        input_str = str(geom_hdf)
-        if not input_str.endswith('.hdf') and '/' not in input_str and '\\' not in input_str:
-            # May be a geometry number — try resolving via geom_df
-            geom_num = input_str.lstrip('gG')
-            if hasattr(_ras, 'geom_df') and _ras.geom_df is not None and len(_ras.geom_df) > 0:
-                matches = _ras.geom_df[_ras.geom_df['geom_number'] == geom_num]
-                if len(matches) > 0:
-                    geom_file = Path(matches.iloc[0]['full_path'])
-                    geom_path = geom_file.with_suffix(geom_file.suffix + '.hdf')
 
         if not geom_path.exists():
             raise FileNotFoundError(f"Geometry HDF not found: {geom_path}")

--- a/ras_commander/hdf/HdfResultsPlan.py
+++ b/ras_commander/hdf/HdfResultsPlan.py
@@ -37,7 +37,7 @@ import h5py
 import pandas as pd
 import xarray as xr
 from ..Decorators import standardize_input, log_call
-from .HdfUtils import HdfUtils
+from .HdfUtils import HdfAttributeSpec, HdfPathSpec, HdfUtils
 from .HdfResultsXsec import HdfResultsXsec
 from ..LoggingConfig import get_logger
 import numpy as np
@@ -89,16 +89,10 @@ class HdfResultsPlan:
                 if "Results/Unsteady" not in hdf_file:
                     raise KeyError("Results/Unsteady group not found in the HDF file.")
                 
-                # Create dictionary from attributes and decode byte strings
-                attrs_dict = {}
-                for key, value in dict(hdf_file["Results/Unsteady"].attrs).items():
-                    if isinstance(value, bytes):
-                        attrs_dict[key] = value.decode('utf-8')
-                    else:
-                        attrs_dict[key] = value
-                
-                # Create DataFrame with a single row index
-                return pd.DataFrame(attrs_dict, index=[0])
+                return HdfUtils.read_attrs_as_frame(
+                    hdf_file,
+                    HdfAttributeSpec(HdfPathSpec("Results/Unsteady")),
+                )
                 
         except FileNotFoundError:
             raise FileNotFoundError(f"HDF file not found: {hdf_path}")
@@ -128,16 +122,10 @@ class HdfResultsPlan:
                 if "Results/Unsteady/Summary" not in hdf_file:
                     raise KeyError("Results/Unsteady/Summary group not found in the HDF file.")
                 
-                # Create dictionary from attributes and decode byte strings
-                attrs_dict = {}
-                for key, value in dict(hdf_file["Results/Unsteady/Summary"].attrs).items():
-                    if isinstance(value, bytes):
-                        attrs_dict[key] = value.decode('utf-8')
-                    else:
-                        attrs_dict[key] = value
-                
-                # Create DataFrame with a single row index
-                return pd.DataFrame(attrs_dict, index=[0])
+                return HdfUtils.read_attrs_as_frame(
+                    hdf_file,
+                    HdfAttributeSpec(HdfPathSpec("Results/Unsteady/Summary")),
+                )
                 
         except FileNotFoundError:
             raise FileNotFoundError(f"HDF file not found: {hdf_path}")
@@ -167,15 +155,10 @@ class HdfResultsPlan:
                 if "Results/Unsteady/Summary/Volume Accounting" not in hdf_file:
                     return None
                 
-                # Get attributes and decode byte strings
-                attrs_dict = {}
-                for key, value in dict(hdf_file["Results/Unsteady/Summary/Volume Accounting"].attrs).items():
-                    if isinstance(value, bytes):
-                        attrs_dict[key] = value.decode('utf-8')
-                    else:
-                        attrs_dict[key] = value
-                
-                return pd.DataFrame(attrs_dict, index=[0])
+                return HdfUtils.read_attrs_as_frame(
+                    hdf_file,
+                    HdfAttributeSpec(HdfPathSpec("Results/Unsteady/Summary/Volume Accounting")),
+                )
                 
         except FileNotFoundError:
             raise FileNotFoundError(f"HDF file not found: {hdf_path}")
@@ -667,38 +650,23 @@ class HdfResultsPlan:
                     raise ValueError(f"HDF file does not contain steady state results: {hdf_path.name}")
 
                 attrs_dict = {}
+                for path in ("Results/Steady/Output", "Results/Steady/Summary"):
+                    if path in hdf_file:
+                        attrs_dict.update(
+                            HdfUtils.read_attrs(
+                                hdf_file,
+                                HdfAttributeSpec(HdfPathSpec(path)),
+                            )
+                        )
 
-                # Get attributes from Results/Steady/Output
-                output_path = "Results/Steady/Output"
-                if output_path in hdf_file:
-                    output_group = hdf_file[output_path]
-                    for key, value in output_group.attrs.items():
-                        if isinstance(value, bytes):
-                            attrs_dict[key] = value.decode('utf-8')
-                        else:
-                            attrs_dict[key] = value
-
-                # Get attributes from Results/Steady/Summary
-                summary_path = "Results/Steady/Summary"
-                if summary_path in hdf_file:
-                    summary_group = hdf_file[summary_path]
-                    for key, value in summary_group.attrs.items():
-                        if isinstance(value, bytes):
-                            attrs_dict[key] = value.decode('utf-8')
-                        else:
-                            attrs_dict[key] = value
-
-                # Add flow file information from Plan Data
-                plan_info_path = "Plan Data/Plan Information"
-                if plan_info_path in hdf_file:
-                    plan_info = hdf_file[plan_info_path]
+                if "Plan Data/Plan Information" in hdf_file:
+                    plan_attrs = HdfUtils.read_attrs(
+                        hdf_file,
+                        HdfAttributeSpec(HdfPathSpec("Plan Data/Plan Information")),
+                    )
                     for key in ['Flow Filename', 'Flow Title']:
-                        if key in plan_info.attrs:
-                            value = plan_info.attrs[key]
-                            if isinstance(value, bytes):
-                                attrs_dict[key] = value.decode('utf-8')
-                            else:
-                                attrs_dict[key] = value
+                        if key in plan_attrs:
+                            attrs_dict[key] = plan_attrs[key]
 
                 if not attrs_dict:
                     logger.warning("No steady state attributes found in HDF file")

--- a/ras_commander/hdf/HdfResultsQuery.py
+++ b/ras_commander/hdf/HdfResultsQuery.py
@@ -24,6 +24,7 @@ from .HdfResultsMesh import HdfResultsMesh
 from .HdfResultsPlan import HdfResultsPlan
 from ..Decorators import standardize_input, log_call
 from ..RasPrj import ras
+from ..RasPrjAssets import RasPrjAssets
 
 logger = logging.getLogger(__name__)
 
@@ -77,29 +78,7 @@ def _normalize_variable(variable: str) -> str:
 
 def _extract_geometry_number(raw_value: Any) -> Optional[str]:
     """Extract a 2-digit geometry number from common plan metadata formats."""
-    if raw_value is None:
-        return None
-
-    try:
-        if pd.isna(raw_value):
-            return None
-    except Exception:
-        pass
-
-    text = str(raw_value).strip()
-    if not text or text.lower() == "none":
-        return None
-
-    candidates = [text, Path(text).stem, Path(text).name]
-    patterns = [r"\.g(\d{1,2})$", r"^g(\d{1,2})$", r"^(\d{1,2})$"]
-
-    for candidate in candidates:
-        for pattern in patterns:
-            match = re.search(pattern, candidate, flags=re.IGNORECASE)
-            if match:
-                return match.group(1).zfill(2)
-
-    return None
+    return RasPrjAssets.extract_number(raw_value, prefix="g")
 
 
 def _project_name_from_plan_hdf(plan_hdf_path: Path) -> str:
@@ -136,102 +115,18 @@ def _resolve_geometry_hdf(
     Returns:
         Path to the geometry HDF file (.g##.hdf)
     """
-    plan_hdf_path = Path(plan_hdf_path)
-    project_folder = plan_hdf_path.parent
-    project_name = _project_name_from_plan_hdf(plan_hdf_path)
-
-    try:
-        plan_info = HdfPlan.get_plan_information(plan_hdf_path)
-        for key in ("Geometry File", "Geom File"):
-            geom_number = _extract_geometry_number(plan_info.get(key))
-            if geom_number:
-                geom_hdf_path = (
-                    project_folder / f"{project_name}.g{geom_number}.hdf"
-                )
-                if geom_hdf_path.exists():
-                    return geom_hdf_path
-                raise FileNotFoundError(
-                    f"Geometry HDF not found: {geom_hdf_path}"
-                )
-    except Exception:
-        pass
+    from ..RasPrjAssets import RasPrjAssets
 
     _ras = ras_object if ras_object is not None else _get_global_ras()
-    plan_df = getattr(_ras, "plan_df", None)
-    geom_df = getattr(_ras, "geom_df", None)
+    geom_hdf_path = RasPrjAssets.geometry_hdf(
+        plan_hdf_path,
+        ras_object=_ras,
+        selector_kind="plan_hdf",
+        must_exist=True,
+    )
 
-    if plan_df is not None and len(plan_df) > 0:
-        plan_row = pd.DataFrame()
-
-        if "HDF_Results_Path" in plan_df.columns:
-            mask = plan_df["HDF_Results_Path"].notna() & plan_df[
-                "HDF_Results_Path"
-            ].map(lambda value: _paths_match(value, plan_hdf_path))
-            plan_row = plan_df[mask]
-
-        if plan_row.empty:
-            plan_match = re.search(
-                r"\.p(\d{2})$",
-                plan_hdf_path.stem,
-                flags=re.IGNORECASE,
-            )
-            if plan_match and "plan_number" in plan_df.columns:
-                plan_number = plan_match.group(1)
-                mask = (
-                    plan_df["plan_number"]
-                    .astype(str)
-                    .str.zfill(2)
-                    .eq(plan_number)
-                )
-                plan_row = plan_df[mask]
-
-        if not plan_row.empty:
-            row = plan_row.iloc[0]
-
-            geom_path_value = row.get("Geom Path")
-            if pd.notna(geom_path_value):
-                geom_base = Path(str(geom_path_value))
-                geom_hdf_path = geom_base.parent / f"{geom_base.name}.hdf"
-                if geom_hdf_path.exists():
-                    return geom_hdf_path
-
-            geom_number = _extract_geometry_number(row.get("Geom File"))
-            if geom_number is None:
-                geom_number = _extract_geometry_number(
-                    row.get("geometry_number")
-                )
-
-            if geom_number:
-                if getattr(_ras, "project_folder", None) is not None:
-                    project_folder = Path(_ras.project_folder)
-                if getattr(_ras, "project_name", None):
-                    project_name = str(_ras.project_name)
-
-                if geom_df is not None and len(geom_df) > 0:
-                    geom_mask = (
-                        geom_df["geom_number"]
-                        .astype(str)
-                        .str.zfill(2)
-                        .eq(geom_number)
-                    )
-                    geom_rows = geom_df[geom_mask]
-                    if (
-                        not geom_rows.empty
-                        and "hdf_path" in geom_rows.columns
-                        and pd.notna(geom_rows.iloc[0]["hdf_path"])
-                    ):
-                        geom_hdf_path = Path(str(geom_rows.iloc[0]["hdf_path"]))
-                        if geom_hdf_path.exists():
-                            return geom_hdf_path
-
-                geom_hdf_path = (
-                    project_folder / f"{project_name}.g{geom_number}.hdf"
-                )
-                if geom_hdf_path.exists():
-                    return geom_hdf_path
-                raise FileNotFoundError(
-                    f"Geometry HDF not found: {geom_hdf_path}"
-                )
+    if geom_hdf_path is not None:
+        return geom_hdf_path
 
     raise FileNotFoundError(
         "Could not resolve geometry HDF from plan HDF. "

--- a/ras_commander/hdf/HdfUtils.py
+++ b/ras_commander/hdf/HdfUtils.py
@@ -43,12 +43,13 @@ Usage Notes:
 - Supports various RAS datetime formats and conversions
 """
 import logging
+from dataclasses import dataclass
 from pathlib import Path
 import h5py
 import numpy as np
 import pandas as pd
 from datetime import datetime, timedelta
-from typing import Union, Optional, Dict, List, Tuple, Any
+from typing import Union, Optional, Dict, List, Tuple, Any, Callable
 from scipy.spatial import KDTree
 import re
 from shapely.geometry import LineString  # Import LineString to avoid NameError
@@ -57,6 +58,52 @@ from ..Decorators import standardize_input, log_call
 from ..LoggingConfig import setup_logging, get_logger
 
 logger = get_logger(__name__)
+
+
+@dataclass(frozen=True)
+class HdfPathSpec:
+    path: str
+    aliases: tuple[str, ...] = ()
+    required: bool = True
+
+
+@dataclass(frozen=True)
+class HdfFieldSpec:
+    source: str
+    column: Optional[str] = None
+    decoder: Optional[Callable[[Any], Any]] = None
+    default: Any = None
+
+
+@dataclass(frozen=True)
+class HdfAttributeSpec:
+    path: HdfPathSpec
+    fields: tuple[HdfFieldSpec, ...] = ()
+
+
+@dataclass(frozen=True)
+class HdfTableSpec:
+    path: HdfPathSpec
+    fields: tuple[HdfFieldSpec, ...] = ()
+
+
+@dataclass(frozen=True)
+class HdfRaggedTableSpec:
+    info_path: HdfPathSpec
+    values_path: HdfPathSpec
+    id_column: str
+    value_columns: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class HdfTimeAxisSpec:
+    timestamp_path: Optional[HdfPathSpec] = None
+    numeric_time_path: Optional[HdfPathSpec] = None
+    start_time_attr_path: Optional[HdfPathSpec] = None
+    start_time_attr: str = "Simulation Start Time"
+    unit: str = "D"
+    round_to: Optional[str] = None
+
 
 class HdfUtils:
     """
@@ -71,6 +118,156 @@ class HdfUtils:
     - Use this class for general HDF utility functions that are not specific to plan or geometry files.
     - All methods in this class are static and can be called without instantiating the class.
     """
+
+    @staticmethod
+    @log_call
+    def resolve_path(hdf_file: h5py.File, spec: HdfPathSpec):
+        """Resolve a path spec to an HDF object, respecting aliases."""
+        for path in (spec.path, *spec.aliases):
+            if path in hdf_file:
+                return hdf_file[path]
+        if spec.required:
+            raise KeyError(f"HDF path not found: {spec.path}")
+        return None
+
+    @staticmethod
+    @log_call
+    def decode_value(value: Any) -> Any:
+        """Decode common HDF scalar and array values into Python objects."""
+        if isinstance(value, bytes):
+            return value.decode("utf-8")
+        if isinstance(value, np.bytes_):
+            return bytes(value).decode("utf-8")
+        if isinstance(value, np.generic):
+            return HdfUtils.decode_value(value.item())
+        if isinstance(value, np.ndarray):
+            if value.shape == ():
+                return HdfUtils.decode_value(value.item())
+            return [HdfUtils.decode_value(item) for item in value.tolist()]
+        if isinstance(value, (list, tuple)):
+            return [HdfUtils.decode_value(item) for item in value]
+        return value
+
+    @staticmethod
+    @log_call
+    def read_attrs(hdf_file: h5py.File, spec: HdfAttributeSpec) -> dict:
+        """Read decoded attributes from a group or dataset."""
+        node = HdfUtils.resolve_path(hdf_file, spec.path)
+        if node is None:
+            return {}
+
+        raw_attrs = {
+            key: HdfUtils.decode_value(value)
+            for key, value in dict(node.attrs).items()
+        }
+
+        if not spec.fields:
+            return raw_attrs
+
+        mapped = {}
+        for field in spec.fields:
+            output_name = field.column or field.source
+            value = raw_attrs.get(field.source, field.default)
+            if field.decoder is not None and value is not None:
+                value = field.decoder(value)
+            mapped[output_name] = value
+        return mapped
+
+    @staticmethod
+    @log_call
+    def read_attrs_as_frame(hdf_file: h5py.File, spec: HdfAttributeSpec) -> pd.DataFrame:
+        """Read decoded attributes as a one-row DataFrame."""
+        attrs = HdfUtils.read_attrs(hdf_file, spec)
+        return pd.DataFrame(attrs, index=[0]) if attrs else pd.DataFrame()
+
+    @staticmethod
+    @log_call
+    def read_compound_table(hdf_file: h5py.File, spec: HdfTableSpec) -> pd.DataFrame:
+        """Read a compound or array dataset into a decoded DataFrame."""
+        node = HdfUtils.resolve_path(hdf_file, spec.path)
+        if node is None:
+            return pd.DataFrame()
+
+        data = node[()]
+        if getattr(data.dtype, "names", None):
+            frame = pd.DataFrame(data)
+        else:
+            frame = pd.DataFrame(data)
+
+        frame = HdfUtils.decode_frame(frame)
+        if not spec.fields:
+            return frame
+
+        output = {}
+        for field in spec.fields:
+            output_name = field.column or field.source
+            if field.source in frame.columns:
+                series = frame[field.source]
+                if field.decoder is not None:
+                    series = series.map(field.decoder)
+                output[output_name] = series
+            else:
+                output[output_name] = field.default
+        return pd.DataFrame(output)
+
+    @staticmethod
+    @log_call
+    def read_ragged_table(hdf_file: h5py.File, spec: HdfRaggedTableSpec) -> pd.DataFrame:
+        """Read an Info/Values ragged table into one row per value record."""
+        info_node = HdfUtils.resolve_path(hdf_file, spec.info_path)
+        values_node = HdfUtils.resolve_path(hdf_file, spec.values_path)
+        if info_node is None or values_node is None:
+            return pd.DataFrame()
+
+        info = np.asarray(info_node[()])
+        values = np.asarray(values_node[()])
+        rows = []
+
+        for info_idx, row in enumerate(info):
+            start = int(row[0])
+            count = int(row[1])
+            for value in values[start:start + count]:
+                value_array = np.atleast_1d(value)
+                output = {spec.id_column: info_idx}
+                for col_idx, column in enumerate(spec.value_columns):
+                    output[column] = HdfUtils.decode_value(value_array[col_idx])
+                rows.append(output)
+
+        return pd.DataFrame(rows)
+
+    @staticmethod
+    @log_call
+    def read_time_axis(hdf_file: h5py.File, spec: HdfTimeAxisSpec) -> pd.DatetimeIndex:
+        """Read a timestamp or numeric-offset time axis."""
+        if spec.timestamp_path is not None:
+            node = HdfUtils.resolve_path(hdf_file, spec.timestamp_path)
+            if node is not None:
+                values = HdfUtils.decode_value(node[()])
+                index = pd.to_datetime(values)
+                if spec.round_to:
+                    return pd.DatetimeIndex(index).round(spec.round_to)
+                return pd.DatetimeIndex(index)
+
+        if spec.numeric_time_path is None or spec.start_time_attr_path is None:
+            raise KeyError("Time axis requires timestamp path or numeric time plus start time attr path")
+
+        time_node = HdfUtils.resolve_path(hdf_file, spec.numeric_time_path)
+        start_node = HdfUtils.resolve_path(hdf_file, spec.start_time_attr_path)
+        start_time = HdfUtils.decode_value(start_node.attrs[spec.start_time_attr])
+        index = pd.to_datetime(start_time) + pd.to_timedelta(time_node[()], unit=spec.unit)
+        if spec.round_to:
+            return pd.DatetimeIndex(index).round(spec.round_to)
+        return pd.DatetimeIndex(index)
+
+    @staticmethod
+    @log_call
+    def decode_frame(frame: pd.DataFrame) -> pd.DataFrame:
+        """Decode byte-like values in a DataFrame without changing column names."""
+        decoded = frame.copy()
+        for column in decoded.columns:
+            if decoded[column].dtype.kind in {"S", "O"}:
+                decoded[column] = decoded[column].map(HdfUtils.decode_value)
+        return decoded
 
 
 
@@ -301,28 +498,40 @@ class HdfUtils:
             >>> geom_hdf = hdfs['geometry']
         """
         from ..RasPrj import ras as default_ras
+        from ..RasPrjAssets import RasPrjAssets
+
         ras_obj = ras_object or default_ras
         ras_obj.check_initialized()
 
-        plan_num = str(plan_number).zfill(2)
-        result = {'plan': None, 'geometry': None}
+        plan_hdf = RasPrjAssets.plan_results_hdf(
+            plan_number,
+            ras_object=ras_obj,
+            must_exist=True,
+        )
+        geom_hdf = RasPrjAssets.geometry_hdf(
+            plan_number,
+            ras_object=ras_obj,
+            selector_kind="plan",
+            must_exist=True,
+        )
 
-        # Scan for HDF files
-        hdf_files = HdfUtils.scan_hdf_files(ras_folder)
+        result = {'plan': plan_hdf, 'geometry': geom_hdf, 'geom': geom_hdf}
 
-        # Get plan HDF
-        plan_key = f"plan_{plan_num}"
-        if plan_key in hdf_files:
-            result['plan'] = hdf_files[plan_key]
+        if result['plan'] is None or result['geometry'] is None:
+            plan_num = RasPrjAssets.normalize_number(plan_number, prefix="p")
+            hdf_files = HdfUtils.scan_hdf_files(Path(ras_folder))
+            result['plan'] = result['plan'] or hdf_files.get(f"plan_{plan_num}")
 
-        # Get geometry HDF if we know the geometry number
-        plan_row = ras_obj.plan_df[ras_obj.plan_df['plan_number'] == plan_num]
-        if not plan_row.empty:
-            geom_num = plan_row.iloc[0].get('geometry_number')
-            if geom_num is not None:
-                geom_key = f"geom_{str(geom_num).zfill(2)}"
-                if geom_key in hdf_files:
-                    result['geometry'] = hdf_files[geom_key]
+            assets = RasPrjAssets.plan_assets(
+                plan_num,
+                ras_object=ras_obj,
+                must_exist=False,
+            )
+            if assets.geometry_number:
+                result['geometry'] = result['geometry'] or hdf_files.get(
+                    f"geom_{assets.geometry_number}"
+                )
+                result['geom'] = result['geometry']
 
         return result
 
@@ -511,5 +720,4 @@ class HdfUtils:
         microseconds = milliseconds * 1000
         parsed_dt = HdfUtils.parse_ras_datetime(datetime_str[:-4]).replace(microsecond=microseconds)
         return parsed_dt
-    
     

--- a/ras_commander/remote/DockerWorker.py
+++ b/ras_commander/remote/DockerWorker.py
@@ -56,10 +56,11 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Dict, Optional, Any
 
-from .RasWorker import RasWorker
+from .RasWorker import RasWorker, WorkerExecutionRequest, WorkerExecutionOutcome
 from ..LoggingConfig import get_logger
 from ..Decorators import log_call
 from ..RasUtils import RasUtils
+from ..RasPrjAssets import RasPrjAssets
 
 logger = get_logger(__name__)
 
@@ -185,6 +186,36 @@ class DockerWorker(RasWorker):
         logger.debug(f"DockerWorker initialized: image={self.docker_image}, "
                     f"host={self.docker_host or 'local'}, remote={self._is_remote}, "
                     f"max_parallel={self.max_parallel_plans}")
+
+    @log_call
+    def execute_plan(self, request: WorkerExecutionRequest) -> WorkerExecutionOutcome:
+        """Execute one plan through the existing Docker worker function."""
+        success = execute_docker_plan(
+            worker=self,
+            plan_number=request.plan_number,
+            ras_obj=request.ras_object,
+            num_cores=request.num_cores,
+            clear_geompre=request.clear_geompre,
+            force_geompre=request.force_geompre,
+            force_rerun=request.force_rerun,
+            sub_worker_id=request.sub_worker_id,
+            autoclean=request.autoclean,
+        )
+        hdf_path = RasPrjAssets.plan_results_hdf(
+            request.plan_number,
+            ras_object=request.ras_object,
+            must_exist=True,
+        )
+        if hdf_path is None:
+            hdf_path = Path(request.ras_object.project_folder) / (
+                f"{request.ras_object.project_name}.p{request.plan_number}.tmp.hdf"
+            )
+            if not hdf_path.exists():
+                hdf_path = None
+        return WorkerExecutionOutcome(
+            success=success,
+            hdf_path=str(hdf_path) if success and hdf_path is not None else None,
+        )
 
 
 @log_call
@@ -367,6 +398,8 @@ def execute_docker_plan(
     ras_obj,
     num_cores: int,
     clear_geompre: bool,
+    force_geompre: bool = False,
+    force_rerun: bool = False,
     sub_worker_id: int = 1,
     autoclean: bool = True
 ) -> bool:
@@ -383,14 +416,14 @@ def execute_docker_plan(
         ras_obj: RasPrj object with project information
         num_cores: Number of cores for simulation
         clear_geompre: Whether to clear geometry preprocessor files
+        force_geompre: Force full geometry reprocessing before staging
+        force_rerun: Force execution even if results are current
         sub_worker_id: Sub-worker identifier for parallel execution
         autoclean: Remove staging files after completion
 
     Returns:
         bool: True if execution succeeded, False otherwise
     """
-    docker = check_docker_dependencies()
-
     # CRITICAL: Capture project info at the START of execution
     # This prevents issues if another thread modifies ras_obj during execution
     # (e.g., via init_ras_project calls in preprocessing)
@@ -403,6 +436,21 @@ def execute_docker_plan(
         logger.error(f"Project folder does not exist: {project_folder}")
         logger.error("This may indicate a thread-safety issue with ras_obj modification")
         return False
+
+    if not force_rerun:
+        from ..RasComputeState import RasComputeState
+        is_current, reason = RasComputeState.are_plan_results_current(plan_number, ras_obj)
+        if is_current:
+            logger.info(f"Skipping Docker execution of plan {plan_number}: {reason}")
+            return True
+        logger.debug(f"Plan {plan_number} needs Docker execution: {reason}")
+
+    if force_geompre:
+        from ..RasComputeState import RasComputeState
+        RasComputeState.clear_geom_hdf(plan_number, ras_obj)
+        logger.info(f"Cleared geometry HDF for plan {plan_number} before Docker execution")
+
+    docker = check_docker_dependencies()
 
     logger.info(f"Starting Docker execution: plan {plan_number}, sub-worker {sub_worker_id}")
 

--- a/ras_commander/remote/Execution.py
+++ b/ras_commander/remote/Execution.py
@@ -13,7 +13,7 @@ from dataclasses import dataclass
 from typing import Dict, List, Optional, Union
 from pathlib import Path
 
-from .RasWorker import RasWorker
+from .RasWorker import RasWorker, WorkerExecutionRequest
 from ..LoggingConfig import get_logger
 from ..Decorators import log_call
 
@@ -221,8 +221,8 @@ def _execute_single_plan(
     """
     Execute a single plan on a specific worker.
 
-    This internal function routes to the appropriate worker-specific execution
-    function based on worker_type.
+    This internal function builds a worker execution request and lets the worker
+    adapter own execution behavior.
 
     Args:
         worker: Worker instance
@@ -246,90 +246,20 @@ def _execute_single_plan(
     )
 
     try:
-        # Route to worker-specific execution
-        if worker.worker_type == "psexec":
-            from .PsexecWorker import execute_psexec_plan
-            success = execute_psexec_plan(
-                worker=worker,
-                plan_number=plan_number,
-                ras_obj=ras_object,
-                num_cores=num_cores,
-                clear_geompre=clear_geompre,
-                force_geompre=force_geompre,
-                force_rerun=force_rerun,
-                sub_worker_id=sub_worker_id,
-                autoclean=autoclean
-            )
-            result.success = success
-
-            if success:
-                project_name = ras_object.project_name
-                hdf_file = Path(ras_object.project_folder) / f"{project_name}.p{plan_number}.hdf"
-                if hdf_file.exists():
-                    result.hdf_path = str(hdf_file)
-
-        elif worker.worker_type == "local":
-            from .LocalWorker import execute_local_plan
-            success = execute_local_plan(
-                worker=worker,
-                plan_number=plan_number,
-                ras_obj=ras_object,
-                num_cores=num_cores,
-                clear_geompre=clear_geompre,
-                force_geompre=force_geompre,
-                force_rerun=force_rerun,
-                sub_worker_id=sub_worker_id,
-                autoclean=autoclean
-            )
-            result.success = success
-
-            if success:
-                project_name = ras_object.project_name
-                hdf_file = Path(ras_object.project_folder) / f"{project_name}.p{plan_number}.hdf"
-                if hdf_file.exists():
-                    result.hdf_path = str(hdf_file)
-
-        elif worker.worker_type == "ssh":
-            result.error_message = "SSH worker not yet implemented"
-
-        elif worker.worker_type == "winrm":
-            result.error_message = "WinRM worker not yet implemented"
-
-        elif worker.worker_type == "docker":
-            from .DockerWorker import execute_docker_plan
-            success = execute_docker_plan(
-                worker=worker,
-                plan_number=plan_number,
-                ras_obj=ras_object,
-                num_cores=num_cores,
-                clear_geompre=clear_geompre,
-                sub_worker_id=sub_worker_id,
-                autoclean=autoclean
-            )
-            result.success = success
-
-            if success:
-                project_name = ras_object.project_name
-                hdf_file = Path(ras_object.project_folder) / f"{project_name}.p{plan_number}.hdf"
-                if hdf_file.exists():
-                    result.hdf_path = str(hdf_file)
-                else:
-                    # Check for .tmp.hdf (Linux container output)
-                    tmp_hdf = Path(ras_object.project_folder) / f"{project_name}.p{plan_number}.tmp.hdf"
-                    if tmp_hdf.exists():
-                        result.hdf_path = str(tmp_hdf)
-
-        elif worker.worker_type == "slurm":
-            result.error_message = "Slurm worker not yet implemented"
-
-        elif worker.worker_type == "aws_ec2":
-            result.error_message = "AWS EC2 worker not yet implemented"
-
-        elif worker.worker_type == "azure_fr":
-            result.error_message = "Azure worker not yet implemented"
-
-        else:
-            result.error_message = f"Unknown worker type: {worker.worker_type}"
+        request = WorkerExecutionRequest(
+            plan_number=plan_number,
+            ras_object=ras_object,
+            num_cores=num_cores,
+            clear_geompre=clear_geompre,
+            force_geompre=force_geompre,
+            force_rerun=force_rerun,
+            sub_worker_id=sub_worker_id,
+            autoclean=autoclean,
+        )
+        outcome = worker.execute_plan(request)
+        result.success = outcome.success
+        result.hdf_path = outcome.hdf_path
+        result.error_message = outcome.error_message
 
     except NotImplementedError as e:
         result.error_message = str(e)

--- a/ras_commander/remote/LocalWorker.py
+++ b/ras_commander/remote/LocalWorker.py
@@ -12,9 +12,11 @@ import uuid
 from dataclasses import dataclass
 from pathlib import Path
 
-from .RasWorker import RasWorker
+from .RasWorker import RasWorker, WorkerExecutionRequest, WorkerExecutionOutcome
 from ..LoggingConfig import get_logger
+from ..Decorators import log_call
 from ..RasUtils import RasUtils
+from ..RasPrjAssets import RasPrjAssets
 
 logger = get_logger(__name__)
 
@@ -85,6 +87,30 @@ class LocalWorker(RasWorker):
                 self.max_parallel_plans = 1
         else:
             self.max_parallel_plans = 1
+
+    @log_call
+    def execute_plan(self, request: WorkerExecutionRequest) -> WorkerExecutionOutcome:
+        """Execute one plan through the existing local worker function."""
+        success = execute_local_plan(
+            worker=self,
+            plan_number=request.plan_number,
+            ras_obj=request.ras_object,
+            num_cores=request.num_cores,
+            clear_geompre=request.clear_geompre,
+            force_geompre=request.force_geompre,
+            force_rerun=request.force_rerun,
+            sub_worker_id=request.sub_worker_id,
+            autoclean=request.autoclean,
+        )
+        hdf_path = RasPrjAssets.plan_results_hdf(
+            request.plan_number,
+            ras_object=request.ras_object,
+            must_exist=True,
+        )
+        return WorkerExecutionOutcome(
+            success=success,
+            hdf_path=str(hdf_path) if success and hdf_path is not None else None,
+        )
 
 
 def init_local_worker(**kwargs) -> LocalWorker:

--- a/ras_commander/remote/PsexecWorker.py
+++ b/ras_commander/remote/PsexecWorker.py
@@ -17,10 +17,12 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Dict, Optional
 
-from .RasWorker import RasWorker
+from .RasWorker import RasWorker, WorkerExecutionRequest, WorkerExecutionOutcome
 from .Utils import convert_unc_to_local_path, authenticate_network_share
 from ..LoggingConfig import get_logger
+from ..Decorators import log_call
 from ..RasUtils import RasUtils
+from ..RasPrjAssets import RasPrjAssets
 
 logger = get_logger(__name__)
 
@@ -160,6 +162,30 @@ class PsexecWorker(RasWorker):
                 self.max_parallel_plans = 1
         else:
             self.max_parallel_plans = 1
+
+    @log_call
+    def execute_plan(self, request: WorkerExecutionRequest) -> WorkerExecutionOutcome:
+        """Execute one plan through the existing PsExec worker function."""
+        success = execute_psexec_plan(
+            worker=self,
+            plan_number=request.plan_number,
+            ras_obj=request.ras_object,
+            num_cores=request.num_cores,
+            clear_geompre=request.clear_geompre,
+            force_geompre=request.force_geompre,
+            force_rerun=request.force_rerun,
+            sub_worker_id=request.sub_worker_id,
+            autoclean=request.autoclean,
+        )
+        hdf_path = RasPrjAssets.plan_results_hdf(
+            request.plan_number,
+            ras_object=request.ras_object,
+            must_exist=True,
+        )
+        return WorkerExecutionOutcome(
+            success=success,
+            hdf_path=str(hdf_path) if success and hdf_path is not None else None,
+        )
 
 
 # =============================================================================
@@ -369,8 +395,8 @@ def execute_psexec_plan(
 
     # Step 0a: Check if results are current (skip if so, unless force_rerun=True)
     if not force_rerun:
-        from ..RasCurrency import RasCurrency
-        is_current, reason = RasCurrency.are_plan_results_current(plan_number, ras_obj)
+        from ..RasComputeState import RasComputeState
+        is_current, reason = RasComputeState.are_plan_results_current(plan_number, ras_obj)
         if is_current:
             logger.info(f"Skipping remote execution of plan {plan_number}: {reason}")
             return True
@@ -379,8 +405,8 @@ def execute_psexec_plan(
 
     # Step 0b: Handle force_geompre (before copying to remote)
     if force_geompre:
-        from ..RasCurrency import RasCurrency
-        RasCurrency.clear_geom_hdf(plan_number, ras_obj)
+        from ..RasComputeState import RasComputeState
+        RasComputeState.clear_geom_hdf(plan_number, ras_obj)
         logger.info(f"Cleared geometry HDF for plan {plan_number} before remote execution")
 
     # Step 1: Authenticate to network share

--- a/ras_commander/remote/RasWorker.py
+++ b/ras_commander/remote/RasWorker.py
@@ -24,6 +24,30 @@ logger = get_logger(__name__)
 # =============================================================================
 
 @dataclass
+class WorkerExecutionRequest:
+    """Request for executing one plan on a worker."""
+
+    plan_number: str
+    ras_object: Any
+    num_cores: int = 4
+    clear_geompre: bool = False
+    force_geompre: bool = False
+    force_rerun: bool = False
+    sub_worker_id: int = 1
+    autoclean: bool = True
+
+
+@dataclass
+class WorkerExecutionOutcome:
+    """Worker-owned execution outcome before public result wrapping."""
+
+    success: bool
+    hdf_path: Optional[str] = None
+    error_message: Optional[str] = None
+    artifacts: Dict[str, str] = field(default_factory=dict)
+
+
+@dataclass
 class RasWorker:
     """
     Base class for remote execution workers.
@@ -51,6 +75,11 @@ class RasWorker:
         if not self.worker_type:
             raise ValueError("worker_type is required")
         # Note: ras_exe_path is optional - will be obtained from ras object during execution
+
+    @log_call
+    def execute_plan(self, request: WorkerExecutionRequest) -> WorkerExecutionOutcome:
+        """Execute one plan on this worker."""
+        raise NotImplementedError(f"{self.worker_type} worker execution is not implemented")
 
 
 # =============================================================================

--- a/tests/test_asset_resolution_migrations.py
+++ b/tests/test_asset_resolution_migrations.py
@@ -1,0 +1,103 @@
+from pathlib import Path
+
+import pandas as pd
+
+from ras_commander.RasComputeState import RasComputeState
+from ras_commander.RasModPuls import RasModPuls
+from ras_commander.check import _utils as check_utils
+from ras_commander.hdf.HdfChannelCapacity import HdfChannelCapacity
+
+
+class FakeRasProject:
+    def __init__(self, project_folder: Path):
+        self.project_folder = Path(project_folder)
+        self.folder = self.project_folder
+        self.project_name = "TestProject"
+        self.plan_df = pd.DataFrame(
+            [
+                {
+                    "plan_number": "01",
+                    "Geom File": "g02",
+                    "Geom Path": str(self.project_folder / "TestProject.g02"),
+                    "Flow Path": str(self.project_folder / "TestProject.u01"),
+                    "full_path": str(self.project_folder / "TestProject.p01"),
+                    "HDF_Results_Path": str(self.project_folder / "TestProject.p01.hdf"),
+                }
+            ]
+        )
+        self.geom_df = pd.DataFrame(
+            [
+                {
+                    "geom_number": "01",
+                    "full_path": str(self.project_folder / "TestProject.g01"),
+                    "hdf_path": str(self.project_folder / "TestProject.g01.hdf"),
+                },
+                {
+                    "geom_number": "02",
+                    "full_path": str(self.project_folder / "TestProject.g02"),
+                    "hdf_path": str(self.project_folder / "TestProject.g02.hdf"),
+                },
+            ]
+        )
+
+    def check_initialized(self):
+        return None
+
+
+def _touch(path: Path) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("", encoding="utf-8")
+    return path
+
+
+def test_compute_state_get_plan_input_files_uses_shared_assets(tmp_path):
+    ras = FakeRasProject(tmp_path)
+
+    files = RasComputeState.get_plan_input_files("p01", ras)
+
+    assert files == {
+        "plan": tmp_path / "TestProject.p01",
+        "geom": tmp_path / "TestProject.g02",
+        "flow": tmp_path / "TestProject.u01",
+    }
+
+
+def test_check_utils_resolve_hdf_paths_uses_shared_plan_geometry_lookup(tmp_path):
+    ras = FakeRasProject(tmp_path)
+    plan_hdf = _touch(tmp_path / "TestProject.p01.hdf")
+    geom_hdf = _touch(tmp_path / "TestProject.g02.hdf")
+
+    assert check_utils.resolve_hdf_paths("p01", ras) == (plan_hdf, geom_hdf)
+
+
+def test_check_utils_resolve_hdf_paths_falls_back_to_plan_hdf_for_embedded_geometry(tmp_path):
+    ras = FakeRasProject(tmp_path)
+    plan_hdf = _touch(tmp_path / "TestProject.p01.hdf")
+
+    assert check_utils.resolve_hdf_paths("01", ras) == (plan_hdf, plan_hdf)
+
+
+def test_modpuls_private_hdf_helpers_delegate_to_shared_assets(tmp_path):
+    ras = FakeRasProject(tmp_path)
+    plan_hdf = _touch(tmp_path / "TestProject.p01.hdf")
+    geom_hdf = _touch(tmp_path / "TestProject.g02.hdf")
+
+    assert RasModPuls._resolve_hdf_path("p01", ras) == plan_hdf
+    assert RasModPuls._get_geom_hdf_path(plan_hdf, "p01", ras) == geom_hdf
+
+
+def test_channel_capacity_distinguishes_plan_and_geometry_number_inputs(tmp_path):
+    ras = FakeRasProject(tmp_path)
+
+    assert (
+        HdfChannelCapacity._standardize_hdf_input("01", "plan", ras)
+        == tmp_path / "TestProject.p01.hdf"
+    )
+    assert (
+        HdfChannelCapacity._standardize_hdf_input("01", "geometry", ras)
+        == tmp_path / "TestProject.g01.hdf"
+    )
+    assert (
+        HdfChannelCapacity._standardize_hdf_input("g02", "geometry", ras)
+        == tmp_path / "TestProject.g02.hdf"
+    )

--- a/tests/test_geom_index.py
+++ b/tests/test_geom_index.py
@@ -1,0 +1,85 @@
+from ras_commander.geom.GeomIndex import GeomIndex
+from ras_commander.geom.GeomBridge import GeomBridge
+from ras_commander.geom.GeomCulvert import GeomCulvert
+from ras_commander.geom.GeomCrossSection import GeomCrossSection
+from ras_commander.geom.GeomInlineWeir import GeomInlineWeir
+
+
+def _sample_lines():
+    return [
+        "River Reach=River A,Reach 1\n",
+        "Type RM Length L Ch R = 1,100.0,0,0,0\n",
+        "#Sta/Elev= 2\n",
+        "       0      10      1      11\n",
+        "Type RM Length L Ch R = 3,90.0,0,0,0\n",
+        "Bridge Culvert- 0,0,0,0,0\n",
+        "Deck Dist Width WeirC= 1,2,3\n",
+        "Type RM Length L Ch R = 4,80.0,0,0,0\n",
+        "IW Pilot Flow= 0\n",
+        "River Reach=River B,Reach 2\n",
+        "Lat Struct=Lat A,0,0\n",
+        "#Lat Struct Sta/Elev= 2\n",
+        "       0      10      1      11\n",
+        "Storage Area=Storage A\n",
+        "SA/2D Area Conn=Conn A,Storage A,Area A\n",
+    ]
+
+
+def test_geom_index_finds_core_record_types():
+    index = GeomIndex.from_lines(_sample_lines())
+
+    xs = GeomIndex.find(
+        index,
+        "cross_section",
+        river="River A",
+        reach="Reach 1",
+        rs="100.0",
+    )
+    bridge = GeomIndex.find(
+        index,
+        "bridge_culvert",
+        river="River A",
+        reach="Reach 1",
+        rs="90.0",
+    )
+    inline = GeomIndex.find(
+        index,
+        "inline_weir",
+        river="River A",
+        reach="Reach 1",
+        rs="80.0",
+    )
+    lateral = GeomIndex.find(index, "lateral_structure", name="Lat A")
+    storage = GeomIndex.find(index, "storage_area", name="Storage A")
+    connection = GeomIndex.find(index, "sa_2d_connection", name="Conn A")
+
+    assert xs.start_idx == 1
+    assert xs.end_idx == 4
+    assert bridge.marker_idx == 5
+    assert inline.marker_idx == 8
+    assert lateral.start_idx == 10
+    assert storage.start_idx == 13
+    assert connection.start_idx == 14
+
+
+def test_geom_index_helpers_find_keywords_and_data_sections():
+    index = GeomIndex.from_lines(_sample_lines())
+    xs = GeomIndex.find(index, "cross_section", rs="100.0")
+    keyword_idx = GeomIndex.find_keyword(index, xs, "#Sta/Elev")
+
+    assert keyword_idx == 2
+    assert GeomIndex.data_section(index, keyword_idx) == (3, 4)
+
+
+def test_existing_private_finders_can_delegate_to_index():
+    lines = _sample_lines()
+
+    assert GeomCrossSection._find_cross_section(
+        lines, "River A", "Reach 1", "100.0"
+    ) == 1
+    assert GeomCrossSection._find_xs_section_end(lines, 1) == 4
+    assert GeomBridge._find_bridge(lines, "River A", "Reach 1", "90.0") == 5
+    assert GeomCulvert._find_bridge(lines, "River A", "Reach 1", "90.0") == 5
+    assert GeomInlineWeir._find_inline_weir(
+        lines, "River A", "Reach 1", "80.0"
+    ) == 8

--- a/tests/test_hdf_utils_readers.py
+++ b/tests/test_hdf_utils_readers.py
@@ -1,0 +1,130 @@
+import h5py
+import numpy as np
+import pandas as pd
+
+from ras_commander.hdf.HdfResultsPlan import HdfResultsPlan
+from ras_commander.hdf.HdfUtils import (
+    HdfAttributeSpec,
+    HdfFieldSpec,
+    HdfPathSpec,
+    HdfUtils,
+    HdfRaggedTableSpec,
+    HdfTableSpec,
+    HdfTimeAxisSpec,
+)
+
+
+def test_read_attrs_decodes_bytes_and_maps_fields(tmp_path):
+    hdf_path = tmp_path / "attrs.hdf"
+    with h5py.File(hdf_path, "w") as hdf:
+        group = hdf.create_group("Plan Data/Plan Information")
+        group.attrs["Plan Name"] = b"Base"
+        group.attrs["Run Count"] = 3
+
+    with h5py.File(hdf_path, "r") as hdf:
+        attrs = HdfUtils.read_attrs(
+            hdf,
+            HdfAttributeSpec(
+                HdfPathSpec("Plan Data/Plan Information"),
+                fields=(
+                    HdfFieldSpec("Plan Name", "plan_name"),
+                    HdfFieldSpec("Run Count", "run_count"),
+                    HdfFieldSpec("Missing", "missing", default="fallback"),
+                ),
+            ),
+        )
+
+    assert attrs == {
+        "plan_name": "Base",
+        "run_count": 3,
+        "missing": "fallback",
+    }
+
+
+def test_read_compound_table_decodes_byte_columns(tmp_path):
+    hdf_path = tmp_path / "table.hdf"
+    dtype = np.dtype([("Name", "S10"), ("Value", "f8")])
+    data = np.array([(b"Class A", 1.5), (b"Class B", 2.5)], dtype=dtype)
+    with h5py.File(hdf_path, "w") as hdf:
+        hdf.create_dataset("Raster Map", data=data)
+
+    with h5py.File(hdf_path, "r") as hdf:
+        table = HdfUtils.read_compound_table(
+            hdf,
+            HdfTableSpec(HdfPathSpec("//Raster Map", aliases=("Raster Map",))),
+        )
+
+    assert table["Name"].tolist() == ["Class A", "Class B"]
+    assert table["Value"].tolist() == [1.5, 2.5]
+
+
+def test_read_ragged_table_expands_info_values(tmp_path):
+    hdf_path = tmp_path / "ragged.hdf"
+    with h5py.File(hdf_path, "w") as hdf:
+        hdf.create_dataset("Info", data=np.array([[0, 2], [2, 1]], dtype="i4"))
+        hdf.create_dataset(
+            "Values",
+            data=np.array([[0.0, 10.0], [1.0, 11.0], [2.0, 12.0]], dtype="f8"),
+        )
+
+    with h5py.File(hdf_path, "r") as hdf:
+        table = HdfUtils.read_ragged_table(
+            hdf,
+            HdfRaggedTableSpec(
+                HdfPathSpec("Info"),
+                HdfPathSpec("Values"),
+                id_column="feature_id",
+                value_columns=("station", "elevation"),
+            ),
+        )
+
+    assert table.to_dict("records") == [
+        {"feature_id": 0, "station": 0.0, "elevation": 10.0},
+        {"feature_id": 0, "station": 1.0, "elevation": 11.0},
+        {"feature_id": 1, "station": 2.0, "elevation": 12.0},
+    ]
+
+
+def test_read_time_axis_from_timestamp_path(tmp_path):
+    hdf_path = tmp_path / "time.hdf"
+    with h5py.File(hdf_path, "w") as hdf:
+        hdf.create_dataset(
+            "Time Date Stamp (ms)",
+            data=np.array([b"2026-01-01 00:00:00", b"2026-01-01 01:00:00"]),
+        )
+
+    with h5py.File(hdf_path, "r") as hdf:
+        index = HdfUtils.read_time_axis(
+            hdf,
+            HdfTimeAxisSpec(timestamp_path=HdfPathSpec("Time Date Stamp (ms)")),
+        )
+
+    assert isinstance(index, pd.DatetimeIndex)
+    assert list(index.hour) == [0, 1]
+
+
+def test_hdf_results_plan_attribute_readers_use_decoded_attrs(tmp_path):
+    hdf_path = tmp_path / "plan.p01.hdf"
+    with h5py.File(hdf_path, "w") as hdf:
+        unsteady = hdf.create_group("Results/Unsteady")
+        unsteady.attrs["Program Name"] = b"RAS"
+        summary = hdf.create_group("Results/Unsteady/Summary")
+        summary.attrs["Solution"] = b"Complete"
+        volume = hdf.create_group("Results/Unsteady/Summary/Volume Accounting")
+        volume.attrs["Error"] = b"0.0"
+
+        steady = hdf.create_group("Results/Steady")
+        output = hdf.create_group("Results/Steady/Output")
+        output.attrs["Solution"] = b"Steady Finished Successfully"
+        hdf.create_group("Results/Steady/Summary").attrs["Profiles"] = 1
+        plan_info = hdf.create_group("Plan Data/Plan Information")
+        plan_info.attrs["Flow Filename"] = b"test.f01"
+        plan_info.attrs["Flow Title"] = b"Base Flow"
+
+    assert HdfResultsPlan.get_unsteady_info(hdf_path)["Program Name"].iloc[0] == "RAS"
+    assert HdfResultsPlan.get_unsteady_summary(hdf_path)["Solution"].iloc[0] == "Complete"
+    assert HdfResultsPlan.get_volume_accounting(hdf_path)["Error"].iloc[0] == "0.0"
+
+    steady_info = HdfResultsPlan.get_steady_info(hdf_path)
+    assert steady_info["Solution"].iloc[0] == "Steady Finished Successfully"
+    assert steady_info["Flow Filename"].iloc[0] == "test.f01"

--- a/tests/test_project_asset_resolution.py
+++ b/tests/test_project_asset_resolution.py
@@ -1,0 +1,160 @@
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from ras_commander.RasPrjAssets import RasPrjAssets, PlanAssets
+
+
+class FakeRasProject:
+    def __init__(self, project_folder: Path, project_name: str = "TestProject"):
+        self.project_folder = Path(project_folder)
+        self.project_name = project_name
+        self.plan_df = pd.DataFrame(
+            [
+                {
+                    "plan_number": "01",
+                    "geometry_number": "02",
+                    "Geom File": "g02",
+                    "Geom Path": str(self.project_folder / f"{project_name}.g02"),
+                    "Flow Path": str(self.project_folder / f"{project_name}.u01"),
+                    "full_path": str(self.project_folder / f"{project_name}.p01"),
+                    "HDF_Results_Path": str(self.project_folder / f"{project_name}.p01.hdf"),
+                },
+                {
+                    "plan_number": "03",
+                    "geometry_number": "04",
+                    "Geom File": "g04",
+                    "Geom Path": str(self.project_folder / f"{project_name}.g04"),
+                    "Flow Path": None,
+                    "full_path": str(self.project_folder / f"{project_name}.p03"),
+                    "HDF_Results_Path": None,
+                },
+            ]
+        )
+        self.geom_df = pd.DataFrame(
+            [
+                {
+                    "geom_number": "02",
+                    "full_path": str(self.project_folder / f"{project_name}.g02"),
+                    "hdf_path": str(self.project_folder / f"{project_name}.g02.hdf"),
+                },
+                {
+                    "geom_number": "04",
+                    "full_path": str(self.project_folder / f"{project_name}.g04"),
+                    "hdf_path": str(self.project_folder / f"{project_name}.g04.hdf"),
+                },
+            ]
+        )
+
+    def check_initialized(self):
+        return None
+
+
+def _touch(path: Path) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("", encoding="utf-8")
+    return path
+
+
+def test_normalize_number_accepts_numbers_prefixes_and_paths(tmp_path):
+    assert RasPrjAssets.normalize_number("1") == "01"
+    assert RasPrjAssets.normalize_number("01") == "01"
+    assert RasPrjAssets.normalize_number(1) == "01"
+    assert RasPrjAssets.normalize_number(1.0) == "01"
+    assert RasPrjAssets.normalize_number("p03", prefix="p") == "03"
+    assert RasPrjAssets.normalize_number("g04", prefix="g") == "04"
+    assert RasPrjAssets.normalize_number(tmp_path / "TestProject.p05", prefix="p") == "05"
+
+
+def test_normalize_number_rejects_invalid_values():
+    with pytest.raises(ValueError):
+        RasPrjAssets.normalize_number("p00", prefix="p")
+    with pytest.raises(ValueError):
+        RasPrjAssets.normalize_number("abc", prefix="p")
+
+
+def test_extract_number_handles_optional_metadata():
+    assert RasPrjAssets.extract_number(None, prefix="p") is None
+    assert RasPrjAssets.extract_number("none", prefix="p") is None
+    assert RasPrjAssets.extract_number("Project.g03.hdf", prefix="g") == "03"
+    assert RasPrjAssets.extract_number(Path("Project.p07.hdf"), prefix="p") == "07"
+    assert RasPrjAssets.extract_number("g04", prefix="g") == "04"
+    assert RasPrjAssets.extract_number("04", prefix="g") == "04"
+    assert RasPrjAssets.extract_number("not-a-number", prefix="g") is None
+
+
+def test_plan_results_hdf_uses_plan_df_path(tmp_path):
+    ras = FakeRasProject(tmp_path)
+    expected = _touch(tmp_path / "TestProject.p01.hdf")
+
+    assert RasPrjAssets.plan_results_hdf("01", ras_object=ras) == expected
+    assert RasPrjAssets.plan_results_hdf("p01", ras_object=ras) == expected
+
+
+def test_plan_results_hdf_can_return_expected_missing_path(tmp_path):
+    ras = FakeRasProject(tmp_path)
+
+    assert RasPrjAssets.plan_results_hdf("03", ras_object=ras) is None
+    assert (
+        RasPrjAssets.plan_results_hdf("03", ras_object=ras, must_exist=False)
+        == tmp_path / "TestProject.p03.hdf"
+    )
+
+
+def test_geometry_hdf_bare_number_keeps_plan_selector_behavior(tmp_path):
+    ras = FakeRasProject(tmp_path)
+    expected = _touch(tmp_path / "TestProject.g02.hdf")
+
+    assert RasPrjAssets.geometry_hdf("01", ras_object=ras) == expected
+    assert RasPrjAssets.geometry_hdf(1, ras_object=ras) == expected
+
+
+def test_geometry_hdf_supports_explicit_geometry_selector(tmp_path):
+    ras = FakeRasProject(tmp_path)
+    expected = _touch(tmp_path / "TestProject.g04.hdf")
+
+    assert RasPrjAssets.geometry_hdf("g04", ras_object=ras) == expected
+    assert RasPrjAssets.geometry_hdf("04", ras_object=ras, selector_kind="geom") == expected
+
+
+def test_plan_assets_returns_passive_container(tmp_path):
+    ras = FakeRasProject(tmp_path)
+    _touch(tmp_path / "TestProject.p01")
+    _touch(tmp_path / "TestProject.p01.hdf")
+    _touch(tmp_path / "TestProject.g02")
+    _touch(tmp_path / "TestProject.g02.hdf")
+    _touch(tmp_path / "TestProject.u01")
+
+    assets = RasPrjAssets.plan_assets("01", ras_object=ras, must_exist=True)
+
+    assert isinstance(assets, PlanAssets)
+    assert assets.plan_number == "01"
+    assert assets.plan_path == tmp_path / "TestProject.p01"
+    assert assets.results_hdf_path == tmp_path / "TestProject.p01.hdf"
+    assert assets.geometry_number == "02"
+    assert assets.geometry_path == tmp_path / "TestProject.g02"
+    assert assets.geometry_hdf_path == tmp_path / "TestProject.g02.hdf"
+    assert assets.flow_path == tmp_path / "TestProject.u01"
+
+
+def test_plan_assets_falls_back_to_plan_geom_path_when_geom_df_is_stale(tmp_path):
+    ras = FakeRasProject(tmp_path)
+    ras.geom_df = pd.DataFrame(columns=["geom_number", "full_path", "hdf_path"])
+
+    assets = RasPrjAssets.plan_assets("01", ras_object=ras, must_exist=False)
+
+    assert assets.geometry_path == tmp_path / "TestProject.g02"
+    assert assets.geometry_hdf_path == tmp_path / "TestProject.g02.hdf"
+
+
+def test_explicit_ras_object_keeps_multi_project_lookup_isolated(tmp_path):
+    project_a = tmp_path / "a"
+    project_b = tmp_path / "b"
+    ras_a = FakeRasProject(project_a, project_name="ProjectA")
+    ras_b = FakeRasProject(project_b, project_name="ProjectB")
+    hdf_a = _touch(project_a / "ProjectA.p01.hdf")
+    hdf_b = _touch(project_b / "ProjectB.p01.hdf")
+
+    assert RasPrjAssets.plan_results_hdf("01", ras_object=ras_a) == hdf_a
+    assert RasPrjAssets.plan_results_hdf("01", ras_object=ras_b) == hdf_b

--- a/tests/test_ras_compute_state.py
+++ b/tests/test_ras_compute_state.py
@@ -1,0 +1,18 @@
+import importlib
+
+import pytest
+
+
+from ras_commander import RasComputeState
+
+
+def test_ras_compute_state_is_public_export():
+    assert RasComputeState.__name__ == "RasComputeState"
+
+
+def test_ras_currency_module_not_retained_as_compatibility_alias():
+    import ras_commander
+
+    assert not hasattr(ras_commander, "RasCurrency")
+    with pytest.raises(ModuleNotFoundError):
+        importlib.import_module("ras_commander.RasCurrency")

--- a/tests/test_remote_worker_adapter.py
+++ b/tests/test_remote_worker_adapter.py
@@ -1,0 +1,130 @@
+import inspect
+import importlib
+from pathlib import Path
+
+import pytest
+
+from ras_commander.remote.Execution import _execute_single_plan
+from ras_commander.remote.LocalWorker import LocalWorker
+from ras_commander.remote.RasWorker import (
+    RasWorker,
+    WorkerExecutionOutcome,
+    WorkerExecutionRequest,
+    init_ras_worker,
+)
+
+
+class FakeRasProject:
+    def __init__(self, project_folder: Path):
+        self.project_folder = Path(project_folder)
+        self.project_name = "TestProject"
+
+
+class RecordingWorker(RasWorker):
+    def __init__(self):
+        super().__init__(worker_type="recording", worker_id="recording-1")
+        self.request = None
+
+    def execute_plan(self, request):
+        self.request = request
+        return WorkerExecutionOutcome(success=True, hdf_path="result.hdf")
+
+
+def test_execute_single_plan_calls_worker_execute_plan(tmp_path):
+    worker = RecordingWorker()
+    ras_object = FakeRasProject(tmp_path)
+
+    result = _execute_single_plan(
+        worker=worker,
+        plan_number="01",
+        ras_object=ras_object,
+        num_cores=2,
+        clear_geompre=True,
+        force_geompre=True,
+        force_rerun=True,
+        sub_worker_id=3,
+        autoclean=False,
+    )
+
+    assert result.success is True
+    assert result.hdf_path == "result.hdf"
+    assert isinstance(worker.request, WorkerExecutionRequest)
+    assert worker.request.plan_number == "01"
+    assert worker.request.num_cores == 2
+    assert worker.request.clear_geompre is True
+    assert worker.request.force_geompre is True
+    assert worker.request.force_rerun is True
+    assert worker.request.sub_worker_id == 3
+    assert worker.request.autoclean is False
+
+
+def test_base_worker_execute_plan_reports_unimplemented(tmp_path):
+    worker = RasWorker(worker_type="ssh", worker_id="ssh-1")
+    ras_object = FakeRasProject(tmp_path)
+
+    result = _execute_single_plan(
+        worker=worker,
+        plan_number="01",
+        ras_object=ras_object,
+        num_cores=4,
+        clear_geompre=False,
+        force_geompre=False,
+        force_rerun=False,
+        sub_worker_id=1,
+    )
+
+    assert result.success is False
+    assert "not implemented" in result.error_message
+
+
+def test_local_worker_execute_plan_delegates_to_legacy_function(monkeypatch, tmp_path):
+    ras_object = FakeRasProject(tmp_path)
+    (tmp_path / "TestProject.p01.hdf").write_text("", encoding="utf-8")
+    worker = LocalWorker(worker_type="local", worker_folder=str(tmp_path / "workers"))
+    calls = {}
+
+    def fake_execute_local_plan(**kwargs):
+        calls.update(kwargs)
+        return True
+
+    local_worker_module = importlib.import_module("ras_commander.remote.LocalWorker")
+    monkeypatch.setattr(local_worker_module, "execute_local_plan", fake_execute_local_plan)
+
+    outcome = worker.execute_plan(
+        WorkerExecutionRequest(
+            plan_number="01",
+            ras_object=ras_object,
+            num_cores=2,
+            clear_geompre=True,
+            force_geompre=True,
+            force_rerun=True,
+            sub_worker_id=2,
+            autoclean=False,
+        )
+    )
+
+    assert outcome.success is True
+    assert outcome.hdf_path == str(tmp_path / "TestProject.p01.hdf")
+    assert calls["worker"] is worker
+    assert calls["ras_obj"] is ras_object
+    assert calls["force_geompre"] is True
+    assert calls["force_rerun"] is True
+
+
+def test_init_ras_worker_local_and_invalid_type(tmp_path):
+    worker = init_ras_worker("local", worker_folder=str(tmp_path / "workers"))
+
+    assert isinstance(worker, LocalWorker)
+    assert Path(worker.worker_folder).exists()
+
+    with pytest.raises(ValueError):
+        init_ras_worker("unknown")
+
+
+def test_docker_legacy_function_accepts_force_flags():
+    from ras_commander.remote.DockerWorker import execute_docker_plan
+
+    signature = inspect.signature(execute_docker_plan)
+
+    assert "force_geompre" in signature.parameters
+    assert "force_rerun" in signature.parameters


### PR DESCRIPTION
## Summary

Second tranche stacked on PR #48. This continues the duplication-reduction work by migrating remaining local selector/HDF lookup blocks onto `RasPrjAssets`.

Key changes:
- Route `RasComputeState.get_plan_input_files()` through `RasPrjAssets.plan_assets()`.
- Route `RasPreprocess` geometry selection through `RasPrjAssets.plan_assets()` and `extract_number()`.
- Route `RasCheck` HDF path resolution through `RasPrjAssets`.
- Route `RasModPuls` private plan/geometry HDF helpers through `RasPrjAssets`.
- Route `HdfChannelCapacity` plan-vs-geometry HDF standardization through `RasPrjAssets` and remove the extra manual `geom_df` lookup.
- Add focused migration tests for these call sites.

## Validation

- Focused migration/asset tests: 24 passed, 2 skipped.
- Broader tranche regression including geometry/HDF/remote/plan-number tests: 165 passed, 16 skipped.
- `uv run python -m compileall -q ras_commander`: passed.
- `git diff --check`: passed.

## Notes

This PR is intended to be reviewed after #48. It intentionally stays narrow: no EBFE changes, no notebook source edits, and no new public API.