### PR TITLE
Parse HEC-RAS Connection geometry blocks

### DIFF
--- a/ras_commander/RasGeometry.py
+++ b/ras_commander/RasGeometry.py
@@ -24,6 +24,7 @@ DEPRECATION NOTICE:
     SA/2D Connection Operations:
     - GeomLateral.get_connections() - replaces RasGeometry.get_connections()
     - GeomLateral.get_connection_profile() - replaces RasGeometry.get_connection_weir_profile()
+    - GeomLateral.set_connection_profile() - replaces RasGeometry.set_connection_weir_profile()
     - GeomLateral.get_connection_gates() - replaces RasGeometry.get_connection_gates()
 
 This module is part of the ras-commander library and uses a centralized logging configuration.
@@ -43,6 +44,7 @@ List of Functions in RasGeometry (all DEPRECATED):
 - get_lateral_weir_profile() - Read station-elevation profile for lateral weir [DEPRECATED]
 - get_connections() - List all SA/2D area connections [DEPRECATED]
 - get_connection_weir_profile() - Read dam/weir crest station-elevation profile [DEPRECATED]
+- set_connection_weir_profile() - Write dam/weir crest station-elevation profile [DEPRECATED]
 - get_connection_gates() - Read gate definitions (CSV format, 23+ parameters) [DEPRECATED]
 """
 
@@ -319,6 +321,28 @@ class RasGeometry:
         )
         from .geom import GeomLateral
         return GeomLateral.get_connection_profile(geom_file, connection_name)
+
+    @staticmethod
+    @log_call
+    def set_connection_weir_profile(geom_file: Union[str, Path],
+                                    connection_name: str,
+                                    sta_elev_df: pd.DataFrame,
+                                    create_backup: bool = True):
+        """
+        Write weir/dam crest station-elevation profile for a connection.
+
+        DEPRECATED: Use GeomLateral.set_connection_profile() instead.
+        """
+        warnings.warn(
+            "RasGeometry.set_connection_weir_profile() is deprecated. "
+            "Use GeomLateral.set_connection_profile() instead.",
+            DeprecationWarning,
+            stacklevel=2
+        )
+        from .geom import GeomLateral
+        return GeomLateral.set_connection_profile(
+            geom_file, connection_name, sta_elev_df, create_backup=create_backup
+        )
 
     @staticmethod
     @log_call

--- a/ras_commander/geom/GeomLateral.py
+++ b/ras_commander/geom/GeomLateral.py
@@ -11,6 +11,7 @@ List of Functions:
 - get_weir_profile() - Read station/elevation profile for lateral weir
 - get_connections() - List all SA/2D area connections
 - get_connection_profile() - Read dam/weir crest profile for connection
+- set_connection_profile() - Write dam/weir crest profile for connection
 - get_connection_gates() - Read gate definitions for connection
 
 Example Usage:
@@ -28,7 +29,7 @@ Example Usage:
 """
 
 from pathlib import Path
-from typing import Union, Optional, List, Dict, Any
+from typing import Union, Optional, List, Dict, Any, Tuple
 import pandas as pd
 
 from ..LoggingConfig import get_logger
@@ -49,6 +50,221 @@ class GeomLateral:
     FIXED_WIDTH_COLUMN = 8      # Character width for numeric data in geometry files
     VALUES_PER_LINE = 10        # Number of values per line in fixed-width format
     DEFAULT_SEARCH_RANGE = 100  # Lines to search for keywords after structure header
