### PR TITLE
feat: add profile-line flow extraction API

### DIFF
--- a/docs/api/hdf.md
+++ b/docs/api/hdf.md
@@ -48,6 +48,8 @@ Mesh geometry data.
 - `get_mesh_timeseries(hdf_path, mesh, var)` - Time series for mesh
 - `get_mesh_cells_timeseries(hdf_path, mesh, cell_ids, var)` - Cell time series
 - `get_mesh_faces_timeseries(hdf_path, mesh, face_ids, var)` - Face time series
+- `get_profile_line_flow_timeseries(hdf_path, line_name, mesh_name=None, profile_lines_path=None, direction="absolute")` - Flow time series across a RAS Mapper profile/reference line
+- `get_profile_line_peak_flow(hdf_path, line_name, mesh_name=None, profile_lines_path=None, direction="absolute")` - Peak Q and peak time for a profile/reference line
 
 ## Plan Results
 

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -1,6 +1,6 @@
 # Example Notebooks
 
-The repository currently ships **88 canonical notebooks** under `examples/`.
+The repository currently ships **89 canonical notebooks** under `examples/`.
 This overview tracks the live notebook inventory in git. Executed copies such as
 `*_executed.ipynb` and local `_test_*.py` helpers are intentionally excluded.
 
@@ -97,6 +97,7 @@ These are the notebooks most directly tied to the April 2026 docs-drift sweep.
 `410_2d_hdf_data_extraction.ipynb`,
 `411_2d_hdf_pipes_and_pumps.ipynb`,
 `412_2d_detail_face_data_extraction.ipynb`,
+`413_profile_line_flow_extraction.ipynb`,
 `415_2d_spatial_result_queries.ipynb`,
 `420_breach_results_extraction.ipynb`,
 `430_1d_channel_capacity_analysis.ipynb`

--- a/docs/reference/dataframe-reference.md
+++ b/docs/reference/dataframe-reference.md
@@ -242,7 +242,37 @@ not. Prefer the dedicated HDF readers and xarray-backed APIs for:
 - 1D cross-section time series
 - 2D mesh cell or face time series
 - reference lines and reference points
+- profile-line flow and peak-Q extraction
 - large raster or mesh-derived result families
+
+### Profile-Line Flow Outputs
+
+`HdfResultsMesh.get_profile_line_flow_timeseries()` returns a profile/reference
+line flow time series. The API uses native HDF reference-line internal faces
+when present, then falls back to RAS Mapper profile-line geometry.
+
+| Column | Meaning |
+|--------|---------|
+| `time` | Output timestamp |
+| `flow` | Sum of selected face flows |
+| `line_name` | Requested profile/reference line |
+| `mesh_name` | 2D flow area used for extraction |
+| `direction` | `absolute` or `signed` aggregation mode |
+| `face_count` | Count of selected mesh faces |
+| `selection_source` | `reference_line_internal_faces` or `profile_lines_geometry` |
+
+`HdfResultsMesh.get_profile_line_peak_flow()` returns one peak-Q row derived
+from the time series.
+
+| Column | Meaning |
+|--------|---------|
+| `line_name` | Requested profile/reference line |
+| `mesh_name` | 2D flow area used for extraction |
+| `peak_time` | Timestamp of peak flow magnitude |
+| `peak_flow` | Peak flow value; signed mode preserves native sign |
+| `direction` | `absolute` or `signed` aggregation mode |
+| `face_count` | Count of selected mesh faces |
+| `selection_source` | `reference_line_internal_faces` or `profile_lines_geometry` |
 
 See:
 

--- a/docs/user-guide/hdf-data-extraction.md
+++ b/docs/user-guide/hdf-data-extraction.md
@@ -91,6 +91,36 @@ face_ts = HdfResultsMesh.get_mesh_faces_timeseries(
 )
 ```
 
+### Profile-Line Flow and Peak Q
+
+Use the profile-line helpers when you need modeled Q across a named RAS Mapper
+profile/reference line. The API uses native HDF reference-line internal faces
+when present. If those are absent, pass a RAS Mapper Profile Lines feature file
+or initialize a project whose `rasmap_df` resolves `profile_lines_path`.
+
+```python
+from ras_commander import HdfResultsMesh
+
+flow_ts = HdfResultsMesh.get_profile_line_flow_timeseries(
+    hdf_path,
+    line_name="Upstream",
+    mesh_name="Perimeter 1",
+    profile_lines_path="Features/Profile Lines.shp",
+    direction="absolute",
+)
+
+peak_q = HdfResultsMesh.get_profile_line_peak_flow(
+    hdf_path,
+    line_name="Upstream",
+    mesh_name="Perimeter 1",
+    profile_lines_path="Features/Profile Lines.shp",
+)
+```
+
+`direction="absolute"` sums absolute face flows to avoid cancellation from
+opposing face-normal signs. `direction="signed"` preserves native HEC-RAS face
+signs, so the line orientation and face normals control the sign convention.
+
 ## 1D Cross-Section Results
 
 ```python

