### PR TITLE
RasMap: add geometry association workflows

### DIFF
--- a/docs/api/core.md
+++ b/docs/api/core.md
@@ -428,13 +428,55 @@ indices = RasUtils.perform_kdtree_query(
       heading_level: 3
       members:
         - parse_rasmap
+        - list_terrain_layers
+        - list_land_classification_layers
+        - list_landcover_layers
+        - list_soils_layers
+        - list_infiltration_layers
         - get_terrain_path
         - get_landcover_path
+        - associate_geometry_layers
+        - get_hdf_geometry_association
         - list_results_plans
         - list_calculated_layers
         - add_calculated_layer
         - remove_calculated_layer
         - add_wse_comparison_layers
+
+#### RASMapper Layer Discovery
+
+The layer-list methods read the `.rasmap` file and return one dataframe row per layer. Use these when a workflow needs discoverable layer names and resolved paths instead of the compact, list-valued `ras.rasmap_df` project summary.
+
+```python
+from ras_commander import RasMap
+
+terrain_layers = RasMap.list_terrain_layers(project_path)
+landcover_layers = RasMap.list_landcover_layers(project_path)
+soils_layers = RasMap.list_soils_layers(project_path)
+infiltration_layers = RasMap.list_infiltration_layers(project_path)
+```
+
+`list_land_classification_layers()` is the broad parser for RASMapper `Type="LandCoverLayer"` entries. The land-cover, soils, and infiltration methods are filtered convenience wrappers around that catalog.
+
+#### Geometry HDF Layer Associations
+
+`RasMap.get_hdf_geometry_association()` reads `/Geometry` association attributes from geometry HDFs and plan/result HDFs without mutation. `RasMap.associate_geometry_layers()` writes the geometry HDF attributes through Python-native `h5py`.
+
+```python
+association = RasMap.get_hdf_geometry_association("MyModel.g01.hdf")
+print(association["terrain_hdf_path"])
+
+RasMap.associate_geometry_layers(
+    project_path,
+    "MyModel.g01.hdf",
+    terrain_hdf_path="Terrain/ExistingTerrain.hdf",
+    landcover_hdf_path="Land Classification/LandCover.hdf",
+    infiltration_hdf_path="Land Classification/Infiltration.hdf",
+)
+```
+
+!!! warning "Compiled HDF only"
+    `associate_geometry_layers()` updates an existing `.g##.hdf`. It does not compile plain-text `.g##` geometry into HDF or create missing geometry datasets.
 
 ### RasProcess
 
@@ -447,12 +489,37 @@ indices = RasUtils.perform_kdtree_query(
         - get_plan_timestamps
         - store_maps
         - store_all_maps
+        - validate_geometry_association_cli
         - run_command
 
 #### RasProcess Details
 
 !!! info "RasProcess.exe CLI"
     RasProcess.exe is an undocumented command-line interface bundled with HEC-RAS that enables headless automation of RASMapper operations. The `RasProcess` class wraps this CLI for programmatic access.
+
+##### Geometry Association Validator
+
+`validate_geometry_association_cli()` runs the native `RasProcess.exe SetGeometryAssociation` command and compares the resulting `/Geometry` attributes against ras-commander's expected HEC-RAS-style attributes.
+
+```python
+from ras_commander import RasProcess
+
+result = RasProcess.validate_geometry_association_cli(
+    "MyModel.g01.hdf",
+    terrain_hdf_path="Terrain/ExistingTerrain.hdf",
+    landcover_hdf_path="Land Classification/LandCover.hdf",
+    ras_version="7.0",
+)
+
+print(result["passed"])
+print(result["return_code"])
+print(result["mismatches"])
+```
+
+The returned dictionary includes the native command arguments, return code, stdout/stderr, before/after attributes, expected attributes, mismatch list, and `passed`.
+
+!!! danger "In-place mutation"
+    This method mutates the supplied HDF. It exists as a native reference validator for disposable copies or intentional validation runs. Normal workflows should call `RasMap.associate_geometry_layers()`.
 
 ##### Supported Map Types
 

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -13,8 +13,8 @@ Primary classes for project management and execution:
 - [`RasUnsteady`](core.md#rasunsteady) - Unsteady flow file management
 - [`RasUtils`](core.md#rasutils) - Utility functions
 - [`RasExamples`](core.md#rasexamples) - Example project management
-- [`RasMap`](core.md#rasmap) - RASMapper configuration and calculated layers
-- [`RasProcess`](core.md#rasprocess) - RasProcess.exe CLI automation (stored maps)
+- [`RasMap`](core.md#rasmap) - RASMapper configuration, layer discovery, and geometry HDF associations
+- [`RasProcess`](core.md#rasprocess) - RasProcess.exe CLI automation, stored maps, and native reference validators
 - [`RasControl`](core.md#rascontrol) - Legacy COM interface
 
 ## HDF Modules

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -46,6 +46,7 @@ Work with geometry files: parsing, modification, and repair.
 | 1D Plaintext Geometry | Parse and modify 1D geometry: cross sections, HTAB, lateral structures | [:material-github:](https://github.com/gpt-cmdr/ras-commander/blob/main/examples/201_1d_plaintext_geometry.ipynb) |
 | 2D Plaintext Geometry | Parse and modify 2D geometry: storage areas, SA/2D connections, dam breach | [:material-github:](https://github.com/gpt-cmdr/ras-commander/blob/main/examples/202_2d_plaintext_geometry.ipynb) |
 | Fixit Blocked Obstructions | Detect and fix overlapping blocked obstructions | [:material-github:](https://github.com/gpt-cmdr/ras-commander/blob/main/examples/210_fixit_blocked_obstructions.ipynb) |
+| Land Cover Manning's n Write | Discover land-cover sidecars, audit geometry HDF associations, and update Manning's n values | [:material-github:](https://github.com/gpt-cmdr/ras-commander/blob/main/examples/212_landcover_mannings_n_write.ipynb) |
 
 ### Boundary Conditions (300s)
 
@@ -88,7 +89,7 @@ Mapping, visualization, and advanced spatial analysis.
 | Floodplain Mapping GUI | RASMapper GUI automation (legacy) | [:material-github:](https://github.com/gpt-cmdr/ras-commander/blob/main/examples/600_floodplain_mapping_gui.ipynb) |
 | Floodplain Mapping RasProcess | RasProcess CLI (recommended) | [:material-github:](https://github.com/gpt-cmdr/ras-commander/blob/main/examples/601_floodplain_mapping_rasprocess.ipynb) |
 | Fluvial-Pluvial Delineation | Classify flooding mechanism | [:material-github:](https://github.com/gpt-cmdr/ras-commander/blob/main/examples/610_fluvial_pluvial_delineation.ipynb) |
-| Map Layer Validation | Validate RASMapper layers | [:material-github:](https://github.com/gpt-cmdr/ras-commander/blob/main/examples/611_validating_map_layers.ipynb) |
+| Map Layer Validation | Validate RASMapper layers, discover registered terrain/classification layers, and audit HDF associations | [:material-github:](https://github.com/gpt-cmdr/ras-commander/blob/main/examples/611_validating_map_layers.ipynb) |
 
 ### Sensitivity & Benchmarking (700s)
 
@@ -127,6 +128,7 @@ Integration with external data sources: precipitation, gauges, etc.
 | USGS Real-Time Monitoring | Real-time gauge monitoring | [:material-github:](https://github.com/gpt-cmdr/ras-commander/blob/main/examples/912_usgs_real_time_monitoring.ipynb) |
 | BC from Live Gauge | Generate BCs from live data | [:material-github:](https://github.com/gpt-cmdr/ras-commander/blob/main/examples/913_bc_generation_from_live_gauge.ipynb) |
 | Model Validation with USGS | Validate results against gauges | [:material-github:](https://github.com/gpt-cmdr/ras-commander/blob/main/examples/914_model_validation_with_usgs.ipynb) |
+| Terrain Creation | Create terrain from USGS 3DEP, register it in RASMapper, and associate it to geometry HDFs | [:material-github:](https://github.com/gpt-cmdr/ras-commander/blob/main/examples/920_terrain_creation.ipynb) |
 
 ## Using Notebooks as Templates
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -103,9 +103,9 @@ pip install pyjnius
 !!! note "Java Required"
     DSS operations require Java 8+ (JRE or JDK) installed on your system.
 
-### Linux/Wine (Headless Map Generation)
+### Linux/Wine (Headless RasProcess Workflows)
 
-On Linux, `RasProcess.exe` can run under Wine to generate stored maps (WSE, Depth, Velocity TIFs) without a display. This enables headless CI/CD pipelines and cloud-based map generation.
+On Linux, `RasProcess.exe` can run under Wine for documented RasProcess workflows such as stored map generation (WSE, Depth, Velocity TIFs) and native reference validation of geometry associations. This enables headless CI/CD pipelines and cloud-based map or QA/QC workflows.
 
 **Requirements**:
 
@@ -139,7 +139,7 @@ winetricks -q corefonts     # Arial, Times New Roman, etc.
     Verified on the CLB07 Proxmox container `ras2cng-wine` (Debian 13, Wine 11.0). Custom `wine_executable` paths or wrappers are supported; helper tools such as `winepath` are resolved automatically.
 
 !!! note "Scope"
-    Wine support covers `RasProcess.exe` (stored map generation) only. Full HEC-RAS simulation (`Ras.exe`) still requires Windows. HDF analysis works natively on Linux without Wine.
+    Wine support covers wrapped `RasProcess.exe` workflows. Full HEC-RAS simulation (`Ras.exe`) still requires Windows. HDF analysis and Python-native geometry association writes work on Linux without Wine.
 
 **Verify installation**:
 
@@ -158,6 +158,17 @@ from ras_commander import RasProcess
 
 # Same API as Windows -- Wine wrapping is automatic
 results = RasProcess.store_maps(plan_number="01", wse=True, depth=True)
+```
+
+```python
+# Optional native reference validator. This mutates the supplied HDF in place,
+# so use it on a disposable copy or intentional validation target.
+validation = RasProcess.validate_geometry_association_cli(
+    "MyModel.g01.hdf",
+    terrain_hdf_path="Terrain/ExistingTerrain.hdf",
+    ras_version="7.0",
+)
+print(validation["passed"])
 ```
 
 ### Remote Execution

--- a/docs/reference/hdf-writing-guide.md
+++ b/docs/reference/hdf-writing-guide.md
@@ -30,6 +30,27 @@ These data types exist **only in HDF** - there is no plain text representation:
 
 For these data types, direct HDF editing is the **only** option.
 
+## Geometry Association Attributes
+
+Compiled geometry HDFs also carry `/Geometry` attributes that link the geometry to RASMapper assets such as terrain, land cover, infiltration, and sediment bed-material soils. ras-commander exposes this narrow write path through `RasMap.associate_geometry_layers()` because the attributes are small, well-bounded, and easy to validate.
+
+```python
+from ras_commander import RasMap
+
+RasMap.associate_geometry_layers(
+    project_path,
+    "MyModel.g01.hdf",
+    terrain_hdf_path="Terrain/ExistingTerrain.hdf",
+    landcover_hdf_path="Land Classification/LandCover.hdf",
+)
+
+association = RasMap.get_hdf_geometry_association("MyModel.g01.hdf")
+print(association["terrain_hdf_path"])
+```
+
+!!! warning "Do not confuse association with compilation"
+    Association writes only update HDF attributes on an existing compiled geometry HDF. They do not create `.g##.hdf` files from plain-text `.g##` geometry and do not regenerate 2D mesh or property-table datasets.
+
 ## The Golden Rule
 
 !!! danger "Match HEC-RAS Exactly"

--- a/docs/user-guide/spatial-data.md
+++ b/docs/user-guide/spatial-data.md
@@ -34,15 +34,150 @@ The `rasmap_df` typically contains paths to:
 ### Accessing Specific Data Paths
 
 ```python
-# Example: Get terrain HDF path
-terrain_path = ras.rasmap_df['terrain_hdf_path'][0]
+# rasmap_df is a compact project summary. Several columns contain lists.
+summary = ras.rasmap_df.iloc[0]
 
-# Example: Get infiltration data path
-infiltration_path = ras.rasmap_df['infiltration_hdf_path'][0][0]
+terrain_paths = summary["terrain_hdf_path"]
+landcover_paths = summary["landcover_hdf_path"]
+soil_paths = summary["soil_layer_path"]
+infiltration_paths = summary["infiltration_hdf_path"]
 
-# Example: Get land cover layer path
-landcover_path = ras.rasmap_df['landcover_hdf_path'][0]
+print(terrain_paths)
 ```
+
+For discoverable automation, prefer the layer-list methods below. They return one row per RASMapper layer rather than one compact project-summary row.
+
+## Discovering RASMapper Layers
+
+`RasMap` can list terrain, land-cover, soils, and infiltration layers directly from the `.rasmap` catalog. These methods are useful when building QA/QC tools because they expose the layer names that users see in RASMapper and the paths that automation needs.
+
+```python
+from ras_commander import RasExamples, RasMap
+
+project_path = RasExamples.extract_project("BaldEagleCrkMulti2D")
+
+terrain_layers = RasMap.list_terrain_layers(project_path)
+landcover_layers = RasMap.list_landcover_layers(project_path)
+soils_layers = RasMap.list_soils_layers(project_path)
+infiltration_layers = RasMap.list_infiltration_layers(project_path)
+
+print(terrain_layers[[
+    "name",
+    "filename",
+    "resolved_path",
+    "checked",
+    "type",
+    "resample_method",
+    "surface_on",
+]])
+
+print(landcover_layers[[
+    "name",
+    "classification_kind",
+    "resolved_path",
+    "selected_parameter",
+]])
+```
+
+### Layer Discovery Methods
+
+| Method | Reads | Typical use |
+|--------|-------|-------------|
+| `RasMap.list_terrain_layers(project_path)` | `.rasmap` `Terrains/Layer` entries | Find valid terrain layer names and HDF paths |
+| `RasMap.list_land_classification_layers(project_path)` | `.rasmap` `Type="LandCoverLayer"` entries | Inspect every land-classification style layer |
+| `RasMap.list_landcover_layers(project_path)` | Filtered land-classification rows | Manning's n / land-cover sidecar workflows |
+| `RasMap.list_soils_layers(project_path)` | Filtered land-classification rows | Hydrologic soils discovery |
+| `RasMap.list_infiltration_layers(project_path)` | Filtered land-classification rows | Infiltration sidecar discovery |
+
+!!! note "rasmap_df vs list methods"
+    `ras.rasmap_df` remains a compact initialization summary. Use it when you want a quick project overview. Use `RasMap.list_*_layers()` when users need names, per-layer metadata, and paths for a workflow.
+
+## Geometry HDF Associations
+
+HEC-RAS stores layer availability in the `.rasmap` file, but compiled geometry and plan/result HDF files also carry `/Geometry` attributes that record which terrain, land-cover, infiltration, and sediment bed-material layers are associated with a geometry.
+
+Use `RasMap.get_hdf_geometry_association()` for read-only QA/QC:
+
+```python
+from pathlib import Path
+from ras_commander import RasMap
+
+project_path = Path(r"C:\Projects\MyModel")
+geometry_hdf = project_path / "MyModel.g01.hdf"
+plan_hdf = project_path / "MyModel.p01.hdf"
+
+geometry_assoc = RasMap.get_hdf_geometry_association(geometry_hdf)
+plan_assoc = RasMap.get_hdf_geometry_association(plan_hdf)
+
+print(geometry_assoc.get("terrain_hdf_path"))
+print(geometry_assoc.get("terrain_layer_name"))
+print(plan_assoc.get("landcover_hdf_path"))
+```
+
+Common returned keys include:
+
+| Key | HEC-RAS attribute |
+|-----|-------------------|
+| `terrain_hdf_path` | `Terrain Filename` |
+| `terrain_layer_name` | `Terrain Layername` |
+| `landcover_hdf_path` | `Land Cover Filename` |
+| `landcover_layer_name` | `Land Cover Layername` |
+| `infiltration_hdf_path` | `Infiltration Filename` |
+| `infiltration_layer_name` | `Infiltration Layername` |
+| `sediment_soils_hdf_path` | `SedimentSoilsFilename` |
+
+### Writing Geometry Associations
+
+Use `RasMap.associate_geometry_layers()` to write HEC-style `/Geometry` association attributes to an existing compiled geometry HDF.
+
+```python
+from pathlib import Path
+from ras_commander import RasMap
+
+project_path = Path(r"C:\Projects\MyModel")
+geometry_hdf = project_path / "MyModel.g01.hdf"
+terrain_hdf = project_path / "Terrain" / "ExistingTerrain.hdf"
+landcover_hdf = project_path / "Land Classification" / "LandCover.hdf"
+
+RasMap.associate_geometry_layers(
+    project_path,
+    geometry_hdf,
+    terrain_hdf_path=terrain_hdf,
+    landcover_hdf_path=landcover_hdf,
+)
+
+updated = RasMap.get_hdf_geometry_association(geometry_hdf)
+print(updated["terrain_hdf_path"])
+print(updated["landcover_hdf_path"])
+```
+
+!!! warning "Existing compiled geometry HDF required"
+    `RasMap.associate_geometry_layers()` updates attributes on an existing `.g##.hdf`. It does not compile a plain-text `.g##` file into HDF and does not create missing geometry datasets. Treat true `.g##` to `.g##.hdf` generation as HEC-RAS/Ras.exe behavior unless a native endpoint is explicitly available.
+
+!!! tip "Layer name resolution"
+    When possible, ras-commander resolves `Terrain Layername`, `Land Cover Layername`, and `Infiltration Layername` from the `.rasmap` catalog. If the layer cannot be found in `.rasmap`, it falls back to the file stem.
+
+### Native RasProcess Reference Validator
+
+`RasProcess.validate_geometry_association_cli()` wraps the native `RasProcess.exe SetGeometryAssociation` command as a reference validator. It is intentionally not the primary workflow because the native command mutates the supplied HDF in place.
+
+```python
+from ras_commander import RasProcess
+
+result = RasProcess.validate_geometry_association_cli(
+    geometry_hdf,
+    terrain_hdf_path=terrain_hdf,
+    landcover_hdf_path=landcover_hdf,
+    ras_version="7.0",
+)
+
+print(result["passed"])
+print(result["command_args"])
+print(result["mismatches"])
+```
+
+!!! danger "Validation/reference only"
+    Run the native validator only on a disposable copy or a model you intentionally want `RasProcess.exe` to mutate. Normal automation should use `RasMap.associate_geometry_layers()`.
 
 ## Map Layer Management
 
@@ -154,6 +289,8 @@ print(f"Available terrains: {terrains}")
 
 This is useful when you have multiple terrain datasets and need to specify which one to use for map generation or analysis.
 
+For richer terrain metadata, use `RasMap.list_terrain_layers(project_path)` as shown above.
+
 ## Land Cover and Soil Layers
 
 Land cover and soil data are critical for 2D modeling, controlling Manning's n roughness and infiltration parameters.
@@ -163,8 +300,9 @@ Land cover and soil data are critical for 2D modeling, controlling Manning's n r
 Land cover datasets define Manning's n values across 2D flow areas. These are typically stored as HDF files referenced in the RASMapper configuration.
 
 ```python
-# Get land cover layer path from rasmap_df
-landcover_path = ras.rasmap_df['landcover_hdf_path'][0]
+# Discover land-cover sidecars and RASMapper layer names
+landcover_layers = RasMap.list_landcover_layers(project_path)
+landcover_path = landcover_layers.iloc[0]["resolved_path"]
 
 # Land cover is used for Manning's n assignment
 # See Manning's n Calibration section below for modification
@@ -175,8 +313,9 @@ landcover_path = ras.rasmap_df['landcover_hdf_path'][0]
 Soil layers define hydrologic soil groups (A, B, C, D) used for infiltration calculations.
 
 ```python
-# Get soil layer path from rasmap_df
-soil_path = ras.rasmap_df['soil_hdf_path'][0]
+# Discover hydrologic soils layers
+soils_layers = RasMap.list_soils_layers(project_path)
+soil_path = soils_layers.iloc[0]["resolved_path"]
 
 # Soil data is used with infiltration methods
 # See Infiltration Data Handling section below

--- a/examples/212_landcover_mannings_n_write.ipynb
+++ b/examples/212_landcover_mannings_n_write.ipynb
@@ -2,6 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "id": "fa367f30",
    "metadata": {},
    "source": [
     "# Writing Manning's N Values to Land Cover Sidecar HDF\n",
@@ -14,6 +15,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "9df6df85",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -27,6 +29,7 @@
     "from IPython.display import display\n",
     "\n",
     "from ras_commander import *\n",
+    "from ras_commander import RasMap\n",
     "from ras_commander.hdf import HdfLandCover\n",
     "\n",
     "for logger_name in [\n",
@@ -42,18 +45,20 @@
   },
   {
    "cell_type": "markdown",
+   "id": "b4f88515",
    "metadata": {},
    "source": [
     "## Setup & Project Extraction\n",
     "\n",
     "Use the reproducible `BaldEagleCrkMulti2D` example project, initialize the\n",
-    "project metadata, and locate the land cover sidecar HDF that stores the base\n",
-    "Manning's N lookup table.\n"
+    "project metadata, discover the registered land-cover sidecar from the `.rasmap`\n",
+    "catalog, and back up the HDF before editing.\n"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "a1b0c69e",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -69,19 +74,84 @@
     "geometry_hdf_path = Path(\n",
     "    ras.geom_df[ras.geom_df['has_2d_mesh']].iloc[0]['hdf_path']\n",
     ")\n",
-    "landcover_hdf_path = Path(ras.rasmap_df.loc[0, 'landcover_hdf_path'][0])\n",
+    "\n",
+    "# Discover the land-cover sidecar through the rasmap layer catalog. The broader\n",
+    "# land-classification call shows every registered classification layer; the\n",
+    "# filtered wrapper gives the Manning's n / land-cover layers used in this notebook.\n",
+    "land_classification_layers = RasMap.list_land_classification_layers(project_path)\n",
+    "landcover_layers = RasMap.list_landcover_layers(project_path)\n",
+    "assert not landcover_layers.empty, 'Expected at least one land-cover layer in this example project.'\n",
+    "\n",
+    "landcover_hdf_path = Path(landcover_layers.iloc[0]['resolved_path'])\n",
+    "compact_landcover_paths = ras.rasmap_df.loc[0, 'landcover_hdf_path']\n",
+    "assert str(landcover_hdf_path) in compact_landcover_paths\n",
+    "\n",
     "backup_path = Path(str(landcover_hdf_path) + '.bak')\n",
+    "shutil.copy2(landcover_hdf_path, backup_path)\n",
     "\n",
     "assert landcover_hdf_path.exists(), 'Expected land cover sidecar HDF.'\n",
     "\n",
     "print(f\"Project: {project_path.name}\")\n",
     "print(f\"Geometry HDF: {geometry_hdf_path.name}\")\n",
     "print(f\"Land cover sidecar: {landcover_hdf_path.name}\")\n",
-    "print(f\"Backup file: {backup_path.name}\")\n"
+    "print(f\"Backup: {backup_path.name}\")\n",
+    "\n",
+    "print(\"\\nAll land-classification layers:\")\n",
+    "display(land_classification_layers[[\n",
+    "    'name',\n",
+    "    'classification_kind',\n",
+    "    'resolved_path',\n",
+    "    'selected_parameter',\n",
+    "]])\n",
+    "\n",
+    "print(\"\\nLand-cover layers available for Manning's n editing:\")\n",
+    "display(landcover_layers[[\n",
+    "    'name',\n",
+    "    'resolved_path',\n",
+    "    'selected_parameter',\n",
+    "]])\n"
    ]
   },
   {
    "cell_type": "markdown",
+   "id": "d4553c61",
+   "metadata": {},
+   "source": [
+    "## Verify Geometry Association\n",
+    "\n",
+    "The land-cover sidecar HDF stores the classification table we edit below. The compiled geometry HDF stores which land-cover, terrain, soils, and infiltration layers are associated with the geometry. `RasMap.get_hdf_geometry_association()` reads those `/Geometry` attributes directly and is useful for QA/QC before and after edits.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9f89259c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "association = RasMap.get_hdf_geometry_association(geometry_hdf_path)\n",
+    "association_summary = pd.DataFrame([{\n",
+    "    'geometry_hdf': geometry_hdf_path.name,\n",
+    "    'associated_terrain': association.get('terrain_hdf_path'),\n",
+    "    'terrain_layer_name': association.get('terrain_layer_name'),\n",
+    "    'associated_landcover': association.get('landcover_hdf_path'),\n",
+    "    'landcover_layer_name': association.get('landcover_layer_name'),\n",
+    "    'associated_infiltration': association.get('infiltration_hdf_path'),\n",
+    "    'infiltration_layer_name': association.get('infiltration_layer_name'),\n",
+    "}])\n",
+    "display(association_summary)\n",
+    "\n",
+    "associated_landcover = association.get('landcover_hdf_path')\n",
+    "if associated_landcover:\n",
+    "    matches_discovered_layer = Path(associated_landcover).resolve() == landcover_hdf_path.resolve()\n",
+    "    print(f\"Associated land-cover matches discovered sidecar: {matches_discovered_layer}\")\n",
+    "else:\n",
+    "    print(\"This geometry HDF does not currently record a land-cover association.\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5ba6c63d",
    "metadata": {},
    "source": [
     "## Read Current Values\n",
@@ -93,6 +163,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "0f34d567",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -128,6 +199,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "5748ddd9",
    "metadata": {},
    "source": [
     "## Detect Sidecar Format\n",
@@ -140,6 +212,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "a9177905",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -152,6 +225,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "f3372952",
    "metadata": {},
    "source": [
     "## Modify Manning's N\n",
@@ -164,6 +238,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "1479a703",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -228,6 +303,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "a6654b59",
    "metadata": {},
    "source": [
     "## Round-Trip Verification\n",
@@ -239,6 +315,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "2d3757f9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -264,6 +341,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "ef949446",
    "metadata": {},
    "source": [
     "## Backup Verification\n",
@@ -276,6 +354,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "09ca9a45",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -309,6 +388,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "bedcc2d4",
    "metadata": {},
    "source": [
     "## Restore from Backup\n",
@@ -321,6 +401,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "8a11639d",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -356,6 +437,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "982226cc",
    "metadata": {},
    "source": [
     "## Calibration Workflow Example\n",
@@ -368,6 +450,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "01feb46b",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -409,6 +492,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "17185dc2",
    "metadata": {},
    "source": [
     "## Key Takeaways\n",

--- a/examples/611_validating_map_layers.ipynb
+++ b/examples/611_validating_map_layers.ipynb
@@ -2,6 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "id": "8671fa34",
    "metadata": {},
    "source": [
     "# Validating RAS Mapper Layers and Terrain Files"
@@ -42,7 +43,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
+   "id": "386b4c11",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2025-12-29T05:36:17.538739Z",
@@ -51,16 +53,7 @@
      "shell.execute_reply": "2025-12-29T05:36:19.547013Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "📁 LOCAL SOURCE MODE: Loading from c:\\GH\\ras-commander/ras_commander\n",
-      "✓ Loaded: c:\\GH\\ras-commander\\ras_commander\\__init__.py\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# =============================================================================\n",
     "# DEVELOPMENT MODE TOGGLE\n",
@@ -201,6 +194,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "6b999345",
    "metadata": {},
    "source": [
     "## Parameters\n",
@@ -210,7 +204,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
+   "id": "e1288ed2",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2025-12-29T05:36:19.550718Z",
@@ -227,17 +222,18 @@
     "from pathlib import Path\n",
     "\n",
     "# Project Configuration\n",
-    "PROJECT_NAME = \"Muncie\"           # Example project to extract\n",
+    "PROJECT_NAME = \"BaldEagleCrkMulti2D\"           # Example project to extract\n",
     "RAS_VERSION = \"7.0\"               # HEC-RAS version (6.3, 6.5, 6.6, etc.)\n",
     "\n",
     "# HDF Analysis Settings\n",
     "PLAN = \"01\"                       # Plan number (for HDF file path)\n",
     "TIME_INDEX = -1                   # Time step index (-1 = last)\n",
-    "PROFILE = \"Max\"                   # Profile name for steady analysis"
+    "PROFILE = \"Max\"                   # Profile name for steady analysis\n"
    ]
   },
   {
    "cell_type": "markdown",
+   "id": "f0132ef0",
    "metadata": {},
    "source": [
     "---"
@@ -245,6 +241,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "20123512",
    "metadata": {},
    "source": [
     "## Overview\n",
@@ -270,6 +267,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "bbaeeea8",
    "metadata": {},
    "source": [
     "---"
@@ -277,6 +275,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "e5ef7b6a",
    "metadata": {},
    "source": [
     "## Extract Example Project"
@@ -284,46 +283,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2025-12-29T05:36:19.556923Z",
-     "iopub.status.busy": "2025-12-29T05:36:19.556708Z",
-     "iopub.status.idle": "2025-12-29T05:36:19.863247Z",
-     "shell.execute_reply": "2025-12-29T05:36:19.862761Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-12 23:58:29 - ras_commander.RasExamples - INFO - Found zip file: C:\\GH\\ras-commander\\examples\\Example_Projects_6_6.zip\n",
-      "2026-01-12 23:58:29 - ras_commander.RasExamples - INFO - Loading project data from CSV...\n",
-      "2026-01-12 23:58:29 - ras_commander.RasExamples - INFO - Loaded 68 projects from CSV.\n",
-      "2026-01-12 23:58:29 - ras_commander.RasExamples - INFO - ----- RasExamples Extracting Project -----\n",
-      "2026-01-12 23:58:29 - ras_commander.RasExamples - INFO - Extracting project 'BaldEagleCrkMulti2D'\n",
-      "2026-01-12 23:58:33 - ras_commander.RasExamples - INFO - Successfully extracted project 'BaldEagleCrkMulti2D' to C:\\GH\\ras-commander\\examples\\example_projects\\BaldEagleCrkMulti2D\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "Project extracted to: C:\\GH\\ras-commander\\examples\\example_projects\\BaldEagleCrkMulti2D\n"
-     ]
-    }
-   ],
+   "execution_count": null,
+   "id": "0bfc839f",
+   "metadata": {},
+   "outputs": [],
    "source": [
-    "# Extract Muncie project (contains RAS Mapper configuration)\n",
-    "project_path = RasExamples.extract_project(\"BaldEagleCrkMulti2D\")\n",
-    "print(f\"\\nProject extracted to: {project_path}\")"
+    "# Extract example project (contains RAS Mapper configuration)\n",
+    "project_path = RasExamples.extract_project(PROJECT_NAME)\n",
+    "print(f\"\\nProject extracted to: {project_path}\")\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
+   "id": "a6642715",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2025-12-29T05:36:19.865455Z",
@@ -332,26 +305,7 @@
      "shell.execute_reply": "2025-12-29T05:36:19.876800Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Found 34 geospatial file(s):\n",
-      "  - Land Classification\\LandCover.tif (12955.67 KB)\n",
-      "  - Soils Data\\Hydrologic Soil Groups.tif (10196.48 KB)\n",
-      "  - Terrain\\Terrain50.baldeagledem.tif (173985.99 KB)\n",
-      "  - Terrain\\Terrain50.dtm_20ft.tif (11063.01 KB)\n",
-      "  - GISData\\MainChannelBanks.shp (28.14 KB)\n",
-      "  - NLD\\Lock_Haven_CenterLine.shp (11.56 KB)\n",
-      "  - NLD\\Lock_Haven_Floodwall.shp (0.10 KB)\n",
-      "  - NLD\\Lock_Haven_LeveedArea.shp (12.96 KB)\n",
-      "  - BaldEagleDamBrk.g01.hdf (4894.39 KB)\n",
-      "  - BaldEagleDamBrk.g02.hdf (1900.81 KB)\n",
-      "  ... and 24 more\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Find geospatial files in the project\n",
     "from pathlib import Path\n",
@@ -375,8 +329,76 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "5e66967f",
+   "metadata": {},
+   "source": [
+    "## 3. Discover Registered RASMapper Layers\n",
+    "\n",
+    "`rasmap_df` is a compact project summary: it keeps terrain, land-cover, soils, and infiltration paths in list-valued columns so a whole project fits on one row. The layer-list methods below are more discoverable for QA/QC workflows because they return one row per registered `.rasmap` layer, including the layer name users see in RAS Mapper, the source filename, the resolved path, and available display/selection metadata.\n"
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
+   "id": "03f01429",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "rasmap_files = list(project_path.glob(\"*.rasmap\"))\n",
+    "rasmap_file = rasmap_files[0] if rasmap_files else None\n",
+    "\n",
+    "if rasmap_file:\n",
+    "    print(f\"Reading layer catalog from: {rasmap_file.name}\")\n",
+    "    compact_rasmap_df = RasMap.parse_rasmap(rasmap_file)\n",
+    "\n",
+    "    terrain_layers = RasMap.list_terrain_layers(project_path)\n",
+    "    land_classification_layers = RasMap.list_land_classification_layers(project_path)\n",
+    "    landcover_layers = RasMap.list_landcover_layers(project_path)\n",
+    "    soils_layers = RasMap.list_soils_layers(project_path)\n",
+    "    infiltration_layers = RasMap.list_infiltration_layers(project_path)\n",
+    "\n",
+    "    print(\"\\nCompact project summary columns:\")\n",
+    "    display(compact_rasmap_df[[\n",
+    "        \"terrain_hdf_path\",\n",
+    "        \"landcover_hdf_path\",\n",
+    "        \"soil_layer_path\",\n",
+    "        \"infiltration_hdf_path\",\n",
+    "    ]])\n",
+    "\n",
+    "    print(\"\\nTerrain layers registered in RASMapper:\")\n",
+    "    display(terrain_layers[[\n",
+    "        \"name\",\n",
+    "        \"filename\",\n",
+    "        \"resolved_path\",\n",
+    "        \"checked\",\n",
+    "        \"type\",\n",
+    "        \"resample_method\",\n",
+    "        \"surface_on\",\n",
+    "    ]])\n",
+    "\n",
+    "    print(\"\\nAll land-classification layers registered in RASMapper:\")\n",
+    "    display(land_classification_layers[[\n",
+    "        \"name\",\n",
+    "        \"classification_kind\",\n",
+    "        \"filename\",\n",
+    "        \"resolved_path\",\n",
+    "        \"checked\",\n",
+    "        \"selected_parameter\",\n",
+    "    ]])\n",
+    "\n",
+    "    print(\"\\nFiltered wrappers for workflow-specific discovery:\")\n",
+    "    print(f\"  land cover:   {len(landcover_layers)} layer(s)\")\n",
+    "    print(f\"  soils:        {len(soils_layers)} layer(s)\")\n",
+    "    print(f\"  infiltration: {len(infiltration_layers)} layer(s)\")\n",
+    "else:\n",
+    "    print(\"No .rasmap file found for this example project.\")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "35624534",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2025-12-29T05:36:19.879525Z",
@@ -385,15 +407,7 @@
      "shell.execute_reply": "2025-12-29T05:36:19.883102Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Using terrain file: LandCover.tif\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Look for terrain files specifically\n",
     "terrain_files = [f for f in geo_files if 'terrain' in f.name.lower() or f.suffix.lower() in ['.tif', '.tiff']]\n",
@@ -408,6 +422,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "86204c94",
    "metadata": {},
    "source": [
     "---"
@@ -415,6 +430,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "fa7dd212",
    "metadata": {},
    "source": [
     "## 1. Format Validation: `check_layer_format()`\n",
@@ -424,7 +440,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
+   "id": "96bc4b11",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2025-12-29T05:36:19.886190Z",
@@ -433,25 +450,7 @@
      "shell.execute_reply": "2025-12-29T05:36:19.918193Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "File: LandCover.tif\n",
-      "Result: [INFO] [PASS] geotiff_format: GeoTIFF format valid (14765x10318, 1 bands)\n",
-      "\n",
-      "Details:\n",
-      "  width: 14765\n",
-      "  height: 10318\n",
-      "  bands: 1\n",
-      "  dtype: int32\n",
-      "  crs: EPSG:2271\n",
-      "  resolution: (10.0, 10.0)\n",
-      "  bounds: BoundingBox(left=1952353.7000038475, bottom=276820.8446467547, right=2100003.7000038475, top=380000.8446467547)\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Example 1: Valid terrain file (GeoTIFF)\n",
     "if terrain_files:\n",
@@ -465,7 +464,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
+   "id": "9ff95f62",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2025-12-29T05:36:19.921533Z",
@@ -474,25 +474,7 @@
      "shell.execute_reply": "2025-12-29T05:36:20.021965Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Format validation by file type:\n",
-      "\n",
-      "✓ GeoTIFF: LandCover.tif\n",
-      "  GeoTIFF format valid (14765x10318, 1 bands)\n",
-      "\n",
-      "✓ Shapefile: MainChannelBanks.shp\n",
-      "  Shapefile format valid (2 features)\n",
-      "\n",
-      "✓ HDF: BaldEagleDamBrk.g01.hdf\n",
-      "  HDF format valid (1 root groups)\n",
-      "\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Example 2: Check various file types\n",
     "file_types_to_check = {\n",
@@ -517,7 +499,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
+   "id": "70d99447",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2025-12-29T05:36:20.025236Z",
@@ -526,18 +509,7 @@
      "shell.execute_reply": "2025-12-29T05:36:20.028367Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "File: missing_terrain.tif\n",
-      "Result: [ERROR] [FAIL] file_existence: File not found: C:\\GH\\ras-commander\\examples\\example_projects\\BaldEagleCrkMulti2D\\missing_terrain.tif\n",
-      "Passed: False\n",
-      "Severity: error\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Example 3: Invalid file (doesn't exist)\n",
     "nonexistent_file = project_path / \"missing_terrain.tif\"\n",
@@ -551,6 +523,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "d0fac052",
    "metadata": {},
    "source": [
     "---"
@@ -558,6 +531,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "c7d2f072",
    "metadata": {},
    "source": [
     "## 2. CRS Validation: `check_layer_crs()`\n",
@@ -567,7 +541,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
+   "id": "39d8b542",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2025-12-29T05:36:20.031028Z",
@@ -576,19 +551,7 @@
      "shell.execute_reply": "2025-12-29T05:36:20.036388Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "File: LandCover.tif\n",
-      "Result: [INFO] [PASS] crs_validation: CRS valid: EPSG:2271\n",
-      "\n",
-      "Details:\n",
-      "  crs: EPSG:2271\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Example 1: Check terrain CRS\n",
     "if terrain_files:\n",
@@ -602,7 +565,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
+   "id": "05a6acdc",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2025-12-29T05:36:20.039564Z",
@@ -611,19 +575,7 @@
      "shell.execute_reply": "2025-12-29T05:36:20.064864Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Terrain CRS: EPSG:2271\n",
-      "\n",
-      "Comparing with: Hydrologic Soil Groups.tif\n",
-      "Result: [INFO] [PASS] crs_validation: CRS valid: EPSG:2271\n",
-      "  CRS matches terrain file\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Example 2: Check CRS compatibility with expected projection\n",
     "if terrain_files:\n",
@@ -657,6 +609,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "6c9e4732",
    "metadata": {},
    "source": [
     "---"
@@ -664,6 +617,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "08e91986",
    "metadata": {},
    "source": [
     "## 3. Raster Metadata: `check_raster_metadata()`\n",
@@ -673,7 +627,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
+   "id": "9ea40785",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2025-12-29T05:36:20.068356Z",
@@ -682,24 +637,7 @@
      "shell.execute_reply": "2025-12-29T05:36:20.079734Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "File: LandCover.tif\n",
-      "Number of checks: 3\n",
-      "\n",
-      "Results:\n",
-      "  [PASS] resolution_check: Raster resolution acceptable: 10.00 meters\n",
-      "      resolution: 10.0\n",
-      "  [PASS] nodata_check: Raster nodata acceptable: 0.0%\n",
-      "      nodata_percent: 0.0\n",
-      "  [PASS] extent_info: Raster extent: (1952353.70, 276820.84, 2100003.70, 380000.84)\n",
-      "      bounds: (1952353.7000038475, 276820.8446467547, 2100003.7000038475, 380000.8446467547)\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Example 1: Check terrain raster metadata\n",
     "if terrain_files:\n",
@@ -717,7 +655,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
+   "id": "b3d86c03",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2025-12-29T05:36:20.082472Z",
@@ -726,31 +665,7 @@
      "shell.execute_reply": "2025-12-29T05:36:20.115163Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Raster metadata for 4 file(s):\n",
-      "\n",
-      "File: LandCover.tif\n",
-      "  Resolution: 10.0 meters\n",
-      "  No-data: 0.0%\n",
-      "  Extent: 1952353.70, 276820.84 to 2100003.70, 380000.84\n",
-      "\n",
-      "File: Hydrologic Soil Groups.tif\n",
-      "  Resolution: 10.0 meters\n",
-      "  No-data: 0.0%\n",
-      "  Extent: 1952353.70, 276820.84 to 2100003.70, 380000.84\n",
-      "\n",
-      "File: Terrain50.baldeagledem.tif\n",
-      "  Resolution: 36.504512049933 meters\n",
-      "  No-data: 0.8%\n",
-      "  Extent: 1834327.20, 162918.81 to 2149835.69, 414872.95\n",
-      "\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Example 2: Check multiple raster files\n",
     "raster_files = [f for f in geo_files if f.suffix.lower() in ['.tif', '.tiff']]\n",
@@ -777,6 +692,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "5ff054d5",
    "metadata": {},
    "source": [
     "---"
@@ -784,6 +700,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "7243b656",
    "metadata": {},
    "source": [
     "## 4. Spatial Extent: `check_spatial_extent()`\n",
@@ -793,7 +710,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
+   "id": "2caefd27",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2025-12-29T05:36:20.118061Z",
@@ -802,21 +720,7 @@
      "shell.execute_reply": "2025-12-29T05:36:20.128182Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "File: LandCover.tif\n",
-      "Model extent (from terrain): (1952353.7000038475, 276820.8446467547, 2100003.7000038475, 380000.8446467547)\n",
-      "\n",
-      "Result: [INFO] [PASS] spatial_coverage: Layer covers 100.0% of model domain\n",
-      "\n",
-      "Details:\n",
-      "  coverage_percent: 100.0\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Example 1: Check terrain spatial extent\n",
     "# First we need to get the layer's bounds to establish a model extent\n",
@@ -842,7 +746,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
+   "id": "1c5cc0df",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2025-12-29T05:36:20.131495Z",
@@ -851,24 +756,7 @@
      "shell.execute_reply": "2025-12-29T05:36:20.144786Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Checking overlap:\n",
-      "\n",
-      "Reference (model extent from terrain): LandCover.tif\n",
-      "  Bounds: minx=1952353.70, miny=276820.84, maxx=2100003.70, maxy=380000.84\n",
-      "\n",
-      "File 2: Hydrologic Soil Groups.tif\n",
-      "  [INFO] [PASS] spatial_coverage: Layer covers 100.0% of model domain\n",
-      "\n",
-      "  Files have overlapping coverage\n",
-      "  Coverage: 100.0%\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Example 2: Check coverage overlap between layers\n",
     "if len(geo_files) >= 2 and terrain_files:\n",
@@ -903,6 +791,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "152c4925",
    "metadata": {},
    "source": [
     "---"
@@ -910,6 +799,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "76d4b79c",
    "metadata": {},
    "source": [
     "## 5. Terrain Layer Validation: `check_terrain_layer()`\n",
@@ -919,7 +809,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": null,
+   "id": "ecd3dcba",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2025-12-29T05:36:20.147676Z",
@@ -928,29 +819,7 @@
      "shell.execute_reply": "2025-12-29T05:36:20.163789Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-12 23:58:43 - ras_commander.RasMap - INFO - Extracted terrain names: ['Terrain50']\n",
-      "2026-01-12 23:58:43 - ras_commander.RasMap - INFO - Extracted terrain names: ['Terrain50']\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "RASMapper file: BaldEagleDamBrk.rasmap\n",
-      "Terrain layer found: Terrain50\n",
-      "\n",
-      "Result: [INFO] [PASS] terrain_layer_validation: Terrain layer 'Terrain50' found in rasmap\n",
-      "\n",
-      "Details:\n",
-      "  layer_name: Terrain50\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Example 1: Comprehensive terrain validation\n",
     "# The check_terrain_layer method validates terrain layers in a rasmap file\n",
@@ -988,7 +857,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": null,
+   "id": "8b35d7ac",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2025-12-29T05:36:20.166391Z",
@@ -997,21 +867,7 @@
      "shell.execute_reply": "2025-12-29T05:36:20.180210Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Terrain elevation statistics for LandCover.tif:\n",
-      "\n",
-      "  Minimum: 11.00\n",
-      "  Maximum: 95.00\n",
-      "  Mean: 46.75\n",
-      "\n",
-      "  Elevation range appears reasonable\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Example 2: Validate elevation range using rasterio directly\n",
     "# Since check_terrain_layer works with rasmap, let's use rasterio for elevation stats\n",
@@ -1050,6 +906,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "f20bd58e",
    "metadata": {},
    "source": [
     "---"
@@ -1057,6 +914,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "f1601e4f",
    "metadata": {},
    "source": [
     "## 6. Land Cover Validation: `check_land_cover_layer()`\n",
@@ -1066,64 +924,31 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2025-12-29T05:36:20.183265Z",
-     "iopub.status.busy": "2025-12-29T05:36:20.182935Z",
-     "iopub.status.idle": "2025-12-29T05:36:20.187470Z",
-     "shell.execute_reply": "2025-12-29T05:36:20.186923Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "RASMapper file: BaldEagleDamBrk.rasmap\n",
-      "\n",
-      "Land cover validation example:\n",
-      "  result = RasMap.check_land_cover_layer('BaldEagleDamBrk.rasmap', 'LandCover')\n",
-      "\n",
-      "Land cover validation checks:\n",
-      "  - Layer exists in rasmap\n",
-      "  - File format (typically raster)\n",
-      "  - CRS matches terrain\n",
-      "  - Categorical data (land use classes)\n",
-      "  - Spatial coverage matches model domain\n"
-     ]
-    }
-   ],
+   "execution_count": null,
+   "id": "970f252b",
+   "metadata": {},
+   "outputs": [],
    "source": [
-    "# Example 1: Check land cover layer\n",
-    "# check_land_cover_layer validates land cover configuration in a rasmap file\n",
-    "rasmap_files = list(project_path.glob(\"*.rasmap\"))\n",
+    "# Example 1: Discover and validate land-cover layers by their RASMapper names.\n",
+    "# list_landcover_layers() filters the broader land-classification catalog to\n",
+    "# Manning's n / land-cover sidecars and exposes the layer name needed below.\n",
+    "if rasmap_file and not landcover_layers.empty:\n",
+    "    for _, layer in landcover_layers.iterrows():\n",
+    "        layer_name = layer[\"name\"]\n",
+    "        print(f\"\\nValidating land-cover layer: {layer_name}\")\n",
+    "        print(f\"  Sidecar HDF: {layer['resolved_path']}\")\n",
     "\n",
-    "# For land cover, we need to know the layer name\n",
-    "# Since there's no get_land_cover_names method, we'll demonstrate the API pattern\n",
-    "if rasmap_files:\n",
-    "    rasmap_file = rasmap_files[0]\n",
-    "    print(f\"RASMapper file: {rasmap_file.name}\")\n",
-    "    \n",
-    "    # Demonstrate with a placeholder - in real use you'd know your layer name\n",
-    "    land_cover_layer = \"LandCover\"  # Example layer name\n",
-    "    \n",
-    "    print(f\"\\nLand cover validation example:\")\n",
-    "    print(f\"  result = RasMap.check_land_cover_layer('{rasmap_file.name}', '{land_cover_layer}')\")\n",
-    "    print(f\"\\nLand cover validation checks:\")\n",
-    "    print(\"  - Layer exists in rasmap\")\n",
-    "    print(\"  - File format (typically raster)\")  \n",
-    "    print(\"  - CRS matches terrain\")\n",
-    "    print(\"  - Categorical data (land use classes)\")\n",
-    "    print(\"  - Spatial coverage matches model domain\")\n",
+    "        land_cover_result = RasMap.check_land_cover_layer(rasmap_file, layer_name)\n",
+    "        print(f\"  Valid: {land_cover_result.passed}\")\n",
+    "        print(f\"  Severity: {land_cover_result.severity.value}\")\n",
+    "        print(f\"  Message: {land_cover_result.message}\")\n",
     "else:\n",
-    "    print(\"No rasmap file found in project\")\n",
-    "    print(\"\\nTo validate land cover layers in a rasmap:\")\n",
-    "    print(\"  result = RasMap.check_land_cover_layer('project.rasmap', 'LandCover_Name')\")"
+    "    print(\"No land-cover layers found in this project rasmap file.\")\n"
    ]
   },
   {
    "cell_type": "markdown",
+   "id": "a3d655b7",
    "metadata": {},
    "source": [
     "---"
@@ -1131,6 +956,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "4f114b81",
    "metadata": {},
    "source": [
     "## 7. Comprehensive Layer Validation: `check_layer()`\n",
@@ -1140,7 +966,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": null,
+   "id": "7ecd0bb6",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2025-12-29T05:36:20.189791Z",
@@ -1149,50 +976,7 @@
      "shell.execute_reply": "2025-12-29T05:36:20.196378Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-12 23:58:46 - ras_commander.RasMap - INFO - Extracted terrain names: ['Terrain50']\n",
-      "2026-01-12 23:58:46 - ras_commander.RasMap - INFO - Extracted terrain names: ['Terrain50']\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "RASMapper file: BaldEagleDamBrk.rasmap\n",
-      "\n",
-      "Validating layer: Terrain50\n",
-      "Layer type: Terrain\n",
-      "\n",
-      "Report summary: 1 info, 0 warnings, 0 errors, 0 critical\n",
-      "Is valid: True\n",
-      "Has warnings: False\n",
-      "\n",
-      "Detailed Report:\n",
-      "\n",
-      "================================================================================\n",
-      "Validation Report: C:\\GH\\ras-commander\\examples\\example_projects\\BaldEagleCrkMulti2D\\BaldEagleDamBrk.rasmap - Terrain50\n",
-      "Timestamp: 2026-01-12T23:58:46.360751\n",
-      "================================================================================\n",
-      "\n",
-      "Summary: 1 info, 0 warnings, 0 errors, 0 critical\n",
-      "Overall Status: VALID\n",
-      "\n",
-      "================================================================================\n",
-      "Detailed Results:\n",
-      "================================================================================\n",
-      "\n",
-      "[INFO] [PASS] terrain_layer_validation: Terrain layer 'Terrain50' found in rasmap\n",
-      "  layer_name: Terrain50\n",
-      "\n",
-      "================================================================================\n",
-      "\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Example 1: Comprehensive validation of a terrain layer in a rasmap file\n",
     "rasmap_files = list(project_path.glob(\"*.rasmap\"))\n",
@@ -1234,7 +1018,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": null,
+   "id": "ef4e9727",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2025-12-29T05:36:20.198973Z",
@@ -1243,28 +1028,7 @@
      "shell.execute_reply": "2025-12-29T05:36:20.206971Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-12 23:58:46 - ras_commander.RasMap - INFO - Extracted terrain names: ['Terrain50']\n",
-      "2026-01-12 23:58:46 - ras_commander.RasMap - INFO - Extracted terrain names: ['Terrain50']\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Errors found: 0\n",
-      "\n",
-      "Warnings found: 0\n",
-      "\n",
-      "Info messages: 1\n",
-      "  [INFO] [INFO] [PASS] terrain_layer_validation: Terrain layer 'Terrain50' found in rasmap\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Example 2: Filter validation results by severity\n",
     "rasmap_files = list(project_path.glob(\"*.rasmap\"))\n",
@@ -1304,6 +1068,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "469855e1",
    "metadata": {},
    "source": [
     "---"
@@ -1311,6 +1076,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "76b2b71f",
    "metadata": {},
    "source": [
     "## 8. Boolean Convenience: `is_valid_layer()`\n",
@@ -1320,7 +1086,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": null,
+   "id": "fe605218",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2025-12-29T05:36:20.210155Z",
@@ -1329,25 +1096,7 @@
      "shell.execute_reply": "2025-12-29T05:36:20.218213Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-12 23:58:46 - ras_commander.RasMap - INFO - Extracted terrain names: ['Terrain50']\n",
-      "2026-01-12 23:58:46 - ras_commander.RasMap - INFO - Extracted terrain names: ['Terrain50']\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Quick validation of terrain layers in BaldEagleDamBrk.rasmap:\n",
-      "\n",
-      "VALID: Terrain50 (Terrain)\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Example: Quick validation of terrain layers in a rasmap file\n",
     "rasmap_files = list(project_path.glob(\"*.rasmap\"))\n",
@@ -1375,6 +1124,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "270a50aa",
    "metadata": {},
    "source": [
     "---"
@@ -1382,6 +1132,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "b5c17d4e",
    "metadata": {},
    "source": [
     "## 9. Practical Use Case: Pre-Flight Check for Model Setup\n",
@@ -1391,7 +1142,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": null,
+   "id": "4753a45d",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2025-12-29T05:36:20.220963Z",
@@ -1400,37 +1152,7 @@
      "shell.execute_reply": "2025-12-29T05:36:20.229972Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-12 23:58:46 - ras_commander.RasMap - INFO - Extracted terrain names: ['Terrain50']\n",
-      "2026-01-12 23:58:46 - ras_commander.RasMap - INFO - Extracted terrain names: ['Terrain50']\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "================================================================================\n",
-      "PRE-FLIGHT CHECK: RAS Mapper Layer Validation\n",
-      "================================================================================\n",
-      "\n",
-      "RASMapper file: BaldEagleDamBrk.rasmap\n",
-      "\n",
-      "================================================================================\n",
-      "Checking: Terrain50 (Terrain)\n",
-      "================================================================================\n",
-      "  PASS\n",
-      "\n",
-      "================================================================================\n",
-      "PRE-FLIGHT CHECK PASSED - All terrain layers valid\n",
-      "  Ready to configure RAS Mapper\n",
-      "================================================================================\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Simulate pre-flight check for model setup\n",
     "print(\"=\" * 80)\n",
@@ -1486,6 +1208,57 @@
   },
   {
    "cell_type": "markdown",
+   "id": "ff7d018b",
+   "metadata": {},
+   "source": [
+    "## Geometry and Plan HDF Association Audit\n",
+    "\n",
+    "The `.rasmap` file tells RAS Mapper which layers are available. Compiled geometry and plan/result HDF files also carry `/Geometry` attributes such as `Terrain Filename`, `Terrain Layername`, `Land Cover Filename`, and `Infiltration Filename`. `RasMap.get_hdf_geometry_association()` reads those attributes without mutating the model, which makes it useful for checking whether plans/results are tied to the expected terrain and classification layers.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ee07d7d5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "\n",
+    "geometry_hdfs = sorted(project_path.glob(\"*.g*.hdf\"))\n",
+    "plan_hdfs = sorted(project_path.glob(f\"*.p{PLAN}.hdf\"))\n",
+    "\n",
+    "association_rows = []\n",
+    "for artifact_type, hdf_candidates in [\n",
+    "    (\"geometry\", geometry_hdfs),\n",
+    "    (\"plan/result\", plan_hdfs),\n",
+    "]:\n",
+    "    if not hdf_candidates:\n",
+    "        continue\n",
+    "\n",
+    "    hdf_path = hdf_candidates[0]\n",
+    "    association = RasMap.get_hdf_geometry_association(hdf_path)\n",
+    "    association_rows.append({\n",
+    "        \"artifact_type\": artifact_type,\n",
+    "        \"hdf_path\": str(hdf_path),\n",
+    "        \"terrain_hdf_path\": association.get(\"terrain_hdf_path\"),\n",
+    "        \"terrain_layer_name\": association.get(\"terrain_layer_name\"),\n",
+    "        \"landcover_hdf_path\": association.get(\"landcover_hdf_path\"),\n",
+    "        \"landcover_layer_name\": association.get(\"landcover_layer_name\"),\n",
+    "        \"infiltration_hdf_path\": association.get(\"infiltration_hdf_path\"),\n",
+    "        \"infiltration_layer_name\": association.get(\"infiltration_layer_name\"),\n",
+    "    })\n",
+    "\n",
+    "if association_rows:\n",
+    "    association_df = pd.DataFrame(association_rows)\n",
+    "    display(association_df)\n",
+    "else:\n",
+    "    print(\"No geometry or plan/result HDF files found to audit.\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c14d783a",
    "metadata": {},
    "source": [
     "---"
@@ -1493,6 +1266,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "e1bd8e8b",
    "metadata": {},
    "source": [
     "## 10. Visualization: Layer Extent Comparison (Optional)\n",
@@ -1502,7 +1276,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": null,
+   "id": "7dd80b4a",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2025-12-29T05:36:20.233517Z",
@@ -1511,27 +1286,7 @@
      "shell.execute_reply": "2025-12-29T05:36:20.458140Z"
     }
    },
-   "outputs": [
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA9cAAAMWCAYAAAD7w3U4AAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjMsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvZiW1igAAAAlwSFlzAAAPYQAAD2EBqD+naQAAkXtJREFUeJzs3XucTWX///H33mPOY8ZpDphxFkYjp2Kqr0NklJRSqdzOFCFDUe5vERJJSESpjMQ3KbmTkEO4b02OiQwSgzBjVGbGaY57/f7ws27bDMYs7Bn79fTYD9Za17rWZ69rz9R7r5PNMAxDAAAAAACg0OyuLgAAAAAAgOKOcA0AAAAAgEWEawAAAAAALCJcAwAAAABgEeEaAAAAAACLCNcAAAAAAFhEuAYAAAAAwCLCNQAAAAAAFhGuAQAAAACwiHANAChSWrRooRYtWhRqXZvNptdff/261oP/On36tHr37q2wsDDZbDbFxsa6uqRihc82ANzaCNcA4MZ27typxx9/XJUrV5aPj48qVqyo+++/X++9994N3W5CQoJef/11HTx48IZuJz8HDx6UzWa77Gv8+PHX3Oebb76pxYsXX/9i8zF//nxNmTLlpmzrUm+++abi4uLUr18/zZ07V126dLlie4fDoU8//VT333+/ypUrJ09PT4WEhKhNmzb68MMPlZmZeZMqv3mKwmd74sSJN33bAACphKsLAAC4xo8//qiWLVuqUqVK6tOnj8LCwvTHH3/op59+0rvvvquBAwfesG0nJCRo1KhRatGihapUqeK07Pvvv79h273Y008/rQcffDDP/AYNGlxzX2+++aYef/xxdejQ4TpUdmXz58/Xr7/+6pKjxmvWrFHTpk01cuTIq7Y9d+6cHn30Ua1YsUJ33323XnrpJYWGhurvv//WunXr9Pzzz2vjxo36+OOPb0LlN09R+GwDAFyDcA0Abmrs2LEKCgrS5s2bVapUKadlKSkprilKkpeX103ZTsOGDfWPf/zjpmzrVpGSkqLIyMgCtR08eLBWrFihKVOmaNCgQU7LXnzxRe3bt08rV668EWUWWTfrs12cnD17Vn5+fq4uAwCuC04LBwA3tX//ftWtWzdPsJakkJAQp2mbzaYBAwZo3rx5qlWrlnx8fNSoUSOtX7/eqd2hQ4f0/PPPq1atWvL19VXZsmX1xBNPOJ0iGxcXpyeeeEKS1LJlS/N07LVr10rKe11qVlaWRowYoUaNGikoKEj+/v76n//5H/3www/XZT9czpo1a2S32zVixAin+fPnz5fNZtOMGTMknd83Z86c0Zw5c8z30r17d7P90aNH1bNnT4WGhsrb21t169bVJ5984tTn2rVrZbPZ9MUXX2js2LEKDw+Xj4+PWrVqpd9//91s16JFCy1dulSHDh0yt3Xx0dH33ntPdevWlZ+fn0qXLq3GjRtr/vz5V32vKSkp6tWrl0JDQ+Xj46M77rhDc+bMyVNfYmKili5dam77cqc+//HHH/roo4/Utm3bPMH6gpo1a+r55593mudwODRlyhTVrVtXPj4+Cg0N1XPPPaeTJ0/mWf/9999X3bp15e3trQoVKqh///5KTU11arNv3z517NhRYWFh8vHxUXh4uJ566imlpaWZbdzxsz179mzdd999CgkJkbe3tyIjI83P8wXdunVTuXLllJ2dnWf9Nm3aqFatWk7zPvvsMzVq1Ei+vr4qU6aMnnrqKf3xxx9ObVq0aKHbb79dW7duVbNmzeTn56d//vOfkqQtW7YoJiZG5cqVk6+vr6pWraqePXte53cOADcWR64BwE1VrlxZ8fHx+vXXX3X77bdftf26deu0YMECvfDCC/L29tb777+vtm3batOmTeb6mzdv1o8//qinnnpK4eHhOnjwoGbMmKEWLVooISFBfn5+atasmV544QVNnTpV//znP1WnTh1JMv++VHp6uj766CM9/fTT6tOnj06dOqWPP/5YMTEx2rRpk+rXr1+o93/27Fn9+eefeeaXKlVKJUqU0H333afnn39e48aNU4cOHdSwYUMlJSVp4MCBat26tfr27StJmjt3rnr37q277rpLzz77rCSpevXqkqTjx4+radOmZoALDg7WsmXL1KtXL6Wnp+c5tXv8+PGy2+166aWXlJaWpgkTJqhz587auHGjJOl///d/lZaWpiNHjmjy5MmSpICAAEnSrFmz9MILL+jxxx/XoEGDlJGRoR07dmjjxo165plnLrsfzp07pxYtWuj333/XgAEDVLVqVS1cuFDdu3dXamqqBg0apDp16mju3LkaPHiwwsPD9eKLL0qSgoOD8+1z2bJlys3NveYzA5577jnFxcWpR48eeuGFF5SYmKhp06bp559/1oYNG+Tp6SlJev311zVq1Ci1bt1a/fr10969ezVjxgxt3rzZbJeVlaWYmBhlZmZq4MCBCgsL09GjR/Xtt98qNTVVQUFB5nZvtc/21cyYMUN169bVww8/rBIlSmjJkiV6/vnn5XA41L9/f0lSly5d9Omnn2rFihV66KGHzHWTk5O1Zs0ap0sDxo4dq9dee01PPvmkevfurRMnTui9995Ts2bN9PPPPzt9gffXX3/pgQce0FNPPaV//OMfCg0NVUpKitq0aaPg4GC98sorKlWqlA4ePKhFixbdkPcPADeMAQBwS99//73h4eFheHh4GNHR0cawYcOMFStWGFlZWXnaSjIkGVu2bDHnHTp0yPDx8TEeffRRc97Zs2fzrBsfH29IMj799FNz3sKFCw1Jxg8//JCnffPmzY3mzZub0zk5OUZmZqZTm5MnTxqhoaFGz54989Q5cuTIK77vxMRE8/3k94qPjzfbnjlzxqhRo4ZRt25dIyMjw2jXrp0RGBhoHDp0yKlPf39/o1u3bnm21atXL6N8+fLGn3/+6TT/qaeeMoKCgsz99cMPPxiSjDp16ji913fffdeQZOzcudOc165dO6Ny5cp5tvXII48YdevWveJ7z8+UKVMMScZnn31mzsvKyjKio6ONgIAAIz093ZxfuXJlo127dlftc/DgwYYkY/v27U7zMzMzjRMnTpivi/fLv//9b0OSMW/ePKd1li9f7jQ/JSXF8PLyMtq0aWPk5uaa7aZNm2ZIMj755BPDMAzj559/NiQZCxcuvGKtt+Jn++23375iu/zeS0xMjFGtWjVzOjc31wgPDzc6derk1G7SpEmGzWYzDhw4YBiGYRw8eNDw8PAwxo4d69Ru586dRokSJZzmN2/e3JBkzJw506nt119/bUgyNm/efMW6AaCo47RwAHBT999/v+Lj4/Xwww/rl19+0YQJExQTE6OKFSvqm2++ydM+OjpajRo1MqcrVaqkRx55RCtWrFBubq4kydfX11yenZ2tv/76SzVq1FCpUqW0bdu2QtXp4eFhXqvqcDj0999/KycnR40bNy50n5L07LPPauXKlXleF19T7Ofnp7i4OO3evVvNmjXT0qVLNXnyZFWqVOmq/RuGoa+++krt27eXYRj6888/zVdMTIzS0tLy1N+jRw+n63L/53/+R5J04MCBq26vVKlSOnLkiDZv3lzQXSBJ+u677xQWFqann37anOfp6akXXnhBp0+f1rp1666pP+n8EVnpv0fVL95WcHCw+apcubK5bOHChQoKCtL999/vtK8aNWqkgIAA81TpVatWKSsrS7GxsbLb//u/MX369FFgYKCWLl0qSeaR6RUrVujs2bNXrPdW+2xfzcXvJS0tTX/++aeaN2+uAwcOmKfM2+12de7cWd98841OnTpltp83b57uvvtuVa1aVZK0aNEiORwOPfnkk07jFhYWppo1a+Y5xd3b21s9evRwmnfhyPa3336b72noAFBcEK4BwI3deeedWrRokU6ePKlNmzZp+PDhOnXqlB5//HElJCQ4ta1Zs2ae9W+77TadPXtWJ06ckHT+FOMRI0YoIiJC3t7eKleunIKDg5Wamup0neu1mjNnjurVqycfHx+VLVtWwcHBWrp0qaU+a9asqdatW+d5BQYGOrW755571K9fP23atEkxMTEFvg70xIkTSk1N1YcffugUKIODg81wcemN4y4N7aVLl5akfK85vtTLL7+sgIAA3XXXXapZs6b69++vDRs2XHW9Q4cOqWbNmk5BVfrvqcyHDh26ah+XKlmypKTzz8W+2D333GN+idGmTRunZfv27VNaWppCQkLy7K/Tp0+b++pCPZde8+vl5aVq1aqZy6tWraohQ4boo48+Urly5RQTE6Pp06fn+5m51T7bV7Nhwwa1bt1a/v7+KlWqlIKDg81rny/ebteuXXXu3Dl9/fXXkqS9e/dq69atTo9g27dvnwzDUM2aNfOM2+7du/N8xitWrJjnxm7NmzdXx44dNWrUKJUrV06PPPKIZs+efUs+qg3ArY1rrgEA8vLy0p133qk777xTt912m3r06KGFCxcW6JFLFxs4cKBmz56t2NhYRUdHKygoSDabTU899ZQcDkehavvss8/UvXt3dejQQUOHDlVISIg8PDw0btw47d+/v1B9XovMzEzzhlT79+8v8N2NL7zff/zjH+rWrVu+berVq+c07eHhkW87wzCuur06depo7969+vbbb7V8+XJ99dVXev/99zVixAiNGjXqqutfT7Vr15Yk/frrr7rjjjvM+cHBwWrdurWk8+N6MYfDoZCQEM2bNy/fPi93ffeVvPPOO+revbv+9a9/6fvvv9cLL7ygcePG6aefflJ4ePg19XWrfLb379+vVq1aqXbt2po0aZIiIiLk5eWl7777TpMnT3Z6L5GRkWrUqJE+++wzde3aVZ999pm8vLz05JNPmm0cDodsNpuWLVuW7+f30rMXLj5qfoHNZtOXX36pn376SUuWLNGKFSvUs2dPvfPOO/rpp5/y9AEARRXhGgDgpHHjxpKkpKQkp/n79u3L0/a3336Tn5+fGXy+/PJLdevWTe+8847ZJiMjI89dnG02W4Hr+fLLL1WtWjUtWrTIab1rDf6FNXLkSO3evVsTJ07Uyy+/rFdeeUVTp051apPf+wkODlbJkiWVm5trBsrr4Ur7zt/fX506dVKnTp2UlZWlxx57TGPHjtXw4cPl4+OT7zqVK1fWjh075HA4nI5e79mzx1x+rR544AF5eHho3rx56ty5c4HWqV69ulatWqV77rkn3wB2cb3S+aOo1apVM+dnZWUpMTExz76OiopSVFSUXn31Vf3444+65557NHPmTL3xxhtmG3f6bC9ZskSZmZn65ptvnM6UuNwdyrt27aohQ4YoKSlJ8+fPV7t27cwzKqTz42YYhqpWrarbbrvNUm1NmzZV06ZNNXbsWM2fP1+dO3fW559/rt69e1vqFwBuFk4LBwA39cMPP+R7RPS7776TlPe02/j4eKfrQP/44w/961//Ups2bcwjVh4eHnn6fO+998zrVi/w9/eXpDzBJD8X+r64340bNyo+Pv6q61q1ceNGTZw4UbGxsXrxxRc1dOhQTZs2Lc91yP7+/nnei4eHhzp27KivvvpKv/76a56+L5xufK38/f3zPWX4r7/+cpr28vJSZGSkDMO44nWsDz74oJKTk7VgwQJzXk5Ojt577z0FBASoefPm11xjpUqV1LNnTy1btkzTpk3Lt82ln5Mnn3xSubm5GjNmTJ62OTk55v5t3bq1vLy8NHXqVKc+Pv74Y6Wlpaldu3aSzl/3nZOT49RPVFSU7HZ7ntON3emznd8209LSNHv27HzbP/3007LZbBo0aJAOHDiQ5w7wjz32mDw8PDRq1Kg8+8cwjDyfy/ycPHkyz7oX7pTOqeEAihOOXAOAmxo4cKDOnj2rRx99VLVr11ZWVpZ+/PFHLViwQFWqVMlz06Hbb79dMTExTo8rkuR0yvFDDz2kuXPnKigoSJGRkYqPj9eqVatUtmxZp77q168vDw8PvfXWW0pLS5O3t7f53N1LPfTQQ1q0aJEeffRRtWvXTomJiZo5c6YiIyPzXNN7LbZt25bn1GTp/JG46OhoZWRkqFu3bqpZs6bGjh1rvtclS5aoR48e2rlzpxmkGjVqpFWrVmnSpEmqUKGCqlatqiZNmmj8+PH64Ycf1KRJE/Xp00eRkZH6+++/tW3bNq1atUp///33NdfdqFEjLViwQEOGDNGdd96pgIAAtW/fXm3atFFYWJjuuecehYaGavfu3Zo2bZratWtnXgOdn2effVYffPCBunfvrq1bt6pKlSr68ssvtWHDBk2ZMuWK617JlClTlJiYqIEDB+rzzz9X+/btFRISoj///FMbNmzQkiVLnL7Aad68uZ577jmNGzdO27dvV5s2beTp6al9+/Zp4cKFevfdd/X4448rODhYw4cP16hRo9S2bVs9/PDD2rt3r95//33deeedZvhbs2aNBgwYoCeeeEK33XabcnJyNHfuXPNLj4vdap/t1atXKyMjI8/8Dh06qE2bNvLy8lL79u313HPP6fTp05o1a5ZCQkLynK0inT8Do23btlq4cKFKlSplfnlxQfXq1fXGG29o+PDhOnjwoDp06KCSJUsqMTFRX3/9tZ599lm99NJLV6x3zpw5ev/99/Xoo4+qevXqOnXqlGbNmqXAwEA9+OCDhd4PAHDT3fT7kwMAioRly5YZPXv2NGrXrm0EBAQYXl5eRo0aNYyBAwcax48fd2oryejfv7/x2WefGTVr1jS8vb2NBg0a5Hnc0MmTJ40ePXoY5cqVMwICAoyYmBhjz549RuXKlfM8qmrWrFlGtWrVDA8PD6dHF136uCKHw2G8+eabRuXKlc3tfvvtt0a3bt3yPJJK1+FRXBfqHDx4sOHh4WFs3LjRaf0tW7YYJUqUMPr162fO27Nnj9GsWTPD19fXqQ/DMIzjx48b/fv3NyIiIgxPT08jLCzMaNWqlfHhhx+abS48iuvSx0ZdqHX27NnmvNOnTxvPPPOMUapUKUOSuQ8++OADo1mzZkbZsmUNb29vo3r16sbQoUONtLS0K+6PCzVeGDcvLy8jKirKaZsXFPRRXBfk5OQYs2fPNu677z6jTJkyRokSJYxy5coZrVq1MmbOnGmcO3cuzzoffvih0ahRI8PX19coWbKkERUVZQwbNsw4duyYU7tp06YZtWvXNjw9PY3Q0FCjX79+xsmTJ83lBw4cMHr27GlUr17d8PHxMcqUKWO0bNnSWLVqlVM/7vTZnjt3rmEYhvHNN98Y9erVM3x8fIwqVaoYb731lvHJJ58YkozExMQ8/X7xxReGJOPZZ5+97La/+uor49577zX8/f0Nf39/o3bt2kb//v2NvXv3mm2aN2+e7+Pitm3bZjz99NNGpUqVDG9vbyMkJMR46KGHnB6PBgDFgc0wCnCXFACAW7PZbOrfv/9lT/EFiis+21f3r3/9Sx06dND69evNx8MBAPLimmsAAABc1qxZs1StWjXde++9ri4FAIo0rrkGAABAHp9//rl27NihpUuX6t13372mO6EDgDsiXAMAACCPp59+WgEBAerVq5eef/55V5cDAEUe11wDAAAAAGAR11wDAAAAAGAR4RoAAAAAAIu45vomcjgcOnbsmEqWLMlNQQAAAACgGDAMQ6dOnVKFChVkt1/++DTh+iY6duyYIiIiXF0GAAAAAOAa/fHHHwoPD7/scsL1TVSyZElJ5wclMDDQxdUUPw6HQydOnFBwcPAVvzHCrYexd1+Mvfti7N0XY+++GHv3VdTHPj09XREREWaeuxzC9U104VTwwMBAwnUhOBwOZWRkKDAwsEj+0OHGYezdF2Pvvhh798XYuy/G3n0Vl7G/2qW9RbdyAAAAAACKCcI1AAAAAAAWEa4BAAAAALCIa64BAACAG8ThcCgrK8vVZRQLDodD2dnZysjIKNLX3eL6c/XYe3p6ysPDw3I/hGsAAADgBsjKylJiYqIcDoerSykWDMOQw+HQqVOnrnrjKNxaisLYlypVSmFhYZa2T7gGAAAArjPDMJSUlCQPDw9FRERwJLYADMNQTk6OSpQoQbh2M64ce8MwdPbsWaWkpEiSypcvX+i+CNcAAADAdZaTk6OzZ8+qQoUK8vPzc3U5xQLh2n25eux9fX0lSSkpKQoJCSn0KeJ8hQYAAABcZ7m5uZIkLy8vF1cCoCAufAmWnZ1d6D4I1wAAAMANwhFYoHi4Hj+rhGsAAAAAACzimmsAAADgZmjcWEpOvvnbDQuTtmy5+dstoO7duys1NVVff/21q0u5buLi4hQbG6vU1FRz3ocffqgxY8bo6NGjmjRpkmJjY11WH24MwjUAAABwMyQnS0ePurqKK7oQdBcvXuzSOpKTkzV27FgtXbpUR48eVUhIiOrXr6/Y2Fi1atXKpbVdqkqVKoqNjXUKy506ddKDDz5oTqenp2vAgAGaNGmSOnbsqKCgIBdUihuNcA0AAADcTHa7ZOFxPwWWlCQVw2dsHzx4UPfee69KlSqlt99+W1FRUcrOztaKFSvUv39/7dmzx2W1ZWVlFegmdb6+vuYdqCXp8OHDys7OVrt27Sw96glFG9dcAwAAADdT+fLSkSM3/nWdQ9ykSZMUFRUlf39/RURE6Pnnn9fp06fN5XFxcSpVqpRWrFihOnXqKCAgQG3btlVSUpLZJjc3V0OGDFGpUqVUtmxZDRs2TIZhOG2nf//+stls2rRpkzp27KjbbrtNdevW1ZAhQ/TTTz+Z7Q4fPqxHHnlEAQEBCgwM1JNPPqnjx49Lkn777TfZbLY8QXzy5MmqXr26Of3rr7/qgQceUEBAgEJDQ9WlSxf9+eef5vIWLVpowIABio2NVbly5RQTE+PUX4sWLXTo0CENHjxYNpvNvCnWhX1x4d9RUVGSpGrVqslms+ngwYPXuvtRDBCuAQAAAFyV3W7X1KlTtWvXLs2ZM0dr1qzRsGHDnNqcPXtWEydO1Ny5c7V+/XodPnxYL730krn8nXfeUVxcnD755BP95z//0d9//+10rfXff/+t5cuXq3///vL3989Tw4XA6nA49Mgjj+jvv//WunXrtHLlSh04cECdOnWSJN12221q3Lix5s2b57T+vHnz9Mwzz0iSUlNTdd9996lBgwbasmWLli9fruPHj+vJJ590WmfOnDny8vLShg0bNHPmTKdlixYtUnh4uEaPHq2kpCSnLxIu6NSpk1atWiVJ2rRpk5KSkhQREXHFfY3iidPCAQAAAFzVxdcUV6lSRW+88Yb69u2r999/35yfnZ2tmTNnmkeHBwwYoNGjR5vLp0yZouHDh+uxxx6TJM2cOVMrVqwwl+/fv1+GYah27dpXrGX16tXauXOnEhMTzaD66aefqm7dutq8ebPuvPNOde7cWdOmTdOYMWMknT+avXXrVn322WeSpGnTpqlBgwZ68803zX4/+eQTRURE6LffftNtt90mSapZs6YmTJiQbx1lypSRh4eHSpYsqbCwsHzb+Pr6qmzZspKk4ODgy7ZD8ceRawAAAABXtWrVKrVq1UoVK1ZUyZIl1aVLF/311186e/as2cbPz8/ptOvy5csrJSVFkpSWlqakpCQ1adLEXF6iRAk1btzYnL70FPHL2b17tyIiIpyOAEdGRqpUqVLavXu3JOmpp57SwYMHzVPJ582bp4YNG5rB/ZdfftEPP/yggIAA83Vh2f79+81+GzVqVLAdBLdHuAYAAABwRQcPHtRDDz2kevXq6auvvtLWrVs1ffp0Sedv8nWBp6en03o2m63AgVmSatSoke+10oURFham++67T/Pnz5ckzZ8/X507dzaXnz59Wu3bt9f27dudXvv27VOzZs3Mdvmdng7kh3ANAAAA4Iq2bt0qh8Ohd955R02bNtVtt92mY8eOXVMfQUFBKl++vDZu3GjOy8nJ0datW83pMmXKKCYmRtOnT9eZM2fy9HHhudF16tTRH3/8oT/++MNclpCQoNTUVEVGRprzOnfurAULFig+Pl4HDhzQU089ZS5r2LChdu3apSpVqqhGjRpOr2sJ1F5eXsrNzS1we9y6CNcAAAAATGlpaXmO5pYrV07Z2dl67733dODAAc2dOzfPzb0KYtCgQRo/frwWL16sPXv26PnnnzcD8wXTpk1Tbm6u7rrrLn311Vfat2+fdu/eralTpyo6OlqS1Lp1a0VFRalz587atm2bNm3apK5du6p58+ZOp5k/9thjOnXqlPr166eWLVuqQoUK5rL+/fvr77//1tNPP63Nmzdr//79WrFihXr06HHFsFy7dm2nm7BVqVJF69ev19GjR53uNA73ww3NAAAAgJspKUkKD7852ymEtWvXqkGDBk7zevXqpUmTJumtt97S8OHD1axZM40bN05du3a9pr5ffPFFJSUlqVu3brLb7erZs6ceffRRpaWlmW2qVaumbdu2aezYsWb74OBgNWrUSDNmzJB0/nTzf/3rXxo4cKCaNWsmu92utm3b6r333nPaXsmSJdW+fXt98cUX+uSTT5yWVahQQRs2bNDLL7+sNm3aKDMzU5UrV1bbtm1lt1/+GOTevXud6h09erSee+45Va9eXZmZmdd0GjxuLTaD0b9p0tPTFRQUpLS0NAUGBrq6nGLH4XAoJSVFISEhV/yFh1sPY+++GHv3xdi7r1tl7DMyMpSYmKiqVavKx8fn/MzwcOno0ZtfTMWK5597XcQZhqGcnByVKFHCfF403ENRGPt8f2b/v4LmOI5cAwAAADeDqx7BxKOfgJuCcA0AAADcDFu2uLoCADdQ8T3XBgAAAACAIoJwDQAAAACARYRrAAAAAAAsIlwDAAAAAGARNzSDqfGHjZV8OtnVZVyWXXZF+kUq4WyCHHK4uhzcRIy9+2Ls3Rdj775ulbGv6FtRbzR8Q5knMmXz5LFSBWGTTT52H2U4MmSIpwW7kwtjn2PLUWRwpKvLKTTCNUzJp5N19JQLnr1YQHbZFWYL09FTR4v1f2xx7Rh798XYuy/G3n3dKmNfwlFCuY5c5Rg5KsZv46bztHkqy5Hl6jLgAp42T+U4clxdhiWEa+Rht9lVPqC8q8vIwy67yviWUUWjYrH+jy2uHWPvvhh798XYu69bZexDfUPlYfdQCVsJ2ewcuS4Im2zysHnIy+7FkWs3U9xD9QWEa+RRPqC8jgw54uoy8nA4HEpJSVFISIjsdm4X4E4Ye/fF2Lsvxt593Spjn5GRocTERFUNriofHx9JUuPGUrILrsALCysaj9g+ePCgqlatqp9//ln169fPs9wwDOXk5KhEiRKy2S7/hcTatWvVsmVLnTx5UqVKlbpu9dlsNn399dfq0KHDdevzWlWpUkWxsbGKjY0tMjXdDDuSd1y1TVxcnGJjY5WammrO+/DDDzVmzBgdPXpUkyZNMvebqxCuAQAAgJsgOVk6WnSvwJMkde/eXampqVq8eLHT/BsVaIuSpKQklS5dutDrr1u3TqNGjdL27duVkZGhihUr6u6779asWbPk5eVVoD42b94sf3//a9pucnKyxo0bp6VLl+rIkSMKCgpSjRo19I9//EPdunWTn59fYd6OS136JYMkderUSQ8++KA5nZ6ergEDBmjSpEnq2LGjgoKCXFCpM8I1AAAAcBPZ7VL5m3AFXlKS5ChGZ9ZffOTaFcLCwgq9bkJCgtq2bauBAwdq6tSp8vX11b59+/TVV18pNze3wP0EBwdf03YPHDige+65R6VKldKbb76pqKgoeXt7a+fOnfrwww9VsWJFPfzww/mum52dLU9Pz2vaniv5+vrK19fXnD58+LCys7PVrl07lb8ZP1AFUHzPtQEAAACKofLlpSNHbvzrRuWNM2fOKDAwUF9++aXT/MWLF8vf31+nTp2SJG3atEkNGjSQj4+PGjdurJ9//tmp/dq1a2Wz2bRs2TI1atRIPj4+2rBhgzIzM/XCCy8oJCREPj4+uvfee7V58+Yr1vTVV1+pbt268vb2VpUqVfTOO+84LU9KSlK7du3k6+urqlWrav78+apSpYqmTJlitrHZbE5H7I8cOaKnn35aZcqUkb+/vxo3bqyNGzfmu/3vv/9eYWFhmjBhgm6//XZVr15dbdu21axZs5wC4dXqvLSmq3n++edVokQJbdmyRU8++aTq1KmjatWq6ZFHHtHSpUvVvn17p/c3Y8YMPfzww/L399fYsWMlSTNmzFD16tXl5eWlWrVqae7cueY6Bw8elM1m0/bt2815qampstlsWrt2raT/juPSpUtVr149+fj4qGnTpvr111/NdQ4dOqT27durdOnS8vf3V926dfXdd9/l+55atGihQ4cOafDgwbLZbOYlAnFxceZZE3FxcYqKipIkVatWTTabTQcPHizwfrtRCNcAAAAACszf319PPfWUZs+e7TR/9uzZevzxx1WyZEmdPn1aDz30kCIjI7V161a9/vrreumll/Lt75VXXtH48eOVkJCgqKgoDRs2TF999ZXmzJmjbdu2qUaNGoqJidHff/+d7/pbt27Vk08+qaeeeko7d+7U66+/rtdee01xcXFmm65du+rYsWNau3atvvrqK3344YdKSUm57Hs8ffq0mjdvrqNHj+qbb77RL7/8omHDhslxmVMBwsLClJSUpPXr11+2z4LUeS3++usvff/99+rfv/9lTyW/9Nr1119/XY8++qh27typnj176uuvv9agQYP04osv6tdff9Vzzz2nHj166IcffrjmeoYOHap33nlHmzdvVnBwsNq3b6/s7GxJUv/+/ZWZman169dr586deuuttxQQEJBvP4sWLVJ4eLhGjx6tpKQkJSUl5WnTqVMnrVq1StL5L3GSkpIUERFxzTVfb5wWDgAAAMD07bff5gk+l57a3Lt3b919991KSkpS+fLllZKSou+++84MPPPnz5fD4dDHH38sHx8f1a1bV0eOHFG/fv3ybG/06NG6//77ZRiG0tLSNHPmTMXFxemBBx6QJM2aNUsrV67Uxx9/rKFDh+ZZf9KkSWrVqpVee+01SdJtt92mhIQEvf322+revbv27NmjVatWafPmzWrcuLEk6aOPPlLNmjUvuw/mz5+vEydOaPPmzSpTpowkqUaNGpdt/8QTT2jFihVq3ry5wsLC1LRpU7Vq1Updu3ZVYGBggeq8Vr///rsMw1CtWrWc5pcrV04ZGRmSzofat956y1z2zDPPqEePHub0008/re7du+v555+XJA0ZMkQ//fSTJk6cqJYtW15TPSNHjtT9998vSZozZ47Cw8P19ddf68knn9Thw4fVsWNHp6PNl1OmTBl5eHioZMmSlz1V39fXV2XLlpV0/lR6K6f0X08cuQYAAABgatmypbZv3+70+uijj5za3HXXXapbt67mzJkjSfrss89UuXJlNWvWTJK0e/du8xThC6Kjo/Pd3oXAK0n79+9Xdna27rnnHnOep6en7rrrLu3evTvf9Xfv3u3UXpLuuece7du3T7m5udq7d69KlCihhg0bmstr1KhxxZuXbd++XQ0aNDCD9dV4eHho9uzZOnLkiCZMmKCKFSvqzTffVN26dc0jr1er83rZtGmTtm/frrp16yozM9Np2cX7+ko1XW5fX8nF41umTBnVqlXL7OeFF17QG2+8oXvuuUcjR47Ujh1Xvzt4cUS4BgAAAGDy9/dXjRo1nF4VK1bM0653797mKc2zZ89Wjx49rvgIrSttr6i5+Drpa1GxYkV16dJF06ZN065du5SRkaGZM2de5+rOq1Gjhmw2m/bu3es0v1q1aqpRo0a+7+Fa9/WFx+EZxn+fO37hVO9r0bt3bx04cEBdunTRzp071bhxY7333nvX3E9RR7gGAAAAcM3+8Y9/6NChQ5o6daoSEhLUrVs3c1mdOnW0Y8cO8/RkSfrpp5+u2ueFG2tt2LDBnJedna3NmzcrMjIy33Xq1Knj1F6SNmzYoNtuu00eHh6qVauWcnJynG6o9vvvv+vkyZOXraNevXravn37Za/zLojSpUurfPnyOnPmTIHqvFZly5bV/fffr2nTppnbuFaXq+nCvr5w9/KLr3u++OZmF7t4fE+ePKnffvtNderUMedFRESob9++WrRokV588UXNmjXrsnV5eXld16P5NwvhGgAAAMA1K126tB577DENHTpUbdq0UXh4uLnsmWeekc1mU58+fZSQkKDvvvtOEydOvGqf/v7+6tu3r4YOHarly5crISFBffr00dmzZ9WrV69813nxxRe1evVqjRkzRr/99pvmzJmjadOmmTdQq127tlq3bq1nn31WmzZt0s8//6xnn31Wvr6+lz3S/vTTTyssLEwdOnTQhg0bdODAAX311VeKj4/Pt/0HH3ygfv366fvvv9f+/fu1a9cuvfzyy9q1a5d5x+6r1VkY77//vnJyctS4cWMtWLBAu3fv1t69e/XZZ59pz549Vw3tQ4cOVVxcnGbMmKF9+/Zp0qRJWrRokVmTr6+vmjZtqvHjx2v37t1at26dXn311Xz7Gj16tFavXq1ff/1V3bt3V7ly5dShQwdJUmxsrFasWKHExERt27ZNP/zwg1PwfuTeR7Tqu1XmdJUqVbR+/XodPXpUf/75Z6H3z83GDc0AAACAmygpSbooh97Q7dxovXr10vz589WzZ0+n+QEBAVqyZIn69u2rBg0aKDIyUm+99ZY6dux41T7Hjx8vwzDUpUsXnTp1So0bN9aKFSsue410w4YN9cUXX2jEiBEaM2aMypcvr9GjRzvdJOzTTz9Vr1691KxZM4WFhWncuHHatWuX0zXhF/Py8tL333+vF198UQ8++KBycnIUGRmp6dOn59v+rrvu0n/+8x/17dtXx44dU0BAgOrWravFixerefPmBa7zWlWvXl0///yz3nzzTQ0fPlxHjhyRt7e3IiMj9dJLL5k3KrucDh066N1339XEiRM1aNAgVa1aVbNnz1aLFi3MNp988ol69eqlRo0aqVatWpowYYLatGmTp6/x48dr0KBB2rdvn+rXr68lS5bIy8tL0vkb4vXv319HjhxRYGCg2rZtq8mTJ5vrHtx/UKfST5nTo0eP1nPPPafq1asrMzPT6bT0osxmFJdKbwHp6ekKCgpSWlqaedfAoiR8UriOnjqqiiUr6siQI64uJw+Hw6GUlBSFhISY13/APTD27ouxd1+Mvfu6VcY+IyNDiYmJqlq1qhngwsOlo0dvfi0VK55/7vWNMHfuXA0ePFjHjh0zg1RhGYahnJwclShRolDXbl+LI0eOKCIiQqtWrVKrVq1u6LZudWvXrlXLli118uRJ8znU12pH8g552jyVbWSrXli961tgAeX3M3tBQXMcR64BAACAm8BVTwu6Eds9e/askpKSNH78eD333HOWg/WNtmbNGp0+fVpRUVFKSkrSsGHDVKVKFfPu5sD1QLgGAAAAboItW1xdwfUzYcIEjR07Vs2aNdPw4cNdXc5VZWdn65///KcOHDigkiVL6u6779a8efPk6enp6tJwCyFcAwAAALgmr7/+ul5//XVXl1FgMTExiomJcXUZt6QWLVoUm2uib7TieyELAAAAAABFBOEaAAAAAACLCNcAAAAAAFhEuAYAAAAAwCLCNQAAAAAAFhGuAQAAAACwiEdxAQAAADdB4w8bK/l08k3fblhAmLY8W7wesr127Vq1bNlSJ0+eVKlSpVxaS4sWLVS/fn1NmTKl0H0U5P3ExcUpNjZWqamphd5OYbz++utavHixtm/fXug+Dh48qKpVq+rnn39W/fr1r1tthZXfvvzwww81ZswYHT16VJMmTVJsbOx13y7hGgAAALgJkk8n6+ipo64u47JsNtsVl48cOfKmPdv67rvvVlJSkoKCggq8TlxcnHr06OE0z9vbWxkZGea0YRgaOXKkZs2apdTUVN1zzz2aMWOGatased1qx81VpUoVxcbGOoXlTp066cEHHzSn09PTNWDAAE2aNEkdO3a8ps/VtSBcAwAAADeR3WZX+YDyN3w7SaeT5DAcBW+flGT+e8GCBRoxYoT27t1rzgsICLim7WdnZ8vT09NpXlZWlry8vK66rpeXl8LCwq5pe5IUGBjoVPOlXxhMmDBBU6dO1Zw5c1S1alW99tpriomJUUJCgnx8fK55eyiafH195evra04fPnxY2dnZateuncqXv3E/e1xzDQAAANxE5QPK68iQIzf8da0BPiwszHwFBQXJZrM5zfv8889Vp04d+fj4qHbt2nr//ffNdQ8ePCibzaYFCxaoefPm8vHx0bx589S9e3d16NBBY8eOVYUKFVSrVi1J0ty5c9W4cWOVLFlSYWFheuaZZ5SSkmL2t3btWtlsNvO03ri4OJUqVUorVqxQnTp1FBAQoLZt2zp9ISApT82hoaHmMsMwNGXKFL366qt65JFHVK9ePX366ac6duyYFi9efMV9k5OTowEDBigoKEjlypXTa6+9JsMwzOVXez/5iYuLU6VKleTn56dHH31Uf/31V542//rXv9SwYUP5+PioWrVqGjVqlHJycszlkyZNUlRUlPz9/RUREaHnn39ep0+fdupj1qxZioiIMLczadKkq55q/9FHH112rCVp06ZNatCggXx8fNS4cWP9/PPPefr49ddf9cADDyggIEChoaHq0qWL/vzzT3N5ixYtNHDgQMXGxure2vfqf27/H3312Vc6c+aMevTooZIlS6pGjRpatmzZZets0aKFDh06pMGDB8tms5lfplz4vFz4d1RUlCSpWrVqstlsOnjw4BXff2ERrgEAAABc0bx58zRixAiNHTtWu3fv1ptvvqnXXntNc+bMcWr3yiuvaNCgQdq9e7diYmIkSatXr9bevXu1cuVKffvtt5LOH9UeM2aMfvnlFy1evFgHDx7Mc0r3pc6ePauJEydq7ty5Wr9+vQ4fPqyXXnrJqc3p06dVuXJlRURE6JFHHtGuXbvMZYmJiUpOTlbr1q3NeUFBQWrSpIni4+OvuO05c+aoRIkS2rRpk959911NmjRJH330kbk8v/fTvXv3y/a3ceNG9erVSwMGDND27dvVsmVLvfHGG05t/v3vf6tr164aNGiQEhIS9MEHHyguLk5jx44129jtdk2dOlW7du3SnDlztGbNGg0bNsxcvmHDBvXt21eDBg3S9u3bdf/99zutn5+rjfXp06f10EMPKTIyUlu3btXrr7+eZxxSU1N13333qUGDBtqyZYuWL1+u48eP68knn8yzX8uVK6d5381T516dNfaVsXriiSd09913a9u2bWrTpo26dOmis2fP5lvrokWLFB4ertGjRyspKSnPly3S+VPEV61aJen8lwJJSUmKiIi44j4oNAM3TVpamiHJSEtLc3Up+ar4TkVDr8uo+E5FV5eSr9zcXCMpKcnIzc11dSm4yRh798XYuy/G3n3dKmN/7tw5IyEhwTh37pw572b/v5aV7c2ePdsICgoyp6tXr27Mnz/fqc2YMWOM6OhowzAMIzEx0ZBkTJkyxalNt27djNDQUCMzM/OK29u8ebMhyfj7778Nh8Nh/PDDD4Yk4+TJk2Y9kozff//dXGf69OlGaGioOf3jjz8ac+bMMX7++Wdj7dq1xkMPPWQEBgYaf/zxh2EYhrFhwwZDknHs2DGnbT/xxBPGk08+ednamjdvbtSpU8dwOBzmvJdfftmoU6fOVd/PqVOnDMMw8ryfp59+2njwwQed1unUqZPTPm/VqpXx5ptvOrWZO3euUb58+ctud+HChUbZsmWd+mzXrp1Tm86dOzttZ+TIkcYdd9xhTl9trD/44AOjbNmyTp/tGTNmGJKMn3/+2Wzfpk0bpz7++OMPQ5Kxd+9ewzDO79d7773XMAzD+CXpF2Pn0Z2Gr5+v0aVLF3OdpKQkQ5IRHx9/2fdcuXJlY/LkyU7zLv38/vzzz4YkIzEx8bL95Pcze0FBcxxHrgEAAABc1pkzZ7R//3716tVLAQEB5uuNN97Q/v37ndo2btw4z/pRUVF5rrPeunWr2rdvr0qVKqlkyZJq3ry5pPPXxl6On5+fqlevbk6XL1/e6dTr6Ohode3aVfXr11fz5s21aNEiBQcH64MPPijU+75Y06ZNna7fjo6O1r59+5Sbm1uo97N79241adLEaV50dLTT9C+//KLRo0c77fM+ffooKSnJPJK7atUqtWrVShUrVlTJkiXVpUsX/fXXX+byvXv36q677nLq99LpixVkrHfv3q169eo5XaOeX+0//PCDUx+1a9eWJKfPTL169cx/e3h4qFTpUuYp3JLM0/qvdop9UcENzQAAAABc1oVreGfNmpUnEHp4eDhN+/v751n/0nlnzpxRTEyMYmJiNG/ePAUHB+vw4cOKiYlRVlbWZeu49OZoNpvN6brn/No3aNBAv//+uySZN0g7fvy4002tjh8/bunxUYV9P1dz+vRpjRo1So899lieZT4+Pjp48KAeeugh9evXT2PHjlWZMmX0n//8R7169VJWVpb8/PwKtU2pYGN9tX7at2+vt956K8+yi/d9fmN68bwLX2g4HAW/MZ8rEa4BAAAAXFZoaKgqVKigAwcOqHPnzpb727Nnj/766y+NHz/evPZ1y5br/xzu3Nxc7dy503wkU9WqVRUWFqbVq1ebYTo9PV0bN25Uv379rtjXxo0bnaZ/+ukn1axZUx4eHoV6P3Xq1Mm3z4s1bNhQe/fuVY0aNfLtY+vWrXI4HHrnnXdkt58/IfmLL75walOrVi1t3rzZad6l0xcryFjXqVNHc+fOVUZGhnn0Or/av/rqK1WpUkUlStzYyOnl5WWeQeBqnBYOAAAA4IpGjRqlcePGaerUqfrtt9+0c+dOzZ49W5MmTbrmvipVqiQvLy+99957OnDggL755huNGTPGco2jR4/W999/rwMHDmjbtm36xz/+oUOHDql3796Szh8FjY2N1RtvvKFvvvlGO3fuVNeuXVWhQgV16NDB7KdVq1aaNm2aU9+HDx/WkCFDtHfvXv3f//2f3nvvPQ0aNKjQ7+eFF17Q8uXLNXHiRO3bt0/Tpk3T8uXLndqMGDFCn376qUaNGqVdu3Zp9+7d+vzzz/Xqq69KkmrUqKHs7Gxzu3PnztXMmTOd+hg4cKC+++47TZo0Sfv27dMHH3ygZcuWXfGZ5lcb62eeeUY2m019+vRRQkKCvvvuO02cONGpj/79++vvv//W008/rc2bN2v//v1asWKFevToYTkI165dW19//bU5XaVKFa1fv15Hjx51uhu5K3DkGgAAALiJkk4nKXxS+E3ZzvXSu3dv+fn56e2339bQoUPl7++vqKgoxcbGXnNfwcHBiouL0z//+U9NnTpVDRs21MSJE/Xwww9bqvHkyZPq06ePkpOTVbp0aTVq1Eg//vijIiMjzTbDhg3TmTNn9Oyzzyo1NVX33nuvli9f7nT98P79+/OEtK5du+rcuXO666675OHhoUGDBunZZ58t9Ptp2rSpZs2apZEjR2rEiBFq3bq1Xn31VadQHhMTo2+//VajR4/WW2+9JU9PT9WuXdv8suCOO+7QpEmT9NZbb2n48OFq1qyZxo0bp65du5p93HPPPZo5c6ZGjRqlV199VTExMRo8eHCeLw8udrWxDggI0JIlS9S3b181aNBAkZGReuutt9SxY0ezjwoVKmjDhg16+eWX1aZNG2VmZqpy5cpq27ateZS9sPbu3au0tDRzevTo0XruuedUvXp1ZWZmXvFSgRvNZrhy6xcZP368hg8frkGDBmnKlCmSpIyMDL344ov6/PPPlZmZqZiYGL3//vtOz6s7fPiw+vXrZ14w361bN40bN87p9IO1a9dqyJAh2rVrlyIiIvTqq6/muTX+9OnT9fbbbys5OVl33HGH3nvvPaeL/QtSy9Wkp6crKChIaWlpCgwMLNyOuoHCJ4Xr6Kmjqliyoo4MOeLqcvJwOBxKSUlRSEiI5R9KFC+Mvfti7N0XY+++bpWxz8jIUGJioqpWrWoGtwv/r3WzFdX/t7uUYRjKyclRiRIlrnhkFdb06dNHe/bs0b///W9Xl2LakbxDnjZPZRvZqhdW7+or3AD5/cxeUNAcVySOXG/evFkffPCB093iJGnw4MFaunSpFi5cqKCgIA0YMECPPfaYNmzYIOn8dRTt2rVTWFiYfvzxRyUlJalr167y9PTUm2++Ken88+zatWunvn37at68eVq9erV69+6t8uXLm8/eW7BggYYMGaKZM2eqSZMmmjJlimJiYrR3716FhIQUqBYAAADgSsICwtxquygaJk6cqPvvv1/+/v5atmyZ5syZo/fff9/VZd2arvigrpvg1KlTRs2aNY2VK1cazZs3NwYNGmQYhmGkpqYanp6exsKFC822u3fvdnrO2XfffWfY7XYjOTnZbDNjxgwjMDDQfJbesGHDjLp16zpts1OnTkZMTIw5fddddxn9+/c3p3Nzc40KFSoY48aNK3AtBcFzrq25VZ57iWvH2Lsvxt59Mfbu61YZ+ys9Mxf5czgcRlZWltPzpGHdE088YQQHBxs+Pj5GZGSkMWPGDFeXlMcvSb8YCckJxi9Jv7ishuvxnGuXH7nu37+/2rVrp9atW+uNN94w52/dulXZ2dlq3bq1Oa927dqqVKmS4uPj1bRpU8XHxysqKsrp1OyYmBj169dPu3btUoMGDRQfH+/Ux4U2F64ZyMrK0tatWzV8+HBzud1uV+vWrRUfH1/gWvKTmZmpzMxMczo9PV3S+dOdiuLt5O0X/SmK9TkcDhmGUSRrw43F2Lsvxt59Mfbu61YZ+wvv48ILBXNhX7HPrp8FCxbkmVeU96+rarvws5pfVivo7yOXhuvPP/9c27Zty/d28MnJyfLy8lKpUqWc5oeGhio5Odlsc+k1zxemr9YmPT1d586d08mTJ5Wbm5tvmz179hS4lvyMGzdOo0aNyjP/xIkTysjIuOx6rhLpF6kwW5jK+JYpkg9qdzgcSktLk2EYxfoaLFw7xt59Mfbui7F3X7fK2GdnZ8vhcCgnJ0c5OTmuLqdYMAzDvJM011y7F1+7rzxsHiphlHDZz0tOTo4cDof++uuvPM/fPnXqVIH6cFm4/uOPPzRo0CCtXLkyzwXjt4rhw4dryJAh5nR6eroiIiIUHBxcJG9olnA24fwNzYyK5rXmRYnD4ZDNZlNwcHCx/o8trh1j774Ye/fF2LuvW2XsMzIydOrUKZUoUeKGP+f3VnNpsMGt75zjnHlDM1f9vJQoUUJ2u11ly5bNk08Lmldd9pO+detWpaSkqGHDhua83NxcrV+/XtOmTdOKFSuUlZWl1NRUpyPGx48fV1jY+ZsyhIWFadOmTU79Hj9+3Fx24e8L8y5uExgYKF9fX3l4eMjDwyPfNhf3cbVa8uPt7S1vb+888+12e5H8j4Xjoj9FsT7p/LeYRXX/4cZi7N0XY+++GHv3dSuMvd1ul81mM1+4OsMwzH3FPnNfrhr7Cz+r+f3uKejvIpf9xmrVqpV27typ7du3m6/GjRurc+fO5r89PT21evVqc529e/fq8OHDio6OliRFR0dr586dTqcwr1y5UoGBgebz7KKjo536uNDmQh9eXl5q1KiRUxuHw6HVq1ebbRo1anTVWgAAAAAA7stlR65Lliyp22+/3Wmev7+/ypYta87v1auXhgwZojJlyigwMFADBw5UdHS0eQOxNm3aKDIyUl26dNGECROUnJysV199Vf379zePGPft21fTpk3TsGHD1LNnT61Zs0ZffPGFli5dam53yJAh6tatmxo3bqy77rpLU6ZM0ZkzZ9SjRw9JUlBQ0FVrAQAAAAC4ryJ9AcjkyZNlt9vVsWNHZWZmKiYmxumZbB4eHvr222/Vr18/RUdHy9/fX926ddPo0aPNNlWrVtXSpUs1ePBgvfvuuwoPD9dHH31kPuNakjp16qQTJ05oxIgRSk5OVv369bV8+XKnm5xdrRYAAAAAgPuyGUX5Puy3mPT0dAUFBSktLa1I3tAsfFL4+RualayoI0OOuLqcPBwOh1JSUhQSElKsr8HCtWPs3Rdj774Ye/d1q4x9RkaGEhMTVbVq1f/eDGl5Y+nc5Z80c8P4hkltt9z87V4jwzCUk5OjEiVKaN26dWrZsqVOnjyZ54k9RUGLFi1Uv359TZkyxdWlFMrixYv10ksvKTExUQMHDrT0PtauXZtnrK61/x3JO8wbmtULq1foWqzI92f2/ytojiu+v7EAAACA4uRcsnTuqAteBQv0F9+ALb/X66+/fmP3z0XuvvtuJSUlKSgoqMDrxMXF5an50pBkGIZGjBih8uXLy9fXV61bt9a+ffss11ulSpUbHrSzs7P18ssvKyoqSv7+/qpQoYK6du2qY8eOObX7+++/1blzZwUGBqpUqVLq1auXTp8+7dTmueee0+OPP64//vhDY8aMUffu3dWhQ4er1tCiRQvFxsY6zctvrC7t310U6dPCAQAAgFuOzS75lL/x28lIkgxHgZsnJSWZ/16wYIFGjBihvXv3mvMCAgKuafPZ2dl5HquVlZUlLy+vq67r5eV1xafyXE5gYKBTzZfeeXrChAmaOnWq5syZo6pVq+q1115TTEyMEhISivzjgc+ePatt27bptdde0x133KGTJ09q0KBBevjhh7Vly3/PTOjcubOSkpK0cuVKZWdnq0ePHnr22Wc1f/58SdLp06eVkpKimJgYVahQwXJdl47V9e6/WDFw06SlpRmSjLS0NFeXkq+K71Q09LqMiu9UdHUp+crNzTWSkpKM3NxcV5eCm4yxd1+Mvfti7N3XrTL2586dMxISEoxz5879d+aiioYxT+f/vhksbG/27NlGUFCQ07xZs2YZtWvXNry9vY1atWoZ06dPN5clJiYakozPP//caNasmeHt7W3Mnj3b6Natm/HII48Yb7zxhlG+fHmjSpUqhmEYxqeffmo0atTICAgIMEJDQ42nn37aSE5ONrKysgyHw2H88MMPhiTj5MmTTvUsX77cqF27tuHv72/ExMQYx44du2LNF3M4HEZYWJjx9ttvm/NSU1MNb29v4//+7/8uu97p06eNLl26GP7+/kZYWJgxceJEo3nz5sagQYMMwzCM5s2bG5KcXhfXs2TJEuO2224zfH19jY4dOxpnzpwx4uLijMqVKxulSpUyBg4caOTk5BRkWPLYtGmTIck4dOiQYRiGkZCQYEgyNm/ebLZZtmyZYbPZjKNHj5r79eJXfvX/8MMPebbVrVu3PO0SExOdxiq//vPr61K/JP1iJCQnGL8k/VKo/XA95Psz+/8VNMdxWjgAAACAK5o3b55GjBihsWPHavfu3XrzzTf12muvac6cOU7tXnnlFQ0aNEi7d+82byC8evVq7d27VytXrtS3334r6fxR7TFjxuiXX37R4sWLdfDgQfNJPZdz9uxZTZw4UXPnztX69et1+PBhvfTSS05tTp8+rcqVKysiIkKPPPKIdu3aZS5LTExUcnKyWrdubc4LCgpSkyZNFB8ff9ntDh06VOvWrdO//vUvff/991q7dq22bdtmLl+0aJHCw8M1evRoJSUlOZ0BcPbsWU2dOlWff/65li9frrVr1+rRRx/Vd999p++++05z587VBx98oC+//PKK7/1y0tLSZLPZzGud4+PjVapUKTVu3Nhs07p1a9ntdm3cuFF33323eWT/q6++UlJSkr755hs9+eSTatu2rVn/3XffnWdb7777rqKjo9WnTx+zXUREhFOb/PrPr69bFaeFAwAAALiikSNH6p133tFjjz0m6fwTeRISEvTBBx+oW7duZrvY2FizzQX+/v766KOPnE4H79mzp/nvatWqaerUqbrzzjt1+vTpy97ALDs7WzNnzlT16tUlSQMGDHB6SlCtWrX0ySefqF69ekpLS9PEiRN19913a9euXQoPD1dy8vlrzy9+ItCF6QvLLnX69Gl9/PHH+uyzz9SqVStJ0pw5cxQeHm62KVOmjDw8PFSyZMk8p7JnZ2drxowZZs2PP/645s6dq+PHjysgIECRkZFq2bKlfvjhB3Xq1CnfGi4nIyNDL7/8sp5++mnzJlvJyckKCQlxaleiRAmVKVNGycnJ8vLyMpeXKVPGrNfX11eZmZlXPBU/KChIXl5e8vPzu2y7y/XvLgjXAAAAAC7rzJkz2r9/v3r16qU+ffqY83NycvLccOziI6YXREVF5bnOeuvWrXr99df1yy+/6OTJk3I4zl8bfvjw4cuGaz8/PzOkSlL58uWVkpJiTkdHRys6Otqcvvvuu1WnTh198MEHhb6p1v79+5WVlaUmTZqY88qUKaNatWoVaP1Law4NDVWVKlWcrl8PDQ11eh8FkZ2drSeffFKGYWjGjBnXtC5uHMI1AAAAgMu6cKfpWbNmOYVMSfLw8HCa9vf3z7P+pfPOnDmjmJgYxcTEaN68eQoODtbhw4cVExOjrKysy9Zx6c3RbDabjCs8VdjT01MNGjTQ77//LknmUdTjx4+rfPn/3lDu+PHjql+//mX7sSK/mvObd+HLhYK4EKwPHTqkNWvWOD0aKiwsLE9Qz8nJ0d9//+12R5FdgWuuAQAAAFxWaGioKlSooAMHDqhGjRpOr6pVq15zf3v27NFff/2l8ePH63/+539Uu3btaz5yWxC5ubnauXOnGaSrVq2qsLAwrV692myTnp6ujRs3Oh3xvlj16tXl6empjRs3mvNOnjyp3377zamdl5eXcnNzr/t7uNSFYL1v3z6tWrVKZcuWdVoeHR2t1NRUbd261Zy3Zs0aORyOPF+MXKyg9d+s91lcEa4BAAAAXNGoUaM0btw4TZ06Vb/99pt27typ2bNna9KkSdfcV6VKleTl5aX33ntPBw4c0DfffHNdnoU8evRoff/99zpw4IC2bdumf/zjHzp06JB69+4t6fwR4tjYWL3xxhv65ptvtHPnTnXt2lUVKlRwesZzq1atNG3aNEnnHz/Wq1cvDR06VGvWrNGvv/6q7t27y253jlFVqlTR+vXrdfToUf3555+W30t+srOz9fjjj2vLli2aN2+ecnNzlZycrOTkZPOIf506ddS2bVv16dNHmzZt0oYNGzRgwAA99dRTV3wsVpUqVbRjxw7t3btXf/75p7Kzs/PsiwvtNm7cqIMHD+rPP/+8piPu7oDTwgEAAICbKSNJ+jr86u2ux3auk969e8vPz09vv/22hg4dKn9/f0VFRSk2Nvaa+woODlZcXJz++c9/aurUqWrYsKEmTpyohx9+2FKNJ0+eVJ8+fZScnKzSpUurUaNG+vHHHxUZGWm2GTZsmM6cOaNnn31Wqampuvfee7V8+XKnZ1zv37/fKSC//fbbOn36tNq3b6+SJUvqxRdfVFpamtO2R48ereeee07Vq1dXZmbmFU9XL6yjR4/qm2++kaQ8p7H/8MMPatGihaTzd3YfMGCAWrVqJbvdro4dO2rq1KlX7LtPnz5au3atGjdurNOnT5v9XbovXnrpJXXr1k2RkZE6d+6cEhMTr+t7LO5sxo0YeeQrPT1dQUFBSktLc7o2oqgInxSuo6eOqmLJijoy5Iiry8nD4XAoJSVFISEheb4txK2NsXdfjL37Yuzd160y9hkZGUpMTFTVqlX/G9y+DpfOHb35xfhWlB4tev9vdynDMJSTk6MSJUrIZrO5uhzcRDuSd8jT5qlsI1v1wuq5pIZ8f2b/v4LmOI5cAwAAADeDr4tuKOWq7QJuhnANAAAA3Axtt7i6AhRh//73v/XAAw9cdvmFu7aj6CJcAwAAAICLNW7cWNu3b3d1GbCAcA0AAAAALubr66saNWq4ugxYUHzvEgEAAAAAQBFBuAYAAABuEB7MAxQP1+OZ3ZwWDgAAAFxnnp6estlsOnHihIKDg3m0VAHwKC73ZWQbctgcMgxDGRkZN3fbhqGsrCydOHFCdrtdXl5ehe6LcA0AAABcZx4eHgoPD9eRI0d08OBBV5dTLBiGIYfDIbvdTrh2MynpKfKQh3KVK6/ThQ+3Vvj5+alSpUqy2wt/cjfhGgAAALgBAgICVLNmTWVnZ7u6lGLB4XDor7/+UtmyZS0FHBQ/PWf3VDlbOf1p/Kkfevxw07fv4eFxXc6YIFwDAAAAN4iHh4c8PDxcXUax4HA45OnpKR8fH8K1mzl67qhybblKNpLl4+Pj6nIKjU8tAAAAAAAWEa4BAAAAALCIcA0AAAAAgEWEawAAAAAALCJcAwAAAABgEeEaAAAAAACLCNcAAAAAAFhEuAYAAAAAwCLCNQAAAAAAFhGuAQAAAACwiHANAAAAAIBFhGsAAAAAACwiXAMAAAAAYBHhGgAAAAAAiwjXAAAAAABYRLgGAAAAAMAiwjUAAAAAABYRrgEAAAAAsIhwDQAAAACARYRrAAAAAAAsIlwDAAAAAGAR4RoAAAAAAItKuLoAAACuVWP/BCVnlHZ1GbiB7HZDkQ1TlbDNIYfD5upycBMx9u7rwtj/lfCXNp+q6+pygGtGuAYAFDvJGaV11FHe1WXgBrLLoTDDrqOOEDkcnGjnThh793Vh7I9nOFxdClAohGsAQLFlV67K21NcXQZuALvdUBlbqiraHXKIo5fuhLF3X8dVztUlAJYQrgEAxVZ5e4qO5HIE+1bkcDiUkmJXSEiI7HaOXroTxt59VfI8Jm4JheKMTy8AAAAAABYRrgEAAAAAsIhwDQAAAACARYRrAAAAAAAsIlwDAAAAAGAR4RoAAAAAAIsI1wAAAAAAWES4BgAAAADAIsI1AAAAAAAWEa4BAAAAALCIcA0AAAAAgEWEawAAAAAALCrh6gIAALhWS0e1VdlSf8lDDulrvie+NdklRUpKkORwcS24uRh7l/ENk9pucXUVQLFFuAYAFDshpU6ofJmk8xPnXFsLbhS75BEm5R4VAcvdMPYAiifCNQCg2Mp12OXhX97VZeCGsEsqI6miCFjuhrG/6TKSJIN9DVhFuAYAFFspqaEq/48jri4DN4LDIaWkSCEhkp1T/90KY3/zfR0unTvq6iqAYo/fWAAAAAAAWES4BgAAAADAIsI1AAAAAAAWEa4BAAAAALCIcA0AAAAAgEWEawAAAAAALCJcAwAAAABgEeEaAAAAAACLCNcAAAAAAFhEuAYAAAAAwCLCNQAAAAAAFhGuAQAAAACwiHANAAAAAIBFhGsAAAAAACwiXAMAAAAAYBHhGgAAAAAAiwjXAAAAAABYRLgGAAAAAMAiwjUAAAAAABYRrgEAAAAAsIhwDQAAAACARYRrAAAAAAAsIlwDAAAAAGAR4RoAAAAAAIsI1wAAAAAAWES4BgAAAADAIsI1AAAAAAAWEa4BAAAAALCIcA0AAAAAgEWEawAAAAAALCJcAwAAAABgEeEaAAAAAACLCNcAAAAAAFhEuAYAAAAAwCLCNQAAAAAAFhGuAQAAAACwiHANAAAAAIBFhGsAAAAAACwiXAMAAAAAYBHhGgAAAAAAiwjXAAAAAABYRLgGAAAAAMAiwjUAAAAAABYRrgEAAAAAsIhwDQAAAACARYRrAAAAAAAsIlwDAAAAAGAR4RoAAAAAAIsI1wAAAAAAWES4BgAAAADAIsI1AAAAAAAWEa4BAAAAALCIcA0AAAAAgEUuDdczZsxQvXr1FBgYqMDAQEVHR2vZsmXm8hYtWshmszm9+vbt69TH4cOH1a5dO/n5+SkkJERDhw5VTk6OU5u1a9eqYcOG8vb2Vo0aNRQXF5enlunTp6tKlSry8fFRkyZNtGnTJqflGRkZ6t+/v8qWLauAgAB17NhRx48fv347AwAAAABQbLk0XIeHh2v8+PHaunWrtmzZovvuu0+PPPKIdu3aZbbp06ePkpKSzNeECRPMZbm5uWrXrp2ysrL0448/as6cOYqLi9OIESPMNomJiWrXrp1atmyp7du3KzY2Vr1799aKFSvMNgsWLNCQIUM0cuRIbdu2TXfccYdiYmKUkpJithk8eLCWLFmihQsXat26dTp27Jgee+yxG7yHAAAAAADFgUvDdfv27fXggw+qZs2auu222zR27FgFBATop59+Mtv4+fkpLCzMfAUGBprLvv/+eyUkJOizzz5T/fr19cADD2jMmDGaPn26srKyJEkzZ85U1apV9c4776hOnToaMGCAHn/8cU2ePNnsZ9KkSerTp4969OihyMhIzZw5U35+fvrkk08kSWlpafr44481adIk3XfffWrUqJFmz56tH3/80alWAAAAAIB7KuHqAi7Izc3VwoULdebMGUVHR5vz582bp88++0xhYWFq3769XnvtNfn5+UmS4uPjFRUVpdDQULN9TEyM+vXrp127dqlBgwaKj49X69atnbYVExOj2NhYSVJWVpa2bt2q4cOHm8vtdrtat26t+Ph4SdLWrVuVnZ3t1E/t2rVVqVIlxcfHq2nTpvm+p8zMTGVmZprT6enpkiSHwyGHw1GY3XRD2S/6UxTrczgcMgyjSNaGG4uxd1+XG3tDdjlkP/83n4tbEj/37ouxdwX7f18u3O92uyGbzZDdzvi7G7vssslWpHNIQbg8XO/cuVPR0dHKyMhQQECAvv76a0VGRkqSnnnmGVWuXFkVKlTQjh079PLLL2vv3r1atGiRJCk5OdkpWEsyp5OTk6/YJj09XefOndPJkyeVm5ubb5s9e/aYfXh5ealUqVJ52lzYTn7GjRunUaNG5Zl/4sQJZWRkXG3X3HSRfpEKs4WpjG8Zp1PiiwqHw6G0tDQZhiG7nXvxuRPG3n1dbuxTferK7lFBqT6lZS+Cv69gHT/37ouxd4VIySNMUhnJhb9TIxukqXR1m8raDKWkeLisDtx8kX6RKm0rrbJG2SKZQ06dOlWgdi4P17Vq1dL27duVlpamL7/8Ut26ddO6desUGRmpZ5991mwXFRWl8uXLq1WrVtq/f7+qV6/uwqoLZvjw4RoyZIg5nZ6eroiICAUHBzud3l5UJJxN0NFTR1XRqKiQkBBXl5OHw+GQzWZTcHAw/7F1M4y9+7rc2DsydinEL0mOjPJF8vcVrOPn3n0x9q6QIOUelVRRcuHv1ISfcxVq2HV8u4Pf7W4m4WyCQm2hOm4cL5Jj7+PjU6B2Lg/XXl5eqlGjhiSpUaNG2rx5s95991198MEHedo2adJEkvT777+revXqCgsLy3NX7wt38A4LCzP/vvSu3sePH1dgYKB8fX3l4eEhDw+PfNtc3EdWVpZSU1Odjl5f3CY/3t7e8vb2zjPfbrcXyf9YOC76UxTrkySbzVZk9x9uLMbefeU39jY5ZJfj/N98Jm5Z/Ny7L8b+ZnP89+XCfe5w2GQYNjkcNsbezTjkkCGjyOaQgtZU5Cp3OBxO1ylfbPv27ZKk8uXLS5Kio6O1c+dOp1MHVq5cqcDAQPPU8ujoaK1evdqpn5UrV5rXdXt5ealRo0ZObRwOh1avXm22adSokTw9PZ3a7N27V4cPH3a6PhwAAAAA4J5ceuR6+PDheuCBB1SpUiWdOnVK8+fP19q1a7VixQrt379f8+fP14MPPqiyZctqx44dGjx4sJo1a6Z69epJktq0aaPIyEh16dJFEyZMUHJysl599VX179/fPGLct29fTZs2TcOGDVPPnj21Zs0affHFF1q6dKlZx5AhQ9StWzc1btxYd911l6ZMmaIzZ86oR48ekqSgoCD16tVLQ4YMUZkyZRQYGKiBAwcqOjr6sjczAwAAAAC4D5eG65SUFHXt2lVJSUkKCgpSvXr1tGLFCt1///36448/tGrVKjPoRkREqGPHjnr11VfN9T08PPTtt9+qX79+io6Olr+/v7p166bRo0ebbapWraqlS5dq8ODBevfddxUeHq6PPvpIMTExZptOnTrpxIkTGjFihJKTk1W/fn0tX77c6SZnkydPlt1uV8eOHZWZmamYmBi9//77N2dHAQAAAACKNJeG648//viyyyIiIrRu3bqr9lG5cmV99913V2zTokUL/fzzz1dsM2DAAA0YMOCyy318fDR9+nRNnz79qjUBAAAAANxLkbvmGgAAAACA4oZwDQAAAACARYRrAAAAAAAsIlwDAAAAAGAR4RoAAAAAAIsI1wAAAAAAWES4BgAAAADAIsI1AAAAAAAWEa4BAAAAALCIcA0AAAAAgEWEawAAAAAALCJcAwAAAABgEeEaAAAAAACLCNcAAAAAAFhEuAYAAAAAwCLCNQAAAAAAFhGuAQAAAACwiHANAAAAAIBFhGsAAAAAACwiXAMAAAAAYBHhGgAAAAAAiwjXAAAAAABYRLgGAAAAAMAiwjUAAAAAABYRrgEAAAAAsIhwDQAAAACARYRrAAAAAAAsIlwDAAAAAGAR4RoAAAAAAIsI1wAAAAAAWES4BgAAAADAIsI1AAAAAAAWEa4BAAAAALCIcA0AAAAAgEWEawAAAAAALCJcAwAAAABgEeEaAAAAAACLCNcAAAAAAFhEuAYAAAAAwCLCNQAAAAAAFhGuAQAAAACwiHANAAAAAIBFhGsAAAAAACwiXAMAAAAAYBHhGgAAAAAAiwjXAAAAAABYRLgGAAAAAMAiwjUAAAAAABYRrgEAAAAAsIhwDQAAAACARYRrAAAAAAAsIlwDAAAAAGAR4RoAAAAAAIsI1wAAAAAAWES4BgAAAADAIsI1AAAAAAAWEa4BAAAAALCIcA0AAAAAgEWEawAAAAAALCJcAwAAAABgEeEaAAAAAACLCNcAAAAAAFhEuAYAAAAAwCLCNQAAAAAAFhGuAQAAAACwiHANAAAAAIBFhGsAAAAAACwiXAMAAAAAYBHhGgAAAAAAiwjXAAAAAABYRLgGAAAAAMAiwjUAAAAAABYRrgEAAAAAsIhwDQAAAACARYRrAAAAAAAsIlwDAAAAAGAR4RoAAAAAAIsI1wAAAAAAWES4BgAAAADAIsI1AAAAAAAWEa4BAAAAALCIcA0AAAAAgEWEawAAAAAALCJcAwAAAABgEeEaAAAAAACLCNcAAAAAAFhEuAYAAAAAwCLCNQAAAAAAFhGuAQAAAACwiHANAAAAAIBFhGsAAAAAACwiXAMAAAAAYBHhGgAAAAAAiwjXAAAAAABYRLgGAAAAAMAiwjUAAAAAABYRrgEAAAAAsIhwDQAAAACARYRrAAAAAAAsIlwDAAAAAGAR4RoAAAAAAIsI1wAAAAAAWES4BgAAAADAIsI1AAAAAAAWEa4BAAAAALCIcA0AAAAAgEWEawAAAAAALCJcAwAAAABgEeEaAAAAAACLCNcAAAAAAFhEuAYAAAAAwCLCNQAAAAAAFhGuAQAAAACwiHANAAAAAIBFhGsAAAAAACwiXAMAAAAAYJFLw/WMGTNUr149BQYGKjAwUNHR0Vq2bJm5PCMjQ/3791fZsmUVEBCgjh076vjx4059HD58WO3atZOfn59CQkI0dOhQ5eTkOLVZu3atGjZsKG9vb9WoUUNxcXF5apk+fbqqVKkiHx8fNWnSRJs2bXJaXpBaAAAAAADuyaXhOjw8XOPHj9fWrVu1ZcsW3XfffXrkkUe0a9cuSdLgwYO1ZMkSLVy4UOvWrdOxY8f02GOPmevn5uaqXbt2ysrK0o8//qg5c+YoLi5OI0aMMNskJiaqXbt2atmypbZv367Y2Fj17t1bK1asMNssWLBAQ4YM0ciRI7Vt2zbdcccdiomJUUpKitnmarUAAAAAANyXS8N1+/bt9eCDD6pmzZq67bbbNHbsWAUEBOinn35SWlqaPv74Y02aNEn33XefGjVqpNmzZ+vHH3/UTz/9JEn6/vvvlZCQoM8++0z169fXAw88oDFjxmj69OnKysqSJM2cOVNVq1bVO++8ozp16mjAgAF6/PHHNXnyZLOOSZMmqU+fPurRo4ciIyM1c+ZM+fn56ZNPPpGkAtUCAAAAAHBfJVxdwAW5ublauHChzpw5o+joaG3dulXZ2dlq3bq12aZ27dqqVKmS4uPj1bRpU8XHxysqKkqhoaFmm5iYGPXr10+7du1SgwYNFB8f79THhTaxsbGSpKysLG3dulXDhw83l9vtdrVu3Vrx8fGSVKBa8pOZmanMzExzOj09XZLkcDjkcDgKuaduHPtFf4pifQ6HQ4ZhFMnacGMx9u7rcmNvyC6H7Of/5nNxS+Ln3n0x9q5g/+/Lhfvdbjdksxmy2xl/d2OXXTbZinQOKQiXh+udO3cqOjpaGRkZCggI0Ndff63IyEht375dXl5eKlWqlFP70NBQJScnS5KSk5OdgvWF5ReWXalNenq6zp07p5MnTyo3NzffNnv27DH7uFot+Rk3bpxGjRqVZ/6JEyeUkZFx2fVcJdIvUmG2MJXxLeN0SnxR4XA4lJaWJsMwZLdzLz53wti7r8uNfapPXdk9KijVp7TsRfD3Fazj5959MfauECl5hEkqI7nwd2pkgzSVrm5TWZuhlBQPl9WBmy/SL1KlbaVV1ihbJHPIqVOnCtTO5eG6Vq1a2r59u9LS0vTll1+qW7duWrdunavLui6GDx+uIUOGmNPp6emKiIhQcHCwAgMDXVhZ/hLOJujoqaOqaFRUSEiIq8vJw+FwyGazKTg4mP/YuhnG3n1dbuwdGbsU4pckR0b5Ivn7Ctbxc+++GHtXSJByj0qqKLnwd2rCz7kKNew6vt3B73Y3k3A2QaG2UB03jhfJsffx8SlQu0KF6wunN1/KZrPJ29tbXl5eBe7Ly8tLNWrUkCQ1atRImzdv1rvvvqtOnTopKytLqampTkeMjx8/rrCwMElSWFhYnrt6X7iD98VtLr2r9/HjxxUYGChfX195eHjIw8Mj3zYX93G1WvLj7e0tb2/vPPPtdnuR/I+F46I/RbE+6fxnrKjuP9xYjL37ym/sbXLILsf5v/lM3LL4uXdfjP3N5vjvy4X73OGwyTBscjhsjL2bccghQ0aRzSEFralQlZcqVUqlS5fO8ypVqpR8fX1VuXJljRw5slDnyzscDmVmZqpRo0by9PTU6tWrzWV79+7V4cOHFR0dLUmKjo7Wzp07nU4dWLlypQIDAxUZGWm2ubiPC20u9OHl5aVGjRo5tXE4HFq9erXZpiC1AAAAAADcV6GOXMfFxel///d/1b17d911112SpE2bNmnOnDl69dVXdeLECU2cOFHe3t765z//edl+hg8frgceeECVKlXSqVOnNH/+fK1du1YrVqxQUFCQevXqpSFDhqhMmTIKDAzUwIEDFR0dbd5ArE2bNoqMjFSXLl00YcIEJScn69VXX1X//v3NI8Z9+/bVtGnTNGzYMPXs2VNr1qzRF198oaVLl5p1DBkyRN26dVPjxo111113acqUKTpz5ox69OghSQWqBQAAAADgvgoVrufMmaN33nlHTz75pDmvffv2ioqK0gcffKDVq1erUqVKGjt27BXDdUpKirp27aqkpCQFBQWpXr16WrFihe6//35J0uTJk2W329WxY0dlZmYqJiZG77//vrm+h4eHvv32W/Xr10/R0dHy9/dXt27dNHr0aLNN1apVtXTpUg0ePFjvvvuuwsPD9dFHHykmJsZs06lTJ504cUIjRoxQcnKy6tevr+XLlzvd5OxqtQAAAAAA3JfNMAzjWlfy9fXVjh07VLNmTaf5+/bt0x133KGzZ88qMTFRdevW1dmzZ69bscVdenq6goKClJaWViRvaBY+Kfz8Dc1KVtSRIUdcXU4eDodDKSkpCgkJKZLXYuDGYezd1+XGPmlaBZUvk6Skv8ur/IBjLqwQNwo/9+6LsXeBr8Olc0cl34rSo677f8BKnscU1sCu5J8dOpxdwWV14OarNKmSwmxhSjaSdXjIYVeXk0dBc1yhfmNFRETo448/zjP/448/VkREhCTpr7/+UunSpQvTPQAAAAAAxUqhTgufOHGinnjiCS1btkx33nmnJGnLli3as2ePvvzyS0nS5s2b1alTp+tXKQAAAAAARVShwvXDDz+sPXv26IMPPtBvv/0mSXrggQe0ePFiValSRZLUr1+/61YkAAAAAABFWaHCtXT+RmHjx4+/nrUAAAAAAFAsFTpcp6amatOmTUpJScnzPOuuXbtaLgwAAAAAgOKiUOF6yZIl6ty5s06fPq3AwEDZbDZzmc1mI1wDAAAAANxKoe4W/uKLL6pnz546ffq0UlNTdfLkSfP1999/X+8aAQAAAAAo0goVro8ePaoXXnhBfn5+17seAAAAAACKnUKF65iYGG3ZsuV61wIAAAAAQLFUqGuu27Vrp6FDhyohIUFRUVHy9PR0Wv7www9fl+IAAAAAACgOChWu+/TpI0kaPXp0nmU2m025ubnWqgIAAAAAoBgpVLi+9NFbAAAAAAC4s0Jdcw0AAAAAAP6rwEeup06dqmeffVY+Pj6aOnXqFdu+8MILlgsDAAAAAKC4KHC4njx5sjp37iwfHx9Nnjz5su1sNhvhGgAAAADgVgocrhMTE/P9NwAAAAAA7o5rrgEAAAAAsKhQdwvPzc1VXFycVq9erZSUlDx3D1+zZs11KQ4AAAAAgOKgUOF60KBBiouLU7t27XT77bfLZrNd77oAAAAAACg2ChWuP//8c33xxRd68MEHr3c9AAAAAAAUO4W65trLy0s1atS43rUAAAAAAFAsFSpcv/jii3r33XdlGMb1rgcAAAAAgGKnwKeFP/bYY07Ta9as0bJly1S3bl15eno6LVu0aNH1qQ4AAAAAgGKgwOE6KCjIafrRRx+97sUAAAAAAFAcFThcz549+0bWAQAAAABAsVWoa67vu+8+paam5pmfnp6u++67z2pNAAAAAAAUK4UK12vXrlVWVlae+RkZGfr3v/9tuSgAAAAAAIqTa3rO9Y4dO8x/JyQkKDk52ZzOzc3V8uXLVbFixetXHQAAAAAAxcA1hev69evLZrPJZrPle/q3r6+v3nvvvetWHAAAAAAAxcE1hevExEQZhqFq1app06ZNCg4ONpd5eXkpJCREHh4e171IAAAAAACKsmsK15UrV1Z2dra6deumsmXLqnLlyjeqLgAAAAAAio1rvqGZp6envv766xtRCwAAAAAAxVKh7hb+yCOPaPHixde5FAAAAAAAiqdrOi38gpo1a2r06NHasGGDGjVqJH9/f6flL7zwwnUpDgAAAACA4qBQ4frjjz9WqVKltHXrVm3dutVpmc1mI1wDAAAAANxKocJ1YmLi9a4DAAAAAIBiq1DXXF/MMAwZhnE9agEAAAAAoFgqdLj+9NNPFRUVJV9fX/n6+qpevXqaO3fu9awNAAAAAIBioVCnhU+aNEmvvfaaBgwYoHvuuUeS9J///Ed9+/bVn3/+qcGDB1/XIgEAAAAAKMoKFa7fe+89zZgxQ127djXnPfzww6pbt65ef/11wjUAAAAAwK0U6rTwpKQk3X333Xnm33333UpKSrJcFAAAAAAAxUmhwnWNGjX0xRdf5Jm/YMEC1axZ03JRAAAAAAAUJ4U6LXzUqFHq1KmT1q9fb15zvWHDBq1evTrf0A0AAAAAwK2sUEeuO3bsqI0bN6ps2bJavHixFi9erHLlymnTpk169NFHr3eNAAAAAAAUaYU6ci1JjRo10rx5865nLQAAAAAAFEvXFK7tdrtsNtsV29hsNuXk5FgqCgAAAACA4uSawvXXX3992WXx8fGaOnWqHA6H5aIAAAAAAChOrilcP/LII3nm7d27V6+88oqWLFmizp07a/To0detOAAAAAAAioNC3dBMko4dO6Y+ffooKipKOTk52r59u+bMmaPKlStfz/oAAAAAACjyrjlcp6Wl6eWXX1aNGjW0a9curV69WkuWLNHtt99+I+oDAAAAAKDIu6bTwidMmKC33npLYWFh+r//+798TxMHAAAAAMDdXFO4fuWVV+Tr66saNWpozpw5mjNnTr7tFi1adF2KAwDgSkJKHVfStAquLgM3gCG7Un3qypGxSzZxs1R3wtjffCGljsvDLiUddehOjySX1XFcwQrTXy7bPmDVNYXrrl27XvVRXAAA3CwedofKl3Hd/wjixnHILrtHBYX4JclOwHIrjL3r5Mquo47yLtu+3c54o3i7pnAdFxd3g8oAAKDgTqaXcXUJuMHOH70sLUdGeY5euhnG3nX+Si2rinbXfWFptxsqY0uV4WNI4qwkFD/XFK4BACgKIv/5q6tLwA3mcDhkT0lRSEiI7PZCP9wExRBj7zrlJR151XXbdzgcSkmxKyQkxHVFABbwGwsAAAAAAIsI1wAAAAAAWES4BgAAAADAIsI1AAAAAAAWEa4BAAAAALCIcA0AAAAAgEWEawAAAAAALCJcAwAAAABgEeEaAAAAAACLCNcAAAAAAFhEuAYAAAAAwCLCNQAAAAAAFhGuAQAAAACwiHANAAAAAIBFhGsAAAAAACwiXAMAAAAAYBHhGgAAAAAAiwjXAAAAAABYRLgGAAAAAMAiwjUAAAAAABYRrgEAAAAAsIhwDQAAAACARYRrAAAAAAAsIlwDAAAAAGAR4RoAAAAAAIsI1wAAAAAAWES4BgAAAADAIsI1AAAAAAAWEa4BAAAAALCIcA0AAAAAgEWEawAAAAAALCJcAwAAAABgEeEaAAAAAACLCNcAAAAAAFhEuAYAAAAAwCLCNQAAAAAAFhGuAQAAAACwiHANAAAAAIBFhGsAAAAAACwiXAMAAAAAYBHhGgAAAAAAiwjXAAAAAABYRLgGAAAAAMAiwjUAAAAAABYRrgEAAAAAsIhwDQAAAACARYRrAAAAAAAsIlwDAAAAAGAR4RoAAAAAAIsI1wAAAAAAWES4BgAAAADAIsI1AAAAAAAWEa4BAAAAALCIcA0AAAAAgEWEawAAAAAALCJcAwAAAABgEeEaAAAAAACLCNcAAAAAAFhEuAYAAAAAwCLCNQAAAAAAFhGuAQAAAACwyKXhety4cbrzzjtVsmRJhYSEqEOHDtq7d69TmxYtWshmszm9+vbt69Tm8OHDateunfz8/BQSEqKhQ4cqJyfHqc3atWvVsGFDeXt7q0aNGoqLi8tTz/Tp01WlShX5+PioSZMm2rRpk9PyjIwM9e/fX2XLllVAQIA6duyo48ePX5+dAQAAAAAotlwartetW6f+/fvrp59+0sqVK5Wdna02bdrozJkzTu369OmjpKQk8zVhwgRzWW5urtq1a6esrCz9+OOPmjNnjuLi4jRixAizTWJiotq1a6eWLVtq+/btio2NVe/evbVixQqzzYIFCzRkyBCNHDlS27Zt0x133KGYmBilpKSYbQYPHqwlS5Zo4cKFWrdunY4dO6bHHnvsBu4hAAAAAEBxUMKVG1++fLnTdFxcnEJCQrR161Y1a9bMnO/n56ewsLB8+/j++++VkJCgVatWKTQ0VPXr19eYMWP08ssv6/XXX5eXl5dmzpypqlWr6p133pEk1alTR//5z380efJkxcTESJImTZqkPn36qEePHpKkmTNnaunSpfrkk0/0yiuvKC0tTR9//LHmz5+v++67T5I0e/Zs1alTRz/99JOaNm163fcPAAAAAKB4cGm4vlRaWpokqUyZMk7z582bp88++0xhYWFq3769XnvtNfn5+UmS4uPjFRUVpdDQULN9TEyM+vXrp127dqlBgwaKj49X69atnfqMiYlRbGysJCkrK0tbt27V8OHDzeV2u12tW7dWfHy8JGnr1q3Kzs526qd27dqqVKmS4uPj8w3XmZmZyszMNKfT09MlSQ6HQw6H45r3z41mv+hPUazP4XDIMIwiWRtuLMbefTH27ouxd1+Mvfti7N2XXXbZZCvSOaQgiky4djgcio2N1T333KPbb7/dnP/MM8+ocuXKqlChgnbs2KGXX35Ze/fu1aJFiyRJycnJTsFakjmdnJx8xTbp6ek6d+6cTp48qdzc3Hzb7Nmzx+zDy8tLpUqVytPmwnYuNW7cOI0aNSrP/BMnTigjI+Nqu+Smi/SLVJgtTGV8yzidDl9UOBwOpaWlyTAM2e3ci8+dMPbui7F3X4y9+2Ls3Rdj774i/SJV2lZaZY2yRTKHnDp1qkDtiky47t+/v3799Vf95z//cZr/7LPPmv+OiopS+fLl1apVK+3fv1/Vq1e/2WVek+HDh2vIkCHmdHp6uiIiIhQcHKzAwEAXVpa/hLMJOnrqqCoaFRUSEuLqcvJwOByy2WwKDg7mF66bYezdF2Pvvhh798XYuy/G3n0lnE1QqC1Ux43jRTKH+Pj4FKhdkQjXAwYM0Lfffqv169crPDz8im2bNGkiSfr9999VvXp1hYWF5bmr94U7eF+4TjssLCzPXb2PHz+uwMBA+fr6ysPDQx4eHvm2ubiPrKwspaamOh29vrjNpby9veXt7Z1nvt1uL5K/MBwX/SmK9UmSzWYrsvsPNxZj774Ye/fF2Lsvxt59MfbuySGHDBlFNocUtCaXVm4YhgYMGKCvv/5aa9asUdWqVa+6zvbt2yVJ5cuXlyRFR0dr586dTqcPrFy5UoGBgYqMjDTbrF692qmflStXKjo6WpLk5eWlRo0aObVxOBxavXq12aZRo0by9PR0arN3714dPnzYbAMAAAAAcE8uPXLdv39/zZ8/X//6179UsmRJ89rloKAg+fr6av/+/Zo/f74efPBBlS1bVjt27NDgwYPVrFkz1atXT5LUpk0bRUZGqkuXLpowYYKSk5P16quvqn///uZR4759+2ratGkaNmyYevbsqTVr1uiLL77Q0qVLzVqGDBmibt26qXHjxrrrrrs0ZcoUnTlzxrx7eFBQkHr16qUhQ4aoTJkyCgwM1MCBAxUdHc2dwgEAAADAzbk0XM+YMUOS1KJFC6f5s2fPVvfu3eXl5aVVq1aZQTciIkIdO3bUq6++arb18PDQt99+q379+ik6Olr+/v7q1q2bRo8ebbapWrWqli5dqsGDB+vdd99VeHi4PvroI/MxXJLUqVMnnThxQiNGjFBycrLq16+v5cuXO93kbPLkybLb7erYsaMyMzMVExOj999//wbtHQAAAABAcWEzDMNwdRHuIj09XUFBQUpLSyuSNzQLnxR+/oZmJSvqyJAjri4nD4fDoZSUFIWEhBTJazFw4zD27ouxd1+Mvfti7N0XY+++Kk2qpDBbmJKNZB0ectjV5eRR0BzHpxYAAAAAAIsI1wAAAAAAWES4BgAAAADAIsI1AAAAAAAWEa4BAAAAALCIcA0AAAAAgEWEawAAAAAALCJcAwAAAABgEeEaAAAAAACLCNcAAAAAAFhEuAYAAAAAwCLCNQAAAAAAFhGuAQAAAACwiHANAAAAAIBFhGsAAAAAACwiXAMAAAAAYBHhGgAAAAAAiwjXAAAAAABYRLgGAAAAAMAiwjUAAAAAABYRrgEAAAAAsIhwDQAAAACARYRrAAAAAAAsIlwDAAAAAGAR4RoAAAAAAIsI1wAAAAAAWES4BgAAAADAIsI1AAAAAAAWEa4BAAAAALCIcA0AAAAAgEWEawAAAAAALCJcAwAAAABgEeEaAAAAAACLCNcAAAAAAFhEuAYAAAAAwCLCNQAAAAAAFhGuAQAAAACwiHANAAAAAIBFhGsAAAAAACwiXAMAAAAAYBHhGgAAAAAAiwjXAAAAAABYRLgGAAAAAMAiwjUAAAAAABYRrgEAAAAAsIhwDQAAAACARYRrAAAAAAAsIlwDAAAAAGAR4RoAAAAAAIsI1wAAAAAAWES4BgAAAADAIsI1AAAAAAAWEa4BAAAAALCIcA0AAAAAgEWEawAAAAAALCJcAwAAAABgEeEaAAAAAACLCNcAAAAAAFhEuAYAAAAAwCLCNQAAAAAAFhGuAQAAAACwiHANAAAAAIBFhGsAAAAAACwiXAMAAAAAYBHhGgAAAAAAiwjXAAAAAABYRLgGAAAAAMAiwjUAAAAAABYRrgEAAAAAsIhwDQAAAACARYRrAAAAAAAsIlwDAAAAAGAR4RoAAAAAAIsI1wAAAAAAWES4BgAAAADAIsI1AAAAAAAWEa4BAAAAALCIcA0AAAAAgEWEawAAAAAALCJcAwAAAABgEeEaAAAAAACLCNcAAAAAAFhEuAYAAAAAwCLCNQAAAAAAFhGuAQAAAACwiHANAAAAAIBFhGsAAAAAACwiXAMAAAAAYBHhGgAAAAAAiwjXAAAAAABYRLgGAAAAAMAiwjUAAAAAABYRrgEAAAAAsIhwDQAAAACARYRrAAAAAAAsIlwDAAAAAGAR4RoAAAAAAIsI1wAAAAAAWES4BgAAAADAIsI1AAAAAAAWEa4BAAAAALCIcA0AAAAAgEWEawAAAAAALCJcAwAAAABgEeEaAAAAAACLCNcAAAAAAFhEuAYAAAAAwCLCNQAAAAAAFhGuAQAAAACwiHANAAAAAIBFhGsAAAAAACwiXAMAAAAAYBHhGgAAAAAAiwjXAAAAAABYRLgGAAAAAMAiwjUAAAAAABa5NFyPGzdOd955p0qWLKmQkBB16NBBe/fudWqTkZGh/v37q2zZsgoICFDHjh11/PhxpzaHDx9Wu3bt5Ofnp5CQEA0dOlQ5OTlObdauXauGDRvK29tbNWrUUFxcXJ56pk+fripVqsjHx0dNmjTRpk2brrkWAAAAAID7cWm4Xrdunfr376+ffvpJK1euVHZ2ttq0aaMzZ86YbQYPHqwlS5Zo4cKFWrdunY4dO6bHHnvMXJ6bm6t27dopKytLP/74o+bMmaO4uDiNGDHCbJOYmKh27dqpZcuW2r59u2JjY9W7d2+tWLHCbLNgwQINGTJEI0eO1LZt23THHXcoJiZGKSkpBa4FAAAAAOCebIZhGK4u4oITJ04oJCRE69atU7NmzZSWlqbg4GDNnz9fjz/+uCRpz549qlOnjuLj49W0aVMtW7ZMDz30kI4dO6bQ0FBJ0syZM/Xyyy/rxIkT8vLy0ssvv6ylS5fq119/Nbf11FNPKTU1VcuXL5ckNWnSRHfeeaemTZsmSXI4HIqIiNDAgQP1yiuvFKiWq0lPT1dQUJDS0tIUGBh4Xffd9RA+KVxHTx1VxZIVdWTIEVeXk4fD4VBKSopCQkJkt3NFgzth7N0XY+++GHv3xdi7L8befVWaVElhtjAlG8k6POSwq8vJo6A5rsRNrOmq0tLSJEllypSRJG3dulXZ2dlq3bq12aZ27dqqVKmSGWjj4+MVFRVlBmtJiomJUb9+/bRr1y41aNBA8fHxTn1caBMbGytJysrK0tatWzV8+HBzud1uV+vWrRUfH1/gWi6VmZmpzMxMczo9PV3S+V8cDoejUPvoRrJf9Kco1udwOGQYRpGsDTcWY+++GHv3xdi7L8befTH27ssuu2yyFekcUhBFJlw7HA7Fxsbqnnvu0e233y5JSk5OlpeXl0qVKuXUNjQ0VMnJyWabi4P1heUXll2pTXp6us6dO6eTJ08qNzc33zZ79uwpcC2XGjdunEaNGpVn/okTJ5SRkXG5XeEykX6RCrOFqYxvGafT4YsKh8OhtLQ0GYbBt5luhrF3X4y9+2Ls3Rdj774Ye/cV6Rep0rbSKmuULZI55NSpUwVqV2TCdf/+/fXrr7/qP//5j6tLuW6GDx+uIUOGmNPp6emKiIhQcHBwkTwtPOFswvnTwo2KCgkJcXU5eTgcDtlsNgUHB/ML180w9u6LsXdfjL37YuzdF2PvvhLOJijUFqrjxvEimUN8fHwK1K5IhOsBAwbo22+/1fr16xUeHm7ODwsLU1ZWllJTU52OGB8/flxhYWFmm0vv6n3hDt4Xt7n0rt7Hjx9XYGCgfH195eHhIQ8Pj3zbXNzH1Wq5lLe3t7y9vf9fe/ceHFV5/3H8swm5iSRAEZJACIk2ETABhIKRqjimJKAMzFDFynAXJYRWCihoa5BaG0EEhQK2IqFYhELlUi4DRa4jImgINQSICAFECRE7SCAlYvb5/cGw4/4CJOHJ5sJ5v5gdyNnnnP0+fPMEPnvO7pbb7ufnVyd/YLh/9Ksu1idJLperzv79wbfovXPRe+ei985F752L3juTW24ZmTqbQypbU61WbozRmDFjtHLlSm3ZskUxMTFe93fu3FkBAQHavHmzZ1t+fr5OnDihpKQkSVJSUpJyc3O9Lh/YtGmTQkND1a5dO8+YHx/jypgrxwgMDFTnzp29xrjdbm3evNkzpjK1AAAAAACcqVbPXKenp+u9997T6tWr1ahRI89rl8PCwhQSEqKwsDCNGDFC48aNU9OmTRUaGqpf//rXSkpK8ryBWM+ePdWuXTsNGjRI06ZNU2FhoX7/+98rPT3dc9Z41KhR+vOf/6znnntOw4cP15YtW7Rs2TKtW7fOU8u4ceM0ZMgQdenSRV27dtUbb7yhCxcuaNiwYZ6aKqoFAAAAAOBMtRqu582bJ0nq0aOH1/asrCwNHTpUkjRz5kz5+fmpf//+Ki0tVUpKiubOnesZ6+/vr7Vr1yotLU1JSUlq2LChhgwZoj/84Q+eMTExMVq3bp1++9vf6s0331SrVq00f/58paSkeMYMGDBA33zzjTIyMlRYWKiOHTtqw4YNXm9yVlEtAAAAAABnqlOfc32z43Ou7fDZh85F752L3jsXvXcueu9c9N65bpbPuea7FgAAAAAAS4RrAAAAAAAsEa4BAAAAALBEuAYAAAAAwBLhGgAAAAAAS4RrAAAAAAAsEa4BAAAAALBEuAYAAAAAwBLhGgAAAAAAS4RrAAAAAAAsEa4BAAAAALBEuAYAAAAAwBLhGgAAAAAAS4RrAAAAAAAsEa4BAAAAALBEuAYAAAAAwBLhGgAAAAAAS4RrAAAAAAAsEa4BAAAAALBEuAYAAAAAwBLhGgAAAAAAS4RrAAAAAAAsEa4BAAAAALBEuAYAAAAAwBLhGgAAAAAAS4RrAAAAAAAsEa4BAAAAALBEuAYAAAAAwBLhGgAAAAAAS4RrAAAAAAAsEa4BAAAAALBEuAYAAAAAwBLhGgAAAAAAS4RrAAAAAAAsEa4BAAAAALBEuAYAAAAAwBLhGgAAAAAAS4RrAAAAAAAsEa4BAAAAALBEuAYAAAAAwBLhGgAAAAAAS4RrAAAAAAAsEa4BAAAAALBEuAYAAAAAwBLhGgAAAAAAS4RrAAAAAAAsEa4BAAAAALBEuAYAAAAAwBLhGgAAAAAAS4RrAAAAAAAsEa4BAAAAALBEuAYAAAAAwBLhGgAAAAAAS4RrAAAAAAAsEa4BAAAAALBEuAYAAAAAwBLhGgAAAAAAS4RrAAAAAAAsEa4BAAAAALBEuAYAAAAAwBLhGgAAAAAAS4RrAAAAAAAsEa4BAAAAALBEuAYAAAAAwBLhGgAAAAAAS4RrAAAAAAAsEa4BAAAAALBEuAYAAAAAwBLhGgAAAAAAS4RrAAAAAAAsEa4BAAAAALBEuAYAAAAAwBLhGgAAAAAAS4RrAAAAAAAsEa4BAAAAALBEuAYAAAAAwBLhGgAAAAAAS4RrAAAAAAAsEa4BAAAAALBEuAYAAAAAwBLhGgAAAAAAS4RrAAAAAAAsEa4BAAAAALBEuAYAAAAAwBLhGgAAAAAAS4RrAAAAAAAsEa4BAAAAALDUoLYLQN1z6vwptZrRqrbLKMdPfmp3SzsdKDkgt9y1XQ5qEL13LnrvXPTeuei9c9F75zp9/rTCG4XXdhnWCNcox23c+qr4q9ouoxw/+SncFa6vir/iB67D0HvnovfORe+di947F713Lr+b5IJqwjU8wm+t288W+clPTUOaqqVpyQ9ch6H3zkXvnYveOxe9dy5671xXem/8TG2XYoVwDY9Pn/q0tku4LrfbraKiIjVv3lx+fjfHs1uoHHrvXPTeuei9c9F756L3zvXj3tdnfNcCAAAAAGCJcA0AAAAAgCXCNQAAAAAAlgjXAAAAAABYIlwDAAAAAGCJcA0AAAAAgCXCNQAAAAAAlgjXAAAAAABYIlwDAAAAAGCJcA0AAAAAgCXCNQAAAAAAlgjXAAAAAABYIlwDAAAAAGCJcA0AAAAAgCXCNQAAAAAAlgjXAAAAAABYIlwDAAAAAGCJcA0AAAAAgCXCNQAAAAAAlgjXAAAAAABYIlwDAAAAAGCJcA0AAAAAgCXCNQAAAAAAlgjXAAAAAABYIlwDAAAAAGCJcA0AAAAAgCXCNQAAAAAAlgjXAAAAAABYalDbBTiJMUaSdO7cuVqupH5yu90qLi5WcHCw/Px4XshJ6L1z0XvnovfORe+di947V13v/ZX8diXPXQvhugYVFxdLkqKiomq5EgAAAABAVRQXFyssLOya97tMRfEb1cbtduvrr79Wo0aN5HK5aruceufcuXOKiorSl19+qdDQ0NouBzWI3jsXvXcueu9c9N656L1z1fXeG2NUXFysyMjI655Z58x1DfLz81OrVq1qu4x6LzQ0tE4uOvgevXcueu9c9N656L1z0Xvnqsu9v94Z6yvq3gXtAAAAAADUM4RrAAAAAAAsEa5RbwQFBWny5MkKCgqq7VJQw+i9c9F756L3zkXvnYveO9fN0nve0AwAAAAAAEucuQYAAAAAwBLhGgAAAAAAS4RrAAAAAAAsEa5RK3bs2KE+ffooMjJSLpdLq1atqnCfxYsXq0OHDrrlllsUERGh4cOH69tvv/Xcv3DhQrlcLq9bcHCwD2eBG3EjvZ8zZ47atm2rkJAQxcfHa9GiReXGLF++XHfeeaeCg4OVkJCg9evX+6B62PBF71n39UNmZqZ+9rOfqVGjRmrevLn69eun/Pz8CveraF0bY5SRkaGIiAiFhIQoOTlZhw8f9tU0cAN81fuhQ4eWW/upqam+mgZuwI30Pi8vT/3791ebNm3kcrn0xhtvXHXcnDlz1KZNGwUHB6tbt27as2ePD2aAG+Wr3r/00kvl1v2dd97po1ncGMI1asWFCxfUoUMHzZkzp1Ljd+7cqcGDB2vEiBHKy8vT8uXLtWfPHo0cOdJrXGhoqE6dOuW5HT9+3Bflw0JVez9v3jw9//zzeumll5SXl6cpU6YoPT1da9as8Yz56KOP9Ktf/UojRoxQTk6O+vXrp379+mn//v2+mgZugC96L7Hu64Pt27crPT1dH3/8sTZt2qRLly6pZ8+eunDhwjX3qcy6njZtmmbNmqW33npLu3fvVsOGDZWSkqKLFy/WxLRQCb7qvSSlpqZ6rf0lS5b4ejqoghvpfUlJiWJjY/Xqq68qPDz8qmP+8Y9/aNy4cZo8ebL27t2rDh06KCUlRUVFRb6aCqrIV72XpPbt23ut+w8//NAXU7hxBqhlkszKlSuvO+a1114zsbGxXttmzZplWrZs6fk6KyvLhIWF+aBC+Eplep+UlGQmTJjgtW3cuHGme/funq8fe+wx8/DDD3uN6datm3n66aerrVZUr+rqPeu+fioqKjKSzPbt2685pqJ17Xa7TXh4uHnttdc89589e9YEBQWZJUuW+KZwWKuO3htjzJAhQ0zfvn19VSZ8oDK9/7Ho6Ggzc+bMctu7du1q0tPTPV+XlZWZyMhIk5mZWV2loppVV+8nT55sOnToUL3FVTPOXKNeSEpK0pdffqn169fLGKPTp0/rn//8p3r37u017vz584qOjlZUVJT69u2rvLy8WqoY1aW0tLTcZb4hISHas2ePLl26JEnatWuXkpOTvcakpKRo165dNVYnql9lei+x7uuj7777TpLUtGnTa46paF0XFBSosLDQa0xYWJi6devG2q/DqqP3V2zbtk3NmzdXfHy80tLSvF4qhrqnMr2vyPfff6/s7Gyv7w8/Pz8lJyez7uuw6uj9FYcPH1ZkZKRiY2M1cOBAnThxwvqY1YlwjXqhe/fuWrx4sQYMGKDAwECFh4crLCzM6/LS+Ph4LViwQKtXr9bf//53ud1u3XvvvTp58mQtVg5bKSkpmj9/vrKzs2WM0aeffqr58+fr0qVLOnPmjCSpsLBQLVq08NqvRYsWKiwsrI2SUU0q03vWff3jdrs1duxYde/eXXfdddc1x1W0rq/8ztqvP6qr99LlS8IXLVqkzZs3a+rUqdq+fbt69eqlsrIyn9WPG1fZ3lfkzJkzKisrY93XI9XVe0nq1q2bFi5cqA0bNmjevHkqKCjQfffdp+Li4mqq1l6D2i4AqIwDBw7omWeeUUZGhlJSUnTq1Ck9++yzGjVqlN555x1Jl89uJyUlefa599571bZtW/3lL3/Ryy+/XFulw9KLL76owsJC3XPPPTLGqEWLFhoyZIimTZsmPz+eH7yZVab3rPv6Jz09Xfv37697r5ODz1Vn7x9//HHPnxMSEpSYmKjbb79d27Zt00MPPWR9fFQv1r1zVWfve/Xq5flzYmKiunXrpujoaC1btkwjRoywPn514H+mqBcyMzPVvXt3Pfvss0pMTFRKSormzp2rBQsW6NSpU1fdJyAgQJ06ddIXX3xRw9WiOoWEhGjBggUqKSnRsWPHdOLECbVp00aNGjXSbbfdJkkKDw/X6dOnvfY7ffr0dd8QA3VfZXr//7Hu67YxY8Zo7dq12rp1q1q1anXdsRWt6yu/s/brh+rs/dXExsaqWbNmrP06qCq9r0izZs3k7+/Puq8nqrP3V9O4cWPFxcXVqXVPuEa9UFJSUu4spb+/v6TLH8VyNWVlZcrNzVVERITP64PvBQQEqFWrVvL399fSpUv1yCOPeJ293Lx5s9f4TZs2eZ3RRP11vd7/f6z7uskYozFjxmjlypXasmWLYmJiKtynonUdExOj8PBwrzHnzp3T7t27Wft1iC96fzUnT57Ut99+y9qvQ26k9xUJDAxU586dvb4/3G63Nm/ezLqvQ3zR+6s5f/68jhw5UrfWfW29kxqcrbi42OTk5JicnBwjycyYMcPk5OSY48ePG2OMmTRpkhk0aJBnfFZWlmnQoIGZO3euOXLkiPnwww9Nly5dTNeuXT1jpkyZYjZu3GiOHDlisrOzzeOPP26Cg4NNXl5ejc8P11bV3ufn55t3333XfP7552b37t1mwIABpmnTpqagoMAzZufOnaZBgwZm+vTp5uDBg2by5MkmICDA5Obm1vT0cB2+6D3rvn5IS0szYWFhZtu2bebUqVOeW0lJiWfMoEGDzKRJkzxfV2Zdv/rqq6Zx48Zm9erV5rPPPjN9+/Y1MTEx5n//+1+Nzg/X5oveFxcXmwkTJphdu3aZgoIC88EHH5i7777b/PSnPzUXL16s8Tni6m6k96WlpZ5/JyIiIsyECRNMTk6OOXz4sGfM0qVLTVBQkFm4cKE5cOCAeeqpp0zjxo1NYWFhjc4P1+ar3o8fP95s27bNFBQUmJ07d5rk5GTTrFkzU1RUVKPzux7CNWrF1q1bjaRytyFDhhhjLn/ExgMPPOC1z6xZs0y7du1MSEiIiYiIMAMHDjQnT5703D927FjTunVrExgYaFq0aGF69+5t9u7dW4OzQmVUtfcHDhwwHTt2NCEhISY0NNT07dvXHDp0qNxxly1bZuLi4kxgYKBp3769WbduXQ3NCJXli96z7uuHq/VdksnKyvKMeeCBBzzfC1dUtK7dbrd58cUXTYsWLUxQUJB56KGHTH5+fg3MCJXli96XlJSYnj17mttuu80EBASY6OhoM3LkSMJVHXMjvS8oKLjqPv///4SzZ8/2/Ozv2rWr+fjjj2tmUqgUX/V+wIABJiIiwgQGBpqWLVuaAQMGmC+++KLmJlYJLmOucU0tAAAAAACoFF5zDQAAAACAJcI1AAAAAACWCNcAAAAAAFgiXAMAAAAAYIlwDQAAAACAJcI1AAAAAACWCNcAAAAAAFgiXAMAAAAAYIlwDQAAfKJHjx4aO3ZsbZcBALjJ7dixQ3369FFkZKRcLpdWrVpV5WMYYzR9+nTFxcUpKChILVu21CuvvFKlYxCuAQBwgKFDh8rlcpW7paamWh9727ZtcrlcOnv2rNf2FStW6OWXX7Y+PgAA13PhwgV16NBBc+bMueFjPPPMM5o/f76mT5+uQ4cO6V//+pe6du1apWM0uOFHBwAA9UpqaqqysrK8tgUFBfns8Zo2beqzYwMAcEWvXr3Uq1eva95fWlqq3/3ud1qyZInOnj2ru+66S1OnTlWPHj0kSQcPHtS8efO0f/9+xcfHS5JiYmKqXAdnrgEAcIigoCCFh4d73Zo0aSJJmjFjhhISEtSwYUNFRUVp9OjROn/+vGff48ePq0+fPmrSpIkaNmyo9u3ba/369Tp27JgefPBBSVKTJk3kcrk0dOhQSeUvC2/Tpo3+9Kc/afjw4WrUqJFat26tv/71r141fvTRR+rYsaOCg4PVpUsXrVq1Si6XS/v27fPp3w0A4OY1ZswY7dq1S0uXLtVnn32mRx99VKmpqTp8+LAkac2aNYqNjdXatWsVExOjNm3a6Mknn9R///vfKj0O4RoAAMjPz0+zZs1SXl6e/va3v2nLli167rnnPPenp6ertLRUO3bsUG5urqZOnapbb71VUVFRev/99yVJ+fn5OnXqlN58881rPs7rr7+uLl26KCcnR6NHj1ZaWpry8/MlSefOnVOfPn2UkJCgvXv36uWXX9bEiRN9O3EAwE3txIkTysrK0vLly3Xffffp9ttv14QJE/Tzn//cczXX0aNHdfz4cS1fvlyLFi3SwoULlZ2drV/+8pdVeiwuCwcAwCHWrl2rW2+91WvbCy+8oBdeeKHcGeY//vGPGjVqlObOnSvp8n9O+vfvr4SEBElSbGysZ/yVy7+bN2+uxo0bX7eG3r17a/To0ZKkiRMnaubMmdq6davi4+P13nvvyeVy6e2331ZwcLDatWunr776SiNHjrSdOgDAoXJzc1VWVqa4uDiv7aWlpfrJT34iSXK73SotLdWiRYs849555x117txZ+fn5nkvFK0K4BgDAIR588EHNmzfPa9uVYPzBBx8oMzNThw4d0rlz5/TDDz/o4sWLKikp0S233KLf/OY3SktL07///W8lJyerf//+SkxMrHINP97H5XIpPDxcRUVFki6f+U5MTFRwcLBnTFXfTAYAgB87f/68/P39lZ2dLX9/f6/7rjzhHBERoQYNGngF8LZt20q6/ORyZcM1l4UDAOAQDRs21B133OF1a9q0qY4dO6ZHHnlEiYmJev/995Wdne15x9Xvv/9ekvTkk0/q6NGjGjRokHJzc9WlSxfNnj27yjUEBAR4fe1yueR2u+0nBwDAVXTq1EllZWUqKioq929geHi4JKl79+764YcfdOTIEc9+n3/+uSQpOjq60o9FuAYAwOGys7Pldrv1+uuv65577lFcXJy+/vrrcuOioqI0atQorVixQuPHj9fbb78tSQoMDJQklZWVWdURHx+v3NxclZaWerZ98sknVscEANz8zp8/r3379nne/LKgoED79u3TiRMnFBcXp4EDB2rw4MFasWKFCgoKtGfPHmVmZmrdunWSpOTkZN19990aPny4cnJylJ2draefflq/+MUvyl1Ofj2EawAAHKK0tFSFhYVetzNnzuiOO+7QpUuXNHv2bB09elTvvvuu3nrrLa99x44dq40bN6qgoEB79+7V1q1bPZfMRUdHy+Vyae3atfrmm2+83mW8Kp544gm53W499dRTOnjwoDZu3Kjp06dLunyGGwCAq/n000/VqVMnderUSZI0btw4derUSRkZGZKkrKwsDR48WOPHj1d8fLz69eunTz75RK1bt5Z0+U0916xZo2bNmun+++/Xww8/rLZt22rp0qVVqoPXXAMA4BAbNmxQRESE17b4+HgdOnRIM2bM0NSpU/X888/r/vvvV2ZmpgYPHuwZV1ZWpvT0dJ08eVKhoaFKTU3VzJkzJUktW7bUlClTNGnSJA0bNkyDBw/WwoULq1xfaGio1qxZo7S0NHXs2FEJCQnKyMjQE0884fU6bAAAfqxHjx4yxlzz/oCAAE2ZMkVTpky55pjIyEjPp1/cKJe5XhUAAAC1aPHixRo2bJi+++47hYSE1HY5AABcE2euAQBAnbFo0SLFxsaqZcuW+s9//qOJEyfqscceI1gDAOo8wjUAAKgzCgsLlZGRocLCQkVEROjRRx/VK6+8UttlAQBQIS4LBwAAAADAEu8WDgAAAACAJcI1AAAAAACWCNcAAAAAAFgiXAMAAAAAYIlwDQAAAACAJcI1AAAAAACWCNcAAAAAAFgiXAMAAAAAYIlwDQAAAACApf8DgYo38uCtR1oAAAAASUVORK5CYII=",
-      "text/plain": [
-       "<Figure size 1000x800 with 1 Axes>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "Extent visualization complete\n",
-      "  Overlapping rectangles indicate good coverage alignment\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Optional: Visualize layer extents using matplotlib and rasterio\n",
     "try:\n",
@@ -1591,6 +1346,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "760b88e3",
    "metadata": {},
    "source": [
     "---"
@@ -1598,6 +1354,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "af903f44",
    "metadata": {},
    "source": [
     "## Cleanup"
@@ -1605,7 +1362,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": null,
+   "id": "9f374008",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2025-12-29T05:36:20.461678Z",
@@ -1614,15 +1372,7 @@
      "shell.execute_reply": "2025-12-29T05:36:22.010037Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "✓ Cleaned up example projects\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Clean up extracted project\n",
     "import shutil\n",
@@ -1634,6 +1384,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "23e82abd",
    "metadata": {},
    "source": [
     "---"
@@ -1641,6 +1392,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "328b3c9a",
    "metadata": {},
    "source": [
     "## Summary\n",
@@ -1692,5 +1444,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 4
+ "nbformat_minor": 5
 }

--- a/examples/920_terrain_creation.ipynb
+++ b/examples/920_terrain_creation.ipynb
@@ -36,7 +36,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "setup-cell",
    "metadata": {
     "execution": {
@@ -46,22 +46,7 @@
      "shell.execute_reply": "2026-04-23T12:54:17.762823Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "LOCAL SOURCE MODE: Loading from G:\\GH\\ras-commander/ras_commander\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Loaded: G:\\GH\\ras-commander\\ras_commander\\__init__.py\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# =============================================================================\n",
     "# DEVELOPMENT MODE TOGGLE\n",
@@ -85,17 +70,17 @@
     "    print(\"PIP PACKAGE MODE: Loading installed ras-commander\")\n",
     "\n",
     "# Import ras-commander\n",
-    "from ras_commander import RasExamples, RasMap, init_ras_project, ras\n",
+    "from ras_commander import RasExamples, RasMap, RasProcess, init_ras_project, ras\n",
     "from ras_commander.terrain import RasTerrain, Usgs3depAws\n",
     "\n",
     "# Verify which version loaded\n",
     "import ras_commander\n",
-    "print(f\"Loaded: {ras_commander.__file__}\")"
+    "print(f\"Loaded: {ras_commander.__file__}\")\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "additional-imports",
    "metadata": {
     "execution": {
@@ -105,19 +90,7 @@
      "shell.execute_reply": "2026-04-23T12:54:17.768759Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "rasterio available\n",
-      "geopandas available\n",
-      "create_vrt() uses HEC-RAS bundled GDAL tools\n",
-      "Example projects root: G:\\GH\\ras-commander\\example_projects\n",
-      "USGS cache folder: G:\\GH\\ras-commander\\cache\\usgs3dep\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Additional imports for terrain operations\n",
     "from pathlib import Path\n",
@@ -168,7 +141,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "id": "parameters-cell",
    "metadata": {
     "execution": {
@@ -178,21 +151,7 @@
      "shell.execute_reply": "2026-04-23T12:54:17.773857Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Project: BaldEagleCrkMulti2D\n",
-      "Notebook suffix: 920\n",
-      "HEC-RAS Version: 7.0\n",
-      "Target Resolution: 1m\n",
-      "Create overviews: False\n",
-      "Terrain HDF timeout: 14400 seconds\n",
-      "RasProcess.exe exists: True\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# =============================================================================\n",
     "# PARAMETERS - Edit these to customize the notebook\n",
@@ -238,7 +197,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "id": "extract-cell",
    "metadata": {
     "execution": {
@@ -248,198 +207,7 @@
      "shell.execute_reply": "2026-04-23T12:54:18.087511Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-04-23 08:54:17 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 7.0 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\7.0\\Ras.exe via filesystem (x86)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-04-23 08:54:17 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 6.7 Beta 5 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.7 Beta 5\\Ras.exe via filesystem (x86)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-04-23 08:54:17 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 6.5 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.5\\Ras.exe via filesystem (x86)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-04-23 08:54:17 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 6.3.1 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.3.1\\Ras.exe via filesystem (x86)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-04-23 08:54:17 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 6.2 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.2\\Ras.exe via filesystem (x86)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-04-23 08:54:17 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 6.1 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.1\\Ras.exe via filesystem (x86)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-04-23 08:54:17 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 6.0 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.0\\Ras.exe via filesystem (x86)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-04-23 08:54:17 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 5.0.7 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\5.0.7\\Ras.exe via filesystem (x86)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-04-23 08:54:17 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 5.0.6 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\5.0.6\\Ras.exe via filesystem (x86)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-04-23 08:54:17 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 5.0.5 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\5.0.5\\Ras.exe via filesystem (x86)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-04-23 08:54:17 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 5.0.4 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\5.0.4\\Ras.exe via filesystem (x86)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-04-23 08:54:17 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 5.0.3 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\5.0.3\\Ras.exe via filesystem (x86)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-04-23 08:54:17 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 5.0.1 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\5.0.1\\Ras.exe via filesystem (x86)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-04-23 08:54:17 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 5.0 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\5.0\\Ras.exe via filesystem (x86)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-04-23 08:54:17 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 4.1.0 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\4.1.0\\Ras.exe via filesystem (x86)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-04-23 08:54:17 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 6.6 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.6\\Ras.exe via filesystem (x86)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-04-23 08:54:17 - ras_commander.RasUtils - INFO - Discovered 16 installed HEC-RAS version(s)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-04-23 08:54:17 - ras_commander.RasPrj - INFO - HEC-RAS 7.0 found via version discovery: C:\\Program Files (x86)\\HEC\\HEC-RAS\\7.0\\Ras.exe\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Reusing extracted project: G:\\GH\\ras-commander\\example_projects\\BaldEagleCrkMulti2D_920\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-04-23 08:54:18 - ras_commander.RasMap - INFO - Successfully parsed RASMapper file: G:\\GH\\ras-commander\\example_projects\\BaldEagleCrkMulti2D_920\\BaldEagleDamBrk.rasmap\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-04-23 08:54:18 - ras_commander.hdf.HdfBase - INFO - Found projection in HDF file: G:\\GH\\ras-commander\\example_projects\\BaldEagleCrkMulti2D_920\\BaldEagleDamBrk.g09.hdf\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-04-23 08:54:18 - ras_commander.hdf.HdfBase - INFO - Converted WKT to EPSG:2271 from HDF file BaldEagleDamBrk.g09.hdf\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-04-23 08:54:18 - ras_commander.RasPrj - INFO - Updated results_df with 11 plan(s)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-04-23 08:54:18 - ras_commander.RasPrj - INFO - ras-commander v0.94.0 | An open-source project of CLB Engineering Corporation (https://clbengineering.com/) | Docs: https://ras-commander.readthedocs.io | GitHub: https://github.com/gpt-cmdr/ras-commander\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-04-23 08:54:18 - ras_commander.RasPrj - INFO - Project initialized: BaldEagleDamBrk | Folder: G:\\GH\\ras-commander\\example_projects\\BaldEagleCrkMulti2D_920\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-04-23 08:54:18 - ras_commander.RasPrj - INFO - Using HEC-RAS executable: C:\\Program Files (x86)\\HEC\\HEC-RAS\\7.0\\Ras.exe\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Project initialized: BaldEagleDamBrk\n",
-      "Terrain folder: G:\\GH\\ras-commander\\example_projects\\BaldEagleCrkMulti2D_920\\Terrain\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Reuse a stable extracted project for this notebook when available.\n",
     "project_folder_name = f\"{PROJECT_NAME}_{NOTEBOOK_SUFFIX}\"\n",
@@ -477,7 +245,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "id": "get-extents-cell",
    "metadata": {
     "execution": {
@@ -487,22 +255,7 @@
      "shell.execute_reply": "2026-04-23T12:54:18.141813Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Found 4 TIFF files\n",
-      "Found 2 HDF files\n",
-      "\n",
-      "Using Terrain50.baldeagledem.tif to determine project extents:\n",
-      "  Bounds (native CRS): BoundingBox(left=1834327.1955903, bottom=162918.80517492996, right=2149835.693237871, top=414872.9473435675)\n",
-      "  CRS: EPSG:2271\n",
-      "  Resolution: 36.50 x 36.50\n",
-      "  Size: 8643 x 6902 pixels\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Find existing terrain to get extents\n",
     "existing_tiffs = list(terrain_folder.glob(\"*.tif\"))\n",
@@ -535,7 +288,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "id": "convert-bounds-cell",
    "metadata": {
     "execution": {
@@ -545,23 +298,7 @@
      "shell.execute_reply": "2026-04-23T12:54:18.171764Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Full terrain extent:\n",
-      "  Bounds (WGS84): (-78.233233, 40.612784) to (-77.089997, 41.303441)\n",
-      "  Approx area: 7449.7 sq km\n",
-      "\n",
-      "Download bounding box (WGS84):\n",
-      "  West:  -78.233233\n",
-      "  South: 40.612784\n",
-      "  East:  -77.089997\n",
-      "  North: 41.303441\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Convert bounds to WGS84 (lat/lon) for USGS 3DEP\n",
     "if PROJECT_BOUNDS and RASTERIO_AVAILABLE:\n",
@@ -623,7 +360,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "id": "check-availability-cell",
    "metadata": {
     "execution": {
@@ -633,49 +370,7 @@
      "shell.execute_reply": "2026-04-23T12:54:32.857948Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-04-23 08:54:18 - ras_commander.terrain.Usgs3depAws - INFO - Using cached 1m tile index: G:\\GH\\ras-commander\\cache\\usgs3dep\\FESM_1m.gpkg\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Finding USGS 3DEP 1m projects for this area...\n",
-      "This will download a cached tile index on first use if it is not already present.\n",
-      "Cache folder: G:\\GH\\ras-commander\\cache\\usgs3dep\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-04-23 08:54:32 - ras_commander.terrain.Usgs3depAws - INFO -   Loaded 906 tiles\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-04-23 08:54:32 - ras_commander.terrain.Usgs3depAws - INFO - Found 3 projects intersecting bbox\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "Found 3 project(s) with 1m data:\n",
-      "  - PA_Northcentral_2019_B19 (published: 2022-05-02 00:00:00)\n",
-      "  - PA_South_Central_2017_D17 (published: 2019-04-16 00:00:00)\n",
-      "  - PA_South_Central_2017_D17 (published: 2019-04-11 00:00:00)\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Find USGS 3DEP projects covering this area\n",
     "if DOWNLOAD_BBOX and GEOPANDAS_AVAILABLE:\n",
@@ -705,7 +400,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "id": "download-dem-cell",
    "metadata": {
     "execution": {
@@ -715,926 +410,7 @@
      "shell.execute_reply": "2026-04-23T12:54:47.329602Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-04-23 08:54:32 - ras_commander.terrain.Usgs3depAws - INFO - Using cached 1m tile index: G:\\GH\\ras-commander\\cache\\usgs3dep\\FESM_1m.gpkg\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Downloading 1m DEM tiles for project area...\n",
-      "Note: This checks each tile in intersecting project(s) for overlap with the full project extent.\n",
-      "      Existing files in the notebook project folder are reused when sizes match.\n",
-      "\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-04-23 08:54:36 - ras_commander.terrain.Usgs3depAws - INFO -   Loaded 906 tiles\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-04-23 08:54:36 - ras_commander.terrain.Usgs3depAws - INFO - Found 3 projects intersecting bbox\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-04-23 08:54:36 - ras_commander.terrain.Usgs3depAws - INFO - Found 3 projects intersecting bbox\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-04-23 08:54:36 - ras_commander.terrain.Usgs3depAws - INFO -   Selecting most recent project (year 2019)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-04-23 08:54:36 - ras_commander.terrain.Usgs3depAws - INFO -     Selected: PA_Northcentral_2019_B19\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-04-23 08:54:36 - ras_commander.terrain.Usgs3depAws - INFO -     Skipping 2 older project(s):\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-04-23 08:54:36 - ras_commander.terrain.Usgs3depAws - INFO -       - PA_South_Central_2017_D17 (year 2017)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-04-23 08:54:36 - ras_commander.terrain.Usgs3depAws - INFO -       - PA_South_Central_2017_D17 (year 2017)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-04-23 08:54:36 - ras_commander.terrain.Usgs3depAws - INFO - \n",
-      "Processing project: PA_Northcentral_2019_B19\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-04-23 08:54:36 - ras_commander.terrain.Usgs3depAws - INFO - Fetching tile list from: PA_Northcentral_2019_B19\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-04-23 08:54:37 - ras_commander.terrain.Usgs3depAws - INFO -   Found 653 tiles in project\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-04-23 08:54:37 - ras_commander.terrain.Usgs3depAws - INFO -   Checking 653 tiles for intersection...\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-04-23 08:54:38 - ras_commander.terrain.Usgs3depAws - INFO -   Found 98 intersecting tiles\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-04-23 08:54:38 - ras_commander.terrain.Usgs3depAws - INFO -   Downloading tiles with 3 concurrent workers...\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-04-23 08:54:38 - ras_commander.terrain.Usgs3depAws - INFO -     Using cached: USGS_1M_17_x76y455_PA_Northcentral_2019_B19.tif (308.78 MB)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-04-23 08:54:38 - ras_commander.terrain.Usgs3depAws - INFO -     Using cached: USGS_1M_17_x76y457_PA_Northcentral_2019_B19.tif (293.74 MB)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-04-23 08:54:38 - ras_commander.terrain.Usgs3depAws - INFO -     Using cached: USGS_1M_17_x76y456_PA_Northcentral_2019_B19.tif (312.02 MB)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-04-23 08:54:38 - ras_commander.terrain.Usgs3depAws - INFO -     Using cached: USGS_1M_17_x76y452_PA_Northcentral_2019_B19.tif (295.65 MB)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-04-23 08:54:38 - ras_commander.terrain.Usgs3depAws - INFO -     Using cached: USGS_1M_17_x76y454_PA_Northcentral_2019_B19.tif (320.38 MB)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-04-23 08:54:38 - ras_commander.terrain.Usgs3depAws - INFO -     Using cached: USGS_1M_17_x76y453_PA_Northcentral_2019_B19.tif (299.71 MB)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-04-23 08:54:38 - ras_commander.terrain.Usgs3depAws - INFO -     Using cached: USGS_1M_17_x76y451_PA_Northcentral_2019_B19.tif (317.89 MB)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-04-23 08:54:38 - ras_commander.terrain.Usgs3depAws - INFO -     Using cached: USGS_1M_17_x76y450_PA_Northcentral_2019_B19.tif (303.93 MB)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-04-23 08:54:38 - ras_commander.terrain.Usgs3depAws - INFO -     Using cached: USGS_1M_17_x75y457_PA_Northcentral_2019_B19.tif (311.43 MB)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-04-23 08:54:39 - ras_commander.terrain.Usgs3depAws - INFO -     Using cached: USGS_1M_17_x75y456_PA_Northcentral_2019_B19.tif (292.75 MB)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-04-23 08:54:39 - ras_commander.terrain.Usgs3depAws - INFO -     Using cached: USGS_1M_17_x75y455_PA_Northcentral_2019_B19.tif (295.42 MB)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-04-23 08:54:39 - ras_commander.terrain.Usgs3depAws - INFO -     Using cached: USGS_1M_17_x75y454_PA_Northcentral_2019_B19.tif (295.85 MB)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-04-23 08:54:39 - ras_commander.terrain.Usgs3depAws - INFO -     Using cached: USGS_1M_17_x75y453_PA_Northcentral_2019_B19.tif (311.08 MB)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-04-23 08:54:39 - ras_commander.terrain.Usgs3depAws - INFO -     Using cached: USGS_1M_17_x75y451_PA_Northcentral_2019_B19.tif (310.71 MB)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-04-23 08:54:39 - ras_commander.terrain.Usgs3depAws - INFO -     Using cached: USGS_1M_17_x75y452_PA_Northcentral_2019_B19.tif (294.59 MB)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-04-23 08:54:39 - ras_commander.terrain.Usgs3depAws - INFO -     Using cached: USGS_1M_17_x75y450_PA_Northcentral_2019_B19.tif (322.25 MB)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-04-23 08:54:39 - ras_commander.terrain.Usgs3depAws - INFO -     Using cached: USGS_1M_17_x74y456_PA_Northcentral_2019_B19.tif (313.53 MB)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-04-23 08:54:39 - ras_commander.terrain.Usgs3depAws - INFO -     Using cached: USGS_1M_17_x74y457_PA_Northcentral_2019_B19.tif (303.97 MB)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-04-23 08:54:39 - ras_commander.terrain.Usgs3depAws - INFO -     Using cached: USGS_1M_17_x74y454_PA_Northcentral_2019_B19.tif (287.92 MB)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-04-23 08:54:39 - ras_commander.terrain.Usgs3depAws - INFO -     Using cached: USGS_1M_17_x74y455_PA_Northcentral_2019_B19.tif (311.69 MB)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-04-23 08:54:39 - ras_commander.terrain.Usgs3depAws - INFO -     Using cached: USGS_1M_17_x74y453_PA_Northcentral_2019_B19.tif (297.32 MB)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-04-23 08:54:40 - ras_commander.terrain.Usgs3depAws - INFO -     Using cached: USGS_1M_17_x74y452_PA_Northcentral_2019_B19.tif (307.41 MB)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-04-23 08:54:40 - ras_commander.terrain.Usgs3depAws - INFO -     Using cached: USGS_1M_17_x74y451_PA_Northcentral_2019_B19.tif (306.54 MB)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-04-23 08:54:40 - ras_commander.terrain.Usgs3depAws - INFO -     Using cached: USGS_1M_17_x74y450_PA_Northcentral_2019_B19.tif (324.93 MB)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-04-23 08:54:40 - ras_commander.terrain.Usgs3depAws - INFO -     Using cached: USGS_1M_17_x74y449_PA_Northcentral_2019_B19.tif (323.01 MB)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-04-23 08:54:40 - ras_commander.terrain.Usgs3depAws - INFO -     Using cached: USGS_1M_17_x73y457_PA_Northcentral_2019_B19.tif (286.54 MB)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-04-23 08:54:40 - ras_commander.terrain.Usgs3depAws - INFO -     Using cached: USGS_1M_17_x73y456_PA_Northcentral_2019_B19.tif (311.63 MB)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-04-23 08:54:40 - ras_commander.terrain.Usgs3depAws - INFO -     Using cached: USGS_1M_17_x73y453_PA_Northcentral_2019_B19.tif (290.43 MB)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-04-23 08:54:40 - ras_commander.terrain.Usgs3depAws - INFO -     Using cached: USGS_1M_17_x73y455_PA_Northcentral_2019_B19.tif (306.19 MB)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-04-23 08:54:40 - ras_commander.terrain.Usgs3depAws - INFO -     Using cached: USGS_1M_17_x73y454_PA_Northcentral_2019_B19.tif (299.73 MB)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-04-23 08:54:41 - ras_commander.terrain.Usgs3depAws - INFO -     Using cached: USGS_1M_17_x73y451_PA_Northcentral_2019_B19.tif (313.95 MB)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-04-23 08:54:41 - ras_commander.terrain.Usgs3depAws - INFO -     Using cached: USGS_1M_17_x73y452_PA_Northcentral_2019_B19.tif (302.27 MB)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-04-23 08:54:41 - ras_commander.terrain.Usgs3depAws - INFO -     Using cached: USGS_1M_17_x73y450_PA_Northcentral_2019_B19.tif (304.33 MB)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-04-23 08:54:41 - ras_commander.terrain.Usgs3depAws - INFO -     Using cached: USGS_1M_17_x73y449_PA_Northcentral_2019_B19.tif (310.05 MB)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-04-23 08:54:41 - ras_commander.terrain.Usgs3depAws - INFO -     Using cached: USGS_1M_18_x31y457_PA_Northcentral_2019_B19.tif (5.31 MB)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-04-23 08:54:41 - ras_commander.terrain.Usgs3depAws - INFO -     Using cached: USGS_1M_18_x32y455_PA_Northcentral_2019_B19.tif (13.35 MB)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-04-23 08:54:41 - ras_commander.terrain.Usgs3depAws - INFO -     Using cached: USGS_1M_18_x31y454_PA_Northcentral_2019_B19.tif (62.59 MB)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-04-23 08:54:41 - ras_commander.terrain.Usgs3depAws - INFO -     Using cached: USGS_1M_18_x31y456_PA_Northcentral_2019_B19.tif (139.34 MB)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-04-23 08:54:41 - ras_commander.terrain.Usgs3depAws - INFO -     Using cached: USGS_1M_18_x31y455_PA_Northcentral_2019_B19.tif (262.44 MB)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-04-23 08:54:41 - ras_commander.terrain.Usgs3depAws - INFO -     Using cached: USGS_1M_18_x30y457_PA_Northcentral_2019_B19.tif (189.91 MB)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-04-23 08:54:41 - ras_commander.terrain.Usgs3depAws - INFO -     Using cached: USGS_1M_18_x30y456_PA_Northcentral_2019_B19.tif (305.63 MB)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-04-23 08:54:41 - ras_commander.terrain.Usgs3depAws - INFO -     Using cached: USGS_1M_18_x30y455_PA_Northcentral_2019_B19.tif (286.54 MB)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-04-23 08:54:42 - ras_commander.terrain.Usgs3depAws - INFO -     Using cached: USGS_1M_18_x30y454_PA_Northcentral_2019_B19.tif (287.64 MB)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-04-23 08:54:42 - ras_commander.terrain.Usgs3depAws - INFO -     Using cached: USGS_1M_18_x29y457_PA_Northcentral_2019_B19.tif (325.11 MB)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-04-23 08:54:42 - ras_commander.terrain.Usgs3depAws - INFO -     Using cached: USGS_1M_18_x30y453_PA_Northcentral_2019_B19.tif (89.23 MB)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-04-23 08:54:42 - ras_commander.terrain.Usgs3depAws - INFO -     Using cached: USGS_1M_18_x29y456_PA_Northcentral_2019_B19.tif (317.07 MB)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-04-23 08:54:42 - ras_commander.terrain.Usgs3depAws - INFO -     Using cached: USGS_1M_18_x29y455_PA_Northcentral_2019_B19.tif (307.80 MB)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-04-23 08:54:42 - ras_commander.terrain.Usgs3depAws - INFO -     Using cached: USGS_1M_18_x29y454_PA_Northcentral_2019_B19.tif (295.35 MB)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-04-23 08:54:42 - ras_commander.terrain.Usgs3depAws - INFO -     Using cached: USGS_1M_18_x29y453_PA_Northcentral_2019_B19.tif (263.46 MB)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-04-23 08:54:42 - ras_commander.terrain.Usgs3depAws - INFO -     Using cached: USGS_1M_18_x28y457_PA_Northcentral_2019_B19.tif (327.76 MB)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-04-23 08:54:42 - ras_commander.terrain.Usgs3depAws - INFO -     Using cached: USGS_1M_18_x29y452_PA_Northcentral_2019_B19.tif (5.63 MB)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-04-23 08:54:43 - ras_commander.terrain.Usgs3depAws - INFO -     Using cached: USGS_1M_18_x28y455_PA_Northcentral_2019_B19.tif (306.60 MB)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-04-23 08:54:43 - ras_commander.terrain.Usgs3depAws - INFO -     Using cached: USGS_1M_18_x28y456_PA_Northcentral_2019_B19.tif (325.80 MB)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-04-23 08:54:43 - ras_commander.terrain.Usgs3depAws - INFO -     Using cached: USGS_1M_18_x28y454_PA_Northcentral_2019_B19.tif (297.64 MB)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-04-23 08:54:43 - ras_commander.terrain.Usgs3depAws - INFO -     Using cached: USGS_1M_18_x28y453_PA_Northcentral_2019_B19.tif (302.18 MB)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-04-23 08:54:43 - ras_commander.terrain.Usgs3depAws - INFO -     Using cached: USGS_1M_18_x28y452_PA_Northcentral_2019_B19.tif (105.74 MB)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-04-23 08:54:43 - ras_commander.terrain.Usgs3depAws - INFO -     Using cached: USGS_1M_18_x27y457_PA_Northcentral_2019_B19.tif (307.12 MB)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-04-23 08:54:43 - ras_commander.terrain.Usgs3depAws - INFO -     Using cached: USGS_1M_18_x27y454_PA_Northcentral_2019_B19.tif (299.83 MB)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-04-23 08:54:43 - ras_commander.terrain.Usgs3depAws - INFO -     Using cached: USGS_1M_18_x27y456_PA_Northcentral_2019_B19.tif (320.21 MB)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-04-23 08:54:43 - ras_commander.terrain.Usgs3depAws - INFO -     Using cached: USGS_1M_18_x27y455_PA_Northcentral_2019_B19.tif (317.54 MB)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-04-23 08:54:43 - ras_commander.terrain.Usgs3depAws - INFO -     Using cached: USGS_1M_18_x27y453_PA_Northcentral_2019_B19.tif (287.21 MB)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-04-23 08:54:43 - ras_commander.terrain.Usgs3depAws - INFO -     Using cached: USGS_1M_18_x27y452_PA_Northcentral_2019_B19.tif (243.78 MB)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-04-23 08:54:43 - ras_commander.terrain.Usgs3depAws - INFO -     Using cached: USGS_1M_18_x27y451_PA_Northcentral_2019_B19.tif (61.05 MB)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-04-23 08:54:44 - ras_commander.terrain.Usgs3depAws - INFO -     Using cached: USGS_1M_18_x26y456_PA_Northcentral_2019_B19.tif (319.73 MB)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-04-23 08:54:44 - ras_commander.terrain.Usgs3depAws - INFO -     Using cached: USGS_1M_18_x26y457_PA_Northcentral_2019_B19.tif (294.77 MB)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-04-23 08:54:44 - ras_commander.terrain.Usgs3depAws - INFO -     Using cached: USGS_1M_18_x26y455_PA_Northcentral_2019_B19.tif (310.12 MB)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-04-23 08:54:44 - ras_commander.terrain.Usgs3depAws - INFO -     Using cached: USGS_1M_18_x26y454_PA_Northcentral_2019_B19.tif (319.13 MB)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-04-23 08:54:44 - ras_commander.terrain.Usgs3depAws - INFO -     Using cached: USGS_1M_18_x26y452_PA_Northcentral_2019_B19.tif (297.00 MB)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-04-23 08:54:44 - ras_commander.terrain.Usgs3depAws - INFO -     Using cached: USGS_1M_18_x26y453_PA_Northcentral_2019_B19.tif (296.93 MB)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-04-23 08:54:44 - ras_commander.terrain.Usgs3depAws - INFO -     Using cached: USGS_1M_18_x26y451_PA_Northcentral_2019_B19.tif (296.55 MB)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-04-23 08:54:44 - ras_commander.terrain.Usgs3depAws - INFO -     Using cached: USGS_1M_18_x26y450_PA_Northcentral_2019_B19.tif (70.76 MB)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-04-23 08:54:44 - ras_commander.terrain.Usgs3depAws - INFO -     Using cached: USGS_1M_18_x26y449_PA_Northcentral_2019_B19.tif (25.74 MB)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-04-23 08:54:44 - ras_commander.terrain.Usgs3depAws - INFO -     Using cached: USGS_1M_18_x25y456_PA_Northcentral_2019_B19.tif (296.43 MB)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-04-23 08:54:45 - ras_commander.terrain.Usgs3depAws - INFO -     Using cached: USGS_1M_18_x25y457_PA_Northcentral_2019_B19.tif (304.62 MB)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-04-23 08:54:45 - ras_commander.terrain.Usgs3depAws - INFO -     Using cached: USGS_1M_18_x25y455_PA_Northcentral_2019_B19.tif (298.55 MB)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-04-23 08:54:45 - ras_commander.terrain.Usgs3depAws - INFO -     Using cached: USGS_1M_18_x25y453_PA_Northcentral_2019_B19.tif (304.44 MB)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-04-23 08:54:45 - ras_commander.terrain.Usgs3depAws - INFO -     Using cached: USGS_1M_18_x25y454_PA_Northcentral_2019_B19.tif (313.29 MB)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-04-23 08:54:45 - ras_commander.terrain.Usgs3depAws - INFO -     Using cached: USGS_1M_18_x25y452_PA_Northcentral_2019_B19.tif (289.76 MB)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-04-23 08:54:45 - ras_commander.terrain.Usgs3depAws - INFO -     Using cached: USGS_1M_18_x25y451_PA_Northcentral_2019_B19.tif (317.18 MB)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-04-23 08:54:45 - ras_commander.terrain.Usgs3depAws - INFO -     Using cached: USGS_1M_18_x25y450_PA_Northcentral_2019_B19.tif (325.42 MB)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-04-23 08:54:45 - ras_commander.terrain.Usgs3depAws - INFO -     Using cached: USGS_1M_18_x25y449_PA_Northcentral_2019_B19.tif (299.78 MB)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-04-23 08:54:45 - ras_commander.terrain.Usgs3depAws - INFO -     Using cached: USGS_1M_18_x24y456_PA_Northcentral_2019_B19.tif (304.06 MB)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-04-23 08:54:45 - ras_commander.terrain.Usgs3depAws - INFO -     Using cached: USGS_1M_18_x24y455_PA_Northcentral_2019_B19.tif (309.55 MB)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-04-23 08:54:45 - ras_commander.terrain.Usgs3depAws - INFO -     Using cached: USGS_1M_18_x24y457_PA_Northcentral_2019_B19.tif (313.60 MB)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-04-23 08:54:46 - ras_commander.terrain.Usgs3depAws - INFO -     Using cached: USGS_1M_18_x24y454_PA_Northcentral_2019_B19.tif (281.36 MB)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-04-23 08:54:46 - ras_commander.terrain.Usgs3depAws - INFO -     Using cached: USGS_1M_18_x24y453_PA_Northcentral_2019_B19.tif (309.04 MB)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-04-23 08:54:46 - ras_commander.terrain.Usgs3depAws - INFO -     Using cached: USGS_1M_18_x24y452_PA_Northcentral_2019_B19.tif (299.36 MB)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-04-23 08:54:46 - ras_commander.terrain.Usgs3depAws - INFO -     Using cached: USGS_1M_18_x24y449_PA_Northcentral_2019_B19.tif (328.36 MB)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-04-23 08:54:46 - ras_commander.terrain.Usgs3depAws - INFO -     Using cached: USGS_1M_18_x24y450_PA_Northcentral_2019_B19.tif (321.94 MB)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-04-23 08:54:46 - ras_commander.terrain.Usgs3depAws - INFO -     Using cached: USGS_1M_18_x24y451_PA_Northcentral_2019_B19.tif (306.88 MB)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-04-23 08:54:46 - ras_commander.terrain.Usgs3depAws - INFO -     Using cached: USGS_1M_18_x23y457_PA_Northcentral_2019_B19.tif (288.89 MB)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-04-23 08:54:46 - ras_commander.terrain.Usgs3depAws - INFO -     Using cached: USGS_1M_18_x23y456_PA_Northcentral_2019_B19.tif (314.91 MB)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-04-23 08:54:46 - ras_commander.terrain.Usgs3depAws - INFO -     Using cached: USGS_1M_18_x23y455_PA_Northcentral_2019_B19.tif (306.60 MB)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-04-23 08:54:47 - ras_commander.terrain.Usgs3depAws - INFO -     Using cached: USGS_1M_18_x23y452_PA_Northcentral_2019_B19.tif (308.41 MB)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-04-23 08:54:47 - ras_commander.terrain.Usgs3depAws - INFO -     Using cached: USGS_1M_18_x23y454_PA_Northcentral_2019_B19.tif (296.91 MB)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-04-23 08:54:47 - ras_commander.terrain.Usgs3depAws - INFO -     Using cached: USGS_1M_18_x23y453_PA_Northcentral_2019_B19.tif (288.08 MB)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-04-23 08:54:47 - ras_commander.terrain.Usgs3depAws - INFO -     Using cached: USGS_1M_18_x23y450_PA_Northcentral_2019_B19.tif (322.39 MB)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-04-23 08:54:47 - ras_commander.terrain.Usgs3depAws - INFO -     Using cached: USGS_1M_18_x23y451_PA_Northcentral_2019_B19.tif (307.31 MB)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-04-23 08:54:47 - ras_commander.terrain.Usgs3depAws - INFO - \n",
-      "Total tiles downloaded: 98\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "Downloaded 98 tiles:\n",
-      "  USGS_1M_17_x76y455_PA_Northcentral_2019_B19.tif (308.78 MB)\n",
-      "  USGS_1M_17_x76y457_PA_Northcentral_2019_B19.tif (293.74 MB)\n",
-      "  USGS_1M_17_x76y456_PA_Northcentral_2019_B19.tif (312.02 MB)\n",
-      "  USGS_1M_17_x76y452_PA_Northcentral_2019_B19.tif (295.65 MB)\n",
-      "  USGS_1M_17_x76y454_PA_Northcentral_2019_B19.tif (320.38 MB)\n",
-      "  USGS_1M_17_x76y453_PA_Northcentral_2019_B19.tif (299.71 MB)\n",
-      "  USGS_1M_17_x76y451_PA_Northcentral_2019_B19.tif (317.89 MB)\n",
-      "  USGS_1M_17_x76y450_PA_Northcentral_2019_B19.tif (303.93 MB)\n",
-      "  USGS_1M_17_x75y457_PA_Northcentral_2019_B19.tif (311.43 MB)\n",
-      "  USGS_1M_17_x75y456_PA_Northcentral_2019_B19.tif (292.75 MB)\n",
-      "  USGS_1M_17_x75y455_PA_Northcentral_2019_B19.tif (295.42 MB)\n",
-      "  USGS_1M_17_x75y454_PA_Northcentral_2019_B19.tif (295.85 MB)\n",
-      "  USGS_1M_17_x75y453_PA_Northcentral_2019_B19.tif (311.08 MB)\n",
-      "  USGS_1M_17_x75y451_PA_Northcentral_2019_B19.tif (310.71 MB)\n",
-      "  USGS_1M_17_x75y452_PA_Northcentral_2019_B19.tif (294.59 MB)\n",
-      "  USGS_1M_17_x75y450_PA_Northcentral_2019_B19.tif (322.25 MB)\n",
-      "  USGS_1M_17_x74y456_PA_Northcentral_2019_B19.tif (313.53 MB)\n",
-      "  USGS_1M_17_x74y457_PA_Northcentral_2019_B19.tif (303.97 MB)\n",
-      "  USGS_1M_17_x74y454_PA_Northcentral_2019_B19.tif (287.92 MB)\n",
-      "  USGS_1M_17_x74y455_PA_Northcentral_2019_B19.tif (311.69 MB)\n",
-      "  USGS_1M_17_x74y453_PA_Northcentral_2019_B19.tif (297.32 MB)\n",
-      "  USGS_1M_17_x74y452_PA_Northcentral_2019_B19.tif (307.41 MB)\n",
-      "  USGS_1M_17_x74y451_PA_Northcentral_2019_B19.tif (306.54 MB)\n",
-      "  USGS_1M_17_x74y450_PA_Northcentral_2019_B19.tif (324.93 MB)\n",
-      "  USGS_1M_17_x74y449_PA_Northcentral_2019_B19.tif (323.01 MB)\n",
-      "  USGS_1M_17_x73y457_PA_Northcentral_2019_B19.tif (286.54 MB)\n",
-      "  USGS_1M_17_x73y456_PA_Northcentral_2019_B19.tif (311.63 MB)\n",
-      "  USGS_1M_17_x73y453_PA_Northcentral_2019_B19.tif (290.43 MB)\n",
-      "  USGS_1M_17_x73y455_PA_Northcentral_2019_B19.tif (306.19 MB)\n",
-      "  USGS_1M_17_x73y454_PA_Northcentral_2019_B19.tif (299.73 MB)\n",
-      "  USGS_1M_17_x73y451_PA_Northcentral_2019_B19.tif (313.95 MB)\n",
-      "  USGS_1M_17_x73y452_PA_Northcentral_2019_B19.tif (302.27 MB)\n",
-      "  USGS_1M_17_x73y450_PA_Northcentral_2019_B19.tif (304.33 MB)\n",
-      "  USGS_1M_17_x73y449_PA_Northcentral_2019_B19.tif (310.05 MB)\n",
-      "  USGS_1M_18_x31y457_PA_Northcentral_2019_B19.tif (5.31 MB)\n",
-      "  USGS_1M_18_x32y455_PA_Northcentral_2019_B19.tif (13.35 MB)\n",
-      "  USGS_1M_18_x31y454_PA_Northcentral_2019_B19.tif (62.59 MB)\n",
-      "  USGS_1M_18_x31y456_PA_Northcentral_2019_B19.tif (139.34 MB)\n",
-      "  USGS_1M_18_x31y455_PA_Northcentral_2019_B19.tif (262.44 MB)\n",
-      "  USGS_1M_18_x30y457_PA_Northcentral_2019_B19.tif (189.91 MB)\n",
-      "  USGS_1M_18_x30y456_PA_Northcentral_2019_B19.tif (305.63 MB)\n",
-      "  USGS_1M_18_x30y455_PA_Northcentral_2019_B19.tif (286.54 MB)\n",
-      "  USGS_1M_18_x30y454_PA_Northcentral_2019_B19.tif (287.64 MB)\n",
-      "  USGS_1M_18_x29y457_PA_Northcentral_2019_B19.tif (325.11 MB)\n",
-      "  USGS_1M_18_x30y453_PA_Northcentral_2019_B19.tif (89.23 MB)\n",
-      "  USGS_1M_18_x29y456_PA_Northcentral_2019_B19.tif (317.07 MB)\n",
-      "  USGS_1M_18_x29y455_PA_Northcentral_2019_B19.tif (307.80 MB)\n",
-      "  USGS_1M_18_x29y454_PA_Northcentral_2019_B19.tif (295.35 MB)\n",
-      "  USGS_1M_18_x29y453_PA_Northcentral_2019_B19.tif (263.46 MB)\n",
-      "  USGS_1M_18_x28y457_PA_Northcentral_2019_B19.tif (327.76 MB)\n",
-      "  USGS_1M_18_x29y452_PA_Northcentral_2019_B19.tif (5.63 MB)\n",
-      "  USGS_1M_18_x28y455_PA_Northcentral_2019_B19.tif (306.60 MB)\n",
-      "  USGS_1M_18_x28y456_PA_Northcentral_2019_B19.tif (325.80 MB)\n",
-      "  USGS_1M_18_x28y454_PA_Northcentral_2019_B19.tif (297.64 MB)\n",
-      "  USGS_1M_18_x28y453_PA_Northcentral_2019_B19.tif (302.18 MB)\n",
-      "  USGS_1M_18_x28y452_PA_Northcentral_2019_B19.tif (105.74 MB)\n",
-      "  USGS_1M_18_x27y457_PA_Northcentral_2019_B19.tif (307.12 MB)\n",
-      "  USGS_1M_18_x27y454_PA_Northcentral_2019_B19.tif (299.83 MB)\n",
-      "  USGS_1M_18_x27y456_PA_Northcentral_2019_B19.tif (320.21 MB)\n",
-      "  USGS_1M_18_x27y455_PA_Northcentral_2019_B19.tif (317.54 MB)\n",
-      "  USGS_1M_18_x27y453_PA_Northcentral_2019_B19.tif (287.21 MB)\n",
-      "  USGS_1M_18_x27y452_PA_Northcentral_2019_B19.tif (243.78 MB)\n",
-      "  USGS_1M_18_x27y451_PA_Northcentral_2019_B19.tif (61.05 MB)\n",
-      "  USGS_1M_18_x26y456_PA_Northcentral_2019_B19.tif (319.73 MB)\n",
-      "  USGS_1M_18_x26y457_PA_Northcentral_2019_B19.tif (294.77 MB)\n",
-      "  USGS_1M_18_x26y455_PA_Northcentral_2019_B19.tif (310.12 MB)\n",
-      "  USGS_1M_18_x26y454_PA_Northcentral_2019_B19.tif (319.13 MB)\n",
-      "  USGS_1M_18_x26y452_PA_Northcentral_2019_B19.tif (297.00 MB)\n",
-      "  USGS_1M_18_x26y453_PA_Northcentral_2019_B19.tif (296.93 MB)\n",
-      "  USGS_1M_18_x26y451_PA_Northcentral_2019_B19.tif (296.55 MB)\n",
-      "  USGS_1M_18_x26y450_PA_Northcentral_2019_B19.tif (70.76 MB)\n",
-      "  USGS_1M_18_x26y449_PA_Northcentral_2019_B19.tif (25.74 MB)\n",
-      "  USGS_1M_18_x25y456_PA_Northcentral_2019_B19.tif (296.43 MB)\n",
-      "  USGS_1M_18_x25y457_PA_Northcentral_2019_B19.tif (304.62 MB)\n",
-      "  USGS_1M_18_x25y455_PA_Northcentral_2019_B19.tif (298.55 MB)\n",
-      "  USGS_1M_18_x25y453_PA_Northcentral_2019_B19.tif (304.44 MB)\n",
-      "  USGS_1M_18_x25y454_PA_Northcentral_2019_B19.tif (313.29 MB)\n",
-      "  USGS_1M_18_x25y452_PA_Northcentral_2019_B19.tif (289.76 MB)\n",
-      "  USGS_1M_18_x25y451_PA_Northcentral_2019_B19.tif (317.18 MB)\n",
-      "  USGS_1M_18_x25y450_PA_Northcentral_2019_B19.tif (325.42 MB)\n",
-      "  USGS_1M_18_x25y449_PA_Northcentral_2019_B19.tif (299.78 MB)\n",
-      "  USGS_1M_18_x24y456_PA_Northcentral_2019_B19.tif (304.06 MB)\n",
-      "  USGS_1M_18_x24y455_PA_Northcentral_2019_B19.tif (309.55 MB)\n",
-      "  USGS_1M_18_x24y457_PA_Northcentral_2019_B19.tif (313.60 MB)\n",
-      "  USGS_1M_18_x24y454_PA_Northcentral_2019_B19.tif (281.36 MB)\n",
-      "  USGS_1M_18_x24y453_PA_Northcentral_2019_B19.tif (309.04 MB)\n",
-      "  USGS_1M_18_x24y452_PA_Northcentral_2019_B19.tif (299.36 MB)\n",
-      "  USGS_1M_18_x24y449_PA_Northcentral_2019_B19.tif (328.36 MB)\n",
-      "  USGS_1M_18_x24y450_PA_Northcentral_2019_B19.tif (321.94 MB)\n",
-      "  USGS_1M_18_x24y451_PA_Northcentral_2019_B19.tif (306.88 MB)\n",
-      "  USGS_1M_18_x23y457_PA_Northcentral_2019_B19.tif (288.89 MB)\n",
-      "  USGS_1M_18_x23y456_PA_Northcentral_2019_B19.tif (314.91 MB)\n",
-      "  USGS_1M_18_x23y455_PA_Northcentral_2019_B19.tif (306.60 MB)\n",
-      "  USGS_1M_18_x23y452_PA_Northcentral_2019_B19.tif (308.41 MB)\n",
-      "  USGS_1M_18_x23y454_PA_Northcentral_2019_B19.tif (296.91 MB)\n",
-      "  USGS_1M_18_x23y453_PA_Northcentral_2019_B19.tif (288.08 MB)\n",
-      "  USGS_1M_18_x23y450_PA_Northcentral_2019_B19.tif (322.39 MB)\n",
-      "  USGS_1M_18_x23y451_PA_Northcentral_2019_B19.tif (307.31 MB)\n",
-      "\n",
-      "Total size: 27234.32 MB\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Download 1m DEM tiles from USGS 3DEP (AWS S3)\n",
     "if DOWNLOAD_BBOX and USGS_PROJECTS is not None and len(USGS_PROJECTS) > 0:\n",
@@ -1675,7 +451,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "id": "reproject-dem-cell",
    "metadata": {
     "execution": {
@@ -1685,75 +461,7 @@
      "shell.execute_reply": "2026-04-23T13:11:05.934058Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-04-23 08:54:47 - ras_commander.terrain.Usgs3depAws - INFO - Creating VRT mosaic from 98 tiles...\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Creating mosaic from 98 tiles...\n",
-      "Attempting VRT-based mosaic with HEC-RAS GDAL tools...\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-04-23 08:54:47 - ras_commander.terrain.Usgs3depAws - INFO -   Created: G:\\GH\\ras-commander\\example_projects\\BaldEagleCrkMulti2D_920\\Terrain\\Terrain_3DEP.vrt\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-04-23 08:54:47 - ras_commander.terrain.RasTerrain - INFO - Converting VRT to TIFF: G:\\GH\\ras-commander\\example_projects\\BaldEagleCrkMulti2D_920\\Terrain\\Terrain_3DEP.vrt -> G:\\GH\\ras-commander\\example_projects\\BaldEagleCrkMulti2D_920\\Terrain\\Terrain_3DEP.tif\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Created VRT mosaic: Terrain_3DEP.vrt\n",
-      "\n",
-      "Converting VRT to TIFF...\n",
-      "Note: This may take several minutes for large mosaics\n",
-      "Creating TIFF overviews is disabled for faster execution\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-04-23 09:11:05 - ras_commander.terrain.RasTerrain - INFO - TIFF created: G:\\GH\\ras-commander\\example_projects\\BaldEagleCrkMulti2D_920\\Terrain\\Terrain_3DEP.tif\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-04-23 09:11:05 - ras_commander.terrain.RasTerrain - INFO - VRT to TIFF conversion complete: G:\\GH\\ras-commander\\example_projects\\BaldEagleCrkMulti2D_920\\Terrain\\Terrain_3DEP.tif (33,278,650,254 bytes, 31736.99 MB)\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "Saved: G:\\GH\\ras-commander\\example_projects\\BaldEagleCrkMulti2D_920\\Terrain\\Terrain_3DEP.tif\n",
-      "  Size: 31736.99 MB\n",
-      "  Shape: 90012 x 540012 pixels\n",
-      "  CRS: None\n",
-      "  Resolution: 1.00 x 1.00\n",
-      "  Bounds: BoundingBox(left=229993.99996416102, bottom=4479994.000048335, right=770005.9999641611, top=4570006.000048335)\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Create mosaic from downloaded tiles\n",
     "# Prefer the VRT workflow first. Usgs3depAws.create_vrt() uses HEC-RAS bundled\n",
@@ -1846,7 +554,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "id": "find-or-create-prj",
    "metadata": {
     "execution": {
@@ -1856,16 +564,7 @@
      "shell.execute_reply": "2026-04-23T13:11:05.939560Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Found 1 projection files\n",
-      "Using existing: Projection.prj\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Find or create projection file\n",
     "prj_files = list(terrain_folder.glob(\"*.prj\"))\n",
@@ -1891,7 +590,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "id": "create-terrain-cell",
    "metadata": {
     "execution": {
@@ -1901,60 +600,7 @@
      "shell.execute_reply": "2026-04-23T14:56:49.871859Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-04-23 09:11:05 - ras_commander.terrain.RasTerrain - INFO - Removed existing terrain HDF: G:\\GH\\ras-commander\\example_projects\\BaldEagleCrkMulti2D_920\\Terrain\\Terrain_3DEP.hdf\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-04-23 09:11:05 - ras_commander.terrain.RasTerrain - INFO - Executing terrain creation command...\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Creating terrain HDF:\n",
-      "  Input TIFF: Terrain_3DEP.tif\n",
-      "  Output HDF: Terrain_3DEP.hdf\n",
-      "  Projection: Projection.prj\n",
-      "  Units: Feet\n",
-      "  Timeout: 14400 seconds\n",
-      "\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-04-23 10:56:49 - ras_commander.terrain.RasTerrain - WARNING - STDERR: Warning 1: TIFFFetchNormalTag:ASCII value for tag \"GDALNoDataValue\" contains null byte in value; value incorrectly truncated during reading due to implementation limitations\n",
-      "\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-04-23 10:56:49 - ras_commander.terrain.RasTerrain - INFO - Terrain HDF created successfully: G:\\GH\\ras-commander\\example_projects\\BaldEagleCrkMulti2D_920\\Terrain\\Terrain_3DEP.hdf (555,408,441 bytes, 529.68 MB)\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "SUCCESS! Terrain HDF created\n",
-      "  File: G:\\GH\\ras-commander\\example_projects\\BaldEagleCrkMulti2D_920\\Terrain\\Terrain_3DEP.hdf\n",
-      "  Size: 529.68 MB\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Create terrain HDF using RasTerrain class\n",
     "if DOWNLOADED_TIFF and DOWNLOADED_TIFF.exists() and projection_prj and projection_prj.exists():\n",
@@ -2014,7 +660,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "id": "fallback-cell",
    "metadata": {
     "execution": {
@@ -2024,15 +670,7 @@
      "shell.execute_reply": "2026-04-23T14:56:49.877861Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Using newly created terrain: Terrain_3DEP.hdf\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Fallback to existing terrain if new terrain wasn't created\n",
     "if NEW_TERRAIN_HDF is None or not NEW_TERRAIN_HDF.exists():\n",
@@ -2062,7 +700,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "id": "find-rasmap",
    "metadata": {
     "execution": {
@@ -2072,16 +710,7 @@
      "shell.execute_reply": "2026-04-23T14:56:49.883069Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Found 1 .rasmap files:\n",
-      "  BaldEagleDamBrk.rasmap (43.5 KB)\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Find the .rasmap file\n",
     "rasmap_files = list(project_path.glob(\"*.rasmap\"))\n",
@@ -2092,7 +721,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "id": "inspect-rasmap-terrains",
    "metadata": {
     "execution": {
@@ -2102,19 +731,7 @@
      "shell.execute_reply": "2026-04-23T14:56:49.893066Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Existing Terrains section in BaldEagleDamBrk.rasmap:\n",
-      "\n",
-      "  Terrain layers (1):\n",
-      "    - Name: Terrain50\n",
-      "      Filename: .\\Terrain\\Terrain50.hdf\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Inspect existing terrain configuration in .rasmap\n",
     "import xml.etree.ElementTree as ET\n",
@@ -2141,7 +758,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": null,
    "id": "add-terrain-layer",
    "metadata": {
     "execution": {
@@ -2151,33 +768,7 @@
      "shell.execute_reply": "2026-04-23T14:56:49.903712Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-04-23 10:56:49 - ras_commander.RasMap - INFO - Updated projection reference: .\\Terrain\\Projection.prj\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-04-23 10:56:49 - ras_commander.RasMap - INFO - Added terrain layer 'Terrain_3DEP' to .rasmap file: .\\Terrain\\Terrain_3DEP.hdf\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Adding terrain layer to BaldEagleDamBrk.rasmap:\n",
-      "  Terrain HDF: Terrain_3DEP.hdf\n",
-      "  Layer name: Terrain_3DEP\n",
-      "\n",
-      "Terrain layer added successfully!\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Add the new terrain layer to the .rasmap file\n",
     "if rasmap_files and NEW_TERRAIN_HDF and NEW_TERRAIN_HDF.exists():\n",
@@ -2205,7 +796,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": null,
    "id": "verify-rasmap-update",
    "metadata": {
     "execution": {
@@ -2215,17 +806,7 @@
      "shell.execute_reply": "2026-04-23T14:56:49.916299Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Updated Terrains section (2 layers):\n",
-      "  - Terrain50: .\\Terrain\\Terrain50.hdf\n",
-      "  - Terrain_3DEP: .\\Terrain\\Terrain_3DEP.hdf <-- NEW\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Verify the terrain layer was added\n",
     "if rasmap_files:\n",
@@ -2241,6 +822,114 @@
     "            name = layer.get('Name')\n",
     "            marker = \" <-- NEW\" if name == NEW_TERRAIN_NAME else \"\"\n",
     "            print(f\"  - {name}: {layer.get('Filename')}{marker}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "29572417",
+   "metadata": {},
+   "source": [
+    "## List Registered Terrain Layers\n",
+    "\n",
+    "`RasMap.add_terrain_layer()` updates the `.rasmap` catalog. `RasMap.list_terrain_layers()` reads that catalog back as a dataframe so automation can confirm the new layer name, source filename, resolved path, checked state, terrain type, resampling method, and surface-on flag without manual XML parsing.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "144533be",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "terrain_layers = RasMap.list_terrain_layers(project_path)\n",
+    "print(f\"Registered terrain layers: {len(terrain_layers)}\")\n",
+    "display(terrain_layers[[\n",
+    "    \"name\",\n",
+    "    \"filename\",\n",
+    "    \"resolved_path\",\n",
+    "    \"checked\",\n",
+    "    \"type\",\n",
+    "    \"resample_method\",\n",
+    "    \"surface_on\",\n",
+    "]])\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6aa44a30",
+   "metadata": {},
+   "source": [
+    "## Associate Terrain With Geometry HDF\n",
+    "\n",
+    "Registering a terrain in `.rasmap` makes it available to RAS Mapper. Associating a terrain with a compiled geometry HDF writes the HEC-RAS `/Geometry` attributes used by geometry preprocessing/property-table workflows. This is intentionally Python-native for normal automation; it requires an existing `.g##.hdf` and does not compile a text `.g##` file into HDF.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "89f4549b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "geometry_hdf_path = None\n",
+    "if getattr(ras, \"geom_df\", None) is not None and not ras.geom_df.empty:\n",
+    "    mesh_rows = ras.geom_df\n",
+    "    if \"has_2d_mesh\" in mesh_rows.columns:\n",
+    "        mesh_rows = mesh_rows[mesh_rows[\"has_2d_mesh\"]]\n",
+    "    if not mesh_rows.empty and \"hdf_path\" in mesh_rows.columns:\n",
+    "        candidate = Path(mesh_rows.iloc[0][\"hdf_path\"])\n",
+    "        if candidate.exists():\n",
+    "            geometry_hdf_path = candidate\n",
+    "\n",
+    "if geometry_hdf_path and NEW_TERRAIN_HDF and NEW_TERRAIN_HDF.exists():\n",
+    "    print(f\"Associating terrain with geometry HDF: {geometry_hdf_path.name}\")\n",
+    "    RasMap.associate_geometry_layers(\n",
+    "        project_path,\n",
+    "        geometry_hdf_path,\n",
+    "        terrain_hdf_path=NEW_TERRAIN_HDF,\n",
+    "    )\n",
+    "\n",
+    "    association = RasMap.get_hdf_geometry_association(geometry_hdf_path)\n",
+    "    print(\"Updated geometry association:\")\n",
+    "    for key in [\"terrain_hdf_path\", \"terrain_layer_name\", \"terrain_date\"]:\n",
+    "        print(f\"  {key}: {association.get(key)}\")\n",
+    "else:\n",
+    "    print(\"Skipping geometry association because no existing geometry HDF or terrain HDF was found.\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "12c8d829",
+   "metadata": {},
+   "source": [
+    "## Optional Native CLI Validator\n",
+    "\n",
+    "`RasProcess.validate_geometry_association_cli()` is a reference/validation path around `RasProcess.exe SetGeometryAssociation`. It mutates the supplied HDF in place, so run it only on a disposable copy or a model you intentionally want the native executable to touch. The main public workflow remains `RasMap.associate_geometry_layers()` above.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4ab5c9d1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "RUN_NATIVE_ASSOCIATION_VALIDATOR = False\n",
+    "\n",
+    "if RUN_NATIVE_ASSOCIATION_VALIDATOR and geometry_hdf_path and NEW_TERRAIN_HDF:\n",
+    "    import pandas as pd\n",
+    "\n",
+    "    cli_result = RasProcess.validate_geometry_association_cli(\n",
+    "        geometry_hdf_path,\n",
+    "        terrain_hdf_path=NEW_TERRAIN_HDF,\n",
+    "        ras_version=RAS_VERSION,\n",
+    "    )\n",
+    "    print(f\"Native validator passed: {cli_result['passed']}\")\n",
+    "    print(f\"Return code: {cli_result['return_code']}\")\n",
+    "    if cli_result[\"mismatches\"]:\n",
+    "        display(pd.DataFrame(cli_result[\"mismatches\"]))\n",
+    "else:\n",
+    "    print(\"Native RasProcess.exe validator skipped. Set RUN_NATIVE_ASSOCIATION_VALIDATOR = True to run it.\")\n"
    ]
   },
   {
@@ -2268,6 +957,12 @@
     "\n",
     "5. **Register in RasMap** - Added terrain to project configuration\n",
     "\n",
+    "6. **List Terrain Layers** - Used `RasMap.list_terrain_layers()` for dataframe-based discovery\n",
+    "\n",
+    "7. **Associate Geometry** - Used `RasMap.associate_geometry_layers()` to write terrain association attributes to an existing geometry HDF\n",
+    "\n",
+    "8. **Native Validation Option** - Included guarded `RasProcess.validate_geometry_association_cli()` usage for disposable/reference checks\n",
+    "\n",
     "### Next Steps\n",
     "\n",
     "- Open project in HEC-RAS and verify terrain displays correctly\n",
@@ -2289,7 +984,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": null,
    "id": "inspect-hdf-structure",
    "metadata": {
     "execution": {
@@ -2299,17 +994,7 @@
      "shell.execute_reply": "2026-04-23T14:56:49.922606Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Found 2 terrain HDF files:\n",
-      "  Terrain50.hdf (4.69 MB)\n",
-      "  Terrain_3DEP.hdf (529.68 MB)\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "def print_hdf_structure(hdf_file, prefix=\"\", max_depth=3, current_depth=0):\n",
     "    \"\"\"Recursively print HDF5 file structure with dataset info.\"\"\"\n",
@@ -2335,7 +1020,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": null,
    "id": "explore-terrain-hdf",
    "metadata": {
     "execution": {
@@ -2345,36 +1030,7 @@
      "shell.execute_reply": "2026-04-23T14:56:49.958614Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "Exploring: Terrain50.hdf\n",
-      "============================================================\n",
-      "Terrain/\n",
-      "  Stitch TIN Points (shape=(72592, 4), dtype=float64)\n",
-      "  Stitch TIN Triangles (shape=(72301, 3), dtype=int32)\n",
-      "  Stitches (shape=(103000, 7), dtype=float64)\n",
-      "  Terrain50.baldeagledem/\n",
-      "    0/\n",
-      "    1/\n",
-      "    2/\n",
-      "    3/\n",
-      "    4/\n",
-      "    5/\n",
-      "    6/\n",
-      "  Terrain50.dtm_20ft/\n",
-      "    0/\n",
-      "    1/\n",
-      "    2/\n",
-      "    3/\n",
-      "    4/\n",
-      "    5/\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Open and explore the first terrain HDF\n",
     "if terrain_hdfs:\n",
@@ -2390,7 +1046,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": null,
    "id": "inspect-stitch-data",
    "metadata": {
     "execution": {
@@ -2400,29 +1056,7 @@
      "shell.execute_reply": "2026-04-23T14:56:49.975771Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Stitch TIN Points:\n",
-      "  Shape: (72592, 4)\n",
-      "  Columns: X, Y, Z, M (material/priority)\n",
-      "  Sample (first 3 points):\n",
-      "    [0] X=2075224.54, Y=371231.14, Z=796.59, M=20\n",
-      "    [1] X=2075224.54, Y=371251.14, Z=803.22, M=20\n",
-      "    [2] X=2075244.54, Y=371251.14, Z=803.09, M=20\n",
-      "\n",
-      "Stitch TIN Triangles:\n",
-      "  Shape: (72301, 3)\n",
-      "  Columns: p0, p1, p2 (vertex indices)\n",
-      "\n",
-      "Source terrain layers:\n",
-      "  Terrain50.baldeagledem\n",
-      "  Terrain50.dtm_20ft\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Inspect the stitching data structure\n",
     "if terrain_hdfs:\n",
@@ -2457,7 +1091,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": null,
    "id": "inspect-pyramid-levels",
    "metadata": {
     "execution": {
@@ -2467,52 +1101,7 @@
      "shell.execute_reply": "2026-04-23T14:56:49.987406Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Source layer: Terrain50.baldeagledem\n",
-      "\n",
-      "Pyramid levels (resolution hierarchy):\n",
-      "\n",
-      "  Level 0:\n",
-      "    Mask: shape=(918, 65536), dtype=uint8\n",
-      "    Min-Max: shape=(918, 3), dtype=float32\n",
-      "    Perimeter: shape=(918, 513), dtype=float32\n",
-      "\n",
-      "  Level 1:\n",
-      "    Mask: shape=(238, 65536), dtype=uint8\n",
-      "    Min-Max: shape=(238, 3), dtype=float32\n",
-      "    Perimeter: shape=(238, 513), dtype=float32\n",
-      "\n",
-      "  Level 2:\n",
-      "    Mask: shape=(63, 65536), dtype=uint8\n",
-      "    Min-Max: shape=(63, 3), dtype=float32\n",
-      "    Perimeter: shape=(63, 513), dtype=float32\n",
-      "\n",
-      "  Level 3:\n",
-      "    Mask: shape=(20, 65536), dtype=uint8\n",
-      "    Min-Max: shape=(20, 3), dtype=float32\n",
-      "    Perimeter: shape=(20, 513), dtype=float32\n",
-      "\n",
-      "  Level 4:\n",
-      "    Mask: shape=(6, 65536), dtype=uint8\n",
-      "    Min-Max: shape=(6, 3), dtype=float32\n",
-      "    Perimeter: shape=(6, 513), dtype=float32\n",
-      "\n",
-      "  Level 5:\n",
-      "    Mask: shape=(2, 65536), dtype=uint8\n",
-      "    Min-Max: shape=(2, 3), dtype=float32\n",
-      "    Perimeter: shape=(2, 513), dtype=float32\n",
-      "\n",
-      "  Level 6:\n",
-      "    Mask: shape=(1, 65536), dtype=uint8\n",
-      "    Min-Max: shape=(1, 3), dtype=float32\n",
-      "    Perimeter: shape=(1, 513), dtype=float32\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Inspect pyramid levels in a source terrain layer\n",
     "if terrain_hdfs:\n",
@@ -2565,7 +1154,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": null,
    "id": "cleanup-cell",
    "metadata": {
     "execution": {
@@ -2575,16 +1164,7 @@
      "shell.execute_reply": "2026-04-23T14:56:49.992335Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Project preserved at: G:\\GH\\ras-commander\\example_projects\\BaldEagleCrkMulti2D_920\n",
-      "Set CLEANUP_PROJECT = True to remove on next run\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Optional: Clean up extracted project\n",
     "CLEANUP_PROJECT = False  # Set to True to remove extracted project\n",

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -60,7 +60,7 @@ plugins:
             heading_level: 2
             separate_signature: true
             show_signature_annotations: true
-  # DISABLED for pre-rendered notebooks: # DISABLED for pre-rendered notebooks: # DISABLED for pre-rendered notebooks: - mkdocs-jupyter:
+  # DISABLED for pre-rendered notebooks: - mkdocs-jupyter:
   # include_source: true
   # execute: false
   # include: ["notebooks/*.md"]
@@ -68,11 +68,13 @@ plugins:
   # ignore_h1_titles: true
   - git-revision-date-localized:
       enable_creation_date: true
+      enable_git_follow: false
       type: date
 
 markdown_extensions:
   - pymdownx.highlight:
       anchor_linenums: true
+      auto_title: true
       line_spans: __span
       pygments_lang_class: true
   - pymdownx.inlinehilite
@@ -170,6 +172,7 @@ nav:
       - 2D Plaintext Geometry: notebooks/202_2d_plaintext_geometry.md
       - Extract XYZ from Geometry: notebooks/205_extract_xs_xyz_from_geometry.md
       - Fixit Blocked Obstructions: notebooks/210_fixit_blocked_obstructions.md
+      - Land Cover Manning's n Write: notebooks/212_landcover_mannings_n_write.md
     - Boundary Conditions (300s):
       - Unsteady Flow Operations: notebooks/300_unsteady_flow_operations.md
       - DSS Boundary Extraction: notebooks/310_dss_boundary_extraction.md
@@ -218,6 +221,7 @@ nav:
       - USGS Real-Time Monitoring: notebooks/912_usgs_real_time_monitoring.md
       - BC from Live Gauge: notebooks/913_bc_generation_from_live_gauge.md
       - Model Validation with USGS: notebooks/914_model_validation_with_usgs.md
+      - Terrain Creation: notebooks/920_terrain_creation.md
     - Real-Time Forecast Workflows (915-919):
       - Forecast Workflow Overview: notebooks/915_realtime_forecast_workflow.md
       - HRRR Precipitation Forecast: notebooks/916_hrrr_precipitation_forecast.md

--- a/ras_commander/RasMap.py
+++ b/ras_commander/RasMap.py
@@ -361,6 +361,114 @@ class RasMap:
 
     @staticmethod
     @log_call
+    def list_terrain_layers(
+        ras_project_path: Union[str, Path],
+        ras_object=None,
+    ) -> pd.DataFrame:
+        """
+        List terrain layers registered in a project .rasmap file.
+
+        Args:
+            ras_project_path: Project folder, .prj file, or .rasmap file.
+            ras_object: Optional RasPrj object. Present for API consistency.
+
+        Returns:
+            DataFrame with one row per ``Terrains/Layer`` entry.
+        """
+        ras_project_path = Path(ras_project_path)
+        from . import _land_classification_helper as _lch
+
+        project_paths = _lch.resolve_project_paths(ras_project_path)
+        rasmap_path = project_paths.rasmap_path
+        columns = [
+            "name",
+            "filename",
+            "resolved_path",
+            "checked",
+            "type",
+            "resample_method",
+            "surface_on",
+        ]
+
+        if not rasmap_path.exists():
+            logger.warning(f"RASMapper file not found: {rasmap_path}")
+            return pd.DataFrame(columns=columns)
+
+        try:
+            root = ET.parse(rasmap_path).getroot()
+        except ET.ParseError as e:
+            logger.error(f"Error parsing .rasmap XML: {e}")
+            return pd.DataFrame(columns=columns)
+
+        records = []
+        for layer in root.findall(".//Terrains/Layer"):
+            filename = layer.attrib.get("Filename")
+            resolved_path = _lch.resolve_rasmap_relative_path(
+                project_paths.project_folder,
+                filename,
+            )
+            surface = layer.find("Surface")
+            records.append(
+                {
+                    "name": layer.attrib.get("Name", ""),
+                    "filename": filename,
+                    "resolved_path": (
+                        str(resolved_path) if resolved_path is not None else None
+                    ),
+                    "checked": layer.attrib.get("Checked", "True").lower() == "true",
+                    "type": layer.attrib.get("Type", ""),
+                    "resample_method": layer.findtext("ResampleMethod"),
+                    "surface_on": (
+                        surface.attrib.get("On", "False").lower() == "true"
+                        if surface is not None
+                        else None
+                    ),
+                }
+            )
+
+        return pd.DataFrame(records, columns=columns)
+
+    @staticmethod
+    @log_call
+    def list_landcover_layers(
+        ras_project_path: Union[str, Path],
+        ras_object=None,
+    ) -> pd.DataFrame:
+        """List land-cover layers registered in a project .rasmap file."""
+        layers = RasMap.list_land_classification_layers(
+            ras_project_path,
+            ras_object=ras_object,
+        )
+        return layers.loc[layers["classification_kind"] == "landcover"].copy()
+
+    @staticmethod
+    @log_call
+    def list_soils_layers(
+        ras_project_path: Union[str, Path],
+        ras_object=None,
+    ) -> pd.DataFrame:
+        """List hydrologic soils layers registered in a project .rasmap file."""
+        layers = RasMap.list_land_classification_layers(
+            ras_project_path,
+            ras_object=ras_object,
+        )
+        return layers.loc[layers["classification_kind"] == "soils"].copy()
+
+    @staticmethod
+    @log_call
+    def list_infiltration_layers(
+        ras_project_path: Union[str, Path],
+        ras_object=None,
+    ) -> pd.DataFrame:
+        """List infiltration layers registered in a project .rasmap file."""
+        layers = RasMap.list_land_classification_layers(
+            ras_project_path,
+            ras_object=ras_object,
+        )
+        return layers.loc[layers["classification_kind"] == "infiltration"].copy()
+
+    @staticmethod
+    @log_call
     def add_landcover_layer(
         ras_project_path: Union[str, Path],
         source_path: Union[str, Path],
@@ -454,10 +562,21 @@ class RasMap:
         landcover_hdf_path: Optional[Union[str, Path]] = None,
         soil_layer_path: Optional[Union[str, Path]] = None,
         infiltration_hdf_path: Optional[Union[str, Path]] = None,
+        terrain_hdf_path: Optional[Union[str, Path]] = None,
+        sediment_soils_hdf_path: Optional[Union[str, Path]] = None,
         ras_object=None,
     ) -> Path:
         """
-        Associate generated classification layers to a geometry.
+        Associate terrain / classification layers to a compiled geometry HDF.
+
+        This public workflow writes HEC-RAS ``/Geometry`` association
+        attributes directly with h5py. Use
+        ``RasProcess.validate_geometry_association_cli()`` only as an optional
+        native-reference validator on disposable or intentionally mutated HDFs.
+
+        ``soil_layer_path`` is retained for compatibility with the
+        land-classification workflow. Use ``sediment_soils_hdf_path`` for the
+        HEC-RAS ``SedimentSoilsFilename`` geometry association.
         """
         ras_project_path = Path(ras_project_path)
         geom_file = Path(geom_file)
@@ -468,6 +587,14 @@ class RasMap:
         infiltration_hdf_path = (
             Path(infiltration_hdf_path) if infiltration_hdf_path is not None else None
         )
+        terrain_hdf_path = (
+            Path(terrain_hdf_path) if terrain_hdf_path is not None else None
+        )
+        sediment_soils_hdf_path = (
+            Path(sediment_soils_hdf_path)
+            if sediment_soils_hdf_path is not None
+            else None
+        )
         from . import _land_classification_helper as _lch
 
         return _lch.associate_geometry_layers(
@@ -476,7 +603,80 @@ class RasMap:
             landcover_hdf_path=landcover_hdf_path,
             soil_layer_path=soil_layer_path,
             infiltration_hdf_path=infiltration_hdf_path,
+            terrain_hdf_path=terrain_hdf_path,
+            sediment_soils_hdf_path=sediment_soils_hdf_path,
             ras_object=ras_object,
+        )
+
+    @staticmethod
+    @log_call
+    def set_geometry_association(
+        geom_number: Union[str, Path],
+        terrain_hdf_path: Optional[Union[str, Path]] = None,
+        landcover_hdf_path: Optional[Union[str, Path]] = None,
+        infiltration_hdf_path: Optional[Union[str, Path]] = None,
+        sediment_soils_hdf_path: Optional[Union[str, Path]] = None,
+        hecras_dir: Optional[Union[str, Path]] = None,
+        ras_object=None,
+        validate: bool = True,
+    ) -> Path:
+        """
+        Associate terrain / classification layers directly on a geometry HDF.
+        """
+        from .geom.GeomMesh import GeomMesh
+
+        return GeomMesh.set_geometry_association(
+            geom_number,
+            terrain_hdf_path=terrain_hdf_path,
+            landcover_hdf_path=landcover_hdf_path,
+            infiltration_hdf_path=infiltration_hdf_path,
+            sediment_soils_hdf_path=sediment_soils_hdf_path,
+            hecras_dir=hecras_dir,
+            ras_object=ras_object,
+            validate=validate,
+        )
+
+    @staticmethod
+    @log_call
+    def get_geometry_association(
+        geom_number: Union[str, Path],
+        hecras_dir: Optional[Union[str, Path]] = None,
+        ras_object=None,
+        resolve_paths: bool = True,
+    ) -> dict:
+        """
+        Read terrain / classification associations from a geometry HDF.
+        """
+        from .geom.GeomMesh import GeomMesh
+
+        return GeomMesh.get_geometry_association(
+            geom_number,
+            hecras_dir=hecras_dir,
+            ras_object=ras_object,
+            resolve_paths=resolve_paths,
+        )
+
+    @staticmethod
+    @log_call
+    def get_hdf_geometry_association(
+        hdf_path: Union[str, Path],
+        resolve_paths: bool = True,
+        include_2d_area_attrs: bool = True,
+        ras_object=None,
+    ) -> dict:
+        """
+        Read ``/Geometry`` association attrs from a geometry, plan, or result HDF.
+
+        This is read-only and intended for QA/QC workflows that need to audit
+        terrain, land-cover, infiltration, or sediment bed-material links
+        already stored in HEC-RAS HDF artifacts.
+        """
+        from ._geometry_association import read_geometry_association
+
+        return read_geometry_association(
+            hdf_path,
+            resolve_paths=resolve_paths,
+            include_2d_area_attrs=include_2d_area_attrs,
         )
 
     @staticmethod

--- a/ras_commander/RasProcess.py
+++ b/ras_commander/RasProcess.py
@@ -796,6 +796,119 @@ Step 5: Configure (optional — auto-detection usually works)
 
     @staticmethod
     @log_call
+    def validate_geometry_association_cli(
+        hdf_path: Union[str, Path],
+        terrain_hdf_path: Optional[Union[str, Path]] = None,
+        landcover_hdf_path: Optional[Union[str, Path]] = None,
+        infiltration_hdf_path: Optional[Union[str, Path]] = None,
+        sediment_soils_hdf_path: Optional[Union[str, Path]] = None,
+        ras_version: str = None,
+        timeout: int = 600,
+        ras_object=None,
+    ) -> Dict[str, Any]:
+        """
+        Validate geometry association behavior against RasProcess.exe.
+
+        Warning:
+            This method runs RasProcess.exe ``SetGeometryAssociation`` in-place
+            and mutates the supplied geometry HDF. It is a reference/validation
+            path only. Normal workflows should call
+            ``RasMap.associate_geometry_layers(...)``, which writes the same
+            ``/Geometry`` association attributes through Python-native h5py.
+
+        Args:
+            hdf_path: Existing geometry HDF to mutate and validate.
+            terrain_hdf_path: Optional terrain HDF to associate.
+            landcover_hdf_path: Optional land-cover/Manning's n HDF.
+            infiltration_hdf_path: Optional infiltration HDF.
+            sediment_soils_hdf_path: Optional sediment bed-material soils HDF.
+            ras_version: Optional HEC-RAS version for RasProcess.exe lookup.
+            timeout: Command timeout in seconds.
+            ras_object: Optional RasPrj object. Present for API consistency.
+
+        Returns:
+            Dict containing command args, return code, stdout/stderr,
+            before/after association attrs, expected attrs, mismatches, and
+            ``passed``.
+        """
+        from ._geometry_association import (
+            build_expected_geometry_association_attrs,
+            build_set_geometry_association_args,
+            compare_expected_geometry_association_attrs,
+            read_geometry_association,
+            safe_resolve_path,
+        )
+
+        hdf_path = safe_resolve_path(hdf_path)
+        if not hdf_path.exists():
+            raise FileNotFoundError(f"Geometry HDF not found: {hdf_path}")
+
+        supplied = {
+            "terrain_hdf_path": terrain_hdf_path,
+            "landcover_hdf_path": landcover_hdf_path,
+            "infiltration_hdf_path": infiltration_hdf_path,
+            "sediment_soils_hdf_path": sediment_soils_hdf_path,
+        }
+        if all(path is None for path in supplied.values()):
+            raise ValueError("Provide at least one geometry association path.")
+
+        resolved_paths: Dict[str, Path] = {}
+        for key, path_value in supplied.items():
+            if path_value is None:
+                continue
+            resolved_path = safe_resolve_path(path_value)
+            if not resolved_path.exists():
+                raise FileNotFoundError(
+                    f"Association artifact not found for {key}: {resolved_path}"
+                )
+            resolved_paths[key] = resolved_path
+
+        before = read_geometry_association(hdf_path, resolve_paths=True)
+        expected_attrs = build_expected_geometry_association_attrs(
+            hdf_path,
+            resolved_paths,
+            project_folder=hdf_path.parent,
+        )
+
+        rasprocess = RasProcess.find_rasprocess(ras_version)
+        if rasprocess is None:
+            raise FileNotFoundError("RasProcess.exe not found")
+
+        command_args = build_set_geometry_association_args(
+            hdf_path,
+            resolved_paths,
+            path_formatter=RasProcess._resolve_path_for_rasprocess,
+        )
+        result = RasProcess._run_rasprocess(
+            rasprocess,
+            command_args,
+            timeout=timeout,
+            working_dir=hdf_path.parent,
+        )
+
+        after = read_geometry_association(hdf_path, resolve_paths=True)
+        mismatches = compare_expected_geometry_association_attrs(
+            hdf_path,
+            after,
+            expected_attrs,
+        )
+        passed = result.returncode == 0 and not mismatches
+
+        return {
+            "rasprocess_path": str(rasprocess),
+            "command_args": command_args,
+            "return_code": result.returncode,
+            "stdout": result.stdout or "",
+            "stderr": result.stderr or "",
+            "before": before,
+            "after": after,
+            "expected_attrs": expected_attrs,
+            "mismatches": mismatches,
+            "passed": passed,
+        }
+
+    @staticmethod
+    @log_call
     def get_plan_timestamps(
         plan_number: str,
         ras_object=None

--- a/ras_commander/_geometry_association.py
+++ b/ras_commander/_geometry_association.py
@@ -1,0 +1,593 @@
+"""Shared helpers for HEC-RAS geometry HDF layer associations.
+
+HEC-RAS stores terrain, land-cover, infiltration, and sediment bed-material
+links as attributes on the ``/Geometry`` group.  This module keeps the
+attribute names, RasProcess argument names, and comparison logic in one place
+so the Python-native RasMap workflow and the RasProcess reference validator do
+not drift apart.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import xml.etree.ElementTree as ET
+from datetime import datetime
+from pathlib import Path, PureWindowsPath
+from typing import Any, Callable, Dict, Mapping, Optional, Union
+
+from .RasUtils import RasUtils
+
+
+PathLike = Union[str, Path]
+
+GEOMETRY_ASSOCIATION_FIELDS: Dict[str, Dict[str, Any]] = {
+    "terrain_hdf_path": {
+        "cli_arg": "TerrainFilename",
+        "command_property": "TerrainFilename",
+        "filename_attr": "Terrain Filename",
+        "layer_attr": "Terrain Layername",
+        "date_attr": "Terrain File Date",
+        "date_key": "terrain_file_date",
+        "layer_kind": "terrain",
+    },
+    "landcover_hdf_path": {
+        "cli_arg": "NValueFilename",
+        "command_property": "NValueFilename",
+        "filename_attr": "Land Cover Filename",
+        "layer_attr": "Land Cover Layername",
+        "date_attr": "Land Cover File Date",
+        "date_key": "landcover_file_date",
+        "extra_date_attrs": ("Land Cover Date Last Modified",),
+        "extra_date_keys": ("landcover_date_last_modified",),
+        "layer_kind": "landcover",
+    },
+    "infiltration_hdf_path": {
+        "cli_arg": "InfiltrationFilename",
+        "command_property": "InfiltrationFilename",
+        "filename_attr": "Infiltration Filename",
+        "layer_attr": "Infiltration Layername",
+        "date_attr": "Infiltration File Date",
+        "date_key": "infiltration_file_date",
+        "layer_kind": "infiltration",
+    },
+    "sediment_soils_hdf_path": {
+        "cli_arg": "SedimentSoilsFilename",
+        "command_property": "SedimentSoilsFilename",
+        "filename_attr": "Sediment Bed Material Filename",
+        "layer_attr": "Sediment Bed Material Layername",
+        "date_attr": "Sediment Bed Material File Date",
+        "date_key": "sediment_soils_file_date",
+        "layer_kind": "sediment_soils",
+    },
+}
+
+FIELD_ORDER = tuple(GEOMETRY_ASSOCIATION_FIELDS)
+_WINDOWS_ENV_VAR_PATTERN = re.compile(r"%([^%]+)%")
+_PLAN_OR_RESULT_HDF_PATTERN = re.compile(r"\.[pou]\d{2}\.hdf$", re.IGNORECASE)
+
+
+def safe_resolve_path(path: PathLike) -> Path:
+    """Resolve a path without requiring it to exist."""
+    return RasUtils.safe_resolve(Path(path))
+
+
+def decode_hdf_attr(value: Any) -> Optional[str]:
+    """Decode an HDF attribute value to a clean string."""
+    if value is None:
+        return None
+    if isinstance(value, (list, tuple)) and len(value) == 1:
+        value = value[0]
+    if hasattr(value, "item") and not isinstance(value, (str, bytes, bytearray)):
+        try:
+            value = value.item()
+        except (AttributeError, ValueError, TypeError):
+            pass
+    if isinstance(value, bytearray):
+        value = bytes(value)
+    if isinstance(value, bytes):
+        text = value.decode("utf-8", errors="replace")
+    else:
+        text = str(value)
+    text = text.strip("\x00").strip()
+    return text if text else None
+
+
+def encode_hdf_attr(value: str) -> bytes:
+    """Encode an HDF string attribute in the byte-string style HEC-RAS uses."""
+    return str(value).encode("utf-8")
+
+
+def resolve_association_attr_path(hdf_path: PathLike, attr_value: str) -> Path:
+    """Resolve a filename attribute relative to the HDF folder."""
+    hdf_path = Path(hdf_path)
+    attr_text = str(attr_value).strip()
+    attr_text = _WINDOWS_ENV_VAR_PATTERN.sub(
+        lambda match: os.environ.get(match.group(1), match.group(0)),
+        attr_text,
+    )
+
+    posix_path = Path(attr_text)
+    windows_path = PureWindowsPath(attr_text.replace("/", "\\"))
+
+    if posix_path.is_absolute():
+        return safe_resolve_path(posix_path)
+    if windows_path.is_absolute():
+        return safe_resolve_path(Path(str(windows_path)))
+
+    relative_text = attr_text.replace("/", "\\")
+    if relative_text.startswith(".\\") or relative_text.startswith("./"):
+        relative_text = relative_text[2:]
+    relative_path = Path(*PureWindowsPath(relative_text).parts)
+    return safe_resolve_path(hdf_path.parent / relative_path)
+
+
+def format_hec_relative_path(target_path: PathLike, base_folder: PathLike) -> str:
+    """Format a target as a RAS-style Windows path, relative when possible."""
+    target = safe_resolve_path(target_path)
+    base = safe_resolve_path(base_folder)
+    try:
+        relative = os.path.relpath(target, base)
+    except ValueError:
+        return str(target).replace("/", "\\")
+
+    relative = relative.replace("/", "\\")
+    if relative == ".":
+        return "."
+    if relative.startswith("..\\") or relative == "..":
+        return relative
+    return ".\\" + relative
+
+
+def format_hec_file_date(path: PathLike) -> str:
+    """Format file mtime the way HEC-RAS stores association dates."""
+    timestamp = Path(path).stat().st_mtime
+    return datetime.fromtimestamp(timestamp).strftime("%d%b%Y %H:%M:%S").upper()
+
+
+def is_plan_or_result_hdf(path: PathLike) -> bool:
+    """Return True for plan/result HDF names such as ``.p01.hdf``."""
+    return bool(_PLAN_OR_RESULT_HDF_PATTERN.search(Path(path).name))
+
+
+def ensure_geometry_group(hdf_path: PathLike) -> None:
+    """Validate that an HDF file contains the required ``/Geometry`` group."""
+    import h5py
+
+    hdf_path = Path(hdf_path)
+    with h5py.File(str(hdf_path), "r") as hdf_file:
+        if "Geometry" not in hdf_file:
+            raise RuntimeError(f"HDF is missing the /Geometry group: {hdf_path}")
+
+
+def _field_attr_names() -> tuple[str, ...]:
+    attrs = ["SI Units"]
+    for field in GEOMETRY_ASSOCIATION_FIELDS.values():
+        attrs.extend([field["filename_attr"], field["layer_attr"]])
+        if field.get("date_attr"):
+            attrs.append(field["date_attr"])
+        attrs.extend(field.get("extra_date_attrs", ()))
+    return tuple(dict.fromkeys(attrs))
+
+
+def read_geometry_association(
+    hdf_path: PathLike,
+    *,
+    resolve_paths: bool = True,
+    include_2d_area_attrs: bool = False,
+) -> dict[str, Any]:
+    """Read ``/Geometry`` association attributes from a geometry or result HDF."""
+    import h5py
+
+    hdf_path = safe_resolve_path(hdf_path)
+    ensure_geometry_group(hdf_path)
+
+    association: dict[str, Any] = {}
+    with h5py.File(str(hdf_path), "r") as hdf_file:
+        attrs = hdf_file["Geometry"].attrs
+        raw_attrs = {}
+        for attr_name in _field_attr_names():
+            attr_value = decode_hdf_attr(attrs.get(attr_name))
+            if attr_value is not None:
+                raw_attrs[attr_name] = attr_value
+
+        for key, field in GEOMETRY_ASSOCIATION_FIELDS.items():
+            raw_filename = raw_attrs.get(field["filename_attr"])
+            raw_key = key.replace("_hdf_path", "_raw_filename")
+            layer_key = key.replace("_hdf_path", "_layer_name")
+
+            association[raw_key] = raw_filename
+            if raw_filename:
+                association[key] = (
+                    str(resolve_association_attr_path(hdf_path, raw_filename))
+                    if resolve_paths
+                    else raw_filename
+                )
+            else:
+                association[key] = None
+
+            association[layer_key] = raw_attrs.get(field["layer_attr"])
+            if field.get("date_attr"):
+                association[field["date_key"]] = raw_attrs.get(field["date_attr"])
+            for attr_name, attr_key in zip(
+                field.get("extra_date_attrs", ()),
+                field.get("extra_date_keys", ()),
+            ):
+                association[attr_key] = raw_attrs.get(attr_name)
+
+        association["si_units"] = raw_attrs.get("SI Units")
+        association["hdf_attrs"] = raw_attrs
+
+        if include_2d_area_attrs:
+            association["two_d_area_terrain_associations"] = (
+                _read_two_d_area_terrain_associations(hdf_file, hdf_path, resolve_paths)
+            )
+
+    return association
+
+
+def _read_two_d_area_terrain_associations(hdf_file, hdf_path: Path, resolve_paths: bool):
+    area_records = []
+    flow_areas = hdf_file.get("Geometry/2D Flow Areas")
+    if flow_areas is None:
+        return area_records
+
+    for area_name, area_group in flow_areas.items():
+        raw_filename = decode_hdf_attr(area_group.attrs.get("Terrain Filename"))
+        record = {
+            "flow_area": area_name,
+            "terrain_raw_filename": raw_filename,
+            "terrain_layer_name": decode_hdf_attr(
+                area_group.attrs.get("Terrain Layername")
+            ),
+            "terrain_file_date": decode_hdf_attr(
+                area_group.attrs.get("Terrain File Date")
+            ),
+        }
+        if raw_filename:
+            record["terrain_hdf_path"] = (
+                str(resolve_association_attr_path(hdf_path, raw_filename))
+                if resolve_paths
+                else raw_filename
+            )
+        else:
+            record["terrain_hdf_path"] = None
+        area_records.append(record)
+    return area_records
+
+
+def list_registered_rasmap_layers(
+    project_folder: PathLike,
+    rasmap_path: Optional[PathLike] = None,
+) -> list[dict[str, Any]]:
+    """List terrain and land-classification layer names registered in .rasmap."""
+    project_folder = safe_resolve_path(project_folder)
+    rasmap_path = Path(rasmap_path) if rasmap_path is not None else None
+    if rasmap_path is None:
+        candidates = sorted(project_folder.glob("*.rasmap"))
+        rasmap_path = candidates[0] if candidates else None
+    if rasmap_path is None or not Path(rasmap_path).exists():
+        return []
+
+    root = ET.parse(rasmap_path).getroot()
+    records: list[dict[str, Any]] = []
+
+    for layer in root.findall(".//Terrains/Layer"):
+        filename = layer.attrib.get("Filename")
+        resolved_path = _resolve_rasmap_filename(project_folder, filename)
+        records.append(
+            {
+                "name": layer.attrib.get("Name", ""),
+                "type": layer.attrib.get("Type", ""),
+                "filename": filename,
+                "resolved_path": str(resolved_path) if resolved_path else None,
+                "layer_kind": "terrain",
+            }
+        )
+
+    map_layers = root.find("MapLayers")
+    if map_layers is not None:
+        for layer in map_layers.findall("Layer"):
+            if layer.attrib.get("Type") != "LandCoverLayer":
+                continue
+            filename = layer.attrib.get("Filename")
+            resolved_path = _resolve_rasmap_filename(project_folder, filename)
+            records.append(
+                {
+                    "name": layer.attrib.get("Name", ""),
+                    "type": layer.attrib.get("Type", ""),
+                    "filename": filename,
+                    "resolved_path": str(resolved_path) if resolved_path else None,
+                    "layer_kind": _infer_land_classification_kind(
+                        filename,
+                        _get_selected_parameter(layer),
+                    ),
+                }
+            )
+
+    return records
+
+
+def resolve_registered_layer_name(
+    target_path: PathLike,
+    layer_kind: str,
+    *,
+    project_folder: Optional[PathLike] = None,
+    rasmap_path: Optional[PathLike] = None,
+) -> str:
+    """Resolve the RASMapper layer name for a path, falling back to its stem."""
+    target = safe_resolve_path(target_path)
+    if project_folder is not None or rasmap_path is not None:
+        project = safe_resolve_path(project_folder or Path(rasmap_path).parent)
+        for record in list_registered_rasmap_layers(project, rasmap_path):
+            resolved = record.get("resolved_path")
+            if not resolved:
+                continue
+            if not _paths_equivalent(resolved, target):
+                continue
+            if record.get("layer_kind") == layer_kind:
+                return record.get("name") or target.stem
+
+        for record in list_registered_rasmap_layers(project, rasmap_path):
+            resolved = record.get("resolved_path")
+            if resolved and _paths_equivalent(resolved, target):
+                return record.get("name") or target.stem
+    return target.stem
+
+
+def build_expected_geometry_association_attrs(
+    hdf_path: PathLike,
+    supplied_paths: Mapping[str, Optional[PathLike]],
+    *,
+    project_folder: Optional[PathLike] = None,
+    rasmap_path: Optional[PathLike] = None,
+    layer_names: Optional[Mapping[str, str]] = None,
+) -> dict[str, str]:
+    """Build the expected ``/Geometry`` attrs for supplied association paths."""
+    hdf_path = safe_resolve_path(hdf_path)
+    base_folder = safe_resolve_path(project_folder or hdf_path.parent)
+    layer_names = layer_names or {}
+    expected: dict[str, str] = {}
+
+    for key in FIELD_ORDER:
+        path_value = supplied_paths.get(key)
+        if path_value is None:
+            continue
+        field = GEOMETRY_ASSOCIATION_FIELDS[key]
+        resolved_path = safe_resolve_path(path_value)
+        layer_name = layer_names.get(key) or resolve_registered_layer_name(
+            resolved_path,
+            field["layer_kind"],
+            project_folder=project_folder,
+            rasmap_path=rasmap_path,
+        )
+        file_date = format_hec_file_date(resolved_path)
+
+        expected[field["filename_attr"]] = format_hec_relative_path(
+            resolved_path,
+            base_folder,
+        )
+        expected[field["layer_attr"]] = layer_name
+        if field.get("date_attr"):
+            expected[field["date_attr"]] = file_date
+        for attr_name in field.get("extra_date_attrs", ()):
+            expected[attr_name] = file_date
+
+    return expected
+
+
+def write_geometry_association(
+    hdf_path: PathLike,
+    *,
+    terrain_hdf_path: Optional[PathLike] = None,
+    landcover_hdf_path: Optional[PathLike] = None,
+    infiltration_hdf_path: Optional[PathLike] = None,
+    sediment_soils_hdf_path: Optional[PathLike] = None,
+    project_folder: Optional[PathLike] = None,
+    rasmap_path: Optional[PathLike] = None,
+    layer_names: Optional[Mapping[str, str]] = None,
+    validate: bool = True,
+    allow_plan_result_hdf: bool = False,
+) -> Path:
+    """Write HEC-RAS geometry association attrs with h5py."""
+    import h5py
+
+    hdf_path = safe_resolve_path(hdf_path)
+    if not hdf_path.exists():
+        raise FileNotFoundError(f"Geometry HDF not found: {hdf_path}")
+    if is_plan_or_result_hdf(hdf_path) and not allow_plan_result_hdf:
+        raise RuntimeError(
+            "Refusing to mutate a plan/result HDF. Geometry association writes "
+            f"are only supported for geometry HDFs: {hdf_path}"
+        )
+
+    supplied = {
+        "terrain_hdf_path": terrain_hdf_path,
+        "landcover_hdf_path": landcover_hdf_path,
+        "infiltration_hdf_path": infiltration_hdf_path,
+        "sediment_soils_hdf_path": sediment_soils_hdf_path,
+    }
+    if all(path is None for path in supplied.values()):
+        raise ValueError("Provide at least one geometry association path.")
+
+    resolved_paths: dict[str, Path] = {}
+    for key, path_value in supplied.items():
+        if path_value is None:
+            continue
+        resolved_path = safe_resolve_path(path_value)
+        if not resolved_path.exists():
+            raise FileNotFoundError(
+                f"Association artifact not found for {key}: {resolved_path}"
+            )
+        resolved_paths[key] = resolved_path
+
+    ensure_geometry_group(hdf_path)
+    expected_attrs = build_expected_geometry_association_attrs(
+        hdf_path,
+        resolved_paths,
+        project_folder=project_folder,
+        rasmap_path=rasmap_path,
+        layer_names=layer_names,
+    )
+
+    with h5py.File(str(hdf_path), "a") as hdf_file:
+        geometry_attrs = hdf_file["Geometry"].attrs
+        for attr_name, attr_value in expected_attrs.items():
+            geometry_attrs[attr_name] = encode_hdf_attr(attr_value)
+
+    if validate:
+        observed = read_geometry_association(hdf_path, resolve_paths=True)
+        mismatches = compare_expected_geometry_association_attrs(
+            hdf_path,
+            observed,
+            expected_attrs,
+        )
+        if mismatches:
+            raise RuntimeError(
+                "Geometry association attributes did not persist: "
+                + "; ".join(
+                    f"{item['attribute']} expected {item['expected']!r}, "
+                    f"observed {item['observed']!r}"
+                    for item in mismatches
+                )
+            )
+
+    return hdf_path
+
+
+def build_set_geometry_association_args(
+    hdf_path: PathLike,
+    supplied_paths: Mapping[str, Optional[PathLike]],
+    *,
+    path_formatter: Optional[Callable[[Path], str]] = None,
+) -> list[str]:
+    """Build RasProcess.exe ``SetGeometryAssociation`` command arguments."""
+    formatter = path_formatter or (lambda value: str(value))
+    hdf_path = safe_resolve_path(hdf_path)
+    args = [
+        "SetGeometryAssociation",
+        f"GeometryFilename={formatter(hdf_path)}",
+    ]
+    for key in FIELD_ORDER:
+        path_value = supplied_paths.get(key)
+        if path_value is None:
+            continue
+        field = GEOMETRY_ASSOCIATION_FIELDS[key]
+        args.append(f"{field['cli_arg']}={formatter(safe_resolve_path(path_value))}")
+    return args
+
+
+def compare_expected_geometry_association_attrs(
+    hdf_path: PathLike,
+    observed_association: Mapping[str, Any],
+    expected_attrs: Mapping[str, str],
+) -> list[dict[str, Any]]:
+    """Compare observed association attrs to expected HEC-RAS attrs."""
+    hdf_path = safe_resolve_path(hdf_path)
+    observed_attrs = observed_association.get("hdf_attrs", {})
+    mismatches: list[dict[str, Any]] = []
+    filename_attrs = {
+        field["filename_attr"] for field in GEOMETRY_ASSOCIATION_FIELDS.values()
+    }
+
+    for attr_name, expected in expected_attrs.items():
+        observed = observed_attrs.get(attr_name)
+        if attr_name in filename_attrs:
+            if not observed or not _paths_equivalent(
+                resolve_association_attr_path(hdf_path, observed),
+                resolve_association_attr_path(hdf_path, expected),
+            ):
+                mismatches.append(
+                    {
+                        "attribute": attr_name,
+                        "expected": expected,
+                        "observed": observed,
+                    }
+                )
+            continue
+
+        if observed != expected:
+            mismatches.append(
+                {
+                    "attribute": attr_name,
+                    "expected": expected,
+                    "observed": observed,
+                }
+            )
+
+    return mismatches
+
+
+def compare_geometry_association_paths(
+    observed_association: Mapping[str, Any],
+    expected_paths: Mapping[str, PathLike],
+) -> list[dict[str, Any]]:
+    """Compare normalized association path keys in a read-association dict."""
+    mismatches: list[dict[str, Any]] = []
+    for key, expected_path in expected_paths.items():
+        observed_path = observed_association.get(key)
+        if not observed_path or not _paths_equivalent(observed_path, expected_path):
+            mismatches.append(
+                {
+                    "key": key,
+                    "expected": str(safe_resolve_path(expected_path)),
+                    "observed": observed_path,
+                }
+            )
+    return mismatches
+
+
+def _resolve_rasmap_filename(
+    project_folder: Path,
+    filename: Optional[Union[str, Path]],
+) -> Optional[Path]:
+    if filename in (None, ""):
+        return None
+    filename_text = _WINDOWS_ENV_VAR_PATTERN.sub(
+        lambda match: os.environ.get(match.group(1), match.group(0)),
+        str(filename).strip(),
+    )
+    posix_path = Path(filename_text)
+    windows_path = PureWindowsPath(filename_text.replace("/", "\\"))
+    if posix_path.is_absolute():
+        return safe_resolve_path(posix_path)
+    if windows_path.is_absolute():
+        return safe_resolve_path(Path(str(windows_path)))
+    relative_text = filename_text.replace("/", "\\")
+    if relative_text.startswith(".\\") or relative_text.startswith("./"):
+        relative_text = relative_text[2:]
+    return safe_resolve_path(project_folder / Path(*PureWindowsPath(relative_text).parts))
+
+
+def _get_selected_parameter(layer_elem: ET.Element) -> Optional[str]:
+    for child in layer_elem.iter():
+        if child.tag == "Selected Parameter":
+            text = (child.text or "").strip()
+            return text or child.attrib.get("Name")
+    return None
+
+
+def _infer_land_classification_kind(
+    filename: Optional[Union[str, Path]],
+    selected_parameter: Optional[str],
+) -> str:
+    filename_str = str(filename or "").replace("\\", "/").lower()
+    parameter = str(selected_parameter or "").strip().lower()
+    if "infiltration" in filename_str:
+        return "infiltration"
+    if any(token in filename_str for token in ("soil", "ssurgo", "gssurgo")):
+        return "soils"
+    if parameter in {"manningsn", "percent impervious"}:
+        return "landcover"
+    if any(token in filename_str for token in ("landcover", "land classification")):
+        return "landcover"
+    if parameter == "id":
+        return "landcover"
+    return "unknown"
+
+
+def _paths_equivalent(first: PathLike, second: PathLike) -> bool:
+    try:
+        return safe_resolve_path(first) == safe_resolve_path(second)
+    except (OSError, RuntimeError, TypeError, ValueError):
+        return os.path.normcase(str(first)) == os.path.normcase(str(second))

--- a/ras_commander/_land_classification_helper.py
+++ b/ras_commander/_land_classification_helper.py
@@ -2170,9 +2170,11 @@ def associate_geometry_layers(
     landcover_hdf_path: Optional[Union[str, Path]] = None,
     soil_layer_path: Optional[Union[str, Path]] = None,
     infiltration_hdf_path: Optional[Union[str, Path]] = None,
+    terrain_hdf_path: Optional[Union[str, Path]] = None,
+    sediment_soils_hdf_path: Optional[Union[str, Path]] = None,
     ras_object: Any = None,
 ) -> Path:
-    """Associate project land-cover / infiltration layers to a geometry HDF."""
+    """Associate project terrain / classification layers to a geometry HDF."""
     project_paths = resolve_project_paths(ras_project_path)
     geom_hdf_path = resolve_geometry_hdf_path(
         project_paths,
@@ -2195,25 +2197,36 @@ def associate_geometry_layers(
         if infiltration_hdf_path is not None
         else resolve_registered_land_classification_path(project_paths, "infiltration")
     )
+    resolved_terrain_path = (
+        RasUtils.safe_resolve(Path(terrain_hdf_path))
+        if terrain_hdf_path is not None
+        else None
+    )
+    resolved_sediment_soils_path = (
+        RasUtils.safe_resolve(Path(sediment_soils_hdf_path))
+        if sediment_soils_hdf_path is not None
+        else None
+    )
 
-    ns = get_interop_namespace()
-    set_geometry_association_command = ns["SetGeometryAssociationCommand"]()
-    set_geometry_association_command.GeometryFilename = str(geom_hdf_path)
-    if resolved_landcover_path is not None:
-        set_geometry_association_command.NValueFilename = str(resolved_landcover_path)
-    if resolved_infiltration_path is not None:
-        set_geometry_association_command.InfiltrationFilename = str(resolved_infiltration_path)
-
-    # SedimentSoilsFilename is for sediment bed material, not hydrologic soils groups.
     if resolved_soil_path is not None:
         logger.debug(
             "Hydrologic soils layer resolved for association but not passed to "
             "SedimentSoilsFilename because that geometry attribute is for sediment "
-            "bed material, not infiltration soils."
+            "bed material, not infiltration soils. Use sediment_soils_hdf_path "
+            "to write the SedimentSoilsFilename association explicitly."
         )
 
-    set_geometry_association_command.Execute(None)
-    return geom_hdf_path
+    from ._geometry_association import write_geometry_association
+
+    return write_geometry_association(
+        geom_hdf_path,
+        terrain_hdf_path=resolved_terrain_path,
+        landcover_hdf_path=resolved_landcover_path,
+        infiltration_hdf_path=resolved_infiltration_path,
+        sediment_soils_hdf_path=resolved_sediment_soils_path,
+        project_folder=project_paths.project_folder,
+        rasmap_path=project_paths.rasmap_path,
+    )
 
 
 def recompute_property_tables(

--- a/ras_commander/geom/GeomMesh.py
+++ b/ras_commander/geom/GeomMesh.py
@@ -4,8 +4,8 @@ GeomMesh - Headless 2D mesh generation, repair, and BC conflict resolution.
 Provides headless (no-GUI) mesh generation via RasMapperLib.dll + pythonnet.
 Replaces the need for RAS Mapper or RasProcess.exe for mesh operations.
 
-Architecture: Text-First
-~~~~~~~~~~~~~~~~~~~~~~~~~
+Architecture: Text-First, Existing-HDF Workspace
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 The .g## plain text file is the sole persistent output and source of truth.
 HEC-RAS preprocessing reads "Storage Area 2D Points= N" plus the XY seed
 coordinates from text and regenerates the mesh — overriding any HDF content.
@@ -13,28 +13,31 @@ coordinates from text and regenerates the mesh — overriding any HDF content.
 The HDF (.g##.hdf) is used only as a *temporary workspace*:
   - .NET RASGeometry loads geometry from HDF (perimeter, breaklines)
   - geom.Save() writes cell centers to HDF so we can bulk-read via h5py
-  - The HDF is NEVER the deliverable — HEC-RAS will recompile it from text
+  - ras-commander does not generate .g##.hdf from .g## text; that remains
+    a full HEC-RAS/Ras.exe responsibility
 
 Production Workflow (generate)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 1. **Breakline spacing** — Read per-breakline CellSize Min/Max from .g01 text.
    Only overwrite if the caller explicitly passes bl_spacing_near/bl_spacing_far.
-2. **Text → HDF sync** — Sync per-breakline spacing from text into the HDF so
+2. **Existing HDF validation** — Require a current .g##.hdf compiled by
+   HEC-RAS/Ras.exe before any mesh-generation work begins.
+3. **Text → HDF sync** — Sync per-breakline spacing from text into the HDF so
    RegenerateMeshPoints (which reads HDF, not text) uses correct values.
-3. **Load .NET geometry** — RASGeometry(hdf_path) → D2FlowArea → perimeter,
+4. **Load .NET geometry** — RASGeometry(hdf_path) → D2FlowArea → perimeter,
    breaklines (merged BreakLines + Regions + Structures via _build_breaklines).
-4. **Generate seeds** — Primary: RegenerateMeshPoints (private .NET method via
+5. **Generate seeds** — Primary: RegenerateMeshPoints (private .NET method via
    reflection) produces breakline-aware seeds. Fallback: PointGenerator.
    GeneratePoints(perim, cell_size) for base-grid seeds.
-5. **Fix loop** (matches TryAutoFix tier ordering):
+6. **Fix loop** (matches TryAutoFix tier ordering):
    - Tier 0: Pre-flight removal of short perimeter segments
    - Tier 2 first: MaxFacesPerCellExceeded → add midpoint seeds
    - Tier 3: FacePerimeterConnectionError → remove bad perimeter vertices
    - Tier 1: Ratio escalation [0.05 → 0.10 → 0.15 → 0.25]
    - Tier 4: Douglas-Peucker perimeter simplification (last resort)
-6. **Extract cell centers** — geom.Save() + h5py read (fast), or .NET Cell(i)
+7. **Extract cell centers** — geom.Save() + h5py read (fast), or .NET Cell(i)
    iteration (slow fallback).
-7. **Write .g01 text** — _patch_text_seeds() writes cell centers as the sole
+8. **Write .g01 text** — _patch_text_seeds() writes cell centers as the sole
    persistent output. _set_point_generation_data() updates the seed count header.
 
 Requires:
@@ -65,6 +68,14 @@ from .._gdal_runtime import (
     configure_hecras_gdal_runtime,
     configure_rasmapper_gdal_bridge,
 )
+from .._geometry_association import (
+    GEOMETRY_ASSOCIATION_FIELDS,
+    compare_geometry_association_paths,
+    decode_hdf_attr as _shared_decode_hdf_attr,
+    ensure_geometry_group,
+    read_geometry_association,
+    resolve_association_attr_path as _shared_resolve_association_attr_path,
+)
 from ..LoggingConfig import get_logger
 from .GeomMeshDataclasses import BCConflict, BCFixResult, MeshResult
 
@@ -83,6 +94,7 @@ _DEPS = ["Utility.Core", "Geospatial.Core", "H5Assist", "RasMapperLib"]
 MAX_FACES_PER_CELL = 8
 PERIMETER_NEAR_DUPLICATE_TOL = 1e-6
 _RATIO_LADDER = [0.05, 0.10, 0.15, 0.25]
+_GEOMETRY_ASSOCIATION_FIELDS = GEOMETRY_ASSOCIATION_FIELDS
 
 # ── Module-level state ────────────────────────────────────────────────────────
 
@@ -984,7 +996,7 @@ def _sync_breakline_spacing_text_to_hdf(
     """Sync breakline spacing from .g01 text (source of truth) into HDF.
 
     RegenerateMeshPoints reads spacing from the HDF, not from text.
-    When the HDF is pre-compiled or stale, its spacing may differ.
+    The existing HDF workspace may not yet reflect current run parameters.
     """
     try:
         import h5py
@@ -1144,46 +1156,13 @@ def _reseed_after_perimeter_fix(
     ns: dict,
     hecras_dir=None,
 ) -> "PointMs":
-    """Text-first reseed: write perimeter to text, recompile, regenerate seeds.
-
-    After a perimeter mutation (vertex removal, Douglas-Peucker), this writes
-    the modified perimeter to .g01 text, recompiles the HDF, syncs spacing,
-    and regenerates breakline-aware seeds via RegenerateMeshPoints.
-    """
-    _patch_text_perimeter(text_path, current_perim, mesh_name=mesh_name)
-
-    from RasMapperLib.Scripting import CompleteGeometryCommand  # type: ignore
-    cmd = CompleteGeometryCommand()
-    cmd.GeometryFilename = str(text_path)
-    cmd.ExecuteOutOfProcess(True)
-    hdf_path = text_path.with_suffix(text_path.suffix + ".hdf")
-
-    _sync_breakline_spacing_text_to_hdf(text_path, hdf_path)
-    _sync_cell_size_to_hdf(hdf_path, cell_size, mesh_name=mesh_name)
-    reseed_geom = ns["RASGeometry"](str(hdf_path))
-    reseed_d2fa = reseed_geom.D2FlowArea
-    reseed_fid = fid
-    if mesh_name is not None:
-        try:
-            resolved_fid = reseed_d2fa.GetFeatureByName(mesh_name)
-            if resolved_fid >= 0:
-                reseed_fid = int(resolved_fid)
-        except Exception:
-            pass
-    try:
-        seeds = _generate_seeds_via_net(str(hdf_path), ns, fid=reseed_fid)
-        logger.info(
-            f"[{mesh_name}] Reseeded via .NET after perimeter fix: "
-            f"{seeds.Count} seeds"
-        )
-        return seeds
-    except Exception as exc:
-        logger.warning(
-            f"[{mesh_name}] .NET reseed failed after perimeter fix: "
-            f"{exc}, falling back"
-        )
-        perim_ns = reseed_d2fa.Geometry.MeshPerimeters.Polygon(reseed_fid)
-        return _generate_seeds_safe(perim_ns, cell_size, ns)
+    """Reject perimeter fixes that require text-to-HDF regeneration."""
+    raise RuntimeError(
+        "Perimeter repair would require regenerating the compiled geometry HDF "
+        f"from {text_path.name}. ras-commander cannot generate .g##.hdf from "
+        ".g## text with RasMapperLib; create or refresh the geometry HDF through "
+        "full HEC-RAS/Ras.exe behavior, then retry."
+    )
 
 
 def _set_point_generation_data(
@@ -1358,16 +1337,123 @@ def _resolve_geom_text_path(
     )
 
 
-def _ensure_hdf(geom_text_path: Path, hecras_dir=None) -> Path:
-    """Return an up-to-date HDF for *geom_text_path*, recompiling if stale."""
+def _geometry_hdf_unavailable_message(
+    geom_text_path: Path,
+    hdf_path: Path,
+    reason: str,
+) -> str:
+    return (
+        f"Compiled geometry HDF is {reason}: {hdf_path}. "
+        "ras-commander cannot generate .g##.hdf from .g## text with "
+        "RasMapperLib; CompleteGeometryCommand completes existing HDF files "
+        "and is not a text-geometry compiler. Refresh the geometry through "
+        "full HEC-RAS/Ras.exe behavior, then retry."
+    )
+
+
+def _ensure_hdf(
+    geom_text_path: Path,
+    hecras_dir=None,
+    *,
+    require_current: bool = True,
+) -> Path:
+    """Return an existing compiled HDF for *geom_text_path*.
+
+    This helper intentionally does not call ``compile_geometry()``. True
+    .g## text -> .g##.hdf generation is unavailable here unless HEC-RAS/Ras.exe
+    drives it.
+    """
     hdf_path = geom_text_path.with_suffix(geom_text_path.suffix + ".hdf")
-    need_compile = not hdf_path.exists()
-    if not need_compile and geom_text_path.stat().st_mtime > hdf_path.stat().st_mtime:
-        logger.info(f"{geom_text_path.name} is newer than HDF — recompiling")
-        need_compile = True
-    if need_compile:
-        hdf_path = GeomMesh.compile_geometry(geom_text_path, hecras_dir=hecras_dir)
+    if not hdf_path.exists():
+        raise RuntimeError(
+            _geometry_hdf_unavailable_message(geom_text_path, hdf_path, "missing")
+        )
+    if geom_text_path.stat().st_mtime > hdf_path.stat().st_mtime:
+        message = _geometry_hdf_unavailable_message(
+            geom_text_path,
+            hdf_path,
+            f"stale; {geom_text_path.name} is newer than {hdf_path.name}",
+        )
+        if require_current:
+            raise RuntimeError(message)
+        logger.warning(message)
     return hdf_path
+
+
+def _safe_resolve_path(path: Path) -> Path:
+    try:
+        return path.resolve(strict=False)
+    except OSError:
+        return path.absolute()
+
+
+def _paths_equivalent(left: Union[str, Path], right: Union[str, Path]) -> bool:
+    left_norm = os.path.normcase(os.path.normpath(str(left)))
+    right_norm = os.path.normcase(os.path.normpath(str(right)))
+    return left_norm == right_norm
+
+
+def _resolve_geom_hdf_path(
+    geom_number: Union[str, Number, Path],
+    hecras_dir=None,
+    ras_object=None,
+    *,
+    require_current: bool = True,
+) -> Path:
+    """Resolve a geometry number, .g## text path, or .g##.hdf path to HDF."""
+    candidate = None
+    if isinstance(geom_number, Path):
+        candidate = geom_number
+    elif isinstance(geom_number, str):
+        candidate = Path(geom_number)
+
+    if candidate is not None and candidate.suffix.lower() in {".hdf", ".h5"}:
+        if candidate.is_file():
+            return candidate
+        raise FileNotFoundError(f"Geometry HDF not found: {candidate}")
+
+    geom_text_path = _resolve_geom_text_path(geom_number, ras_object)
+    return _ensure_hdf(
+        geom_text_path,
+        hecras_dir=hecras_dir,
+        require_current=require_current,
+    )
+
+
+def _decode_hdf_attr(value) -> Optional[str]:
+    return _shared_decode_hdf_attr(value)
+
+
+def _resolve_association_attr_path(geom_hdf_path: Path, attr_value: str) -> Path:
+    return _shared_resolve_association_attr_path(geom_hdf_path, attr_value)
+
+
+def _validate_geometry_hdf_path(hdf_path: Path) -> None:
+    ensure_geometry_group(hdf_path)
+
+
+def _read_geometry_association(
+    hdf_path: Path,
+    *,
+    resolve_paths: bool = True,
+) -> dict:
+    return read_geometry_association(hdf_path, resolve_paths=resolve_paths)
+
+
+def _validate_geometry_association(
+    hdf_path: Path,
+    expected_paths: dict[str, Path],
+) -> None:
+    observed = _read_geometry_association(hdf_path, resolve_paths=True)
+    mismatches = compare_geometry_association_paths(observed, expected_paths)
+    if mismatches:
+        mismatch = mismatches[0]
+        field = _GEOMETRY_ASSOCIATION_FIELDS[mismatch["key"]]["filename_attr"]
+        raise RuntimeError(
+            f"SetGeometryAssociationCommand did not persist {field} on "
+            f"{hdf_path}. Expected {mismatch['expected']}, "
+            f"observed {mismatch['observed']!r}."
+        )
 
 
 def _normalise_polygon_coords(polygon) -> "numpy.ndarray":
@@ -1640,8 +1726,8 @@ class GeomMesh:
         ``set_refinement_region_name()`` by name.  When duplicates
         exist, targeting by *region_fid* is the most reliable approach.
 
-        Refinement regions are stored in HDF, not .g## text.  If the
-        HDF does not exist it is compiled first.
+        Refinement regions are stored in HDF, not .g## text.  The compiled
+        HDF must already exist.
 
         Returns:
             List of (fid, name) tuples in HDF order.  *fid* is the
@@ -1769,8 +1855,8 @@ class GeomMesh:
         ``set_refinement_region_name(region_fid=...)`` when names are
         ambiguous.
 
-        Refinement regions are stored in HDF, not .g## text.  If the HDF
-        does not exist it is compiled first.
+        Refinement regions are stored in HDF, not .g## text.  The compiled
+        HDF must already exist.
 
         Returns:
             List of dicts with keys: fid, name, spacing_dx, spacing_dy.
@@ -2096,10 +2182,12 @@ class GeomMesh:
         ras_object=None,
     ) -> Path:
         """
-        Compile a .g## text file into .g##.hdf without Ras.exe.
+        Disabled compatibility shim for .g## text -> .g##.hdf generation.
 
-        Uses RasMapperLib's CompleteGeometryCommand to convert the plain-text
-        geometry file into its compiled HDF representation, bypassing Ras.exe.
+        ras-commander cannot compile a plain-text geometry file into its
+        compiled HDF representation without full HEC-RAS/Ras.exe behavior.
+        RasMapperLib's CompleteGeometryCommand only completes existing HDF
+        files; it is not a text geometry compiler.
 
         Args:
             geom_number: Geometry number ("01", 1) or path to .g## text file.
@@ -2107,34 +2195,148 @@ class GeomMesh:
             ras_object: Optional RasPrj instance for multi-project support.
 
         Returns:
-            Path to the compiled .g##.hdf file.
+            Never returns successfully.
 
         Raises:
             FileNotFoundError: If geometry file cannot be resolved.
-            RuntimeError: If compilation fails.
+            RuntimeError: Always, because this path is unavailable.
         """
         geom_text_path = _resolve_geom_text_path(geom_number, ras_object)
+        hdf_path = geom_text_path.with_suffix(geom_text_path.suffix + ".hdf")
+        raise RuntimeError(
+            _geometry_hdf_unavailable_message(
+                geom_text_path,
+                hdf_path,
+                "not generated by ras-commander",
+            )
+        )
+
+    @staticmethod
+    @log_call
+    def get_geometry_association(
+        geom_number: Union[str, Number, Path],
+        hecras_dir: Optional[Union[str, Path]] = None,
+        ras_object=None,
+        resolve_paths: bool = True,
+    ) -> dict:
+        """
+        Read terrain and classification associations from a geometry HDF.
+
+        Args:
+            geom_number: Geometry number, .g## text path, or .g##.hdf path.
+                Text inputs require an existing current .g##.hdf.
+            hecras_dir: Kept for API symmetry; no DLLs are loaded here.
+            ras_object: Optional RasPrj instance for geometry-number lookup.
+            resolve_paths: If True, return absolute paths resolved relative to
+                the geometry HDF. If False, return the raw HDF attribute text.
+
+        Returns:
+            Dict with keys ``terrain_hdf_path``, ``landcover_hdf_path``,
+            ``infiltration_hdf_path``, ``sediment_soils_hdf_path``, matching
+            ``*_layer_name`` keys, and ``si_units``.
+        """
+        hdf_path = _resolve_geom_hdf_path(
+            geom_number,
+            hecras_dir=hecras_dir,
+            ras_object=ras_object,
+        )
+        hdf_path = _safe_resolve_path(hdf_path)
+        return _read_geometry_association(hdf_path, resolve_paths=resolve_paths)
+
+    @staticmethod
+    @log_call
+    def set_geometry_association(
+        geom_number: Union[str, Number, Path],
+        terrain_hdf_path: Optional[Union[str, Path]] = None,
+        landcover_hdf_path: Optional[Union[str, Path]] = None,
+        infiltration_hdf_path: Optional[Union[str, Path]] = None,
+        sediment_soils_hdf_path: Optional[Union[str, Path]] = None,
+        hecras_dir: Optional[Union[str, Path]] = None,
+        ras_object=None,
+        validate: bool = True,
+    ) -> Path:
+        """
+        Associate terrain / classification layers to an existing geometry HDF.
+
+        This wraps RasMapperLib's ``SetGeometryAssociationCommand`` and writes
+        attributes under ``/Geometry`` in the compiled ``.g##.hdf``. It does
+        not create or refresh a missing geometry HDF.
+
+        Args:
+            geom_number: Geometry number, .g## text path, or .g##.hdf path.
+                Text inputs require an existing current .g##.hdf.
+            terrain_hdf_path: Terrain HDF to associate.
+            landcover_hdf_path: Land-cover / Manning's n HDF.
+            infiltration_hdf_path: Infiltration HDF.
+            sediment_soils_hdf_path: Sediment bed-material soils HDF. This is
+                the HEC-RAS ``SedimentSoilsFilename`` slot, not the hydrologic
+                soils layer used to build infiltration data.
+            hecras_dir: Override HEC-RAS installation directory.
+            ras_object: Optional RasPrj instance for geometry-number lookup.
+            validate: Re-read ``/Geometry`` attributes after execution and
+                verify supplied paths were persisted.
+
+        Returns:
+            Path to the existing geometry HDF that was updated.
+
+        Raises:
+            ValueError: If no association paths are supplied.
+            FileNotFoundError: If any supplied artifact is missing.
+            RuntimeError: If the HDF is missing /Geometry, execution fails, or
+                validation does not find the expected attributes.
+        """
+        supplied = {
+            "terrain_hdf_path": terrain_hdf_path,
+            "landcover_hdf_path": landcover_hdf_path,
+            "infiltration_hdf_path": infiltration_hdf_path,
+            "sediment_soils_hdf_path": sediment_soils_hdf_path,
+        }
+        if all(path is None for path in supplied.values()):
+            raise ValueError("Provide at least one geometry association path.")
+
+        hdf_path = _resolve_geom_hdf_path(
+            geom_number,
+            hecras_dir=hecras_dir,
+            ras_object=ras_object,
+        )
+        hdf_path = _safe_resolve_path(hdf_path)
+        _validate_geometry_hdf_path(hdf_path)
+
+        resolved_paths = {}
+        for key, path_value in supplied.items():
+            if path_value is None:
+                continue
+            resolved_path = _safe_resolve_path(Path(path_value))
+            if not resolved_path.exists():
+                raise FileNotFoundError(
+                    f"Association artifact not found for {key}: {resolved_path}"
+                )
+            resolved_paths[key] = resolved_path
 
         _load_dlls(hecras_dir)
+        from RasMapperLib.Scripting import SetGeometryAssociationCommand  # type: ignore
 
-        from RasMapperLib.Scripting import CompleteGeometryCommand  # type: ignore
-
-        cmd = CompleteGeometryCommand()
-        cmd.GeometryFilename = str(geom_text_path)
+        cmd = SetGeometryAssociationCommand()
+        cmd.GeometryFilename = str(hdf_path)
+        for key, resolved_path in resolved_paths.items():
+            command_property = _GEOMETRY_ASSOCIATION_FIELDS[key]["command_property"]
+            setattr(cmd, command_property, str(resolved_path))
 
         try:
-            cmd.ExecuteOutOfProcess(True)
+            cmd.Execute(None)
         except Exception as exc:
             raise RuntimeError(
-                f"CompleteGeometryCommand failed for {geom_text_path.name}: {exc}"
+                f"SetGeometryAssociationCommand failed for {hdf_path.name}: {exc}"
             ) from exc
 
-        hdf_path = geom_text_path.with_suffix(geom_text_path.suffix + ".hdf")
-        if not hdf_path.exists():
-            raise RuntimeError(
-                f"CompleteGeometryCommand did not produce {hdf_path.name}"
-            )
-        logger.info(f"Compiled geometry: {geom_text_path.name} -> {hdf_path.name}")
+        if validate:
+            _validate_geometry_association(hdf_path, resolved_paths)
+
+        logger.info(
+            "Updated geometry associations on %s: %s",
+            hdf_path.name,
+            ", ".join(sorted(resolved_paths)),
+        )
         return hdf_path
 
     @staticmethod
@@ -2235,27 +2437,29 @@ class GeomMesh:
         bl_spacing_near: Optional[float] = None,
         bl_spacing_far: Optional[float] = None,
         ras_object=None,
+        _require_current_hdf: bool = True,
     ) -> MeshResult:
         """
         Generate or regenerate a 2D mesh headlessly via text-first workflow.
 
         The .g01 text file is the sole persistent output. The HDF is used only
-        as a temporary workspace for .NET geometry loading and cell center
-        extraction. HEC-RAS will recompile the HDF from text on project open.
+        as an existing temporary workspace for .NET geometry loading and cell
+        center extraction. ras-commander does not generate .g##.hdf from text.
 
         Workflow:
-            1. Read per-breakline spacing from .g01 text (preserve existing)
-            2. Sync text spacing → HDF (RegenerateMeshPoints reads HDF)
-            3. Load .NET geometry → perimeter, breaklines
-            4. Generate seeds: RegenerateMeshPoints (primary) or GeneratePoints
-            5. Fix loop (matches TryAutoFix tier ordering):
+            1. Validate an existing current compiled .g##.hdf workspace.
+            2. Read per-breakline spacing from .g01 text (preserve existing)
+            3. Sync text spacing -> HDF (RegenerateMeshPoints reads HDF)
+            4. Load .NET geometry -> perimeter, breaklines
+            5. Generate seeds: RegenerateMeshPoints (primary) or GeneratePoints
+            6. Fix loop (matches TryAutoFix tier ordering):
                - Tier 0: Remove short perimeter segments (pre-flight)
-               - Tier 2: MaxFaces → add midpoint seeds (before ratio escalation)
-               - Tier 3: Perimeter errors → remove bad vertices
-               - Tier 1: Escalate MinFaceLengthRatio [0.05 → 0.25]
+               - Tier 2: MaxFaces -> add midpoint seeds (before ratio escalation)
+               - Tier 3: Perimeter errors -> remove bad vertices
+               - Tier 1: Escalate MinFaceLengthRatio [0.05 -> 0.25]
                - Tier 4: Douglas-Peucker perimeter simplification (last resort)
-            6. Extract cell centers via geom.Save() + h5py read
-            7. Write cell centers to .g01 text — sole persistent output
+            7. Extract cell centers via geom.Save() + h5py read
+            8. Write cell centers to .g01 text - sole persistent output
 
         Args:
             geom_number: Geometry number ("01", 1) or path to .g## text file.
@@ -2313,6 +2517,16 @@ class GeomMesh:
         try:
             text_path = geom_path
 
+            # ── Step 1: Validate existing compiled HDF workspace ─────
+            # True .g## text -> .g##.hdf generation is a full HEC-RAS/Ras.exe
+            # responsibility. This method only works against an existing
+            # compiled geometry HDF.
+            hdf_path = _ensure_hdf(
+                text_path,
+                hecras_dir=hecras_dir,
+                require_current=_require_current_hdf,
+            )
+
             # Only modify .g01 text breakline properties if explicitly provided.
             # Otherwise the geometry's existing per-breakline values are
             # the source of truth — don't overwrite them with defaults.
@@ -2328,15 +2542,10 @@ class GeomMesh:
                     all_breaklines=True,
                 )
 
-            # ── Step 1: Compile .g01 text → HDF ────────────────────────
-            # Always recompile when text is newer than HDF so that
-            # perimeter/breakline/structure edits are picked up.
-            hdf_path = _ensure_hdf(text_path, hecras_dir=hecras_dir)
-
             # ── Step 1b: Sync text → HDF ────────────────────────────────
             # RegenerateMeshPoints reads spacing from the HDF, not from
-            # .g01 text.  The HDF may be pre-compiled or stale, so sync
-            # cell size and per-breakline values from text into HDF.
+            # .g01 text. Sync current cell size and per-breakline values from
+            # text into the existing HDF workspace.
             _sync_cell_size_to_hdf(hdf_path, cell_size, mesh_name=mesh_name)
             _sync_breakline_spacing_text_to_hdf(text_path, hdf_path)
 
@@ -2458,8 +2667,8 @@ class GeomMesh:
                     #
                     # geom.Save() is used only to bulk-write cell centers
                     # to HDF so we can read them back via h5py (fast).
-                    # The HDF is NOT patched further — it's a temporary
-                    # workspace that HEC-RAS will recompile from text.
+                    # The HDF is a temporary workspace created by
+                    # HEC-RAS/Ras.exe, not a deliverable generated here.
 
                     import numpy as _np
                     _nv = mesh.NonVirtualCellCount
@@ -2650,7 +2859,11 @@ class GeomMesh:
         text_path = _resolve_geom_text_path(geom_number, ras_object=ras_object)
         _load_dlls(hecras_dir)
         ns = _imports()
-        hdf_path = _ensure_hdf(text_path, hecras_dir=hecras_dir)
+        hdf_path = _ensure_hdf(
+            text_path,
+            hecras_dir=hecras_dir,
+            require_current=True,
+        )
         geom = ns["RASGeometry"](str(hdf_path))
         d2fa = geom.D2FlowArea
         count = d2fa.FeatureCount()
@@ -2670,6 +2883,7 @@ class GeomMesh:
                 max_iterations=max_iterations,
                 hecras_dir=hecras_dir,
                 ras_object=ras_object,
+                _require_current_hdf=False,
             )
             results.append(r)
         return results

--- a/tests/test_geom_mesh.py
+++ b/tests/test_geom_mesh.py
@@ -23,6 +23,7 @@ GeomMesh = geom_mesh_module.GeomMesh
 _patch_text_seeds = geom_mesh_module._patch_text_seeds
 _reseed_after_perimeter_fix = geom_mesh_module._reseed_after_perimeter_fix
 _remove_short_perimeter_segments = geom_mesh_module._remove_short_perimeter_segments
+_ensure_hdf = geom_mesh_module._ensure_hdf
 
 HECRAS_INTEGRATION_ENV = "RAS_COMMANDER_RUN_HECRAS_INTEGRATION"
 
@@ -284,13 +285,17 @@ def storage_area_geom_text(tmp_path):
     return geom_text
 
 
-def _mock_generate_success(monkeypatch, compiled_geom_path: Path, *, has_breaklines: bool):
+def _mock_generate_success(monkeypatch, geom_text_path: Path, *, has_breaklines: bool):
     """Patch the heavy .NET entrypoints so generate() can be unit tested.
 
     Follows the RASDecomp-style architecture: load geometry from .NET,
     generate seeds via .NET, compute mesh, save via .NET + patch text.
     """
     captured = {}
+    hdf_path = geom_text_path.with_suffix(geom_text_path.suffix + ".hdf")
+    hdf_path.write_text("compiled", encoding="utf-8")
+    hdf_mtime = geom_text_path.stat().st_mtime + 1.0
+    os.utime(hdf_path, (hdf_mtime, hdf_mtime))
 
     monkeypatch.setattr(geom_mesh_module, "_load_dlls", lambda hecras_dir=None: None)
 
@@ -364,14 +369,16 @@ def _mock_generate_success(monkeypatch, compiled_geom_path: Path, *, has_breakli
         "_save_mesh",
         lambda geom, d2fa, fid, mesh, ns: None,
     )
-
-    def fake_compile_geometry(geom_text_path, hecras_dir=None):
-        hdf_path = Path(geom_text_path).with_suffix(Path(geom_text_path).suffix + ".hdf")
-        hdf_path.write_text("compiled", encoding="utf-8")
-        compiled_geom_path.write_text("compiled", encoding="utf-8")
-        return hdf_path
-
-    monkeypatch.setattr(GeomMesh, "compile_geometry", staticmethod(fake_compile_geometry))
+    monkeypatch.setattr(
+        geom_mesh_module,
+        "_sync_cell_size_to_hdf",
+        lambda *args, **kwargs: None,
+    )
+    monkeypatch.setattr(
+        geom_mesh_module,
+        "_sync_breakline_spacing_text_to_hdf",
+        lambda *args, **kwargs: None,
+    )
     captured["geom"] = mock_geom_obj
     return captured
 
@@ -381,14 +388,41 @@ def _install_fake_rasmapper_scripting(monkeypatch):
 
     fake_scripting = types.ModuleType("RasMapperLib.Scripting")
 
-    class FakeCompleteGeometryCommand:
+    class FakeSetGeometryAssociationCommand:
         def __init__(self):
             self.GeometryFilename = None
+            self.TerrainFilename = None
+            self.NValueFilename = None
+            self.InfiltrationFilename = None
+            self.SedimentSoilsFilename = None
 
-        def ExecuteOutOfProcess(self, wait_for_completion):
-            return None
+        def Execute(self, progress):
+            field_map = {
+                "TerrainFilename": ("Terrain Filename", "Terrain Layername"),
+                "NValueFilename": ("Land Cover Filename", "Land Cover Layername"),
+                "InfiltrationFilename": (
+                    "Infiltration Filename",
+                    "Infiltration Layername",
+                ),
+                "SedimentSoilsFilename": (
+                    "Sediment Bed Material Filename",
+                    "Sediment Bed Material Layername",
+                ),
+            }
+            geom_hdf_path = Path(self.GeometryFilename)
+            with h5py.File(str(geom_hdf_path), "r+") as hf:
+                geom_group = hf.require_group("Geometry")
+                for prop_name, (filename_attr, layer_attr) in field_map.items():
+                    value = getattr(self, prop_name)
+                    if not value:
+                        continue
+                    value_path = Path(value)
+                    relative = os.path.relpath(value_path, geom_hdf_path.parent)
+                    geom_group.attrs[filename_attr] = relative.encode("utf-8")
+                    geom_group.attrs[layer_attr] = value_path.stem.encode("utf-8")
+                geom_group.attrs["SI Units"] = b"False"
 
-    fake_scripting.CompleteGeometryCommand = FakeCompleteGeometryCommand
+    fake_scripting.SetGeometryAssociationCommand = FakeSetGeometryAssociationCommand
 
     fake_rasmapper = types.ModuleType("RasMapperLib")
     fake_rasmapper.Scripting = fake_scripting
@@ -493,73 +527,120 @@ class TestPatchTextSeeds:
 
 
 class TestReseedAfterPerimeterFix:
-    """Test mesh targeting after perimeter mutation recompiles."""
+    """Test perimeter mutation refuses unavailable text-to-HDF regeneration."""
 
-    def test_fallback_uses_selected_flow_area(self, monkeypatch, tmp_path):
+    def test_requires_external_geometry_hdf_regeneration(self, monkeypatch, tmp_path):
         geom_text_path = tmp_path / "test.g01"
         geom_text_path.write_text("Geom Title=Test\n", encoding="utf-8")
-        _install_fake_rasmapper_scripting(monkeypatch)
-
-        polygon_calls = []
-        seed_calls = []
-        selected_polygon = MockPolygon(
-            [(200.0, 0.0), (300.0, 0.0), (300.0, 100.0), (200.0, 100.0)]
-        )
-
-        mock_geom_obj = MagicMock()
-        mock_geom_obj.D2FlowArea.GetFeatureByName.side_effect = (
-            lambda name: 1 if name == "SecondaryArea" else -1
-        )
-        mock_geom_obj.D2FlowArea.Geometry.MeshPerimeters.Polygon.side_effect = (
-            lambda fid: polygon_calls.append(fid) or selected_polygon
-        )
-
         monkeypatch.setattr(
             geom_mesh_module,
             "_patch_text_perimeter",
-            lambda *args, **kwargs: None,
-        )
-        monkeypatch.setattr(
-            geom_mesh_module,
-            "_sync_breakline_spacing_text_to_hdf",
-            lambda *args, **kwargs: None,
-        )
-        monkeypatch.setattr(
-            geom_mesh_module,
-            "_sync_cell_size_to_hdf",
-            lambda *args, **kwargs: None,
-        )
-        monkeypatch.setattr(
-            geom_mesh_module,
-            "_generate_seeds_via_net",
-            lambda hdf_path, ns, fid=0: seed_calls.append(fid) or (_ for _ in ()).throw(
-                RuntimeError("mock: .NET unavailable")
-            ),
+            lambda *args, **kwargs: pytest.fail("perimeter text was patched"),
         )
 
-        def fake_generate_seeds_safe(perim, cell_size, ns):
-            assert perim is selected_polygon
-            return FakePointCollection()
+        with pytest.raises(RuntimeError, match="cannot generate .g##.hdf"):
+            _reseed_after_perimeter_fix(
+                geom_text_path,
+                geom_text_path.with_suffix(".g01.hdf"),
+                MockPolygon(
+                    [(0.0, 0.0), (100.0, 0.0), (100.0, 100.0), (0.0, 100.0)]
+                ),
+                100.0,
+                1,
+                "SecondaryArea",
+                {"RASGeometry": lambda path: MagicMock()},
+            )
 
-        monkeypatch.setattr(
-            geom_mesh_module,
-            "_generate_seeds_safe",
-            fake_generate_seeds_safe,
+
+class TestGeometryHdfAvailability:
+    """Test the explicit boundary around unavailable text-to-HDF generation."""
+
+    def test_compile_geometry_is_disabled(self, breakline_geom_text):
+        with pytest.raises(RuntimeError, match="not a text-geometry compiler"):
+            GeomMesh.compile_geometry(breakline_geom_text)
+
+    def test_ensure_hdf_rejects_missing_compiled_geometry(self, breakline_geom_text):
+        with pytest.raises(RuntimeError, match="Compiled geometry HDF is missing"):
+            _ensure_hdf(breakline_geom_text)
+
+    def test_ensure_hdf_rejects_stale_compiled_geometry(self, breakline_geom_text):
+        hdf_path = breakline_geom_text.with_suffix(breakline_geom_text.suffix + ".hdf")
+        hdf_path.write_text("compiled", encoding="utf-8")
+        text_mtime = breakline_geom_text.stat().st_mtime + 10.0
+        os.utime(hdf_path, (text_mtime - 5.0, text_mtime - 5.0))
+        os.utime(breakline_geom_text, (text_mtime, text_mtime))
+
+        with pytest.raises(RuntimeError, match="is newer than"):
+            _ensure_hdf(breakline_geom_text)
+
+
+class TestGeometryAssociation:
+    """Test geometry HDF association API."""
+
+    def _make_geometry_hdf(self, tmp_path):
+        hdf_path = tmp_path / "test.g01.hdf"
+        with h5py.File(str(hdf_path), "w") as hf:
+            hf.create_group("Geometry")
+        return hdf_path
+
+    def _make_artifact(self, path):
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("artifact", encoding="utf-8")
+        return path
+
+    def test_sets_and_reads_all_association_paths(self, monkeypatch, tmp_path):
+        geom_hdf_path = self._make_geometry_hdf(tmp_path)
+        terrain = self._make_artifact(tmp_path / "Terrain" / "Terrain50.hdf")
+        landcover = self._make_artifact(
+            tmp_path / "Land Classification" / "LandCover.hdf"
+        )
+        infiltration = self._make_artifact(tmp_path / "Soils" / "Infiltration.hdf")
+        sediment_soils = self._make_artifact(
+            tmp_path / "Soils" / "Hydrologic Soil Groups.hdf"
         )
 
-        seeds = _reseed_after_perimeter_fix(
-            geom_text_path,
-            geom_text_path.with_suffix(".g01.hdf"),
-            MockPolygon([(0.0, 0.0), (100.0, 0.0), (100.0, 100.0), (0.0, 100.0)]),
-            100.0,
-            1,
-            "SecondaryArea",
-            {"RASGeometry": lambda path: mock_geom_obj},
+        _install_fake_rasmapper_scripting(monkeypatch)
+        monkeypatch.setattr(geom_mesh_module, "_load_dlls", lambda hecras_dir=None: None)
+
+        result = GeomMesh.set_geometry_association(
+            geom_hdf_path,
+            terrain_hdf_path=terrain,
+            landcover_hdf_path=landcover,
+            infiltration_hdf_path=infiltration,
+            sediment_soils_hdf_path=sediment_soils,
         )
 
-        assert seeds.Count == 2
-        assert seed_calls == [1]
-        assert polygon_calls == [1]
+        assert result == geom_hdf_path
+        association = GeomMesh.get_geometry_association(geom_hdf_path)
+        assert Path(association["terrain_hdf_path"]).resolve() == terrain.resolve()
+        assert Path(association["landcover_hdf_path"]).resolve() == landcover.resolve()
+        assert Path(association["infiltration_hdf_path"]).resolve() == infiltration.resolve()
+        assert (
+            Path(association["sediment_soils_hdf_path"]).resolve()
+            == sediment_soils.resolve()
+        )
+        assert association["terrain_layer_name"] == "Terrain50"
+        assert association["landcover_layer_name"] == "LandCover"
+        assert association["infiltration_layer_name"] == "Infiltration"
+        assert association["sediment_soils_layer_name"] == "Hydrologic Soil Groups"
+        assert association["si_units"] == "False"
+
+    def test_requires_at_least_one_association_path(self, tmp_path):
+        geom_hdf_path = self._make_geometry_hdf(tmp_path)
+
+        with pytest.raises(ValueError, match="at least one"):
+            GeomMesh.set_geometry_association(geom_hdf_path)
+
+    def test_rejects_missing_association_artifact(self, monkeypatch, tmp_path):
+        geom_hdf_path = self._make_geometry_hdf(tmp_path)
+        missing_terrain = tmp_path / "Terrain" / "Missing.hdf"
+        monkeypatch.setattr(geom_mesh_module, "_load_dlls", lambda hecras_dir=None: None)
+
+        with pytest.raises(FileNotFoundError, match="terrain_hdf_path"):
+            GeomMesh.set_geometry_association(
+                geom_hdf_path,
+                terrain_hdf_path=missing_terrain,
+            )
 
 
 class TestDetectBcConflicts:
@@ -634,11 +715,10 @@ class TestFixBcConflicts:
 class TestGenerate:
     """Test generate() normalization and persistence semantics."""
 
-    def test_defaults_persist_geometry_and_compile(self, monkeypatch, breakline_geom_text):
-        compiled_marker = breakline_geom_text.with_suffix(".compiled")
+    def test_defaults_persist_geometry_with_existing_hdf(self, monkeypatch, breakline_geom_text):
         captured = _mock_generate_success(
             monkeypatch,
-            compiled_marker,
+            breakline_geom_text,
             has_breaklines=True,
         )
 
@@ -656,10 +736,9 @@ class TestGenerate:
         assert "Storage Area 2D Points= 2 " in text
 
     def test_accepts_breakline_spacing_override(self, monkeypatch, breakline_geom_text):
-        compiled_marker = breakline_geom_text.with_suffix(".compiled")
         captured = _mock_generate_success(
             monkeypatch,
-            compiled_marker,
+            breakline_geom_text,
             has_breaklines=True,
         )
 
@@ -675,16 +754,14 @@ class TestGenerate:
         assert "BreakLine CellSize Min=75.000000" in text
         assert "BreakLine CellSize Max=125.000000" in text
 
-    def test_reseed_after_perimeter_fix_preserves_selected_mesh(
+    def test_perimeter_fix_reports_external_hdf_requirement(
         self, monkeypatch, breakline_geom_text
     ):
-        compiled_marker = breakline_geom_text.with_suffix(".compiled")
         captured = _mock_generate_success(
             monkeypatch,
-            compiled_marker,
+            breakline_geom_text,
             has_breaklines=True,
         )
-        _install_fake_rasmapper_scripting(monkeypatch)
 
         feature_names = ["MainArea", "SecondaryArea"]
         polygons = {
@@ -732,8 +809,10 @@ class TestGenerate:
 
         result = GeomMesh.generate(breakline_geom_text, mesh_index=1)
 
-        assert result.ok
-        assert seed_calls == [1, 1]
+        assert result.ok is False
+        assert result.status == "exception"
+        assert "cannot generate .g##.hdf" in result.error_message
+        assert seed_calls == [1]
 
     @pytest.mark.parametrize(
         "kwargs",
@@ -749,19 +828,17 @@ class TestGenerate:
         with pytest.raises(ValueError, match="must be greater than 0.0"):
             GeomMesh.generate(breakline_geom_text, **kwargs)
 
-    def test_does_not_report_complete_when_compile_fails(self, monkeypatch, breakline_geom_text):
-        _mock_generate_success(monkeypatch, breakline_geom_text.with_suffix(".compiled"), has_breaklines=False)
-
-        def fake_compile_geometry(*args, **kwargs):
-            raise RuntimeError("compile failed")
-
-        monkeypatch.setattr(GeomMesh, "compile_geometry", staticmethod(fake_compile_geometry))
+    def test_does_not_report_complete_when_geometry_hdf_missing(
+        self, monkeypatch, breakline_geom_text
+    ):
+        monkeypatch.setattr(geom_mesh_module, "_load_dlls", lambda hecras_dir=None: None)
+        monkeypatch.setattr(geom_mesh_module, "_imports", lambda: {})
 
         result = GeomMesh.generate(breakline_geom_text)
 
         assert result.ok is False
         assert result.status == "exception"
-        assert "compile failed" in result.error_message
+        assert "Compiled geometry HDF is missing" in result.error_message
 
 
 @pytest.mark.skipif(

--- a/tests/test_geometry_association.py
+++ b/tests/test_geometry_association.py
@@ -1,0 +1,166 @@
+from pathlib import Path
+import sys
+
+import h5py
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from ras_commander import RasMap
+
+
+def _make_project(tmp_path: Path) -> Path:
+    project_dir = tmp_path / "AssocProject"
+    project_dir.mkdir()
+    (project_dir / "AssocProject.prj").write_text(
+        "Proj Title=Association Project\nCurrent Plan=\n",
+        encoding="utf-8",
+    )
+    return project_dir
+
+
+def _touch(path: Path) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("artifact", encoding="utf-8")
+    return path
+
+
+def _make_geometry_hdf(path: Path) -> Path:
+    with h5py.File(path, "w") as hdf_file:
+        hdf_file.create_group("Geometry")
+    return path
+
+
+def test_rasmap_associate_geometry_layers_writes_hdf_attrs_with_layer_names(tmp_path):
+    project_dir = _make_project(tmp_path)
+    terrain = _touch(project_dir / "Terrain" / "TerrainA.hdf")
+    landcover = _touch(project_dir / "Land" / "cover.hdf")
+    soils = _touch(project_dir / "Soils Data" / "Hydrologic Soil Groups.hdf")
+    infiltration = _touch(project_dir / "Soils Data" / "infiltration.hdf")
+    sediment = _touch(project_dir / "Sediment" / "bed_material.hdf")
+    geom_hdf = _make_geometry_hdf(project_dir / "AssocProject.g01.hdf")
+
+    (project_dir / "AssocProject.rasmap").write_text(
+        (
+            "<RASMapper>\n"
+            "  <MapLayers>\n"
+            '    <Layer Name="Custom Land" Type="LandCoverLayer" '
+            'Filename=".\\Land\\cover.hdf" '
+            'SelectedParameterForSurfaceFillLabel="ManningsN" />\n'
+            '    <Layer Name="Custom Soils" Type="LandCoverLayer" '
+            'Filename=".\\Soils Data\\Hydrologic Soil Groups.hdf" '
+            'SelectedParameterForSurfaceFillLabel="ID" />\n'
+            '    <Layer Name="Custom Infiltration" Type="LandCoverLayer" '
+            'Filename=".\\Soils Data\\infiltration.hdf" '
+            'SelectedParameterForSurfaceFillLabel="ID" />\n'
+            "  </MapLayers>\n"
+            "  <Terrains>\n"
+            '    <Layer Name="Custom Terrain" Type="TerrainLayer" Checked="True" '
+            'Filename=".\\Terrain\\TerrainA.hdf">\n'
+            "      <ResampleMethod>near</ResampleMethod>\n"
+            '      <Surface On="True" />\n'
+            "    </Layer>\n"
+            "  </Terrains>\n"
+            "</RASMapper>\n"
+        ),
+        encoding="utf-8",
+    )
+
+    result = RasMap.associate_geometry_layers(
+        project_dir,
+        geom_hdf,
+        terrain_hdf_path=terrain,
+        landcover_hdf_path=landcover,
+        soil_layer_path=soils,
+        infiltration_hdf_path=infiltration,
+        sediment_soils_hdf_path=sediment,
+    )
+
+    assert result == geom_hdf
+    association = RasMap.get_hdf_geometry_association(geom_hdf)
+    assert Path(association["terrain_hdf_path"]) == terrain
+    assert Path(association["landcover_hdf_path"]) == landcover
+    assert Path(association["infiltration_hdf_path"]) == infiltration
+    assert Path(association["sediment_soils_hdf_path"]) == sediment
+    assert association["terrain_layer_name"] == "Custom Terrain"
+    assert association["landcover_layer_name"] == "Custom Land"
+    assert association["infiltration_layer_name"] == "Custom Infiltration"
+    assert association["sediment_soils_layer_name"] == "bed_material"
+    assert association["hdf_attrs"]["Terrain Filename"] == ".\\Terrain\\TerrainA.hdf"
+    assert association["hdf_attrs"]["Land Cover File Date"] is not None
+    assert association["hdf_attrs"]["Land Cover Date Last Modified"] is not None
+
+
+def test_soil_layer_path_does_not_write_sediment_soils_attr(tmp_path):
+    project_dir = _make_project(tmp_path)
+    soils = _touch(project_dir / "Soils Data" / "Hydrologic Soil Groups.hdf")
+    landcover = _touch(project_dir / "Land" / "LandCover.hdf")
+    geom_hdf = _make_geometry_hdf(project_dir / "AssocProject.g01.hdf")
+    (project_dir / "AssocProject.rasmap").write_text(
+        (
+            "<RASMapper>\n"
+            "  <MapLayers>\n"
+            '    <Layer Name="Land" Type="LandCoverLayer" '
+            'Filename=".\\Land\\LandCover.hdf" '
+            'SelectedParameterForSurfaceFillLabel="ManningsN" />\n'
+            '    <Layer Name="Hydrologic Soil Groups" Type="LandCoverLayer" '
+            'Filename=".\\Soils Data\\Hydrologic Soil Groups.hdf" '
+            'SelectedParameterForSurfaceFillLabel="ID" />\n'
+            "  </MapLayers>\n"
+            "</RASMapper>\n"
+        ),
+        encoding="utf-8",
+    )
+
+    RasMap.associate_geometry_layers(
+        project_dir,
+        geom_hdf,
+        landcover_hdf_path=landcover,
+        soil_layer_path=soils,
+    )
+
+    association = RasMap.get_hdf_geometry_association(geom_hdf)
+    assert Path(association["landcover_hdf_path"]) == landcover
+    assert association["sediment_soils_hdf_path"] is None
+    assert association["sediment_soils_layer_name"] is None
+
+
+def test_get_hdf_geometry_association_reads_plan_hdf_without_mutation(tmp_path):
+    project_dir = tmp_path / "PlanProject"
+    project_dir.mkdir()
+    terrain = _touch(project_dir / "Terrain" / "PlanTerrain.hdf")
+    plan_hdf = project_dir / "PlanProject.p01.hdf"
+    with h5py.File(plan_hdf, "w") as hdf_file:
+        geometry = hdf_file.create_group("Geometry")
+        geometry.attrs["Terrain Filename"] = b".\\Terrain\\PlanTerrain.hdf"
+        geometry.attrs["Terrain Layername"] = b"Plan Terrain"
+        geometry.attrs["Terrain File Date"] = b"01JAN2025 00:00:00"
+        area = hdf_file.create_group("Geometry/2D Flow Areas/Main")
+        area.attrs["Terrain Filename"] = b".\\Terrain\\PlanTerrain.hdf"
+        area.attrs["Terrain File Date"] = b"01JAN2025 00:00:00"
+
+    association = RasMap.get_hdf_geometry_association(plan_hdf)
+
+    assert Path(association["terrain_hdf_path"]) == terrain
+    assert association["terrain_layer_name"] == "Plan Terrain"
+    assert association["terrain_file_date"] == "01JAN2025 00:00:00"
+    assert association["two_d_area_terrain_associations"] == [
+        {
+            "flow_area": "Main",
+            "terrain_raw_filename": ".\\Terrain\\PlanTerrain.hdf",
+            "terrain_layer_name": None,
+            "terrain_file_date": "01JAN2025 00:00:00",
+            "terrain_hdf_path": str(terrain),
+        }
+    ]
+
+
+def test_missing_geometry_group_rejected_for_read(tmp_path):
+    hdf_path = tmp_path / "empty.g01.hdf"
+    with h5py.File(hdf_path, "w"):
+        pass
+
+    with pytest.raises(RuntimeError, match="/Geometry"):
+        RasMap.get_hdf_geometry_association(hdf_path)

--- a/tests/test_rasmap_land_classification.py
+++ b/tests/test_rasmap_land_classification.py
@@ -102,6 +102,11 @@ class TestPublicAPISurface:
             "associate_geometry_layers",
             "recompute_property_tables",
             "list_land_classification_layers",
+            "list_terrain_layers",
+            "list_landcover_layers",
+            "list_soils_layers",
+            "list_infiltration_layers",
+            "get_hdf_geometry_association",
         ],
     )
     def test_method_exists_and_is_static_style(self, method_name):
@@ -195,6 +200,26 @@ class TestRealRasmapParsing:
         assert parsed.at[0, "infiltration_hdf_path"] == [
             str(project_path / "Soils Data" / "Infiltration.hdf")
         ]
+
+        terrain_layers = RasMap.list_terrain_layers(project_path)
+        assert len(terrain_layers) == 1
+        assert terrain_layers.iloc[0]["name"] == "Terrain50"
+        assert terrain_layers.iloc[0]["filename"] == ".\\Terrain\\Terrain50.hdf"
+        assert terrain_layers.iloc[0]["resolved_path"] == str(
+            project_path / "Terrain" / "Terrain50.hdf"
+        )
+        assert terrain_layers.iloc[0]["resample_method"] == "near"
+        assert bool(terrain_layers.iloc[0]["surface_on"]) is True
+        assert parsed.at[0, "terrain_hdf_path"] == [
+            terrain_layers.iloc[0]["resolved_path"]
+        ]
+
+        landcover_layers = RasMap.list_landcover_layers(project_path)
+        soils_layers = RasMap.list_soils_layers(project_path)
+        infiltration_layers = RasMap.list_infiltration_layers(project_path)
+        assert list(landcover_layers["name"]) == ["LandCover"]
+        assert list(soils_layers["name"]) == ["Hydrologic Soil Groups"]
+        assert list(infiltration_layers["name"]) == ["Infiltration"]
 
     def test_muncie_nonstandard_names_still_classify_as_landcover(self):
         project_path = REPO_ROOT / "example_projects" / "Muncie_test_export"

--- a/tests/test_rasprocess_geometry_association_validator.py
+++ b/tests/test_rasprocess_geometry_association_validator.py
@@ -1,0 +1,104 @@
+from pathlib import Path
+import subprocess
+import sys
+
+import h5py
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from ras_commander import RasProcess
+from ras_commander._geometry_association import write_geometry_association
+
+
+def _make_geometry_hdf(path: Path) -> Path:
+    with h5py.File(path, "w") as hdf_file:
+        hdf_file.create_group("Geometry")
+    return path
+
+
+def _touch(path: Path) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("artifact", encoding="utf-8")
+    return path
+
+
+def test_validate_geometry_association_cli_reports_native_mutation(
+    monkeypatch,
+    tmp_path,
+):
+    geom_hdf = _make_geometry_hdf(tmp_path / "Model.g01.hdf")
+    terrain = _touch(tmp_path / "Terrain" / "Terrain50.hdf")
+    fake_exe = _touch(tmp_path / "RasProcess.exe")
+    captured = {}
+
+    def fake_run(rasprocess_path, args, timeout=600, working_dir=None):
+        captured["rasprocess_path"] = rasprocess_path
+        captured["args"] = args
+        captured["timeout"] = timeout
+        captured["working_dir"] = working_dir
+        arg_map = dict(arg.split("=", 1) for arg in args[1:])
+        write_geometry_association(
+            arg_map["GeometryFilename"],
+            terrain_hdf_path=arg_map["TerrainFilename"],
+            project_folder=Path(arg_map["GeometryFilename"]).parent,
+            validate=False,
+        )
+        return subprocess.CompletedProcess(args, 0, "terrain set\n", "")
+
+    monkeypatch.setattr(
+        RasProcess,
+        "find_rasprocess",
+        staticmethod(lambda ras_version=None: fake_exe),
+    )
+    monkeypatch.setattr(RasProcess, "_run_rasprocess", staticmethod(fake_run))
+
+    result = RasProcess.validate_geometry_association_cli(
+        geom_hdf,
+        terrain_hdf_path=terrain,
+        ras_version="6.6",
+        timeout=42,
+    )
+
+    assert result["passed"] is True
+    assert result["mismatches"] == []
+    assert result["return_code"] == 0
+    assert result["stdout"] == "terrain set\n"
+    assert result["before"]["terrain_hdf_path"] is None
+    assert Path(result["after"]["terrain_hdf_path"]) == terrain
+    assert result["command_args"][0] == "SetGeometryAssociation"
+    assert result["command_args"][1] == f"GeometryFilename={geom_hdf}"
+    assert result["command_args"][2] == f"TerrainFilename={terrain}"
+    assert captured["rasprocess_path"] == fake_exe
+    assert captured["timeout"] == 42
+    assert captured["working_dir"] == geom_hdf.parent
+
+
+def test_validate_geometry_association_cli_reports_mismatches(
+    monkeypatch,
+    tmp_path,
+):
+    geom_hdf = _make_geometry_hdf(tmp_path / "Model.g01.hdf")
+    terrain = _touch(tmp_path / "Terrain" / "Terrain50.hdf")
+    fake_exe = _touch(tmp_path / "RasProcess.exe")
+
+    def fake_run(rasprocess_path, args, timeout=600, working_dir=None):
+        return subprocess.CompletedProcess(args, 0, "", "")
+
+    monkeypatch.setattr(
+        RasProcess,
+        "find_rasprocess",
+        staticmethod(lambda ras_version=None: fake_exe),
+    )
+    monkeypatch.setattr(RasProcess, "_run_rasprocess", staticmethod(fake_run))
+
+    result = RasProcess.validate_geometry_association_cli(
+        geom_hdf,
+        terrain_hdf_path=terrain,
+    )
+
+    assert result["passed"] is False
+    assert result["return_code"] == 0
+    assert result["mismatches"]
+    assert result["mismatches"][0]["attribute"] == "Terrain Filename"


### PR DESCRIPTION
## Summary
- Add RasMap APIs for RASMapper layer discovery and geometry HDF association reads/writes.
- Add RasProcess native SetGeometryAssociation reference validator.
- Update examples and MkDocs documentation for terrain, land-cover, soils, infiltration, and HDF association workflows.

## Validation
- Executed QA copies of notebooks 212, 611, and 920 successfully.
- Focused tests passed: geometry association, RasProcess validator, RasMap land classification, GeomMesh, and Wine config tests.
- mkdocs build passed; strict mode still reports existing git-revision-date warnings for generated notebook pages.