+
+    CONNECTION_HEADER_KEYWORDS = ("Connection", "SA/2D Area Conn")
+    CONNECTION_HEADER_PREFIXES = tuple(f"{keyword}=" for keyword in CONNECTION_HEADER_KEYWORDS)
+    CONNECTION_PROFILE_KEYWORDS = ("Conn Weir SE", "#Conn Weir Sta/Elev")
+    CONNECTION_BLOCK_TERMINATORS = (
+        "Connection=",
+        "SA/2D Area Conn=",
+        "Storage Area=",
+        "River Reach=",
+        "Junct Name=",
+        "Lat Struct=",
+        "Weir Embankment=",
+        "Pump Station=",
+        "BC Line Name=",
+        "LCMann Time=",
+        "Chan Stop Cuts=",
+        "Observed WS=",
+    )
+
+    @staticmethod
+    def _is_connection_header(line: str) -> bool:
+        """Return True when *line* starts a SA/2D connection block."""
+        return line.startswith(GeomLateral.CONNECTION_HEADER_PREFIXES)
+
+    @staticmethod
+    def _connection_keyword(line: str) -> Optional[str]:
+        """Return the connection header keyword used by *line*."""
+        for keyword in GeomLateral.CONNECTION_HEADER_KEYWORDS:
+            if line.startswith(f"{keyword}="):
+                return keyword
+        return None
+
+    @staticmethod
+    def _extract_connection_header(line: str) -> Dict[str, Any]:
+        """Parse a connection header line into name and optional centroid fields."""
+        keyword = GeomLateral._connection_keyword(line)
+        if keyword is None:
+            return {
+                'Header': None,
+                'Name': "",
+                'RawName': "",
+                'CenterX': None,
+                'CenterY': None,
+            }
+
+        value_str = GeomParser.extract_keyword_value(line, keyword)
+        parts = value_str.split(',')
+        raw_name = parts[0] if parts else value_str
+
+        data = {
+            'Header': keyword,
+            'Name': raw_name.strip(),
+            'RawName': raw_name,
+            'CenterX': None,
+            'CenterY': None,
+        }
+
+        if len(parts) > 1 and parts[1].strip():
+            try:
+                data['CenterX'] = float(parts[1].strip())
+            except ValueError:
+                pass
+
+        if len(parts) > 2 and parts[2].strip():
+            try:
+                data['CenterY'] = float(parts[2].strip())
+            except ValueError:
+                pass
+
+        return data
+
+    @staticmethod
+    def _is_connection_block_terminator(line: str) -> bool:
+        """Return True when *line* starts a new top-level geometry block."""
+        return line.startswith(GeomLateral.CONNECTION_BLOCK_TERMINATORS)
+
+    @staticmethod
+    def _iter_connection_blocks(lines: List[str]):
+        """Yield (start_idx, end_idx, block_lines, header_data) for connection blocks."""
+        i = 0
+        while i < len(lines):
+            if GeomLateral._is_connection_header(lines[i]):
+                start_idx = i
+                header_data = GeomLateral._extract_connection_header(lines[i])
+                end_idx = i + 1
+
+                while end_idx < len(lines):
+                    if GeomLateral._is_connection_block_terminator(lines[end_idx]):
+                        break
+                    end_idx += 1
+
+                yield start_idx, end_idx, lines[start_idx:end_idx], header_data
+                i = end_idx
+                continue
+
+            i += 1
+
+    @staticmethod
+    def _find_connection_block(lines: List[str], connection_name: str):
+        """Return the connection block matching a stripped or raw connection name."""
+        for start_idx, end_idx, block_lines, header_data in GeomLateral._iter_connection_blocks(lines):
+            if (
+                header_data['Name'] == connection_name
+                or header_data['RawName'] == connection_name
+                or header_data['RawName'].strip() == connection_name.strip()
+            ):
+                return start_idx, end_idx, block_lines, header_data
+        return None
+
+    @staticmethod
+    def _find_connection_profile_marker(block_lines: List[str]) -> Optional[Tuple[int, str, int]]:
+        """Return (local index, keyword, point count) for a connection crest profile."""
+        for idx, line in enumerate(block_lines):
+            for keyword in GeomLateral.CONNECTION_PROFILE_KEYWORDS:
+                if line.startswith(f"{keyword}="):
+                    count_str = GeomParser.extract_keyword_value(line, keyword)
+                    try:
+                        return idx, keyword, int(count_str.strip())
+                    except ValueError:
+                        return idx, keyword, 0
+        return None
+
+    @staticmethod
+    def _parse_paired_data(lines: List[str], start_idx: int, count: int) -> pd.DataFrame:
+        """Parse station/elevation fixed-width pairs from *lines*."""
+        total_values = count * 2
+        values = []
+        i = start_idx
+
+        while len(values) < total_values and i < len(lines):
+            if '=' in lines[i]:
+                break
+            parsed = GeomParser.parse_fixed_width(lines[i], GeomLateral.FIXED_WIDTH_COLUMN)
+            values.extend(parsed)
+            i += 1
+
+        stations = values[0::2]
+        elevations = values[1::2]
+
+        return pd.DataFrame({
+            'Station': stations[:count],
+            'Elevation': elevations[:count],
+        })
+
+    @staticmethod
+    def _storage_area_type_map(lines: List[str]) -> Dict[str, bool]:
+        """Map storage-area names to True when the area is a 2D flow area."""
+        area_types = {}
+        i = 0
+
+        while i < len(lines):
+            line = lines[i]
+            if not line.startswith("Storage Area="):
+                i += 1
+                continue
+
+            value_str = GeomParser.extract_keyword_value(line, "Storage Area")
+            parts = [p.strip() for p in value_str.split(',')]
+            area_name = parts[0] if parts else value_str.strip()
+            is_2d = False
+
+            j = i + 1
+            while j < len(lines):
+                if lines[j].startswith(("Storage Area=", "Connection=", "SA/2D Area Conn=", "River Reach=")):
+                    break
+                if lines[j].startswith("Storage Area Is2D="):
+                    is2d_str = GeomParser.extract_keyword_value(lines[j], "Storage Area Is2D")
+                    try:
+                        is_2d = int(is2d_str.strip()) == -1
+                    except ValueError:
+                        is_2d = False
+                j += 1
+
+            area_types[area_name] = is_2d
+            i = j
+
+        return area_types
+
+    @staticmethod
+    def _classify_connection(
+        from_area: Optional[str],
+        to_area: Optional[str],
+        area_types: Dict[str, bool],
+        fallback: str = "Unknown",
+    ) -> str:
+        """Classify a connection as SA/2D when storage-area metadata is available."""
+        if not from_area or not to_area:
+            return fallback
+
+        def label(area_name: str) -> Optional[str]:
+            key = area_name.strip()
+            if key in area_types:
+                return "2D" if area_types[key] else "SA"
+            return None
+
+        from_label = label(from_area)
+        to_label = label(to_area)
+        if from_label and to_label:
+            return f"{from_label} to {to_label}"
+
+        return fallback
+
+    @staticmethod
+    def _parse_optional_int(value: str) -> Optional[int]:
+        try:
+            return int(value.strip())
+        except (TypeError, ValueError):
+            return None
+
+    @staticmethod
+    def _parse_optional_float(value: str) -> Optional[float]:
+        try:
+            return float(value.strip())
+        except (TypeError, ValueError):
+            return None
 
     @staticmethod
     @log_call