--- a/examples/413_profile_line_flow_extraction.ipynb
+++ b/examples/413_profile_line_flow_extraction.ipynb
@@ -1,0 +1,812 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "6ec0a2f7",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-01T16:58:18.891295Z",
+     "iopub.status.busy": "2026-05-01T16:58:18.891295Z",
+     "iopub.status.idle": "2026-05-01T16:58:20.276209Z",
+     "shell.execute_reply": "2026-05-01T16:58:20.276209Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "from pathlib import Path\n",
+    "import os\n",
+    "\n",
+    "import matplotlib.pyplot as plt\n",
+    "import pandas as pd\n",
+    "\n",
+    "from ras_commander import HdfResultsMesh"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4d34d5b8",
+   "metadata": {},
+   "source": [
+    "Development mode: run this notebook with `PYTHONPATH` pointed at the repository root when testing local source changes. The committed import cell above intentionally uses the installed/importable package form."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "94d88280",
+   "metadata": {},
+   "source": [
+    "# Profile-Line Flow Extraction\n",
+    "\n",
+    "This workflow extracts a modeled flow time series and peak Q across a RAS Mapper profile/reference line from completed 2D plan HDF results."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "8e2f90fd",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-01T16:58:20.277216Z",
+     "iopub.status.busy": "2026-05-01T16:58:20.277216Z",
+     "iopub.status.idle": "2026-05-01T16:58:20.282620Z",
+     "shell.execute_reply": "2026-05-01T16:58:20.282620Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Plan HDF: H:\\Symphony\\ras-commander\\CLB-214\\profile_line_flow_validation\\project\\Chippewa_2D_profile_line_flow\\Chippewa_2D.p02.hdf\n",
+      "Profile line source: H:\\Symphony\\ras-commander\\CLB-214\\profile_line_flow_validation\\profile_line_input\n"
+     ]
+    }
+   ],
+   "source": [
+    "validation_root = Path(\n",
+    "    os.environ.get(\n",
+    "        \"CLB214_PROFILE_LINE_VALIDATION\",\n",
+    "        r\"H:/Symphony/ras-commander/CLB-214/profile_line_flow_validation\",\n",
+    "    )\n",
+    ")\n",
+    "project_dir = validation_root / \"project\" / \"Chippewa_2D_profile_line_flow\"\n",
+    "plan_hdf = project_dir / \"Chippewa_2D.p02.hdf\"\n",
+    "profile_lines_path = validation_root / \"profile_line_input\"\n",
+    "\n",
+    "line_name = \"Upstream\"\n",
+    "mesh_name = \"Perimeter 1\"\n",
+    "\n",
+    "if not plan_hdf.exists():\n",
+    "    raise FileNotFoundError(\n",
+    "        f\"Completed plan HDF not found: {plan_hdf}. \"\n",
+    "        \"Set CLB214_PROFILE_LINE_VALIDATION or replace plan_hdf/profile_lines_path \"\n",
+    "        \"with a completed project that outputs Face Flow.\"\n",
+    "    )\n",
+    "\n",
+    "print(f\"Plan HDF: {plan_hdf}\")\n",
+    "print(f\"Profile line source: {profile_lines_path}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "8642b210",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-01T16:58:20.282620Z",
+     "iopub.status.busy": "2026-05-01T16:58:20.282620Z",
+     "iopub.status.idle": "2026-05-01T16:58:21.546793Z",
+     "shell.execute_reply": "2026-05-01T16:58:21.546793Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-01 12:58:20 - ras_commander.hdf.HdfResultsMesh - INFO - Using existing Path object HDF file: H:\\Symphony\\ras-commander\\CLB-214\\profile_line_flow_validation\\project\\Chippewa_2D_profile_line_flow\\Chippewa_2D.p02.hdf\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-01 12:58:20 - ras_commander.hdf.HdfResultsMesh - INFO - Final validated file path: H:\\Symphony\\ras-commander\\CLB-214\\profile_line_flow_validation\\project\\Chippewa_2D_profile_line_flow\\Chippewa_2D.p02.hdf\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-01 12:58:20 - ras_commander.hdf.HdfMesh - INFO - Using existing Path object HDF file: H:\\Symphony\\ras-commander\\CLB-214\\profile_line_flow_validation\\project\\Chippewa_2D_profile_line_flow\\Chippewa_2D.g01.hdf\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-01 12:58:20 - ras_commander.hdf.HdfMesh - INFO - Final validated file path: H:\\Symphony\\ras-commander\\CLB-214\\profile_line_flow_validation\\project\\Chippewa_2D_profile_line_flow\\Chippewa_2D.g01.hdf\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-01 12:58:20 - ras_commander.hdf.HdfMesh - INFO - Using existing Path object HDF file: H:\\Symphony\\ras-commander\\CLB-214\\profile_line_flow_validation\\project\\Chippewa_2D_profile_line_flow\\Chippewa_2D.p02.hdf\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-01 12:58:20 - ras_commander.hdf.HdfMesh - INFO - Final validated file path: H:\\Symphony\\ras-commander\\CLB-214\\profile_line_flow_validation\\project\\Chippewa_2D_profile_line_flow\\Chippewa_2D.p02.hdf\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-01 12:58:20 - ras_commander.hdf.HdfMesh - INFO - Using existing Path object HDF file: H:\\Symphony\\ras-commander\\CLB-214\\profile_line_flow_validation\\project\\Chippewa_2D_profile_line_flow\\Chippewa_2D.p02.hdf\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-01 12:58:20 - ras_commander.hdf.HdfMesh - INFO - Final validated file path: H:\\Symphony\\ras-commander\\CLB-214\\profile_line_flow_validation\\project\\Chippewa_2D_profile_line_flow\\Chippewa_2D.p02.hdf\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-01 12:58:20 - ras_commander.hdf.HdfBase - INFO - Using HDF file from h5py.File object: H:\\Symphony\\ras-commander\\CLB-214\\profile_line_flow_validation\\project\\Chippewa_2D_profile_line_flow\\Chippewa_2D.p02.hdf\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-01 12:58:20 - ras_commander.hdf.HdfBase - INFO - Final validated file path: H:\\Symphony\\ras-commander\\CLB-214\\profile_line_flow_validation\\project\\Chippewa_2D_profile_line_flow\\Chippewa_2D.p02.hdf\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-01 12:58:20 - ras_commander.hdf.HdfBase - CRITICAL - No valid projection found. Checked:\n",
+      "1. HDF file projection attribute: H:\\Symphony\\ras-commander\\CLB-214\\profile_line_flow_validation\\project\\Chippewa_2D_profile_line_flow\\Chippewa_2D.p02.hdf\n",
+      "2. RASMapper projection file H:\\Symphony\\ras-commander\\CLB-214\\profile_line_flow_validation\\project\\Chippewa_2D_profile_line_flow\\.Winona_Upload\\LifeSim model\\Winona Levee SQRA 2019\\RAS\\AW\\MMC_Projection.prj found in RASMapper file, but was invalid\n",
+      "To fix this:\n",
+      "1. Open RASMapper\n",
+      "2. Click Map > Set Projection\n",
+      "3. Select an appropriate projection file or coordinate system\n",
+      "4. Save the RASMapper project\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-01 12:58:20 - ras_commander.hdf.HdfMesh - INFO - Found 6 faces along profile line\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-01 12:58:20 - ras_commander.hdf.HdfResultsMesh - INFO - Using existing Path object HDF file: H:\\Symphony\\ras-commander\\CLB-214\\profile_line_flow_validation\\project\\Chippewa_2D_profile_line_flow\\Chippewa_2D.p02.hdf\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-01 12:58:20 - ras_commander.hdf.HdfResultsMesh - INFO - Final validated file path: H:\\Symphony\\ras-commander\\CLB-214\\profile_line_flow_validation\\project\\Chippewa_2D_profile_line_flow\\Chippewa_2D.p02.hdf\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-01 12:58:20 - ras_commander.hdf.HdfResultsMesh - INFO - Using existing Path object HDF file: H:\\Symphony\\ras-commander\\CLB-214\\profile_line_flow_validation\\project\\Chippewa_2D_profile_line_flow\\Chippewa_2D.p02.hdf\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-01 12:58:20 - ras_commander.hdf.HdfResultsMesh - INFO - Final validated file path: H:\\Symphony\\ras-commander\\CLB-214\\profile_line_flow_validation\\project\\Chippewa_2D_profile_line_flow\\Chippewa_2D.p02.hdf\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-01 12:58:21 - ras_commander.hdf.HdfResultsMesh - INFO - Using existing Path object HDF file: H:\\Symphony\\ras-commander\\CLB-214\\profile_line_flow_validation\\project\\Chippewa_2D_profile_line_flow\\Chippewa_2D.p02.hdf\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-01 12:58:21 - ras_commander.hdf.HdfResultsMesh - INFO - Final validated file path: H:\\Symphony\\ras-commander\\CLB-214\\profile_line_flow_validation\\project\\Chippewa_2D_profile_line_flow\\Chippewa_2D.p02.hdf\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-01 12:58:21 - ras_commander.hdf.HdfMesh - INFO - Using existing Path object HDF file: H:\\Symphony\\ras-commander\\CLB-214\\profile_line_flow_validation\\project\\Chippewa_2D_profile_line_flow\\Chippewa_2D.g01.hdf\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-01 12:58:21 - ras_commander.hdf.HdfMesh - INFO - Final validated file path: H:\\Symphony\\ras-commander\\CLB-214\\profile_line_flow_validation\\project\\Chippewa_2D_profile_line_flow\\Chippewa_2D.g01.hdf\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-01 12:58:21 - ras_commander.hdf.HdfMesh - INFO - Using existing Path object HDF file: H:\\Symphony\\ras-commander\\CLB-214\\profile_line_flow_validation\\project\\Chippewa_2D_profile_line_flow\\Chippewa_2D.p02.hdf\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-01 12:58:21 - ras_commander.hdf.HdfMesh - INFO - Final validated file path: H:\\Symphony\\ras-commander\\CLB-214\\profile_line_flow_validation\\project\\Chippewa_2D_profile_line_flow\\Chippewa_2D.p02.hdf\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-01 12:58:21 - ras_commander.hdf.HdfMesh - INFO - Using existing Path object HDF file: H:\\Symphony\\ras-commander\\CLB-214\\profile_line_flow_validation\\project\\Chippewa_2D_profile_line_flow\\Chippewa_2D.p02.hdf\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-01 12:58:21 - ras_commander.hdf.HdfMesh - INFO - Final validated file path: H:\\Symphony\\ras-commander\\CLB-214\\profile_line_flow_validation\\project\\Chippewa_2D_profile_line_flow\\Chippewa_2D.p02.hdf\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-01 12:58:21 - ras_commander.hdf.HdfBase - INFO - Using HDF file from h5py.File object: H:\\Symphony\\ras-commander\\CLB-214\\profile_line_flow_validation\\project\\Chippewa_2D_profile_line_flow\\Chippewa_2D.p02.hdf\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-01 12:58:21 - ras_commander.hdf.HdfBase - INFO - Final validated file path: H:\\Symphony\\ras-commander\\CLB-214\\profile_line_flow_validation\\project\\Chippewa_2D_profile_line_flow\\Chippewa_2D.p02.hdf\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-01 12:58:21 - ras_commander.hdf.HdfBase - CRITICAL - No valid projection found. Checked:\n",
+      "1. HDF file projection attribute: H:\\Symphony\\ras-commander\\CLB-214\\profile_line_flow_validation\\project\\Chippewa_2D_profile_line_flow\\Chippewa_2D.p02.hdf\n",
+      "2. RASMapper projection file H:\\Symphony\\ras-commander\\CLB-214\\profile_line_flow_validation\\project\\Chippewa_2D_profile_line_flow\\.Winona_Upload\\LifeSim model\\Winona Levee SQRA 2019\\RAS\\AW\\MMC_Projection.prj found in RASMapper file, but was invalid\n",
+      "To fix this:\n",
+      "1. Open RASMapper\n",
+      "2. Click Map > Set Projection\n",
+      "3. Select an appropriate projection file or coordinate system\n",
+      "4. Save the RASMapper project\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-01 12:58:21 - ras_commander.hdf.HdfMesh - INFO - Found 6 faces along profile line\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-01 12:58:21 - ras_commander.hdf.HdfResultsMesh - INFO - Using existing Path object HDF file: H:\\Symphony\\ras-commander\\CLB-214\\profile_line_flow_validation\\project\\Chippewa_2D_profile_line_flow\\Chippewa_2D.p02.hdf\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-01 12:58:21 - ras_commander.hdf.HdfResultsMesh - INFO - Final validated file path: H:\\Symphony\\ras-commander\\CLB-214\\profile_line_flow_validation\\project\\Chippewa_2D_profile_line_flow\\Chippewa_2D.p02.hdf\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>time</th>\n",
+       "      <th>flow</th>\n",
+       "      <th>line_name</th>\n",
+       "      <th>mesh_name</th>\n",
+       "      <th>direction</th>\n",
+       "      <th>face_count</th>\n",
+       "      <th>selection_source</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>2019-04-02 00:00:00</td>\n",
+       "      <td>1948.334485</td>\n",
+       "      <td>Upstream</td>\n",
+       "      <td>Perimeter 1</td>\n",
+       "      <td>absolute</td>\n",
+       "      <td>6</td>\n",
+       "      <td>profile_lines_geometry</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>2019-04-02 00:30:00</td>\n",
+       "      <td>1945.119192</td>\n",
+       "      <td>Upstream</td>\n",
+       "      <td>Perimeter 1</td>\n",
+       "      <td>absolute</td>\n",
+       "      <td>6</td>\n",
+       "      <td>profile_lines_geometry</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>2019-04-02 01:00:00</td>\n",
+       "      <td>1919.116215</td>\n",
+       "      <td>Upstream</td>\n",
+       "      <td>Perimeter 1</td>\n",
+       "      <td>absolute</td>\n",
+       "      <td>6</td>\n",
+       "      <td>profile_lines_geometry</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>2019-04-02 01:30:00</td>\n",
+       "      <td>1881.967214</td>\n",
+       "      <td>Upstream</td>\n",
+       "      <td>Perimeter 1</td>\n",
+       "      <td>absolute</td>\n",
+       "      <td>6</td>\n",
+       "      <td>profile_lines_geometry</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>2019-04-02 02:00:00</td>\n",
+       "      <td>1849.279263</td>\n",
+       "      <td>Upstream</td>\n",
+       "      <td>Perimeter 1</td>\n",
+       "      <td>absolute</td>\n",
+       "      <td>6</td>\n",
+       "      <td>profile_lines_geometry</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                 time         flow line_name    mesh_name direction  \\\n",
+       "0 2019-04-02 00:00:00  1948.334485  Upstream  Perimeter 1  absolute   \n",
+       "1 2019-04-02 00:30:00  1945.119192  Upstream  Perimeter 1  absolute   \n",
+       "2 2019-04-02 01:00:00  1919.116215  Upstream  Perimeter 1  absolute   \n",
+       "3 2019-04-02 01:30:00  1881.967214  Upstream  Perimeter 1  absolute   \n",
+       "4 2019-04-02 02:00:00  1849.279263  Upstream  Perimeter 1  absolute   \n",
+       "\n",
+       "   face_count        selection_source  \n",
+       "0           6  profile_lines_geometry  \n",
+       "1           6  profile_lines_geometry  \n",
+       "2           6  profile_lines_geometry  \n",
+       "3           6  profile_lines_geometry  \n",
+       "4           6  profile_lines_geometry  "
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>line_name</th>\n",
+       "      <th>mesh_name</th>\n",
+       "      <th>peak_time</th>\n",
+       "      <th>peak_flow</th>\n",
+       "      <th>direction</th>\n",
+       "      <th>face_count</th>\n",
+       "      <th>selection_source</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>Upstream</td>\n",
+       "      <td>Perimeter 1</td>\n",
+       "      <td>2019-04-21 01:00:00</td>\n",
+       "      <td>2316.140572</td>\n",
+       "      <td>absolute</td>\n",
+       "      <td>6</td>\n",
+       "      <td>profile_lines_geometry</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "  line_name    mesh_name           peak_time    peak_flow direction  \\\n",
+       "0  Upstream  Perimeter 1 2019-04-21 01:00:00  2316.140572  absolute   \n",
+       "\n",
+       "   face_count        selection_source  \n",
+       "0           6  profile_lines_geometry  "
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "flow_ts = HdfResultsMesh.get_profile_line_flow_timeseries(\n",
+    "    plan_hdf,\n",
+    "    line_name,\n",
+    "    mesh_name=mesh_name,\n",
+    "    profile_lines_path=profile_lines_path,\n",
+    "    direction=\"absolute\",\n",
+    ")\n",
+    "\n",
+    "peak_q = HdfResultsMesh.get_profile_line_peak_flow(\n",
+    "    plan_hdf,\n",
+    "    line_name,\n",
+    "    mesh_name=mesh_name,\n",
+    "    profile_lines_path=profile_lines_path,\n",
+    ")\n",
+    "\n",
+    "display(flow_ts.head())\n",
+    "display(peak_q)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "d4a7a491",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-01T16:58:21.546793Z",
+     "iopub.status.busy": "2026-05-01T16:58:21.546793Z",
+     "iopub.status.idle": "2026-05-01T16:58:22.084770Z",
+     "shell.execute_reply": "2026-05-01T16:58:22.084770Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-01 12:58:21 - ras_commander.hdf.HdfResultsMesh - INFO - Using existing Path object HDF file: H:\\Symphony\\ras-commander\\CLB-214\\profile_line_flow_validation\\project\\Chippewa_2D_profile_line_flow\\Chippewa_2D.p02.hdf\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-01 12:58:21 - ras_commander.hdf.HdfResultsMesh - INFO - Final validated file path: H:\\Symphony\\ras-commander\\CLB-214\\profile_line_flow_validation\\project\\Chippewa_2D_profile_line_flow\\Chippewa_2D.p02.hdf\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-01 12:58:21 - ras_commander.hdf.HdfMesh - INFO - Using existing Path object HDF file: H:\\Symphony\\ras-commander\\CLB-214\\profile_line_flow_validation\\project\\Chippewa_2D_profile_line_flow\\Chippewa_2D.g01.hdf\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-01 12:58:21 - ras_commander.hdf.HdfMesh - INFO - Final validated file path: H:\\Symphony\\ras-commander\\CLB-214\\profile_line_flow_validation\\project\\Chippewa_2D_profile_line_flow\\Chippewa_2D.g01.hdf\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-01 12:58:21 - ras_commander.hdf.HdfMesh - INFO - Using existing Path object HDF file: H:\\Symphony\\ras-commander\\CLB-214\\profile_line_flow_validation\\project\\Chippewa_2D_profile_line_flow\\Chippewa_2D.p02.hdf\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-01 12:58:21 - ras_commander.hdf.HdfMesh - INFO - Final validated file path: H:\\Symphony\\ras-commander\\CLB-214\\profile_line_flow_validation\\project\\Chippewa_2D_profile_line_flow\\Chippewa_2D.p02.hdf\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-01 12:58:21 - ras_commander.hdf.HdfMesh - INFO - Using existing Path object HDF file: H:\\Symphony\\ras-commander\\CLB-214\\profile_line_flow_validation\\project\\Chippewa_2D_profile_line_flow\\Chippewa_2D.p02.hdf\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-01 12:58:21 - ras_commander.hdf.HdfMesh - INFO - Final validated file path: H:\\Symphony\\ras-commander\\CLB-214\\profile_line_flow_validation\\project\\Chippewa_2D_profile_line_flow\\Chippewa_2D.p02.hdf\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-01 12:58:21 - ras_commander.hdf.HdfBase - INFO - Using HDF file from h5py.File object: H:\\Symphony\\ras-commander\\CLB-214\\profile_line_flow_validation\\project\\Chippewa_2D_profile_line_flow\\Chippewa_2D.p02.hdf\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-01 12:58:21 - ras_commander.hdf.HdfBase - INFO - Final validated file path: H:\\Symphony\\ras-commander\\CLB-214\\profile_line_flow_validation\\project\\Chippewa_2D_profile_line_flow\\Chippewa_2D.p02.hdf\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-01 12:58:21 - ras_commander.hdf.HdfBase - CRITICAL - No valid projection found. Checked:\n",
+      "1. HDF file projection attribute: H:\\Symphony\\ras-commander\\CLB-214\\profile_line_flow_validation\\project\\Chippewa_2D_profile_line_flow\\Chippewa_2D.p02.hdf\n",
+      "2. RASMapper projection file H:\\Symphony\\ras-commander\\CLB-214\\profile_line_flow_validation\\project\\Chippewa_2D_profile_line_flow\\.Winona_Upload\\LifeSim model\\Winona Levee SQRA 2019\\RAS\\AW\\MMC_Projection.prj found in RASMapper file, but was invalid\n",
+      "To fix this:\n",
+      "1. Open RASMapper\n",
+      "2. Click Map > Set Projection\n",
+      "3. Select an appropriate projection file or coordinate system\n",
+      "4. Save the RASMapper project\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-01 12:58:22 - ras_commander.hdf.HdfMesh - INFO - Found 6 faces along profile line\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-01 12:58:22 - ras_commander.hdf.HdfResultsMesh - INFO - Using existing Path object HDF file: H:\\Symphony\\ras-commander\\CLB-214\\profile_line_flow_validation\\project\\Chippewa_2D_profile_line_flow\\Chippewa_2D.p02.hdf\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-01 12:58:22 - ras_commander.hdf.HdfResultsMesh - INFO - Final validated file path: H:\\Symphony\\ras-commander\\CLB-214\\profile_line_flow_validation\\project\\Chippewa_2D_profile_line_flow\\Chippewa_2D.p02.hdf\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>time</th>\n",
+       "      <th>absolute_flow</th>\n",
+       "      <th>signed_flow</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>2019-04-02 00:00:00</td>\n",
+       "      <td>1948.334485</td>\n",
+       "      <td>494.805432</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>2019-04-02 00:30:00</td>\n",
+       "      <td>1945.119192</td>\n",
+       "      <td>490.561087</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>2019-04-02 01:00:00</td>\n",
+       "      <td>1919.116215</td>\n",
+       "      <td>466.979741</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>2019-04-02 01:30:00</td>\n",
+       "      <td>1881.967214</td>\n",
+       "      <td>432.740896</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>2019-04-02 02:00:00</td>\n",
+       "      <td>1849.279263</td>\n",
+       "      <td>406.301601</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                 time  absolute_flow  signed_flow\n",
+       "0 2019-04-02 00:00:00    1948.334485   494.805432\n",
+       "1 2019-04-02 00:30:00    1945.119192   490.561087\n",
+       "2 2019-04-02 01:00:00    1919.116215   466.979741\n",
+       "3 2019-04-02 01:30:00    1881.967214   432.740896\n",
+       "4 2019-04-02 02:00:00    1849.279263   406.301601"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "signed_flow_ts = HdfResultsMesh.get_profile_line_flow_timeseries(\n",
+    "    plan_hdf,\n",
+    "    line_name,\n",
+    "    mesh_name=mesh_name,\n",
+    "    profile_lines_path=profile_lines_path,\n",
+    "    direction=\"signed\",\n",
+    ")\n",
+    "\n",
+    "comparison = flow_ts[[\"time\", \"flow\"]].rename(columns={\"flow\": \"absolute_flow\"}).merge(\n",
+    "    signed_flow_ts[[\"time\", \"flow\"]].rename(columns={\"flow\": \"signed_flow\"}),\n",
+    "    on=\"time\",\n",
+    ")\n",
+    "display(comparison.head())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "f5101b2e",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-01T16:58:22.086771Z",
+     "iopub.status.busy": "2026-05-01T16:58:22.086771Z",
+     "iopub.status.idle": "2026-05-01T16:58:22.108716Z",
+     "shell.execute_reply": "2026-05-01T16:58:22.108716Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Max absolute-flow difference: 0.0\n",
+      "Max signed-flow difference: 0.0\n"
+     ]
+    }
+   ],
+   "source": [
+    "manual_validation_csv = validation_root / \"manual_face_flow_validation.csv\"\n",
+    "if manual_validation_csv.exists():\n",
+    "    manual = pd.read_csv(manual_validation_csv, parse_dates=[\"time\"])\n",
+    "    validation = comparison.merge(manual, on=\"time\")\n",
+    "    print(\n",
+    "        \"Max absolute-flow difference:\",\n",
+    "        validation[\"absolute_difference\"].abs().max(),\n",
+    "    )\n",
+    "    print(\n",
+    "        \"Max signed-flow difference:\",\n",
+    "        validation[\"signed_difference\"].abs().max(),\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "9524a561",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-01T16:58:22.108716Z",
+     "iopub.status.busy": "2026-05-01T16:58:22.108716Z",
+     "iopub.status.idle": "2026-05-01T16:58:22.234992Z",
+     "shell.execute_reply": "2026-05-01T16:58:22.234992Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA1sAAAF4CAYAAACim+O0AAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjksIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvJkbTWQAAAAlwSFlzAAAPYQAAD2EBqD+naQAAtKpJREFUeJzs3QeUE9X3B/Bvku2d7X3ZAixl6b13pCmg2BVUsKI/xYpd//ZeESuKgggWEFB6k95Z2gILy/bee0v+575JsoUFtqTnfs7JmUnZZPIym8yd+959MpVKpQJjjDHGGGOMMZ2S6/bpGGOMMcYYY4xxsMUYY4wxxhhjesKZLcYYY4wxxhjTAw62GGOMMcYYY0wPONhijDHGGGOMMT3gYIsxxhhjjDHG9ICDLcYYY4wxxhjTAw62GGOMMcYYY0wPONhijDHGGGOMMT3gYIsxxhjToZqaGjzzzDMICQmBXC7HtGnTxO0ymQyvvvqq9nE//vijuO3SpUs6e+3Zs2ejffv2DW5r/LqGdPDgQQwePBjOzs5iO44dOya2hdYZY8wacLDFGGMmQnMQmpOT0+T93bp1w8iRI/X2+m+99RZWrVqlt+e3Fj/88APef/993HTTTfjpp5/wxBNPwBpVV1dj5syZyMvLw8cff4yff/4ZYWFhxt4sxhgzKBvDvhxjjDFTRcEWBQiaTAxrna1btyIoKEgEGPWVl5fDxsbwP7vGet0LFy4gMTER3377LebMmWPw12eMMVPAmS3GGGMtVlpaajWt1tL3mpWVBQ8Pj8tud3BwMErQY6zXpXYgTbUFY4xZCw62GGPMTG3fvl10O/ztt9/w/PPPw9/fX4yNuf7665GcnNzgsefPn8eNN94oHkMH38HBwbj11ltRWFgo7qfnoaCCur3ROl1o/E/97o2nT5/G7bffjnbt2mHo0KHa5/7ll1/Qp08fODo6wtPTUzxv49f/77//RJey0NBQ2Nvbi/FM1L2Osi710Wu6uLggKSkJU6ZMEeuUJfryyy/F/SdOnMDo0aPF+6QuacuWLbtmO9GYKNr+Dz74QGSb6O9oW0eMGIGTJ082+fqUlZk0aRJcXV1xxx13iPuofZ588kmx7fQeOnXqJJ5TpVI1eJ1t27bh1KlT2nakz6klY6f+/fdfDBs2TLxHev3JkyeL52utxq+r+Tzj4+PF+6VgyN3dHffccw/Kysou+/vmfL6N0fNS+xL63On1rtYFlsa5/d///R8iIyNF29K4M9qnKysrtY+ZP38+vLy8tO1NHn30UfHcn332mfa2zMxMcdtXX33VglZijDH94G6EjDFm5t58801xcPnss8+KbMInn3yCsWPHimIEdIBcVVWFCRMmiANXOjilgCs1NRVr165FQUGBONCm8TTU1at///64//77xfPSgW99dNDcoUMH0d1Qc8BLr/3SSy/h5ptvFn+fnZ2Nzz//HMOHD8fRo0e1WY2VK1eKA/mHHnpIHDAfOHBAPC4lJUXcV19tbS0mTpwonuO9997D0qVLMW/ePBF8vPDCCyL4mTFjBhYtWoS7774bgwYNQnh4+DXbacmSJSguLsYjjzyCiooKfPrppyJwowDOz8+vwYE/tRcFlBRMOTk5ifdLQSwFUvfddx969uyJDRs24OmnnxZtSUGcj4+PaEdqk5KSErz99tvi+Tp37tzsz5L+ftasWeL13333XdFmFDTQtlB7Ni5+0Rb0mVG70XYeOXIE3333HXx9fcXrajT3823sgQceEEEy7SuPPfYY+vXr16CNG6PnpkCfurFSQLt//36xXWfOnMFff/0lHkMBKLUzBZ40flETxFMRElrS62huI7SNjDFmdCrGGGMm4ZVXXqEIRpWdnd3k/V27dlWNGDFCe33btm3i8UFBQaqioiLt7StWrBC3f/rpp+L60aNHxfWVK1de9fWdnZ1Vs2bNuuJ23XbbbQ1uv3TpkkqhUKjefPPNBrefOHFCZWNj0+D2srKyy5737bffVslkMlViYqL2Nnp9eq233npLe1t+fr7K0dFRPHb58uXa2+Pi4sRjafuuJiEhQTyOniMlJUV7+/79+8XtTzzxxGWv/9xzzzV4jlWrVonb33jjjQa333TTTWK74uPjtbfRZ0SfVWONt3Xx4sXiNto+UlxcrPLw8FDNnTu3wd9lZGSo3N3dL7u9KbT9YWFhV31dzed57733Nnjc9OnTVV5eXq36fJui2T8b73ea19c4duyYuD5nzpwGj3vqqafE7Vu3bhXXs7KyxPWFCxeK6wUFBSq5XK6aOXOmys/PT/t3jz32mMrT01OlVCqvun2MMWYI3I2QMcbMHGV3qLuZBmUHAgIC8M8//4jrlLkilIlpqptYcz344IMNrv/5559QKpUi60EVFDUXypxRBoyyQBqUYdOg7nj0OCoJTrEAZUgaq19QgbIn1GWPMlv0Whp0G9138eLFZm0/Ff6gbIsGZfEGDBigbaf6KANXHz1GoVBosycalIWh90Bd/9pq06ZNItN42223NWhPel3azvrtqQuNP0/KHOXm5qKoqKjFn29baNqfugk2bluybt06saTMYXR0NHbu3Cmu7969W7QNZRep6yB1ldVktigTyOXlGWOmgLsRMsaYGWnqAJIOfBs/JioqSjt/E3UVowPZjz76SHTJo4Nq6hJ35513agOx5mjcVY8ObinQaPz6Gra2ttp1GoP18ssv4++//0Z+fn6Dx2nGjWnQmDI6sK6PtpPGmTV+/3R74+e7kqa2s2PHjlixYkWD26iYBL1WfVRVLzAwsEFQW7+LIN3fVppggbo2NsXNzU0saZxb4zajAKilaPxcfTQWj1B70mu15PNtC2o76gpI+2zj90TBdP22pX1XE5xRUNW3b19xobFkdJ26Kh4/flyMLWSMMVPAwRZjjJkICjJI46IRGpSV0jympT788ENRtGD16tXYuHGjyNDQmJh9+/ZdFlhcSf3sFKGsBwU/lNWhDENjVGhCMwZr3LhxYr4lGldG2QnKUtFYJ9omep76mnquq91ev2CCLlCBBjr4NzRNO9C4raaCJ01FQSqIQsUs2toG12rP5n6+utKcTBRlrKiUPGUzKbii4Iv+jm6n6xQQ03bT7YwxZgo42GKMMROhmfD17NmzouJd40CLKsCNHz/+ihmR+gfLVGmue/fuDW6PiYkRlxdffBF79uzBkCFDRJGJN954Q9zf0m5XVECDXosyXpQhuhIqQHHu3DlRAIG6PNbvNmdIjduJ0HY1p+gEfTabN28WBTbqZ7fi4uK097eVpiAJFamgAidXQsUzDNF2zf1824rajgIk+nzqFxOhroHUrbJ+22qCKHr/Bw8exHPPPacthkGFRCjYokCeqicyxpgp4DFbjDFmIsaMGQM7Oztx0Ng42/PNN9+IKnlUpe9KVfY0fv/9d6Snp2sfS2Nw6G/ro6CLsjf1S2vTQSod3DYXVQSkjMdrr712WWaFrtP4H6LJitR/DK1TNUBDWrVqlcimaVBFRKp611SbNkZl4ClD98UXXzS4narjUZDanOe4FgqiqPseVfCrrq6+7H6qBEhoPB4FY/Uv+tDcz7etqG0JVdGsj7q9Eip9r0GBn2bCaGojOmGgCcKoXD/t+wMHDjTKvGKMMdYU/jZijDETQRkNGtdEmSc6U0/jqqjsOGWhfv31V5HVmjp16mV/R+NVqBsVdS2jbAAdtNL4l7lz54r7t27dKkqnU+l2ylBQ4EVd1ehAmube0qBsAGVv6CCXMgR0YEuFGa6W+aCs2IIFC8T4MCpAQVmfhIQEUa6bSsg/9dRTotsgPZbWKdihgOKPP/5o9lgrXaE2oXai4hcUZFI7URn6Z5555pp/S+0+atQoUXqe3muPHj1Ed0zqlvn4449fVia/NahdKNC+66670Lt3bzGfFY1do/FuVCSCAovGwZ4+NffzbStqSyp3TycUKNin+bkoEKZMKL0mtXt9FFgtX75cnDDQjDOj9qKTBZSp5PFajDFTwsEWY4yZEDqYp25tdFD9+uuvi8CIgh7KLtB4p6bGEtHkr7GxsWIMFmW4KEO2cOFCEahpDmYpa7JmzRoR7NDtdBuNxaEsgAYFWXQATcEejRujA+CrBVuEunFRAEeZBtpGQl0gKTCkYFFTSIFeWzNOjMadTZ8+XQSAtB2GQl0Yqf0oyKL5yKgaIbUzZYquhf6OintQMExjphYvXiw+p/fff19bNU8XKFCgQPedd94Rz01BIWVyKMBoPE7LEJrz+eoCzfEVERGBH3/8UQRyNGaNgrxXXnnlssdqgq36E2tTJovmW6OTBTxeizFmSmRU/93YG8EYY6zltm/fLs7606TAVO6dNY2yMhSwUvCii0wMY4wx1lw8ZosxxhhjjDHG9ICDLcYYY4wxxhjTAw62GGOMMcYYY0wPeMwWY4wxxhhjjOkBZ7YYY4wxxhhjTA842GKMMcYYY4wxPeB5tppBqVQiLS1NTOYok8n08TkwxhhjjDHGzADNnEXzWtK8iE3Nf1kfB1vNQIEWTeLIGGOMMcYYYyQ5ORnBwcG4Gg62moEyWpoGdXNzQ0uzYtnZ2fDx8blm5Mu4LQ2F90tuS1PD+yS3pSni/dL62tJcttPUWXo7FhUViUSMJka4Gg62mkHTdZACrdYEWxUVFeLvLHFnMyRuS25LU8T7JbejqeF9ktvSFJnLfmku22nqrKUdZc0YXmS5754xxhhjjDHGjIiDLcYYY4wxxhjTAw62GGOMMcYYY0wPONhijDHGGGOMMT3gYIsxxhhjjDHG9ICDLcYYY4wxxhjTAw62GGOMMcYYY0wPONhijDHGGGOMMT3gSY0ZY4wxC6JSqXAstQSnjhfA180Bwe2cEOrlBHdHW3i72Bt78xhjzKpwsMUYY4yZsepaJbafzcbhxHzsT8jFiZRC1ChVTT52QLgn7Gzk6BHsgQgfZ3QOcEOYlxMcbRWQyWQG33bGGLN0HGwxxhhjZhZc7b+Yh61xWTieUiCCrOban5Anlv+dz2ny/l6hHnhhUmf0CPGArYJHGjDGWFtxsMUYY4yZuPKqWmw6k4l/T6Rjz4VcFJZXN7jfxd4GYzv7ItLHBT1D3OGKCnRqH4CSSiVSC8qRXlCOlPxybD+Xhbj0YuSWVjX5OkeTCnDTor1iPcDdQXQ9vG9ouAi+Ovq5GuS9MsaYJeFgizHGGDNBVTXUPTALvx9Owc7z2aioVja4v397T0ztGYhe6kCIugcSpVKJrKws2Nso4GhnCx9Xe/QM8RD3zR0eIZY1tUrkl1XjZGohjiYX4NClPBHE1ZdeWCEuT/8eK67f3DcYz1wXzeO+GGOsBTjYYowxxkzIhewSEWCtOZ4mslH1s1djOvvi5r4hInhytm/9T7iNQi6CsFHRvuJSv7jGpdwy7DqfjUU7LoqsmMaKQyniMjDCEx/d3BOBHo5teJeMMWYdONhijDHGjKyiuhYrDiVj/cmMBhkmhVyG67r5494h4ege7K73cVRUJCPc21lc7hrUXtyWkl+GvRdytRmufRfzMPidrbihZyDemh7TpqCPMcYsHX9DMsYYY0aSXVyJz7acx6bTmcgoqhC3yWXAsA4+GBzphVv7h4pxU8ZEpeNn9nXC+K7+eGrlcbGtZPWxNHH57f6BGBDhZdRtZIwxU8XBFmOMMWYESblluP27fdqugn5u9ri1Xyhm9g0WAY6poaDv27v7oriiGg/8fFibgbvlm32Y2iMQH93cgysYMsZYIxxsMcYYYwaWVlCOGxftEZktDydb/G9MB8zsGyLGZZk6VwdbLJs7EKfSCjH5s13iNhpftjs+B3/PG2KSgSJjjBkLT6LBGGOMGVBWcQXu++mQCLQifZyx/n/Dcc+QcLMItOrrGuiOC29NwuSYAHE9r7QKQ9/dhtXHUo29aYwxZjI42GKMMcYMpKiiGnN+OoQz6UWiW97i2f3h7+5gtu1PBTy+vKM33rupu/a2/y0/hi+3xRt1uxhjzFRwsMUYY4wZAM1t9fTK44hNKYSbgw1WPDAIoV6W0eWOytHvWzBGlJMn7284i8eXHxWl5BljzJpxsMUYY4zpGQUdL646iQ2nMmEjl2HJfQPQyd/VotqdMnT/PTNKVFEkq46lYe6SQyLIZIwxa8XBFmOMMaZn3+9KwPKDyWL9w5t7iEmJLZGDrUIUz3hsdJS4vvlMFu76/oCYR4wxxqwRB1uMMcaYHsWmFOC9DWfF+guTOuOGnkEW397zx3fCi5M7i/W9F3NFhquqhjNcjDHrY16ljxhjjDEzUlpZg4d+OSICjVGdfDBnWDjMSm01UFMBlGYDbkHAha3Ani+ARKnke5PatQe63IA5gx6FjbwLXl1zGv+dz8HDS4/gm7v6QE6zNjPGmJXgYIsxxhjT4zit1IJyBLdzxOe394ZMpg40SrKAi9uB7LNAVSngHQUolYBHCODsC7j4AK6B9CyAwla/n09xBpBzHojfBGSeAjxCgczTQM45oDyv5c+XfwnY/am4zIYMMd0ewU0nB2LzmUw8+0cs3p/ZQx/vgjHGTBIHW4wxxpgebDiVgb+OpoqCGO/e2B0u5WnAgZXA8eVSINNcDh6Aqz/gGQm0CwM8IwC/rkBQX8DGrnnPoakKWJYLZMcBsb8B8VuAojbMiRXcH/CPAWwcgPJ86T3lJ0ivUffC6BP/BRIcvsA9VU9j5WEgqJ0jHh/bsfWvyxhjZoSDLcYYY0zHsooq8PLqU2L98aG+GHLhY2DpQkBVb9wSdcsL7CUFQhT0uAUC+YlAYQpQWVj3uIoC6UJBUmMeYUDIACCgBxDQXVqX20qvU1kMnF4FnPwDSNgh3a6svvbG+0QDTl6Ae7AU2IllJFBVAvh2kbZTk6G7EsrWHf0F+PdZKTsHYLHd+/i8Zho+3HwzOvq5YpJ6MmTGGLNkHGwxxhhjOvb2v3HIKq7EDV4pePjcAqAgUbqDgpbedwMxMwH3KxTKoOCrplIKwGjMVEUhUJgsdfGjsVO0TDsqBTH0vHQ5sUL6W1snyEIGwP/itsuft6lAq+NEIHwYEDFS6j5or6Ny9HbOwIAHpMvFHcAvMwBlDR61WYUYWQIeXvEcOvq5IMrXssrfM8ZYYxxsMcYYYzq05Uym6D44SbEfn5R9AZmqVspiTXwX6Dz12k9AWSNbB8Arst6NA4CYm+qu1lQBxWlAyiEgcTeQe0HKfJVkQtZUoEVFK3rcDrQfKmWunKW5sAwiYgSwIAX47U4gfjNGKo7j69o38dgv/4eVjwyHsz0fijDGLBd/wzHGGGM6QvNJvbTqJKbK9+Bz2y+kHnQdrwOu/0IqeqErNFaLAii6aIIwyohlnYYqdiWqL+6GTefrII+eDPhGw+hsHYE7/wD2LQLWP4thipNQ5r+CV1Z9jLdv6g1bBc9EwxizTBxsMcYYYzryxdZ4BBQdxzv230k39LwTmPopoDDAzy1lxPy6QjWmM/JisuDr6wvITSyIGfig1BbrnsQIRSyqTz6Fe5IfxsJ50+HmoOeqi4wxZgQm9i3MGGOMmaek3DL8tuMoFtp9CmdUSOOgDBVomZN+c4Dxb4jVsYqjWFj8GF78egUSckqNvWWMMaZzHGwxxhhjOvDhhtNYaPMh/GQFgHdH4NZfOdC6ksGPArcsRYVTANxk5Xg/73/4Y9GrKKms4X2RMWZRONhijDHG2mjnuWx4n/oB/eTnUGvrCsz8CbBz4na9ms5T4DB3PSr9esFeVo2nar7BNx88h7i0fG43xgysqkaJgrIqbnc94GCLMcYYawOVSoW16/7C8zbLxHXF+NcAvy7cps3Rrj3sH9yG/KAR4ur86m8Ru/hxpOSXcfsxZkB3fb8ffd/YjNfXnEZaQTm3vQ5xsMUYY4y1wT/Hk3FP/mdQyFSojJ4O9L2X27MlZDK0u2clivrPF1dvrl6Fi59MxNlLydyOjOnRucxi/HkkBe+tj8P+hDzUKFX4YXcCBr+zFdMX7saqo6nc/uYebL399tvo168fXF1dRdWkadOm4ezZsw0eU1FRgUceeQReXl5wcXHBjTfeiMzMzAaPSUpKwuTJk+Hk5CSe5+mnn0ZNTcN+39u3b0fv3r1hb2+PqKgo/PjjjwZ5j4wxxiwXjTFKWP0WOsuTUW7jDvvrP5KqArKWsbGH28SXkRszR1wdLjuGtCVzcfwCH+wxpg8HL+Vh/Mc7MX/FcSzcfkF7e4C7g1geTSrA478dw/sb4qBU0hwWzCyDrR07dohAat++fdi0aROqq6sxfvx4lJbWVSR64oknsGbNGqxcuVI8Pi0tDTNmzNDeX1tbKwKtqqoq7NmzBz/99JMIpF5++WXtYxISEsRjRo0ahWPHjuHxxx/HnDlzsGHDBoO/Z8YYY5Zj1aZteEC5QqzbXPcG4ORp7E0yXzIZvG78EDmTpLL5o5R7YbdkErLyi429ZYxZlNySSvxxOEWsh3o64fYBoXhxcmfsXTAau54dje/u7osp3QPE/V9uu4AXV5/kgKsNZCrqbG4isrOzRWaKgqrhw4ejsLAQPj4+WLZsGW66SZq0MS4uDp07d8bevXsxcOBA/Pvvv5gyZYoIwvz8/MRjFi1ahGeffVY8n52dnVhft24dTp48qX2tW2+9FQUFBVi/fv01t6uoqAju7u5ie9zc3Fr0npRKJbKypPlO5KY234mZ4bbktjRFvF9abzvSAUvsB5MwCoeQ4TcS/g+thikwx7ZsrPTUBshWzoITyvGvzRh0uGcRooJ8Db4dltCWpsJc2tJctrO1lu5PxMurT6FWna1678buuLlfSJOP/e1gEp7784SYL/3WfiF4a3oM5PLmZe4tvR2LWhAbmNTkH7TBxNNTOjN4+PBhke0aO3as9jHR0dEIDQ3VBlu0jImJ0QZaZMKECXjooYdw6tQp9OrVSzym/nNoHkMZrqZUVlaKS/0G1ew4dGkJejzFsy39O8ZtqU+8X3Jbmhpz3CfX/vgeZuEQaiGH1/R3TGbbzbEtG3PsPA5pQ1+B067nMLFmC3b8MAvBz66BnY1hD9osoS1Nhbm0pblsZ2tkFlXghb+kxIO/mz0GR3pjYje/K77XmX2CYSuX4anfY7H8YDKUKhXent4NsmZ0lbbkdiQteV82prTRFPwMGTIE3bp1E7dlZGSIzJSHh0eDx1JgRfdpHlM/0NLcr7nvao+hIKq8vByOjo6XjSV77bXXLttGypTRGLKWvi8KImmHs8TI3pC4LbktTRHvl9bZjucSkzEj+0tABqR0ngN7tAOysmAKzK0tr8Sm23RcUjii/Y7/YUTtHiz78GH0nPk8PF2kMSWGYCltaQrMpS3NZTtb4+GVUl2EYHd7rJzdVQRNpYV5uNp04oODbPHKhHC8tiEBKw6lwElegwcHB1l1O5Li4mLzC7Zo7BZ189u1a5exNwULFizA/PlSVSRCQVlISIjo0tiaboS0M9PfWuLOZkjcltyWpoj3S+trRzp4OPzzArjKypHs0BEhN70NyExnm82pLa/J925cyjiO9md/wO2Vv2HVendMfeidZp1Z1wWLaksjM5e2NJftbImK6lrEZ5XgdKY0pcKDI6MuS0JczV2+vrBzcsaCP0/ixwMZ2HmxGLf0C8bswe1hq5BbTTvW5+DgYF7B1rx587B27Vrs3LkTwcHB2tv9/f1F4QsaW1U/u0XVCOk+zWMOHDjQ4Pk01QrrP6ZxBUO6ToFT46wWoYqFdGmMdpbW7DC0s7X2bxm3pb7wfsltaWrMZZ/cumMbxpWsFlkthwmvQq4wiZ9Ss2zL5mh/28dIXO2NsKPvYWL2D/j1O2/cNvcZKJo5dqStLKktjc1c2tJctvNaiiqqcff3BxCbUgBNQcF2Tra4Y2BYi09Y3NY/DFlFVfh48zlczCnF2/+eRWxqET6c2QMOtgqLbsemtOQ9yY19dpACrb/++gtbt25FeHh4g/v79OkDW1tbbNmyRXsblYanUu+DBg0S12l54sQJMQhPgyobUiDVpUsX7WPqP4fmMZrnMDc5JXXjyZj+bDyVgY82nkVxRTU3M2NMoBLIdv+9AztZLS56DodPz0ncMgYQNuUZpHgNgb2sBnemv4Wtm9ZwuzN2DdvPZuNYshRoeTjZon97T/zftOaNuWrKY2OiROVCjXWx6XhxVV3xOdY0G2N3HaRKg6tXrxZzbWnGWFF1D8o40fK+++4TXfqoaAYFUI8++qgIkqg4BqFS8RRU3XXXXXjvvffEc7z44oviuTXZqQcffBBffPEFnnnmGdx7770isFuxYoWoUGhuTqQU4uav9+LJ8R0xZ1iEsTfHIvxzIh3L9idhZCcfXMotFV9OMUHu+PektD/uOJeNUdG+6BHigVGdfEUFn/c2xOFIYj5entIVMcHuxn4LjDEDOXhoL4bW7IMSMvjd+C7PqWUoClsEP7IG57+8ER1yt6H7nkexMjcLM2+X5uVijEmyiivw++EUxKUXi7m0yF0Dw/D6DdIYrbagv39zWjfcO6Q9EnLKMHfJIfx9LA13DgxDz5CG9RWYiQRbX331lViOHDmywe2LFy/G7NmzxfrHH38sUnU0mTFVCKQqggsXLtQ+VqFQiC6IVH2QgjBnZ2fMmjULr7/+uvYxlDGjwIrm7Pr0009FV8XvvvtOPJe5+fdkOsqra/HmP2cwpXsg/NWTz7Hmq65V4p1/45BRVIHTaUVIyJGGhu6Kz9E+JiW/XLt+PKVQXIiPq70ItvJKq8T1R5YdwcYnhl8xhc4Ys6ysVt526XfrnNtgRAdJvSeYgcgVCL3jM+Qsug5+VamYevY57DvSBwN79+KPgDG1V/8+hX9OZNT928iA67r562ycIz1PlK+ruAyJ8sLu+Fzc/u0+/PnwYET7t6yugbUwarDVnCm+aADal19+KS5XEhYWhn/++eeqz0MB3dGjR2Hunp7QCX8fTxPBQFxGEQdbLQiwFm2/AHtbOWSQ4ftdCZc9xtXBBsUVNYjydYG9jRxJuWUiXf7zvkSUVdWKx2QXN+zCmZRXhq+2X8AT4zrq4uNljJmwAwf3YELpGjFWy2XgLGNvjlWy9wyF/dOHkfb+QARWXYLH37ORGLAZYQE+xt40xoyqplaJk2lF2HdRymbdPzwCAyM80TXQHX5u+jkx//VdfTH7hwM4lJiPv46mYsFEDraaYnqjetk1zyj0CPYQwdb5zBKM7GT4SR7NxaWcUmw+kym6/8WmFOLDTecue0y3IDc42drgwZER6BPqiTMZRRgQ7tngDNDDI6NQo1SKdPzRpAKM6OiDfuGe2HgqU2S2KNi6oWcgInxcDPwOGWOGVLr7G8hlKsS7DULUoJu58Y3F1hGe9/yGom/GIlp1CVuXPIzQZ1YYrEIhY6bo3p8OYee5bLFO89HRcBN7G/32unGxt8FNfYJFsEXDXFjTONgyQxE+zmKZmHe1mRGs0/6LuaioUYpBoDRos37XQBLt7yrGZVVUK7FszgAMjvJucP/ACK/LntPdyVYsr+sWIC4ak2L8ReBFY7poksBlcwfwjz1jFio9Oxf9CjeKrJbTiEd5rJaROQREo2jq13D7+3aMLt+I5V+/gRlzXjD4pMeMmQIq664JtAZFeOHW/iF6D7Q0ugdLY7WoEAeVmN9zIQeRPi4IaXd5tW9rxcGWGQr0kHbgtIKWTbBsiSpranE2o1j8Y9PM6Ld9u09U3bFTyFGr7qaq6R4Y5OGIVY8M0ZZD9XVtW1qdzqK+Ma0bxn28A3sv5ooBqTP7hujkfTHGTEvshsWYICtDpiIAgb0mGntzGE3B1XsyLh6djojkv3BrxgfY9Hcgxs24j9uGWR0KdAj1zPn1fqmAnKHQSWxvFzvklFThuk924lJuGcK9nbFl/nCDbocp41NAZh1s1RVxsLbxV+XqMVQfbTqH67/YjZ6vb8R9Px0SgRYNBq2qVYpCFt4u9jj60jise2woVs8bIgpZ0KWtgZZGiKcTHh8rjdd6+vdYDHp7C+Kzmj+rOGPMPMZCBF1YLtZzo2+nCVaMvUlMLeLexTgbMlOsRx9/Bzv37uO2YVYnIadELGnMuaHJ5TJMipF6/VCgJW1PqTgBziSc2TJDQR5SoJBqhcEWdREc/eFOUdq0b5gnLmRLXzDVtSptVUEaYzWjdxD2J+ShW6A7bBRyMUBUX+4bGo4Vh5JxMbsU6YUVmLvkMNY+OhTO9vzvxZglOLh3GwapzqMaNogc/4CxN4fVJ5MhfObbyPl0J0JqMxGyYQL+yF2KG6dM4XZiFqusqkaUXKdx5LGphdqTvJRRMobZg9tjyd7EBredTC1EjBePoyR8NGiGAtylzBZ1jaPucG4O0pgiS7Y2Ng0Lt8XDzU6mDTKp657Gb/cPxOn0IlEd8N6h4fB0tjNYwQpbhRzf3NVHjBGjKkAU9G04lYEZvYMN8vqMMf2q2Pe9WJ73GoUu7n7c3CbGzs0HHo/tQPpnYxBQm4obD92BbQd7I6//M5gx6ToeS8sszrv/xuGnRsGNr6u9mBPUGOh469nrokWAVVBeJcrBx6YWIcaL5yElHGyZIcqY0EzgBWXVSC+ogJu/5QZbibmleHLFcVHppj4aADqhq58ogNE5wA0DIrzExVhovonl9w/Cu+vjRHVC+qLhYIsx85eSnon+xZtFYYx2wx809uawK7BxDwAmvgusvVNcHyU7Ahy8FVsPDUTYPd8jMpRPfjHL6db8z0lpHq3b+oeKQl1dA90Q3M7RqCcWHhoZKZY/7bkkjoFOpBYC3TnYIhxsmalAd0cRbNG4rU7+rrBEfx5JwcurT6GkskZ7W7CHPSprgTnDwjGmsx9mDwmHKekRLH2xXFT3n2aMmbfTG7/HeFklUm1CENR9jLE3h11FQN+pQM8sJCz9H8ITfhW3jVbtA37oivU2oxFx5yfo2D6M25CZtbWx6WLOz3ZOtnj1+i4GqzrYXN2CpOMgynI1Zz5da8CjfM28SIYljtuiwhaLdydg/orjDQKtPqEeWDmrK/YvGC0CLVPkr+7imVHIA0MZM3fVNbVon/CbWC/scieXezcHNvYIn7UIeDkPF6Pu1t58Xc1WRC7ugTV/LjHq5jHWFlU1SlEYTDNe3NQCLdIlwA0KuUxUJ8wqqTb25pgEDrbMvEiGpVUkzCqqwJK9l/DamtPa22wVMmx9coQYl2Xqk1b6q2dpzyquFEEjY8x8Hdq9ER1xCRWwQ4fxc429Oawl5ApE3Pk5Kh8+giRvqQS1QqbC1NhHceTlPtiwZRO3JzM7X2w9L8amU6VlGp9uihztFIhSj5k/ny1VJ7R23I3QTFla+XdKNVNafPj728SEwxrPTYzGLX1D0M7ZDkpl3e2mysfVXpzRoUCL3o+/u25KzFsjKv7y37HTyDuxCdVFOUDUGNhmHkOJWwf4+/qiNO0MQvpMRF56AlycneHjH4Kqqkr0jvDH+awS0X+dipdQ+dkwL+NUaGLmrerQz2J53nssYlyMNyaUtZ69byRC561BwYWDUCydAVdlEXrL44H/bsK/Byehz/1fwddTmpSVMVP359FUsXxmQic42ZnuITwNbzmbWYwLOZZxjNpWpvtJMaua2PiRZUfwzwlpwKfGE2M7Ys7QcFG63VxQoEWTJ9OZp4vZJRxstVJiVgHOLboDk5W76m48+pW0TAMQp74tfr72bqVKBrlMhaPKKATLslECBc4hDF1xAduU4ahSOCEnaAw6D78RvTtFtP5DZlYhv7AYPYu2S4UxBs0y9uawNvKI7Ae8cBEJK55D+NnvxG0TK/5B0afR+MttBkbMfR+ebnxShpkumvImJb+cZjvAxBh/mDJRS+A4cCGXgy1iPkexzCLHbO08ly1mHG8caN07JByPjIo0q0BLQ1OwhM7qsJY7cTYeRV+Oxjh1oFUhdxLL2mt8XVGgRXrJ4+EjK0SALA8jZEfhLSvCKMVxTMBe3JH6BryWXYe4iw1L5jLWWOy2FXCXlSJb5o3gXuO5gSyBwhbht30I1QuZiA+aJm5yk5VjevFSlH7YAwcPHTD2FjLWJOot89mW82K9k58rXE18yp9o9XHQhVzLSAi0FWe2zBRlT0hGUYX4J6SMirlJyS/DY8uPiqqKGt2C3PDGtBj0DDHfbh30RbjpdCbOZnCw1VJpOQWo/fUO9JRdQBVsUDh1MXz6XA9UFEFhY0/9TYHceMAzHDVZ5yCrLoXcOwr5R1bBPbAjcs7thdzeGbZl2SjMSoKjbwTkibtQ5ugP26JkBBQdR5gsE3t+vR94YYNePn9mGRzO/C6WaSFT4CM3v5M+7Mpktg6ImvsTii8eROlvc+BfeQkhsmz4rbkOv+x5GOPvfg6+HvqZp1GpVCE2/hJKC3Pg4dce7VwcEOhpmRWFme58s/MiftmXJNZ7hbYzm5POiXkVqK5Vwt7Kv0M52DJTNDbIRi5DjVIlUsuaiY7NZXwWFZC46au9DQItyma9PLULzJ3mSyaOg60WiU9OQ+biOzEEcSiBM+T3roNPaC/pTge3ugf6dxMLm2D1fQA8R0jzH/l1GK29ralwPevoP/BdfRsGVO3H/iOHMaB3n5ZtJLMKqWmp6FWxX3QhDB7BXQgtlWtEP7guOI6k3csRuukB2MlqcWfe50j8+DccmLkO/bt1bPVzF5VX4WJyCgqy01GacAgoTEa73CNoV5uD7kjSZuKrVQpsdhyDKls3IOYmONrZYsiQUbCzNb0qc8w4KED/7r+L2uszegeZRULAxd5GVJS+mF2KzoHWPd8WB1tmijJZfm4Oohshjdsyp2Br4fYLeH/DWe11Nwcb7FkwRvxjWgJN+vx8ZrH4kpSbYdbR0I7GnYdy+d0YgtOogRzl076rC7R0yLfXJJzf0hcdSg7BZ/WdyAzbAz8v0z9LyAzr3NafESSrRaJtBMIie3PzW7jQIbeioutIZH57E8JKTyBMloWw3/thXfxXuG7qLVf929ySShSUVeH8wY2oLUiBXeo+uFRkILL2InrKCi7/A/XPAXWLVkAJW1ktxlZsBKi31R4pm1qwzRmnZUHItw+GSiZHod9A+HQcgKCwSIQHm/6BNtOtw0n5yC2tEuub549AlK9+sq66RJWjO/m54HBSgRhSwcEWM1t05kAKtsrRJ8z0DxhpWx9eegTHk+t+gB4YEYG7B7W3mECLtPd2hp1CjtKqWvGeQzylMUesaZu3bkL0jgcRLMtBOexRdfNy+HSpy1DpWuDtX6Lw23GIQBrW/vIyJj36GQfErAHPS+vEsiByGngKXOvg4OGPsKd3Iev4Rvj+NVPcNvnYQ0g9+iLiRn4DR7dhSLh0CbnJp1GZkwTbtINwrMxG1+qTiJSVILLxE9Y7x5Zm1x7lDn6o8YqGc3hfuAd3gWtYD5SnxCJp8yLISzMRnrcLNqgVj/eQlaInzgGV0nxKSNwMqIeZHpF1QaXcGfkdboStsztGTbxF/JUpzrfEdGP/xVyxnNoj0CwCLQ3aVgq2LuWUwtpZzhGuFQo0o7m2/jySgu/+S8Dp9CLtbQ+NjMTT4ztZ3IEulRuP9HXBmfQi0ZWQg60rW7v2Lww8+JgoYpGr8IX9rT/BvcNgvX4+zoHRSBj+f3Df8T9MyV+CTWsHYtz1d+j1NZn5SElJRrfqE+JgOWzY7cbeHGZgvj3GozYqAUlfzUB4yVEEyXIRtONG5G53RU9Z8VUzVakOHVHp4AWEDoZ9u0AE9Z0ChVM7BCqaLmbgGNYHne77VrpC41FlMqQd+AtVRVmooUtxFjyTN8OrJkNkwUhv1Wl6MSDuoLiee+gZlMIRJ0PvRI8pDyHIz1dfTcOM5ERqoVj2CDavrnjujtJ+X1olnUSwZhxsmTFzmWuL5jmav+J4g9s6B7hZZKBVvyuhCLbSizCui5+xN8ckx+2tXv07xh19BM6ySqTZRyLgsU2QORtmLqPwEXfjXNx6dMz8F1FH3kDKgAkI9vM2yGsz03Zx1woEy1RIsI1CeFAHY28OMwKFsyfCn9qOlK3fInjnU+I2L3WglSv3RrXcHsXOYVAG9YOzTyiCe02AwsEdofXHlrYU1fOm3/X+05u8u7YsH0l7fkdNxinYpB6EV0US3FRFYru8UIzQ5I9QsPBrbB/wEUZOurX128FMzslU6SR1tyDzCrac7KRsa0llDawdB1tmLEATbBWabmlNSh+P/GB7g9uWzRmA/uGeFhtokc4BrvjrKHAmoy6TxyQ0ju33xR9getLbYrzCJZeeCHv4L8icPA3XRHI5wu/+CkUfxCBclYYdi+cg6Nm/RD9zZt2cE9aLZX7oBIQbe2OYUQWPnovy7hOQGrsNQVExkNs6wss/WgRGhp7liDJk4WPnNritPOMsyjIuIPfg7+iY+ofofjh0/0PYa2uLQeNuNPAWMn3YE58jhiPQT1PXwDYE80bgpB4eUsaZLZ5ny5z5uNhpB+iaqkU7LmjXB0V44ad7+2NQpJdZzp/VEpS5I2fSufx7fZU1tfj9u7dwc/IbUqDlMQihD68ybKClZuvcDhXXfysmQx5RsQ0b1iw3+DYw05Kbl4tuFUfEevBgadwOs272nsFw6TIB9sE9YR/QWZuBMgWO/p3g1XMSOs79Abmz/0O+zAM2MiU673oU504fM/bmsTbKK63C7d/tF+t+rg4mP7dWY87qzFYZZ7Y42DJn7ZykYCu/Xvl0Uzqo3nU+B8sPJovrns52oqz7iI4+VpE90ARbl3JLUcpfNEJ5ZQ3WLXoeN6e9J65fCJ2J9o+ugdzJeMVdfHtNxFm/SWJ94OEnkZaZabRtYcZ39r8/YC+rQao8EL4RPY29OYw1m1f77nBbEId4u2iR4fL9bTL2blvDLWjG9lzI0a53MbOsFnGykzJbpZzZ4mDLnHmZcGbr572JuPN76YwM2f3saG0AYg28Xezh62ovxjzzfFsQkxpu+fIRzMhZJNonIWoWImd/DVxh4LghRd/3NdIVgeIA5cRvr4nxZMw6Kc79I5YZgWNNKoPBWHMo7BzhO/cPZMm84CErQd/ts7Bv6ypuPDO154JUhZC8PMX85iB1tpcyW6V8wpmDLUvIbBVV1IiDWVNyUl09hwzr4A1HdTrZmmgmN47Psu6uhGWV1fj3kwcwpUjqppfQ+SGE3/EpIDeNfUJm74ryoQvE+oS8pdi3c4OxN4kZQUlpKbqW7BPrPv14vAszT24+wVDetkJMDE9dtTvveBinY6XKhcy87FUHW9/d3VdMKWNunNWZrTLObHGwZc48nOy0J1/zy6QJ70wFTbRMnp7QCQvvsM5JQSN9pPkwLmRb7xwTFVU12PXJ3bi+eIW4Ht/lUYTf8o7JZQ0iRt6F055jxLrtf++iqppL1Vqb03vWwUVWjhxZO4TEDDP25jDWav4d+8JxQTzi7bvAXVYKtz/vQGpKEreoGaEq0wk5paA6Yv0jDD+mWRecNJmtKq5GaNlVCiycQi4TXdVIujq4MRXJ+WViOTDCy+wGdepKpI90Jup8pnVmtsorq7H947sxvvwfKCFDQt8XEXXzGzBJMhkCpr+JWpUMfWuOYMeyd4y9RczAqk/9LZZJPiMhM5GsK2OtpbB3gv+DfyFd7o9gZKL6uwk4GXuIG9TMuhB2D/aAm5keQzmrM1slFRxscbBl5kLaOYllUp4U3JiC3fE5SC+sEMmLMC9p+6wRfUmSQ5fyTa6bp76VVlRh2+cP4LrydeL6pX4vI3zK0zBl7UI642znh8V694vfIr/QOoNka1RdU4NOBTvFukvPacbeHMZ0wqWdPxR3rUQhXNAeaQj/YxJiD/3HrWtGxTEGRxpm7kl9cHNQB1uVNWLKF2vGwZaZC/U0rWArv7QKd6hLld7aL1QUirBWNAGhh5MtiitrcDy5ANaiqkaJHYsex6SSP8T1hEFvImLyfJiD6BkvI0fmCT9ZPo5996CxN4cZSNyRnfBGIUrgiMh+E7ndmcXwDe+Oslv/RKbcR0wg77t2FlKSLhp7s9hVUJGmPfFSZmtwpLfZtpWbo5SRU6q4KyEHW2YuuJ16YuOCcpiCHeeyteuzB7eHtXfzHBIlfVHuPF9XwtXSfyQ2L/wfJhUsFdcvUkZrwjyYC7mdA4pGSl0dhxetw9nTx429ScwACmKlKoQXXPtBYWu9J4iYZQqIHgC3xw8gWREMf+Si5MeZyMrLM/ZmsSugsVoZRRWwU8jRt73xpkZpK3sbOWwV0vhsKuRmzTjYMnM+bg5imVVsGuXfn/0jVizHd/HTVuOzZiM6+IjlznpBqKWiudVWL3wOk/KWiOvnOz+MiMlPwtxEjLgDZ5z7QyFTIW/186i1si6g1sgrXepapYyQiqQwZmkc3TzhNOsPFMAV0cp4+H4WjoNbpN4HzHRQd7vRH+4Q671CPeBga77jR2lOVRd1kYxCE5wP1pA42DJzmgIZphBsncssRmWNdGA6roufsTfHJAzrKGW2YlMKRBdLS5WTl4fDb4/HtGxpHq2z7e9Eh1vehrlyn/gyalRyDKrchSO7pKwHs0zZmenoVHNWrLcfcL2xN4cxvfEKjUb+1B+01zvtnIfzp49wi5uQg5fqMo5D1T1jzJmbOtgqquBgi1lAsJVjAsHWkcR87fq0XkFG3RZTEeDuiI5+LqLP8q54y+1KeHz56xhcK1W6Ot95HjrN+sLYm9Qmgd2G4aTvVLHuvONVlFUY//+L6Uf83lUii5moCEO7wAhuZmbRwvuMR9HcA2IidzdZGexW3oGc7ExjbxZTWxObpm2LOweGmX27uNhLRTKKyjnYYmbMT9uNsMLo1V6OqYtAPDQyErYKTppqjOzkK5bbz1pmV8L4+LMYnCmN0bow7GN0uOVNk5tHqzUCJjwOpUqGLsrz2Lf0NWNvDtMTu7hVYpkdNJbbmFkFt6BOcH5oMzJl3ghTpSHlm1tQWcUnlEyhK/7a2HSx/vN9/dHO2Q7mzlWb2aqBNeMjYgsItmzkMlTXqpBZXGESwVbPEKnkOZOM6CiN29oVny0KSFiazD8XwFFWhfMOMYgcfQ8shV9Ub5zq+JBYj0leiuKSEmNvEtOxvLxcdCuXMrKBQ+/g9mVWw807CNUzl6Ic9uhZfRTFb3ZA0oU4Y2+W1UovLMcDPx9GQVk1/NzszboKYX3aMVvlnNliZl7xTlORMDHXeOXfaR4pGrNFuge7G207TFHv0HYiIM4sqkSqiVSN1JWzp45jUOlWse5y/XsWkdGqr+vNr4pS8D4owOGfnjH25jAdO7dzJexlNUiWByOwQ29uX2ZVgrsMRMLwj8W6t6wQlUtvRXGR9UxTYkru+v6AtvfLtJ5B4tjOEmgzW+UcbDEzF2ICc21lF1eKcUkUVPi5Sl0bmcTRToGugW5ifZuFdSXM2vQh5DIVTjkPRECXwbA0clt75A59Vaz3zfoT+flcLtmS2JxbI5bpQeMt7kQBY83RZfQdSJq6AsVwQgdlAs4suhtKrsBq8F5B8Vl1PSdu6hMMS+GqGbNVwcEWM3NhXupgy4iZLZoTQlOwQ24hZ2R0aWqPQLFcui/RYroSJl86j/7568S608jHYak6jroTKfIguMjKcWyVdBaYmb+iogJ0LT0g1v0H3GzszWHMaEL7TEDmlJ9QrVKgf9kOHH5vIgoL6gpeMf1avDtBu75gYjQ6+FnOtDmaboRF5Txmi5m5UBPIbGWpgy0/d85qNWVmnxA42MoRl1GMQ/WqNpqzi2s/EF2w4uxjEN73OlgqmVyBvO5zxPrAS4tEqXBm/uL++1OMNUyT+SO060Bjbw5jRhXVdzxO9nxRrPer3IeMz8eipEQaGsD0I6+0Cj/uTsCa41IFwjXzhuKBEZEW1dyaboSF3I2QmbtQT2exTDRisJWcJ41FCuBgq0nuTra4oYdUDn/J3kSYu4zMDPTOXi3WFUMft/guWN2vfxwJNhHi4DxuvTSXGDNzcdL8aSn+Yyx+/2WsOXpNn4/DIVKRo0618Tj91V3cpVBPqHr0fT8dxKtrToshGFRIK8YCx7u7OvA8W0avRrhz505MnToVgYGBYqbpVaukErwas2fPFrfXv1x3XcMz6Hl5ebjjjjvg5uYGDw8P3HfffShpVDUsNjYWw4YNg4ODA0JCQvDee+/BEjNbyUYMtg4lSmNZYoK4EuGV3DVImjNj/cl0s59N/eyaj+EqK0eyTRg6DJkBiyeXo6DrLLHaOWExMjJSjL1FrA1qqqsRVbxPrLv3lOZTY4wBfe77BOcmLpe6FJZuw+4lUraL6UatUoXVx1Lx7vo4HE2qK0by1PhOFtnE2jFb5eZ9zGPWwVZpaSl69OiBL7/88oqPoeAqPT1de/n1118b3E+B1qlTp7Bp0yasXbtWBHD333+/9v6ioiKMHz8eYWFhOHz4MN5//328+uqr+Oabb2ApQtVjtiglXWykQYhn0qXuBlz2/cq6Bbmjg6+LKNO/Jc58J5GsqKxEVMqfYj2/18MiELEG3SbOEWO3vFGI82s+MfbmsDY4e2QHPFEsigJE9R7DbclYPR0HTMSJ7lKQ1ffSt8hKS+L20ZFPNp/D/5Yfw9c7L4rrt/QNwc6nR1lkVqv+mK1inmfLeCZOnIg33ngD06dPv+Jj7O3t4e/vr720a9dOe9+ZM2ewfv16fPfddxgwYACGDh2Kzz//HMuXL0damtQHdunSpaiqqsIPP/yArl274tZbb8Vjjz2Gjz76CJaCZuj2Uk9+Z6xxW/llVWLp62ZvlNc3F1O6S4UyPtx4DmVV5jlg9NDfXyEIWSiAK6JHWc/cRLYOLsjr94RY75T6O4qLi4y9SayVSvZ8K5bn3QZDYWv+E4cypmu9pj+OeJso0XW68LsbUFFeyo3chmzWT3suYen+RHy+NV57eyc/V7w1I0Z7wtwScel3iZTfM2Hbt2+Hr6+vCLJGjx4tgjMvLy9x3969e0XXwb59+2ofP3bsWMjlcuzfv18EcfSY4cOHw86u7gd1woQJePfdd5Gfn98geNOorKwUl/rZMaJUKsWlJejxVH2upX/XUuHezsgtrcLJ1EJ09jdsJZuaWqX2rIWbvUJv79VQbalP9w0Nw2+HksR8W3SG67nroi97zJfb4pGUV44XJkXDzdHWpNqSSgIHnZYOVC90nINeDs5m/Xm0FAWXOQfehK8qH//98jyGPPCZReyXpsBQ7UgHjd0KtgEywGXYAxb5ufE+yW2pCw43f4f8Zdejg/Ii9vy9EANnPmkV+6Wut5OqEL/y9+kGt43s5IPXr+8CGeh1LKNCcWPUfi52Us+X4soaVNfUWsz8YaQl+4dJB1vUhXDGjBkIDw/HhQsX8Pzzz4tsGAVQCoUCGRkZIhCrz8bGBp6enuI+Qkv6+/r8/Py09zUVbL399tt47bXXLrs9OzsbFRVS1b2WfBiFhYXiH5eCQH3p5mePQ4nAtlOpGBFi2DO1BfVKelYWFyCrTD//TIZqS32bPzwIT/19Ad//l4BxEU4I8air4JiUX4EPN50X6xtOpuObW6LR3tPBZNry3NEdGK5KQYXKFt4Db0dWVhasTWL3p+B9/AV0y1iFpMT5sLN3sIj90tgM9f99/sC/GCarRBbawTWoq0Xuw5byXWkKrLktbdwCcDLkdgxLXoQep99HfNx1cPP0sfi21OV2FlbU4KNN57TXu/g54YsbO8LJTgFUlyCr3vxalobasaa87v1dTEmHu4NJhx0tUlzc/GqdJv2uqcufRkxMDLp3747IyEiR7RozRn/97BcsWID58+c3yGxRYQ0fHx9RiKOlOxsV9qC/1eeXy9Bo4McDGbiYX3VZAKpvJTml2r65gQFSIKsPhmpLfZvh64u/zxRi5/kcfHsgB5/f1hO2Cun9/Hj0rPZxRZW1+GpfJr65q4/2fmO3ZcbRr8TytM916Nk+CtbIe/JcZMV+BF/k4sTupRh86wKL2C+NzVD/35cubZeWXsPR1z8AlshSvitNgbW3pdedr+Hie+sRUXsJ+f++hsj/LYesle1gLm2pq+0sqazBwE82aa9/dmtPjI72gZOdSR9667wdHW2TUF5dC3sXD/iqC7pZAiq611xm9YlHRETA29sb8fHxItiiMVyNz0rW1NSICoV0H6FlZmbDYgSa65rHNDVOjC6N0T9da/7xaGdr7d82Vyd/KQi8lFMmyoja6Pjg/Go0XQjdHe30/gVqiLY0hHmjO2DPhVxsPJ2JL7ddwPzxnVBaWYMf91wS988dFo5v/0vAjnM5+GjTeSyY1NnobXnu1GH0rDqKWpUMoTe8bPafQWvJ7eyREn0ffM+8h57nF6Ks7FGL2S+NTd/tSN1gw/N2inXHblMt+vPifZLbUhfk9g6oHP1/qNk4CwOKN2H3khcw5N53LX6/1MV2/nNC6mFFZg9uj+t7StO/WBNqRzdHGxFslVTWmvzn3hIteS9m9a5TUlKQm5uLgADpbOSgQYNQUFAgqgxqbN26VUTTVDBD8xiqUFhdXVeljyoXdurUqckuhOYqyMMRjrYKVNUqcVGdaTKUAnUZcw8n/YwvskT9wz3x/szuYp2CqgvZJXj+rxOoqFaKYidPT4jGvFFS5mjbWdPo5pS95QuxPOU6GN4hHWHNet30LNJkfnCTleHkxp+MvTmsmeJjd8MPeShT2aPjoEncbow1Q+ch1+NYzAtifUjSIhz6dwm32zUs3B6P5/48IdbbOdniqQmWWdq9OdwdpGNDa57Y2KjBFs2HdezYMXEhCQkJYj0pKUnc9/TTT2Pfvn24dOkStmzZghtuuAFRUVGiwAXp3LmzGNc1d+5cHDhwALt378a8efNE90Oau4vcfvvtojgGzb9FJeJ/++03fPrppw26CVoCuVyGXqHSHFf7L+Ya9LWziqVxbD6uXImwJab1DEKfsHbijM+YD3dg9TGpguar13eFnY0ctw8IFdcvZpeiqsa4A4oz0pLQM3edWLcb/BCsnUxhg9SImWK9/ckvUFrS/L7bzHhyDktzOZ5z6Qd7B2kyeMbYtfW96Skc8LtZrHsffA+VleXcbFdABbDeW183JGDnM6NE1Whr5aou9GXNc20ZNdg6dOgQevXqJS6EAiBaf/nll0UBDJqM+Prrr0fHjh1FsNSnTx/8999/Dbr4UWn36Oho0a1w0qRJovx7/Tm03N3dsXHjRhHI0d8/+eST4vnrz8VlKQZFqKs0GjrYKpIqN/pysNXi9PrCO3qLgEujW5AbpvaQThQEuDuICQFrlCokGDhb2dj5NR/CWVaJeNsO6DRwslG3xVR0uX4+MmXeCEQWEncvN/bmsGbwTd8mljUdruP2YqyFom97G8VwRHtlMo4vnM3t1wSasHjIO1u119+7sTtc1Zkda+WmLopRZKR5YE2BUUPtkSNHimovV7Jhw4ZrPgdVHly2bNlVH0OFNShIs3SDIr2ATcC+i3miXelg3hCyijXBlu6r5lk6PzcH/HhPP4z+cAeyiyvx4IhI7X30+XX0d8XhxHyczSxGJwOX9Nc4F3sAA9J+FqWyS3s92OrB0ZbG2d0LpzveA7+z7yPs0kqolAusZoJnc1SYl4Wo2gtiPXLwDGNvDmNmx83DG6dGf4XOW+5B/8L1uHDyACK79Tf2ZpmE6lolPthwVjtZMVl+/0AMVJ8Et2Zu2syWec4tqgt8ZGBBugd7iO5neaVVuJRbZvBuhDyhcevQWa+1jw7F9qdGaic91ujoJwVYZzOMN4Fu/qb3YCerRZx9d8SMn2W07TBF0RMfQJXKBpGqRCSel/rnM9OUeGK3WKbK/NHO1/oGqjOmC12HT8cJJ2lMfPWqx6yqUWlO0SslCL7fldAg0Hp6QicOtNTcecwWB1uWhAKtroFSVcKDl/IM9rqc2dJNhqu99+VjSDoHSMHW6TTjBFvJCWfRu0jqEmE/6U3Ibay7O0Rjrh4+OO/QTaxnHPrb2JvDrqL04n6xzHDtyu3EWBv43/GlOMkUXXMGB9d9ZxVt+f6GOHR6ab3oIkjFrOKzirUB2MnUQny2RZofkyybOwCPqAtcMcpscTdCzmxZmOEdpAkHf1KXEDfomC03LpCha92C3MXyRKqRgq01b8NWVovT9j0R3mO4UbbB1JVFTBTLgITfjb0p7CocsqVCTNX+0hhhxljr+AVH4WjQ7WK9y4HnkZ9TV+Lc0lDBsTfWnhZTtNQqVUgrrMCy/UkY9/FOrDyUjLt/OIApn+9CWVUteoR44MALYzA40tvYm21S3NSZLS6QwSwGzeUglwGn0oqQXqj/akGUUqexRoQLZOhetHqcVk5JJQrVJfYNJT8vBz1y/xHr8pFPG/S1zUmn8fehWqVAuDIJyRdOGXtzWBNUSiVCys6IdY+oQdxGjLVR33s/wkVFe1E4Ke731y2yPWnuy1u+2YfvdiWI63cNDBNjrId39AH1Jnz691gxXyYJbucoCl7x2PXLuWozW9Y7ZqvFBTKoqh8Vm0hMTERZWZmYYZsqCNJ8Vi2ZTZnpRztnO/QM8cCRpAL8eSRV76lsmmOL5vYiXPpd92imeWpXCmgT80rR3Ukq728Ip/9ZiCGySlySh6LTAJ6T6EpcqFCGXRd0qz6BlP2rERLJ3dRMTWbqRfijADUqOdp3G2jszWHM7ClsbFHY93Fg/+MYlLEUJ3dNRLehU2FJ6KS1hr+bA56dGC1KuEd4u2D4+1JlU/LujTGY3itYDOVgl3PnMVvN70ZIJdb79++PyMhIPPvss1i1apUIur777jsx15Wfnx8efvhhEYQx47pzYJhYLt59CRXVtXp9rSNJ+dqslr2NQq+vZa3CPJ3E0pBFT0pKihARL03Wm9NlNlcgvIY8/6Fi6ZS0Rf8fDmuxtFO7xPKSTTgcnFy4BRnTgV4T78HBdtJUILW7PhUZZEtyJr0u2Fo9b4h2rqwQT0dtr5NHRkXiln6hHGg1qxphNaxVs4Itylx99tlnmD17tgim0tPTcfjwYezatQunT59GUVERVq9eDaVSib59+2LlypX633J2RTRPk5+bveh6ti42Xa8ttel0plhO7h7An4iehHlJhTOScg0319aJ7+chADliHqlukyxvTjpd8+gyTiyjy4+jtMR4lSNZ0yoTD4plrodUzIQxphu+E54W3ah7VBzE/t8/tKhmLVOfrL6pT7AoYlV/WhYKvnY+PQpPje9kxC00D248z1bzgq133nkH+/fvF5mrkJCQy+6nSYZpzqxFixYhLi4OERER+vi8WDPZKuSYqi4h/vra03qdSO5CdolYUtdFph9hXlJmK9FAma0Lpw+hf55UWS9/3CdwcDLO/F7mxCesM9JlPrCXVePs3jXG3hzWiGveSbGUB3JxDMZ0KSy6Fw53kErAB5/5DrU1ljMuR6mUyrzb0ED4RqgnT6iXk8HmMzVnbjqcZ+ubnRfw1fYLSC3Qf00CgwdbEyZMaPYTenl5oU+fPm3ZJqYDj47uILJbheXV+GxzXUlSXaLKPHHpUvnTSB/umqP3YCtP/8EWdQMp/+txKGQqHHMZhujBltUHX19oouckb6laY/VpqagIMw1UxCewUpr/xiOit7E3hzGLE3PD4yhROSJYlYGDK96FpaBjHCJvIthizeeuDrbKq2tRVaNs03f5d/8l4N31cbiUY7iePrrQ4tF8R44cwYkTdZN3UvfBadOm4fnnn0dVVZWut4+1kruTLeaP6yjWqZLOhlO6L8266mgqiitrRD9mDrb0J1Q9ZivJAJmt0/s3ikIP5So7+N30vt5fz5I4dZsilpH5u6Cs1e9YSdZ8OZnJ8EQRlCoZgjtysMWYrjm7euBUZym7FX7ue2SlStX7zF2tev5iBWev2sRFPdaNtKWn1dnMYjGvq4OtHH3C2sGig60HHngA586dE+sXL17ErbfeCicnJzFO65lnntHHNrJWmtYrCN2DpXmaHvj5MP45odvxW/suSiVP7xgQCkc7Lo6h7zFbGUUVei94UrbnW7E86TkOAe076/W1LE3HAdehBI7wRgHOHdtp7M1hahnnDotlqjwAjs7cJZYxfeg+9VFkwAd+yEXtt+OQlWq4uT713Y1QwZmtNlHIZXBVB1xtKZLx37kcsRwQ7gUHW4VlB1sUaPXs2VOsU4A1fPhwLFu2DD/++CP++OMPfWwjayXqU/zb/YMQ6C4N7Hx46RG88NcJFFdU44ut53HDF7vE5MeUmm0pKr6x8nCKWDe3Mwzmpp2TrfaLKlmPXQlzMlPRo2i79JojHtTb61gqWzsHnHPpL9bzjqw29uYwtdLkWLHMdorkNmFMT+hERvUdfyBZFogAZKPk+xtQVVlh1u1do+lGyJkt3Y3bqmj9uK2d57PFkuY5MzctDrbowJyqDpLNmzdj0iRp/h0qnJGTI0WdzHRQxunvR4ci3FvKjizdn4SYVzfig43ncDylEK/8fQofb5IylS3x5bZ4bV/cIVE8W7o+0QBcGoir7/Lv59Z/BTtZDc7bdEBUT2n8EWsZVceJYumfXjcHCzMuRbY0mXGVZzR/FIzpUUiHHlDMWoV8uCFCeQnH1i4y6/ZWqk9E2yh4zJaugq3CVma2qFfPgYQ8sT68g7flB1tU2v2NN97Azz//jB07dmDy5MnayY5pri1merxd7LH20aG4pW/DSpKazPhnW+ORXliu3aGvNfAwJb9MzOGlmWPCuV5/XKbvioT6GRRaW1uL9pdWiPWCLnfp5TWsQYchM1CrkokDjbRLZ429OYyKYhRLBYLsg2O4PRjTs8D2nRAXdrtY7xX7Os4d2WH+BTI4s6W78u/lrQu2dpzLRmWNUvTUivJ1sfxg65NPPhFFMubNm4cXXngBUVFR4vbff/8dgwcP1sc2Mh2ggOjdm7rj2Mvj8M6MGMwbFYXDL45D5wA3cf/hxHws2XsJQ9/dhpEfbMfyA0lNPk9eaZV4jAbNms70L9RTPdeWnroRnj2wEYGqTBTBCTHX3auX17AGbl5+OGsvzeWUtPdPY2+O1aNCJcE10neZdyQXx2DMEPre8TpiHfrAVlaL3EN/WMCYLWNviSV1I6xu1d+vVc8ZOykmwCzL7TcrJUETGt9///1wcHCAh4cHjh8/Drm84d73/vvvQ6EwrwFr1sjDyQ639g/VXu8b1k7Mkv7F1njEZUhl3Mkb686goLwaZzOKYW8jx8hOvlgbm6bd4cnCO3rDx9Xe4O/BGrVXZ7YS9FTutDB2rViecxuCvjyvVpsUh44F4k/A6dImAAt08wGxVsnLToW3rEpkG/1DpeqsjDH9srWzR3nEdcDpw+iWugI11R/AxtbO7Jq9Vt2NkKsRtp2bQ+vn2qIeV5tPZ4r1qT2kOWTNTbPi9fnz56OoqEish4eHNzk2iwIxW1upMZn56B0mTUasCbTGRPuiS4AbSipr8M6/cfjraCqWH0zGg78cbhBoPTW+ozjDwAyjS6CUgYxNKWxVQZNr8c+UqufJOjV/Tj3WtMABM8QyuuIYigqlPubMOPLSpPm1cmXtxAEgY8wwvDtL435dZeU4tPwN8y6QwdUI28zN0abVY7Z2nc8Rc3QFeThqK2xbZLAVGBgoKg0mJiaKA72UlBQkJSU1eWHmpVdIw0qCE7r545c5A/DgiEhc19W/yb9Z8cAgzBvdwUBbyEi0v5vIMNIXla6zWzS2KFyZhBqVHFGDp3GDt1FIh+6iIpedrBbnd6/i9jSikixpbGm+jS9/DowZUGTMQOzzv0Os94//DIf/WWy23QhtONjS2cTGRa3oRrj5jJTVGtvZ1yy7EDa7G+GLL76IRx99VIzTojfar1+/yx5DQRjdRwPtmXkVXrCzkWtn9e7X3hOeznZ4bmK09suGJi4ur6oVZyYcbRVmu7ObM/qMYoLccSgxH0eTChDho7sBokn7/gIl5s/Zd0WXduZXUtUUpfqNQkjGUijP/gtM4jFwxlKZdUEsSxw5C8+YofWb8xkOfpGLfgXrEXbgVSSFd4dDuyCz60bImS1ddiOsbtHf0THo5jNZYn1sF/MtwteszBaN16KugzRWi4KqTZs2iSIZ9S9Hjx4VS2ZeKHCiroMk0sdZWyJeg75k6IyEv7sDnOxsONAyol6hUpfPg5d02zXN8dJmsSwKGa3T57Vm7r2uF8sOhXtQU11l7M2xWg6Z0m9StW93Y28KY1ZHYWODLvd9LSY7psnenX67CcWF5jNFkHqWIx6zZcR5to6nFIh5XWmuUZrM2Fw1u2a3q6srunXrhsWLF2PIkCGwt+f+75bilaldMTjKGyPNcKI4a0IT+X37X4JIqVNJWl3Mal9aXIjo8mOADAjod4NOtpMBHfuMQcG/LvBACU4f2oIug6T5t5jhqJRKhJSeFOvuHblSLmPG4OzqgfIHtyJn0TD4Ig9ly29B2p0rEBzZ1XwKZHA3QqOVft+kLowxopOP6OFjrlq85V26dMGxY8cuu33//v04dOiQrraLGRBlre4aGIYQT6niHTNNAyO8xBdWTkkVDrUgu0XZ6G1xWU3O0XV+/z+wl1UjTeaH0I69dLzF1kthY4vz7tIBfuHxv429OVYpI/m8OJterVIgPGaosTeHMavl7R+KrAmLxLjg9qoU+C4ZjkPrvoWpq63lebZ0PmarvGXB1tY4dRfCzubbhbBVwdYjjzyC5OTky25PTU0V9zHG9MNWIce4LlLRkt8OXv4/2BTKgD37Ryzu+fEgnlxx/LL7q8/8K5bJ3sMgazSdA2sbRfQksQzKNN9JPc1Z6kmpwuYl2wg4OJnfJJiMWRLK7p8cvggp8IedrAYBh96HqePMlnHn2courtRWyh7awRvmrMVHV6dPn0bv3pdPDtmrVy9xH2NMf+4eFCaWfx9PQ3ph+VUfm5xXhlk/HMCKQyniOhXXaNzNKjx/t1h36ioFBkx3Og65AVUqBUJVqUg6f3mgy/SrJvGAWOa168FNzZgJ6D5qJjLHfirWHVQVMHV0spJwN8K2c7GXuhEWt2DM1u54aXwfTUfk7WJvXcEWjdXKzJT6UNaXnp4OG5tmDwFjjLVCjxAP9A/3FPN/0DxomtK0GnR9/8VcLPjzBMZ+tAO71F9WmsqT9WVcOiX1oVfZo+PA6/jz0DEXN0+cdZAO9FP3/8Xta2BORVIlQlkgB1uMmQqFjXTQbIOWT25raEoes6UzTnYKsaysUWqD2Gv577x0/DLMzLNapMXR0fjx47FgwQKsXr0a7u7S5GIFBQV4/vnnMW7cOH1sI2OsnifHdcSt3+7D6mNpIs0+oau/mGH9XGYJ9l7IQVph3RnDQRFeuLFPMJ5aeVz7w6FRmiFN+JpiG4aODg2rUDLdKAsfD8QdgXsSVXx8lZvVgBRK6WBOYc/7NmOmQqGQupPZqGrNJ7PF0920mZNdXbhBExRrMl1XG2uuyWyZexfCVgVbH3zwAYYPH46wsDDRdZBQwQw/Pz/8/PPP+thGxlg9AyK88OHMHnjujxPYcyFXXOqjEqkTY/wxrVeQCLZiUwoblLHVqCmQJiEvdqBZtpg+hA6aAcS9g06VJ1GQkwEP76YnCme6J1dJwZZcwT0uGDMVcht1sAXzCbZ4nq22c7Ct60hXVlVzzWDrUm4ZMooqYKeQi/lfzV2Lf4WCgoIQGxuLpUuXinm3HB0dcc899+C2226Dra30T8QY068ZvYPFF9CyA0k4n1kCZ3sFIrxd0C3IDUOivOFgK6Xs6/c3b5zZsimWxnJVuQbzx6UnAWGdcEERgcjaizi7bSkGzHyS29pA5Ooz5zI5/y4xZirkCum3SWEOwZa2G6Gxt8Qy5nR1tFWIrFZFVaMzv004kCCdRO4Z4tHgeMZcteqUn7Ozs5jomDFmPFSq/9nroq/5OE0PiMb9pH0LT4iljV9n/WwgE7LDb0Bk/MdwP7eSOoFyqxiIXH0wJ+PMFmMmNS0GsZEpRZEmU66CqxkTrTDhbTS3cVvl1bUoq772eL0DCVJBr37h7WAJmrUH7du3r9lPWFZWhlOnTrVlmxhjOtRUZisnPREdlVIBgfCBPJmxPkWNuQe1Khmiq88gmasSGjyzxd0IGTO9MVukuroKpozHbOmWo7pIRlnVtbOaB9VziVpCF8JmB1t33XUXJkyYgJUrV6K09PKJUQmVfaciGZGRkTh8+LCut5Mx1kpydWqrfmIrYd8qsTxn0xHe/iHctnrkHRCGU459xXravx9wWxu6GyFnthgzGYp6w01qqithytRzGnM3Qh1XJCy/RrCVUViBpLwy0HniPmGWkdlqVjdCCqS++uorvPjii7j99tvRsWNHBAYGwsHBAfn5+YiLi0NJSQmmT5+OjRs3IiYmRv9bzhhrUbBVvxuh3YVNYpkbOJJb0QDkw/4HbLoTfXLXorS4AM6uHtzuBupGKLex47ZmzETI62W2ampMu/x7rbqqlOY3lLWNo23zgq0D6qxWl0A3uDrYWk9miwpfPPbYYzh79iz27t2LuXPnolu3bqJYxsiRI/H1118jLS0Nv/76KwdajJl4N0I62O9Uekise/e63qjbZi26DZmKDHiLcQoJx3cae3OsgoKrETJmcmzqZbZqTb4bobTkSY113I2w+urB1sEEKdjq394LlqLFBTL69u0rLowx86COtbSDfc/tXYteskqkwB8RMYOMu3FWJMWtF/yLNqH84FJgKAe5+qbQjtmyjDOjjFkCuVwhxrAqZCqTD7Z4UmPdclbPtVVWWdPM8VqW0YWQcIkVxqylG6E6s1VdKlX5ybYLMulKUJbGbeSjYtmrYCPSLp019uZYPE1paS6QwZhpqVGf56+pMZMCGZozlqxN3BylE1/FFVcOtmgOrnOZxWK9t4WM1yJ8pMWYhdNMyKgdsqWUvuhUMvOfu8KcdOw9Aifse4uuhMl/v2HszbF4ckh9gBQ2PKkxY6akVn3oWWviY7a0pd95zJZOuDpI38VFFdVXfMyJlEJxrOLv5gA/NwdYCg62GLNwmh8KzQ+Hqlb6gVPK+CDU4J/FqGfFsm/uGlw8ud/gr2+dmS3uRsiYKalR//bU1ph2NcIa9W+m5oQlaxs3dbGLovIrB1vHkgu0kxlbEg62GLOWMVuaebY4s2U0XQZehyMuw8V4hbI1z4hJPZmegy31JKqMMdNQA6lXRW3NlQ+6TYGm6z13I9QNN0dNZuvKGc3jKepgK9TKg62Kigr9bAljTO/dCFUqFVTqYEvJ3QiNwv+mD1CpskW3ymM4vm2FcTbCCtioC2QouPQ7YyY5ZsvkC2TwmC3DZ7aSOLMleHh4YPjw4XjppZewZcsWlJeXt7rhd+7cialTp4o5u2QyGVatkiZa1aADw5dffhkBAQFwdHTE2LFjcf78+QaPycvLwx133AE3Nzexbffdd5+Y86u+2NhYDBs2TMwLFhISgvfee6/V28yYuak/R4g4UafJbMm5G6ExBLbvhCOBt4l1z92vo7rKtLvSmCsbdWaLx2wxZlqU6vP8SnWXdlM1rXod3rdZBAXq5qhk+iuQkVVUgbTCCtEbJybI3bozW5s3b8Z1112H/fv344YbbkC7du0wdOhQvPDCC9i0SZootblKS0vRo0cPfPnll03eT0HRZ599hkWLFonXc3Z2xoQJExpk1yjQOnXqlHjttWvXigDu/vvv195fVFSE8ePHIywsDIcPH8b777+PV199Fd98801L3zpjZqn+4F7qFqEZs8UFMoyn6y2vIg9uCFWm4shfHxtxSyy/G6GCuxEyZpJjtpQmXI2wOD8HT9Z8h5k2O+FXfMrYm2NZma2K6quO1+ro5wpnexvrDrYosHr++eexceNGFBQUYNu2bYiKihKBEQVhLTFx4kS88cYbmD59+mX3UVbrk08+wYsvviiCuu7du2PJkiVi8mRNBuzMmTNYv349vvvuOwwYMEBs2+eff47ly5eLx5GlS5eiqqoKP/zwA7p27Ypbb71VTND80UcftfStM2aW6ld3F6VsecyW0bl5eOF8F6kUfMczX6AwP8fYm2RRlLW1YlwcUXCBDMZMSq22QIbpjtlKO/iXdt3fw8mo22Jx1QjLq62qOAZpVeh47tw5bN++XXuprKzElClTMHLkSJ1tWEJCAjIyMkTXQQ13d3cRVO3du1cETbSkroP1J1mmx8vlcpEJoyCOHkPdHu3s7LSPoezYu+++i/z8fJGZa4zeD13qZ8eIUqkUl5agx1Pg2NK/Y9yWOqMpjEE/brVK+oWT9k2ZgvdLHWjt/3ivGx5DYtxPCFOm4PD396HX/Lofd2uky+/K6uoq2NebRNXavn/5d4fb0pT3y1ptgYxKk/zfpG3yTvqnwXWY4Haa2/eQi71Cm9lq6nM/qh6v1SPY3ST3i8Zaso0tDraCgoLEOC0KrOjy7LPPiqwTjbnSJQq0iJ+fX4Pb6brmPlr6+vo2uN/Gxgaenp4NHhMeHn7Zc2juayrYevvtt/Haa69ddnt2dnaLC4TQh1FYWCh2OAoCWetxW7ZORU3dF0JGVhaqK6VxlrUqICsri/dLI+6XKT2fQtiRx9GnZDuSU5Jga2c584oY8/+7sqIMYer1vIIClFeb/g+3LvF3JbelKe+XNupgq7iwUPwGmZqs5PPoXnNaez0/LxfVtqa3neb2PVRVJmW0SiprkZ6R2aDKI1VLjk3JF+vBTrUmuV80VlwsTb6sl2DLx8cHcXFxIlChS2Zmpgi+nJwsJ826YMECzJ8/v0Fmiwpr0HunQhwt3dkoEKW/5WCrbbgtW6eyRhq7Qry8vZFlI33ByW3sxckK3i+Nt1+6jJwGHHlcrLfzcIeTi2UNCjbW/3dJkXSGlPgHBMLewXJ+n5qDvyu5LU15v3RUSgfSQw7/D6e8f0PnAeNhSi79/nyD6+08PIBGJ/ZZy7+HPMSJ31hxn5O7J9zVBTNIYm4pSquUsLORo390KGwVpp+coKJ7egu2jh07JsZqUSGKHTt2iPFbp0+fRs+ePTFq1Ci8+eab0AV/f3+xpGCOqhFq0HV6Lc1jGke/NTU1okKh5u9pSX9Tn+a65jGN2dvbi0tjtLO05iCAdrbW/i3jtmwrW0WDvREyZa22QAbvl7rR2v/x+kFAbW2t1X9H6Oq7UlVbNybAzs7BKtuVf3e4LU11v0xyiIZHxSFxveuGW3BxU3tkBo9H0NA7ENpROr4jCaf2w87RTVRwlRnof7gwLxs9stfQT6WWSMBY4XeIrr+HHOzkcLRVoLy6VmS32jnXHWfHZUhVxKP9XWFvax7FMVryu9Kqd0TjpK6//noMGTIEgwcPxurVq/Hrr7+KcVK6Crao6x8FQ1ReXhNcUYaJXuOhhx4S1wcNGiQCP6oy2KdPH3Hb1q1bRTRNY7s0j6FKidXV1bC1laJoqlzYqVOnJrsQMmbJpd/FtCHqAhng0u9GZ1OvUl5NFc9hqCs19QbeW2OgxZgpc5n6NvZt/waKqkL0KNiKCOUlRCR9Ayz7BhcU4SiyD4BHRRrClZfE42tVMsTbdkJewDD49J2GyJjBegu+zmz4BgNlVbggb48IDzlkeRcbjHtmbZ/YuLy6FoXl1Qipd/upNKk2QpeAlvUeMxctDrb+/PNPbWEMymjR+CiqAvjhhx9ixIgRLXoumg8rPj6+QVEMypzRc4aGhuLxxx8X1Qo7dOgggi+a24vm5Jo2bZp4fOfOnUUFxLlz54ry8BRQzZs3TxTPoMeR22+/XYy/ovm3aHzZyZMn8emnn+Ljj7ncMrOuSY011Qhl6sleIW+Q8mJGQAcM1SoFbGW1Jl2Zy9xo5u8RbcvBFmMmpX3nvojo2l+s52en49iu32F/djW6lB9BZG0CUJbQ4PFUWbRTTRyQTJdvkfmXFy55DYNjzPXoNHCizroJp148ha5xn4usVnLYDEQU/S3dobKuMZ/65OVsj8yiSiTmlqFbvbm0TqUVimXXQA62hAcffFBU96O5rCi4iomJaXWjHzp0SHQ91NCMk5o1axZ+/PFHPPPMM2IuLnotymBRUEel3uv3k6TS7hRgjRkzRpzBvPHGG8XcXPUrGFKZ+kceeURkv7y9vcVEyfXn4mLM0lG8Jaq+0xk6ntTYpFTDBraoRQ1PbqwzmsC1FnLU5Q4ZY6amnU8A+k+naTAeFYHXue3LoEjajVo7Vzh1vwEd+o1HduoFpMdug83FzYguOQA/WS78clcB21ehcpstLtiEIDtiOqIn3A8P76aHh1xLRVkJXJaMg6usHEmyIIQOvQ34d636Xs5s6cqQKC+cTi/ClrhMTO5eN0SIbiNdAi1z3HKLM1u6rBBC1QypSsnV+nq+/vrr4nIllAVbtmzZVV+HqiX+999/bdpWxswZVf1R1qpEsCXjboQmpUZWVwaZ6UZtjZTZ0pSYZoyZR+A1YOaTAOhSJ6RDD3EBHkdFeSmO712HilNrEZG7Ez6yfETWXkTk+Q8ButCJfLexiLjzM3j6BjXrdeOP70LUX5PhoO6yiNt/hZMzZVjUvUI4s6UzYzr74dv/ErAtLgvVtUpRCCOnpFJku2jEA43ZskStGrNFA7lpYmGaVJh06dJFTDysUPAPG2OmO25L1bAbofognxlXrfprmLsR6k5NtRS41vI+zphFcXB0Ro/RNwOjbxaTlyfEHULW9m/QL+sPyNUTmfct2gws7ILziijk+gyAyrEdbD1DYefqjdKL+yErz4Nj8SUoVNXwqMpElCpd+/wHQ+5F/6gYKbGgGe/MY7Z0pm9YO3i72IsA65d9ibhnSDhOq8drhXs7w9nePIpjtFSL3xWNsZo0aRJSU1NFkQnNvFRUGn3dunWIjIzUx3YyxnRQJIN+M3jMlul1IyTcjVB3MmK3iHm2shT+sMwRAIwxuUKB8K4DxKWq8ksc//d7eJxcjA4150XjdKiNR4cMdV2AhsPAmnSw51sYOO2RuslqtcEWj9nSFRuFHPNGReLVNafx55FUEWxZenEM0uJyLo899pgIqJKTk3HkyBFxSUpKEgUs6D7GmOnRTB5ImS25Ul2IgasRmgRNVzdlvXLlrG2lm8NPfSHWc9pP4aZkzArY2Tug37RH0OHFQ6h9MReH+n2AU3bU9fDKEuUhiHXoi30Rj6FqQab4+wZkmkNkHrOlS1N6BMJOIceJ1ELsic/RjtfqaqHjtVqV2aK5tfbt2yfGSml4eXnhnXfeEaXgGWOmR3OCrlZVvxqhZabrzU2tzEb8liurq4y9KRbhzPIXMBB5SJIHoeeNzxh7cxhjBqawsUHfyXOByXNF4Yvq6io4u7ijKD8b7p6+2kqwlP2+Os5s6YO3iz1u6huMZfuT8OfRVG0lwi4WWomwVZktmuy3uLi4yTLudnZ2utouxpgeMltUkIa7EZqWGgq2xNxQXCCjrTJTLqBX5p9ivXDEG3BwcmnzczLGzBd9B7i6e4ouh1SpkIKsZs/RpclscWJL56b1lIqX/H44BRezS8U6dyOsZ8qUKaJsOk0uTAdudKFMF5WEp4mOGWOmO2arVol61Qi5QIbJZLbo95zn2WqzpJULYC+rxmm7GHQbJs3HyBhjrcJjtvSmX/t2oliGRpCHI3xc7WGpWpzZojmsaMzWoEGDxHxXdKHug1FRUWKyYMaY6QZbVPpdzt0ITYpSHWzV1nA3wtYqKsjF/i/uRb/CDVCqZJCPebn5Z68ZY6wpPGZLb2QyGZ6aIBXZ0wRflqzFgzY8PDywevVqnD9/HnFxceK2zp07i2CLMWaa1L0IpQIZ6mBLzmO2TEKtTJp2V8mZrRYrKynE8ZVvof+lrzFAXfZ5f8TDGDRgvK4/JsaY1eExW/o0MMILDwyPwLHkAtw/3LIrmbd6hHyHDh3EhTFmTmO2UJfZUnCBDFOgmQtKVcuZrZY4vnUFvP57GYNojhwZkA9XnO/xDAbeME9PnxRjzKpox2zxoC19WTCpM6xBs4625s+f3+wn/Oijj9qyPYwxfY7ZUqlgqw62ZJzZMqluhCruRthsR9b/iB57H4dCpkIe3HCu00PoNf1x9Hdw0t8HxRizMpzZYgYMto4ePdrsPpiMMdOjGb5SXlqMwJpMsS6zsdzBqOZEKVd3I+R5tppl/4r30efUWyLQOuIyAhGzv8FAb3/9fkiMMeujPablzBYzQLC1bdu2Nr4MY8yYFOofjczVL2MQ8pAJLwR2GcwfiklltnhS48LcDPj6SvPgNOXEjj/R99SbItA65DoGvf63QsypwxhjOsfVCJmONLtc08WLF0WZd8aYeXYj7CGLx9Syv8T19GFvw9HZcicQNCcqTXdOKx6zpaytxaHP7kCnlSNw8I+mu6If37oc4VsfFoHWAY9J6PPE7xxoMcb0h8dsMUMHW1QMIzs7W3v9lltuQWam1B2JMWbaZFDhbdvvpYyA2zh0HzXT2JvE1JRyaTJ4ZXmBVbZJRVkJDi68F/0L/hHXO536GLU16rng1A6t+xbddjwIF1k5ztpEo8eD33Npd8aYnlnZmC1OqBg/2Gqc1frnn39QWirN+swYM20ReTvRRZ6IYpUjIu/63Nibw+qpCegtlp0Sl6Ewr+6EljU4vfdfVL3XEQNyV2lv80AJzh7a3CDQ6nngGXGi4KD7eAT/bwPsuRAGY0zfrG2erZWzgTcDgb8fBS5sA8ryOADTEZ71kTEr8JD9erHc6z4Z7XwCjL05rJ7eM55EojwEnihC3NKnrKZtaqqrYL95AdxQigqVLfZG/g97XcaJ+yp3foacjGQc/Hgm+h58CjYyJQ56TESfx5bD2dXD2JvOGLOqMVsWHGylHgaOLgV2vAecXgVUlwJHlgA/TwPeCwcWTwLyEoy9ldYTbFGlwcbVBrn6IGPmoZO7VO59xKRbjL0prBE7eweUjHlXrPfLWY1zR3ZYfBuplEocWXgPImsTUKpyQPm8Exhwx6uwH3Q/alRy9CrbDe9F3dCvcCOUKhn2+d2G3vN+gVwhzUnGGGN6Z+ljti7uAL4dDax+GNj2Zt3tHSYAmrHESXuAr4YAJ/8w2mZaApuWdCOcPXs27O2lctEVFRV48MEH4ezs3OBxf/75p+63kjHWJs520kGqvZ00PoiZlq5DJuPQ/nHoW7QJsn+eRG33fRZd/GH/L69gYP5a1KpkOD/0Y/T0CYBSqURgZHcc7vYCep18C3ayWpyz6QjVde9iYN/Rxt5kxpjVsdDS7zSn49l1wOGfpOuekUDoIMAtEOh+C+AdBVSXA4UpwN+PSQHX7/cCaUeBMa8CCsv9bdKXZrfYrFmzGly/88479bE9jDF90A7w5bnwTFX72z9C8Vf90aHmPA7+/SX6zfgfLFHCqf3ofeFLsSse6vIcBoy7vcH9/W6cj6JRdyIzPxMdImO4EAZjzMiZLQsrkPHnXKnLoMaYl4Gu0xo+xtYR8O4AzF4LbHkd2P0JsOdzIOMkcPMSwIGrGesl2Fq8eHGLnpgxZkI03SC0A36ZqfH2D8W+Dg9iYPzHiIj9EMVj7oKruycsSUV5KVR/3C+yVkedhqD/zGeafJyHt7+4MMaY0VjimK29C+sCre63AkG9gc5Tr/x4uQIY9xoQ2BNY9QhwcRvw0xRg0geAszfgGWGwTTdnfOTFmDXQnJlrNO6SmZbeM59DsiwQXijE6SVPiLFNluTY4scRobyEPLgh5O5FnLVijJkuS5vUmILGvV9I65GjgRlfAwMekAKqa+k6XcpyOXkD6ceB78cBn/UCNrwAWOm0JS3BwRZjVoEzW+ZSLCNv2GtincqhH/jyHjHhryVITzyLvpm/i/XkER+JTB5jjJkuCxizVVsNrJ0PfDMSeD8KKEqVbr+pFb3VKAt230bAI6zuNgrefpkBVBbrbpstEAdbjFkDHrNlNnqMvhn7u74kqvBRwHXy/XFmP/8WTVxcuuQ2UcL9lF139OBJtRljps4Sxmyd3wgc+l4qblGWI93W6y7AsZVTaHhFAnO2AJM/BKZ8AsgUUvn4rwYDxZk63XRLwsEWY9aAx2yZlQEzn8LR/h+gWqVA94rDuPjdLGSlJuDI+h9RWlwguhfS+Kd9Xz0IvOqOfV89IAIaU3Vs9aeIqr2AfLjB49ZFxt4cxhiz3DFbOfHAv88BS28G1j0p3RY9BXhwF/BsInCDuitha7n4AP3mAH3vAW7/DXDxAwqSpKCONYnrNzJmVd0IecyWuegzeQ5OuHgieuscMe8Uvu0JX7pj3/+QAw94owAD1Y8dmLkcZz6ORfSC3SY3Diol/iRi4j4TPXLOdZ6HARFdjb1JjDFmuZmt9c8C8Zvr3SAD+t4L+Mfo/rU6jANGLgDWPg4k/AcMr5FemzJgVFKeCRxsMWYNuBuhWYoZMQPHqivR8b//wUlWqb2dAq3GOlefxr5v5mHggwthKigDV7J8DoJlFThlF4O+N6rPsjLGmMkzszFb1J3vxO/Apd11Jd0DegI+nQD3YP29bsRIaZm8D1g5C4hbC7iHAo8d099rmhkOthizBprfCi79bnZ6jr0NqRE9Ebt3BcKG3ooqGv9UmA0Pv/bw8AmAk4s79i55CYMufobe6ctx4cTdiIzR5LyM6+jGJehdcwblKjt43fWjRU/UzBizMOaU2aJJiJfdApSqx/e6BgBDngAM0dPBMxwIGSgFWxRokcIkIDuOBnmBcbDFmJWVfjf2hrDWCIrojKCIV654/8A7X8Opd7aha9UJVK55CqquO43enTAvKxWR+54X68d9b8DAkCijbg9jjFnsmK2L2+sCLZoDK2qsYQItDZqL64cJDW+79B/QvtFkyVbKtDr3M8b0hEu/WzIKrNxu/kpUMOxSdQIHV39p7E3ChaXz4Y5SXJS3R5+5xt8exhhrXWbLDIKtrNPSMuZmoP9cKdtkSKEDgYnvA73vBgbNEzfJEnYadhtMGPfpYMwa8JgtixcSFYN9/rdiYOavCIhdiPLxs+Ho7GqUbTm2ZTn6Fa4XwV/VxA9ha2dvlO1gjDGLHLNFEwnHrgCyzwA554GMWOl2Gp9lLAPul5Yph6T5txJ3AUrLmCeyrTizxZg14NLvViFq+gsoVjkiRJWG2HX6KbFeVlKIfcv+D4c/nIaEU/ub7D4Y9N9zYv2A/62I7jdWL9vBGGOG6UZogmO2Nr4A/Ps0cOgHqbteRSGgsAMiRxl7y6SiHHaukFUUwiaXxm0xDrYYswpc+t0aePuH4GTEfWI9/PRClBTl6/T5lbW1yP1wIAae+wB9irchfOV4HN3wU4PHpH93C3yQjyR5EHrO+kCnr88YY7D2MVvl+cCpVdJ6//uBaV8B920CnjoHBPUx9tYBChsgpL9Ytcs4YuytMQkcbDFmVQUy+F/e0nWZ8piYh8sXeTizeYlOnzs/J11kzeqzPfKDdv34tpWiSEeVSoHam36Cg5OLTl+fMcZg7dUI93wBVJUAvl2Bie8BPW+XghvHdjAZNIaLfh8yjxp7S0wCH3kxZg20Z+a4HKGlc/fyw/mQmWI9MvYDVJSV6Oy5i/MytOvJskCxDK+IQ21NjVhX7PtCLI/63IDwLv109rqMMWZ4JjhmKyce2KeeS3HU83XZN1MTMkAsOLMl4WCLMavKbJnoFzPTqZiZLyAX7vBEEU6s/15nz1ualymW1EUw8IUTKFPZw1lWgaRzR0XARYEX8Rn5oM5ekzHGjMIUM1vrngCqy4DAXkD0ZJis4L5QyeRQlKQDxemwdhxsMWYVuPS7NXFxa4dzgTeI9YjYD1FTXaWT560olDJbpQoPMUFxgr1U+Sr79H9ISzglAi+awDgs2gTGDTDGmCWN2aoqAxL3SuuTPzTtk6d2zoB3R2k94wSsHQdbjFkDLv1udXrd+TaK4AQvFOLwqs/b/HyFuZnoc2C+WK+wk8YGFPlJXUUc4tciL/msWE9XBIpAjDHGzJopZbZqKoG1TwDKasAtGAjsDZPn11VaZp6CteNgizFroB2yxf/y1oKKU5z2ny7WQ099BZWy9QcM1EXQ7rNu2uuVftIPfciI2WLZpfwoyhIPi/UCx5A2bjljjJkCExqztflVIHa5tN5+iGlntTRcpXG9srJcWDs+8mLMKnDpd2vU/c63UaGyRQCyIXu9HS7E7mnxc+RnpyP5rZ5wlEldEfcF34f+d7wq1oOjuolCGTYyJQYlSvN6VbqH6/hdMMaYFWe2SrLqimKQLlIXcVOncvSoK1Vv5Uw62Hr11Vchk8kaXKKjo7X3V1RU4JFHHoGXlxdcXFxw4403IjNTGsCtkZSUhMmTJ8PJyQm+vr54+umnUaOunMVYq1Fa/MjPQFWpeTQiF8iwSk4u7jgaeJv2euSfE7Fv4dxm/33SuWNo92U02iuTtbf1m/0e5AqF9npKcN0gbRqvFTqWi2MwxixpzJaRt+P06rr1u1aZdmGM+jSl6CsKYO1MOtgiXbt2RXp6uvaya9cu7X1PPPEE1qxZg5UrV2LHjh1IS0vDjBkztPfX1taKQKuqqgp79uzBTz/9hB9//BEvv/yykd4NM0mn/waW3wGc+F2aKPDf54C0Y8D3E4AvBwCXdkmDUvMvSQNl47cAiycCf88Dfp4u9aU2dVz63Wp1vvGFBtcHZq3A/i/vQ1lJ4RX/pjAvGwf++hyhy0ZobytROSJzzpHLxmP1vPUVnLWJRrVKgRMxCxAUoe6nzxhjFhFsGTmzlbBTWo5+EYgcBbPhoMlsFcDamfwoZhsbG/j7+192e2FhIb7//nssW7YMo0ePFrctXrwYnTt3xr59+zBw4EBs3LgRp0+fxubNm+Hn54eePXvi//7v//Dss8+KrJmdnR3MUnU5YOto7K0wX2V5wNKbgIoioCARqFVXaotbW/eY/V/Vrf94lbNIyfuBNY8D0xaadh9qzmxZLQ9vf8RNXImilFPof0Lq/jcg+3cUv78ORwa+jS4jb4aDo7O4PT3xLC5t/gaDkr9D/3rPsd/rBvR58Du42F7+neno7IrIZ/9DZUUZ+ruqf1wZY8zsmcCYLRprSyd8SfvhMCvazFY+rJ3JB1vnz59HYGAgHBwcMGjQILz99tsIDQ3F4cOHUV1djbFjx2ofS10M6b69e/eKYIuWMTExItDSmDBhAh566CGcOnUKvXr1avI1KysrxUWjqKhILJVKpbi0BD1epVK1+O+uKOccZL9Mh2rcG0BXafC7tWhTW+YnQrbiDkDhADi1gyxVGsxfn0puA5ny2l1MVbbOQK87oAodBNkfcyA7vgxKzwhg2JMwVTKoxM+Gkn4z1PuxTvdLK2YObdmx31ig31gcubAZvcukH25XWTl6738c2P84CuEMd5QiABCX+k6N/xX9Bl4n1q/0HuUKGzg6u7WpDcyhHc0FtyW3pSkyl/1Ss530q0m/myplbZsKDLVadRnkbweJVZXCHqqAHlLwZSaU9m5S97nyApP/zFujJe/JpIOtAQMGiG5/nTp1El0IX3vtNQwbNgwnT55ERkaGyEx5eDQ8k0qBFd1HaFk/0NLcr7nvSiigo9dqLDs7W4wTa+mHQVk4+seVy9vea9N1z1dwLkoDVj2ILNeuUGnStFagpW3peGoZnI//gBqvznBI2HjZ/VW+3VEVMhRKO3dUho8BlLWwSz+I8o43wCb/IuSVBajy7w3X/R+Jyfkq24+GTX48KiInQWXvJp7DacgLcNv1OuTb3kD1sd9QGTYCpT3ug8rRE6bET1krljm5eVBWOeh8v7Rm5tSWgXd/jzNZKVCtfgRdaqUJiAkFWvXlwRUnwmbDr9+N8PIOQFZWlt63zZza0dRxW3JbmiJz2S812+lWXgHK+ZeWlqDEAN+BjTnG/Ql39XqtWzBycs2rO56stBZ0xK0qyzfIb4ihFRcXW0awNXHiRO169+7dRfAVFhaGFStWwNFRf93oFixYgPnzpflkNJmtkJAQ+Pj4wM1NOshuyT8tFfagv9XJl8v1H0B1cT1kJRnwqUkDfNWTxlmBa7ZldRlky24BKouAsKGQ7Zeq99gU1Q3uVw2dD5Rmi+o+NlM+gY2r1EXVRfOAjv3hSsuA4LrnnfaRWDipr4r7NUY/AVVtHmR7v4Bt/nlxcU7ZCdW9GwEHzdek6fD28QHcfHW/X1oxc2tLKhRU02kHYvf+A+X+RehcdgT2smpx33lFFDD1E0R2H4JhBt4uc2tHU8ZtyW1pisxlv9Rsp6Oz1L3a2dERTr6+Bt8O2cZN2nX5lI/Fd7c5UbrYiqW8tgK+nu6AjT0sCfW4s4hgqzHKYnXs2BHx8fEYN26cKHxRUFDQILtF1Qg1Y7xoeeDAgQbPoalW2NQ4MA17e3txaYy+HFrzBUH/tK392yY2AgjpD5z5G/KsU0CUNF7NWlzWlnHrgC2vAz6dAMomJar7NmfESkuFHTDiGSD5oGg32fCn6p5LVxs17v+kcV8HvwdUtZBRV8+jS4Ah/4PpkPqcy+UKaR/S9X5p5cytLe3sHdB95Axg5AzRPaYwPxvuXn7oYOTtMrd2NGXcltyWpshc9kupArbmt5KqwMsNP7Y8YYe0Pu8w5N5RMDuO7uqumCrI6SS4XcOeZuauJfuwae/tjZSUlODChQsICAhAnz59YGtriy1btmjvP3v2rCj1TmO7CC1PnDjRIH25adMmkZ3q0qULzJavetuzz8LqqJSQrX4YWDwJ2PomsO1tIDtOKo16eLH0mPbDgD6zgZCBwHXvAMOfBu5YAdQLtHSK/uEmvQ+8kgdM/lC6LX4zTLNAhln9yzMDoIMICrQYY4w1+HI0XjVCOpGsqgX8ugHmGGgRmRwqe3UPHyufa8ukM1tPPfUUpk6dKroOUln3V155BQqFArfddhvc3d1x3333ie5+np6eIoB69NFHRYBFxTHI+PHjRVB111134b333hPjtF588UUxN1dTmSuzQcUYSF4CrMal3ZDt/xquNh6QnfhVui1xd939Ax8BMk8AhSnAuNeBoN7G2U6/GNP8bLj0O2OMMdaKYEtlvLm1ukyDORNFMioLrH6uLZMOtlJSUkRglZubK/r4Dh06VJR1p3Xy8ccfizQeTWZM1QOp0uDChXWzbFNgtnbtWlF9kIIwZ2dnzJo1C6+//jrMmlektMy7CItH7/Gvh4DkfaLbn3P97J5fVyBxD+AfA0x40zRKr3uGS0sK+mqqABtTmV5A/WPBmS3GGGOsGYw0zxYNe4hXj9fqat7BlqaYGKx8ri2TDraWL19+zcFpX375pbhcCWXF/vnnH1gUTWarOA2oKgPsNKUbLAiV1Nz0ErD3i4Y32zhBpqqRxl51uxEmx9kHsHMBqkqkQNE32thb1PCsnCkEpIwxxpip0/5eGjCzVZAMfK+e0sg1EPA29kjatlHaayY25m6EzNw4eUozc1cUAPkJUobHklQUAj9PBxrNhaWKHIOscQvh6+MDmUIBk/1ypkxb0l4g7aiJBFv1z8pxsMUYY4w1O9gyZDfCA9/Urfe4FeZOaa+u30zHdVaMR8ube3Yr9wIsKpu18SXgvYiGgZZXB+DpC1DdvtI8sjOB6vFiaUdgEjizxRhjjJnumC16jcJU4NDiuvHf+irqZYxuhBXcjZCZ67gtOpinzJYlOL4c2PM5kHmy4e1ztgDBfaV1c5mBXFOco1Fmzni4GyFjjDFmkmO26Nhm5SwxpY/g0xl4YKd2mhZzprTTBFvWndky6TFbrDkVCc28SEbmKWDvQuDYLw1v94kG7vlX6jJpbjTBVsYJoLoCsG3+xHd6Uf+HggtkMMYYY9em/b3Uc2bryE91gRahOTotINAiXCBDwsGWubKEYCv/ErBkGlBaNw+aMP1r8+6r3C4ccPEHSjKAlINA+DDjbk+DLhAm3gWTMcYYM6kxW3rKbP33EbDjXaCmou62qHFAzExYCir9LnBmi5klc55riyooXtwO0OTE9SvUUHXBCW8Brv4w+y9oCrBOrAQSdppAsMWZLcYYY8xoY7ZomhrvTtJ8oDQui5771J8Nx3rf8w+gsLeYrBZRabsRFsCacWbLnLMnmvmcTKGrWnNln5XKuR9ZUnebkzcwZxPgHgooLGSXDB9eF2zhBSNvDI/ZYowxxlpGR5mt2BXAn3OvfD9NF3PDl4CtIyyN0rGdtFLSqAeTlbGQI1sr5OwN2LkCVcVAQSLg0wkmrbocuLQLWHpTw9unfgp0mgy4SBNVW4z26mxW6iGgqhSw007HbHic2WKMMcZa9tMpk6vDLVXbMlpXCrSipwDTFgJyG+MeI+hRrUugtFKUKmUITb2atJ5wsGWuaIf1DAcyYqVxW6YcbFGg9Xkf6Z+tPiqAETYYFqldeylTV5gkzbkVpZ6k0Bh4zBZjjDFm2DFbGSeBxRPrrjv7AP3mAF1nADnngI4TAIWtRX8qtc7qYSHVZdKwEXMseqYDltMx1BqZQ5GMsjzg2zENAy2aN2vyR5YbaNUft0VEV0Jj4m6EjDHGmMEmNf7vQ2DRkLrrUz4Bno4HRj4H+HQEOk+x+EBLsLGHioJMzbAXK8WZLXNmDsHW5leBrFN11+mMzvWfAZpZxS0Zjds6thRI+M+428HdCBljjLEWqpfZSo8FTqwAetwG+HW98p9kxQFLbpCqEWvMWmv8QlnG5OILlGZLFyvFwZY5o26EmhLqpqY4Q10I46e62+78w7jd6Yw1biv9GFBeADh6GGc7uBshY4wx1rpqhEd/Bk79BVSVAHs+B8KGAsPmA1Fj6h5bkAwsuxnIOt3wOWb+aN2BFnH0rOvpZKU42DJnroF1gY2poUCLvpQIDf58IcM6Uub1uQcBnpFA3gVpkGz0JOMHWzypMWOMMXZNssqiuisUaGkk7pIutyyVSppTtcGME0B5vWAiuD8we63oRmf1nLykJqjfPlaGgy1z5hYgLYvSYHJyztetD3nc+gKt+l0JKdi6sMV4wRaP2WKMMcZapiCpbt3FH3h4rxRcbXoZOLMG+O2Oy/8mqA9w8xLAPZhbW8NRXf69LLftbaJUmuU8ZOa3xayOa0Dd2YKaStNqGc04srtWAWNegtWi0q7kxO9SVUajj9myzrKrjDHGWEuoBj4iBQqRY4AHdkiV9Gis/JhXmw6ynjgFzN3KgdaVMltlOshsrZwF/DgFSD4Ic8KZLXNGXwI2DkBNhVTlxSsSJoHS6VTWlHhFwapFjgLcQ4DCZOD030CPW4zYjZADLcYYY6xZgnoDzzYxJp6OtUIGAKmHgWFPAiMX8InMqx2COHpKRx9tzWxVlQHnNwE15WbXPZMzW2Y/15Y6wMqNh8n452lp2XEi4BECqyZXAL3vltbrFwsxKHWwxVktxhhjrG3ot/Se9cCzicCo5/m39VqcPHUzZuvidinQojlM/WNgTjizZe5ovgYqrZ59Vpogz9joTA9N4kuMkcUxRT1vB7a9KRXJKM0BnL2N042Qi2OwFqqtrUV1dbVB2k2pVIrXqqiogNwM++SbEmO1pa2tLRQKhcFejzGjof8rexf+AFrUjTC3be0Vt05adppodgEuB1vmzrujtKQiDKagfj9azXgla0cDZf27Axk0T8fvwMAHDfv63I2QtXiXUSEjIwMFBQUGfU0KEoqLiyEzsx9SU2PMtvTw8IC/vz9/hoyxRqXf81vfIspa4Nx6aT16stm1LAdb5o7GA5HCVGNvCVBbDax/Vlof/rT1ViBsSp/ZwLr50qzyPW417JxbnNliLaQJtHx9feHk5GSQA2cKEGpqamBjY8MH6mbYlvSaZWVlyMrKEtcDAtQFnBhj1s1JB5mtxN1AWQ7g4A6EDYa54WDL3GnKi1KBDGNLOVS3HjHKmFtienrdCexbKI2t2/YWMOk9A744j9liLes6qAm0vLzUP5IGwMGW+belo6OjWFLARfsPdylkjMFJXfqdxltRkQs7p5Y3Suxv0rLLNLM8kc8d4y0ms5XccPJaY0g5IC1DBwHthxh3W0wNVc6Z9IG0fvDbqwfHlCGkuSR0hTNbrAU0Y7Qoo8VYS2n2G0ON9WOMmTg7V0Bu2/oiGTRtDlVzJt3NsxYAB1vmziMUkNtIs5sbe3LjZHWw1fE6426HKZeBbz9MCn62vd10cEz9khdPAt6PBDa8AFQUtv11ecwWawUeN8V4v2GMtZlMVleRsDVzbdFYrcoiKblAJ/PNEAdb5s7GDvDqIK1nnjLutqSoi2PQ/BOsaSOfk5bHfgE2vnh5wBW3VsoQ0tmfvV8Af8wFSrJ11I2Q/90ZY4wxZkbjtmJXSsuYmVIVSDNknlvNGvLrKi2pBLyxVBQBJZnSun83422HqWs/FJj8kbROwRRVJ9SgwGv3pw0ff36DVFijLTQBHVd4Y1Zu+/btImOnzyqLI0eOxOOPPw5jjdW6//77xVg7Ozs7HDt2zKjbwxhjDSoStrQbYVUpEL+5LtgyUxxsWQK/LsbPbBWpqyFSpRh7V+Nthznod5806zz5cw6w+zNpfdfH0jxlCjvgqfPAqBfrqvC0ZTwedyNkVmTv3r2iMMPkyeZRHvjSpUsiAKTAqK3Wr1+PH3/8EWvWrEFSUhK6deMTX4wxE+DUym6EF3cAtZWARxjg2xnmioMtS+CrzmxlnjZ+sOWmro7Irm7Ec0D3W6X1TS8Ba+cDW16Trg99AnDxBYY8JgVelHbPv6SDAhk8dxGzfN9//z0effRR7Ny5E2lpRh7HamAXLlwQJdcHDx4s5rqiaoSMMWa2wdb5DdKyw3izPobhYMsSaKL9nHNSJTtjKEiWlm6Bxnl9cxxrN+NroP/90vVD30tLGgA64tm6CoY0GXLjsvotxt0ImXUoKSnBb7/9hoceekhktijL05Tdu3eje/fucHBwwMCBA3Hy5EntfYmJiZg6dSratWsHZ2dndO3aFf/884/2/h07dqB///6wt7cXgc1zzz0nyqxfCWWtVq1addnEv5ptCw8PF8tevXqJx1K3P43vvvsOnTt3FtsZHR2NhQsXXvF1Zs+eLYJMymjJ5XJ06KAey9tIfn4+7r77bvH+qHLgxIkTcf78eW03RB8fH/z+e1335p49ezaYM2vXrl3ivdOcWowxprcxWyoVcH6TtN5xglk3NAdbloAO0O1cAGU1kHfRONuQtE9a8nitlpn4HjDjW+nzIxR8yRV19wf3lZbJ+1v/2XDpd6aLCWuragx+oddtiRUrVoigpFOnTrjzzjvxww8/NPkcTz/9ND788EMcPHhQBBcUXGlKlT/yyCOorKwUmbETJ07g3XffhYuL9P+ZmpqKSZMmoV+/fjh+/Di++uorkUl74403Wt22Bw5IVVw3b96M9PR0/Pnnn+L60qVL8fLLL+PNN9/EmTNn8NZbb+Gll17CTz/91OTzfPrpp3j99dcRHBwsMnp79uy5YlB26NAh/P3336LLJbUPvSd6/xTsDR8+XIxt0wRm9Nrl5eWIi4vTBpv0/nlqAMaYXsdsZZ6Uek3ZOErj3c0Y9zGwBFSdhYpk0AF50l7Ap5Px5tgKH2741zZnlBbvfjMQNgQoTgcCeze8n75g9i8CLm5r/WvwmC3WRuXVtejysro7hwGdfn0CnOya/zNFgQ8FWeS6665DYWGhCA7qZ4vIK6+8gnHjxol1Cl4oQPnrr79w8803i8zQjTfeiJiYGHF/RESE9u8osxQSEoIvvvhCBCYU2FFg8+yzz4rAiDJKLUXBHqGiFtT1r/42UkA4Y8YMbQbs9OnT+PrrrzFr1qzLnsfd3R2urq5ivBo9T1PZNspgUZBFmT3qaqgJ6ug9UfZt5syZoq3oNQgFnJRxo+ejAIzeLy1HjBjR4vfJGLNiTq3IbJ1T/+ZEjABspQnTzRVntiwF9Wetv3MaWmmOtHQPNc7rmzv3ICmL1fhgjeblIrnxrZufQuDS78zynT17VmSJbrvtNnGdxivdcsstIgBrbNCgurlaPD09RSaMMjjkscceE5mqIUOGiIAnNjZW+1h6DP1t/TnI6HHUfTEl5SoTlbdQaWmpGH913333iaya5kLbRbe3Fm0/tcuAAXXTc1CQV//9UyBFQV12drY2UKULBVmU/aKMWePglTHGdD5m6/ymhse3ZowzW5YiYiSw9f+k7BZlMgw5kLCmSppwrv4/FNMNRw+gXTiQnwBkxEqfc0txgQzW1t3QViGyTPpE3dkoG0PBgCaYoddtLgqq6O8DAwMbPCeNL6JMFGV+mmPOnDmYMGEC1q1bh40bN+Ltt98WGSYaD9Ua9F4ad2XUdFm8EgreyLffftsgMCKUudInyuhRAEqBFl2oGyNltqg7JXW7pG3XZMUYY6xlma285j2eHqfpMWUBwRZntiwFFVJQ2EspWiqUYUiaPrg0aa6Dh2Ff2xoEqItkpNedYW/dPFv8787Q6oCBuvMZ+lI/g3Q1FGQtWbJEBEVUQl1zoXFVFHz9+uuvDR6/b596jKl6XNK5c+dEIQoN6lb34IMPivFTTz75pAh6CD1GM85Jg7rkUfc96op4pW6CNBarfle++sUlaD4sUltbq73Nz89PbPfFixcRFRXV4KIpqNEatP3UVvv3140Bzc3NFVnBLl2kKUSozYcNG4bVq1fj1KlTGDp0qCgmQuPYqHth3759ReEQxhhrNsd2LRuzFb9FOlFM1bY9Qsy+ofnoy5Kq22kGEJ5bb9jX1vTBpQGQZjq7t0nzl8aOIONE6/5ek9mC+ZZNZexq1q5dK4Im6nZHc0vVv9D4q8ZdCamQxJYtW0QVQioY4e3tjWnTpon7aALgDRs2ICEhAUeOHMG2bdu0gdjDDz+M5ORkkeWighEUkFBXw/nz519xvNbo0aNFZu3o0aOiMAUFcba2ttr7fX194ejoKObIyszMFOPMyGuvvSayap999pkIBqlYx+LFi/HRR+pJ0VuBKhTecMMNmDt3rqgqSMEojXELCgoSt2tQN0EKUKkSIXVfpPdGhTNofBeP12KMtZi9m7SsKgGUmmOS5pR8l8bWmjs+MrYknSZKy7P/Gme8liZNzHRLU/6duhG2Cpd+Z5aNgqmxY8c22VWQgi0KcuqPvXrnnXfwv//9D3369EFGRoaYBLh+hokqElKARUU2OnbsqC25TkEJlYGnsWE9evQQgRMFeC++qJ6AvAmUbaNMGWWLbr/9djz11FMNKvlRt0kKqChrRNksTdBD3Rmp9DsFWNS1j4IcKhfflswWoeej9z1lyhQx/oyydPSe6geA9FrUDvXHZtF649sYY6xZ7NUVlzUB19Uoa4H4zRZR8l1DpmppbV0rVFRUJH7E6Yyjm5s6Om8mpVKJrKwscfayNZWqWqQgCfgkRuou9lQ84Gyg4Of4cuCvB6RKhLPW6O1lDNqWpqQoHfgoWvpcn09reVWe1MPAt6OlKQKeOGndbakHltaWFRUVIqtDB/U0v5OhNDVmi5lfWxpr/9EXS/v/NiZzaUtz2U5T16AdZTLg/7wBZQ0w/8zV52SlqYR+mCANS3n6AqCwMfvYgPciS+IRCvjFSN3GTtZNSql3FOSJ1w8z3GtaE1d/wMlb+lyzTrf877WnU/gAljHGGGMGJpPVzSdaWXz1x176r67ku4kGWi3FwZal6SXNMYP/Pmpev1hdKEiUlhxs6e9Lqk1FMrgbIWOMMcZMYNxW5TW6ESbulZY0/6iFsKpg68svv0T79u1F1wYqp0v97i1O33sBe3egJAOI/c3AmS2eY8ski2Rw6XfGGGOMmcK4rUr1VEFXGq+VrD42Dx0IS2E1wdZvv/0mKkZR5SiqMEWDm2kuFepPanFVCfvPldY3vQRUler/NTnYMu0iGVz6nTHGGGPGZO967QIZmaeAqmLAzhXw6wZLYTXBFpXLpXK399xzj5hPZNGiRaIi1A8//ACLM/I5oF17oDQb+PP+uoNtfaCzEIUp0jpntvQfbNEXEbV5S3Dpd8YYY4wZk10zxmwlqbsQhvQH5PqdwN2QrCLYqqqqwuHDh0VpYA2qMEPXaYJKi6OwBSa8Ja3HrQV2fay/gCtxt1RdRm4rFXJg+uEVCdg6AdVlQNaZFv4xT2rMGGOMMVOY2Dj/2sFW2CBYEsso83ENOTk5Yn4QPz+/BrfTdZqYsrHKykpxqV/eUVPGki4tQY+nMrwt/bs26zgRsmFPQfbfB8CW16DKPAnV+LcAF9+6MwunV0sZE03xhVaQHV0qatypOk6Aitb0+D6N1pYmQQZZ+2GQnd8A1alVUPl2af6fJu0TZ1VUChuo1G1n3W2pW5bWlpr3o7kYkub1eEYS821LzX7Tmt9LU2Rp/9/GZC5taS7baeoat6PMyVM6XizN0R6LNKBSQZa0TzxGGTzQcEXeWqkl+4dVBFst9fbbb+O111677Pbs7Gwxh0hLPwyqwU87nMHna+h8D9yyLsLp7J+QnfwDqrPrUdFhKmraRcLl4GeQVxWLAKm05xyUDHyq5c+vUsH37L/iH6MgbCIq9Tz+zahtaQIcwibAg4Kt/YuQHXkjVA7qs0RXoqyFy8FP4HL0G3G1JGw8StWfkbW3pS5ZWltWV1eL90TzNNHFUKj96KQY4Xm2zLctaZ+h/Sc3N7fBRMnmytL+v43JXNrSXLbT1DVuR2elPWjUVnleKoqaOF5UFCXDpzgdKrktsuxCABOvqVBcfI0S9tYWbHl7e0OhUCAzM7PB7XTd3//yrm8LFiwQxTTqZ7ZCQkLg4+PTqkmN6ceO/tYo/7Q3fwfl0eGQrXsS8upSOJ1e3uBuGVRwOfYtnAbMAvy6AhWFQEkW4N3h2s998g/IKwvFqnvHIUA7ddZMT4zelsbmMwuqEz9AnnkSvmeWQDXhzSs/tigVsjX/g+zCFnFVNWgenMe8BGd1H2irb0sdsrS2pBNK9CNCE+LSxdAs4QDdVBijLWmfof8DLy8vi5nU2JL+v43JXNrSXLbT1F3Wjj4h4nZHVTkcfJs4XkzfKi0De8I30PSrW7fk+80qgi07Ozv06dMHW7ZswbRp07Q7AV2fN2/eZY+3t7cXl8ZoZ2nNPx7tbK39W53oew/QdRpw6AcgYSeQEw84tQOmfAJsfweI3wT5ufXA7o+BU6sAVS0w80eg6/QrPyelT/+cI617hEHu2V6aD0rPjN6WRiUHxr0G/HIjZIe+g6z/HGksl0ZtDUDB1c73gZSD0m02jsANX0AWc9NlUxpbd1vqliW1Jb0Hej+ai6HQ2U/N6+nrdel5//rrL+3vgDFda1uoPR544AH8/vvvyM/Px9GjR/H444+jZ8+e+OSTT4zellei2W8s5f+BWNr7MSZzaUtz2U5T16Adnb2l28ryIGuqXZP3SfeHDmr6fhPTkn3DKoItQpmqWbNmoW/fvujfv7/4sSotLRXVCa1mYOKwJ6VLfVFjRbCFbW80vH3nB0DYUGleBFvHy5/vrwfq1qd8bJBAiwGIHANEjAIubgN+mCAFxFTePz8RyDrVcOCpdyfgph8Af8spn8rYlVA375dffhnr1q0TvRbatWsnpvig24YMkSbHTE9PF7ebg/Xr1+PHH3/E9u3bERERIXpoMMaY2XL0lJbledcojjEYlsZqgq1bbrlF+2OckZEhzg7Sj1njohlWJ2pMw+u9Z0nZrcyTwAdR0m0BPYDxb0oH7WV5wLJbgNzzdX9DB//MMCionfop8PM0IO8icEAaj9Xgy6zn7cDAhwH3IP5UmNW48cYbReXZn376SQQnFHBR7wUaO6TRVLdxU3XhwgUEBARg8GDLO/BgjFkhJy9pWVb3naxVmgPknJPWQwbA0ph+nk6HqMtgYmKiqDS4f/9+DBhgeR9oi3lFAc4+ddf73Qfc/CPgGVF3W/px4KcpwLvtgc97Nwy05h2mXKpht9natQsDHt4H3Pg9MGielK0c93/A7HXAU+cBGsvFgRazIgUFBfjvv//w7rvvYtSoUQgLCxM9GGj87fXXX9+gS8uqVau01/fs2SNOvFHfe+r1QPfRY44dOybup6wSXaegje6nuRkp+Dl79myD11+9ejV69+4tnocCPSqwVL+4yPnz5zF8+HBxP83zuGnTpqu+n9mzZ+PRRx9FUlKSeP327ds3+TjqXnj33XeLbB1t28SJE8VraboS+vr6im6IGvReKYDT2LVrl+gyX1ZW1oLWZoyxNgZbqkZVUpP3S0ufzoCTOgNmQawms8WukinpM1sa50PdBimLRR47ClSVAZteBg5+2/Tf0gG/tzr7xQzLxh6IuUm6MKZv9MNIc7zp+zUoQFHa1HVLprnlmtFF2cXFRVwoWBo4cGCTY24bo8JHU6dOxaRJk7Bs2TJxIo7GRDXlhRdewIcffigGej/44IO49957sXv3bnEfBXkU8Hz22WcYNmyYyEjdf//94r5XXnlFjA+eMWOG6EVBJ/moOteVXkfj008/RWRkJL755hscPHhQFHi6UlBGwdXff/8tijc9++yz4v2cOnVKBGkU4FHAeNNNN4nA7MyZM3B0dBRTnkRHR2PHjh3o16+fCNQYY0yvnNRBFM3NStMPOdQrOJe4R1qGDrTID4GDLQaMegHocRvg0qhLpZ0TMPkDYMxLQOwK4PhyaUZvGidEAVpTY7kYY5aHAq23AvX6EhRSXVY77/k0wM65WRXwaHzT3LlzsWjRIpFlGjFiBG699VZ07970PIIUYFFA8u2332ozTqmpqeI5GnvzzTfF85HnnnsOkydPFlUb6e8oi0W30ZhgQpmt//u//8Mzzzwjgq3NmzeL4GbDhg0IDJTa8K233hJZqCtxd3eHq6urCLKu1PVRE2RR0Kfparh06VJROZeCzunTp4ttpoCN7Ny5E7169RLPRwEYBVu01LwvxhjTK1tH6QQa/Z5Qdqt+sKXJbIVa1mTGGtz/i0lnjqmqHRXDaIqDO9B/LjB3C3DfRmDgQxxoMcZMbsxWWlqaCECuu+46EUhQ0EVBWFOoKyAFYvXL91LXw6bUD9g03fCy1HPAHD9+HK+//ro2u0YXCtioGAd1z6NsEgVAmkCLDBrU9gMKel4KMut3h6dy6506dRL3EQqkTp8+LcYrUxZr5MiR4kJtQ/OpUTdKus4YYwbtSlhSbw6tmiogPVZaD+5rkR8EZ7YYY4xdHZ2NpCyTHtEYIxrnRAGEtlw5vW4LUOA0btw4cXnppZcwZ84ckV2i7na6mq9Ks23UPZCUlJSI7BZ1FWxqe4wpJiYGnp6eItCiC2XoKLNFY9uoeyIFXFyAgzFmMP4xQGEycOZvIFR9oogqKddWAg4eDesFWBAOthhjjF0dBRjN6M7X5jFb8hrqE6izqSSoa2D9ghj1UQbol19+EQWTNGO8KABpKcqeUZYsKqrp8audO3dGcnKyyHRpsmL79knzybQFPS8FpzQOTBMwUeVF2hZ635rAkMaRUQEPGsc1dOhQMT6L3vPXX38tin44O+v5c2WMMQ0agnL2H+Doz8CQxwEXHyD1iHRfUG+LnUaIuxEyxhgzaxRkjB49WgRPsbGxSEhIwMqVK/Hee+/hhhtuaPJvbr/9dpGdomIW1O2OxlR98MEHLZ4ImKYTWbJkichuUUBDz7V8+XK8+OKL4v6xY8eiY8eOYkwXdTmkghpUcKOtOnToIN4bdVmkqoL03HfeeSeCgoIavGfqJvjrr7+KSoTUxZEm4qTCGTS+i8drMcYMKmqsNAdoRSGw+RXptjR1sBXY22I/DA62GGOMmTUKImjs0scffywCiW7duoluhBSIfPHFF03+DVXvW7NmjSjzToEIBUAUOLW0+9+ECROwdu1abNy4UVT2o2qItB1Ufp5QcPPXX3+hvLxcjAmjro3UnU8XFi9ejD59+mDKlCliHBh1xfznn38adHukgKq2trbB2Cxab3wbY4zpnVwBTFsorR9bBiTtb5jZslAyFX07s2uWCKbqUFSyl36gW4LOnNJAaprvhH50WetxW+oOtyW35ZVQlT3KDIWHhxt0zFGTY7YMjLI999xzj/iupxLp5sqYbWms/Udf+LvS+trSXLbT1F21HVc9DBxbKmW5xGTGKmB+HOBWNw+gJcUGPGaLMcaYVaLuf1SqnbreUTc8mqfq5ptvNutAizHGTN6YV4BTq4Ac9QTxHqFmFWi1FIfsjDHGrFJGRoYY50TFJp544gnMnDlTOy8VY4wxPXH1A0Y8XXe945XnHbQEnNlijDFmlWjiYbowxhgzsMGPAVVlQFEaMPI5i25+DrYYY4wxxhhjhi2WMbrtlVnNAXcjZIwxdhmuncRag/cbxhhriIMtxhhjWpqy4WVlZdwqrMU0+0398vOMMWbNuBshY4wxLYVCAQ8PD1Gylzg5ORmkfLgplH63FMZoS3pNCrRov6H9h/YjxhhjHGwxxhhrxN/fXyw1AZehDtZpXhaaj4WDLfNtSwq0NPsPY4wxDrYYY4w1QgfoAQEBYjLK6upqg7QPBQe5ubnw8vLiiUTNtC2p6yBntBhjrCHuRsgYY6xJdOBsqINnChDoYN3BwYGDLW5LxhizGFwggzHGGGOMMcb0gIMtxhhjjDHGGNMDDrYYY4wxxhhjTA94zFYLJmksKipq1TiE4uJiHoegA9yWusNtyW1panif5LY0RbxfWl9bmst2mjpLb8cidUzQnIncOdhqBtpZSEhISFs/G8YYY4wxxpiFxAju7u5XfYxM1ZyQzMpRdJ6WlgZXV9cWz1lCkS8FacnJyXBzc9PbNloDbktuS1PE+yW3o6nhfZLb0hSZy35pLttp6iy9HVUqlQi0AgMDr5m548xWM1AjBgcHt+lDoR3NEnc2Y+C25LY0RbxfcjuaGt4nuS1Nkbnsl+aynabOzYLb8VoZLQ3L60TJGGOMMcYYYyaAgy3GGGOMMcYY0wMOtvTM3t4er7zyilgybktTwfslt6Wp4X2S29IU8X5pfW1pLttp6rgd63CBDMYYY4wxxhjTA85sMcYYY4wxxpgecLDFGGOMMcYYY3rAwRZjjDHGGGOM6QEHW4wxxhhjjDGmBxxsMcYYY4wxxpgecLDFTEZNTY2xN4ExpkcHDhxAQUGBWFepVNzWzOj4d4cx/v/RNw62WqmoqAiZmZliXalU6vIzsTppaWno378/Xn75ZWNvitmjffLvv//G8ePH+SBCB225aNEi/PPPP0hISBC3cYDQOqmpqbj55psxcOBAvPfee+I2mUzW1o/I6vDvju7w7471/e7w/4/u8P9Py3Cw1QpvvPEGoqKi8MUXX0iNKOdmbK0nnngC7du3h7+/P+bNm9fq52EQwWpERAQ+/fRTDB8+HA8//DBOnz4tmoZPCLTM888/j8jISKxcuRL33HMPZs+eLdqSAgQOuFrmySefRGhoKCorKxEdHQ1HR0f+d20F/t3RHf7dsb7fHf7/0R3+/2k5jhJaoKSkRHyRrFq1SgQIhw4dwu7du8V9fADWMklJSQgKChJnw3bt2iWWgYGBLXwWprF8+XJs2LABa9aswcaNG7FkyRIkJiaKIIHwCYHmycnJwfXXX4+tW7di3bp12Lx5M37++WeUl5eL2whnZJqH/q9dXV2xZcsWbN++HatXr0bfvn217cjfmc3Dvzu6w7871ve7w/8/usP/P61n/P8EE1f/gMDe3l6coX3qqafw+eefiwOzv/76SxyI8RnvlrWlQqEQwRZ1H6TLkSNH8Mwzz+Cjjz4SB7gVFRV6+kQtqy01S9oPKVgdPXq0aNsbbrhBtCudEPjkk08aPJZdmZ2dHSZPniz+v0eMGCH+r8ePHy8OGgYPHnxZ+7MrKy0tFQdfx44dw7Bhw8RZ7m7duonvTep2xEHrtf+/Cf/u6K4tbWxs+HfHCn53+P9HP23Jx22tZ9OGv7V4dMBfXV0tzs5qvqgps+Xm5iauT5w4EZs2bcL69esxffp0PnhoQVvSF/Trr7+OSZMmIS8vD3FxcejRo4doSzoQmzFjBhYuXMhteo22pANWOnNH/eQp21pVVSUCBmJra4vOnTuLbh733Xeftu1Zwx8SakNqP/r/pja644474OLiIu6nYg50lpbO1lI3FOom8+ijj4ofHdZ0W9K+SfvehAkTtPdRoEUBK7VrYWEht99V0P8wtRXtj/y7o9u2DAgI4N8dHbSlKf/u8HGb/tqSj9tajzNbV/DKK6+gd+/euO666/DCCy8gPT1dfMFQoKXph0xjjOisI3WPocGChM94X7stqa2oLSlTcP/994tg6/fff8dvv/2G2NhY8Zi9e/eK4gSs6bakQJ/aiQoP0AFsTEyM6Kr1f//3fyJzQD90n332mRh75OnpyW3ZhA8//BBz5swR65qDMdovNYEW/c8PGTIEZWVloi3poIIyXnPnzjW58Qim1JZ0sNWYJos1duxY0a7x8fHiOn9fNkQBPX1PUoaA9jX6bqS2o4MdTVvx707r2jI3N1e05aBBg/DAAw/w704r2nLatGnaXj30PUmZ6h07dpjM7w4ft+mvLfm4rY1U7DLz5s1T/X97ZwJUZdXG8SNGLkhpKjgppqNoaWUIaBkmLY5GWZJJqSU6GjmWubeNToMxSZukSRqJ00DZkHs5aS65JBkEZSoYhgYoaZqWImiyPN885/ve97ssmsDl3nM4/99MwX3v4vHn8973PdvzdO/enVauXEkzZsygPn36UHBwMBUVFdmvKSsrkz8/+ugj6tu3Ly1ZssR+rqKiAlav4DIoKIjOnz8vnz906BDt2bOHysvL5X/M6dOnaciQIfK9lmdQs8vAwEAqLS2lS5cu0axZs8jf35/atWtHPXr0oO3bt0tt999/P73++utQ+D+ysrJo2LBh5OXlRb6+vtKn4zntSHZ2dqXHfL6z31OnTsFnLV0y+/bto1tvvVV6BP8nMzNTfi/27t2bEhMT6YknnqCAgACaPn16JU3WdySuO7V3OW3aNPs1OTk5uO7Uw+ULL7wgn//nn39o5syZ8nrj7usO7tsa1iXu2+oHOlsOcCeJb6LuuOMO+vDDD+3jv/76K7Vt21Ze+IqLiytd9Jjw8HAaPnw4/fjjj7Rq1SqaM2cOmc6/ueQL34ULF6q9z/Las2dPioqKcmmbdXU5ZcoU21thYaGMQ0f8/Pxo/vz5Lm+3qvCN6iOPPEIpKSk0duxYCgkJkTcNVxoosY7zhYcHV3hAAIMqtXfJnbBOnTrR22+/bT82HR7E44GSp556iv7++2/7OF9HuCP7119/2cccneK6U3uXZ86cqeaRwXWn9i6tASd2d/z4cbddd3Df5jqXuG+rO+hsVeHEiRPk4eFhf3HwrAGTnJxM1157Le3cubPaF/SWLVvkKAAHo6enJ82bN68e/yRmunRk69atciYxNTXVpe1tjC65888ujxw5QqZj3WCdO3eOdu3aJX9fu3atHLWzbgocB1FqmpXh0dp3332XTKcuLq3HY8aMoaFDh7q8zarCDuPj4+3vO+vc5g4pzxRcziOuO/V36QiuO7VzeaWBEldfd3Df5h6XjuD8uTLobFWBRxH79+8vZwuqjoDxkq1Ro0bJ360v7by8PDkD06RJExo/frwc8Qa1c8nHebnWjh075PKENm3ayFlEXhoHrs7l6NGj7bjk137xxRdyKUCrVq3olVdekRdGzMRU588//5SzVby0jc9lxvEmIjc3lzZt2iRdent704QJE+zZbVA7lxY8E3bffffZswygsifr2sIzCBERETXqwXXHOS5x3XGeS3ded3Df5nqXuG+rHchGWIWWLVvKlM+7du0SBw4ckBtArUw7L730koiMjJRVyK2MhFyDh9OfpqWlieDg4PpuoTPWJVeeX758uUyjv3HjRtG/f393N19bl+Xl5SI9PV3s379fptGHy5rhwaa2bdvKulrsa/78+XJDt2OmQa4rsmLFCpnUgV1yWmNQN5ccl/z4ueeek1nh2rRpA5X/c+foyUomwuUwOPul9RrHVPm47jjHJSdkSkxMxHXHCS7ded3BfZt7XOK+rRaQQRw9epTi4uLo8OHD1Xrs1lQp880339CAAQNo0qRJld6/ceNGuummm+SmUdNxlssffvhBPub9W5wsw0Sc5TIjI8M+5pjMxSSu1qXjY55BjY2NlfsEv/32W3nMWjrDz/E+OBNxlktOgGMytfFozR7wHhlelu64ZKegoIBMx1kurZlXTtSE6079XObn59vvb4jrDv9bc2IOXjZbFdy3uccl7ttqjzBpiQvvJ+A1p7zxz5oerzpNvmjRIvn7m2++KW8YOAOPxdKlS2UmnpoSO5gEXMKlrnHJNwQLFiyo9JjZv38/PfbYYzLBw4MPPiiXBXOmPVNxtsuqWR1NoS4emdWrV1O3bt3k78eOHaORI0dS+/bt6eTJk2Qqznb5xx9/kKno4JL//GeffVZ+fzz99NNyD5njcxa4b4NLHTCmzlaLFi1E69atZbE9runEU92MNU2+bNkyWbCNl2fwFOnYsWNFRESErB3DBXa5Lsfs2bPFiBEj5HSqyfVh4BIudY1LXr72+eef23XxrCUw7du3l8W0U1NT5efk5eWJXr16CVNxtkv+HBOpi0eGi7wHBASIN954Q/j7+8vi2pmZmdKtqTjbpY+PjzAV1V1u27ZNtGvXTi5LzMjIEElJSXZhXceli7hvg0ttIEPgzCoPPfSQzI7DqYejo6PtdKZr1qyRqS6XLVtWbUN3UlISvfjii3Kkdtu2bW5qvVrAJVw2prj8+eefZX0yzii6e/duN7VeLeDSvR779esnR/RvueUW+vrrr53UGr2BS3NcxsTEUNeuXWXCDYaXyCckJMgaXlYSsg0bNsjZOdy3waUONLrOVtW1xtZ0M3+phIaGyt9nz54tT9IDBw7YNWEuXrxY6X1XShFrCnAJl405Li1KSkpo/fr1ZCJwqZ5H3kf06quv0ieffEImApfmuazaTt6bx1nvHnjgAZm9tEuXLrKj17p1a1lg2VqWzN/djuC+DS5VpVF1tubOnSsLPXLqUT4ZHUdlPvvsM7rnnnvsxzwyw2kseZSGN/0BuERcmneOm5wOHy7V9GgycGmey6rttEq+fPzxx9SrVy/Z2eLVB7xHjIsn87ERI0bIDhmAS11oFHu2Tp06JUJCQsS6detEnz59xObNm8WoUaPEokWL7NdwWtIBAwbI3/l1hYWFMq3lzJkzxdChQ93YerWAS7g0KS4d02mbAlyq7dFE4NI8l5dr58KFC+XzI0eOFNOnTxexsbHi9ttvFx07dhQdOnQQ8fHxYsOGDeLMmTPydSbvn7eASw2gRgCv6+WRGSs1Lk+BT5s2Ta75tdIP8+gJF9scOHCgLJrL6WN5ZIfTYObk5Lj5b6AOcAmXKoK4hEvVQEzCpYroEpdX086aUslz2v6mTZvSunXrXNJOHYBL9WkUnS3eIOnn52evN2Z++eUXGjZsGN15553yMa8zvvHGG2nixIl2jQ7ebOnh4SE3XmKtL1wiLtUF5zhcqgZiEi5VRJe4vFI777rrrsu+75133pE1oHgPGYBLXWgUna0PPviAgoKCKD09vdJxzqrDmXa4188nNI/YVN2jkZycfNmN8yYCl3CpIohLuFQNxCRcqogucXmldnbu3JlSUlLsY3v37qWDBw/S5MmTydfXl+Lj48n0PbeOwKX6aNHZutwJZR3nCuY33HADvffee/bmSus4j5JwYbyqn2HqTBZcwqWKIC7hUjUQk3CpIrrEZX3ayUkxoqKi7Ndy+R2eibv77rtlsgzTgEv9UT5BRlFRUaXHjpsheZMn07lzZ7mxMi4uTmRlZdnP83FPT09x9uxZuRHe8b0eHsr/1Z0OXMKliiAu4VI1EJNwqSK6xGV923nNNdeIc+fO2QmMnn/+ebFy5Uqxe/dumSzDJOCycaBsj6O0tFRMmjRJhIWFiccff1xWEGf45CsrK5O/8wl58eJF8dNPP8kMNnwSL168WOTn51f6LK6Ubr3XROASLlUEcQmXqoGYhEsV0SUuG6KdjJ+fn5090RTgspFBCsIbNrnI3qBBg+T64vHjx8usNTyt7MjChQvJ29ubZs2aJR+vWrVKFr7jLDu8+XLq1KnUrl072rp1K5kKXMKliiAu4VI1EJNwqSK6xKUu7dQBuGx8KNnZWrx4saxuXlxcbK9XXbJkiSy4t3r1arm++OWXX5YpSzmrjuN6Y17PO2bMGBoyZIjMaLNnzx4yGbiESxVBXMKlaiAm4VJFdIlLXdqpA3DZ+FCys8W1FkJCQiptDORsK3zSBgQE0OnTp+nkyZN09uzZy24gdHzOZOASLlUEcQmXqoGYhEsV0SUudWmnDsBl48Pte7bS09Plz4qKCvuYt7e3aN68ufjqq6/sdcWpqakiOjpaZGdniy+//FK0b99eeHl52e+puv74uuuuE6YBl3CpIohLuFQNxCRcqogucalLO3UALg3BXb28tWvXylSenPrzt99+k8es4nbZ2dkUHh5O119/vaxo3qpVK7mmt7CwkJ588kl6+OGH3dVsJYFLuFQRxCVcqgZiEi5VRJe41KWdOgCXZtGE/+fqDt6nn34qs9B069ZNHDt2TPTu3VssXbrU6vzJ0Y6jR4+KrVu3iszMTDF48GDx6KOPyufDw8NFp06dxPvvv+/qZisJXMKliiAu4VI1EJNwqSK6xKUu7dQBuDQQV/bsysrK5M/vv/9ebpTk4nVvvfUW9ezZk7Zv3y6fKy0tvez7jx8/ToGBgRQXF0emA5dwqSKIS7hUDcQkXKqILnGpSzt1AC7NxSWdrUOHDlXbCGmdnAcOHJDVwsPCwuznqr42Ly+Pjh07JrPV8EZLPtlNBS7hUkUQl3CpGohJuFQRXeJSl3bqAFyCBu1spaSkUJcuXeQICK/dTUxMrPHEXL58OfXq1Uv+ZBxTgpaUlNCcOXPkGuGBAwdSbm6ukf9qcAmXKoK4hEvVQEzCpYroEpe6tFMH4BI0eGdr8+bN8oSNj4+nTZs20YwZM8jT05MSEhLkieg4SsKjHxMmTKDg4GAqKiqSxy5dumR/1t69e2nnzp1kKnAJlyqCuIRL1UBMwqWK6BKXurRTB+ASNGhnyxr5iI6Olut0HU++yZMnU1BQEK1Zs6ba+zZs2CCfe+2112SBO85cU1BQQCYDl3CpIohLuFQNxCRcqogucalLO3UALoFL6mxZdRO4rgJnrfH09BSlpaXyWExMjKzDsH79enHixAl5rLy8XP689957Rb9+/cS8efNEYGCgfI+Pj48wGbiESxVBXMKlaiAm4VJFdIlLXdqpA3AJaoScMFU6ZcoUmWkmLS3NPs7Tzt7e3nb2FWukhI/36NGDduzYYb/2/Pnz8v1Nmzal0NBQ2rdvH5kIXMKliiAu4VI1EJNwqSK6xKUu7dQBuARXQ507W7///rucMvbx8ZHZZm677TZZzM46cXNycqhjx440d+7cSoXvmA4dOlRKA5qVlUX9+/enpKQkMhG4hEsVQVzCpWogJuFSRXSJS13aqQNwCRq8s1VcXEyRkZGySviRI0fs45y5Zty4cfL3c+fOUUxMDLVo0cJew2utZR00aBBNnDixLn90owMu4VJFEJdwqRqISbhUEV3iUpd26gBcApfs2WrZsqVo1qyZGDdunOjatasoKyuTx8PCwsTBgwdlNXFvb28xevRo0bdvXxERESHy8/PlWtaCggJx8uRJMXz48Lr80Y0OuIRLFUFcwqVqICbhUkV0iUtd2qkDcAlqSxPucdX6XULIjZC8iZKpqKgQHh4eYsyYMcLLy0skJCTYryssLBShoaHyxA4KChLfffeduPnmm8WKFSuEr69vXf7oRgdcwqWKIC7hUjUQk3CpIrrEpS7t1AG4BC7pbNVESEiIeOaZZ0RkZKQ8kRk+mXNzc0VmZqZIS0sTffr0kc8DuHQViEu4VBHEJTyqBmLSPJe6tFMH4BJcFnIShw8fJl9fX8rIyLCPOW6uBHDpDhCXcKkiiEt4VA3EpHkudWmnDsAlaNA6W9bE2O7du0WrVq1krQUmOjpaTJ06Va7zBXDpahCXcKkiiEt4VA3EpHkudWmnDsAluBquEU4q4Jaeni5GjBghtmzZIqKiokRJSYlITk42vsAdXLoHxCVcqgjiEh5VAzFpnktd2qkDcAmuCnICFy5coO7du1OTJk2oWbNmFBsb64yPNRK4hEsVQVzCpWogJuFSRXSJS13aqQNwCf4NpyXIGDx4sPD39xcLFiwQzZs3d8ZHGgtcwqWKIC7hUjUQk3CpIrrEpS7t1AG4BFfCaZ2t8vJy0bRpU2d8lPHApfOAS7hUEcQlPKoGYtI8l7q0UwfgErgs9TsAAAAAAAAAgP9S72yEAAAAAAAAAACqg84WAAAAAAAAADQA6GwBAAAAAAAAQAOAzhYAAAAAAAAANADobAEAAAAAAABAA4DOFgAAAAAAAAA0AOhsAQAAAAAAAEADgM4WAAAAAAAAADQA6GwBAAAAAAAAQAOAzhYAAAAAAAAACOfzH67aHr0g7EByAAAAAElFTkSuQmCC",
+      "text/plain": [
+       "<Figure size 1000x400 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "fig, ax = plt.subplots(figsize=(10, 4))\n",
+    "ax.plot(flow_ts[\"time\"], flow_ts[\"flow\"], label=\"Absolute flow\")\n",
+    "ax.plot(signed_flow_ts[\"time\"], signed_flow_ts[\"flow\"], label=\"Signed flow\")\n",
+    "ax.set_ylabel(\"Flow (cfs)\")\n",
+    "ax.set_title(f\"{line_name} profile-line flow\")\n",
+    "ax.legend()\n",
+    "ax.grid(True, alpha=0.3)\n",
+    "fig.autofmt_xdate()\n",
+    "plt.show()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/README.md
+++ b/examples/README.md
@@ -216,6 +216,16 @@ This notebook demonstrates techniques for detailed face data extraction from 2D 
 - Visualizing time series data for selected faces
 - Creating profile-specific result datasets for analysis
 
+### [413_profile_line_flow_extraction.ipynb](413_profile_line_flow_extraction.ipynb)
+
+This notebook demonstrates the callable profile-line flow API for completed 2D plan HDF results.
+
+**Key contents:**
+- Extracting a flow time series across a named RAS Mapper profile/reference line
+- Retrieving peak Q and peak time for the same line
+- Comparing absolute and signed face-flow aggregation
+- Validating API output against manual selected-face aggregation
+
 ### [14_fluvial_pluvial_delineation.ipynb](14_fluvial_pluvial_delineation.ipynb)
 
 This notebook demonstrates how to delineate fluvial and pluvial flooding areas based on the timing of maximum water surface elevations.

--- a/ras_commander/Decorators.py
+++ b/ras_commander/Decorators.py
@@ -69,6 +69,8 @@ def standardize_input(file_type: str = 'plan_hdf'):
             # ras_object is always keyword-only, never in args
             ras_object = kwargs.pop('ras_object', None)
             ras_obj = ras_object or ras
+            if ras_object is not None and 'ras_object' in param_names:
+                kwargs['ras_object'] = ras_object
 
             # If no hdf_input provided, return the function unmodified
             if hdf_input is None:

--- a/ras_commander/hdf/HdfResultsMesh.py
+++ b/ras_commander/hdf/HdfResultsMesh.py
@@ -193,6 +193,556 @@ class HdfResultsMesh:
     @staticmethod
     @log_call
     @standardize_input(file_type='plan_hdf')
+    def get_profile_line_flow_timeseries(
+        hdf_path: Path,
+        line_name: str,
+        mesh_name: Optional[str] = None,
+        profile_lines_path: Optional[Union[str, Path]] = None,
+        direction: str = "absolute",
+        truncate: bool = False,
+        ras_object: Optional[Any] = None,
+    ) -> pd.DataFrame:
+        """
+        Return a flow time series across a RAS Mapper profile/reference line.
+
+        The method first looks for native HEC-RAS reference-line internal-face
+        metadata in the plan HDF. If no matching native reference line is found,
+        it reads the RAS Mapper Profile Lines feature file and uses
+        ``HdfMesh.get_faces_along_profile_line()`` to select mesh faces
+        geometrically. Face flows are read through ``get_mesh_timeseries()``.
+
+        Parameters
+        ----------
+        hdf_path : Path
+            Plan HDF path, plan number, or other input accepted by
+            ``@standardize_input(file_type='plan_hdf')``.
+        line_name : str
+            Profile/reference line name to extract.
+        mesh_name : Optional[str], optional
+            2D flow area name. Required when the line resolves to more than one
+            mesh area.
+        profile_lines_path : Optional[Union[str, Path]], optional
+            Explicit RAS Mapper Profile Lines feature path. If omitted, the
+            method attempts to use ``ras_object.rasmap_df.profile_lines_path``.
+        direction : str, default "absolute"
+            ``"absolute"`` sums absolute face flows to avoid face-normal sign
+            cancellation. ``"signed"`` preserves native HEC-RAS face-flow signs;
+            orientation is controlled by the underlying face normals.
+        truncate : bool, default False
+            Passed to ``get_mesh_timeseries()``.
+        ras_object : Optional[Any], optional
+            RAS project object used for plan-number and rasmap path resolution.
+
+        Returns
+        -------
+        pd.DataFrame
+            Columns: ``time``, ``flow``, ``line_name``, ``mesh_name``,
+            ``direction``, ``face_count``, and ``selection_source``.
+        """
+        direction = HdfResultsMesh._normalize_profile_line_direction(direction)
+        selected_faces, resolved_mesh_name, selection_source = (
+            HdfResultsMesh._resolve_profile_line_faces(
+                hdf_path=hdf_path,
+                line_name=line_name,
+                mesh_name=mesh_name,
+                profile_lines_path=profile_lines_path,
+                ras_object=ras_object,
+            )
+        )
+
+        face_ids = HdfResultsMesh._unique_int_values(selected_faces['face_id'])
+        if not face_ids:
+            raise ValueError(f"No valid face IDs resolved for profile line '{line_name}'.")
+
+        face_flow = HdfResultsMesh.get_mesh_timeseries(
+            hdf_path,
+            resolved_mesh_name,
+            "Face Flow",
+            truncate=truncate,
+        )
+        if "face_id" not in face_flow.coords:
+            raise ValueError(
+                f"Face Flow output for mesh '{resolved_mesh_name}' does not include face_id coordinates."
+            )
+
+        available_face_ids = {
+            int(face_id) for face_id in face_flow.coords["face_id"].values.tolist()
+        }
+        missing_face_ids = [
+            face_id for face_id in face_ids if face_id not in available_face_ids
+        ]
+        if missing_face_ids:
+            preview = missing_face_ids[:10]
+            more = "" if len(missing_face_ids) <= len(preview) else (
+                f" and {len(missing_face_ids) - len(preview)} more"
+            )
+            raise ValueError(
+                f"Face Flow output for mesh '{resolved_mesh_name}' is missing selected "
+                f"face IDs: {preview}{more}"
+            )
+
+        selected_flow = face_flow.sel(face_id=face_ids)
+        values = np.asarray(selected_flow.values, dtype=float)
+        if values.ndim == 1:
+            values = values.reshape((-1, 1))
+
+        if direction == "absolute":
+            flow = np.abs(values).sum(axis=1)
+        else:
+            flow = values.sum(axis=1)
+
+        result = pd.DataFrame({
+            "time": pd.to_datetime(face_flow.coords["time"].values),
+            "flow": flow,
+            "line_name": str(line_name),
+            "mesh_name": resolved_mesh_name,
+            "direction": direction,
+            "face_count": len(face_ids),
+            "selection_source": selection_source,
+        })
+        result.attrs["face_ids"] = face_ids
+        result.attrs["units"] = face_flow.attrs.get("units", "")
+        result.attrs["variable"] = "Face Flow"
+        return result
+
+    @staticmethod
+    @log_call
+    @standardize_input(file_type='plan_hdf')
+    def get_profile_line_peak_flow(
+        hdf_path: Path,
+        line_name: str,
+        mesh_name: Optional[str] = None,
+        profile_lines_path: Optional[Union[str, Path]] = None,
+        direction: str = "absolute",
+        ras_object: Optional[Any] = None,
+    ) -> pd.DataFrame:
+        """
+        Return peak flow across a RAS Mapper profile/reference line.
+
+        For ``direction="absolute"``, the peak is the maximum absolute-flow
+        sum. For ``direction="signed"``, the peak timestep is selected by
+        maximum signed-flow magnitude and the returned ``peak_flow`` preserves
+        the native sign at that timestep.
+        """
+        flow_df = HdfResultsMesh.get_profile_line_flow_timeseries(
+            hdf_path=hdf_path,
+            line_name=line_name,
+            mesh_name=mesh_name,
+            profile_lines_path=profile_lines_path,
+            direction=direction,
+            truncate=False,
+            ras_object=ras_object,
+        )
+        if flow_df.empty:
+            return pd.DataFrame(
+                columns=[
+                    "line_name",
+                    "mesh_name",
+                    "peak_time",
+                    "peak_flow",
+                    "direction",
+                    "face_count",
+                    "selection_source",
+                ]
+            )
+
+        peak_index = flow_df["flow"].abs().idxmax()
+        peak_row = flow_df.loc[peak_index]
+        return pd.DataFrame([{
+            "line_name": peak_row["line_name"],
+            "mesh_name": peak_row["mesh_name"],
+            "peak_time": peak_row["time"],
+            "peak_flow": peak_row["flow"],
+            "direction": peak_row["direction"],
+            "face_count": peak_row["face_count"],
+            "selection_source": peak_row["selection_source"],
+        }])
+
+    @staticmethod
+    def _normalize_profile_line_direction(direction: str) -> str:
+        normalized = str(direction).strip().lower()
+        if normalized not in {"absolute", "signed"}:
+            raise ValueError("direction must be either 'absolute' or 'signed'")
+        return normalized
+
+    @staticmethod
+    def _resolve_profile_line_faces(
+        hdf_path: Path,
+        line_name: str,
+        mesh_name: Optional[str],
+        profile_lines_path: Optional[Union[str, Path]],
+        ras_object: Optional[Any],
+    ) -> Tuple[pd.DataFrame, str, str]:
+        native_faces = HdfResultsMesh._get_native_profile_line_faces(
+            hdf_path=hdf_path,
+            line_name=line_name,
+            mesh_name=mesh_name,
+            ras_object=ras_object,
+        )
+        if not native_faces.empty:
+            resolved_mesh_name = HdfResultsMesh._resolve_single_mesh_name(
+                native_faces,
+                mesh_name,
+                line_name,
+            )
+            return native_faces, resolved_mesh_name, "reference_line_internal_faces"
+
+        resolved_profile_lines_path = HdfResultsMesh._resolve_profile_lines_path(
+            profile_lines_path=profile_lines_path,
+            ras_object=ras_object,
+        )
+        if resolved_profile_lines_path is None:
+            raise ValueError(
+                f"Profile/reference line '{line_name}' was not found in native HDF "
+                "reference-line internal faces, and no RAS Mapper profile-lines "
+                "feature path could be resolved. Pass profile_lines_path or initialize "
+                "a ras_object with rasmap_df."
+            )
+
+        cell_faces = HdfMesh.get_mesh_cell_faces(hdf_path)
+        if cell_faces is None or cell_faces.empty:
+            raise ValueError(f"No mesh cell faces found in HDF file: {hdf_path}")
+
+        profile_line = HdfResultsMesh._read_profile_line_geometry(
+            profile_lines_path=resolved_profile_lines_path,
+            line_name=line_name,
+            target_crs=getattr(cell_faces, "crs", None),
+        )
+        selected_faces = HdfMesh.get_faces_along_profile_line(
+            profile_line=profile_line,
+            cell_faces_gdf=cell_faces,
+            mesh_name=mesh_name,
+        )
+        if selected_faces is None or selected_faces.empty:
+            raise ValueError(
+                f"No mesh faces found along profile line '{line_name}'. "
+                "Check that the line crosses the target mesh and that the HDF "
+                "and feature file use compatible coordinates."
+            )
+
+        resolved_mesh_name = HdfResultsMesh._resolve_single_mesh_name(
+            selected_faces,
+            mesh_name,
+            line_name,
+        )
+        selected_faces = selected_faces[selected_faces["mesh_name"] == resolved_mesh_name]
+        return selected_faces, resolved_mesh_name, "profile_lines_geometry"
+
+    @staticmethod
+    def _get_native_profile_line_faces(
+        hdf_path: Path,
+        line_name: str,
+        mesh_name: Optional[str],
+        ras_object: Optional[Any],
+    ) -> pd.DataFrame:
+        reference_hdf_path = HdfResultsMesh._resolve_reference_line_hdf_path(
+            hdf_path,
+            ras_object=ras_object,
+        )
+        reference_faces = HdfMesh.get_reference_line_internal_faces(
+            reference_hdf_path,
+            mesh_name=mesh_name,
+        )
+        if reference_faces.empty or "profile_name" not in reference_faces.columns:
+            return reference_faces.iloc[0:0].copy()
+
+        target_name = str(line_name).strip()
+        profile_names = reference_faces["profile_name"].fillna("").astype(str).str.strip()
+        selected = reference_faces.loc[profile_names == target_name].copy()
+        if selected.empty:
+            selected = reference_faces.loc[
+                profile_names.str.lower() == target_name.lower()
+            ].copy()
+
+        if selected.empty:
+            return selected
+
+        selected["face_id"] = pd.to_numeric(selected["face_id"], errors="coerce")
+        selected = selected.dropna(subset=["face_id"]).copy()
+        selected["face_id"] = selected["face_id"].astype(int)
+        if "station_start" in selected.columns:
+            selected = selected.sort_values(
+                ["mesh_name", "station_start", "station_end", "face_id"],
+                na_position="last",
+            )
+        return selected.reset_index(drop=True)
+
+    @staticmethod
+    def _resolve_reference_line_hdf_path(
+        hdf_path: Path,
+        ras_object: Optional[Any],
+    ) -> Path:
+        hdf_path = Path(hdf_path)
+        reference_faces_path = "Geometry/Reference Lines/Internal Faces"
+        if HdfResultsMesh._hdf_contains_path(hdf_path, reference_faces_path):
+            return hdf_path
+
+        geom_hdf_path = (
+            HdfResultsMesh._geometry_hdf_from_ras_object(hdf_path, ras_object)
+            or HdfResultsMesh._geometry_hdf_from_plan_hdf_path(hdf_path)
+        )
+        if geom_hdf_path is not None and geom_hdf_path.exists():
+            return geom_hdf_path
+        return hdf_path
+
+    @staticmethod
+    def _hdf_contains_path(hdf_path: Path, hdf_internal_path: str) -> bool:
+        try:
+            with h5py.File(hdf_path, "r") as hdf_file:
+                return hdf_internal_path in hdf_file
+        except Exception:
+            return False
+
+    @staticmethod
+    def _geometry_hdf_from_ras_object(
+        hdf_path: Path,
+        ras_object: Optional[Any],
+    ) -> Optional[Path]:
+        if ras_object is None:
+            return None
+
+        plan_df = getattr(ras_object, "plan_df", None)
+        if plan_df is None or plan_df.empty:
+            return None
+
+        target = HdfResultsMesh._normalized_path_string(hdf_path)
+        for _, row in plan_df.iterrows():
+            result_paths = []
+            for column in ("HDF_Results_Path", "hdf_path", "results_path"):
+                if column in row and pd.notna(row[column]):
+                    result_paths.append(row[column])
+
+            if not any(
+                HdfResultsMesh._normalized_path_string(path_value) == target
+                for path_value in result_paths
+            ):
+                continue
+
+            plan_number = row.get("plan_number")
+            if pd.notna(plan_number) and hasattr(ras_object, "get_hdf_paths"):
+                try:
+                    paths = ras_object.get_hdf_paths(str(plan_number))
+                    geom_hdf_path = paths.get("geometry")
+                    if geom_hdf_path is not None and Path(geom_hdf_path).exists():
+                        return Path(geom_hdf_path)
+                except Exception:
+                    pass
+
+            geom_path = row.get("Geom Path")
+            if pd.notna(geom_path):
+                geom_hdf_path = Path(str(geom_path) + ".hdf")
+                if geom_hdf_path.exists():
+                    return geom_hdf_path
+
+        return None
+
+    @staticmethod
+    def _geometry_hdf_from_plan_hdf_path(hdf_path: Path) -> Optional[Path]:
+        if hdf_path.suffix.lower() != ".hdf":
+            return None
+
+        plan_path = Path(str(hdf_path)[:-4])
+        if not plan_path.exists():
+            return None
+
+        geom_file = None
+        try:
+            with open(plan_path, "r", encoding="utf-8", errors="ignore") as plan_file:
+                for line in plan_file:
+                    if line.startswith("Geom File="):
+                        geom_file = line.split("=", 1)[1].strip()
+                        break
+        except Exception:
+            return None
+
+        if not geom_file:
+            return None
+
+        plan_name = plan_path.name
+        if "." not in plan_name:
+            return None
+        project_name = plan_name.rsplit(".", 1)[0]
+        geom_hdf_path = hdf_path.parent / f"{project_name}.{geom_file}.hdf"
+        return geom_hdf_path if geom_hdf_path.exists() else None
+
+    @staticmethod
+    def _normalized_path_string(path_value) -> str:
+        try:
+            return str(Path(str(path_value)).resolve()).lower()
+        except Exception:
+            return str(path_value).lower()
+
+    @staticmethod
+    def _resolve_single_mesh_name(
+        selected_faces: pd.DataFrame,
+        mesh_name: Optional[str],
+        line_name: str,
+    ) -> str:
+        if mesh_name is not None:
+            return str(mesh_name)
+
+        mesh_names = [
+            str(value)
+            for value in selected_faces.get("mesh_name", pd.Series(dtype=object)).dropna().unique()
+        ]
+        if len(mesh_names) == 1:
+            return mesh_names[0]
+        if not mesh_names:
+            raise ValueError(
+                f"Profile line '{line_name}' did not resolve a mesh name. "
+                "Specify mesh_name explicitly."
+            )
+        raise ValueError(
+            f"Profile line '{line_name}' intersects multiple mesh areas: {mesh_names}. "
+            "Specify mesh_name explicitly."
+        )
+
+    @staticmethod
+    def _resolve_profile_lines_path(
+        profile_lines_path: Optional[Union[str, Path]],
+        ras_object: Optional[Any],
+    ) -> Optional[Path]:
+        candidate_paths = []
+        ras_obj = ras_object
+        if profile_lines_path is not None:
+            candidate_paths.append(profile_lines_path)
+        else:
+            if ras_obj is None:
+                try:
+                    from ..RasPrj import ras as ras_obj
+                except Exception:
+                    ras_obj = None
+
+            rasmap_df = getattr(ras_obj, "rasmap_df", None)
+            if rasmap_df is not None and not rasmap_df.empty and "profile_lines_path" in rasmap_df.columns:
+                for value in rasmap_df["profile_lines_path"].tolist():
+                    if isinstance(value, (list, tuple, set)):
+                        candidate_paths.extend(value)
+                    elif pd.notna(value):
+                        candidate_paths.append(value)
+
+        project_folder = getattr(ras_obj, "project_folder", None)
+        for candidate in candidate_paths:
+            if candidate is None or (not isinstance(candidate, (list, tuple, set)) and pd.isna(candidate)):
+                continue
+            path = Path(candidate)
+            if not path.is_absolute() and project_folder is not None:
+                path = Path(project_folder) / path
+
+            resolved = HdfResultsMesh._resolve_profile_lines_file(path)
+            if resolved is not None:
+                return resolved
+        return None
+
+    @staticmethod
+    def _resolve_profile_lines_file(path: Path) -> Optional[Path]:
+        if path.is_file():
+            return path
+        if path.is_dir():
+            for pattern in ("*.shp", "*.geojson", "*.json", "*.gpkg"):
+                matches = sorted(path.glob(pattern))
+                if matches:
+                    return matches[0]
+        return None
+
+    @staticmethod
+    def _read_profile_line_geometry(
+        profile_lines_path: Path,
+        line_name: str,
+        target_crs: Optional[Any] = None,
+    ):
+        from shapely.geometry import LineString
+        from shapely.ops import linemerge, unary_union
+
+        profile_lines_gdf = gpd.read_file(profile_lines_path)
+        if profile_lines_gdf.empty:
+            raise ValueError(f"No profile-line features found in {profile_lines_path}")
+
+        name_column = HdfResultsMesh._profile_line_name_column(profile_lines_gdf)
+        target_name = str(line_name).strip()
+        names = profile_lines_gdf[name_column].fillna("").astype(str).str.strip()
+        selected = profile_lines_gdf.loc[names == target_name].copy()
+        if selected.empty:
+            selected = profile_lines_gdf.loc[names.str.lower() == target_name.lower()].copy()
+
+        if selected.empty:
+            available_names = sorted(names[names != ""].unique().tolist())
+            raise ValueError(
+                f"Profile line '{line_name}' not found in {profile_lines_path}. "
+                f"Available profile lines: {available_names}"
+            )
+
+        if (
+            target_crs is not None
+            and selected.crs is not None
+            and selected.crs != target_crs
+        ):
+            selected = selected.to_crs(target_crs)
+
+        geometries = [geom for geom in selected.geometry if geom is not None and not geom.is_empty]
+        if not geometries:
+            raise ValueError(f"Profile line '{line_name}' has no valid geometry.")
+
+        if len(geometries) == 1:
+            profile_line = geometries[0]
+        else:
+            merged_geometry = unary_union(geometries)
+            if merged_geometry.geom_type in {"LineString", "LinearRing"}:
+                profile_line = merged_geometry
+            else:
+                profile_line = linemerge(merged_geometry)
+        if profile_line.geom_type == "MultiLineString":
+            profile_line = max(profile_line.geoms, key=lambda geom: geom.length)
+
+        if profile_line.geom_type == "LinearRing":
+            profile_line = LineString(profile_line)
+        if profile_line.geom_type != "LineString":
+            raise ValueError(
+                f"Profile line '{line_name}' geometry must be a LineString; "
+                f"got {profile_line.geom_type}."
+            )
+        return profile_line
+
+    @staticmethod
+    def _profile_line_name_column(profile_lines_gdf: gpd.GeoDataFrame) -> str:
+        for candidate in (
+            "Name",
+            "name",
+            "Profile",
+            "ProfileName",
+            "profile_name",
+            "LineName",
+            "line_name",
+        ):
+            if candidate in profile_lines_gdf.columns:
+                return candidate
+
+        non_geometry_columns = [
+            column
+            for column in profile_lines_gdf.columns
+            if column != profile_lines_gdf.geometry.name
+        ]
+        if len(non_geometry_columns) == 1:
+            return non_geometry_columns[0]
+        raise ValueError(
+            "Could not identify a profile-line name column. Expected one of "
+            "Name, name, Profile, ProfileName, profile_name, LineName, or line_name."
+        )
+
+    @staticmethod
+    def _unique_int_values(values) -> List[int]:
+        result = []
+        seen = set()
+        for value in pd.to_numeric(pd.Series(values), errors="coerce").dropna():
+            int_value = int(value)
+            if int_value not in seen:
+                seen.add(int_value)
+                result.append(int_value)
+        return result
+
+    @staticmethod
+    @log_call
+    @standardize_input(file_type='plan_hdf')
     def get_mesh_faces_timeseries(
         hdf_path: Path,
         mesh_name: str,

--- a/tests/test_hdf_profile_line_flow.py
+++ b/tests/test_hdf_profile_line_flow.py
@@ -1,0 +1,214 @@
+"""Real-HDF coverage for profile/reference-line flow extraction."""
+
+from pathlib import Path
+import shutil
+
+import h5py
+import numpy as np
+import pandas as pd
+import pytest
+
+from ras_commander import HdfResultsMesh, init_ras_project
+
+
+VALIDATION_ROOT = Path(
+    r"H:/Symphony/ras-commander/CLB-214/profile_line_flow_validation"
+)
+LINE_NAME = "Upstream"
+MESH_NAME = "Perimeter 1"
+
+
+@pytest.fixture(scope="module")
+def validation_paths():
+    project_dir = VALIDATION_ROOT / "project" / "Chippewa_2D_profile_line_flow"
+    paths = {
+        "project_dir": project_dir,
+        "plan_hdf": project_dir / "Chippewa_2D.p02.hdf",
+        "profile_lines_dir": VALIDATION_ROOT / "profile_line_input",
+        "selected_faces_csv": VALIDATION_ROOT / "selected_faces.csv",
+        "absolute_csv": VALIDATION_ROOT / "flow_timeseries_absolute.csv",
+        "signed_csv": VALIDATION_ROOT / "flow_timeseries_signed.csv",
+        "manual_csv": VALIDATION_ROOT / "manual_face_flow_validation.csv",
+        "peak_csv": VALIDATION_ROOT / "peak_flow.csv",
+    }
+    missing = [str(path) for path in paths.values() if not path.exists()]
+    if missing:
+        pytest.skip(
+            "CLB-214 Chippewa profile-line validation artifacts are not available: "
+            + ", ".join(missing)
+        )
+    return paths
+
+
+@pytest.fixture(scope="module")
+def absolute_flow_df(validation_paths):
+    return HdfResultsMesh.get_profile_line_flow_timeseries(
+        validation_paths["plan_hdf"],
+        LINE_NAME,
+        mesh_name=MESH_NAME,
+        profile_lines_path=validation_paths["profile_lines_dir"],
+        direction="absolute",
+    )
+
+
+def test_profile_line_flow_timeseries_matches_validation_csv(
+    validation_paths,
+    absolute_flow_df,
+):
+    expected = pd.read_csv(validation_paths["absolute_csv"], parse_dates=["time"])
+
+    assert list(absolute_flow_df.columns) == [
+        "time",
+        "flow",
+        "line_name",
+        "mesh_name",
+        "direction",
+        "face_count",
+        "selection_source",
+    ]
+    assert len(absolute_flow_df) == len(expected) == 1633
+    assert absolute_flow_df["line_name"].unique().tolist() == [LINE_NAME]
+    assert absolute_flow_df["mesh_name"].unique().tolist() == [MESH_NAME]
+    assert absolute_flow_df["direction"].unique().tolist() == ["absolute"]
+    assert absolute_flow_df["selection_source"].unique().tolist() == [
+        "profile_lines_geometry"
+    ]
+    assert absolute_flow_df["face_count"].unique().tolist() == [6]
+    assert absolute_flow_df["time"].tolist() == expected["time"].tolist()
+    np.testing.assert_allclose(absolute_flow_df["flow"], expected["flow"])
+
+    selected_faces = pd.read_csv(validation_paths["selected_faces_csv"])
+    assert absolute_flow_df.attrs["face_ids"] == selected_faces["face_id"].tolist()
+    assert absolute_flow_df.attrs["units"] == "cfs"
+
+
+def test_profile_line_peak_flow_matches_validation_csv(
+    validation_paths,
+    absolute_flow_df,
+):
+    expected = pd.read_csv(validation_paths["peak_csv"], parse_dates=["peak_time"])
+    peak = HdfResultsMesh.get_profile_line_peak_flow(
+        validation_paths["plan_hdf"],
+        LINE_NAME,
+        mesh_name=MESH_NAME,
+        profile_lines_path=validation_paths["profile_lines_dir"],
+    )
+
+    assert list(peak.columns) == [
+        "line_name",
+        "mesh_name",
+        "peak_time",
+        "peak_flow",
+        "direction",
+        "face_count",
+        "selection_source",
+    ]
+    assert len(peak) == 1
+    assert peak.loc[0, "line_name"] == LINE_NAME
+    assert peak.loc[0, "mesh_name"] == MESH_NAME
+    assert peak.loc[0, "peak_time"] == expected.loc[0, "peak_time"]
+    assert peak.loc[0, "peak_flow"] == absolute_flow_df["flow"].max()
+    np.testing.assert_allclose(peak.loc[0, "peak_flow"], expected.loc[0, "peak_flow"])
+
+
+def test_profile_line_signed_direction_matches_manual_validation(validation_paths):
+    signed = HdfResultsMesh.get_profile_line_flow_timeseries(
+        validation_paths["plan_hdf"],
+        LINE_NAME,
+        mesh_name=MESH_NAME,
+        profile_lines_path=validation_paths["profile_lines_dir"],
+        direction="signed",
+    )
+    expected_signed = pd.read_csv(validation_paths["signed_csv"], parse_dates=["time"])
+    manual = pd.read_csv(validation_paths["manual_csv"], parse_dates=["time"])
+
+    assert signed["direction"].unique().tolist() == ["signed"]
+    assert signed["selection_source"].unique().tolist() == ["profile_lines_geometry"]
+    assert signed["time"].tolist() == expected_signed["time"].tolist()
+    np.testing.assert_allclose(signed["flow"], expected_signed["flow"])
+    np.testing.assert_allclose(signed["flow"], manual["manual_signed_face_sum"])
+    assert (manual["signed_difference"].abs() == 0).all()
+
+
+def test_profile_line_missing_name_raises(validation_paths):
+    with pytest.raises(ValueError, match="Profile line 'Definitely Missing' not found"):
+        HdfResultsMesh.get_profile_line_flow_timeseries(
+            validation_paths["plan_hdf"],
+            "Definitely Missing",
+            mesh_name=MESH_NAME,
+            profile_lines_path=validation_paths["profile_lines_dir"],
+        )
+
+
+def test_profile_line_plan_number_preserves_ras_object(validation_paths):
+    ras_object = init_ras_project(
+        validation_paths["project_dir"],
+        "7.0",
+        ras_object="new",
+        load_results_summary=False,
+    )
+    ras_object.rasmap_df.at[0, "profile_lines_path"] = [
+        str(validation_paths["profile_lines_dir"] / "Profile Lines.shp")
+    ]
+
+    result = HdfResultsMesh.get_profile_line_flow_timeseries(
+        "02",
+        LINE_NAME,
+        mesh_name=MESH_NAME,
+        ras_object=ras_object,
+    )
+
+    assert len(result) == 1633
+    assert result["selection_source"].unique().tolist() == ["profile_lines_geometry"]
+    np.testing.assert_allclose(result["flow"].max(), 2316.1405715942383)
+
+
+def test_profile_line_uses_native_reference_faces_when_present(
+    tmp_path_factory,
+    validation_paths,
+):
+    native_hdf = tmp_path_factory.mktemp("profile_line_native") / "Chippewa_2D.p02.hdf"
+    shutil.copy2(validation_paths["plan_hdf"], native_hdf)
+    selected_faces = pd.read_csv(validation_paths["selected_faces_csv"])
+
+    attr_dtype = np.dtype([("Name", "S64"), ("SA-2D", "S64")])
+    face_dtype = np.dtype([
+        ("Reference Line ID", "<i4"),
+        ("Face Index", "<i4"),
+        ("FP Start Index", "<i4"),
+        ("FP End Index", "<i4"),
+        ("Station Start", "<f8"),
+        ("Station End", "<f8"),
+    ])
+    face_rows = []
+    for station, face_id in enumerate(selected_faces["face_id"].astype(int).tolist()):
+        face_rows.append((0, face_id, 0, 0, float(station), float(station + 1)))
+
+    with h5py.File(native_hdf, "a") as hdf:
+        reference_group = hdf.require_group("Geometry/Reference Lines")
+        for dataset_name in ("Attributes", "Internal Faces"):
+            if dataset_name in reference_group:
+                del reference_group[dataset_name]
+        reference_group.create_dataset(
+            "Attributes",
+            data=np.array([(b"Native Upstream", b"Perimeter 1")], dtype=attr_dtype),
+        )
+        reference_group.create_dataset(
+            "Internal Faces",
+            data=np.array(face_rows, dtype=face_dtype),
+        )
+
+    native = HdfResultsMesh.get_profile_line_flow_timeseries(
+        native_hdf,
+        "Native Upstream",
+        direction="absolute",
+    )
+    expected = pd.read_csv(validation_paths["absolute_csv"], parse_dates=["time"])
+
+    assert native["mesh_name"].unique().tolist() == [MESH_NAME]
+    assert native["selection_source"].unique().tolist() == [
+        "reference_line_internal_faces"
+    ]
+    assert native["face_count"].unique().tolist() == [6]
+    assert native["time"].tolist() == expected["time"].tolist()
+    np.testing.assert_allclose(native["flow"], expected["flow"])


### PR DESCRIPTION
## Summary
- Adds `HdfResultsMesh.get_profile_line_flow_timeseries()` and `get_profile_line_peak_flow()` for extracting 2D mesh face flows along RAS Mapper profile/reference lines
- Supports both native HEC-RAS reference-line faces and geometric face selection
- Includes signed and absolute flow direction modes
- Example notebook `413_profile_line_flow_extraction.ipynb` with executed output and flow timeseries plot

## Files changed
- `ras_commander/hdf/HdfResultsMesh.py` — +550 lines, two new public methods + internal helpers
- `ras_commander/Decorators.py` — fix ras_object passthrough for decorated methods
- `tests/test_hdf_profile_line_flow.py` — 6 tests (1 skipped)
- `examples/413_profile_line_flow_extraction.ipynb` — executed notebook with matplotlib figure
- Docs updates: `docs/api/hdf.md`, `docs/reference/dataframe-reference.md`, `docs/user-guide/hdf-data-extraction.md`, `docs/examples/index.md`, `examples/README.md`

## Test plan
- [x] 6 unit tests passing, 1 skipped
- [x] Notebook executed with real plan HDF data
- [x] Flow timeseries plot renders in notebook

Closes CLB-214

🤖 Generated with [Claude Code](https://claude.com/claude-code)