### PR TITLE
fix(RasUnsteady): replace existing restart filename instead of duplicating

### DIFF
--- a/ras_commander/RasUnsteady.py
+++ b/ras_commander/RasUnsteady.py
@@ -251,6 +251,7 @@ class RasUnsteady:
         
         updated = False
         restart_line_index = None
+        restart_filename_index = None
         for i, line in enumerate(lines):
             if line.startswith("Use Restart="):
                 restart_line_index = i
@@ -259,17 +260,26 @@ class RasUnsteady:
                 lines[i] = f"Use Restart={new_value}\n"
                 updated = True
                 logger.info(f"Updated Use Restart from {old_value} to {new_value}")
-                break
-        
+            elif line.startswith("Restart Filename="):
+                restart_filename_index = i
+
         if use_restart:
             if not restart_filename:
                 logger.error("Restart filename must be specified when enabling restart.")
                 raise ValueError("Restart filename must be specified when enabling restart.")
-            if restart_line_index is not None:
+            if restart_filename_index is not None:
+                lines[restart_filename_index] = f"Restart Filename={restart_filename}\n"
+                logger.info(f"Updated Restart Filename: {restart_filename}")
+            elif restart_line_index is not None:
                 lines.insert(restart_line_index + 1, f"Restart Filename={restart_filename}\n")
                 logger.info(f"Added Restart Filename: {restart_filename}")
             else:
                 logger.warning("Could not find 'Use Restart' line to insert 'Restart Filename'")
+        else:
+            if restart_filename_index is not None:
+                removed_line = lines.pop(restart_filename_index).strip()
+                updated = True
+                logger.info(f"Removed existing restart filename: {removed_line}")
         
         if updated:
             try:

--- a/tests/test_rasunsteady_restart_settings.py
+++ b/tests/test_rasunsteady_restart_settings.py
@@ -1,0 +1,111 @@
+"""
+Tests for RasUnsteady.update_restart_settings().
+
+Verifies:
+1. Enabling restart replaces an existing Restart Filename= line (no duplicates)
+2. Enabling restart inserts exactly one Restart Filename= when none exists
+3. Disabling restart removes an existing Restart Filename= line
+"""
+
+import pytest
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock
+
+
+SAMPLE_UNSTEADY = """\
+Flow Title=Test Flow
+Use Restart=-1
+Restart Filename=old_restart.rst
+Boundary Location=
+"""
+
+SAMPLE_UNSTEADY_NO_RESTART_FILENAME = """\
+Flow Title=Test Flow
+Use Restart=0
+Boundary Location=
+"""
+
+
+@pytest.fixture
+def ras_object():
+    obj = MagicMock()
+    obj.check_initialized = MagicMock()
+    obj.get_unsteady_entries = MagicMock(return_value=None)
+    return obj
+
+
+@pytest.fixture
+def unsteady_file_with_restart(tmp_path):
+    p = tmp_path / "test.u01"
+    p.write_text(SAMPLE_UNSTEADY)
+    return p
+
+
+@pytest.fixture
+def unsteady_file_without_restart(tmp_path):
+    p = tmp_path / "test.u01"
+    p.write_text(SAMPLE_UNSTEADY_NO_RESTART_FILENAME)
+    return p
+
+
+class TestUpdateRestartSettings:
+
+    def test_replace_existing_restart_filename(self, unsteady_file_with_restart, ras_object):
+        """Enabling restart when a Restart Filename= line already exists should replace it, not duplicate."""
+        from ras_commander.RasUnsteady import RasUnsteady
+
+        RasUnsteady.update_restart_settings(
+            str(unsteady_file_with_restart),
+            use_restart=True,
+            restart_filename="new_restart.rst",
+            ras_object=ras_object,
+        )
+
+        content = unsteady_file_with_restart.read_text()
+        lines = content.splitlines()
+
+        restart_filename_lines = [l for l in lines if l.startswith("Restart Filename=")]
+        assert len(restart_filename_lines) == 1, f"Expected 1 Restart Filename line, got {len(restart_filename_lines)}: {restart_filename_lines}"
+        assert restart_filename_lines[0] == "Restart Filename=new_restart.rst"
+
+        use_restart_lines = [l for l in lines if l.startswith("Use Restart=")]
+        assert len(use_restart_lines) == 1
+        assert use_restart_lines[0] == "Use Restart=-1"
+
+    def test_insert_restart_filename_when_none_exists(self, unsteady_file_without_restart, ras_object):
+        """Enabling restart when no Restart Filename= line exists should insert exactly one."""
+        from ras_commander.RasUnsteady import RasUnsteady
+
+        RasUnsteady.update_restart_settings(
+            str(unsteady_file_without_restart),
+            use_restart=True,
+            restart_filename="brand_new.rst",
+            ras_object=ras_object,
+        )
+
+        content = unsteady_file_without_restart.read_text()
+        lines = content.splitlines()
+
+        restart_filename_lines = [l for l in lines if l.startswith("Restart Filename=")]
+        assert len(restart_filename_lines) == 1
+        assert restart_filename_lines[0] == "Restart Filename=brand_new.rst"
+
+    def test_disable_restart_removes_filename(self, unsteady_file_with_restart, ras_object):
+        """Disabling restart should remove any existing Restart Filename= line."""
+        from ras_commander.RasUnsteady import RasUnsteady
+
+        RasUnsteady.update_restart_settings(
+            str(unsteady_file_with_restart),
+            use_restart=False,
+            ras_object=ras_object,
+        )
+
+        content = unsteady_file_with_restart.read_text()
+        lines = content.splitlines()
+
+        restart_filename_lines = [l for l in lines if l.startswith("Restart Filename=")]
+        assert len(restart_filename_lines) == 0, f"Expected 0 Restart Filename lines after disabling, got: {restart_filename_lines}"
+
+        use_restart_lines = [l for l in lines if l.startswith("Use Restart=")]
+        assert use_restart_lines[0] == "Use Restart=0"


### PR DESCRIPTION
## Summary
- `update_restart_settings()` now replaces an existing `Restart Filename=` line instead of inserting a duplicate
- Disabling restart removes any existing `Restart Filename=` line
- Added 3 focused pytest cases using temp `.u01` files; no HEC-RAS invocation needed

Closes #17
Resolves Linear CLB-261

## Test plan
- [x] `pytest tests/test_rasunsteady_restart_settings.py -v` — 3/3 pass
- [x] Verified duplicate filename no longer appears when calling with existing restart file
- [x] Verified new filename line is inserted when none exists
- [x] Verified disabling restart removes the filename line

🤖 Generated with [Claude Code](https://claude.com/claude-code)