@@ -284,61 +500,76 @@ class GeomLateral:
                 lines = f.readlines()
 
             connections = []
-            i = 0
+            area_types = GeomLateral._storage_area_type_map(lines)
 
-            while i < len(lines):
-                line = lines[i]
+            for start_idx, end_idx, block_lines, header_data in GeomLateral._iter_connection_blocks(lines):
+                from_area = None
+                to_area = None
+                conn_type = "Unknown"
+                routing_type = None
+                line_points = None
+                has_gate = False
+                has_culvert = False
 
-                # Find SA/2D Connection definition
-                if line.startswith("SA/2D Area Conn="):
-                    conn_values = GeomParser.extract_comma_list(line, "SA/2D Area Conn")
-                    conn_name = conn_values[0] if conn_values else ""
+                for block_line in block_lines[1:]:
+                    if block_line.startswith("From Storage Area="):
+                        from_area = GeomParser.extract_keyword_value(block_line, "From Storage Area").strip()
+                    elif block_line.startswith("To Storage Area="):
+                        to_area = GeomParser.extract_keyword_value(block_line, "To Storage Area").strip()
+                    elif block_line.startswith("From 2D Area="):
+                        from_area = GeomParser.extract_keyword_value(block_line, "From 2D Area").strip()
+                        conn_type = "2D to SA" if to_area else "2D to 2D"
+                    elif block_line.startswith("To 2D Area="):
+                        to_area = GeomParser.extract_keyword_value(block_line, "To 2D Area").strip()
+                        if from_area:
+                            conn_type = "SA to 2D"
+                    elif block_line.startswith("Connection Up SA="):
+                        from_area = GeomParser.extract_keyword_value(block_line, "Connection Up SA").strip()
+                    elif block_line.startswith("Connection Dn SA="):
+                        to_area = GeomParser.extract_keyword_value(block_line, "Connection Dn SA").strip()
+                    elif block_line.startswith("Conn Routing Type="):
+                        routing_type = GeomLateral._parse_optional_int(
+                            GeomParser.extract_keyword_value(block_line, "Conn Routing Type")
+                        )
+                    elif block_line.startswith("Connection Line="):
+                        line_points = GeomLateral._parse_optional_int(
+                            GeomParser.extract_keyword_value(block_line, "Connection Line")
+                        )
+                    elif block_line.startswith("Conn Gate Name"):
+                        has_gate = True
+                    elif block_line.startswith(("Connection Culv=", "Conn Culv")):
+                        has_culvert = True
 
-                    # Parse connection parameters
-                    from_area = None
-                    to_area = None
-                    conn_type = "Unknown"
-                    num_points = 0
+                marker = GeomLateral._find_connection_profile_marker(block_lines)
+                num_points = marker[2] if marker else 0
 
-                    for j in range(i+1, min(i+50, len(lines))):
-                        if lines[j].startswith("From Storage Area="):
-                            from_area = GeomParser.extract_keyword_value(lines[j], "From Storage Area")
-                        elif lines[j].startswith("To Storage Area="):
-                            to_area = GeomParser.extract_keyword_value(lines[j], "To Storage Area")
-                        elif lines[j].startswith("From 2D Area="):
-                            from_area = GeomParser.extract_keyword_value(lines[j], "From 2D Area")
-                            conn_type = "2D to SA" if to_area else "2D to 2D"
-                        elif lines[j].startswith("To 2D Area="):
-                            to_area = GeomParser.extract_keyword_value(lines[j], "To 2D Area")
-                            conn_type = "SA to 2D" if from_area and "2D" not in str(from_area) else conn_type
-                        elif lines[j].startswith("#Conn Weir Sta/Elev="):
-                            count_str = GeomParser.extract_keyword_value(lines[j], "#Conn Weir Sta/Elev")
-                            try:
-                                num_points = int(count_str.strip())
-                            except ValueError:
-                                pass
-                            break
+                if from_area and to_area:
+                    conn_type = GeomLateral._classify_connection(
+                        from_area,
+                        to_area,
+                        area_types,
+                        fallback="SA/2D Connection" if header_data['Header'] == "Connection" else conn_type,
+                    )
+                    if conn_type == "Unknown":
+                        conn_type = "SA to SA"
 
-                        # Stop at next structure
-                        if lines[j].startswith("SA/2D Area Conn=") or lines[j].startswith("Storage Area="):
-                            break
-
-                    # Determine type
-                    if from_area and to_area:
-                        if "2D" in conn_type:
-                            pass  # Already set
-                        else:
-                            conn_type = "SA to SA"
-
-                    connections.append({
-                        'Name': conn_name,
-                        'Type': conn_type,
-                        'From': from_area,
-                        'To': to_area,
-                        'NumPoints': num_points
-                    })
-
-                i += 1
+                connections.append({
+                    'Name': header_data['Name'],
+                    'Type': conn_type,
+                    'From': from_area,
+                    'To': to_area,
+                    'NumPoints': num_points,
+                    'Header': header_data['Header'],
+                    'RawName': header_data['RawName'],
+                    'CenterX': header_data['CenterX'],
+                    'CenterY': header_data['CenterY'],
+                    'LinePoints': line_points,
+                    'RoutingType': routing_type,
+                    'HasGate': has_gate,
+                    'HasCulvert': has_culvert,
+                    'StartLine': start_idx + 1,
+                    'EndLine': end_idx,
+                })
 
             df = pd.DataFrame(connections)
             logger.debug(f"Found {len(df)} SA/2D connections in {geom_file.name}")
@@ -383,52 +614,20 @@ class GeomLateral:
             with open(geom_file, 'r', encoding='utf-8', errors='replace') as f:
                 lines = f.readlines()
 
-            # Find the connection
-            conn_idx = None
-            for i, line in enumerate(lines):
-                if line.startswith("SA/2D Area Conn="):
-                    conn_values = GeomParser.extract_comma_list(line, "SA/2D Area Conn")
-                    if conn_values and conn_values[0] == connection_name:
-                        conn_idx = i
-                        break
-
-            if conn_idx is None:
+            block = GeomLateral._find_connection_block(lines, connection_name)
+            if block is None:
                 raise ValueError(f"Connection not found: {connection_name}")
 
-            # Find weir profile data
-            for j in range(conn_idx+1, min(conn_idx+GeomLateral.DEFAULT_SEARCH_RANGE, len(lines))):
-                if lines[j].startswith("#Conn Weir Sta/Elev="):
-                    count_str = GeomParser.extract_keyword_value(lines[j], "#Conn Weir Sta/Elev")
-                    count = int(count_str.strip())
+            _, _, block_lines, _ = block
+            marker = GeomLateral._find_connection_profile_marker(block_lines)
+            if marker is None:
+                raise ValueError(f"Weir profile not found for connection {connection_name}")
 
-                    # Parse paired data
-                    total_values = count * 2
-                    values = []
-                    k = j + 1
-                    while len(values) < total_values and k < len(lines):
-                        if '=' in lines[k]:
-                            break
-                        parsed = GeomParser.parse_fixed_width(lines[k], GeomLateral.FIXED_WIDTH_COLUMN)
-                        values.extend(parsed)
-                        k += 1
+            marker_idx, _, count = marker
+            df = GeomLateral._parse_paired_data(block_lines, marker_idx + 1, count)
 
-                    # Split into stations and elevations
-                    stations = values[0::2]
-                    elevations = values[1::2]
-
-                    df = pd.DataFrame({
-                        'Station': stations[:count],
-                        'Elevation': elevations[:count]
-                    })
-
-                    logger.info(f"Extracted {len(df)} weir profile points for connection {connection_name}")
-                    return df
-
-                # Stop at next structure
-                if lines[j].startswith("SA/2D Area Conn="):
-                    break
-
-            raise ValueError(f"Weir profile not found for connection {connection_name}")
+            logger.info(f"Extracted {len(df)} weir profile points for connection {connection_name}")
+            return df
 
         except FileNotFoundError:
             raise
@@ -437,6 +636,92 @@ class GeomLateral:
         except Exception as e:
             logger.error(f"Error reading connection profile: {str(e)}")
             raise IOError(f"Failed to read connection profile: {str(e)}")
+
+    @staticmethod
+    @log_call
+    def set_connection_profile(
+        geom_file: Union[str, Path],
+        connection_name: str,
+        sta_elev_df: pd.DataFrame,
+        create_backup: bool = True,
+    ) -> Optional[Path]:
+        """
+        Write the dam/weir crest station-elevation profile for a connection.
+
+        Supports both modern ``Connection=`` blocks with ``Conn Weir SE=``
+        records and legacy ``SA/2D Area Conn=`` blocks with
+        ``#Conn Weir Sta/Elev=`` records.
+
+        Parameters:
+            geom_file: Path to geometry file
+            connection_name: Connection name
+            sta_elev_df: DataFrame with Station and Elevation columns
+            create_backup: Create a .bak backup before writing (default True)
+
+        Returns:
+            Optional[Path]: Backup path when create_backup=True, else None
+
+        Raises:
+            FileNotFoundError: If geometry file doesn't exist
+            ValueError: If the connection/profile or required columns are missing
+        """
+        geom_file = Path(geom_file)
+
+        if not geom_file.exists():
+            raise FileNotFoundError(f"Geometry file not found: {geom_file}")
+
+        if not {'Station', 'Elevation'}.issubset(sta_elev_df.columns):
+            raise ValueError("sta_elev_df must contain Station and Elevation columns")
+        if sta_elev_df.empty:
+            raise ValueError("sta_elev_df must contain at least one station/elevation row")
+
+        try:
+            with open(geom_file, 'r', encoding='utf-8', errors='replace') as f:
+                lines = f.readlines()
+
+            block = GeomLateral._find_connection_block(lines, connection_name)
+            if block is None:
+                raise ValueError(f"Connection not found: {connection_name}")
+
+            start_idx, end_idx, block_lines, _ = block
+            marker = GeomLateral._find_connection_profile_marker(block_lines)
+            if marker is None:
+                raise ValueError(f"Weir profile not found for connection {connection_name}")
+
+            marker_idx, keyword, _ = marker
+            profile_idx = start_idx + marker_idx
+            data_start = profile_idx + 1
+            data_end = data_start
+            while data_end < end_idx and '=' not in lines[data_end]:
+                data_end += 1
+
+            values = []
+            for _, row in sta_elev_df.iterrows():
+                values.extend([float(row['Station']), float(row['Elevation'])])
+
+            new_data_lines = GeomParser.format_fixed_width(
+                values,
+                column_width=GeomLateral.FIXED_WIDTH_COLUMN,
+                values_per_line=GeomLateral.VALUES_PER_LINE,
+                precision=3,
+            )
+
+            line_ending = '\n' if lines[profile_idx].endswith('\n') else ''
+            if keyword == "Conn Weir SE":
+                lines[profile_idx] = f"Conn Weir SE= {len(sta_elev_df)} {line_ending}"
+            else:
+                lines[profile_idx] = f"#Conn Weir Sta/Elev= {len(sta_elev_df)}{line_ending}"
+
+            lines[data_start:data_end] = new_data_lines
+            return GeomParser.safe_write_geometry(geom_file, lines, create_backup=create_backup)
+
+        except FileNotFoundError:
+            raise
+        except ValueError:
+            raise
+        except Exception as e:
+            logger.error(f"Error writing connection profile: {str(e)}")
+            raise IOError(f"Failed to write connection profile: {str(e)}")
 
     @staticmethod
     @log_call
@@ -470,42 +755,59 @@ class GeomLateral:
             with open(geom_file, 'r', encoding='utf-8', errors='replace') as f:
                 lines = f.readlines()
 
-            # Find the connection
-            conn_idx = None
-            for i, line in enumerate(lines):
-                if line.startswith("SA/2D Area Conn="):
-                    conn_values = GeomParser.extract_comma_list(line, "SA/2D Area Conn")
-                    if conn_values and conn_values[0] == connection_name:
-                        conn_idx = i
-                        break
-
-            if conn_idx is None:
+            block = GeomLateral._find_connection_block(lines, connection_name)
+            if block is None:
                 raise ValueError(f"Connection not found: {connection_name}")
 
-            # Find gate definitions
+            _, _, block_lines, _ = block
             gates = []
-            i = conn_idx + 1
-            while i < min(conn_idx + GeomLateral.DEFAULT_SEARCH_RANGE, len(lines)):
-                line = lines[i]
+            i = 1
+            while i < len(block_lines):
+                line = block_lines[i]
 
-                # Stop at next structure
-                if line.startswith("SA/2D Area Conn=") or line.startswith("Storage Area="):
-                    break
-
-                # Found gate header (simplified parsing - actual format varies)
                 if line.startswith("Conn Gate Name"):
-                    if i + 1 < len(lines):
-                        gate_line = lines[i + 1]
+                    if i + 1 < len(block_lines):
+                        gate_line = block_lines[i + 1]
                         parts = [p.strip() for p in gate_line.split(',')]
 
                         gate_data = {
                             'GateName': parts[0] if len(parts) > 0 else None,
-                            'Width': float(parts[1]) if len(parts) > 1 and parts[1] else None,
-                            'Height': float(parts[2]) if len(parts) > 2 and parts[2] else None,
-                            'InvertElevation': float(parts[3]) if len(parts) > 3 and parts[3] else None,
+                            'Width': GeomLateral._parse_optional_float(parts[1]) if len(parts) > 1 else None,
+                            'Height': GeomLateral._parse_optional_float(parts[2]) if len(parts) > 2 else None,
+                            'InvertElevation': GeomLateral._parse_optional_float(parts[3]) if len(parts) > 3 else None,
+                            'GateCoefficient': GeomLateral._parse_optional_float(parts[4]) if len(parts) > 4 else None,
+                            'ExpansionTop': GeomLateral._parse_optional_float(parts[5]) if len(parts) > 5 else None,
+                            'ExpansionOrifice': GeomLateral._parse_optional_float(parts[6]) if len(parts) > 6 else None,
+                            'ExpansionHydraulic': GeomLateral._parse_optional_float(parts[7]) if len(parts) > 7 else None,
+                            'GateType': GeomLateral._parse_optional_float(parts[8]) if len(parts) > 8 else None,
+                            'WeirCoefficient': GeomLateral._parse_optional_float(parts[9]) if len(parts) > 9 else None,
+                            'IsOgee': GeomLateral._parse_optional_int(parts[10]) if len(parts) > 10 else None,
+                            'SpillwayHeight': GeomLateral._parse_optional_float(parts[11]) if len(parts) > 11 else None,
+                            'DesignHead': GeomLateral._parse_optional_float(parts[12]) if len(parts) > 12 else None,
+                            'NumOpenings': GeomLateral._parse_optional_int(parts[13]) if len(parts) > 13 else 0,
+                            'OpeningStations': [],
                         }
+
+                        num_openings = gate_data['NumOpenings'] or 0
+                        station_idx = i + 2
+                        opening_stations = []
+                        while (
+                            num_openings > 0
+                            and len(opening_stations) < num_openings
+                            and station_idx < len(block_lines)
+                            and '=' not in block_lines[station_idx]
+                        ):
+                            opening_stations.extend(
+                                GeomParser.parse_fixed_width(
+                                    block_lines[station_idx],
+                                    GeomLateral.FIXED_WIDTH_COLUMN,
+                                )
+                            )
+                            station_idx += 1
+                        gate_data['OpeningStations'] = opening_stations[:num_openings]
+
                         gates.append(gate_data)
-                        i += 2
+                        i = station_idx
                         continue
 
                 i += 1

--- a/tests/test_geom_lateral_connections.py
+++ b/tests/test_geom_lateral_connections.py
@@ -1,0 +1,178 @@
+"""Regression coverage for SA/2D connection blocks in .g## geometry files."""
+
+from pathlib import Path
+import shutil
+
+import pandas as pd
+import pytest
+
+from ras_commander.RasExamples import RasExamples
+from ras_commander.geom.GeomLateral import GeomLateral
+
+
+@pytest.fixture(scope="module")
+def example_output_dir(tmp_path_factory):
+    return tmp_path_factory.mktemp("ras_examples")
+
+
+@pytest.fixture(scope="module")
+def bald_eagle_project(example_output_dir):
+    return RasExamples.extract_project("BaldEagleCrkMulti2D", output_path=example_output_dir)
+
+
+@pytest.fixture(scope="module")
+def muncie_project(example_output_dir):
+    return RasExamples.extract_project("Muncie", output_path=example_output_dir)
+
+
+def _write_geom_file(tmp_path: Path, lines: list[str]) -> Path:
+    geom_file = tmp_path / "connections.g01"
+    geom_file.write_text("".join(lines), encoding="utf-8")
+    return geom_file
+
+
+def test_bald_eagle_g13_connection_blocks_are_parsed(bald_eagle_project):
+    geom_file = bald_eagle_project / "BaldEagleDamBrk.g13"
+
+    connections = GeomLateral.get_connections(geom_file)
+
+    assert list(connections["Name"]) == [
+        "Dam",
+        "Lower Levee",
+        "Middle Levee",
+        "Upper Levee",
+    ]
+    assert len(connections) == 4
+    assert set(connections["Header"]) == {"Connection"}
+
+    dam = connections.loc[connections["Name"] == "Dam"].iloc[0]
+    assert dam["From"] == "Reservoir Pool"
+    assert dam["To"] == "BaldEagleCr"
+    assert dam["Type"] == "SA to 2D"
+    assert dam["NumPoints"] == 6
+    assert dam["LinePoints"] == 18
+    assert bool(dam["HasGate"]) is True
+
+    levee = connections.loc[connections["Name"] == "Lower Levee"].iloc[0]
+    assert levee["Type"] == "2D to 2D"
+    assert levee["NumPoints"] == 94
+
+
+def test_muncie_connections_and_conn_weir_se_profile_are_parsed(muncie_project):
+    geom_file = muncie_project / "Muncie.g01"
+
+    connections = GeomLateral.get_connections(geom_file)
+    profile = GeomLateral.get_connection_profile(geom_file, "162")
+
+    assert len(connections) == 10
+    assert list(connections["Name"].head(4)) == ["162", "163", "164", "165"]
+
+    first = connections.loc[connections["Name"] == "162"].iloc[0]
+    assert first["NumPoints"] == 66
+    assert first["From"] == "146"
+    assert first["To"] == "148"
+
+    assert len(profile) == 66
+    assert profile.iloc[0]["Station"] == pytest.approx(0.0)
+    assert profile.iloc[0]["Elevation"] == pytest.approx(956.819)
+    assert profile.iloc[-1]["Station"] == pytest.approx(409.015)
+    assert profile.iloc[-1]["Elevation"] == pytest.approx(956.886)
+
+
+def test_connection_gates_parse_modern_connection_blocks(bald_eagle_project):
+    geom_file = bald_eagle_project / "BaldEagleDamBrk.g13"
+
+    gates = GeomLateral.get_connection_gates(geom_file, "Dam")
+
+    assert len(gates) == 1
+    gate = gates.iloc[0]
+    assert gate["GateName"] == "Gate #1"
+    assert gate["Width"] == pytest.approx(7.0)
+    assert gate["Height"] == pytest.approx(15.0)
+    assert gate["InvertElevation"] == pytest.approx(590.0)
+    assert gate["NumOpenings"] == 2
+    assert gate["OpeningStations"] == [5745.0, 5765.0]
+
+
+def test_legacy_sa2d_area_conn_blocks_still_parse(tmp_path):
+    geom_file = _write_geom_file(
+        tmp_path,
+        [
+            "Geom Title=Legacy Connection Test\n",
+            "SA/2D Area Conn=Legacy Connection\n",
+            "From Storage Area=Legacy Pool\n",
+            "To 2D Area=Legacy Mesh\n",
+            "#Conn Weir Sta/Elev= 2\n",
+            "    0.00  100.00   50.00  101.25\n",
+            "Storage Area=Legacy Mesh,0,0\n",
+            "Storage Area Is2D=-1\n",
+        ],
+    )
+
+    connections = GeomLateral.get_connections(geom_file)
+    profile = GeomLateral.get_connection_profile(geom_file, "Legacy Connection")
+
+    assert len(connections) == 1
+    assert connections.iloc[0]["Header"] == "SA/2D Area Conn"
+    assert connections.iloc[0]["Type"] == "SA to 2D"
+    assert connections.iloc[0]["NumPoints"] == 2
+    assert list(profile["Station"]) == [0.0, 50.0]
+    assert list(profile["Elevation"]) == [100.0, 101.25]
+
+
+def test_set_connection_profile_round_trips_existing_connection_block(tmp_path, bald_eagle_project):
+    source_geom = bald_eagle_project / "BaldEagleDamBrk.g13"
+    geom_file = tmp_path / "BaldEagleDamBrk.g13"
+    shutil.copy2(source_geom, geom_file)
+
+    profile = GeomLateral.get_connection_profile(geom_file, "Dam")
+    modified = profile.copy()
+    modified.loc[0, "Elevation"] = modified.loc[0, "Elevation"] + 0.125
+
+    backup = GeomLateral.set_connection_profile(
+        geom_file,
+        "Dam",
+        modified,
+        create_backup=False,
+    )
+
+    updated = GeomLateral.get_connection_profile(geom_file, "Dam")
+    connections = GeomLateral.get_connections(geom_file)
+
+    assert backup is None
+    assert len(updated) == len(profile)
+    assert updated.iloc[0]["Elevation"] == pytest.approx(profile.iloc[0]["Elevation"] + 0.125)
+    assert len(connections) == 4
+    assert connections.loc[connections["Name"] == "Dam", "NumPoints"].iloc[0] == len(profile)
+
+
+def test_set_connection_profile_round_trips_legacy_profile_block(tmp_path):
+    geom_file = _write_geom_file(
+        tmp_path,
+        [
+            "Geom Title=Legacy Connection Test\n",
+            "SA/2D Area Conn=Legacy Connection\n",
+            "From Storage Area=Legacy Pool\n",
+            "To Storage Area=Legacy Downstream\n",
+            "#Conn Weir Sta/Elev= 2\n",
+            "    0.00  100.00   50.00  101.25\n",
+        ],
+    )
+    replacement = pd.DataFrame(
+        {
+            "Station": [0.0, 25.0, 50.0],
+            "Elevation": [100.0, 100.5, 101.0],
+        }
+    )
+
+    GeomLateral.set_connection_profile(
+        geom_file,
+        "Legacy Connection",
+        replacement,
+        create_backup=False,
+    )
+
+    updated = GeomLateral.get_connection_profile(geom_file, "Legacy Connection")
+    assert len(updated) == 3
+    assert list(updated["Station"]) == [0.0, 25.0, 50.0]
+    assert list(updated["Elevation"]) == [100.0, 100.5, 101.0]


### PR DESCRIPTION
## Summary

Adds first-class support for modern HEC-RAS `Connection=` SA/2D connection blocks in geometry parsing while preserving legacy `SA/2D Area Conn=` compatibility.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)
- [ ] Example notebook

---

## LLM Self-Review

> **ras-commander encourages LLM-assisted contributions.** If your agent prepared this code, confirm it reviewed the style guide. See [CONTRIBUTING.md](../CONTRIBUTING.md) for details.

### Style Compliance

- [x] Static class pattern followed (`.claude/rules/python/static-classes.md`)
- [x] `@staticmethod` + `@log_call` on public methods (`.claude/rules/python/decorators.md`)
- [x] Naming conventions followed (`.claude/rules/python/naming-conventions.md`)
- [x] `pathlib.Path` used, accepts both `str` and `Path` (`.claude/rules/python/path-handling.md`)
- [x] DataFrames used for project metadata, not glob (`.claude/rules/python/dataframe-first-principle.md`)

### Code Quality

- [x] Google-style docstrings with Args, Returns, Raises
- [x] Tested with real HEC-RAS project (`RasExamples.extract_project()`)
- [x] No hardcoded file paths
- [x] Uses logging, not `print()`
- [x] Proper error handling with informative messages

### API Changes (if applicable)

- [ ] `ras_object=None` parameter included for multi-project support
- [x] Standard parameter names (`plan_number`, `geom_file`)
- [x] API consistency auditor 5 rules followed (`.claude/agents/api-consistency-auditor.md`)
- [x] Return types consistent (DataFrames for tabular data)

### Notebooks (if applicable)

- [ ] First cell is markdown with H1 title
- [ ] Uses `RasExamples.extract_project()` for data
- [ ] Development toggle cell included (`USE_LOCAL_SOURCE`)

---

## Test Plan

Validated on a clean branch from `origin/main` using the CLB-213 patch only.

- `python -m py_compile ras_commander/geom/GeomLateral.py ras_commander/RasGeometry.py tests/test_geom_lateral_connections.py`
- `python -m pytest tests/test_geom_lateral_connections.py -q` -> 6 passed
- `python -m pytest tests/test_geom_lateral_connections.py tests/test_geom_storage_2d_flow_area_writer.py tests/test_geom_river_centerlines.py -q` -> 33 passed
- `git diff --check` -> no whitespace errors

Real project coverage includes Bald Eagle and Muncie example geometry. The implementation was based on an audit of HEC-RAS 6.6 and 7.0 example project geometry archives, where modern `Connection=` blocks were present and legacy `SA/2D Area Conn=` blocks were not present.

## LLM Attribution

**Model/Tool used**: Codex GPT-5.5

Linear: CLB-213
