### PR TITLE
Add bridge hydraulic method comparison API

### DIFF
--- a/docs/api/geometry.md
+++ b/docs/api/geometry.md
@@ -58,14 +58,15 @@ Inline structure parsing.
 - `get_bridge_abutment(geom, river, reach, station)` - Get abutment data
 - `get_bridge_approach_sections(geom, river, reach, station)` - Get approach sections
 - `get_bridge_coefficients(geom, river, reach, station)` - Get coefficients
-- `get_hydraulic_methods(geom, river, reach, station)` - Get bridge low-flow/high-flow method selections from `Bridge Culvert-`, `BR Coef=`, and `WSPro=` records
-- `set_hydraulic_methods(geom, river, reach, station, low_flow_method=..., high_flow_method=...)` - Set bridge modeling approach method selections
+- `get_hydraulic_methods(geom, river, reach, station)` - Get bridge low-flow/high-flow method selections from `Bridge Culvert-`, `Deck Dist Width WeirC`, `BR Coef=`, and `WSPro=` records
+- `set_hydraulic_methods(geom, river, reach, station, low_flow_method=..., high_flow_method=..., weir_coefficient=...)` - Set bridge modeling approach method selections and related coefficients
 - `get_bridge_htab(geom, river, reach, station)` - Get HTAB settings
 
 Accepted `low_flow_method` values are `energy`, `momentum`, `yarnell`, and `wspro`.
 Accepted `high_flow_method` values are `energy` and `pressure_weir`.
 Optional compute flags are `use_energy`, `use_momentum`, `use_yarnell`, and `use_wspro`.
-Unsupported combinations, such as disabling the selected low-flow method, raise `ValueError`.
+Optional coefficient fields include `momentum_cd`, `yarnell_k`, `pressure_flow_submerged_inlet_cd`, `pressure_flow_submerged_inlet_outlet_cd`, and positive `weir_coefficient`.
+Unsupported combinations, such as disabling the selected low-flow method or selecting Momentum/Yarnell without an existing or supplied coefficient, raise `ValueError`.
 
 ### Culvert Methods
 

--- a/docs/api/geometry.md
+++ b/docs/api/geometry.md
@@ -58,7 +58,14 @@ Inline structure parsing.
 - `get_bridge_abutment(geom, river, reach, station)` - Get abutment data
 - `get_bridge_approach_sections(geom, river, reach, station)` - Get approach sections
 - `get_bridge_coefficients(geom, river, reach, station)` - Get coefficients
+- `get_hydraulic_methods(geom, river, reach, station)` - Get bridge low-flow/high-flow method selections from `Bridge Culvert-`, `BR Coef=`, and `WSPro=` records
+- `set_hydraulic_methods(geom, river, reach, station, low_flow_method=..., high_flow_method=...)` - Set bridge modeling approach method selections
 - `get_bridge_htab(geom, river, reach, station)` - Get HTAB settings
+
+Accepted `low_flow_method` values are `energy`, `momentum`, `yarnell`, and `wspro`.
+Accepted `high_flow_method` values are `energy` and `pressure_weir`.
+Optional compute flags are `use_energy`, `use_momentum`, `use_yarnell`, and `use_wspro`.
+Unsupported combinations, such as disabling the selected low-flow method, raise `ValueError`.
 
 ### Culvert Methods
 

--- a/examples/208_bridge_method_comparison.ipynb
+++ b/examples/208_bridge_method_comparison.ipynb
@@ -1,0 +1,1105 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "1c8d3a4e",
+   "metadata": {},
+   "source": [
+    "# Bridge Method Comparison\n",
+    "\n",
+    "Compare bridge hydraulic method selections with a real HEC-RAS bridge example and show the effect on computed WSE."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "e9532fd4",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-01T18:28:59.484444Z",
+     "iopub.status.busy": "2026-05-01T18:28:59.484231Z",
+     "iopub.status.idle": "2026-05-01T18:28:59.487395Z",
+     "shell.execute_reply": "2026-05-01T18:28:59.486887Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "#!pip install --upgrade ras-commander"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "391e3ffa",
+   "metadata": {},
+   "source": [
+    "## Development Mode\n",
+    "\n",
+    "Set `USE_LOCAL_SOURCE = True` when running from a local ras-commander checkout. The committed default uses the installed package; repository test execution can still use local source through `PYTHONPATH`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "ec842e1f",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-01T18:28:59.489168Z",
+     "iopub.status.busy": "2026-05-01T18:28:59.489037Z",
+     "iopub.status.idle": "2026-05-01T18:29:01.034240Z",
+     "shell.execute_reply": "2026-05-01T18:29:01.033709Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "PIP PACKAGE MODE: loading installed ras-commander\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Imports complete\n"
+     ]
+    }
+   ],
+   "source": [
+    "# =============================================================================\n",
+    "# DEVELOPMENT MODE TOGGLE\n",
+    "# =============================================================================\n",
+    "USE_LOCAL_SOURCE = False\n",
+    "\n",
+    "if USE_LOCAL_SOURCE:\n",
+    "    import sys\n",
+    "    from pathlib import Path\n",
+    "\n",
+    "    cwd = Path.cwd()\n",
+    "    local_path = cwd if (cwd / \"ras_commander\").exists() else cwd.parent\n",
+    "    if str(local_path) not in sys.path:\n",
+    "        sys.path.insert(0, str(local_path))\n",
+    "    print(f\"LOCAL SOURCE MODE: loading from {local_path / 'ras_commander'}\")\n",
+    "else:\n",
+    "    print(\"PIP PACKAGE MODE: loading installed ras-commander\")\n",
+    "\n",
+    "from pathlib import Path\n",
+    "import os\n",
+    "import shutil\n",
+    "import time\n",
+    "import warnings\n",
+    "import logging\n",
+    "\n",
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "from ras_commander import RasCmdr, RasExamples, init_ras_project\n",
+    "from ras_commander.geom import GeomBridge\n",
+    "from ras_commander.hdf import HdfResultsXsec\n",
+    "\n",
+    "warnings.filterwarnings(\"ignore\", category=FutureWarning)\n",
+    "logging.getLogger(\"ras_commander\").setLevel(logging.ERROR)\n",
+    "\n",
+    "pd.set_option(\"display.max_rows\", 20)\n",
+    "pd.set_option(\"display.max_columns\", None)\n",
+    "\n",
+    "print(\"Imports complete\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a2bab1cc",
+   "metadata": {},
+   "source": [
+    "## Parameters\n",
+    "\n",
+    "The workflow uses the `Bridge Hydraulics` example project because it includes one bridge with existing low-flow and pressure/weir method records. HEC-RAS 7.0 is used for execution so plan HDF results are available for extraction."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "e3c5f419",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-01T18:29:01.036252Z",
+     "iopub.status.busy": "2026-05-01T18:29:01.035949Z",
+     "iopub.status.idle": "2026-05-01T18:29:01.040492Z",
+     "shell.execute_reply": "2026-05-01T18:29:01.039997Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "HEC-RAS executable: C:\\Program Files (x86)\\HEC\\HEC-RAS\\7.0\\Ras.exe\n",
+      "Working folder: C:\\GH\\symphony-workspaces\\ras-commander\\CLB-304\\working\\bridge_method_comparison\n"
+     ]
+    }
+   ],
+   "source": [
+    "PROJECT_NAME = \"Bridge Hydraulics\"\n",
+    "RAS_EXE = Path(os.environ.get(\n",
+    "    \"HECRAS_EXE\",\n",
+    "    r\"C:/Program Files (x86)/HEC/HEC-RAS/7.0/Ras.exe\",\n",
+    "))\n",
+    "\n",
+    "cwd = Path.cwd()\n",
+    "REPO_ROOT = cwd if (cwd / \"ras_commander\").exists() else cwd.parent\n",
+    "WORK_ROOT = Path(os.environ.get(\n",
+    "    \"RAS_COMMANDER_WORKDIR\",\n",
+    "    REPO_ROOT / \"working\" / \"bridge_method_comparison\",\n",
+    "))\n",
+    "\n",
+    "BRIDGE_STATION = 5.4\n",
+    "PROFILE_HALF_WINDOW = 10\n",
+    "PLAN_NUMBER = \"03\"\n",
+    "NUM_CORES = 1\n",
+    "\n",
+    "LOW_FLOW_SCENARIOS = [\n",
+    "    {\"label\": \"Baseline\", \"low_flow_method\": None},\n",
+    "    {\"label\": \"Energy\", \"low_flow_method\": \"energy\"},\n",
+    "    {\"label\": \"Momentum\", \"low_flow_method\": \"momentum\", \"momentum_cd\": 2.0},\n",
+    "    {\"label\": \"Yarnell\", \"low_flow_method\": \"yarnell\", \"yarnell_k\": 1.25},\n",
+    "]\n",
+    "\n",
+    "WEIR_COEFFICIENTS = [2.6, 2.9, 3.1, 3.5, 4.0]\n",
+    "PRESSURE_FLOW_CDS = {\n",
+    "    \"pressure_flow_submerged_inlet_cd\": 0.4,\n",
+    "    \"pressure_flow_submerged_inlet_outlet_cd\": 0.8,\n",
+    "}\n",
+    "\n",
+    "if not RAS_EXE.exists():\n",
+    "    raise FileNotFoundError(f\"HEC-RAS executable not found: {RAS_EXE}\")\n",
+    "\n",
+    "WORK_ROOT.mkdir(parents=True, exist_ok=True)\n",
+    "print(f\"HEC-RAS executable: {RAS_EXE}\")\n",
+    "print(f\"Working folder: {WORK_ROOT}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dda0ce9e",
+   "metadata": {},
+   "source": [
+    "## Helpers"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "14ecf486",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-01T18:29:01.042158Z",
+     "iopub.status.busy": "2026-05-01T18:29:01.041988Z",
+     "iopub.status.idle": "2026-05-01T18:29:01.049116Z",
+     "shell.execute_reply": "2026-05-01T18:29:01.048626Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Helper functions ready\n"
+     ]
+    }
+   ],
+   "source": [
+    "def _safe_suffix(value):\n",
+    "    return str(value).lower().replace(\" \", \"_\").replace(\".\", \"_\").replace(\"-\", \"_\")\n",
+    "\n",
+    "\n",
+    "def extract_clean_project(suffix):\n",
+    "    target = WORK_ROOT / f\"{PROJECT_NAME}_{suffix}\"\n",
+    "    if target.exists():\n",
+    "        shutil.rmtree(target)\n",
+    "    return RasExamples.extract_project(PROJECT_NAME, output_path=WORK_ROOT, suffix=suffix)\n",
+    "\n",
+    "\n",
+    "def initialize_bridge_project(project_path):\n",
+    "    ras_obj = init_ras_project(project_path, str(RAS_EXE), load_results_summary=False)\n",
+    "    plan = str(ras_obj.plan_df.iloc[0][\"plan_number\"])\n",
+    "    geom_file = Path(ras_obj.plan_df.iloc[0][\"Geom Path\"])\n",
+    "    bridge = GeomBridge.get_bridges(geom_file).iloc[0]\n",
+    "    return ras_obj, plan, geom_file, bridge\n",
+    "\n",
+    "\n",
+    "def extract_wse_dataset(plan, ras_obj):\n",
+    "    ds = HdfResultsXsec.get_xsec_timeseries(plan, ras_object=ras_obj)\n",
+    "    stations = np.array([float(str(value).replace(\"*\", \"\")) for value in ds[\"Station\"].values])\n",
+    "    return ds, stations\n",
+    "\n",
+    "\n",
+    "def profile_window_indices(stations, bridge_station=BRIDGE_STATION, half_window=PROFILE_HALF_WINDOW):\n",
+    "    nearest_idx = int(np.argmin(np.abs(stations - bridge_station)))\n",
+    "    start = max(0, nearest_idx - half_window)\n",
+    "    stop = min(len(stations), nearest_idx + half_window + 1)\n",
+    "    return np.arange(start, stop)\n",
+    "\n",
+    "\n",
+    "def run_scenario(label, *, suffix, low_flow_method=None, high_flow_method=None,\n",
+    "                 momentum_cd=None, yarnell_k=None, weir_coefficient=None,\n",
+    "                 pressure_flow_submerged_inlet_cd=None,\n",
+    "                 pressure_flow_submerged_inlet_outlet_cd=None):\n",
+    "    project_path = extract_clean_project(suffix)\n",
+    "    ras_obj, plan, geom_file, bridge = initialize_bridge_project(project_path)\n",
+    "\n",
+    "    before = GeomBridge.get_hydraulic_methods(\n",
+    "        geom_file,\n",
+    "        bridge[\"River\"],\n",
+    "        bridge[\"Reach\"],\n",
+    "        str(bridge[\"RS\"]),\n",
+    "    )\n",
+    "\n",
+    "    should_edit = any(value is not None for value in [\n",
+    "        low_flow_method,\n",
+    "        high_flow_method,\n",
+    "        momentum_cd,\n",
+    "        yarnell_k,\n",
+    "        weir_coefficient,\n",
+    "        pressure_flow_submerged_inlet_cd,\n",
+    "        pressure_flow_submerged_inlet_outlet_cd,\n",
+    "    ])\n",
+    "\n",
+    "    edit_result = None\n",
+    "    if should_edit:\n",
+    "        edit_result = GeomBridge.set_hydraulic_methods(\n",
+    "            geom_file,\n",
+    "            bridge[\"River\"],\n",
+    "            bridge[\"Reach\"],\n",
+    "            str(bridge[\"RS\"]),\n",
+    "            low_flow_method=low_flow_method,\n",
+    "            high_flow_method=high_flow_method,\n",
+    "            momentum_cd=momentum_cd,\n",
+    "            yarnell_k=yarnell_k,\n",
+    "            pressure_flow_submerged_inlet_cd=pressure_flow_submerged_inlet_cd,\n",
+    "            pressure_flow_submerged_inlet_outlet_cd=pressure_flow_submerged_inlet_outlet_cd,\n",
+    "            weir_coefficient=weir_coefficient,\n",
+    "            create_backup=False,\n",
+    "        )\n",
+    "\n",
+    "    started = time.perf_counter()\n",
+    "    compute_result = RasCmdr.compute_plan(\n",
+    "        plan,\n",
+    "        ras_object=ras_obj,\n",
+    "        force_geompre=True,\n",
+    "        force_rerun=True,\n",
+    "        num_cores=NUM_CORES,\n",
+    "        verify=False,\n",
+    "    )\n",
+    "    runtime_sec = time.perf_counter() - started\n",
+    "    if not compute_result:\n",
+    "        raise RuntimeError(f\"HEC-RAS compute failed for scenario {label}\")\n",
+    "\n",
+    "    ds, stations = extract_wse_dataset(plan, ras_obj)\n",
+    "    after = GeomBridge.get_hydraulic_methods(\n",
+    "        geom_file,\n",
+    "        bridge[\"River\"],\n",
+    "        bridge[\"Reach\"],\n",
+    "        str(bridge[\"RS\"]),\n",
+    "    )\n",
+    "\n",
+    "    return {\n",
+    "        \"label\": label,\n",
+    "        \"suffix\": suffix,\n",
+    "        \"project_path\": project_path,\n",
+    "        \"plan\": plan,\n",
+    "        \"geom_file\": geom_file,\n",
+    "        \"bridge\": bridge,\n",
+    "        \"before\": before,\n",
+    "        \"after\": after,\n",
+    "        \"edit_result\": edit_result,\n",
+    "        \"compute_result\": compute_result,\n",
+    "        \"runtime_sec\": runtime_sec,\n",
+    "        \"dataset\": ds,\n",
+    "        \"stations\": stations,\n",
+    "    }\n",
+    "\n",
+    "\n",
+    "def dataset_profile_frame(result, time_index, window_indices):\n",
+    "    ds = result[\"dataset\"]\n",
+    "    wse = ds[\"Water_Surface\"].isel(time=time_index, cross_section=window_indices).values\n",
+    "    return pd.DataFrame({\n",
+    "        \"Scenario\": result[\"label\"],\n",
+    "        \"Station\": [str(value) for value in ds[\"Station\"].values[window_indices]],\n",
+    "        \"StationNum\": result[\"stations\"][window_indices],\n",
+    "        \"WSE\": wse.astype(float),\n",
+    "    })\n",
+    "\n",
+    "print(\"Helper functions ready\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "37c11eea",
+   "metadata": {},
+   "source": [
+    "## Baseline And Low-Flow Method Runs\n",
+    "\n",
+    "The baseline preserves the example project's existing method settings. The comparison runs set the same bridge to Energy, Momentum, and Yarnell low-flow methods while keeping pressure/weir high-flow handling enabled."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "dbe00218",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-01T18:29:01.050846Z",
+     "iopub.status.busy": "2026-05-01T18:29:01.050679Z",
+     "iopub.status.idle": "2026-05-01T18:29:47.136541Z",
+     "shell.execute_reply": "2026-05-01T18:29:47.136028Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Baseline | low=momentum high=pressure_weir runtime=11.1s\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Energy   | low=energy   high=pressure_weir runtime=11.2s\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Momentum | low=momentum high=pressure_weir runtime=11.9s\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Yarnell  | low=yarnell  high=pressure_weir runtime=11.3s\n",
+      "\n",
+      "Bridge:\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>River</th>\n",
+       "      <th>Reach</th>\n",
+       "      <th>RS</th>\n",
+       "      <th>Baseline Low Flow</th>\n",
+       "      <th>Baseline High Flow</th>\n",
+       "      <th>Deck/Weir Coefficient</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>Beaver Creek</td>\n",
+       "      <td>Kentwood</td>\n",
+       "      <td>5.4</td>\n",
+       "      <td>momentum</td>\n",
+       "      <td>pressure_weir</td>\n",
+       "      <td>2.6</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "          River     Reach   RS Baseline Low Flow Baseline High Flow  \\\n",
+       "0  Beaver Creek  Kentwood  5.4          momentum      pressure_weir   \n",
+       "\n",
+       "   Deck/Weir Coefficient  \n",
+       "0                    2.6  "
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "method_results = []\n",
+    "\n",
+    "for config in LOW_FLOW_SCENARIOS:\n",
+    "    label = config[\"label\"]\n",
+    "    suffix = f\"method_{_safe_suffix(label)}\"\n",
+    "    kwargs = {key: value for key, value in config.items() if key != \"label\"}\n",
+    "    if label != \"Baseline\":\n",
+    "        kwargs[\"high_flow_method\"] = \"pressure_weir\"\n",
+    "    result = run_scenario(label, suffix=suffix, **kwargs)\n",
+    "    method_results.append(result)\n",
+    "    print(\n",
+    "        f\"{label:8s} | low={result['after']['low_flow_method']:<8s} \"\n",
+    "        f\"high={result['after']['high_flow_method']:<13s} \"\n",
+    "        f\"runtime={result['runtime_sec']:.1f}s\"\n",
+    "    )\n",
+    "\n",
+    "baseline = method_results[0]\n",
+    "bridge = baseline[\"bridge\"]\n",
+    "print(\"\\nBridge:\")\n",
+    "display(pd.DataFrame([{\n",
+    "    \"River\": bridge[\"River\"],\n",
+    "    \"Reach\": bridge[\"Reach\"],\n",
+    "    \"RS\": bridge[\"RS\"],\n",
+    "    \"Baseline Low Flow\": baseline[\"before\"][\"low_flow_method\"],\n",
+    "    \"Baseline High Flow\": baseline[\"before\"][\"high_flow_method\"],\n",
+    "    \"Deck/Weir Coefficient\": baseline[\"before\"][\"coefficients\"][\"weir_coefficient\"],\n",
+    "}]))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "52e2a60b",
+   "metadata": {},
+   "source": [
+    "## Truncated WSE Profile Near The Bridge\n",
+    "\n",
+    "The plotted time step is selected from the computed results: it is the time where Energy, Momentum, and Yarnell produce the largest WSE spread within the bridge-centered profile window."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "21180279",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-01T18:29:47.138623Z",
+     "iopub.status.busy": "2026-05-01T18:29:47.138265Z",
+     "iopub.status.idle": "2026-05-01T18:29:47.157117Z",
+     "shell.execute_reply": "2026-05-01T18:29:47.156618Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Selected profile time: 1990-02-10 19:00:00\n",
+      "Maximum method WSE spread in plotted window: 0.602 ft\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th>Scenario</th>\n",
+       "      <th>Station</th>\n",
+       "      <th>StationNum</th>\n",
+       "      <th>Baseline</th>\n",
+       "      <th>Energy</th>\n",
+       "      <th>Momentum</th>\n",
+       "      <th>Yarnell</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>5.226</td>\n",
+       "      <td>5.226</td>\n",
+       "      <td>213.609</td>\n",
+       "      <td>213.609</td>\n",
+       "      <td>213.609</td>\n",
+       "      <td>213.617</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>5.242</td>\n",
+       "      <td>5.242</td>\n",
+       "      <td>213.730</td>\n",
+       "      <td>213.730</td>\n",
+       "      <td>213.730</td>\n",
+       "      <td>213.738</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>5.258</td>\n",
+       "      <td>5.258</td>\n",
+       "      <td>213.840</td>\n",
+       "      <td>213.840</td>\n",
+       "      <td>213.840</td>\n",
+       "      <td>213.848</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>5.274</td>\n",
+       "      <td>5.274</td>\n",
+       "      <td>213.940</td>\n",
+       "      <td>213.940</td>\n",
+       "      <td>213.940</td>\n",
+       "      <td>213.948</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>5.29</td>\n",
+       "      <td>5.290</td>\n",
+       "      <td>214.032</td>\n",
+       "      <td>214.032</td>\n",
+       "      <td>214.032</td>\n",
+       "      <td>214.040</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>...</th>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>16</th>\n",
+       "      <td>5.508</td>\n",
+       "      <td>5.508</td>\n",
+       "      <td>216.086</td>\n",
+       "      <td>216.086</td>\n",
+       "      <td>216.086</td>\n",
+       "      <td>215.721</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>17</th>\n",
+       "      <td>5.525</td>\n",
+       "      <td>5.525</td>\n",
+       "      <td>216.126</td>\n",
+       "      <td>216.126</td>\n",
+       "      <td>216.126</td>\n",
+       "      <td>215.775</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>18</th>\n",
+       "      <td>5.542</td>\n",
+       "      <td>5.542</td>\n",
+       "      <td>216.173</td>\n",
+       "      <td>216.173</td>\n",
+       "      <td>216.173</td>\n",
+       "      <td>215.838</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>19</th>\n",
+       "      <td>5.559</td>\n",
+       "      <td>5.559</td>\n",
+       "      <td>216.220</td>\n",
+       "      <td>216.220</td>\n",
+       "      <td>216.220</td>\n",
+       "      <td>215.900</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>20</th>\n",
+       "      <td>5.576</td>\n",
+       "      <td>5.576</td>\n",
+       "      <td>216.267</td>\n",
+       "      <td>216.267</td>\n",
+       "      <td>216.267</td>\n",
+       "      <td>215.963</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>21 rows × 6 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "Scenario Station  StationNum  Baseline   Energy  Momentum  Yarnell\n",
+       "0          5.226       5.226   213.609  213.609   213.609  213.617\n",
+       "1          5.242       5.242   213.730  213.730   213.730  213.738\n",
+       "2          5.258       5.258   213.840  213.840   213.840  213.848\n",
+       "3          5.274       5.274   213.940  213.940   213.940  213.948\n",
+       "4           5.29       5.290   214.032  214.032   214.032  214.040\n",
+       "..           ...         ...       ...      ...       ...      ...\n",
+       "16         5.508       5.508   216.086  216.086   216.086  215.721\n",
+       "17         5.525       5.525   216.126  216.126   216.126  215.775\n",
+       "18         5.542       5.542   216.173  216.173   216.173  215.838\n",
+       "19         5.559       5.559   216.220  216.220   216.220  215.900\n",
+       "20         5.576       5.576   216.267  216.267   216.267  215.963\n",
+       "\n",
+       "[21 rows x 6 columns]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "stations = baseline[\"stations\"]\n",
+    "window_indices = profile_window_indices(stations)\n",
+    "comparison_labels = [\"Energy\", \"Momentum\", \"Yarnell\"]\n",
+    "comparison_results = [result for result in method_results if result[\"label\"] in comparison_labels]\n",
+    "\n",
+    "stack = np.stack([\n",
+    "    result[\"dataset\"][\"Water_Surface\"].isel(cross_section=window_indices).values\n",
+    "    for result in comparison_results\n",
+    "])\n",
+    "spread = np.nanmax(stack, axis=0) - np.nanmin(stack, axis=0)\n",
+    "time_index, local_xs_index = np.unravel_index(np.nanargmax(spread), spread.shape)\n",
+    "profile_time = pd.Timestamp(str(baseline[\"dataset\"][\"time\"].values[time_index]))\n",
+    "max_spread = float(spread[time_index, local_xs_index])\n",
+    "\n",
+    "profile_df = pd.concat([\n",
+    "    dataset_profile_frame(result, time_index, window_indices)\n",
+    "    for result in method_results\n",
+    "], ignore_index=True)\n",
+    "\n",
+    "print(f\"Selected profile time: {profile_time}\")\n",
+    "print(f\"Maximum method WSE spread in plotted window: {max_spread:.3f} ft\")\n",
+    "\n",
+    "pivot = profile_df.pivot_table(\n",
+    "    index=[\"Station\", \"StationNum\"],\n",
+    "    columns=\"Scenario\",\n",
+    "    values=\"WSE\",\n",
+    ").reset_index()\n",
+    "display(pivot.round(3))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "1f545648",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-01T18:29:47.159031Z",
+     "iopub.status.busy": "2026-05-01T18:29:47.158703Z",
+     "iopub.status.idle": "2026-05-01T18:29:47.293857Z",
+     "shell.execute_reply": "2026-05-01T18:29:47.293423Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA94AAAIcCAYAAAAAOnYgAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjgsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvwVt1zgAAAAlwSFlzAAAPYQAAD2EBqD+naQAA9ytJREFUeJzs3Xd4U2UbwOHfSdJNW1q6C5Sy9ypb9h4iIIqKMhQQEUQQlPWpOBiKIhtxMAQUQRQVFdkoiIyy9yq7C1q62zTJ+f4ojYS2dNCSjue+rl6QM97znLxJ2ifvUlRVVRFCCCGEEEIIIUSB0Fg7ACGEEEIIIYQQojiTxFsIIYQQQgghhChAkngLIYQQQgghhBAFSBJvIYQQQgghhBCiAEniLYQQQgghhBBCFCBJvIUQQgghhBBCiAIkibcQQgghhBBCCFGAJPEWQgghhBBCCCEKkCTeQgghhBBCCCFEAZLEWwgh8ujy5csoisLy5cuzPXbw4MFUqFChwGMqbBRFYdSoUQV+neXLl6MoCpcvXy7waxV1uXndiuJn586dKIrCzp07rR1KkXT+/Hk6d+6Mq6sriqKwYcOGTD9/2rZtS9u2ba0WpxCi8JHEWwhR4qT/kXTvj5eXF+3ateOPP/6wdnj5Lv0ehw4dmun+KVOmmI+5detWrsv/559/mDp1Knfu3HnISB+dI0eO8MILL1CuXDns7Oxwd3enY8eOLFu2DKPRaO3wRDYyew9n9lOUv+yaPn06GzZssMq1165di6Io/PTTTxn21atXD0VR2LFjR4Z95cuXp0WLFubHer2euXPn0qBBA1xcXChdujS1atXi5Zdf5syZM+bjsqvPf//994Hxtm3b1uJ4d3d3GjduzNKlSzGZTA/xTGQ0aNAgjh8/zrRp01i5ciWNGjXK1/KFEMWXztoBCCGEtbz//vsEBgaiqirh4eEsX76c7t278+uvv/L4449ne35AQABJSUnY2Ng8gmgfjr29PevXr2fRokXY2tpa7Pvuu++wt7cnOTk5T2X/888/vPfeewwePJjSpUvnQ7QF66uvvuKVV17B29ubAQMGUKVKFeLi4ti2bRtDhgwhNDSUyZMnWzvMAlOUXrdZad26NStXrrTYNnToUJo0acLLL79s3laqVKlHHVq+mT59Ok899RS9e/d+5Ndu2bIlALt376ZPnz7m7bGxsZw4cQKdTseePXto166ded+1a9e4du0azz77rHlb3759+eOPP3juuecYNmwYqampnDlzho0bN9KiRQuqV69ucd30z+T7Va5cOduYy5Yty4wZMwCIjIzkm2++YciQIZw7d46ZM2fm7gnIQlJSEnv37mXKlCkWPXkGDBjAs88+i52dXb5cRwhRPEniLYQosbp162bRWjFkyBC8vb357rvvHph4GwwGTCYTtra22NvbP4pQH1rXrl355Zdf+OOPP+jVq5d5+z///ENISAh9+/Zl/fr1Vozw0fj333955ZVXaN68Ob///jvOzs7mfWPGjOHgwYOcOHHCihEWnKL4us1KxYoVqVixosW2V155hYoVK/LCCy9ked69z4HImp+fH4GBgezevdti+969e1FVlaeffjrDvvTH6Un7gQMH2LhxI9OmTcvwRdaCBQsy7SFz/2dybri6ulrU/fDhw6lWrRoLFizggw8+yPSLJpPJhF6vz/H7ITIyEiDDF4xarRatVpunuIUQJYd0NRdCiLtKly6Ng4MDOt1/30mmj4f95JNPmDNnDpUqVcLOzo5Tp05lOVZ2w4YN1K5dG3t7e2rXrp1pd02A27dvM2DAAHMXzEGDBnH06NFMyzxz5gxPPfUU7u7u2Nvb06hRI3755Zcc35u/vz+tW7fm22+/tdi+evVq6tSpQ+3atTM9b9++fXTt2hVXV1ccHR1p06YNe/bsMe+fOnUqb775JgCBgYHmrp73j7VOf07s7OyoVasWmzZtynCtw4cP061bN1xcXChVqhQdOnTItIvpyZMnad++PQ4ODpQtW5YPP/wwx91J33vvPRRFYfXq1RZJd7pGjRoxePBg8+OEhATGjRtn7pJerVo1PvnkE1RVtTgvfSz7unXrqFmzJg4ODjRv3pzjx48DsGTJEipXroy9vT1t27bN8Py0bduW2rVrExwcTIsWLXBwcCAwMJDPP//c4ji9Xs8777xDUFAQrq6uODk50apVqwzdfnP7ug0LC+PFF1+kbNmy2NnZ4evrS69evTLEuWjRImrVqoWdnR1+fn6MHDkyQwKVfi+nTp2iXbt2ODo64u/vz8cff/yAmsl/D3oOspoTILPxz7m5n+TkZKZOnUrVqlWxt7fH19eXJ598kosXL5qP+eSTT2jRogVlypTBwcGBoKAgfvjhB4tyFEUhISGBFStWmN9T974ub9y4wUsvvYS3t7f5PbV06dIM8Vy/fp3evXvj5OSEl5cXY8eOJSUlJUfPX8uWLTl8+DBJSUnmbXv27KFWrVp069aNf//91+J9t2fPHhRF4bHHHgMw33P643tptVrKlCmTozjyytHRkWbNmpGQkGBOmNPfp6tXrza/jtM/i7L7/Jk6dSoBAQEAvPnmmxZDGXI6x0RKSgrvvvsulStXxs7OjnLlyvHWW2/luE6EEEWbtHgLIUqsmJgYbt26haqqREREMH/+fOLj4zNtMVu2bBnJycm8/PLL5jHBmSV7mzdvpm/fvtSsWZMZM2Zw+/Ztc0JzL5PJRM+ePdm/fz8jRoygevXq/PzzzwwaNChDmSdPnuSxxx7D39+fiRMn4uTkxNq1a+nduzfr16+36Ar6IP379+f1118nPj6eUqVKYTAYWLduHW+88Uam3cy3b99Ot27dCAoK4t1330Wj0bBs2TLat2/P33//TZMmTXjyySc5d+4c3333HZ999hkeHh4AeHp6msvZvXs3P/74I6+++irOzs7MmzePvn37cvXqVfMf3ydPnqRVq1a4uLjw1ltvYWNjw5IlS2jbti27du2iadOmQFqC2K5dOwwGg/m5+OKLL3BwcMj2/hMTE9m2bRutW7emfPny2R6vqipPPPEEO3bsYMiQIdSvX58///yTN998kxs3bvDZZ59ZHP/333/zyy+/MHLkSABmzJjB448/zltvvcWiRYt49dVXiY6O5uOPP+all15i+/btFudHR0fTvXt3+vXrx3PPPcfatWsZMWIEtra2vPTSS0BaV9+vvvrK3HU3Li6Or7/+mi5durB//37q169vUWZOX7d9+/bl5MmTvPbaa1SoUIGIiAi2bNnC1atXzcnF1KlTee+99+jYsSMjRozg7NmzLF68mAMHDrBnzx6LFsXo6Gi6du3Kk08+Sb9+/fjhhx+YMGECderUoVu3btk+9/kps+cgt3JyP0ajkccff5xt27bx7LPP8vrrrxMXF8eWLVs4ceIElSpVAmDu3Lk88cQTPP/88+j1etasWcPTTz/Nxo0b6dGjBwArV67M0HU+/fzw8HCaNWtmTiI9PT35448/GDJkCLGxsYwZMwZI6xbdoUMHrl69yujRo/Hz82PlypUZXndZadmyJStXrmTfvn3mScL27NlDixYtaNGiBTExMZw4cYK6deua91WvXt38nk5PUlevXs1jjz1m8YVmVtI/k++lKEqek/RLly6h1WotWqi3b9/O2rVrGTVqFB4eHlSoUCFHnz9PPvkkpUuXZuzYsTz33HN07949V0MZTCYTTzzxBLt37+bll1+mRo0aHD9+nM8++4xz585ZbTy/EOIRUoUQooRZtmyZCmT4sbOzU5cvX25xbEhIiAqoLi4uakRERKb7li1bZt5Wv3591dfXV71z54552+bNm1VADQgIMG9bv369Cqhz5swxbzMajWr79u0zlNmhQwe1Tp06anJysnmbyWRSW7RooVapUiXb+wXUkSNHqlFRUaqtra26cuVKVVVV9bffflMVRVEvX76svvvuuyqgRkZGmsuvUqWK2qVLF9VkMpnLSkxMVAMDA9VOnTqZt82aNUsF1JCQkEyvbWtrq164cMG87ejRoyqgzp8/37ytd+/eqq2trXrx4kXztps3b6rOzs5q69atzdvGjBmjAuq+ffvM2yIiIlRXV9csY7j/uq+//nq2z5mqquqGDRtUQP3www8ttj/11FOqoigW95T++rn3+kuWLFEB1cfHR42NjTVvnzRpUoZY27RpowLqp59+at6WkpKi1q9fX/Xy8lL1er2qqqpqMBjUlJQUi3iio6NVb29v9aWXXjJvy83rNjo6WgXUWbNmZflcREREqLa2tmrnzp1Vo9Fo3r5gwQIVUJcuXZrhXr755huLe/Hx8VH79u2b5TUelpOTkzpo0CDz4wc9B+mfAfe/Xnbs2KEC6o4dO8zbcno/S5cuVQF19uzZGWK7/z10L71er9auXVtt3779A+8n3ZAhQ1RfX1/11q1bFtufffZZ1dXV1Vz+nDlzVEBdu3at+ZiEhAS1cuXKGe4xMydPnlQB9YMPPlBVVVVTU1NVJycndcWKFaqqqqq3t7e6cOFCVVVVNTY2VtVqteqwYcMs7jn9ufP29lafe+45deHCheqVK1cyXCurz+T091V22rRpo1avXl2NjIxUIyMj1dOnT6ujR49WAbVnz57m4wBVo9GoJ0+etDg/p58/6a+p+98rmb2e2rRpo7Zp08b8eOXKlapGo1H//vtvi3M///xzFVD37NmT7X0KIYo26WouhCixFi5cyJYtW9iyZQurVq2iXbt2DB06lB9//DHDsX379rVoxc1MaGgoR44cYdCgQbi6upq3d+rUiZo1a1ocu2nTJmxsbBg2bJh5m0ajMbeWpouKimL79u3069ePuLg4bt26xa1bt7h9+zZdunTh/Pnz3LhxI0f36+bmRteuXfnuu+8A+Pbbb2nRooW5ZepeR44c4fz58/Tv35/bt2+br5uQkECHDh3466+/cty9u2PHjubWOoC6devi4uLCpUuXgLSWws2bN9O7d2+Lcbu+vr7079+f3bt3ExsbC8Dvv/9Os2bNaNKkifk4T09Pnn/++WzjSC8jsy7mmfn999/RarWMHj3aYvu4ceNQVTXDDPgdOnSwmEU7vZW+b9++FtdM355+/+l0Oh3Dhw83P7a1tWX48OFEREQQHBwMpHXRTR+fbDKZiIqKwmAw0KhRIw4dOpThHnLyunVwcMDW1padO3cSHR2d6TFbt25Fr9czZswYNJr//nQYNmwYLi4u/PbbbxbHlypVyqLniK2tLU2aNMlwz49CTp6D7OTkftavX4+HhwevvfZahvMVRTH//97eGdHR0cTExNCqVatM6+9+qqqyfv16evbsiaqq5vflrVu36NKlCzExMeZyfv/9d3x9fXnqqafM5zs6OlpMPvcgNWrUoEyZMuax20ePHiUhIcE8a3mLFi3Mw0727t2L0Wg0j+9Ov+c///yTDz/8EDc3N7777jtGjhxJQEAAzzzzTKZjvO/9TE7/yelKE2fOnMHT0xNPT09q1KjB/Pnz6dGjR4Yu+G3atLH4PM7N58/DWLduHTVq1KB69eoW9da+fXuATGeJF0IUL9LVXAhRYjVp0sRiIp/nnnuOBg0aMGrUKB5//HGLCZgym2n3fleuXAGgSpUqGfZVq1bN4g/rK1eu4Ovri6Ojo8Vx98/ee+HCBVRV5e233+btt9/O9LoRERH4+/tnGx+kdTcfMGAAV69eZcOGDVmOuz1//jxApl3f08XExODm5pbtNTPr1u3m5mZO8iIjI0lMTKRatWoZjqtRowYmk4lr165Rq1Ytrly5Yk5c75XZufdzcXEBIC4uLttjIa2O/Pz8MiTqNWrUMO+/1/33mf7lS7ly5TLdfn+S6+fnh5OTk8W2qlWrAmnjlZs1awbAihUr+PTTTzlz5gypqanmYzN7jebkdWtnZ8dHH33EuHHj8Pb2plmzZjz++OMMHDgQHx8fi3u9/3m2tbWlYsWKGZ6LsmXLWiSbkFbnx44de2AsUVFR6PV682MHBweLL7HyIifPQXZycj8XL16kWrVq2Xap3rhxIx9++CFHjhyxGNt7f/mZiYyM5M6dO3zxxRd88cUXmR4TEREBpNVZ5cqVM5Sbk/dKejwtWrQwf8m2Z88evLy8zJ9RLVq0YMGCBQDmBPzexBvSXltTpkxhypQphIaGsmvXLubOncvatWuxsbFh1apVFsff/5mcGxUqVODLL79EURTs7e2pUqUKXl5eGY67//WQm8+fh3H+/HlOnz6d5ZdA6fUmhCi+JPEWQoi7NBoN7dq1Y+7cuZw/f97iD62cjCEuCOmtyuPHj6dLly6ZHpOTpXbSPfHEE9jZ2TFo0CBSUlLo16/fA687a9asDOOG0+V0fGNWs/2q901QVtAqV66MTqczT3iW37K6z/y8/1WrVjF48GB69+7Nm2++iZeXF1qtlhkzZlhM4JUup6/bMWPG0LNnTzZs2MCff/7J22+/zYwZM9i+fTsNGjTIdZx5vecnn3ySXbt2mR8PGjQow0SDuZXZc5BVkpvVGu75VYd///03TzzxBK1bt2bRokX4+vpiY2PDsmXLMkx8mJn09+ULL7yQ5Zdi6WOu80PLli359ddfOX78uHl8d7oWLVqY5zvYvXs3fn5+GWaav5evry/PPvssffv2pVatWqxdu5bly5fnaOx3Tjg5OdGxY8dsj7PmZ3mdOnWYPXt2pvvv/4JOCFH8SOIthBD3MBgMAMTHx+f63PQu2+mtxfc6e/ZshmN37NhBYmKiRav3hQsXLI5L/0PWxsYmR39UZsfBwYHevXuzatUqunXrZp4M7X7pXcNdXFyyvW5OWuoexNPTE0dHxwzPEaR1H9VoNOY/SgMCAnL0/GbG0dGR9u3bs337dq5du5btH7oBAQFs3bqVuLg4i1bvM2fOmPfnp5s3b5KQkGDR6n3u3DkAcxf2H374gYoVK/Ljjz9aPO/vvvvuQ1+/UqVKjBs3jnHjxnH+/Hnq16/Pp59+yqpVq8z3evbsWYvkSq/XExISki+vTYBPP/3UoieAn59fvpR7v/SeGvd3d76/5T43KlWqxL59+0hNTc1yjfT169djb2/Pn3/+abHm87JlyzIcm9n7ytPTE2dnZ4xGY7bPeUBAACdOnEBVVYuycvJeSXfvet579uwxT9wGEBQUhJ2dHTt37mTfvn107949R2Xa2NhQt25dzp8/z61bt8y9KqwlN58/D6NSpUocPXqUDh06PPRnphCiaJIx3kIIcVdqaiqbN2/G1tbW3J04N3x9falfvz4rVqwgJibGvH3Lli2cOnXK4tguXbqQmprKl19+ad5mMplYuHChxXFeXl60bduWJUuWEBoamuGa6cvk5Mb48eN59913s+y6Dml/VFeqVIlPPvkk0y8h7r1ueqKY2ZjNnNBqtXTu3Jmff/7ZYjme8PBwvv32W1q2bGnuJt69e3f+/fdf9u/fbxHL6tWrc3Std999F1VVGTBgQKb3FRwczIoVK8zXMhqN5u606T777DMURcn32bkNBgNLliwxP9br9SxZsgRPT0+CgoKA/1pe721p3bdvH3v37s3zdRMTEzPMal+pUiWcnZ3NXaE7duyIra0t8+bNs7j2119/TUxMjHk27ocVFBREx44dzT/3z42QX9K/WPrrr7/M24xGY5bdt3Oib9++3Lp1K8PrBf6rL61Wi6IoFi3rly9fznRGaycnpwzvKa1WS9++fVm/fn2m683f+77s3r07N2/etFiqLDExMVf32KhRI+zt7Vm9ejU3btywaPG2s7OjYcOGLFy4kISEhAzdzM+fP8/Vq1czlHnnzh327t2Lm5vbQ4+9zw+5+fx5GP369ePGjRsWn/npkpKSSEhIeOhrCCEKN2nxFkKUWH/88Ye59TIiIoJvv/2W8+fPM3HixDz/oTVjxgx69OhBy5Yteemll4iKimL+/PnUqlXLItHr3bs3TZo0Ydy4cVy4cIHq1avzyy+/EBUVBVi2di1cuJCWLVtSp04dhg0bRsWKFQkPD2fv3r1cv36do0eP5irGevXqUa9evQceo9Fo+Oqrr+jWrRu1atXixRdfxN/fnxs3brBjxw5cXFz49ddfAcxJ4ZQpU3j22WexsbGhZ8+eGcYrP8iHH37Ili1baNmyJa+++io6nY4lS5aQkpJiMQ79rbfeYuXKlXTt2pXXX3/dvJxYQEBAtuOHIa177MKFC3n11VepXr06AwYMoEqVKsTFxbFz505++eUXPvzwQwB69uxJu3btmDJlCpcvX6ZevXps3ryZn3/+mTFjxlhMGJcf/Pz8+Oijj7h8+TJVq1bl+++/58iRI3zxxRfmFtTHH3+cH3/8kT59+tCjRw9CQkL4/PPPqVmzZp56aUBaq3qHDh3o168fNWvWRKfT8dNPPxEeHs6zzz4LpLUKTpo0iffee4+uXbvyxBNPcPbsWRYtWkTjxo0zXYKvMKtVqxbNmjVj0qRJREVF4e7uzpo1a8w9XvJi4MCBfPPNN7zxxhvs37+fVq1akZCQwNatW3n11Vfp1asXPXr0YPbs2XTt2pX+/fsTERHBwoULqVy5cobXb1BQEFu3bmX27Nn4+fkRGBhI06ZNmTlzJjt27KBp06YMGzaMmjVrEhUVxaFDh9i6dav5M2TYsGEsWLCAgQMHEhwcjK+vLytXrswwr8SD2Nra0rhxY/7++2/s7OzM7/V0LVq04NNPPwUyju8+evQo/fv3p1u3brRq1Qp3d3du3LjBihUruHnzJnPmzMnQhf/ez+T7r/OgbuwPK6efPw9jwIABrF27lldeeYUdO3bw2GOPYTQaOXPmDGvXruXPP//M8/h2IUQRYZW51IUQwooyW7rG3t5erV+/vrp48WKLpX+yWj7m3n33Lv2lqmlLhdWoUUO1s7NTa9asqf7444/qoEGDLJYTU1VVjYyMVPv37686Ozurrq6u6uDBg9U9e/aogLpmzRqLYy9evKgOHDhQ9fHxUW1sbFR/f3/18ccfV3/44Yds75e7y4k9yP3LiaU7fPiw+uSTT6plypRR7ezs1ICAALVfv37qtm3bLI774IMPVH9/f1Wj0Vgsq5PVtQMCAjIslXTo0CG1S5cuaqlSpVRHR0e1Xbt26j///JPh3GPHjqlt2rRR7e3tVX9/f/WDDz5Qv/7662yXE7tXcHCw2r9/f9XPz0+1sbFR3dzc1A4dOqgrVqywWC4rLi5OHTt2rPm4KlWqqLNmzbJ4jWR1n1m9dtKXrFq3bp15W5s2bdRatWqpBw8eVJs3b67a29urAQEB6oIFCyzONZlM6vTp09WAgADVzs5ObdCggbpx48YMr6/cvG5v3bqljhw5Uq1evbrq5OSkurq6qk2bNrVYhirdggUL1OrVq6s2Njaqt7e3OmLECDU6OtrimPR7uV9m74H8lNVyYlktk3bx4kW1Y8eOqp2dnert7a1OnjxZ3bJlS6bLieX0fhITE9UpU6aogYGBqo2Njerj46M+9dRTFstUff3112qVKlVUOzs7tXr16uqyZcvM7797nTlzRm3durXq4OCgAhb3Fh4ero4cOVItV66c+TodOnRQv/jiC4syrly5oj7xxBOqo6Oj6uHhob7++uvqpk2bcrScWLr05e9atGiRYd+PP/6oAqqzs7NqMBgs9oWHh6szZ85U27Rpo/r6+qo6nU51c3NT27dvn+Fz60HLiWX2GXu/rOrofg/6LMzJ58/DLCemqmlLx3300UdqrVq1VDs7O9XNzU0NCgpS33vvPTUmJibb+IUQRZuiqo94dhshhBBZ2rBhA3369GH37t089thj1g5HPCJt27bl1q1bmXYfFkIIIUTRJ2O8hRDCSpKSkiweG41G5s+fj4uLCw0bNrRSVEIIIYQQIr/JGG8hhLCS1157jaSkJJo3b05KSgo//vgj//zzD9OnT7fakjdCCCGEECL/SeIthBBW0r59ez799FM2btxIcnIylStXZv78+YwaNcraoQkhhBBCiHwkY7yFEEIIIYQQQogCJGO8hRBCCCGEEEKIAiSJtxBCCCGEEEIIUYBkjHcemUwmbt68ibOzM4qiWDscIYQQQgghhBCPkKqqxMXF4efnh0bz4DZtSbzz6ObNm5QrV87aYQghhBBCCCGEsKJr165RtmzZBx4jiXceOTs7A2lPsouLi5WjEelMJhPR0dG4ubll+62TKBqkTosfqdPi58aNG3z55ZcMGzYMf39/a4cj8oG8T4sfqdPiR+rU+mJjYylXrpw5N3wQSbzzKL17uYuLiyTehYjJZMJgMODi4iIfQMWE1GnxI3Va/Ny8eZPDhw+jKIr8Tiwm5H1a/EidFj9Sp4VHToYeSw0JIYQQQgghhBAFSBJvIYQQQgghhBCiAEniLYQQQgghhBBCFCAZ4y2EEEKIh+Lh4UH//v3x8PCwdihCCJElk8mEXq+3dhj5xmQykZqaSnJysozxLiA2NjZotdp8KUsSbyGEEEI8FHd3d/r06YO7u7u1QxFCiEzp9XpCQkIwmUzWDiXfqKpqntk8J5N7ibwpXbo0Pj4+D/0cS+IthBBCiIcSHx/PgQMHeOyxx2RWcyFEoaOqKqGhoWi1WsqVK1dsWodVVcVgMKDT6STxLgCqqpKYmEhERAQAvr6+D1WeJN5CCCGEeCg3b97k448/ZvHixZJ4CyEKHYPBQGJiIn5+fjg6Olo7nHwjiXfBc3BwACAiIgIvL6+H6nZePL7uEUIIIYQQQohMGI1GAGxtba0ciSiK0r+sSU1NfahyJPEWQgghhBBCFHvSKizyIr9eN5J4CyGEEEIIIYQQBUgSbyGEEEI8FFtbW8qWLSvdOIUQopipUKECc+bMMT9WFIUNGzZYLZ6iTBJvIYQQQjyUChUq8Nlnn1GhQgVrhyKEEAXGaFLZe/E2Px+5wd6LtzGa1AK93uDBg1EUxfxTpkwZunbtyrFjxwr0ug8SGhpKt27drHb9okxmNRdCCCGEEEKIB9h0IpT3fj1FaEyyeZuvqz3v9qxJ19oPt8zUg3Tt2pVly5YBEBYWxv/+9z8ef/xxrl69WmDXfBAfHx+rXLc4kBbvYkqvT2HtlnksWD+etVvmodenWDskIYQQxdSFCxcYOHAgFy5csHYoQgiR7zadCGXEqkMWSTdAWEwyI1YdYtOJ0AK7tp2dHT4+Pvj4+FC/fn0mTpzItWvXiIyMBGDSpElUq1YNR0dHKlasyNtvv20x+/bRo0dp164dzs7OuLi4EBQUxMGDB837d+/eTatWrXBwcKBcuXKMHj2ahISELOO5t6v55cuXURSFH3/8kXbt2uHo6Ei9evXYu3evxTm5vUZxJYl3MfTFz1PosrIhH9z8kiXxf/LBzS/psrIhX/w8xdqhCSGEKIZMJhNJSUmYTCZrhyKEEPnKaFJ579dTZNapPH3be7+eKvBu5wDx8fGsWrWKypUrU6ZMGQCcnZ1ZtmwZp06dYu7cuXz55Zd89tln5nOef/55ypYty4EDBwgODmbixInY2NgAcPHiRbp27Urfvn05duwY33//Pbt372bUqFG5imvKlCmMHz+eI0eOULVqVZ577jkMBkO+XqM4kK7mxcwXP09hQfTPqFrLae9vaxUWRP8MP8PLvaZZKTohhBBCCCGsr+f83UTGZd8jNMVgJDox6/WbVSA0JplGH27BTqfNtjxPZzt+fa1ljuPcuHEjpUqVAiAhIQFfX182btyIRqNBVVUmT56MTqdDURQqVKjA+PHjWbNmDW+99RYAV69e5c0336R69eoAVKlSxVz2jBkzeP755xkzZox537x582jTpg2LFy/G3t4+RzGOHz+eHj16APDee+9Rq1YtLly4QPXq1fPtGsWBJN7FiF6fwne3NqQl3fetN6cqCoqqsubWBgbr38HW1s5KUQohhBBCCGFdkXEphMUmZ39gDqUl51kn6HnVrl07Fi9enHaN6GgWLVpEt27d2L9/P+XLl2ft2rUsWrSIixcvEh8fj8FgwMXFxXz+G2+8wdChQ1m5ciUdO3bk6aefplKlSkBaN/Rjx46xevVq8/GqqmIymQgJCaFGjRo5irFu3brm//v6po13j4iIoHr16vl2jeJAEu9iZMOuJdzSZT16QFUUInUKE1c8Qbtqz9CyXk/cXD0fYYRCCCGEEEJYn6dzzhqhsmvxTufmaJPjFu/ccHJyonLlyubHX331Fa6urnz55Zd0796dQYMGMXXqVLp27Yqrqytr1qzh008/NR8/depU+vfvz2+//cYff/zBu+++y5o1a+jTpw/x8fEMHz6c0aNHZ7hu+fLlcxxjetd1SBsDDpiHHuXXNYoDSbyLkYjYnM1uuMX2JltCPkO5NBs/A/gZS+Fn508lj/oEVetE7YqN0Wiz/+AQQgghIO2Pp48++qjE/RElhCi6ctrd22hSafnRdsJikjMd560APq727J7QHq1GyeSI/KUoChqNhqSkJP755x8CAgKYMmWKOeG9cuVKhnOqVq1K1apVGTt2LM899xzLli2jT58+NGzYkFOnTlkk9vntUVyjqJDEuxjxcikP8Tk/XlUUbtjADZsE4BzcPgf/rMX5bxNlDTb4KR6Ud6lKzXKP0bxuN1xLuRdY7EIIIYoue3t7KlasWKLG6gkhSgatRuHdnjUZseoQClgk3+lp9rs9axZY0p2SkkJYWBiQ1tV8wYIFxMfH07NnT2JiYrh69Spr1qyhSZMm/Pbbb/z000/mc5OSknjzzTd56qmnCAwM5Pr16xw4cIC+ffsCMGHCBJo1a8aoUaMYOnQoTk5OnDp1ii1btrBgwYJ8if9RXKOokMS7GOndZjiLVy7htlZBVTJ586sqpU0qnbQNuJlyhTBiuGZjQn/fB0WcVsNprZHThENyOJz/G+25Gfilgp/qjJ9dOSp71qdx9S5UC6ifp9ZxvT6FDbuWEBF7FS+X8vRuM1zGnQshRBEVHh7OihUrGDRokHl8nxBCFBdda/uy+IWGGdbx9nkE63hv2rTJ/Lnq7OxM9erVWbduHW3btkVVVUaPHs1rr71GSkoKPXr04O2332bq1KkAaLVabt++zcCBAwkPD8fDw4Mnn3yS9957D0gbm71r1y6mTJlCq1atUFWVSpUq8cwzz+Rb/I/iGkWFoqpqwc99XwzFxsbi6upKTEyMxQQG1pY+qzlgkXwrd6t5lFsvi1nNk1MSOXByK0dD/uLKnVOEGsK5rkvm9gPGit/L1WiinMEWH40nAS7VqFW+Jc3qdMHZqfQDY/zu1gaL8egeBhPPefR+6BnXTSYTUVFRuLu7o9HIannFgdRp8SN1WvycOXOGESNGsHjxYvPMuaJok/dp8VOS6zQ5OZmQkBACAwMfqmeO0aSyPySKiLhkvJztaRLo/ki6l2dFVVUMBoN5VnNRMB70+slNTigt3sXMy72mwc/cTWz/ewN6GFWezSSxtbdzpFXDJ2jV8AmL7SE3zrDv5O+cCw/mRtIVQpUYrtmoGO57U8doNcRoDZwgFJJC4exOdGc+wD9VwU91wd++HJW9GtK4RleqBtSV5c6EEEIIIUSRpNUoNK9UxtphiCJKEu9i6OVe0xisf+ehunIH+lcn0N+y1SIxOYF9xzdx/PLfXIk5Q6gxguu6FKLvax03KApXbOEKsaCehPCTEL6S0gYTiRoFVUGWOxNCCCGEEEKUGJJ4F1O2tnb065Rx2v6H4WjvRLvGfWnXuK/F9nNXjnHg9CYuRBzievJVQpU4bmTSOn4nm+7r6cudrf7zY17s+Xa+xi6EEEIIIYQQ1iKJt3hoVQPqUjWgrsW2uIQ7/Hv8T05e3c2V2LOEmiK5ZKMnKQdjimZHreW7r77H3+iEn23aMmeNqneWZc6EEKKQcnNzo0ePHri5uVk7FCGEEKJQksRbFAhnp9J0avYMnZr9N2Ph2s1z+CD06xydH2qjEGqTCJyHqPPwzzpc/k6byM1P40WAa3XqVmhN0zpdcbR3KqC7EEIIkROenp4MHjwYd3dZdlIIIYTIjCTe4pHp3XYEi1d++cDlzhxUlbKpWq7ZmEi+b5bIWK2Gk1oDJ7kJiTfh1HZsTr5LuVQFX7U05RwrUs23MTXLt5Q//oQQ4hFKSkri7Nmz1K9fHycn+TJUCCGEuJ8k3uKRsbW14zmP3iyI/hlFVTNd7myoe9rM63p9CsFndnDkwg5Cok9w0xCW6TJnqYrCJVu4xB0wHoLrh+D6Enx2qfgbHfFP76perRO1KzXNUVd1WWNcCCFy59q1a/zvf/+T5cSEEEKILEjiLR6pnC53ZmtrR/O6XWlet6vF+ekTuZ0PP8T15Cvc1MRxwwZM97Wgh9kohNkkEcwFiLoAe3/AebeJ8gZbfDWeBLikdVVvVrebRVf1DGuMx8PilUvyZY1xIYQQQgghRMkkibd45B5mubPMJnKLjonkn+O/cfLaP1yLP0+oGsVVG0OGidzizF3V7645fnoHNqemmruqK8Bu22iQNcaFEEIIIYQQ+UgSb2EV+bncmZurJz1aDqYHgzGZTERFReHi4syhs7s4fGEHIdHHuZkaxnVd0oO7qgOQcey5qigga4wLIYQQQggh8kgSb1Es6XQ2NKvTmWZ1Oltsv3D1BPtP/8H58GCuJ1/lhhKbaVf1DO6uMd57RRAV8aCsY0Wq+TWheZ0e+HiUK8A7EUKIwk+r1eLs7IxWlnwUQhRnJiNc+Qfiw6GUNwS0AE3Bfe4NHjyYFStWZNjepUsXNm3aVGDXFQVDEm9RolQuX5vK5WtbbLsTd4tPfniZnzXnsz3/mq3CNW6D4TZcPQBXF+KdasLf6IifjS8V3GpRr3I7GlZrIy3jQogSo1KlSixdulRWlBBCFF+nfoFNEyD25n/bXPyg60dQ84kCu2zXrl1ZtmyZxTY7u4L7G1Ov12Nra1tg5ZdkmuwPEaJ4K+3sQd2ybfN8friNhkP2yWzUhrAgdiPDDo3jsdVBPPlFXUZ+2YYZqwfzw7aFXI+4nG8xCyGEEEKIR+TUL7B2oGXSDRAbmrb91C8Fdmk7Ozt8fHwsftzc3ADQaDQsXbqUJ598EkdHR6pUqcIvv1jGcuLECbp160apUqXw9vZmwIAB3Lp1y7y/bdu2jBo1ijFjxuDh4UGXLl0A+OWXX6hSpQr29va0a9eOFStWoCgKd+7cISEhARcXF3744QeLa23YsAEnJyfi4uIK7PkoyiTxFgLo3WY4HgaTeVmz+ymqiqfBxG+df+KD8qN43qYJbfQeVE3R4GgyZTg+WaNw3k7lL9sovjUE8971z+n2R086fF2LgV80ZsLSniz+cQL/HP0DvT4lV7Hq9Sms3TKPBevHs3bLvFyfL4QQ+e3y5cuMGjWKy5cvWzsUIYTIXyZjWks3mf2NeHfbpolpx1nBhx9+yNNPP82xY8fo3r07zz//PFFRUQDcuXOH9u3b06BBAw4ePMimTZsIDw+nX79+FmWsWLECW1tb9uzZw+eff05ISAhPPfUUvXv35ujRowwfPpwpU6aYj3dycuLZZ5/N0BK/bNkynnrqKZydnQv+xosg6WouBDlbY/xZj96U961Med/KwHDzfoMhlSNn93DowjYuR50gVH+TG9oEQm0yjhuP0GmI0CVzmMsQdxmO/I7dIZWyBg1+amn8HQOp6tOYZrW6UM63SobzZbkzIURhpNfrCQ8PR6/XWzsUIYTImSVtID4i++MMKZB0+wEHqBB7A2ZVAV0OuoCX8oLhu3Ic5saNGylVqpTFtsmTJzN58mQABgwYwHPPPYeiKEyfPp158+axf/9+unbtyoIFC2jQoAHTp083n7t06VLKlSvHuXPnqFq1KgBVqlTh448/Nh8zceJEqlWrxqxZswCoVq0aJ06cYNq0//7WHDp0KC1atCA0NBRfX18iIiL4/fff2bp1a47vraSRxFuIu3K6xvj9dDobGtVqS6NabS22R0bf5J9jv3P2xj6uJ1zkpnqbazYGEu9b5ixFo3DRVuUi0WCMhhuH4MYSPA0m/A0O+Oq8CXCryZ2EcNYYD8lyZ0IIIYQQDys+AuJuZn9cTj0wOc+7du3asXjxYott986nUadOHfP/nZyccHFxISIi7QuFo0ePsmPHjgyJO8DFixfNiXdQUJDFvrNnz9K4cWOLbU2aNMnwuFatWqxYsYKJEyeyatUqAgICaN26dR7usmSQxFuIezzMGuP383Tzo1ebocBQ8zaT0ciR8/9w6NxWQm4f56b+Bje1CYTqsGhlB4jUaYjUpXCEqxB39b8d9x2nKgqKLHcmhBBCCJFzpbxydly2Ld53OZTJeYt3Ljg5OVG5cuUs99vY2Fg8VhQF091hkPHx8fTs2ZOPPvoow3m+vr4W18iLoUOHsnDhQiZOnMiyZct48cUXUbJbKagEk8RbiPvk5xrj99NotTSs3oqG1VtZbL99J4x/jv3OmRv7uB5/gZvqba7rUonX3jcNQxYfZurd5c4GLGtKRdsKlHWtQlW/RjSq0R43V88CuRchhBBCiCIrp929TUaYUzttIrVMx3krabObjzleoEuL5UXDhg1Zv349FSpUQKfLedpXrVo1fv/9d4ttBw4cyHDcCy+8wFtvvcW8efM4deoUgwYNeuiYizNJvIUoBMqU9qFn65foyUvmbSajkRMX93Hw7FZ23/ydA/YJ2ZZzyt7IKS5C3EU4uwnOfoh3qglvoz1e2jL4OgYQ6FWPelVaU7lsLTSy5q4QIh/4+/szZcoU/P39rR2KEELkL402bcmwtQMBBcvk+26DSNeZBZZ0p6SkEBYWZrFNp9Ph4eGR7bkjR47kyy+/5LnnnuOtt97C3d2dCxcusGbNGr766iu0WfwdOHz4cGbPns2ECRMYMmQIR44cYfny5QAWLdpubm48+eSTvPnmm3Tu3JmyZcvm/UZLAEm8hSikNFotdau2oG7VFpTaUpoDN7/MUznhNhrCbfRAKKSGwo1/4cYSnI0mfA06PHHB286Pcm7VqRnQjPrVWuNon7cuR5A263p+dNUXQhQdTk5O1K9fP8/dFYUQolCr+QT0+yaLdbxnFug63ps2bbLoFg5pLdJnzpzJ9lw/Pz/27NnDhAkT6Ny5MykpKQQEBNC1a1c0mqwXtwoMDOSHH35g3LhxzJ07l+bNmzNlyhRGjBiRYQ3xIUOG8O233/LSSy9lUZpIp6hqFusniQeKjY3F1dWVmJgYXFxcrB2OuMtkMhEVFYW7u/sDP1CKGr0+hS4rG3Jbq2QYCw5pM697GFXerTud86HBXI0+Q0TKTSKI5aaNkYRcPBc6VcXHAN5GRzx1nvg7V6SSTwOCanTAzzPggedmmHUd8DCYHmrW9eJapyWZ1GnxExkZybp163j66afx9JThLcWBvE+Ln5Jcp8nJyYSEhBAYGIi9vX3eCzIZ4co/EB8OpbwhoIVVu5erqorBYECn0xX42Opp06bx+eefc+3aNYvtK1euZOzYsdy8eRNbW9sCjcFaHvT6yU1OKC3eQhQBOV3urE3jXrShl8W5JqORC9ePc+TcX1yKPEpYwhUi1CjCtSlE6DL+4jUoCtdt4LpNEnAVkq5CyE4I+Qx3gwkfoy1eSml8HMpTwaMWdSq2pGbFxiz9bSoLon9GlVnXhShxbt++zbp162jfvr0k3kKI4kujhcBW2R9XDCxatIjGjRtTpkwZ9uzZw6xZsxg1apR5f2JiIqGhocycOZPhw4cX26Q7P0niLUQRkdflzjRaLVUD6lM1oH6GfbfvhBF8egfnbgZzI/Y8EfpwIjQJ3NSp6DUZvzmN0mmI0hk4xS0w3oLwQxC+Ers9JoyKkjbqSWZdF0IIIYQo0s6fP8+HH35IVFQU5cuXZ9y4cUyaNMm8/+OPP2batGm0bt3aYrvImnQ1zyPpal44lYRuVI9iDLVen8KJC/9y4vIertw+RVjSdSK5Q5gulej7Z1rPhV6mqvRq8ioNqrVGp7PJ/gRKRp2WNFKnxc+ZM2cYMWIEixcvpnr16tYOR+QDeZ8WPyW5TvOtq3kh8yi7mpdk0tVciBKqIJc7u/caDWu2oWHNNhn2Xbl5jiPndnIx/Ag340KIMN3iijaRqEy6rd/vZ805fj44Bvv9KmVTNXjjir9DAJW86hFUtSNVyteVmdaFEEIIIUSxI4m3ECJXAvyqEuBX1WLb2i3z+CAXs64naxQu2Klc4A6Y7kDYUQj7BlejCT+DDb5KGfydKlLVtxGNanXGXuOcvzchhMhXzs7OtGrVCmdnea8KIYQQmZHEWwjx0Hq3Gc7ilUuynHUdVcXFpPKYWoEIQyQ3tYmE6chwbIxWQ4zWyGkiIDUCrv4LVxfgaTDhZ7DHR+dFOZeq1CjbjKZ1uuBayj3XscpyZ0LkP19fX0aPHo27e+7fk0IIIURJIIm3EOKh5WTW9UFlLCeAu30njH0nNnPmxj6ux10gzBjJTV0KtzPpsh6p0xCp03OU65B4Hc5tR3N2Gn4G8DU54WPjR4BbDepWbE1Q9XZZJtIZljuLh8UrlzzUcmdCCNDr9YSGhlKqVKliNX5SCCGEyC+SeAsh8kVuZ10vU9qH7i0H0p2BFtuv3DzH/lObuRAezI3EEMLUaG7oDMTfN6mbKX3ZMxKBCxBzAQ7/il2wir9BwUd1xc++LBU96tOgajv2HP+ZhTG/yHJnQhSAy5cvM3r0aJlcTQghhMiCJN5CiHzzcq9pDNa/81Bdue8fQ24ymbgVGUnonYscvbiTkFvHuJF8jXAlluuZLHuWolG4ZAuXiAE1BiJPQuTqtJZ4kOXOhBBCCCHEIyeJtxAiXxXErOsarZY6VZpRr1oLi+3JKYkcOrOL4yF/czn6FGH6UMK0CdzUpbWI3yvTsef37IvUKUxY8TgtK/WhSY1OlPOtkq/3IIQQQgghSi5JvIUQRZa9nSMt6nWjRb1uFtvvxN1i/4ktnL7+L9diznFWvc5l2+zL22obxtZri+HaYtwNJvyMtnhrPO7OsB5E41pd8PMMKKC7EUIIIURhZjQZORRxiMjESDwdPWno1RCtpuCWQR08eDArVqxg+PDhfP755xb7Ro4cyaJFixgwYAArVqwosBjyw9SpU9mwYQNHjhyxdihWJYm3EKLYKe3sQefmz9GZ54DcL3cGEKXTEKUzcIIw0IfBlX/gynw8DCZ8jXZ4azwoW6oSVfwa0aRmZ3w8yhXErQghhBCiENh6ZSsz988kPDHcvM3b0ZuJTSbSMaBjgV23XLlyrFmzhs8++wwHBwcAkpOT+fbbbylfvnyBXVfkv4zTBz9CM2bMoHHjxjg7O+Pl5UXv3r05e/asxTFffPEFbdu2xcXFBUVRuHPnTqZl/fbbbzRt2hQHBwfc3Nzo3bv3A6+tqirvvPMOvr6+ODg40LFjR86fP59PdyaEKEx6txmOh8FknmE9A1WltNHEs5og2uk9qZGixdVoyvTQWzoNx+1S2WoTyvKU3UwJmUOn37rT/utaPL8kiHFfdWH29yP5bfdyIqNv5jpWvT6FtVvmsWD9eNZumYden5LrMoR41KpWrcq6deuoWrVq9gcLIUQRs/XKVt7Y+YZF0g0QkRjBGzvfYOuVrQV27YYNG1KuXDl+/PFH87Yff/yR8uXL06BBA/O2lJQURo8ejZeXF/b29rRs2ZIDBw6Y9+/cuRNFUfjzzz9p0KABDg4OtG/fnoiICP744w9q1KiBi4sL/fv3JzEx0XyeyWRixowZBAYG4uDgQL169fjhhx8ylLtt2zYaNWqEo6MjLVq0MOd0y5cv57333uPo0aMoioKiKCxfvpzLly+jKIpFK/idO3dQFIWdO3c+VMyFlVVbvHft2sXIkSNp3LgxBoOByZMn07lzZ06dOoWTkxMAiYmJdO3ala5duzJp0qRMy1m/fj3Dhg1j+vTptG/fHoPBwIkTJx547Y8//ph58+axYsUKAgMDefvtt+nSpQunTp2SpVCEKGZystzZgPuWOzMZjVy4fpJDZ7dxMeIooUmXCVfvcEOXSpw26yXPjnETkm/Cxb/g4qd4p5rwMTrgo/OkrHMVqpdtStNanXFz9cxQhix3JoQQQhQuRpORmftncneKVgsqKgoKH+3/iHbl2hVYt/OXXnqJZcuW8fzzzwOwdOlSXnzxRXOCCvDWW2+xfv16VqxYQUBAAB9//DFdunThwoULuLu7m4+bOnUqCxYswNHRkX79+tGvXz/s7Oz49ttviY+Pp0+fPsyfP58JEyYAaQ2lq1at4vPPP6dKlSr89ddfvPDCC3h6etKmTRtzuVOmTOHTTz/F09OTV155hZdeeok9e/bwzDPPcOLECTZt2sTWrWlfULi6uhIebvklxoPkNubCyqqJ96ZNmyweL1++HC8vL4KDg2ndujUAY8aMAbB4Yd3LYDDw+uuvM2vWLIYMGWLeXrNmzSyvq6oqc+bM4X//+x+9evUC4JtvvsHb25sNGzbw7LPPPsRdCSEKo9wud6bRaqkaUJeqAXUttpuMRs5fPUbwue1cijhKaPKVuwl5xiXPAMJtNITbpKStQZ50Hc7vQDk3Ax8D+Jgc8NZ6Uc6lCtGJ4fygHgdZ7kwUQdeuXWPatGlMmTKFgACZB0EIUfg9s/EZbiXdyvY4vVHPnZQ7We5XUQlLDKPt2rbYarOfUMbDwYPvH/8+N6HywgsvMGnSJK5cuQLAnj17WLNmjTk/SkhIYPHixSxfvpxu3dLmvfnyyy/ZsmULX3/9NW+++aa5rA8//JDHHnsMgCFDhjBp0iQuXrxIxYoVAXjqqafYsWMHEyZMICUlhenTp7N161aaN28OQMWKFdm9ezdLliyxSLynTZtmfjxx4kR69OhBcnIyDg4OlCpVCp1Oh4+PT67uOy8xF2aFaox3TEwMgMW3Mtk5dOgQN27cQKPR0KBBA8LCwqhfvz6zZs2idu3amZ4TEhJCWFgYHTv+Nx7D1dWVpk2bsnfvXkm8hSim8mO5M41WS7XABlQLbGCx3WQ0cvryYY6c386lyGOEJl0lnBiu2xhI1Fgm5KqiEGoDoSQDVyHx6n87M5uNXZY7E4VcUlIS58+fJykpydqhCCFEjtxKukVEYkS+lfeg5PxheXp60qNHD5YvX46qqvTo0QMPDw/z/osXL5KammpOTgFsbGxo0qQJp0+ftiirbt3/GhS8vb1xdHQ0J7Dp2/bv3w/AhQsXSExMpFOnThZl6PV6i27u95fr6+sLQERERL6MQ89NzIVZoUm8TSYTY8aM4bHHHssyYc7MpUuXgLQuCLNnz6ZChQp8+umntG3blnPnzmWaxIeFhQFplXQvb29v8777paSkkJLy31jL2NhYc9wmU+ZjQcWjZzKZUFVV6qQYye861elseKrDqAzXeGiKQo3AhtQIbGhZttHIyUsHOHpxFyG3jhOafI1wYrhhYyTpvoT8/qT73u2ROoUXljWhkk0FyrtVp3ZASxpWb4uDvdPDx/6Iyfu0+FHvDtmQei0+5H1a/JTkOk2/9/QfSGt5zonsWrzTlbYrneMWbzWrOWeyoKoqL774Iq+99hoACxYsyLSMe+/v/m3p23U6ncUxNjY2Gc5Jf77i4uIA2LhxI/7+/hbH2NnZPbBcAKPRaHHMvfuVu3/zpF8L0hL6h425IKTHklnel5v3U6FJvEeOHMmJEyfYvXt3rs5Lv9kpU6bQt29fAJYtW0bZsmVZt24dw4cPz5f4ZsyYwXvvvZdhe3R0NAaDIV+ukZ9Uo5HUo8cw3b6NpkwZbOrVRdEW3HIHhYXJZCIuLg5VVdHcn9SIIqk41Kl/mar4l7GcdMpgTOXslcOcubaX/be2sN8+IdtyTtubOM0liL0Ex39Hd0zFP1XB2+SEl86Hci7VqOrflJqBTbG1Kbwt48WhToWl9B5rMTExREVFWTkakR/kfVr8lOQ6TU1NxWQyYTAYzH+3r+qyKkfnGk1GevzSg8jEyEzHeSsoeDl6sfGJjTke453T3CE90TMYDHTs2BG9Xo+iKHTo0AGDwWBONgMCArC1teWvv/7iueeeM9/zgQMHeO211zAYDBiNRvO106+fnkfdG096mQaDgapVq2JnZ0dISIhFa/q995FZuff+azAY0Ol0FvsB3NzcALh+/Tp16tQBIDg4GEhL2PMac0FIf65jYmIyTOKW/uVEThSKxHvUqFFs3LiRv/76i7Jly+bq3PSuDPeO6bazs6NixYpcvXo103PSxxeEh4ebz09/XL9+/UzPmTRpEm+88Yb5cWxsLOXKlcPNzQ0XF5dcxVzQ4rZsIWL6DAz3TFqg8/bGa/IknO/rKlLcmEwmFEXBzc2txP1SKa6Kc516eXalVaOuuG3zYP/Nr3J9vkFRuGILV0gALkLiRTj/O3ZnVfwNCt6qC752/gS416Ze5TbUqdQMnc4mz/Hq9Sn88vcXhMdcxdu1PE+0ejlPXd+Lc52WVK6uruZ/czNcTBRe8j4tfkpynSYnJxMdHY1Op0Ony136o0PHxMYTGbdrHAqKRfKtkNZqO6HxBOwKYCiYRqNBo9GY4z516hSQluuk71cUBVdXV1555RUmTZqEp6cn5cuXZ9asWSQmJjJs2DB0Oh3auw1w9z4H6a+De5+T9DJ1Oh1ubm6MGzeON998E0VRaNmyJTExMezZswcXFxcGDRqUabn3/qvT6ahYsSKXL1/mxIkTlC1bFmdnZ5ydnWnWrBmffPIJlStXJiIigqlTpwKg1WrzHHNB0Ol0aDQaXF1dM0zCnZtrWjXxVlWV1157jZ9++omdO3cSGBiY6zKCgoKws7Pj7NmztGzZEkj7hufy5ctZTvASGBiIj48P27ZtMyfasbGx7Nu3jxEjRmR6jp2dnflFfq/0N0RhEbt5MzfHjIX7uloYIiK4OWYs/nPn4NK5s5WiezQURSl09SIeTnGv095tXmHxyi+4rVUsZlxPp6gqHkaV9+p/xOnre7kSdZqw1FDClHhu2qgY7jsnRaNwyRYuEQvEQtRp2L8Oh39N+Kdq8cYVP/tyVPSsR/0qbakZ2AhNNj1iMsy4ngCLV3+R5xnXi3udljS+vr689tpr+Pr6Sp0WI/I+LX5Kap2mJ2bpP7nVqUInZiuzM13He0KTCQW6jjf81y07/UvOzHz00UeoqsrAgQOJi4ujUaNG/Pnnn+YvQ9PLuPc5uP/fzLZ9+OGHeHl5MXPmTC5dukTp0qVp2LAhkydPzlBWZuUqisJTTz3FTz/9RPv27blz5w7Lli1j8ODBLF26lCFDhtCoUSOqVavGxx9/TOfOnTPUVW5jzm/p18/svZOb95KiFlRn+Bx49dVX+fbbb/n555+pVq2aeburq6t5gfiwsDDCwsI4ePAgw4YN46+//sLZ2Zny5cubX0hjxozhhx9+YOnSpQQEBDBr1ix+/fVXzpw5Y+7GUL16dWbMmEGfPn2AtBfnzJkzLZYTO3bsWI6XE4uNjcXV1ZWYmJhC0+KtGo1c6NARQxbj1FEUdN7eVN62tdh2OzeZTERFReHu7l7ifqkUVyWlTr/4eUra7OWQ6XJno9x6ZZrgJiTGcfD0dk5d+YerMWcI04cRpk3gpg5MOfwFVMpowt+gw1spjZ9DBSp51aNhtfZULlsHjVZrjk0Fi3Ho2cWWlZJSpyWJ1GnxI3Va/JTkOk1OTiYkJITAwMCHWjbYaDJyKOIQkYmReDp60tCrYYEtIZYT6d2rdTpdgSWd4sGvn9zkhFZt8V68eDEAbdu2tdie/i0IwOeff24xtjp9mbF7j5k1axY6nY4BAwaQlJRE06ZN2b59uznpBjh79qx5DBqkrXWXkJDAyy+/zJ07d2jZsiWbNm0q0mt4Jx4MzjrpBlBVDGFhJB4Mxqlpk0cXmBAiW7ld7iydk6MzbYJ60Saol8X2mPgoDpzcxumr/3At9hxhhgjCtEmE6cjQqh6v1XBWa+IsUWCMgtBDELoMV6MJ31QdV2wNaedkMuO6IjOuC+DOnTts2rSJ7t27S1dzIUSxpdVoaezT2NphiCLKqi3eRVlhbPGO2fgbN8ePz/Y42yqVcenWDcdGjXCoVw9NJl3oi6qS/G1ucVXS6lSvT3mo5c6yc/tOGPtPbuHsjf1cj71AmDGCUF0yEbqHe27HeTzL4B5TcnRsSavTkuDMmTOMGDGCxYsXU716dWuHI/KBvE+Ln5Jcp/nV4l3YSIv3o1EsWrxF/tJ5euboOP35C9w6Px8AxcYG+3p1cWzUCMdGjXFsUB+NU9FbnkiI4sLW1o5+nUYXWPllSvvQ7bEBdGOAxfawW9fYf2oz528e5Hr8RcKNt7ipS+F2DhPyT2+tYdVX3+JrdMBH50U5l6rUKNecJrU74VpKWkCFEEIIUbJJ4l2MODYKQufjkzabeVYdGTQauGe9OTU1laSDwSQdDOY2S0Crxb5WrbREvHEjHIOC0BaSFn0hRMHx8SjHE62HAEMstn/9y1TmRK/PURnhNhrCbVKAa5B4Dc5uQ3PmA/wM4GN0wsfWh/Kla1I7oAUVfRrk+z0IIYQQQhRWkngXI4pWi/fkSdx4fUzaWMx7k++73U/8P/sM+1o1STxwkMSDB0g8cJDUe5ddMxpJPnaM5GPHiFq6FBQFu+rV77aIpyXjOhm/J0SJMaDrJFatXJfljOuoKg6qStlULTdsjCTe133RpChct4HrNolgXoN8IzZ31yD3UZ3xtfOngnsd6ldqQ92qLfK85FlBd9MXQgghhMgrSbyLGZfOnWHuHMKnz7CYaE3n7Y335EnmpcRsy5aldJ/eAKSGh5N48CCJBw6QePAg+gsX/ytQVUk5fZqU06eJXrky7dxKle4m4Y1xbNwIG2/vR3Z/QohHy9bWjuc8erMg+mcUVc10xvWh7mmTv5mMRk5c3MeRCzsJuXWMm8nXCVNiuKFTSdFYJu2pisJlW7hMHHAGos5A1Doc9pkom77kmUMAFT3r0rBqB6oF1H/gkmcZljuLh8Url+R5uTORO46OjtSrVw9HR0drhyKEEEIUSjK5Wh4VxsnV7qUajWmznEdGovP0xLFRUI6XEDNERaUl4nd/Uk6fybrrOmBTrpxlIl62bLYTPDxMfA9SkicOKa6kTguHDIkt4GkwPXDG9XR6fQqHzu7i2KW/uRJ1kjD9TUI18dy0AWMOJ4NxNprwN9jgo7jh7xhIZZ8gmtbsTDnfKvm+3JnIPXmfFj9Sp8VPSa5TmVxNPIz8mlxNEu88KuyJd34yxsaSeOgQSQcPknDgAMknToLRmOXxOh8fi67pthUrWnwYxG7enLFF3sfHokU+r0ryL5XiSuq08MivrtzpdWpjp+HQmR2cvLo3bQ3y1PAslzzLirvBRLxGQa+QYbkzSEu+PYwqmwYckm7nBSg1NZXQ0FB8fX2xscnbUAFRuMhnb/FTkutUEm/xMCTxtrKSlHjfz5SQQNLRoyQcOEDSgYMkHTuGqtdnebzW3d2ciKtGAxEfz8rYgp4+Bn3unIdKvkvyL5XiSuq0+MmuTtOXPDt9fR834s4TZrzFTV2yRWt7br3tN6xAZ4sv6WQ5seJHPnuLn5Jcp5J4i4chy4kJq9E4OeHUogVOLVoAYEpJIfnYsbvjxA+SePgwalKS+XhjVBRxmzcTt3lz1oWqKigK4dNn4NyhQ750OxdCFE1ZLXl2LewSB09v5lzoQW4kXCJMjeKyTSpJOfgDMiL2arbHCCGEECJ7FSpUYMyYMYwZMwYARVH46aef6N27t1XjKuwk8RYPTWNnd3d8d2MYkbZEWfKpU/8l4sHBmOLisi9IVTGEhZGwdy+lWrYs+MCFEEVKOZ+KlPN5xWLb2s1z+CD062zP9XIpX1BhCSGEKCEKao6iTK+lqnTq1AmtVsuff/5psW/RokVMnjyZ48eP4+PjUyDXF/lPEm+R7xQbGxzq1cOhXj3KDBmCajSScu4ct5cvJ/bnX7I9/9rwV3BoUP9u9/TGONSvj7aU0yOIXAhR1PRuO4LFK7984HJnLiaV3m2GP/rghBBCFBsFOUdRZhRFYdmyZdSpU4clS5YwfHja77GQkBDeeustFi9eTNmyZTEYDDkqT6/XY2trm+9xipwrWQM8hFUoWi32NWpQ+sm+OTvBaCTpYDC3P1/CtaFDOde0KSFP9yP8o4+J274d4507BRqvEKLoSF/uDP6bxdyCohCnUfhy4/8ebWBCCCGKjdjNm7nx+hiLpBvAEB7OjdfHEPug4ZQPoVy5csydO5fx48cTEhKCqqoMGTKETp06sXPnTipWrIiLiwvVq1dn7ty5FucOHjyY3r17M23aNPz8/KhWrRqXL19GURR+/PFH2rVrZ14Kcu/evRbn7t69m1atWuHg4EC5cuUYPXo0CQkJBXKPJYkk3uKRcWwUhM7HJ9OZh9MpDg7oypez3Gg0knz8OFHLlnH91ZGca9acS0/0Iuz9D4j94w9SIyIKOHIhRGH2cq9pjHLrRRmjZeLtYDIBaTOkfxH7Bwt/fNMa4ZUIFStW5KuvvqJixYrWDkUIIfKVajQSPn1G5kvr3t0WPn0G6gNW/HkYgwYNokOHDrz00kssWLCAEydO8MUXX1C2bFnWrl3L0aNHefvtt5k8eTJr1661OHfbtm2cPXuWLVu2sHHjRvP2KVOmMH78eI4cOULVqlV57rnnzC3nFy9epGvXrvTt25djx47x/fffs3v3bkaNGlUg91eSyKzmeVSSZzV/GOnfGAKWH2D3zWqeGh5BUvBB8zjxlPPnH1iubUAADo0b4RAUhL5yZTxq1kQrE7QVCyV5FtbiqqDq9P7lzh5/7CXeWv04u2xvA6BRVYY5d2VU30/y7ZoijbxPix+p0+KnJNdpZrNSh/R9CsOtW9mea9LrMUVHZ3ucxs0NTQ66cus8PAhc/0P2Qd8jIiKCWrVqERUVxfr1682TmN07q/lrr71GWFgYP/yQVvbgwYPZtGkTV69eNXcxv3z5MoGBgXz11VcMGTIEgFOnTlGrVi1Onz5N9erVGTp0KFqtliVLlpivv3v3btq0aUNCQgL29vYlbnI1mdVcFEkunTvD3DkZx8h4e1uMkbHx9sKme3dcuncHwBAdTdKhQ2mTtR08SPKpU3C3NQtAf+UK+itXiPlhPQCxPj5pE76lryUeGCjLLAhRzNna2mVYMmzOi1sYs6wTu2xvY1IUvozbBOuR5Duf3bx5kzlz5jBmzBjKli1r7XCEECJbhlu3MISH51t5puhoTNkflideXl4MHz6cDRs2mJPbhQsXsnTpUq5evUpSUhJ6vZ769etbnFenTp1Mx3XXrVvX/H9fX18gLbmvXr06R48e5dixY6xevdp8jKqqmEwmQkJCqFGjRv7fYAkhibd45Fw6d8a5Q4dczQqpc3PDuUMHnDt0AMAYH0/S4SNpLeIHD5J87Bhqaqr5eENYGLG//krsr78ClmuJOzZuhF3Vqlle71HOWCmEKFg6nU2mybf6g4nXnppt7fCKjfj4eIKDg4mPj7d2KEIIkSM6D48cHVcQLd55odPp0OnSUrc1a9Ywfvx4PvnkExo3boybmxuffPIJ+/btszjHySnzyYltbGzM/09vmDLdbdCKj49n+PDhjB49OsN55cvLCiEPQxJvYRWKVotT0yZ5Pl9bqhSlWrWkVKu0ZcdMyckkHTtGwoEDxO79F8PJkw9cS1zj7Ixjw4Y4Nk5Lxu1r1UKxsXnkM1YKIQref8l3Z3bZ3sKkKHwVvxl+eEOSbyGEKKFy2t1bNRq50KFjWut4FpN46ry9qbxt6yNrqNmzZw8tWrTg1VdfNXc1v3jxYr6U3bBhQ06dOkXlypXzpTzxH0m8RbGgsbfHqUkTHBo1QvPMM7g5O6M/cybLtcRNcXHE79pF/K5dQNqkbjblyqE/dy5D2ekzVnJ3/LkQouhJS743Z0y+143ltac/s3Z4QgghCilFq8V78qS0vwUVJdM5irwnT3qkvSOrVKnCN998w59//km5cuX47rvvOHDgAIGBgQ9d9oQJE2jWrBmjRo1i6NChODk5cerUKbZs2cKCBQvyIfqSq2TNrCBKjPS1xMsMGUK5zxdT9d+9BG74Ce8pU3Du0gVtmTIWx6tJSZkm3Wk7VVDVAp2xUghR8NKT77b6tG5+JkXhq4QtzF831sqRCSGEKMxcOnfGf+4cdN7eFtt13t7miYEfpeHDh/Pkk0/y7LPP0rJlS27fvs2rr76aL2XXrVuXXbt2ce7cOVq1akWDBg1455138PPzy5fySzKZ1TyPZFbzwimnM3aqqoo+5DKJBw+QePAg8bv3YIqKyrZ8lx7dce3VC4eGDdGWKpWfoYsslORZWIsra9epwZDK2GWd2WmbNputRlUZ4tSR0U/PeeSxFBe3bt3i119/pWfPnnjkcfyiKFys/T4V+a8k1+mDZqXOjcI2D9C9s5rLJMIFJ79mNZfEO48k8S6c8vpLJWbjb9wcPz7nF9JosK9ZE8cmTdLGiQcFoZXXQYEoyX8oFFeFoU5NRiOvL+0oyXc+KQx1KvKX1GnxU5LrNL8S78JGEu9HI78S75L1rhMiCzpPz9ydYDKRfOIEUUuXcn3Eq5xr2oyQJ/sSPmMmcdu2Ybxzp0DiFELkD41Wy9yXtt7X7Xwr89aNsW5gRVRcXBx79+4l7p65NIQQQgjxH0m8hQAcGwWh8/ExT5KRgaKg8/LCb/Zs3Pr3x65KFcv9qkryqVNErVjB9ZGjONe8BZd69yFs2nRiN2/GkINlKIQQj1Z68t1On/bFm3o3+Z677nUrR1b0hIaGMnv2bEJDQ60dihBCCFEoyazmQpDDGSv/NwWXzp1x7d4NAEN0dNqs6fsPkHjgAClnz/53nqqScuYMKWfOEL1yJQB2Varg2LixuXu67r4J3oQQj55Gq2XOS1sYs7QTO2wjURWFrxO2wbrXef3pudYOTwghhBDFhCTeQtzl0rkzzJ2TcR1vb+9M1/HWubnh0qkTLp06AWC8c4fE4GBzIp585gyYTObjU86fJ+X8eaK//RYA20qVcGzSGKfGjXFs3DjH3d0L28QeQhR1WSXf6trRjOk3z9rhCSGEEKIYkMRbiHu4dO6Mc4cOeUpstaVL49yhA84dOgBgjI1NS8QPHExLxE+etEjE9Rcvor94kTvfrQHAtkKFu63hjXFs0hib+5asAIjdvDnjFwM+Ppl+MSCEyLnMku+lidtBkm8hhBBC5ANJvIW4j6LV4tS0yUOXo3VxwbldO5zbtQPAGB9P0qFDJB44QML+/SSfOAn3rAuuv3wZ/eXL3Fm7FgCbgPI4Nv6vRTzpxIm0rvD3LURgCA9P226FdSSFKE7Sk++xSzuz3TbinuT7Ncb0m2/t8Ao1Ozs7AgMDsbOzs3YoQgghRKEky4nlkSwnVjgVpaUyTAkJJB4+QuL+/SQeOEDSiROQmpr1CVqtRaJuQVHQeXtTedvWYtftvCjVqciZwl6nJqPRnHwDKKrKS47tJPl+gMJepyL3pE6Ln5Jcp7KcmHgYspyYEEWcxsmJUi0fw+uNsVT47luq7fuX8ku/psyIV3BoFIRiY2N5QlZJN4CqYggLI/FgcMEGLUQJoNFq+eylzbTXewHcbfnewezvR1k5MiGEEEIUVZJ4C1FIaBwdcWrRAq/XX6fCqlVUPbCf8suX4zFyJLaVKuWojJsTJxL69ttEr11L8pkzqAZDAUctRPH0X/KdNteCqigsT9opyXcWzp8/z3PPPcf58+etHYoQQghg+fLllC5d+oHHTJ06lfr16z+SeIQk3kIUWhp7e5yaNcXztVH4vPNOjs4xhIZyZ90PhL3zLiG9+3C2cRMuv/AC4R99TOwff5B64wYyukSInElLvv/MJPkeaeXICp/07o7y+SKEEPln8ODBKIpi/ilTpgxdu3bl2LFj2Z77zDPPcO7cuUcQZfbatm1rvgd7e3uqVq3KjBkzMvzO+Omnn2jWrBmurq44OztTq1YtxowZ88CyK1SoYPEcKYrCzJkzcxSXqqp069YNRVHYsGFDHu8u52RyNSGKAMdGQeh8fDCEh2eYXM1Mp0ubNf2emdPVpCSSDgaTdE8XdG2ZMjjUqYN93To41K2HQ53aaF1dC/oWhCiS0pPvN5Z2YZtt+N3kexd8P5I3nllo7fCEEEIUc127dmXZsmUAhIWF8b///Y/HH3+cq1evZnlOamoqDg4OODg4PKowszVs2DDef/99UlJS2L59Oy+//DKlS5dmxIgRAGzbto1nnnmGadOm8cQTT6AoCqdOnWLLli3Zlv3+++8zbNgw82NnZ+ccxTRnzpxHOjZeWryFKAIUrRbvyZPuPrjvA0JRQFHwn/0p1Q4eIGD1KrwmTMClezds/P0zlGW8fZv4nTu5NW8+14YO5VzTZlzs0pUbb75F1MpVJB09iikl5RHclRBFg0arZfZLf9LBouV7F7O/f9XKkQkhhCju7Ozs8PHxwcfHh/r16zNx4kSuXbtGZGQkAJcvX0aj0fD999/Tpk0b7O3tWb16daZdzWfOnIm3tzfOzs4MGTKE5ORki/0Gg4HRo0dTunRpypQpw4QJExg0aBC9e/c2H2MymZgxYwaBgYE4ODhQr149fvjhh2zvw9HRER8fHwICAnjxxRepW7euRVL966+/8thjj/Hmm29SrVo1qlatSu/evVm4MPsvuZ2dnc3PkY+PD05OTtmec+TIET799FOWLl2a7bH5RRJvIYoIl86d8Z87B91963vrvL3xv7uUmMbREcegIMq8OBj/2bOpvG0rVfbspuzni/F49VWcWrZEk0nrtv7KFWJ//ZXwadO4/MyznG3UmJCnnibs/fe5s2EDKZcuod7Tkv4gqtFIwr79xGz8jYR9+1EfNCmcEEWEOflO9QHSk++/JPkWQgjxyMTHx7Nq1SoqV65MmTJlLPZNnDiR119/ndOnT9OlS5cM565du5apU6cyffp0Dh48iK+vL4sWLbI45qOPPmL16tUsW7aMPXv2EBsbm6EL9owZM/jmm2/4/PPPOXnyJGPHjuWFF15g165dOboHVVX5+++/OXPmDLa2tubtPj4+nDx5khMnTuTw2fjPzJkzKVOmDA0aNGDWrFkYspnjKDExkf79+7Nw4UJ8fHxyfb28kq7mQhQhLp0749yhA4kHgzFERqLz9MSxUdADlxDTlSmDc9u2OLdtC6R94KVevUrSseMkHTtG8rFjJJ8+jarX/3dSairJJ06QfOIEfPsdAJpSpbCvUzute3rdOtjXqYONl5fFtWI3byZ8+gwMYWH/Xd/HB+/Jk2SNcVHkabRaZr+4iTeWdWWbTZg5+eb7V3njmUXZF1CMBQQEMHv2bAICAqwdihBC5Njt27e5ffu2xTZnZ2d8fX3R6/Vcvnw5wzlVq1YF4OrVqxlajH18fHBxceHOnTtERERY7HN0dKRs2bK5jnHjxo2UKlUKgISEBHx9fdm4cSMajcZijPSYMWN48sknsyxnzpw5DBkyhCFDhgDw4YcfsnXrVot7mD9/PpMmTaJPnz4ALFiwgN9//928PyUlhenTp7N161aaN28OQMWKFdm9ezdLliyhTZs2WV5/0aJFfPXVV+j1elJTU7G3t2f06NHm/a+99hp///03derUISAggGbNmtG5c2eef/557Ozssix39OjRNGzYEHd3d/755x8mTZpEaGgos2fPzvKcsWPH0qJFC3r16pXlMQVBEm8hihhFq8WpaZO8n68o2AYEYBsQgGvPxwFQ9XqSz50n6dhRko8dJ+n4cfQXL1qcZ4qPJ3HvvyTu/de8Tefjg0PdujjUrYMpRc+t+RnXOTaEh3Pj9TFwt1VeiKIsPfket6wbW21CJfm+y87OjnLlyj3wjyMhhChsfv31V1asWGGxrWPHjkyZMoXIyEiGDx+e4ZwdO3YAaa3Dp06dstg3efJkOnXqxI4dO5g3b57FvkaNGjFr1qxcx9iuXTsWL14MQHR0NIsWLaJbt27s37+f8uXLW5T/IKdPn+aVV16x2Na8eXPz/cTExBAeHk6TJv/9janVagkKCsJ0t9fjhQsXSExMpFOnThbl6PV6GjRo8MDrP//880yZMoXo6GjeffddWrRoQYsWLcz7nZyc+O2337h48SI7duzg33//Zdy4ccydO5e9e/fi6OiYablvvPGG+f9169bF1taW4cOHM2PGjEx/J/3yyy9s376dw4cPPzDegiCJtxACxdYWh9q1cKhdC/qnbTPGxZF84kRay/jxYyQfPYbh7niidIawMOLCwojbvDnrwlUVFIXw6TNw7tDhga3zQhQFGq2WT1/8wyL5Xpb8N+qaEYx7drG1w7OK8PBwvvrqK4YOHYqvr6+1wxFCiBzp2bOnRfIH/03M5enpyZIlS7I8d8KECZm2eENaslyrVi2LfVkljtlxcnKicuXK5sdfffUVrq6ufPnll3zwwQcWxxW0+Ph4AH777Tf875tHKLsvXl1dXc33sXbtWipXrkyzZs3o2LGjxXGVKlWiUqVKDB06lClTplC1alW+//57XnzxxRzF2LRpUwwGA5cvX6ZatWoZ9m/fvp2LFy9mGP/et29fWrVqxc6dO3N0nbyQxFsIkSmtszNOzZvjdLcrEUBqWFha9/Tjx0k6dpzk48cxJSZmX5iqYggLI/q77yjdrx+ae8b0CFEU3Z98AyxP2Q0lNPmOiYlh+/btPP3005J4CyGKjDJlymQYK53O1tbW3K08M/e2Nt+vdOnS2a6hnVeKoqDRaEhKSsrVeTVq1GDfvn0MHDjQvO3ff//rxejq6oq3tzcHDhygdevWABiNRg4dOmRe67tmzZrY2dlx9erVB3Yrz06pUqV4/fXXGT9+PIcPH85yZvEKFSrg6OhIQkJCjss+cuQIGo0Gr/uGQ6abOHEiQ4cOtdhWp04dPvvsM3r27Jnzm8gDSbyFEDlm4+ODjY+Pucu4ajSiv3SJqJWruLN2bbbnh384jYiPZ2Ffpw6ODRviENQQxwYNZDkzUSRllXyra15h9JNz2bBrCRGxV/FyKU/vNsOxtZVu2EIIIXInJSWFsLtz50RHR7NgwQLi4+NznSS+/vrrDB48mEaNGvHYY4+xevVqTp48ScWKFc3HvPbaa8yYMYPKlStTvXp15s+fT3R0tDkxdnZ2Zvz48YwdOxaTyUTLli2JiYlhz549uLi4MGjQoBzHM3z4cD744APWr1/PU089xdSpU0lMTKR79+4EBARw584d5s2bR2pqaoau7en27t3Lvn37aNeuHc7Ozuzdu9c82ZubmxsAN27coEOHDnzzzTc0adLEPPP5/cqXL09gYGBuntJck8RbCJFnilaLXZUquPTokaPEG9LGkycFB5MUHAxfpm2zq1IFh4YNcQxqiEPDIGz8/R7puopC5FV68j1+WXe22NwEYEXKHn5c1ZA47d2FQ+Jh8colPOfRm5d7TbNitEIIIYqaTZs2mXsSOTs7U716ddatW0fbtm0tJlfLzjPPPMPFixd56623SE5Opm/fvowYMYI///zTfMyECRMICwtj4MCBaLVaXn75Zbp06YL2nmGCH3zwAZ6ensyYMYNLly5RunRpGjZsyOTJk3N1X+7u7gwcOJCpU6fy5JNP0qZNGxYuXMjAgQMJDw/Hzc2NBg0asHnz5ky7jENa9/Y1a9YwdepUUlJSCAwMZOzYsRbjvlNTUzl79iyJOemhWcAUNTc1JsxiY2NxdXUlJiYGFxcXa4cj7jKZTERFReHu7o5GI6vlPSqq0ciFDh0xhIenjenOhMbVhVJt25F0+DCpV68+sDydt7c5CbevX58ETw/KeHpKnRYTxfF9ajIaLZLv+yl33xej3HoVy+T7zJkzjBgxgsWLF1O9enVrhyPyQXF8n5Z0JblOk5OTCQkJITAwEHt7e2uHk29UVcVgMKDT6QqkwcJkMlGjRg369etnMZ68pHnQ6yc3OaG0eAshHpqi1eI9eVLa7OWKYpl83/1F4PvBB+Yu6qkRESQdOkzS4UMkBh8i+fRpuGe9b0N4OLG//0Hs73+kFeHoSGKD+jgGBeHYMAiHunXQ5HGSEiEKgkarZfrzP7F7TWOSMvmDVlUUFFVlza0NDNa/U+y6nbu5udG7d29z1z4hhBBFz5UrV9i8eTNt2rQhJSWFBQsWEBISQv/+/a0dWrEgibcQIl+4dO4Mc+dkXMfb2zvDOt42Xl7YdO2CS9cuAJgSEkg6dozE4EMkHQom6chRi0nb1MREEvf8Q+Kef+4WqsO+Zk0cGzRIGyfesCE6D48cxakajblaB12InPpl91eZJt3pVEUhUqewYdcS+nUaneVxRZGnpyfPP/887u7u1g5FCCFEHmk0GpYvX8748eNRVZXatWuzdetWatSoYe3QigVJvIUQ+calc2ecO3TIdWKrcXKymEFdNRhIPnuWpOBDJAYHk3DwIKbbt/87wWAg+dgxko8dg7vrb9oGBOAQFIRjwwY4NAzCNrBChm5XsZs3Z/xiwMcnwxcDQuRFROyDh1Dk9riiJDExkZMnTxIUFESpUqWsHY4QQog8KFeuHHv27LF2GMWWJN5CiHylaLU4NW3ycGXodDjUqoVDrVqUfuF5bt++jXNSEimHD5MYfIjEQ8HoL1y0OEd/5Qr6K1eI+fFHALTu7jg0bIBjwyAcgxqSeuMGN8aNzzAG3RAentZFfu4cSb7FQ/FyKQ/xOTyumLl+/TpTp06VMd5CCCFEFiTxFkIUeoqiYFu2LPbly+PaqxcAhuhokg4fIelQMImHDpN8/Dhqaqr5HGNUFPFbtxG/dduDC1dVUBTCp8/AuUMH6XYu8qx3m+EsXrmE21oFNbNJblQVT6NK7zbDH31wQgghcjULuBDp8ut1I4m3EKJI0rm54dy+Hc7t2wFgSkkh+cSJtHHiwcEkHj6MKTY2Z4WpKoawMBIPBj90a70ouWxt7XjOozcLon9GUdVMk+9nPXoXu4nVhBCisEtfDkuv1+Pg4GDlaERRk74UmY2NzUOVI4m3EKJY0NjZpc16HhQEDEM1mUi5cIGkQ4eJ+eUXkg4dyraMG+PH49y2LY6NgnBs1Agbf/+CD1wUKy/3mgY/w3e3NnBLZ5l426gqbes/baXIhBCi5NLpdDg6OhIZGYmNjU2xWU6toJcTK+lUVSUxMZGIiAhKly5tsZ55XkjiLYQolhSNBvuqVbGvWhXbwECuDhqU7TnGyEjurFvHnXXrAND5+eIY1AjHRo1wbBSEbcWK8otNZOvlXtMYrH+HDbuWEBF7lYO3dhFsn0yqRsOCzW8wb9h2a4eY73Q6He7u7uh08meFEKLwURQFX19fQkJCuHLlirXDyTeqqmIymdBoNPL3SQEqXbo0Pj4+D12OospghzzJzWLp4tExmUxERUXh7u5ebL7NLOnyo05Vo5ELHTpiCA/PMLmamY0NmEwW64nfT+vujmNQQxwbNcIhqBH21auhSKKRayXtfXrh6gn6b3uGJI0GnaryZeMFNKrV1tph5auSVqclgdRp8SN1mvYc6PV6a4eRb0wmEzExMbi6upbYOi1oNjY2D2zpzk1OKH8xCiGKPUWrxXvypLTZyxXFMvm++w2x/6efUKpVK5KOHiXxYDCJBw+SdOQIanKy+VBjVBRxW7YSt2UrkLYMmkODBuYWcfs6ddDYyfhdYaly+dp0oDIbuYRBUViyZzKNav1j7bCEEKLE0Wg02NvbWzuMfGMymUhMTMTe3l4S7yJAEm8hRIng0rkzzJ2TcR1vb2+LdbydmjXDqVkzANTUVJJPnSLx4EESDxwk8dAhiwnbTAkJJOzeTcLu3QAotrbY161zNxFvjEP9+mhLOT3CuxSF1es9F/D3L12J0WrYZxvL1n3r6Ni0+Iz3vnTpEhMmTOCjjz6icuXK1g5HCCGEKHQk8RZClBgunTvj3KEDiQeDMURGovP0xLFRUJZLiCk2NjjUq4dDvXqUGTIkbcK28+fTEvGDB0m6W046Va8n6WAwSQeDuc0S0Gqxr1EjbdK3xo1wCApC5+b2wBhVozHH8Ymiw8ejHF1sGrDWdBRVUVhx5KNilXgbDAaioqIwGAzWDkUIIYQolCTxFkKUKIpWm+clwxSNBvtq1bCvVg33559HVVVSr141d01PDA4m9erV/04wGkk+cYLkEyeIWrECANvKldJaxIPSuqfb+PqaD4/dvDlji7yPj0WLvCi6RveZx47vWxGp03DEPoX12xfRt/2r1g5LCCGEEI+AJN5CCJFHiqJgGxCAbUAApfs+CUBqeARJwQfN3dNTzp+3OEd/4SL6Cxe5s+Z7AGz8/XFs1AjFwYE7a9ZkuIYhPDxtbPrcOZJ8F3Gupdx5vFRbliX/BcB3F5bQp81wNNKjQQghhCj2JPEWQoh8ZOPthU337rh07w6A8c4dEg8dMreKJ588aTFzeuqNG8TcuJF1gaoKikL49Bk4d+gg3c6LuFd7z2LrN024Zqtw1s7Eij+m8+Ljb1s7LCGEEEIUMJn+TgghCpC2dGmc27fH+603CVz7PdX276P80q/xePVVHJs0QcnJLOiqiiEsjKhvVmJKSir4oEWBsbdzpLdXH/Pj9aFr0etTrBhR/ihbtixTp06lbNmy1g5FCCGEKJRkHe88knW8CydZo7L4Ke51qur13PriS24tWJCzE3Q67GvVxLFhEI6NgnBo2DDbCdsKm+Jep9kxGY089XUDztul/fod5tiB0U/PsW5QD6mk12lxJHVa/EidFj9Sp9aXm5xQakgIIaxIsbXFsXHjnJ9gMJB89BhRy5ZxfeQozjdvwcXuPQh9+x3ubNiA/to15PvUwk2j1fJM4Evmx7/EbCEhMc6KET28yMhIVq9eTeQ9s/wLIYQQ4j+SeAshhJU5NgpC5+MDipLlMRpXV1yfegrbSpUy7NNfusSddesInTiJi506c6FNW66PHUvUylUknz6Nes+YclE4PNNpDHWSbQAIt9Ew76fXrBzRw4mOjmbDhg1ER0dbOxQhhBCiUJLJ1YQQwsoUrRbvyZPSZi9XlLQJ1cw705Jx3w/eN89qboiOJunQIRKDD5EUHEzSyZNwz/rJhogI4v7YRNwfmwDQODnh0KCBuWu6Q926aOztH9n9icwNqD2Wty58DMAfKQcYGn0TTzc/K0clhBBCiIIgibcQQhQCLp07w9w5Gdfx9vbOsI63zs0N5w4dcO7QAQBTUhJJx46TdCiYxIPBJB0+jCkx0Xy8KSGBhN27Sdi9O22DjQ0OtWrhENQQx6AgHBo0yNE4cdVoJPFgMIbISHSenjg2CpJZ1h9Ct8cGsO7EQg7YJxCt1TD359f4cPB6a4clhBBCiAIgibcQQhQSLp0749yhQ66TW42DA05Nm+DUtAkAqsFAyrlzaUuYHTpEYvBBjJG3/jshNZWkI0dIOnKEqK+XAmBbuVLahG1BDXEIaoSNvx/KPV3fYzdvzvilgI9Phi8FRO4MbfYuhw6/iVFR2KqeYdjNcwT4VbV2WEIIIYTIZ5J4CyFEIaJoteYEOs9l6HTY16yJfc2auA8cgKqqpF67ltY1/W6ruD4kxOIc/YWL6C9c5M7atUBaS3taEh6EqtcT8fEsyy7wgCE8PK17/Nw5knznUYt63Xhs/0z+so0iQaNh3u+j+XToJmuHlWuurq60b98eV1dXa4cihBBCFEqynFgeyXJihZMsq1D8SJ0WDENUVNo48but4smnTlmME88xRUHn7U3lbVtz3O1c6tTSiQv7GPz3EFI0CrYmlRWtvqZ25abWDitXpE6LH6nT4kfqtPiROrW+3OSED93inZKSgp2d3cMWI4QQ4hHSubvj3LEjzh07AmBKTCTp2DESg4NJCj5E4pEjqPeME8+SqmIICyP+r79wbteugKMunmpXbkrbneX4U3MdvUZh0fa3WFR5l7XDypWUlBSuXbuGk5MTDg4O1g5HCCGEKHRy/dXIH3/8waBBg6hYsSI2NjY4Ojri4uJCmzZtmDZtGjdv3iyIOIUQQhQgjaMjTs2a4TlyJOWXfk21/fuo8MMPuPR6IkfnXx/xKpee6EXY++8T89tvpIaHF3DExcvrPeZRymgCYI/tbXYf+d3KEeXOlStXeOONN7hy5Yq1QxFCCCEKpRwn3j/99BNVq1blpZdeQqfTMWHCBH788Uf+/PNPvvrqK9q0acPWrVupWLEir7zyCpGRkQUZtxBCiAKk6HQ41K5F6Sf75viclHPniP72O26OG8+FNm250KEjNydMIHrtWlIuXUJGNmWtnG8VOmpqAmBSFJbuf8/KEQkhhBAiP+U48f7444/57LPPuHHjBl9//TXDhw+nZ8+edOzYkX79+vH++++zY8cOLl68SOnSpVm1alW2Zc6YMYPGjRvj7OyMl5cXvXv35uzZsxbHfPHFF7Rt2xYXFxcUReHOnTsZyqlQoQKKolj8zJw584HXbtu2bYZzXnnllZw+HUIIUSI4NgpC5+NjXk88M4qjI3Y1asB948tSb9wg5udfCHvnXS5178H5Fo9xbdQoopYvJ/X0adTU1IIOv0gZ03s+boa0Vu8Ddon8vvsbK0ckhBBCiPyS4zHee/fuzdFx/v7+2Sa96Xbt2sXIkSNp3LgxBoOByZMn07lzZ06dOoWTkxMAiYmJdO3ala5duzJp0qQsy3r//fcZNmyY+bGzs3O21x82bBjvv/+++bGjo2OO4hZCiJJC0WrxnjwpbfZyRbGc2fxuMu43cwYunTtjjI8n6fAREoMPkhR8iKRjx1BTUsyHG6Ojid+6jfit2wCIcXDAoX49HIMa4dgoCIe6ddGU4M/hMqV96G7flNWGAwCsPDWH7i0HWjkqIYQQQuSHPE2u9v777zN+/PgMiWpSUhKzZs3inXfeyVE5mzZZLpmyfPlyvLy8CA4OpnXr1gCMGTMGgJ07dz6wLGdnZ3x8fHJ2A3c5Ojrm+hwhhChpXDp3hrlzMq7j7e1tsY63tlQpSrVqSalWLQEw6fUknzhpTsQTDx3CFBtrPl9NSiJx778k7v33boFpy6A5BgWlJeING6Jzc3t0N1oIvNZnLtu/bU6ojcIJu1S+/fNT+ncZZ+2wsqUoCjqdzmLtdyGEEEL8J0/LiWm1WkJDQ/Hy8rLYfvv2bby8vDAajXkK5sKFC1SpUoXjx49Tu3Zti307d+6kXbt2REdHU7p0aYt9FSpUIDk5mdTUVMqXL0///v0ZO3YsOl3W3yu0bduWkydPoqoqPj4+9OzZk7fffjvLVu+UlBRS7mm5iY2NpVy5ckRHR8tyYoWIyWQiOjoaNzc3WVahmJA6LTxUo5Gk4GAMkZHoPD1xCArK8RJiAKrJhP7CBRIOHiT2330Yjx/HkM0kbLYVK+IQFIRDUBCOQQ3R+fllmdw9bHyFxcIfx/NFwhYAKqUo/PBiMJpCfh/yPi1+pE6LH6nT4kfq1PpiY2Nxc3MruOXEVFXN9A+fo0eP4u7unpciMZlMjBkzhsceeyxD0p2d0aNH07BhQ9zd3fnnn3+YNGkSoaGhzJ49O8tz+vfvT0BAAH5+fhw7dowJEyZw9uxZfvzxx0yPnzFjBu+9l3Gym+joaAx5WftWFAiTyURcXByqqsoHUDEhdVrIVK4MlStjAJJjYnJ/vocHps6dUZs3x6VUKYiIIPXoUVKPHiP1+DGMly1nxdZfuoT+0iVi1q0DQOPlhU3dutjUq4tN3bpoAwNRNBpSdu0ifs5cTPdM7Knx9KTUmNexa9PmYe74kXu61Zts/mULl23hop3K4p8m81z7CdYO64HkfVr8SJ0WP1KnxY/UqfXFxcXl+NhctXi7ubmhKIo5o783+TYajcTHx/PKK6+wcOHC3EUMjBgxgj/++IPdu3dTtmzZDPsf1OJ9v6VLlzJ8+HDi4+NzvMb49u3b6dChAxcuXKBSpUoZ9kuLd9Eg3/wVP1Knxc+D6tQQFUXSocMkBQeTdOgQyadOwQN6UWlcXLApV5aUk6cy7kwfgz7nM5w7dcrXeyho3/w+g09vrwGgbKrK+uf/xd6u8I5/DwkJYdq0aUyZMoXAwEBrhyPygXz2Fj9Sp8WP1Kn1FViL95w5c1BVlZdeeon33nsPV1dX8z5bW1sqVKhA8+bNcx3wqFGj2LhxI3/99VemSXduNW3aFIPBwOXLl6lWrVqOzwGyTLzt7OwyTeI1Go280AsZRVGkXooZqdPiJ6s6tfXwwLZzJ1w7pyXKpsREko4eJfFgMImHgkk6chQ1Kcl8vCk2NvOkG9ImglMUImbMxKVjxyLV7Xxgt4n89vU6ztgZuW6jsPjnNxn37GJrh5Wl1NRUQkJCSE1NlfdpMSKfvcWP1GnxI3VqXbl53nOceDds2JBt27bh5ubGihUreOmllyhVqlSeAkynqiqvvfYaP/30Ezt37sy3b8mPHDmCRqPJMAY9u3MAfH198yUGIYQQD0/j6IhT8+Y43f1SV01NJfn0aXMinvjvPkzx8VkXoKoYwsJIPBiMU9Mmjyjqh6fRaulf5RXeuZrWg+y3hL8YGh+Fa6m8DecSQgghhHXlOEU/ffo0CQkJAPz1118k3dPikFcjR45k1apVfPvttzg7OxMWFkZYWJhF2WFhYRw5coQLFy4AcPz4cY4cOUJUVBSQtszZnDlzOHr0KJcuXWL16tWMHTuWF154Abe7s+HeuHGD6tWrs3//fgAuXrzIBx98QHBwMJcvX+aXX35h4MCBtG7dmrp16z70fQkhhCgYio0NDnXrUualFym3YAE+U9/N0XmGe8Z+FxV92r1C/eS0nlaROg1zf3rNyhEJIYQQIq9y3OJdv359XnzxRVq2bImqqsyaNSvLFu+cLie2eHFat7m2bdtabF+2bBmDBw8G4PPPP7eY1Cx9mbH0Y+zs7FizZg1Tp04lJSWFwMBAxo4dyxtvvGE+JzU1lbNnz5KYmAikdYvfunUrc+bMISEhgXLlytG3b1/+97//5ShuIYQQhYPOM2c9m3SengUcScF4scFExpyaiqoobE49wtDIK/h5Blg7LCGEEELkUo4nVzt79izvvvsuFy9e5NChQ9SsWTPT5boUReHQoUP5HmhhExsbi6ura44G0otHx2QyERUVhbu7u4x1KSakTouf/KxT1WjkQoeOacuSZfHrTOflReUd24vUGO97vfzFY+y1S1v//HFjIDNe+sXKEWUUExPDX3/9RevWrS3mfxFFl3z2Fj9Sp8WP1Kn15SYnzHGLd7Vq1VizJm2GVY1Gw7Zt23I1hloIIYTIb4pWi/fkSdx4fUzaLOaZJN86Ly8own+QvPzYNA4cGIVBUdimXOTclWNUDShcw6KcnZ1p3rw5zs7O1g5FCCGEKJTy9JeIyWSSpFsIIUSh4NK5M/5z56Dz9rbccXc5seQTJ4he/a0VIssfjWq1pXVq2r0laTQs3PxGNmc8elFRUfz666/m+VeEEEIIYSnHife///6b40ITExM5efJkngISQgghcsulc2cqb9tK+RUr8PvkE8qvWEHZRQvN+yM+/pjks2etGOHDGdn5MxxMJgD+sgnj0KldVo7I0q1bt/jmm2+4deuWtUMRQgghCqUcJ94DBgygS5curFu3zjy7+f1OnTrF5MmTqVSpEsHBwfkWpBBCCJEdRavFqWkTXB/vgVPTJji3a4fbwAEAqHo9N8aNw5QPK3JYQ9WAurRXKwFgUBQ+3z3ZyhEJIYQQIjdynHifOnWKHj168L///Y/SpUtTq1YtOnXqRM+ePWnZsiUeHh40bNiQkJAQNm/ezMCBAwsybiGEECJbXuPHY1e9OgD6CxcJ/+gjK0eUd6N7zsfFmNbq/a9tDDsOrLdyREIIIYTIqRwn3jY2NowePZqzZ8+yd+9ehg0bRu3atfH396dt27YsWbKEmzdv8t1331GnTp2CjFkIIYTIEY2tLf6ffoJibw/AnTXfE7tli5Wjyhs/zwC66OoBoCoKyw7PtHJEQgghhMipHM9qfq9GjRrRqFGj/I5FCCGEyHd2lSrhPWkSYe++C0DY/97GoU4dbHx8rBxZ7o3uM4+da9sQqdNw2C6ZDTuW0LvdcGuHRalSpQgKCqJUqVLWDkUIIYQolIru+ipCCCFEDpXu9zTOnToBYIyJ4eabb6EajVaOKvdKO3vQw6m1+fHq84sxFYL78PPzY+LEifj5+Vk7FCGEEKJQksRbCCFEsacoCr4fvI/ubit34oED3P7ySytHlTcj+3xK2dS09crP2BlZucn6Xc4NBgMxMTEYDAZrhyKEEEIUSpJ4CyGEKBG0pUvjP+tj0KT96oucv4DEw4etHFXu2ds50tvjCfPjH26uwWBItWJEcOnSJYYOHcqlS5esGocQQghRWEniLYQQosRwbNwYj1fujok2Grk5/k2McXHWDSoPhvX8gEp6BYDLtvD5z5OsHJEQQgghHkQSbyGEECWKx6uv4tCgAQCpN24Q9t77qKpq5ahyR6PV0q/8IPPjX6I3kZBY9L5AEEIIIUqKPM1qDrBt2za2bdtGREQEJpPJYt/SpUsfOjAhhBCiICg6HX6zZhHSpw+muDhiN27EqeVjlO7d29qh5Ur/LuP49YtVnLAzEGqjMH/DGCb2/9raYQkhhBAiE3lq8X7vvffo3Lkz27Zt49atW0RHR1v8CCGEEIWZbVl/fN+ban4c/v4H6K9csV5AeTSg5ljz//9I+pfbd8KsGI0QQgghsqKoeehf5+vry8cff8yAAQMKIqYiITY2FldXV2JiYnBxcbF2OOIuk8lEVFQU7u7uaDQykqI4kDotfgpTnd6cPIWYH38EwL52bSp8uxrF1taqMeXWi0uactA+EYA+VOf9QeseeQypqamEhobi6+uLjY3NI7++yH+F6X0q8ofUafEjdWp9uckJ81RDer2eFi1a5Ck4IYQQorDwmTIZ2woVAEg+cYLIefOsG1AeDGn6Lpq736FvMZ7iWuj5Rx6DVqvF0dERrVb7yK8thBBCFAV5SryHDh3Kt99+m9+xCCGEEI+UxskJv08/gbuttLe/+pqEf/6xclS507J+dx7TuwMQr9Uw9/fRjzyG69ev8+GHH3L9+vVHfm0hhBCiKMjT5GrJycl88cUXbN26lbp162boVjZ79ux8CU4IIYQoaA61auE1diwRH38MwI0JE6j488/o3N2tHFnOvdLuY/btHopeo7BTc42TFw9Sq1KjR3b9xMREjh49SmJi4iO7phBCCFGU5KnF+9ixY9SvXx+NRsOJEyc4fPiw+efIkSP5HKIQQghRsNwHD8LpsccAMEbeInTS5CK1xFjdKs1oa/QHIEWjsGjbeCtHJIQQQoh75anFe8eOHfkdhxBCCGE1ikaD38wZXOrdB+Pt28Tv2kX0qtW4D3jB2qHl2Oju89nzZx8SNBr22N5i77FNNK/b1dphCSGEEII8tnjf6/r16zKmSwghRJGn8/TEb8Z08+OIWbNIPnvWihHlToBfVTpSHQCjovDV3qnWDUgIIYQQZnlKvE0mE++//z6urq4EBAQQEBBA6dKl+eCDDzCZTPkdoxBCCPFIlGrdGvdBAwFQ9XpuvDEOU1KSlaPKudd7z8fNmPZ7eL99An/ufTQToXp5eTFkyBC8vLweyfWEEEKIoiZPifeUKVNYsGABM2fONI/tnj59OvPnz+ftt9/O7xiFEEKIR8Zz3DjsatQAQH/xIuEzP7JyRDnn6eZHN7vG5sffHPv0kVy3dOnSdO3aldKlSz+S6wkhhBBFTZ4S7xUrVvDVV18xYsQI6tatS926dXn11Vf58ssvWb58eT6HKIQQQjw6Gltb/D/9BMXeHoA7339P7ObNVo4q50b3mY93alqr9zF7Pd9vmVPg14yNjeWvv/4iNja2wK8lhBBCFEV5SryjoqKoXr16hu3Vq1cnKirqoYMSQgghrMmuYkW8J08yPw59+x1SQ0OtGFHOOTk684RrJ/Pj70OWYjIaC/SaYWFhzJ8/n7CwsAK9jhBCCFFU5SnxrlevHgsWLMiwfcGCBdSrV++hgxJCCCGsrfTTT+PcuTMAppgYbr41AbWAE9j88kqvjwjQp/3/vJ3K2yueZsH68azdMg+9PsW6wQkhhBAlUJ6WE/v444/p0aMHW7dupXnz5gDs3buXa9eu8fvvv+drgEIIIYQ1KIqC7wfvk3T8OIbQUBIPHOD2l1/i8cor1g4tW7a2dvT17cfs22sB+EV7HuLPQzwsXrmE5zx683KvaVaOUgghhCg58tTi3aZNG86dO0efPn24c+cOd+7c4cknn+Ts2bO0atUqv2MUQgghrELr6or/rI9Bk/brMnL+AhIPH7ZyVDmjT00CVc2w/bZWYUH0z3zx8xQrRCWEEEKUTHlq8Qbw8/Nj2jT5tlwIIUTx5tioER6vvMKtRYvAaOTm+DcJ3PATWmdna4eWJb0+hTVRP4NWybBPVRQUVWXNrQ0M1r+Dra3dQ1/PwcGBKlWq4ODg8NBlCSGEEMVRjhPvY8eOUbt2bTQaDceOHXvgsXXr1n3owIQQQojCwuPVEST8+y9Jhw6ReuMGYVPfw++TWShKxsS2MNiwawm3dFl3alMVhUidwoZdS+jXafRDX69cuXJMnz4dd3f3hy5LCCGEKI5ynHjXr1+fsLAwvLy8qF+/PoqioGbShU1RFIxFZPIZIYQQIicUnQ7/WR9zqXcfTHFxxP72G04tW1K6T29rh5apiNir+XqcEEIIIR5Ojsd4h4SE4Onpaf7/pUuXCAkJyfBz6dKlAgtWCCGEsBYbf39833/P/Djsgw/QX75svYAewMulfL4el51z587x9NNPc+7cuXwpTwghhChucpx4BwQEmLvUXblyBX9/fwICAix+/P39uXLlSoEFK4QQQliTS7duuPZ9EgA1MZEb48aj6vVWjiqj3m2G42EwoWTSMw1AUVU8DSZ6txn+iCMTQgghSqY8zWrerl07oqKiMmyPiYmhXbt2Dx2UEEIIUVj5TJmCbYUKACSfPEnE3LnWDSgTtrZ2POfRGyBj8n338bMevfNlYjUhhBBCZC9PibeqqplOKHP79m2cnJweOighhBCisNI4OuL36SdgYwNA1NdLid+zx8pRZfRyr2mMcutFGeN9ibei0FupIet4CyGEEI9QrpYTe/LJtO51iqIwePBg7Oz++6bcaDRy7NgxWrRokb8RCiGEEIWMQ61aeL3xBhEffQTAzYkTqfjzz+gK2azeL/eaxmD9O2zYtYRdIev5yy6tt1pcaoyVIxNCCCFKlly1eLu6uuLq6oqqqjg7O5sfu7q64uPjw8svv8yqVasKKlYhhBCi0HAfNBCnli0BMEbeInTS5ExX+7A2W1s7+nUazcQnlqG7G98R5QYGQ2q+XaNChQrMmzePCne74AshhBDCUq5avJctWwak/YIdP368dCsXQghRYikaDX4zZ3CpV2+Mt28Tv2sX0StX4T5wgLVDy1Q5n4rUTrHniH0Kt3Qafv7rS/q2fzVfyra1tcXX1xdbW9t8KU8IIYQobvI0xvvdd9+VpFsIIUSJp/PwwG/mDPPjiFmzSD5zxooRPVhj95bm//91cX2+lRsaGsq8efMIDQ3NtzKFEEKI4iRPiTfADz/8QL9+/WjWrBkNGza0+BFCCCFKilKtWuE+aBAAamoqN94YhykpycpRZa5fu3HYmu52N9eEoden5Eu5cXFx/P3338TFxeVLeUIIIURxk6fEe968ebz44ot4e3tz+PBhmjRpQpkyZbh06RLdunXL7xiFEEKIQs1z3BvY1awBgP7SJcKmzyBh335iNv5Gwr79qEajlSNM4+NRjjp6RwCidBp+2rXYyhEJIYQQJUOeEu9FixbxxRdfMH/+fGxtbXnrrbfYsmULo0ePJiZGZkoVQghRsmhsbfH/5FMUBwcAYtat4+qgQdwcP56rgwZxoUNHYjdvtnKUaRp7tjH//+/LG6wXiBBCCFGC5Cnxvnr1qnnZMAcHB3PXsgEDBvDdd9/lX3RCCCFEEWFXMRDXXr0y3WcID+fG62MKRfLdr91Y7NK7m2sjSU5JtHJEQgghRPGXp8Tbx8eHqKi0tUDLly/Pv//+C0BISEihXEpFCCGEKGiq0Uj8zh1Z7Ez73Rg+fYbVu517uvlRV18KgBithvU7Fjx0mWXKlOHpp5+mTJkyD12WEEIIURzlKfFu3749v/zyCwAvvvgiY8eOpVOnTjzzzDP06dMnXwMUQvy/vfsOj6Jq+zj+nd1kEwKpQAi9IyggUqQKhC5KE0EFRRBFEVSwg/oqPiLqo6hYUCwUFeVREBQVQWkiPRhA0UBCCSUJgfSEtN15/wgEIi19k+X3ua693J05M3MPt5Pk3jNzjoiUB2nbQ8iOjrl4A9MkOzqatO0hpRfURbSv1iP3/e+Ry4u8v8qVKzN8+HAV3iIiIhdRoHm8z5gzZw4OhwOACRMmULlyZTZu3MjAgQO5//77izVAERGR8iA7NrZY25Wk23o+yiffLOOUxUKo20lS05Kp6OVd6P2lpqYSGhpK+/bt8fYu/H5ERERcVaF6vC0WC25uZ2v222+/nVmzZvHQQw9hs9mKLTgREZHywq1q1WJtV5L8vKvQMtMHgGSrhW/WzCrS/o4ePcr06dM5evRocYQnIiLicgpVeDdq1IgXXniBvXv3Fnc8IiIi5ZJX2za4BQWBYVy4gWHgFhSEV9s2pRvYRXSo3if3/cajPzkxEhEREddXqMJ7woQJ/PDDDzRr1ox27drx9ttvEx0dXdyxiYiIlBuG1Uq1qVNOf7hA8W2aVJs6BcNqLd3ALuK2npOpePqxsZ3u8SSmxDk5IhEREddVqMJ78uTJbNu2jb///pv+/fvz3nvvUbt2bfr06cOCBQuKO0YREZFywadPH2q+/RZu1aqdt86jWTN8+vS5wFbO4V3Rj2uz/AFItVj4evXbTo5IRETEdRWq8D6jSZMmTJs2jb179/Lbb78RGxvLmDFjiis2ERGRcsenTx8a/foLdebPp8Zrr2GtUgWAjL//JmPfPidHl1enmjfmvt8SvarQ+7HZbFSrVk3jvIiIiFxEkQpvgK1btzJp0iSGDBnC3r17GTZsWHHEJSIiUm4ZVisV21+P78ABVBl3X+7yuDJ2V9itwQ/jbc+53XyXeyIJyScKtZ969erx7rvvUq9evWKMTkRExHUUqvDeu3cvzz//PE2aNKFz5878/fffvPrqq8TExPDVV18Vd4wiIiLllu8tQ7FUqgRA4rLvyD550skRnVXRy5trswMASLNYWPTrTCdHJCIi4poKVXg3bdqUFStWMGHCBI4cOcLPP//MqFGjqHT6DwsRERHJYa1UEb/hwwEwMzOJ/7JsfUHdpc6A3PdbYlYXah8RERHcc889REREFFdYIiIiLqVQhXdYWBhbtmzhkUceodoFBpARERGRswLuHAmnRzOPX7gQR0aGkyM6a2jwRHzP3G5uSyE2/liB92G320lOTsZutxd3eCIiIi6hUIV348aNSUhI4OOPP2bKlCnExeVMQbJjxw6OHj1arAGKiIiUd+41auDTty8A9rg4kr7/3skRneXp4UUre1UAMiwG/1vzppMjEhERcT2FKrx37dpF48aNefXVV3n99ddJSEgAYMmSJUyZMqU44xMREXEJAaPvzn1/ct48TNN0YjR53VBvcO77bbHrnBeIiIiIiyr0PN5jxoxh3759eHp65i7v378/69evL7bgREREXEWFli2p0KYNAJnhEaRu2ODkiM4a0m08/tk5t5vvtqURfeKwkyMSERFxLYUqvLdv3879999/3vKaNWsSHR1d5KBERERc0bm93nFz5zkvkH+x2Txo5cgZsyXTYvC/NW8UaPvatWvz0ksvUbt27ZIIT0REpNwrVOHt4eFBUlLSecv37t1L1apVixyUiIiIK/Lu0QP3OnUASN24kfSwvU6O6KxuDW/Nfb8trmC98RUqVOCqq66iQoUKxR2WiIiISyhU4T1w4EBefPFFsrKyADAMg8jISJ566imGDh1arAGKiIi4CsNqJWDUqNzPcfPnOzGavAZ1vY8qp283/9MjncPR+/O9bWxsLPPmzSM2NrakwhMRESnXClV4v/HGG6SkpBAYGMipU6fo1q0bjRo1wtvbm+nTpxd3jCIiIi7Db8hgLD4+ACR9/z3ZZaRYdXNzp5VZE4Bsw+Drdfm/3Tw+Pp4ffviB+Pj4kgpPRESkXCtU4e3r68uqVav4/vvvmTVrFhMnTuTHH39k3bp1VKxYsbhjFBERcRmWihXxv204AGZWFvFffunkiM4KbnJb7vuQhM1OjERERMS1FKrwPqNLly48+OCDPPnkk/Tq1au4YhIREXFp/iNHgpsbAPELv8SRnu7kiHLc3Hk0gadvN9/jkcGhY2XnGXQREZHyzC2/DWfNmpXvnT788MOFCkZERORK4B4UhM+NN5L0/ffYExJIXPZdbi+4M1msVlqZtVnJUbINg/+te4Mn7vjQ2WGJiIiUe/kuvN988818tTMMQ4W3iIjIZQTcfTdJ338P5Ayy5jfsVgxLkW5EKxa9mo1kZfhrAOxI3pqvbXx9fenbty++vr4lGZqIiEi5le/f8AcOHMjXa//+/I+COmPGDNq1a4e3tzeBgYEMHjyYsLCwPG3mzJlD9+7d8fHxwTAMEhISzttPvXr1MAwjz+uVV1655LHT09OZMGEClStXplKlSgwdOpSYmJh8xy4iIlIUFZpfg1e7dgBk7t9Pyvr1To4oR98OI6ieZQKwx5bF3kO7LrtNtWrVuPfee6lWrVpJhyciIlIuFemr9czMTMLCwsjOzi7U9uvWrWPChAls3ryZVatWkZWVRZ8+fUhNTc1tk5aWRr9+/Zg6deol9/Xiiy8SFRWV+3rooYcu2X7y5Ml8//33fP3116xbt45jx45xyy23FOo8RERECiNgzOjc93HzysbUYharlVZGXQAchsGSDW9ddpv09HT2799Pehl5Vl1ERKSsKVThnZaWxtixY/Hy8uKaa64hMjISgIceeuiyPc3nWrFiBaNHj+aaa67h2muvZd68eURGRhISEpLbZtKkSTz99NN06NDhkvvy9vYmKCgo93Wp0dUTExP55JNPmDlzJj169KBNmzbMnTuXjRs3snmzRnEVEZHSUal7d2x1c4rctM2bSf/7bydHlKNP89G573ek7rhs+8jISJ566qncvwdEREQkr0IV3lOmTGHnzp2sXbsWT0/P3OW9evVi0aJFhQ4mMTERgICAgAJv+8orr1C5cmWuu+46/vvf/16yFz4kJISsrKw8I7E3bdqUOnXqsGnTpoIHLiIiUgiGxULA6LtzP5eVXu8ebW+h1unbzf+xZfP3/pDLbCEiIiKXku/B1c61dOlSFi1aRIcOHTAMI3f5NddcQ0RERKECcTgcTJo0ic6dO9O8efMCbfvwww/TunVrAgIC2LhxI1OmTCEqKoqZM2desH10dDQ2mw0/P788y6tVq0Z0dPQFt8nIyCAjIyP3c1JSUm7cDoejQPFKyXE4HJimqZy4EOXU9SineXkPGMDxt97GkZhI4g8/UGXyJNwCA50blGHQytKQI+zHNAyW/P42U+rNu2hz0zRz/6u8ugZdp65HOXU9yqnzFeTfvlCFd2xsLIEX+KMgNTU1TyFeEBMmTODPP/9kw4YNBd720UcfzX3fsmVLbDYb999/PzNmzMDDw6NQ8fzbjBkzmDZt2nnL4+PjC/2MuxQ/h8NBcnIypmliKQOjA0vRKaeuRzk9n+fAgaR99hlkZxP1yadUvH+cs0PihkbDWX4g5/GxP07tJC4u7qJtz9yxlpiYeMl2Un7oOnU9yqnrUU6dLzk5Od9tC1V4t23blh9++CF3ALMzxfbHH39Mx44dC7y/iRMnsnz5ctavX0+tWrUKE1Ie7du3Jzs7m4MHD3LVVVedtz4oKIjMzEwSEhLy9HrHxMQQFBR0wX1OmTIlT4GflJRE7dq18ff3x8fHp8gxS/FwOBwYhoG/v79+ALkI5dT1KKfn8xl7DxFffgnZ2aR/9x01H3kYi5eXU2Pq1+UO3gt7hUgbhHk4OHpyLy0aX3i8FT8/PypUqICfn1+hHheTskfXqetRTl2Pcup8bm75L6cLVXi//PLL3HjjjezZs4fs7Gzefvtt9uzZw8aNG1m3bl2+92OaJg899BDffvsta9eupX79+oUJ5zyhoaFYLJYL9soDtGnTBnd3d3799VeGDh0KQFhYGJGRkRf94sDDw+OCvecWi0X/o5cxhmEoLy5GOXU9ymletqAgfG+6icRly3AkJpL8/ff433GHs8OilVtjItkHwLIt73LtVZ0u2K5JkyYsWLCAgIAA5dSF6Dp1Pcqp61FOnasg/+6FylCXLl0IDQ0lOzubFi1asHLlSgIDA9m0aRNt2rTJ934mTJjA559/zsKFC/H29iY6Opro6GhOnTqV2yY6OprQ0FDCw8MB2L17N6Ghobm3sm3atIm33nqLnTt3sn//fr744gsmT57MnXfeib+/PwBHjx6ladOmbN26FQBfX1/Gjh3Lo48+ypo1awgJCWHMmDF07NjxsqOni4iIlIR/D7JmloFn9m5uc/aW9z/S/3RiJCIiIuVbob8aadiwIR999BFbt25lz549fP7557Ro0aJA+5g9ezaJiYl0796d6tWr577OHRn9gw8+4LrrruO+++4DoGvXrlx33XV89913QE5P9FdffUW3bt245pprmD59OpMnT2bOnDm5+8jKyiIsLIy0tLTcZW+++SY333wzQ4cOpWvXrgQFBbFkyZLC/nOIiIgUiWezZnid/vI389AhUtaudW5AQMeW/aifmfM+3MNkx54L39V28OBBJk+ezMGDB0svOBERkXKkULeaF5czo6BeygsvvMALL7xw0fWtW7e+7Nzb9erVO+9Ynp6evPfee7z33nv5ilVERKSkBYy+m7TTv9Pi5s7Du0cPJ0cErWzNOEDO/OLLtr1P66u7ndcmMzOTI0eOkJmZWdrhiYiIlAt6GEBERKSMqNS1K7YGDQBI27aNU3/+5eSIYGDbB3Pfh2bucWIkIiIi5ZcKbxERkTLCsFgIuPucZ73nz3diNDnaXtOdhpk5s5fst8Hm3SudHJGIiEj5o8JbRESkDPEdNBDr6akuk376iazoaOcGBFzncU3u++XbP3RiJCIiIuVTkQrv8PBwfv7559xRyPPzzLaIiIhcnMXTE/8Rp6cSy84m/osvnBsQMKTDQ7nvQ7P3nre+Ro0aPPnkk9SoUaM0wxIRESk3ClV4nzx5kl69etGkSRP69+9PVFQUAGPHjuWxxx4r1gBFRESuNP533IHh7g5A/KL/4UhNdWo8LZt0oklGzp8Mh2zw247v8qyvVKkS7dq1o1KlSs4IT0REpMwrVOE9efJk3NzciIyMxMvLK3f5bbfdxooVK4otOBERkSuRW9Wq+AwYAIAjKYmEJd86OSK4rsK1ue9/3PlpnnVxcXF8++23xMXFlXZYIiIi5UKhCu+VK1fy6quvUqtWrTzLGzduzKFDh4olMBERkStZnkHWFizAtNudGA0M6fQwxulHykLt4TjOiefEiRMsXLiQEydOOCs8ERGRMq1QhXdqamqenu4z4uLi8PDwKHJQIiIiVzrPq5pQsVMnALIOHyZ59WqnxnNNw7ZclekGwBF3g7Uhzu+FFxERKS8KVXjfcMMNLFiwIPezYRg4HA5ee+01goODiy04ERGRK1nAmNG57+PmOX9qsdYVr8t9v+LPec4LREREpJxxK8xGr732Gj179mT79u1kZmby5JNP8tdffxEXF8fvv/9e3DGKiIhckSp26YKtUUMywyM4FRLCqV27qNCypdPiGdplMl+tGYHDMAh1HMRht2OxWp0Wj4iISHlRqB7v5s2bs3fvXrp06cKgQYNITU3llltu4Y8//qBhw4bFHaOIiMgVyTAMKo8enfvZ2b3eTeq2pFlmzmjrUe4Gq7YuAnJGNe/QoYNGNRcREbmIQvV4A/j6+vLMM88UZywiIiLyLz4DBnB85pvY4+JI+vlnAo89hrsT58tu7d2OvzI3AbBqz2f07TiCGjVq8NhjjxEQEOC0uERERMqyQvV4z507l6+//vq85V9//TXz5zv/GTQRERFXYfHwwH/EiJwPdjtxn3/h1HiGdX0U65nRzc1IHHY7WVlZnDx5kqysLKfGJiIiUlYVqvCeMWMGVapUOW95YGAgL7/8cpGDEhERkbP877gdw2YDIOF//8Oekuq0WOrXbMrVmTmxxLhb+OH3+Rw4cIAHHniAAwcOOC0uERGRsqxQhXdkZCT169c/b3ndunWJjIwsclAiIiJyllvlyvgOGgiAIyWFxMXfODWetr4dct+v3vuVEyMREREpHwpVeAcGBrJr167zlu/cuZPKlSsXOSgRERHJK2DUqNz3cQs+w8zOdlosw7o9jtuZ282No9jtzotFRESkPChU4X3HHXfw8MMPs2bNGux2O3a7ndWrV/PII49w++23F3eMIiIiVzyPxo2peMMNAGQdPUryL786LZbaQQ1onuEJwAk3C+tDv3NaLCIiIuVBoQrv//znP7Rv356ePXtSoUIFKlSoQJ8+fejRo4ee8RYRESkhAaPvzn0fN2+e8wIB2gZ0zn2/44jzvgQQEREpDwpVeNtsNhYtWsQ///zDF198wZIlS4iIiODTTz/FdnrwFxERESleFTt1wqNJEwBOhYaS9scfTovltuDHsTlybjffWzmaefPn0qhRI6fFIyIiUpYVqvA+o0mTJgwbNoybb76ZunXrFldMIiIicgGGYRAwenTu57j5C5wWS1CV2jTPrJATh7uFdTv/h8VSpD8rREREXJZbYTc8cuQI3333HZGRkWRmZuZZN3PmzCIHJiIiIufzufkmjs+cif3ECZJXriTzyFFstWo6JZZ2VbqxI+VnLIkWFv3wI91a3qYv4kVERC6gUIX3r7/+ysCBA2nQoAH//PMPzZs35+DBg5imSevWrYs7RhERETnNYrMRMHIEsW/PAoeD+M8+o9qUp50Sy209HmXe0hVkZxukxRokJsUDKrxFRET+rVD3hE2ZMoXHH3+c3bt34+npyeLFizl8+DDdunVj2LBhxR2jiIiInMPv9tsxPDwASPjmG+zJyU6Jo6p/DVpmVcz9vGa7c+cXFxERKasKVXj//fffjDo9n6ibmxunTp2iUqVKvPjii7z66qvFGqCIiIjk5ebvj+/gwQA4UlNJ+Np5BW/7qj1y34fG/Oa0OERERMqyQhXeFStWzH2uu3r16kREROSuO3HiRPFEJiIiIhcVcPeo3Pdxn32GmZ3tlDiG93gUz9Ojm++zJpCWnuqUOERERMqyQhXeHTp0YMOGDQD079+fxx57jOnTp3PPPffQoUOHYg1QREREzufRoAGVunUDIDsqiuSVK50Sh79vVZp5eJHcKZkkH5NvVr/tlDhERETKskIV3jNnzqR9+/YATJs2jZ49e7Jo0SLq1avHJ598UqwBioiIyIUFjBmd+/7k3HmYpumUODrV6U1GkwxMT5ONR350SgwiIiJlWb4L71mzZpGeng7kPNfdokULIOe28w8++IBdu3axePFiTSMiIiJSSrzat8ejWTMA0nfv5tQffzgljr5tRuMTZsNIN9jpFk9yaoJT4hARESmr8l14P/rooyQlJQFQv359YmNjSywoERERuTzDMKg8+u7cz3Fz5zkljrSUTGybfLCkWkixWvhat5uLiIjkke/Cu0aNGixevJhDhw5hmiZHjhwhMjLygi8REREpHT433ohb1aoAJP/yC5ll4PfwpqifnR2CiIhImZLvwvvZZ59l0qRJNGjQAMMwaNeuHfXr18/zqlevHvXr1y/JeEVEROQchs2G/5135nwwTeIWfOa0WCrac54x3+WeSEKyZjkRERE5I9+F97hx4zhx4gQ7d+7ENE1WrVrFjh078rz++OMPduzYUZLxioiIyL/43zYco0IFABKWLMGemOiUOBrbfQBIs1j43+o3nRKDiIhIWeRWkMbe3t40a9aMuXPn0qxZM6pXr15ScYmIiEg+Wf388BsymPiFX2KmpZHw9ddUvvfeUjt+hQoVuPrqq2lWK4AQ+1IAtkT/yjiml1oMIiIiZVmBpxOzWq3cf//9uSOci4iIiPP533UXGAYAcZ99jpmVVWrHrl27NtOmTWPMLU/ia3cAsMuWwsmE6FKLQUREpCwr1DzezZs3Z//+/cUdi4iIiBSSR/36VAoOBiA7JoakFaU3wJnD4SArKwsPWwWuzc4Z6C3dYrBo9cxSi0FERKQsK1Th/dJLL/H444+zfPlyoqKiSEpKyvMSERGR0heQZ2qxuZimWSrHDQ8PZ8SIEYSHh3NDvUG5y7fFriuV44uIiJR1hSq8+/fvz86dOxk4cCC1atXC398ff39//Pz88Pf3L+4YRUREJB+82rXD85prAEjfs4dT27eXegy3dH8Q/9O3m++2pRJz8mipxyAiIlLWFGhwtTPWrFlT3HGIiIhIERmGQcDo0Rx74gkATs6bj1e7dqUag83mQSt7NdZYY8mwGPxv9es8NEwjnIuIyJWtUIV3t27dijsOERERKQY+/fpy/PXXyY6JIWX1ajIPHsRWr16pxtC1wVDWHPkAgG3xG0r12CIiImVRoQrv9evXX3J9165dCxWMiIiIFI3h7k7AXXdy/PU3wDSJW7CAoP/7v1KNYXC3cbw7/31OulnYbTvFkeMHqRVYr1RjEBERKUsKVXh37979vGXG6SlMAOx2e6EDEhERkaLxGzaM2Pdn58zpveRbqj78MFY/vxI7Xv369fnggw+od7pn3c3NnVZmDX4lmmzD4H9rXufR294tseOLiIiUdYUaXC0+Pj7P6/jx46xYsYJ27dqxcuXK4o5RRERECsDq64vfLbcAYKanE7/ofyV6PHd3dypXroy7u3vusuDGt+W+D0nYVKLHFxERKesKVXj7+vrmeVWpUoXevXvz6quv8uSTTxZ3jCIiIlJAAaPugtN3o5389FMSly4jdctWzBK4K+3YsWO88cYbHDt2LHfZgC5jCMzOGd18j0cGh47tLfbjioiIlBeFKrwvplq1aoSFhRXnLkVERKQQbHXq4NmiBQCOxESOPf00kXffTXjPXiQV891pKSkpbN68mZSUlNxlFquVVmYtALINg6/XzyzWY4qIiJQnhXrGe9euXXk+m6ZJVFQUr7zyCq1atSqOuERERKQIklauJP1fv68BsmNiOPrIJHj7LXz69CnRGHo2HcnKiP8CEJK0tUSPJSIiUpYVqvBu1aoVhmFgmmae5R06dODTTz8tlsBERESkcEy7nZiXZ1xkpQmGQczLM/Du2RPDai2xOPp1HMlb/7xGlLvBHlsm4ZF/0qhO8xI7noiISFlVqML7wIEDeT5bLBaqVq2Kp6dnsQQlIiIihZe2PYTs6OiLNzBNsqOjSdseQsX215dYHBarlWuNukQRicMw+GbDmzw94pMSO56IiEhZVajCu27duuctS0hIUOEtIiJSBmTHxhZru8upUqUKI0aMoEqVKuet63PNKFaEvQTAjpSQYjmeiIhIeVOowdVeffVVFi1alPt5+PDhBAQEULNmTXbu3FlswYmIiEjBuVWtWqztLicgIIAhQ4YQEBBw3rqe7W6lZlbOo2n/2LIJO/BHsRxTRESkPClU4f3BBx9Qu3ZtAFatWsWqVatYsWIFN954I0888USxBigiIiIF49W2DW5BQbnTiV2QYcAlVhdESkoK27ZtyzOq+RkWq5XrLA0AMA2Db35/u3gOKiIiUo4UqvCOjo7OLbyXL1/O8OHD6dOnD08++STbtm0r1gBFRESkYAyrlWpTp5z+cJHq2jQ5fN84kteuLfLxjh07xmuvvZZnHu9z9W05Jvf9H2nq8RYRkStPoQpvf39/Dh8+DMCKFSvo1asXkDOtmN1uL77oREREpFB8+vSh5ttv4VatWp7lbtWq4dG0KQBmRgZHJj5E4vfLSzSW7m2HUDsz53bzMA8Hu/ZtLtHjiYiIlDWFGlztlltuYcSIETRu3JiTJ09y4403AvDHH3/QqFGjYg1QRERECsenTx+8e/bMGeU8Nha3qlXxatsG7HaOPf00ST/+BNnZHHvySexJiQSMHFlisVzn1pjDhAOwdPM7tGzcocSOJSIiUtYUqvB+8803qVevHocPH+a1116jUqVKAERFRfHggw8Wa4AiIiJSeIbVev6UYVYrNf77XyzePiQsWgSmScx/XsKemEiV8eMxLvVseCHd1Hoc34U+CUDoqd3Fvn8REZGyrFCFt7u7O48//vh5yydPnlzkgERERKTkGVYrQS88j9XPj5MffgjAiVnvYE9IoNrTT2NY8v80ms1mo1atWthstou26XTtjdTb+iQHbbDPw2THP7/RuukNRT4PERGR8qBQz3iLiIhI+WcYBoGTJxH45JO5y+IXfEbUlKmYWVn53k+9evVy74a7lOtsTXPff7flvQLHKyIiUl6p8BYREbnCVb5nDNWnT4fTvdyJy5Zx5OFHcKSnF+txBrR9IPf9H5l/Feu+RUREyjIV3iIiIoLf0Fuo+fZbGO7uAKSsWcPh+8Zhv8Dc3P8WHh7OqFGjCA8Pv2S7dtf0pGFGzvPj+22wdfcvRQ9cRESkHChw4W2321m/fj0JCQklEI6IiIg4i0/v3tSe8yEWLy8A0rZtI3LU3WTHxV1yO4fDwalTp3A4HJc9xnWeV+e+/y5kdtECFhERKScKXHhbrVb69OlDfHx8ScQjIiIiTlSxY0fqzJ+H1c8PgPQ9ezg08k6yjh0rlv0Paj8x931o1t5i2aeIiEhZV6hbzZs3b87+/fuLOxYREREpAyq0aEHdzz/DrVo1ADIPHODgiJFkFMPv/lZXdaFJRs6fH4dssOGP5UXep4iISFlXqML7pZde4vHHH2f58uVERUWRlJSU5yUiIiLlm0ejRtRb+AW2unUByI6O5tDIOzm1+88i7/u6Ci1z3/8Y+kmR9yciIlLWFarw7t+/Pzt37mTgwIHUqlULf39//P398fPzw9/fv7hjFBERESdwr1mTugu/wKNZMwDs8fFE3n03qZu35GlXp04dXn31VerUqZOv/Q7ueM7t5tn7cNjtxRe0iIhIGeRWmI3WrFlT3HGIiIhIGeRWuTJ1F8zn8PjxnNoegiMtjcPjxlHzzZl49+wJgKenJw0aNMDT0zNf+2zeqD1NV1v5x8POYZvBuh1LCW43tCRPo9SZdjtp20PIjo3FrWpVvNq2wbBanR2WiIg4SaEK727duhV3HCIiIlJGWb29qfPxxxydNJmUtWsxMzM58vAjVH/pJfyGDCYmJob58+dz9913U7169Xzts3XFVvyTHQLAit3zXKrwTlq5kpiXZ5AdHZ27zC0oiGpTp+DTp48TIxMREWcp9Dzev/32G3feeSedOnXi6NGjAHz22Wds2LCh2IITERGRssHi6Umtd2bhM2BAzgK7nagpU4ibP5/ExER+/vlnEhMT872/oV0mYTFNAEIdB1zmdvOklSs5+sikPEU3QHZMDEcfmUTSypVOikxERJypUIX34sWL6du3LxUqVGDHjh1kZGQAkJiYyMsvv1ysAYqIiEjZYLi7U+PVV/C/887cZTEzXiHhq68KvK8mdVvRLNMdgGPuBqu2Liq2OJ3FtNuJeXkG5ukvFPKuNDFNM2e9i3zJICIi+VfoUc0/+OADPvroI9zd3XOXd+7cmR07duR7PzNmzKBdu3Z4e3sTGBjI4MGDCQsLy9Nmzpw5dO/eHR8fHwzDICEh4aL7y8jIoFWrVhiGQWho6CWP3b17dwzDyPN64IEH8h27iIjIlciwWKj2zFSqTDw7QFriN4tz3lyo4LyE1pXa5r7/Zc/nxRKfM6VtDyE7OhrjIusNckaHT9seUpphiYhIGVCowjssLIyuXbuet9zX1/eShfG/rVu3jgkTJrB582ZWrVpFVlYWffr0ITU1NbdNWloa/fr1Y+rUqZfd35NPPkmNGjXyffz77ruPqKio3Ndrr72W721FRESuVIZhUHXiBKo980ye5SfefhszMzPf+7n1hklYTxfrf5iHyv3t5ik7Q/PVLv3Y0ZINREREypxCDa4WFBREeHg49erVy7N8w4YNNGjQIN/7WbFiRZ7P8+bNIzAwkJCQkNzCftKkSQCsXbv2kvv66aefWLlyJYsXL+ann37K1/G9vLwICgrKd7wiIiJyVsBdd2L19SH+mWfpkZKKZf1vHJ44kVpvv42lQoXLbt+g9jVcnWFjt2cWMe4Wftr0GTd1GV3ygRezU7t3c3LOHJJW/XLR3u5zHXllOkZKKr5DhmCtVLHE4xMREecrVI/3fffdxyOPPMKWLVswDINjx47xxRdf8PjjjzN+/PhCB3NmUJaAgIACbRcTE8N9993HZ599hpeXV763++KLL6hSpQrNmzdnypQppKWlFei4IiIiVzrfgQNp/tab3JqRgb/DQer634gcey/2pKR8bd/Gt33u+1//+bKkwix2pmmSumkTh8aM4eCw4SSfU3Rf7oZ7W2IqMdOnE969OzEzXiHz8OGSDldERJysUD3eTz/9NA6Hg549e5KWlkbXrl3x8PDg8ccf56GHHipUIA6Hg0mTJtG5c2eaN2+e7+1M02T06NE88MADtG3bloMHD+ZruxEjRlC3bl1q1KjBrl27eOqppwgLC2PJkiUXbJ+RkZE7iBxA0uk/KBwOBw6HI9/xSslyOByYpqmcuBDl1PUop67HuP56jk+ehN9772NLSeHUjh0cuusuas2Zg1vVqpfc9tYbJvH5qt/INgxCjSNkZmbg5uZ+yW2cyXQ4SPn1V+I+/pj03X/mWRdXCXbVM+j2p4mDvL0bDnKe8T5UFerFnl6WkkLc/PnELVhApR498L/rTiq0a4dh5KffvGTpOnU9yqnrUU6dryD/9oUqvA3D4JlnnuGJJ54gPDyclJQUrr76aipVqlSY3QEwYcIE/vzzzwJPR/bOO++QnJzMlClTCrTduHHjct+3aNGC6tWr07NnTyIiImjYsOF57WfMmMG0adPOWx4fH092dnaBji0lx+FwkJycjGmaWCyFni1PyhDl1PUop64nPDycFxYs4KUnn6DyzDcxExLICNvLgREj8XtzJtZLjL9S0aMy12R4sNMzk1g3C9/8Ops+7e68aHtnMbOyyFi1irQvFmI/dCjPumg/WNbBwvoWBlhge2OT0b84qJJ8tk2cN8zrZWHrVQa1Y6H/dgc3/GViywZMk5RffyXl11+xNmqE17Bb8ejVC8PDo1TP8Vy6Tl2Pcup6lFPnS05Ovnyj0wzzgnNeXNo999zD22+/jbe3d57lqampPPTQQ3z66acF2t/EiRNZtmwZ69evp379+hdss3btWoKDg4mPj8fPzy93+eDBg/n+++/zfDtst9uxWq2MHDmS+fPn5yuG1NRUKlWqxIoVK+jbt+956y/U4127dm3i4+Px8fHJ55lKSXM4HMTHx+Pv768fQC5COXU9yqnrCQsL48EHH+T999+nvocHh8feS3ZUFADWqlWp/fFHeDRufNHtZ30ziU9OrQGgZ2Y1Zo4tO3NdO9LSSFy8mLi5886bm/tgIHzb0cKWq6B1ViWGNnuAoyfDeS9xGYbDpOkR8E+B+ErwTy0wLQajPbsTnx7Nb/a/ycw06BVq0jfEQUBK3uNaAwLwu204frffftm7BkqCrlPXo5y6HuXU+ZKSkvD39ycxMfGyNWGherznz5/PK6+8cl7hferUKRYsWJDvwts0TR566CG+/fZb1q5de9Gi+1JmzZrFSy+9lPv52LFj9O3bl0WLFtG+fftLbJnXmenHqlevfsH1Hh4eeFzgm2eLxaL/0csYwzCUFxejnLoe5dS1nPny2zAMPBs0oN6XC4m8ZyyZ+/djj40lctTd1PnwAyq0anXB7YcHP8aCH1aTZRiEWqLIzs7CZnNeby+APTGRuC++IH7BZ9j/NWPLntqwtKOFP+tDh6wA3ms9hS6t+ueuN5bBlyeWsqfu2f+/q2Y7uN1/EOMGTQcgLT2VT394ntVtVvJde4MO/5jcuN1Bk2Onjx8Xx8nZH3Dy40/wubEfAXeNokKL/D+KVxx0nboe5dT1KKfOVZB/9wIV3klJSZimiWmaJCcn4+npmbvObrfz448/EhgYmO/9TZgwgYULF7Js2TK8vb2JPv1Nsq+vLxVOj4YaHR1NdHQ04eHhAOzevRtvb2/q1KlDQEAAderUybPPM7e7N2zYkFq1agFw9OhRevbsyYIFC7j++uuJiIhg4cKF9O/fn8qVK7Nr1y4mT55M165dadmyZUH+SURERORf3IOCqPvF5xy+bxzpf/6JIzGRQ/eMpdY7s6jUufN57WtUrUvzjAr84ZnOSTcLy9Z/xLBeEy+w55KXFXOcuPnzif/qK8x/Dboa0shgaUcLkTVMbrDX4rMbXqR5o/O/5B83aDqjM/+Ppes+5HhSJIE+dRjc7f48XyZ4eVZk4tDXmQh8t/4Tvsv+mOevTqbBMei/zUH7MBM3B5CVRdJ335P03fdUaN2agFF34d2rF4ZbofpORETESQr0U9vPzw/DMDAMgyZNmpy33jCMCz4HfTGzZ88GoHv37nmWz507l9GjRwPwwQcf5NnnmWnGzm1zOVlZWYSFheWOWm6z2fjll1946623SE1NpXbt2gwdOpRnn30237GLiIhIDqvVire3N1arNXeZm78/debN48jEiaRt3oyZlsbhB8ZT87//xaff+Y90tat8A3+krgJg/YHFDKN0C+/MQ4c4+fEnJC5dipmVlbvcYcDvzXIK7qTKJt2Nq3iz3yvUrn7xW+cBbDYPhvd+OF/HHth1LAO7juXP8C0sWPcicwcc5LMeFvrucNAz1MTnVE67Uzt2cHTHDtyqVydg5Aj8br0V6zmP34mISNlVoGe8161bh2ma9OjRg8WLF+eZ9stms+WOEn4lSEpKwtfXN1/380vpcTgcxMXFERAQoFtuXIRy6nqUU9dzqZw6MjI4+thjpPzya84Ci4WgF57Hf/jwPO1iTh7lpu/6kmEx8LM7WDVyG54e+Z8itLDS//6bkx99RNKKn+Gc0WkzrbCmpcH37S0YlUx6VmjHAzf/F3/fkn/eOj4xlo9/fJY1Kb8TbcANf5n03+agzom87QxPT3wHDyLgrrvwuMDAsEWh69T1KKeuRzl1voLUhIUaXO3QoUPUrl37ik6wCu+yST+AXI9y6nqUU9dzuZya2dlE/d/zJJ4zZWfVxx6lyn335Wk35sP2bPfMuTttStBoRvR9rETiNU2TU9u3c2LOR6T+9luedWk2WNna4Id2FvxsBn39ejF2wEt4eVYskVguxWG389Uvb/HTwS8J9Uin+SGTm7aZXBdu8u9/5YpduhAw6i4qdumCUQzXla5T16Ocuh7l1PkKUhMW6gGhunXrApCWlkZkZCSZmZl51us5aRERkSvHwYMHmTp1Ki+//DINGjQ4b73h5kb16S9h9fUlbu5cAGLfmIkjMZGqjz2WOzjb9YE92J60HIDfI79jBMVbeJumScqatZz86CNO/fFHnnWJXvBDOwsrWxvUMdy4t+ZQRvWbiuWc2+dLm8VqZUTfxxjBY2zevZIvs15j1tAofBMs3LjdQffdJhVO/wmWumEDqRs2YKtfH/+77sRv0CAsFUv/ywIREbmwQhXesbGxjBkzhp9++umC6+12e5GCEhERkfIjMzOTmJiY876IP5dhGAQ++QRWPz9i33wTgJMff4I9MZGgF17AsFq5vcejfLrke9ItBqHWE6SlpxZLT7OZnU3STz9xcs5HZOzbl2fdcV/4vr2F1S0NmjsqMKXxvQwOvr/IxyxuHVr0oUOLPhyLPcQnK57hx+A/+KqrhR67TPqFOKiWkNMu88ABYl78D7FvvoXfrbfiP3Iktlo1nRq7iIhw3p1K+TJp0iQSEhLYsmULFSpUYMWKFcyfP5/GjRvz3XffFXeMIiIi4gIMw6DK/eMIeuF5ON3LnfD1Nxx99DEcmZn4+1alZVbOVKVJVguLV79TpOM50tOJW7iQiL79OPbEk3mK7sNV4J2bLTw6zkJScz9mtvoPC8ZtK5NF97lqVK3Lc3d9zo+jdjCu+i3sv9adh++38tpQC3/WMXLbOZKTiZs7l4g+fTjy0MOkbd9OIZ4uFBGRYlKoHu/Vq1ezbNky2rZti8VioW7duvTu3RsfHx9mzJjBTTfdVNxxioiIiIvwv/12rD4+HH3qacjKIvnnnzmSnEytd2bRvlovtiYsBeD3Iz9wF08XeP/25GTiv/yKuAULsJ/IOyLZ3hrwbScLfzWAzvbqfNLlBVpd1aU4TqtU2Wwe3DvwRe7lRVZtXsTirHeZ0TieGseh/3YHnf8ysdkBh4PkVatIXrUKj6ubETBqFD79+2Ox2Zx9CiIiV5RC9Xinpqbmztft7+9PbGwsAC1atGDHjh3FF52IiIi4JJ/+/an9/vsYFSoAkLpxI4fuuYdhbe7B6/To4jvd4khOTcj3PrNPnOD4zDcJD+5B7MyZeYru0PoGz4+08upIg+oNG/G/vot5675fymXR/W+9O9zGB+N+46vghVxbtTGL+ho8OMHKohssxJ9zp37Gnr+JenoK4T16Evvue2T/60sJEREpOYUqvK+66irCwsIAuPbaa/nwww85evQoH3zwAdWrVy/WAEVERKRsq1mzJs888ww1axbsWeJKN3ShziefYDk9Emz6zl3EPfAQneJyPqdYLXy9etZl95N55CjRL75IeM9enJwzB0dKCgAOYFNTg6fGWPnoVoOW9a5j2S2/MGPMMurXbFqwkywHmtRtyfQx37L89t8ZXrUnoe2sPDjByqwBFsKDzraznzjBiXffJTy4B8eeeppTf/2VZz+m3U7a1q2kr/qFtK1bMTV2j4hIkRVqOrHPP/+c7OxsRo8eTUhICP369SMuLg6bzca8efO47bbbSiLWMkXTiZVNmlbB9Sinrkc5dT1FzWl6WBiR996LPTanBzbdvyJPDE/nuB/cut+LR9o/j1vVqni1bYNxzijj6Xv3cvLjj0n64Uc4pzjMtsC6Fgbftbdg9YHe3t25f8AMKnp5F/lcyxOH3c536z/mu32fEuKeQqNjBjdtc3B9mIn1X3/9VWjbhoBRo8DhIHrGK9hjYnLXWatVI+iZqfj06VPKZyDFST97XY9y6nwlNo/3gQMHqF+//nnL09LS+Oeff6hTpw5VqlQpeMTlkArvskk/gFyPcup6lFPXExsby9dff82wYcOoWrVqofaRGRlJ5D1jyTpyBIBUD8iygl/a2TZnCkC3qlU5OecjUtasybOPdHdYdZ3B8ustVLFZ6B80mNH9n8PNzb3Q5+YqQsM28Plv09loicSWYtB3h4NeoSaV0vO2O/NHoXGBZbVmva3iuxzTz17Xo5w6X4kV3mcGUgsODqZHjx50796dWrVqFTng8kiFd9mkH0CuRzl1Pcqp6/nnn38YP348s2fPpmnTwt/CnRVznMP33ps7+rjJhQtA41/bJXvCT20trGhj0MDiweCGYxgaPN6pc3CXVScTovnox2dYl7aFWBNu+Muk/zYHtU5eejsHkOlbgVYbt+W560DKD/3sdT3KqfMVpCYs0Kjmq1evZu3ataxdu5Yvv/ySzMxMGjRoQI8ePQgODiY4OJhq1aoVKXgRERG5MrlXC6TO/HmE3dAFi908r8D+9+cT3rD8egtrroWW+PBiy0n07uD6j7sVRWW/IJ4e8QmPZ2fx5co3WOH4mkdbZTBgi4O71ly8L8YCeCaeImnzJnw7l/8B6URESluBCu/u3bvTvXt3ANLT09m4cWNuIT5//nyysrJo2rQpf/1rkA4RERGR/Ej9ew8W++VvxlvW3mDJDQbtzUDe6/Qs7a7pWQrRuQ43N3fu6v80d/E0G0J/ZMPOqUDGZbfbPfdNOre7HkPTkYmIFEih5vEG8PT0pEePHnTp0oXg4GB++uknPvzwQ/7555/ijE9ERESuIJvXL6JOPtq5BXjxee9PaVK3ZYnH5Oq6tOrPwVVfA5sv27byhj2E9+yF/5134n/bcKx+fiUen4iIKyjwwwCZmZmsX7+eadOmERwcjJ+fHw888ADx8fG8++67HDhwoCTiFBERkTLK29ubG264AW/voo8aHuuWkq92QTVaqOguRraW13LCO+dZ7gs59x6E7NhYYt98k33dg4l64QUy9utvPxGRyylQ4d2jRw/8/f158MEHOX78OPfffz8RERGEhYXx0Ucfcdddd1GnTn6+pxYRERFXUb16dR5++GGqV69e5H1drgB0kPNst63ltUU+lpw1OHg8S3oYGJz/b3/m85ddLWxpYuR+NtPTSfhqEfv79+fw/Q+QunkzhZilVkTkilCgwvu3336jcuXK9OjRg549e9K7d+9i+SUrIiIi5VdmZiZRUVFkZmYWeV+XKwANYEkPg8HB44t8LDnLZvOgWachzBxiIe5fNy7EecMbQywcaOPFB0MMHnnAyo9tDU6d85h3yrp1RI4ew4Eht5Dw7VIcxfD/goiIKylQ4Z2QkMCcOXPw8vLi1VdfpUaNGrRo0YKJEyfyzTffEBsbW1JxioiISBl18OBBHn74YQ4ePFjkfV2uAJw5xEKzTkOw2TyKfCzJa9yg6VzfYTDPjzN4YYSFtwdaeGGEhRfGGbTvMJjP7t/G0gEr6F75On7qbjB+gpXPelg4cc4MOhn//EPUlCmE9+zJidmzyY6Pd94JiYiUIQWax/vfkpOT2bBhA2vWrGHt2rXs3LmTxo0b8+effxZnjGWS5vEumzSfoetRTl2Pcup6imse73PNWfYMXx3/lqpRBv4pEF8JTlQ3uS1wCOMGTS+WY8iFZWZmsHTdBxw9EUHNKg0Z3O2B877oSM9IY/6P/2FV7I+Eu9m5Pszk5q0OGkfl3Zfh4YHv4MEE3D0KjwYNSvEs5N/0s9f1KKfOV2LzeP9bxYoVCQgIICAgAH9/f9zc3Pj777+LsksRERERxg2azujM/2Ppug85nhRJoE8dBne7Xz3dpcBm8+DWng9d8g96Tw8v7h8yg/uZwXfrP2FZ1kf8X9NkGh4zuHmrg+v3mlhMMDMySFi0iIRFi6jYrSuV774br44dMYx/z8ouIuLaClR4OxwOtm/fztq1a1mzZg2///47qamp1KxZk+DgYN577z2Cg4NLKlYRERG5gthsHgzv/bCzw5DLGNh1LAO7jiU0bAOf/fYfPhx8hM+SLPTf7qDHTpMKpx/3Tl23ntR16/Fo0oSAu+/GZ8DNWDQfuIhcIQpUePv5+ZGamkpQUBDBwcG8+eabdO/enYYNG5ZUfCIiIiJSDrS6qgutrvqZmJNH+ejHKazoFsL/uljoscvkxu0OAhNz2mXs3UvUM89w/M038b/jdvzvuAO3gADnBi8iUsIK9Iz3hx9+SHBwME2aNCnJmMoFPeNdNulZF9ejnLoe5dT1KKeupzhympmZwdwfp7Hq+A/sc895DvymbQ6uOpq3nWGz4TtoIAF3341Ho0bFEL1ciK5T16OcOl9BasIiDa52JVPhXTbpB5DrUU5dj3LqepRT11PcOf1hwzy+3fMh223JNDgKN29z0D4s5znwc1Xs0oWA0aOp2LmTngMvZrpOXY9y6nwFqQmVIRERESmSw4cPM3XqVA4fPuzsUKSMuqnLaD4et4kFneZQv1ot5gwyeOgBK99fb5B2znh5qRs2cPjeezkwcCAJ33yDIyPDeUGLiBQjFd4iIiJSJKdOnWLfvn2cOnXK2aFIGdeySSfeuHcFywaupGflNqzqamH8BCvzelo47nu2Xca+cKKefY7w4B7EvvMu2SdOOC9oEZFioMJbREREREpVtco1eebO+fwwKoR7qw1h/7XuPPyAlTeGWPin5tl29rg4Trz3HuE9enLsmWdI37vXeUGLiBSBCm8RERERcQqbzYNxg/7D1+NCebnx41Dfh2l3WZk6ysrvzQzspx/zNjMzSVy8hAMDBxF5z1hSfvuNCw1TZNrtpG7ZSuLyH0jdshXTbi/lMxIRubACTScmIiIiIlISbuoympu6jGbXvs0sWDeNTwZE8nmwhRtDHPQKNfE6/bh36saNpG7ciK1hQwLuHoXvwIFYPD1JWrmSmJdnkB0dnbtPt6Agqk2dgk+fPk46KxGRHBrVvJA0qnnZpNEdXY9y6nqUU9eTkJDA6tWr6dGjB35+fs4OR4pBWbhOY04e5eOfnmFd+nbiHRB8ej7woIS87az+/nhdfz3JP/98/k5Oj4xe8+23rvjiuyzkVIqXcup8GtVcRERESo2Pjw9du3bVF9FSrHKeA5/H8lEh3FdtCAdauvPI/Vb+e4uFPbXPtrPHx5P8889csCfJNDFNk5iXZ+i2cxFxKhXeIiIiUiQJCQmsWLGChIQEZ4ciLujc58Bfafwklro+/GeklSl3W9lwtcGZcvpis34bQHZ0NGnbQ0opYhGR86nwFhERkSI5fvw4n3zyCcePH3d2KOLi+ncZxcf3b2JB549pFFibT282mNf7YiV3XulRx0o4OhGRi9PgaiIiIiJSrrRs3IHXG/9EbPwxPj14G3D5eb4PvfM6bm7uePfpjcVmK/kgRUTOoR5vERERESmXqvrXoGKL6znhDY7LtK1w9CTHHn+c8K7diHn1NTL2HyiVGEVEQIW3iIiIiJRjgX51mdfbgsH5xbcDMIG4SmeX2RMSiJs7l/39+3No1N0kLv8BR2Zm6QUsIlck3WouIiIiReLl5cW1116Ll5eXs0ORK9DgbvczO/JDZg6xcPcvDqokn10X5w3zelnYepVBs8PQ+w8H7cNM3E+PyJa2dStpW7di9fPDd8gQ/IYPw6N+feeciIi4NM3jXUiax7ts0nyGrkc5dT3KqetRTl1PecvpnGXP8G78MgyHSdMj4J8C8ZXgn1pgWgyGGi05mRnNVrcYLOkG3Xab9Ap1UCPu/H15XX89fsOHu9yz4OUtp3J5yqnzFaQmVI+3iIiIFIndbictLQ1fX1/98SdOMW7QdFgGX55Yyp66Z/8frJrt4Hb/QTnrgZMJ0cz/+UU2tNrA8uvVCy4ipUc93oWkHu+ySd/8uR7l1PUop67nn3/+Yfz48cyePZumTZs6OxwpBuX1Os3MzGDpug85nhRJoE8dBne7H5vN44JtV21exHe7P2Cr23GsV0AveHnNqVyccup86vEWERERkSuOzebB8N4P56tt7w630bvDbZxMiGbeimn83up39YKLSInRVyMiIiIicsWq7BfEY7fPZsm4Xcxs+hzVgqry8QCDByZaWdDDwrGAs21zR0S/USOii0jBqMdbRERERISzveCx8cdY8PN/2KBecBEpJurxFhERERE5R1X/Gjx2+2y+HbeLN656hsBzesHn97Rw9FK94D+oF1xEzqcebxERESmSBg0a8PHHH1O7dm1nhyJS7Pp0vIM+He8gNv4Y839+kd+v3cgP7XJ6wXv94aDDhXrB/f1zesGH3apecBEB1OMtIiIiReTm5oavry9ubvo+X1xXVf8aPH77B3l6wT+5WC94fDxxn36qXnARyaXfkCIiIlIkx44d46233mLSpEnUqlXL2eGIlLh/94JvaFW0XnDTbidtewjZsbG4Va2KV9s2GFarE85MREqKCm8REREpkpSUFEJCQkhJSXF2KCKl6kwv+OPAz5sW8n3WHD4ZEMu83ha6/mnS6w8HNU/PC36mFzzu009z5gW/bTjevXuTsnYt0dNfxh4Tk7tfa7VqBD0zFZ8+fZxzYiJS7FR4i4iIiIgUUd+OI+jbcQSx8cdOzwu+6bK94JaKFbGnpgJgnLOv7JgYjjz8CLVmva3iW8RF6BlvEREREZFiUtW/Bk/c8SFL79vF61dNJTCoykWfBXekpmKQt+jm9GcTiHjuaUy7vfSCF5ESo8JbRERERKQE9O04gnfvW8t3A1cyxK8z/7SyMnmcledHWtlV99LbWgDPxFMkbd5UKrGKSMlS4S0iIiJFUqVKFUaNGkWVKlWcHYpImVStcs3zesF/a/nvfu4Li3juKeIX/Y/sEydKOEoRKUkqvEVERKRIAgICGDBgAAEBAZdvLHKFO9ML3ibg2ny1r3Asjujnn2ffDV05OPJOTs6bR+aRoyUcpYgUNxXeIiIiUiTJycls2rSJ5ORkZ4ciUm5UbN2eE97guMh6E7Cf2ylumpwKCeH4K68S0asX+2+5hROzZ5Oxbx+maZZCxCJSFCq8RUREpEiioqKYOXMmUVFRzg5FpNwYHDyeJT0MDM4vvs98fnOwhafGWFncyeBI5bxtMvb8Tezbs9g/YCD7b+zP8Tfe4NSuXSrCRcooTScmIiIiIlLKbDYPmnUawkzLUu7+xUGVc24YifOG+b0s1Ljqavyyk1nf6QiLuhnUOGlyfZjJ9XsdNDrne67Mgwc5+dHHnPzoY9yCgvDu2RPv3r3xatsGw01/7ouUBboSRUREREScYNyg6QA83+BbqkYZ+KdAfCU4Ud3ktsDBuesddjvrdixl1Z+fE9o2nKWdLFRONLl+r0m7vSZXHzaxnO7ozo6OJv6LL4j/4gusfn5U6tED7169qNCxg7NOU0RQ4S0iIiIi4jTjBk1ndOb/sXTdhxxPiiTQpw6Du92PzeaR28ZitRLcbijB7YYCsP2vtfwYModdLf9iRVs7lU5B2305veEtD5q4n576256QQOKSJSQuWYLh5YWtQwfc+t+Id/fuWCtVcsbpilyxVHiLiIhIkXh4eFC/fn08PDwu31hEzmOzeTC898P5bt/2mu60vaY7AHsPhbJ04/vsvCqEN1pm4J4JrSJM2u81uS7CpEJmzjZmWhoZq1cTtXo10e7uVOzUCe/evajUowdumpFApMQZpkZgKJSkpCR8fX1JTEzEx8fH2eHIaQ6Hg7i4OAICArBYNHagK1BOXY9y6nqUU9ejnJZPR44f5Nv1s9hx8nf+tKVid0CLAzlFeJt9Jj6nLrCRxYJXmzZ49+6Nd+9euFevXupxS+HoOnW+gtSEKrwLSYV32aQfQK5HOXU9yqnrUU5dj3Ja/iUkn2DJ2vfYGrWK3W7xpBgGzQ6fGZzNpPJFZv/zbN48twj3aNCgdIOWAtF16nwqvEuBCu+yST+AXI9y6nqUU9cTFhbGxIkTeffdd7nqqqucHY4UA12nriU9I42l6z5kw4Hv+MvtOCetBg2i4Pq9DtqHmdSIu/B2toYN8e7dC+9evfG85moMwzivjWm3k7Y9hOzYWNyqVs0ZSd1qLeEzEtB1WhYUpCbUM94iIiJSJKZpkp2drfmDRcooTw8vhvd6hF5xd+Hj482qrV+y1v4166se4stuUPMktA8zuT7MQYOYs9tlRkRwMiKCkx98iFuN6nj36oVP795UaN0aw2olaeVKoqe/jD3m7EbWatUIemYqPn36OOFMRcouFd4iIiIiIlcINzd3buoympu6jMZht/P7zh/4edd8QtvtZUlnC1UTzkxT5qDpYTjTj5p9LIr4BZ8Rv+AzrAEBeFx1FambNgFwbj94dkwMRx5+hFqz3lbxLXIOFd4iIiIiIlcgi9XKDa0HckPrgQCEhm1g+dY57Lp2Fz+1y8Y7DdruzSnEWxw0cXPkbGePiyNt0ybOv/E8pwh3ABHPPU2rnj1127nIaSq8RURERESEVld1odVVXQDYf/gvvv39Xf5oto3XW6XjngGtw3OK8NbhJjb7xfdjATwTT5G0eRO+nbuUTvAiZZwKbxERESmSunXrMnPmTOrWrevsUESkmDSofQ2P3T4bgOgTh1my/h1CWM8HVyfT7k+Y8MPlx3T4a/ZrXN/sas0TLoIKbxERESkiDw8PateujYeHh7NDEZESEFSlNg/e8hoAiSlxfHTgFiDm0hsB/tv3sa9rN7yDu+M75BYqdb0Bw03lh1yZnDru/IwZM2jXrh3e3t4EBgYyePBgwsLC8rSZM2cO3bt3x8fHB8MwSEhIuOj+MjIyaNWqFYZhEBoaesljp6enM2HCBCpXrkylSpUYOnQoMTGX/wEiIiIiecXExDB79mz9HhW5AvhWCqBO58Gc8M55lvtC8vSFZ2eTvOoXjjz4IPuCg4n573/JiIgohUhFyhanFt7r1q1jwoQJbN68mVWrVpGVlUWfPn1ITU3NbZOWlka/fv2YOnXqZff35JNPUqNGjXwde/LkyXz//fd8/fXXrFu3jmPHjnHLLbcU+lxERESuVImJiaxevZrExERnhyIipWBw8HiW9DByB1I715nPn/a2sLSDQXzFs+vssSeI++RT9t90Mwdvu534Rf/DnpxcSlGLOJdT7/VYsWJFns/z5s0jMDCQkJAQunbtCsCkSZMAWLt27SX39dNPP7Fy5UoWL17MTz/9dMm2iYmJfPLJJyxcuJAePXoAMHfuXJo1a8bmzZvp0KFD4U5IRERERMTF2WweNOs0hJmWpdz9i4Mq59TOcd4wr5cF9/p+/G0k8VU3k2v3m/TYZdJm39mR0U/t3MmpnTuJmTED7z698btlKF7Xt8OwOLVfUKTElKmHLM58Ux5QwAEYYmJiuO+++1i6dCleXl6XbR8SEkJWVha9evXKXda0aVPq1KnDpk2bLlh4Z2RkkJGRkfs5KSkJAIfDgcNxsRttpLQ5HA5M01ROXIhy6nqUU9djmmbuf5VX16Dr1PUUd07vHfAfTAc83+BbqkYZ+KdAfCU4Ud1keJXB3DfoPzjsdn7e8iUrsucyp/5xyLDQ5S+T4F0O6h3P2Y+Znk7Sd9+T9N33uNesic+QwfgOGox7zfzdxXol03XqfAX5ty8zhbfD4WDSpEl07tyZ5s2b53s70zQZPXo0DzzwAG3btuXgwYOX3SY6OhqbzYafn1+e5dWqVSM6OvqC28yYMYNp06adtzw+Pp7s7Ox8xysly+FwkJycjGmaWPSNqUtQTl2Pcup6znxxnpiYSFxcnJOjkeKg69T1lEROh94wmQFZD/LL9i84mXKEypVq0avtSGzuHrk/C9o37U/7pv1JTk1k6aZZbG3xG0+1yaDecYPgnQ667DGplJ6zv6yjRzn57nucfO993Fu3xvOmm/Do1hVDAzdekK5T50suwKMSZabwnjBhAn/++ScbNmwo0HbvvPMOycnJTJkypYQiyzFlyhQeffTR3M9JSUnUrl0bf39/fHx8SvTYkn8OhwPDMPD399cPIBehnLoe5dT11KtXj8GDB1OvXr0C37UmZZOuU9dTkjm986bHL9smICCAR2q/CcCufRv5ZuOb/NQjjM96Qtu9JsG7TFoeMHMGoDJNskJCyAoJIdXbG+/+/fEdMhjPFi0wDKNYYy/PdJ06n1sBRukvE4X3xIkTWb58OevXr6dWrVoF2nb16tVs2rTpvClM2rZty8iRI5k/f/552wQFBZGZmUlCQkKeXu+YmBiCgoIueBwPD48LTpNisVj0P3oZYxiG8uJilFPXo5y6lsDAQEaOHElAQIBy6kJ0nbqespLTVld1odVVXcjOzuLbtR/yq/0rZjZNoGIKdN2dcyt6UEJOW0dyMomLFpG4aBG2Rg3xu2UovgMH4FalilPPoawoKzm9UhXk392pGTJNk4kTJ/Ltt9+yevVq6tevX+B9zJo1i507dxIaGkpoaCg//vgjAIsWLWL69OkX3KZNmza4u7vz66+/5i4LCwsjMjKSjh07Fu5kRERErlBpaWn89ddfpKWlOTsUESlH3NzcGdZrIh+M28DygT8zMLAre9q68fADVp4faWVNC4N097PtM8MjOP7aa+zrHszhByeQ/OuvmFlZF9y3abeTumUrict/IHXLVky7vZTOSuTCnNrjPWHCBBYuXMiyZcvw9vbOfb7a19eXChUqADnPY0dHRxMeHg7A7t278fb2pk6dOgQEBFCnTp08+6xUqRIADRs2zO09P3r0KD179mTBggVcf/31+Pr6MnbsWB599FECAgLw8fHhoYceomPHjhrRXEREpICOHDnCCy+8wOzZs2natKmzwxGRcqha5Zo8etv7PAps2rWCb+3v8L8aB5nb20LHf0y673LQ7MjpxtnZpKxeTcrq1VgrV8Z34ED8bhmCR+PGACStXEnMyzPIPmfsJregIKpNnYJPnz6lf3IiOLnwnj17NgDdu3fPs3zu3LmMHj0agA8++CDPoGZnphk7t83lZGVlERYWlueb+DfffBOLxcLQoUPJyMigb9++vP/++4U/GRERERERKbKOLfvRsWU/MjMz+OqXN1hrfsdLLVOoEgfddzvottskICWnrf3kSeLmziVu7lw8W7bEs2lTEv73v/P2mR0Tw9FHJsHbb6n4FqcwzDNzgEiBJCUl4evrS2JiogZXK0McDgdxcXF6ztCFKKeuRzl1Pf/88w/jx49Xj7cL0XXqesp7Tg8d28vnq19m66kQDriZXHsgZ0C2dnvPzg1+hglcaAg2E3APCqLRr79gWK2lEHXJKu85dQUFqQnLxOBqIiIiIiIiF1O3RhOeuXMeAL9s+Zrl9jl8Wu8YH2VY6LInZ0C2+jE5bS827rkBZEdHk7Y9hIrtry+NsEVyqfAWERGRInFzcyMgIKBA06qIiBRWr/bD6NV+GMmpCSxc9RobLCuZ0iadAZscjFx3+Zt506OOUrEU4hQ5l35DioiISJE0aNCADz/8UHN4i0ip8q7ox/2DX+Z+Xubv/SF8GzERSLjsdoffeAVrth2fm27CcnpAZ5GSpocBRERERESkXGvWoA0+LTtxwhscl2nrEZtE1LPPsa9bd2JmvELGgQOlEqNc2VR4i4iISJHs37+f+++/n/379zs7FBG5ggX61WVebwsG5xffDnIGV4v2O2dZUhJx8+ez/8b+RN4zNmde8OzsUotXriwqvEVERKRIsrOziYuLI1t/sIqIEw3udj/7G8LMIRbivPOui/OGN4ZYePgBK1PutrK2hUHmOQObp27cyJEJEwnv3YcTH3xA9okTpRu8uDw94y0iIiIiIuWezebBHVUG8651GdsaW2h6BPxTIL4S/FMLTIvBaI8biK9+nK/7/cOCHhaCd5v03uEgKCFnH9lRUcS+9Tax772PT+/e+I8cQYXWrTGMi42VLpI/KrxFRERERMQljBs0HZbBlyeWsqfu2Zt7q2Y7uN1/UM56ID0jjc9/foXVluU8cn0mLfeb9N1h0jrczLklOCuLpB9/JOnHH/Fo0gT/EXfgc/MArJU0HroUjgpvERERERFxGeMGTWd05v+xdN2HHE+KJNCnDoO73Y/N5pHbxtPDi3sHvsi9vMimXSv4X/ZMZtc7imeyhV6hDnqGmvicymmbsXcv0S9M4/h/X8d38GD877gdj0aNnHR2Ul4ZpmlefrI7OU9SUhK+vr4kJibi4+Pj7HDkNIfDQVxcHAEBAVgsGsLAFSinrkc5dT0pKSmEhITQpk0bKlWq5OxwpBjoOnU9yunlxSfGMnfF86xL+o1Ii0mHf0z67nBw1dHz23pdfz3+I+7Au2dPDHf30g8W5bQsKEhNqB5vERERKRIvLy+uueYavLy8nB2KiEih+ftW5dHb3meS3c4Pv89nuf1T/nN1AjWOQ58/HHT5y8QzK6dt2tatpG3dilvVqvgNH47f8GG4V6vm3BOQMk1fjYiIiEiRxMbG8sUXXxAbG+vsUEREisxitTKg6z18OG4D3/T5hrbVm/NdLwsPTLQyt5eFowFn22bHxnLivfcI79GTIw8/QurmzeiGYrkQ9XiLiIhIkcTHx7N06VL69u1LNfX4iIgLqV+zKc+P+ors7CwWrvwvq1jCo21OcU0k9N1h0navidUE7HaSV64keeVKbA0a4H/HHfgOHoTV++y8ZqbdTtr2ELJjY3GrWhWvtm0wrNaLH1xcigpvERERERGRS3Bzc2dU/6mMYio79qzjS8erfFz7EHNTLfQMddAr1MQ/Nadt5v79xEyfzvE338R3wAD877idzMhIoqe/jD0mJnef1mrVCHpmKj59+jjprKQ0qfAWERERERHJp9ZXd6P11d1ITIlj/k8vsq79GpZ0ttNub85gbNdE5rQz09JIWLSIhEWLOHPz+bmzgWfHxHDk4UeoNettFd9XAD3jLSIiIiIiUkC+lQJ4eNhbLB63k1ebTcW9QRVeucPKo/daWdHaIM12tq1B3qL7zDITiHjuaUy7vfQCF6dQ4S0iIiJF4uvrS48ePfD19XV2KCIiTtG34wjeH7eOpTctp3O11vzcI2cwtuXt/l1u52UBPBNPkbR5U+kEKk6jwltERESKpFq1aowfP14Dq4nIFa9WYD2evWsBP47ZyWP17iGtav7KrT++/kCjobs4Fd4iIiJSJBkZGRw+fJiMjAxnhyIiUiZYrFZu7/MoDau3y1f7aitCOHjb7SSt+Fm3nbsoFd4iIiJSJIcOHeLRRx/l0KFDzg5FRKRMsbW8lhPe4LjI+nP7uNN37eLopElE3Nif+C+/xJGeXhohSilR4S0iIiIiIlICBgePZ0kPA4Pzi+8zn39oa3Aw8OzyrMhIoqe9SHhwD2LffY/s+PhSilZKkgpvERERERGREmCzedCs0xBmDrEQ5513XZw3vDHEwrYbbEwdY+E/t1vYWe/sYGz2+HhOvPsu4cE9iH7xRTIjI0s5eilOmsdbRERERESkhIwbNB2A5xt8S9UoA/8UiK8EJ6qb3BY4mHGDpvNXxHbmrnmOt26LpOpxCwO2OOj0t4nVBDM9nfiFXxL/1SK8+/Sh8th7qNCihZPPSgpKhbeIiIgUiWEYuLm5YRiXnjZHRORKNW7QdEZn/h9L133I8aRIAn3qMLjb/dhsHgBc07Atrzf8iWOxh/jop6f58qZdfNndwk3bHPQMNfHMAhwOklesIHnFCrzatcP/njGY11zj3BOTfDNMjVtfKElJSfj6+pKYmIiPj4+zw5HTHA4HcXFxBAQEYLHoSQpXoJy6HuXU9Sinrkc5dT3KafmSmpbMR8un8kviWk7YTfr8YXLjdgd+qXnbWevXp+q9Y/EbMADDZnNOsFewgtSEuupERERERETKkIpe3kwa/g7f3RPKg3VGsLeNjQkPWvngRgtHA862sx84QPQzzxLeqzcnP/4Ye3Ky84KWS1LhLSIiIkVy6NAhnnzySU0nJiJSzCxWK6P6T+WrcX8wvelTpDTz4fH7LLx6q4W/a51tl338OMdff4Pw7sHEvPoaWdHRzgtaLkiFt4iIiBRJRkYGBw4cICMjw9mhiIi4rBs738Un4zbx8fXv4Vs3iJdHWnnmLitbmhi5U5M5UlOJmzuX8F69OfbU06SH7XVqzHKWCm8REREREZFyou013Xn7vl/5us83XBXUiE8GG0weZ2XVdQaZ1tONsrNJXLaMA4MGEXnfOFI3b0FDezmXCm8REREREZFypm71Jjw26GOWDV1Lz6AO/NDTwoQJVhZ3MkjxPNsu9bffiBw9moO3DiPpxx8xs7Pz7Me020ndspXE5T+QumUrpt1euidyhdB0YiIiIiIiIuWUn3dlnhrxMZMzM5j304v87LacpR3tBO8yuXmrg8DEnHbpf/3F0Ucfw71mTQJGj8Zv6C2kbNhA9PSXscfE5O7PWq0aQc9MxadPHyedkWvSdGKFpOnEyiZNleF6lFPXo5y6nsTERNavX0/Xrl3x9fV1djhSDHSduh7l1PVcLKcOu51l6z/i232fsNP9FB3+MRm4xUGDf423ZvHywp6WBoBxzvIzxWGtWW+r+L4MTScmIiIipcbb25uOHTvi7e3t7FBERK54FquVIcEPsGDcNt5r9QrWhpV57m4L0+6wEFr/bIntSEvDIG/RzenPJhDx3NO67bwYqfAWERGRIomLi+P7778nLi7O2aGIiMg5ulx3M++PW8+X3T+nTq16vDPM4PGxVkLrXXo7C+CZeIqkzZtKI8wrggpvERERKZITJ06wYMECTpw44exQRETkAq6qfx2vjf2BbwetpENQK7Y1/3c/94VtXr+ohCO7cqjwFhERERERuQJUq1yT5+76nFZV2+SrfYVNO8k8cqSEo7oyqPAWERERERG5gni2asMJb3Bcpl3VvbFE9LuRqOeeI/PI0VKJzVWp8BYREREREbmCDA4ez5IeBgbnF98OcgZXSz8z8XR2Nglff0NEv35EPfd/ZB1VAV4YKrxFRESkSCpVqkSbNm2oVKmSs0MREZF8sNk8aNZpCDOHWIj714QUcd7wxhALDzxk5esuBmkep1dkZ5Pw9deE9+1H1PMvkHXsWKnHXZ65Xb6JiIiIyMXVqFGDp59+moCAAGeHIiIi+TRu0HQAnm/wLVWjDPxTIL4SnKhuMrzKIHp6VWaJsYAf29q5aZuD/ttMvDLJKcAXLSJh8WL8bh1Klfvvx716deeeTDmgwltERESKJDs7m8TERHx8fLDZbM4OR0RE8mncoOmMzvw/lq77kONJkQT61GFwt/ux2XK6uW+3T+KrX2ay2PI5P7Szc/NWBzduP6cA/2oRCd8sxm/YrTkFeFCQc0+oDDNM0zSdHUR5lJSUhK+vb+4fGlI2OBwO4uLiCAgIwGLRkxSuQDl1Pcqp6/nnn38YP348s2fPpmnTps4OR4qBrlPXo5y6ntLMqcNuZ+HK11ly+AuOORzcvNVB/+0mFTLPtjHc3fEbNozK4+67YgrwgtSEuupERERERETkoixWK3fe+BTfjP2DCXXuZEcHNyaMt7Kkk8Gp0zc6mVlZxC9cSETvPkT/5yWyYmKcG3QZo8JbRERERERELstitXJX/6f5ZuwfPFDnDrZ3cGPieCvfdjRId89pY2ZlEf/FFzkF+EvTyYo57tygywgV3iIiIiIiIpJvFquVu296hsVj/2BcndvY2smNCQ9aWdrhnAI8M5P4zz8nondvoqe/TNbxK7sAV+EtIiIiIiIiBWaxWhl903MsuecP7qt9G5s7W5nwoJVl/y7AP/uMiN59iJkxg+zYWOcG7SQqvEVERKRIGjZsyPz582nYsKGzQxERESewWK2Mufk5vr0nlHtrDWNTZysTx1tZ1v6cAjwjg7j5Cwjv1ZuYGa9ccQW4Cm8REREpEqvVipeXF1ar1dmhiIiIE1msVu4Z8Dzf3hPKmFpD2dglpwD//nqDjNMTWecU4PMJ792HmFdeJfvECecGXUpUeIuIiEiRHDlyhJdeeokjR444OxQRESkDLFYr9w6cxtJ7QhlT6xZ+u8HKxAf/VYCnpxM3b15OD/hr/yX75Mnc7U27ndQtW0lc/gOpW7Zi2u1OOpPi4+bsAERERKR8S0tLY+fOnaSlpTk7FBERKUNyCvAXGZ39HJ/+8ALf3fAd37U3GbTZQZ8/TGzZpwvwTz8l/ssv8R9xBx4NG3L87VnYz5mOzFqtGkHPTMWnTx8nnk3RqMdbRERERERESoybmzvjBk1n6Zgd3FVzIOu65tyC/kM7g8wzPeCnThH3yaccm/oM2f+aAzw7JoYjDz9C0sqVToi+eKjwFhERERERkRLn5ubO/YNfZumYHYyoMYA1pwvwH9saZJ6uTI3Tr3MZgAlEPPd0ub3tXIW3iIiIiIiIlBo3N3fGD5nBsjE7GFH9Jn7tZuGdgZcuTS2AZ+IpkjZvKp0gi5kKbxERESmSwMBAxo4dS2BgoLNDERGRcsTNzZ3xt7zK0rtDaJedv98hm9cvKuGoSoYKbxERESkSPz8/+vXrh5+fn7NDERGRcshm86BitXr5ahvrllKywZQQFd4iIiJSJElJSaxfv56kpCRnhyIiIuWUreW1nPAGx0XWO4AT3jntyiMV3iIiIlIk0dHRvPPOO0RHRzs7FBERKacGB49nSQ8Dg/OLbwc5A6wt6WEwOHh86QdXDFR4i4iIiIiIiFPZbB406zSEmUMsxHnnXRfnDTOHWGjWaQg2m4dzAiwiN2cHICIiIiIiIjJu0HQAnm/wLVWjDPxTIL4SnKhuclvg4Nz15ZEKbxERERERESkTxg2azujM/2Ppug85nhRJoE8dBne7v9z2dJ+hwltERESKpEKFCjRu3JgKFSo4OxQREXEBNpsHw3s/7OwwipUKbxERESmS2rVr8/LLLxMQEODsUERERMokDa4mIiIiIiIiUoJUeIuIiEiR7N27l2HDhrF3715nhyIiIlImqfAWERERERERKUEqvEVERERERERKkFML7xkzZtCuXTu8vb0JDAxk8ODBhIWF5WkzZ84cunfvjo+PD4ZhkJCQcN5+Bg4cSJ06dfD09KR69ercddddHDt27JLH7t69O4Zh5Hk98MADxXl6IiIiIiIiIs4tvNetW8eECRPYvHkzq1atIisriz59+pCamprbJi0tjX79+jF16tSL7ic4OJj//e9/hIWFsXjxYiIiIrj11lsve/z77ruPqKio3Ndrr71WLOclIiIiIiIicoZTpxNbsWJFns/z5s0jMDCQkJAQunbtCsCkSZMAWLt27UX3M3ny5Nz3devW5emnn2bw4MFkZWXh7u5+0e28vLwICgoq/AmIiIgI9erVY9asWdSrV8/ZoYiIiJRJZeoZ78TERIAizQMaFxfHF198QadOnS5ZdAN88cUXVKlShebNmzNlyhTS0tIKfVwREZErlc1mo3r16thsNmeHIiIiUiY5tcf7XA6Hg0mTJtG5c2eaN29e4O2feuop3n33XdLS0ujQoQPLly+/ZPsRI0ZQt25datSowa5du3jqqacICwtjyZIlF2yfkZFBRkZG7uekpKTcuB0OR4HjlZLhcDgwTVM5cSHKqetRTl3P0aNHmTNnDuPGjaNmzZrODkeKga5T16Ocuh7l1PkK8m9fZgrvCRMm8Oeff7Jhw4ZCbf/EE08wduxYDh06xLRp0xg1ahTLly/HMIwLth83blzu+xYtWlC9enV69uxJREQEDRs2PK/9jBkzmDZt2nnL4+Pjyc7OLlTMUvwcDgfJycmYponFUqZu6JBCUk5dj3Lqeo4ePcqGDRu46aabqFChgrPDkWKg69T1KKeuRzl1vuTk5Hy3LROF98SJE1m+fDnr16+nVq1ahdpHlSpVqFKlCk2aNKFZs2bUrl2bzZs307Fjx3xt3759ewDCw8MvWHhPmTKFRx99NPdzUlIStWvXxt/fHx8fn0LFLMXP4XBgGAb+/v76AeQilFPXo5y6Hl9f39z/FuVxMSk7dJ26HuXU9Sinzufmlv9y2qmFt2maPPTQQ3z77besXbuW+vXrF8t+z3T5n3tr+OWEhoYCUL169Quu9/DwwMPD47zlFotF/6OXMYZhKC8uRjl1Pcqpazlzd9mZvIpr0HXqepRT16OcOldB/t2dWnhPmDCBhQsXsmzZMry9vYmOjgZyvjE/c6tadHQ00dHRhIeHA7B79268vb2pU6cOAQEBbNmyhW3bttGlSxf8/f2JiIjgueeeo2HDhrm93UePHqVnz54sWLCA66+/noiICBYuXEj//v2pXLkyu3btYvLkyXTt2pWWLVvmK3bTNIGzz3pL2XDmlhs3Nzf9AHIRyqnrUU5dT0pKCtnZ2aSkpOj3oovQdep6lFPXo5w635nfeWdqw0synQi44Gvu3Lm5bZ5//vlLttm1a5cZHBxsBgQEmB4eHma9evXMBx54wDxy5EjuPg4cOGAC5po1a0zTNM3IyEiza9euuds0atTIfOKJJ8zExMR8x3748OGLxq+XXnrppZdeeumll1566aXXlfE6fPjwZetH43QBLAXkcDg4duwY3t7eFx3ATUrfmWfvDx8+rGfvXYRy6nqUU9ejnLoe5dT1KKeuRzl1PtM0SU5OpkaNGpe966BMDK5WHlkslkIPBCclz8fHRz+AXIxy6nqUU9ejnLoe5dT1KKeuRzl1rjMDjF6OHgYQERERERERKUEqvEVERERERERKkApvcSkeHh48//zzF5z6Tcon5dT1KKeuRzl1Pcqp61FOXY9yWr5ocDURERERERGREqQebxEREREREZESpMJbREREREREpASp8BYREREREREpQSq8pUx64YUXMAwjz6tp06YXbT9v3rzz2nt6euZpM3r06PPa9OvXr6RPRU4riZyapsn//d//Ub16dSpUqECvXr3Yt29fSZ+KnKOgeT3XV199hWEYDB48OM9yXavOVRI51bXqXAXN6ZIlS2jbti1+fn5UrFiRVq1a8dlnn+Vpo+vUuUoip7pOnaugOf3oo4+44YYb8Pf3x9/fn169erF169Y8bXSdli1uzg5A5GKuueYafvnll9zPbm6X/t/Vx8eHsLCw3M+GYZzXpl+/fsydOzf3s0aBLF3FndPXXnuNWbNmMX/+fOrXr89zzz1H37592bNnz3lFupScguYV4ODBgzz++OPccMMNF1yva9W5ijunuladryA5DQgI4JlnnqFp06bYbDaWL1/OmDFjCAwMpG/fvrntdJ06V3HnVNep8xUkp2vXruWOO+6gU6dOeHp68uqrr9KnTx/++usvatasmdtO12nZocJbyiw3NzeCgoLy3d4wjMu29/DwKNA+pXgVZ05N0+Stt97i2WefZdCgQQAsWLCAatWqsXTpUm6//fZiiVkur6B5tdvtjBw5kmnTpvHbb7+RkJBwXhtdq85VnDnVtVo2FCSn3bt3z/P5kUceYf78+WzYsCFP4a3r1LmKM6e6TsuGguT0iy++yPP5448/ZvHixfz666+MGjUqd7mu07JDt5pLmbVv3z5q1KhBgwYNGDlyJJGRkZdsn5KSQt26dalduzaDBg3ir7/+Oq/N2rVrCQwM5KqrrmL8+PGcPHmypMKXCyjOnB44cIDo6Gh69eqVu8zX15f27duzadOmEjsHOV9B8/riiy8SGBjI2LFjL9pG16pzFWdOda2WDQXN6RmmafLrr78SFhZG165d86zTdepcxZlTXadlQ2FzCpCWlkZWVhYBAQF5lus6LTs0j7eUST/99BMpKSlcddVVREVFMW3aNI4ePcqff/6Jt7f3ee03bdrEvn37aNmyJYmJibz++uusX7+ev/76i1q1agE5zx56eXlRv359IiIimDp1KpUqVWLTpk1YrdbSPsUrTnHndOPGjXTu3Jljx45RvXr13O2GDx+OYRgsWrSoNE/vilXQvG7YsIHbb7+d0NBQqlSpwujRo0lISGDp0qW5bXStOldx51TXqvMVNKcAiYmJ1KxZk4yMDKxWK++//z733HNP7npdp85V3DnVdep8hcnpuR588EF+/vln/vrrr9xHA3SdljGmSDkQHx9v+vj4mB9//HG+2mdmZpoNGzY0n3322Yu2iYiIMAHzl19+Ka4wpQCKmtPff//dBMxjx47laTds2DBz+PDhxR6v5M+l8pqUlGTWq1fP/PHHH3OX3X333eagQYMuuU9dq85V1JzqWi178vPz1263m/v27TP/+OMP8/XXXzd9fX3NNWvWXLS9rlPnKmpOdZ2WPQX5O2nGjBmmv7+/uXPnzku203XqXHrGW8oFPz8/mjRpQnh4eL7au7u7c911112yfYMGDahSpQrh4eH07NmzuEKVfCpqTs88rxQTE5Pn2/mYmBhatWpV7PFK/lwqrxERERw8eJABAwbkLnM4HEDOc21hYWE0bNjwvO10rTpXUXOqa7Xsyc/PX4vFQqNGjQBo1aoVf//9NzNmzDjvWeEzdJ06V1Fzquu07Mnv30mvv/46r7zyCr/88gstW7a8ZFtdp86lZ7ylXEhJSSEiIiLPL4NLsdvt7N69+5Ltjxw5wsmTJ/O9TyleRc1p/fr1CQoK4tdff81tk5SUxJYtW+jYsWOJxCyXd6m8Nm3alN27dxMaGpr7GjhwIMHBwYSGhlK7du0L7lPXqnMVNae6Vsuegv78hZwvVDIyMi66XtepcxU1p7pOy5785PS1117jP//5DytWrKBt27aX3aeuUydzdpe7yIU89thj5tq1a80DBw6Yv//+u9mrVy+zSpUq5vHjx03TNM277rrLfPrpp3PbT5s2zfz555/NiIgIMyQkxLz99ttNT09P86+//jJN0zSTk5PNxx9/3Ny0aZN54MAB85dffjFbt25tNm7c2ExPT3fKOV5pijunpmmar7zyiunn52cuW7bM3LVrlzlo0CCzfv365qlTp0r9/K5UBc3rv/37tmRdq85X3Dk1TV2rzlbQnL788svmypUrzYiICHPPnj3m66+/brq5uZkfffSRaZq6TsuC4s6paeo6dbaC5vSVV14xbTab+c0335hRUVG5r+TkZNM0dZ2WRbrVXMqkI0eOcMcdd3Dy5EmqVq1Kly5d2Lx5M1WrVgUgMjISi+XsDRvx8fHcd999REdH4+/vT5s2bdi4cSNXX301AFarlV27djF//nwSEhKoUaMGffr04T//+Y/mMywlxZ1TgCeffJLU1FTGjRtHQkICXbp0YcWKFZpvtBQVNK+Xo2vV+Yo7p6Br1dkKmtPU1FQefPBBjhw5QoUKFWjatCmff/45t912G6DrtCwo7pyCrlNnK2hOZ8+eTWZmJrfeemue/Tz//PO88MILuk7LII1qLiIiIiIiIlKC9Iy3iIiIiIiISAlS4S0iIiIiIiJSglR4i4iIiIiIiJQgFd4iIiIiIiIiJUiFt4iIiIiIiEgJUuEtIiIiIiIiUoJUeIuIiIiIiIiUIBXeIiIiIiIiIiVIhbeIiEg5c/DgQQzDIDQ01NmhlKjRo0czePBgZ4chIiJSZCq8RUREypDRo0djGAaGYeDu7k79+vV58sknSU9Pz21Tu3ZtoqKiaN68uRMjPd/atWsxDIOEhIQCbXexLxLefvtt5s2bV2zxiYiIOIubswMQERGRvPr168fcuXPJysoiJCSEu+++G8MwePXVVwGwWq0EBQWVaAyZmZnYbLYSPcbl+Pr6OvX4IiIixUU93iIiImWMh4cHQUFB1K5dm8GDB9OrVy9WrVqVu/7cHmKHw0GtWrWYPXt2nn388ccfWCwWDh06BEBCQgL33nsvVatWxcfHhx49erBz587c9i+88AKtWrXi448/pn79+nh6el4wtkOHDjFgwAD8/f2pWLEi11xzDT/++CMHDx4kODgYAH9/fwzDYPTo0QCsWLGCLl264OfnR+XKlbn55puJiIjI3Wf9+vUBuO666zAMg+7duwPn32qekZHBww8/TGBgIJ6ennTp0oVt27blrj/T4/7rr7/Stm1bvLy86NSpE2FhYQXMgIiISPFS4S0iIlKG/fnnn2zcuPGivc8Wi4U77riDhQsX5ln+xRdf0LlzZ+rWrQvAsGHDOH78OD/99BMhISG0bt2anj17EhcXl7tNeHg4ixcvZsmSJRd9fnzChAlkZGSwfv16du/ezauvvkqlSpWoXbs2ixcvBiAsLIyoqCjefvttAFJTU3n00UfZvn07v/76KxaLhSFDhuBwOADYunUrAL/88gtRUVEsWbLkgsd+8sknWbx4MfPnz2fHjh00atSIvn375jkHgGeeeYY33niD7du34+bmxj333HOpf2IREZESp1vNRUREypjly5dTqVIlsrOzycjIwGKx8O677160/ciRI3njjTeIjIykTp06OBwOvvrqK5599lkANmzYwNatWzl+/DgeHh4AvP766yxdupRvvvmGcePGATm3ly9YsICqVate9FiRkZEMHTqUFi1aANCgQYPcdQEBAQAEBgbi5+eXu3zo0KF59vHpp59StWpV9uzZQ/PmzXOPV7ly5YveQp+amsrs2bOZN28eN954IwAfffQRq1at4pNPPuGJJ57IbTt9+nS6desGwNNPP81NN91Eenr6RXvxRURESpp6vEVERMqY4OBgQkND2bJlC3fffTdjxow5r3g9V6tWrWjWrFlur/e6des4fvw4w4YNA2Dnzp2kpKRQuXJlKlWqlPs6cOBAnlu+69ate8miG+Dhhx/mpZdeonPnzjz//PPs2rXrsuezb98+7rjjDho0aICPjw/16tUDcor4/IqIiCArK4vOnTvnLnN3d+f666/n77//ztO2ZcuWue+rV68OwPHjx/N9LBERkeKmwltERKSMqVixIo0aNeLaa6/l008/ZcuWLXzyySeX3GbkyJG5hffChQvp168flStXBiAlJYXq1asTGhqa5xUWFpanp7hixYqXje3ee+9l//793HXXXezevZu2bdvyzjvvXHKbAQMGEBcXx0cffcSWLVvYsmULkNPDXhLc3d1z3xuGAZB7W7uIiIgzqPAWEREpwywWC1OnTuXZZ5/l1KlTF203YsQI/vzzT0JCQvjmm28YOXJk7rrWrVsTHR2Nm5sbjRo1yvOqUqVKgWOqXbs2DzzwAEuWLOGxxx7jo48+Ash9Dt1ut+e2PXnyJGFhYTz77LP07NmTZs2aER8fn2d/F9ru3xo2bIjNZuP333/PXZaVlcW2bdu4+uqrC3wOIiIipUmFt4iISBk3bNgwrFYr77333kXb1KtXj06dOjF27FjsdjsDBw7MXderVy86duzI4MGDWblyJQcPHmTjxo0888wzbN++vUCxTJo0iZ9//pkDBw6wY8cO1qxZQ7NmzYCcW9UNw2D58uXExsaSkpKCv78/lStXZs6cOYSHh7N69WoeffTRPPsMDAykQoUKrFixgpiYGBITE887bsWKFRk/fjxPPPEEK1asYM+ePdx3332kpaUxduzYAp2DiIhIaVPhLSIiUsa5ubkxceJEXnvtNVJTUy/abuTIkezcuZMhQ4ZQoUKF3OWGYfDjjz/StWtXxowZQ5MmTbj99ts5dOgQ1apVK1AsdrudCRMm0KxZM/r160eTJk14//33AahZsybTpk3j6aefplq1akycOBGLxcJXX31FSEgIzZs3Z/Lkyfz3v/897/xmzZrFhx9+SI0aNRg0aNAFj/3KK68wdOhQ7rrrLlq3bk14eDg///wz/v7+BToHERGR0maYpmk6OwgRERERERERV6UebxEREREREZESpMJbREREREREpASp8BYREREREREpQSq8RUREREREREqQCm8RERERERGREqTCW0RERERERKQEqfAWERERERERKUEqvEVERERERERKkApvERERERERkRKkwltERERERESkBKnwFhERERERESlBKrxFREREREREStD/A/+m3aa0vYN8AAAAAElFTkSuQmCC",
+      "text/plain": [
+       "<Figure size 1000x550 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "fig, ax = plt.subplots(figsize=(10, 5.5))\n",
+    "for label, group in profile_df.groupby(\"Scenario\", sort=False):\n",
+    "    ax.plot(group[\"StationNum\"], group[\"WSE\"], marker=\"o\", linewidth=2, label=label)\n",
+    "\n",
+    "ax.axvline(BRIDGE_STATION, color=\"0.25\", linestyle=\"--\", linewidth=1, label=\"Bridge RS 5.4\")\n",
+    "ax.invert_xaxis()\n",
+    "ax.set_xlabel(\"River station\")\n",
+    "ax.set_ylabel(\"Water surface elevation (ft)\")\n",
+    "ax.set_title(\"Bridge Method Comparison - Truncated WSE Profile\")\n",
+    "ax.grid(True, alpha=0.25)\n",
+    "ax.legend(loc=\"best\")\n",
+    "fig.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9613511e",
+   "metadata": {},
+   "source": [
+    "## Pressure/Weir Coefficient Sensitivity\n",
+    "\n",
+    "The pressure/weir run keeps the low-flow method fixed at Energy, sets pressure-flow coefficients, and varies the bridge deck/weir coefficient over broad-crested through ogee-style values. The response metric is maximum WSE at the bridge upstream face cross section nearest RS 5.41."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "cd15871d",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-01T18:29:47.295713Z",
+     "iopub.status.busy": "2026-05-01T18:29:47.295485Z",
+     "iopub.status.idle": "2026-05-01T18:30:43.004783Z",
+     "shell.execute_reply": "2026-05-01T18:30:43.004191Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Cd=2.6 | WSE=217.150 ft | runtime=11.1s\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Cd=2.9 | WSE=217.124 ft | runtime=11.3s\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Cd=3.1 | WSE=217.103 ft | runtime=11.1s\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Cd=3.5 | WSE=217.096 ft | runtime=11.0s\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Cd=4 | WSE=217.048 ft | runtime=10.8s\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>Weir Coefficient</th>\n",
+       "      <th>Nearest Station</th>\n",
+       "      <th>Peak Time</th>\n",
+       "      <th>Max WSE At Bridge (ft)</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>2.6</td>\n",
+       "      <td>5.41</td>\n",
+       "      <td>1990-02-11 05:00:00</td>\n",
+       "      <td>217.150</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>2.9</td>\n",
+       "      <td>5.41</td>\n",
+       "      <td>1990-02-11 05:00:00</td>\n",
+       "      <td>217.124</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>3.1</td>\n",
+       "      <td>5.41</td>\n",
+       "      <td>1990-02-11 05:00:00</td>\n",
+       "      <td>217.103</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>3.5</td>\n",
+       "      <td>5.41</td>\n",
+       "      <td>1990-02-11 05:00:00</td>\n",
+       "      <td>217.096</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>4.0</td>\n",
+       "      <td>5.41</td>\n",
+       "      <td>1990-02-11 05:00:00</td>\n",
+       "      <td>217.048</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   Weir Coefficient Nearest Station           Peak Time  \\\n",
+       "0               2.6            5.41 1990-02-11 05:00:00   \n",
+       "1               2.9            5.41 1990-02-11 05:00:00   \n",
+       "2               3.1            5.41 1990-02-11 05:00:00   \n",
+       "3               3.5            5.41 1990-02-11 05:00:00   \n",
+       "4               4.0            5.41 1990-02-11 05:00:00   \n",
+       "\n",
+       "   Max WSE At Bridge (ft)  \n",
+       "0                 217.150  \n",
+       "1                 217.124  \n",
+       "2                 217.103  \n",
+       "3                 217.096  \n",
+       "4                 217.048  "
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "weir_results = []\n",
+    "weir_rows = []\n",
+    "\n",
+    "for coeff in WEIR_COEFFICIENTS:\n",
+    "    label = f\"Cd {coeff:g}\"\n",
+    "    result = run_scenario(\n",
+    "        label,\n",
+    "        suffix=f\"weir_{_safe_suffix(coeff)}\",\n",
+    "        low_flow_method=\"energy\",\n",
+    "        high_flow_method=\"pressure_weir\",\n",
+    "        weir_coefficient=coeff,\n",
+    "        **PRESSURE_FLOW_CDS,\n",
+    "    )\n",
+    "    weir_results.append(result)\n",
+    "\n",
+    "    ds = result[\"dataset\"]\n",
+    "    stations = result[\"stations\"]\n",
+    "    bridge_face_idx = int(np.argmin(np.abs(stations - 5.41)))\n",
+    "    max_wse_at_bridge = float(ds[\"Water_Surface\"].isel(cross_section=bridge_face_idx).max().values)\n",
+    "    peak_time_idx = int(ds[\"Water_Surface\"].isel(cross_section=bridge_face_idx).argmax().values)\n",
+    "    peak_time = pd.Timestamp(str(ds[\"time\"].values[peak_time_idx]))\n",
+    "    weir_rows.append({\n",
+    "        \"Weir Coefficient\": coeff,\n",
+    "        \"Nearest Station\": str(ds[\"Station\"].values[bridge_face_idx]),\n",
+    "        \"Peak Time\": peak_time,\n",
+    "        \"Max WSE At Bridge (ft)\": max_wse_at_bridge,\n",
+    "        \"Deck Line After\": result[\"edit_result\"][\"deck_line_after\"],\n",
+    "    })\n",
+    "    print(\n",
+    "        f\"Cd={coeff:g} | WSE={max_wse_at_bridge:.3f} ft | \"\n",
+    "        f\"runtime={result['runtime_sec']:.1f}s\"\n",
+    "    )\n",
+    "\n",
+    "weir_df = pd.DataFrame(weir_rows)\n",
+    "display(weir_df[[\"Weir Coefficient\", \"Nearest Station\", \"Peak Time\", \"Max WSE At Bridge (ft)\"]].round(3))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "92af9d47",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-01T18:30:43.006766Z",
+     "iopub.status.busy": "2026-05-01T18:30:43.006510Z",
+     "iopub.status.idle": "2026-05-01T18:30:43.095150Z",
+     "shell.execute_reply": "2026-05-01T18:30:43.094515Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAxYAAAHqCAYAAACZcdjsAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjgsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvwVt1zgAAAAlwSFlzAAAPYQAAD2EBqD+naQAAmHpJREFUeJzs3Xd0VOXWx/HvpIf0BEIoAUKRFpAqkAACSlEBERBQFEGxBhC4V1+xITauFQUERBEURAUFKVJE6b33DqETWioJqXPePyKjMQEyKTMh+X3WmiXznDPn7NkkOHueZjIMw0BERERERCQfHOwdgIiIiIiI3P5UWIiIiIiISL6psBARERERkXxTYSEiIiIiIvmmwkJERERERPJNhYWIiIiIiOSbCgsREREREck3FRYiIiIiIpJvKixERERERCTfVFiIiAgA/fv3p0qVKvYOI1+uXr3KwIEDCQoKwmQyMXToUAAuXLhAz549CQgIwGQy8dlnn7Fy5UpMJhMrV6606h5vvfUWJpOp4IMvxqZNm4bJZOLEiRO3PDevfy8Abdq0oU2bNla/TkQKhgoLEbGp6x8wrj/c3Ny44447GDRoEBcuXLB3eEXGf/7zH+rUqcOsWbMwmUzMnTs32zl33nknJpOJFStWZDtWqVIlwsLCbBFqNhkZGUydOpU2bdrg7++Pq6srVapUYcCAAWzdurVQ7/3+++8zbdo0nn/+eaZPn87jjz8OwLBhw1i6dCkjRoxg+vTpdOrUqVDjyK9z587x1ltvsXPnzly/Zs+ePfTs2ZPKlSvj5uZGhQoVaN++PePGjSu8QPNhwoQJTJs2rVDvkZc8ikjemQzDMOwdhIiUHNOmTWPAgAG8/fbbhISEkJyczNq1a5k+fTqVK1dm7969lCpVyt5h2l2tWrXo0qULw4YNo0KFCgwfPpxPPvnEcjw+Ph4/Pz8cHBwYOXIkr7/+uuXY6dOnqVSpEi+99BIffvhhru+ZlpaG2WzG1dU1z3Ffu3aN7t27s2TJElq3bk2XLl3w9/fnxIkTzJo1i8OHD3Pq1CkqVqyY53vcTPPmzXFycmLt2rVZ2oOCgrj33nuZMWOGpc1sNpOamoqLiwsODrn/ni09PZ309HTc3NwKLO5/27p1K02bNmXq1Kn079//luevX7+etm3bUqlSJZ544gmCgoI4ffo0Gzdu5NixYxw9erTQYs2NjIwM0tLScHV1tfT2hIaGUrp06Ww9E3n9ewFITU0FwMXFBbA+jyKSP072DkBESqb77ruPJk2aADBw4EACAgL49NNPmTdvHo888kiOr0lMTMTDw8OWYeaLYRgkJyfj7u5u1euOHz/OoUOHmDRpEuXLlyckJCTbB+UNGzZgGAYPP/xwtmPXn7ds2dKq+zo7O9/ynPT0dMxms+WD27+99NJLLFmyhDFjxliGIV03cuRIxowZY1VM1rp48SJ16tTJsd3X1zdLm4ODQ56KAycnJ5ycitb/Pt977z18fHzYsmVLtvd58eJF+wT1D46Ojjg6Oubq3Lz+vQA3/LkUEdvQUCgRKRLatWsHQGRkJJA53t/T05Njx45x//334+XlRd++fYHMbzQ/++wz6tati5ubG2XLluXZZ58lJiYmyzW3bt1Kx44dKV26NO7u7oSEhPDkk09mOefHH3+kcePGeHl54e3tTb169fj8888tx280nj6nMeNVqlShc+fOLF26lCZNmuDu7s6XX34JQGxsLEOHDiU4OBhXV1eqV6/OBx98gNlsznbt3377DR8fH0th0LJlS3bs2MG1a9cs56xbt466dety3333sXHjxizXWbduHSaTifDwcEvbjBkzaNy4Me7u7vj7+9OnTx9Onz6d5b7/nmNx4sQJTCYTH3/8MZ999hnVqlXD1dWV/fv3Z4sZ4MyZM3z55Ze0b98+W1EBmR8u//vf/2bprdixYwf33Xcf3t7eeHp6cs8997Bx48Zsr71V/q6Py4+MjOS3336zDLW7/vdkGAZffPGFpf2fr/n3N+abNm3i/vvvx8/PDw8PD+rXr5+rn4nc5LhNmzaEhoayf/9+2rZtS6lSpahQoUKWnqWVK1fStGlTAAYMGJDlvdzIsWPHqFu3braiAiAwMLDQYr1u3Lhx1K1bl1KlSuHn50eTJk2YOXOm5fi/f1+qVKnCvn37WLVqleX9XZ8b8e+/l0GDBuHp6UlSUlK2+z7yyCMEBQWRkZFhifmf17lRHkeOHImzszOXLl3Kds1nnnkGX19fkpOTsx0TkZtTYSEiRcKxY8cACAgIsLSlp6fTsWNHAgMD+fjjj+nRowcAzz77LC+99BLh4eF8/vnnDBgwgO+//56OHTuSlpYGZH5L26FDB06cOMErr7zCuHHj6Nu3b5YPrcuWLeORRx7Bz8+PDz74gP/973+0adOGdevW5fl9HDp0iEceeYT27dvz+eef06BBA5KSkrj77ruZMWMG/fr1Y+zYsYSHhzNixAiGDx+e7RqLFi2iffv2lm/FW7ZsSVpaGps2bbKcs27dOsLCwggLCyMuLo69e/dmOVarVi1LLt977z369etHjRo1+PTTTxk6dCh//vknrVu3JjY29pbvaerUqYwbN45nnnmGTz75BH9//xzPW7x4Menp6ZZ5Dbeyb98+WrVqxa5du3j55Zd54403iIyMpE2bNlnea27yV7t2baZPn07p0qVp0KAB06dPZ/r06TRt2pTp06cD0L59e0v7jSxbtozWrVuzf/9+XnzxRT755BPatm3LwoULb/perMlxTEwMnTp14s477+STTz6hVq1a/N///R+LFy+2vJe3334byPyQez3m1q1b3/D+lStXZtu2bVl+DmwRK8BXX33FkCFDqFOnDp999hmjRo2iQYMGWf4O/+2zzz6jYsWK1KpVy/L+XnvttRzP7d27N4mJifz2229Z2pOSkliwYAE9e/bMsTfkZnl8/PHHSU9P56effsrymtTUVH7++Wd69OhRqEPdRIotQ0TEhqZOnWoAxh9//GFcunTJOH36tPHjjz8aAQEBhru7u3HmzBnDMAzjiSeeMADjlVdeyfL6NWvWGIDx/fffZ2lfsmRJlva5c+cagLFly5YbxvLiiy8a3t7eRnp6+g3PGTlypJHTP5XX30dkZKSlrXLlygZgLFmyJMu577zzjuHh4WEcPnw4S/srr7xiODo6GqdOnbK0JSYmGm5ubsbUqVMtbfv27TMA45133jEMwzDS0tIMDw8P49tvvzUMwzDKli1rfPHFF4ZhGEZ8fLzh6OhoPP3004ZhGMaJEycMR0dH47333sty7z179hhOTk5Z2p944gmjcuXKlueRkZEGYHh7exsXL168YY6uGzZsmAEYO3bsuOW5hmEY3bp1M1xcXIxjx45Z2s6dO2d4eXkZrVu3trRZk7/KlSsbDzzwQLZ7AUZERESWthUrVhiAsWLFCsMwDCM9Pd0ICQkxKleubMTExGQ512w2W/78758Ja3J89913G4Dx3XffWdpSUlKMoKAgo0ePHpa2LVu2GECWn4Ob+f333w1HR0fD0dHRaNGihfHyyy8bS5cuNVJTU7OcVxixPvjgg0bdunVvGl9Ovy9169Y17r777mzn/vvvxWw2GxUqVMhyT8MwjFmzZhmAsXr16iwx//OaN8tjixYtjGbNmmVpmzNnTpZ7i4h11GMhInZx7733UqZMGYKDg+nTpw+enp7MnTuXChUqZDnv+eefz/J89uzZ+Pj40L59ey5fvmx5NG7cGE9PT8sKSdeHhCxcuNDSi/Fvvr6+JCYmsmzZsgJ7XyEhIXTs2DFbzK1atcLPzy9LzPfeey8ZGRmsXr3acu7y5ctJSUnhvvvus7TVrl2bgIAAy9yJXbt2kZiYaFn1KSwszNLLsmHDBjIyMizDqObMmYPZbKZXr15Z7h0UFESNGjVyXFHq33r06EGZMmVueV58fDwAXl5etzw3IyOD33//nW7dulG1alVLe7ly5Xj00UdZu3at5XrW5C8/duzYQWRkJEOHDs02pOhmy8tam2NPT08ee+wxy3MXFxfuuusujh8/nufY27dvz4YNG+jatSu7du3iww8/pGPHjlSoUIH58+cXaqy+vr6cOXOGLVu25Dn+mzGZTDz88MMsWrSIq1evWtp/+uknKlSoYPVcouv69evHpk2bLL2lAN9//z3BwcHcfffd+Y5bpCRSYSEidvHFF1+wbNkyVqxYwf79+zl+/Hi2D+ROTk7ZVg86cuQIcXFxBAYGUqZMmSyPq1evWiaq3n333fTo0YNRo0ZRunRpHnzwQaZOnUpKSorlWi+88AJ33HEH9913HxUrVuTJJ59kyZIl+XpfISEh2dqOHDnCkiVLssV77733Alkn1/722280adKEsmXLWtpMJhNhYWGWuRTr1q0jMDCQ6tWrA1kLi+v/vf5h68iRIxiGQY0aNbLd/8CBA7ma2JvTe8qJt7c3AAkJCbc899KlSyQlJVGzZs1sx2rXro3ZbLaM+bcmf/lx/QNmaGioVa+zNscVK1bMVqj4+fllmyNkraZNmzJnzhxiYmLYvHkzI0aMICEhgZ49e1rmxRRGrP/3f/+Hp6cnd911FzVq1CAiIiJfwwlz0rt3b65du2Ypkq5evcqiRYt4+OGH87ynSO/evXF1deX7778HIC4ujoULF9K3b1/tUyKSR0VrWQsRKTHuuusuy6pQN+Lq6pptuUmz2UxgYKDlw8C/Xf9m3WQy8fPPP7Nx40YWLFjA0qVLefLJJ/nkk0/YuHEjnp6eBAYGsnPnTpYuXcrixYtZvHgxU6dOpV+/fnz77beW6+Tk+mTRf8tpBSiz2Uz79u15+eWXc3zNHXfcYfnzokWLGDBgQLZzWrZsyYIFC9izZ49lfsV1YWFhvPTSS5w9e5a1a9dSvnx5Sy+A2WzGZDKxePHiHMehe3p65hjTrd5TTmrVqgVk7qfQoEGDXL0mN6zJnz1Ym+MbrY5kFNDq7y4uLjRt2pSmTZtyxx13MGDAAGbPns3IkSMLJdbatWtz6NAhFi5cyJIlS/jll1+YMGECb775JqNGjSqQ99S8eXOqVKnCrFmzePTRR1mwYAHXrl2jd+/eeb6mn58fnTt35vvvv+fNN9/k559/JiUlJUsPjYhYR4WFiNxWqlWrxh9//EF4eHiuPvA2b96c5s2b89577zFz5kz69u3Ljz/+yMCBA4HMD2FdunShS5cumM1mXnjhBb788kveeOMNqlevjp+fH5C5KtE/h8ecPHnSqpivXr1q+Yb9Rvbu3cupU6d44IEHsh273gOxdu1a1q1bl2XVpcaNG+Pq6srKlSstKxr9896GYRASElLoH8Dvu+8+HB0dmTFjxi0ncJcpU4ZSpUpx6NChbMcOHjyIg4MDwcHBQO7zl1/VqlUDMv8erLlXYeS4oL4xv168nz9/Hii8nwcPDw969+5N7969SU1NpXv37rz33nuMGDHihpOgrX2PvXr14vPPPyc+Pp6ffvqJKlWq0Lx585u+5lb36NevHw8++CBbtmzh+++/p2HDhtStW9equETkbxoKJSK3lV69epGRkcE777yT7Vh6erplVZuYmJhs3wBf/xb9+nCoK1euZDnu4OBA/fr1s5xz/cPmP8fxJyYmWno0chvzhg0bWLp0abZjsbGxpKenA5m9FWXLls2xJ6dJkya4ubnx/fffc/bs2Sw9Fq6urjRq1IgvvviCxMTELGPOu3fvjqOjI6NGjcqWD8MwsuUgP4KDg3n66af5/fffc9zt2Ww288knn3DmzBkcHR3p0KED8+bNy7Jk74ULF5g5cyYtW7a0DK3Kbf7yq1GjRoSEhPDZZ59lWx3pZr0JhZHj6/u15GbVLoAVK1bkGOOiRYsALEPOCiPWf7/GxcWFOnXqYBjGDec3QeZ7zO37g8yhSykpKXz77bcsWbKEXr163fI1t8rjfffdR+nSpfnggw9YtWqVeitE8kk9FiJyW7n77rt59tlnGT16NDt37qRDhw44Oztz5MgRZs+ezeeff07Pnj359ttvmTBhAg899BDVqlUjISGBr776Cm9vb8s3+gMHDiQ6Opp27dpRsWJFTp48ybhx42jQoAG1a9cGoEOHDlSqVImnnnqKl156CUdHR7755hvKlCnDqVOnchXzSy+9xPz58+ncuTP9+/encePGJCYmsmfPHn7++WdOnDhB6dKl+e2337jvvvty/Jb1+vCWNWvW4OrqSuPGjbMcDwsLs+zM/c/Colq1arz77ruMGDGCEydO0K1bN7y8vIiMjGTu3Lk888wz/Pe//83T30VOPvnkE44dO8aQIUOYM2cOnTt3xs/Pj1OnTjF79mwOHjxInz59AHj33XdZtmwZLVu25IUXXsDJyYkvv/ySlJSULHsl5DZ/+eXg4MDEiRPp0qULDRo0YMCAAZQrV46DBw+yb9++HAsbKJwcV6tWDV9fXyZNmoSXlxceHh40a9bshvNdBg8eTFJSEg899BC1atUiNTWV9evXW77Zvz68rjBi7dChA0FBQYSHh1O2bFkOHDjA+PHjeeCBB246kb9x48ZMnDiRd999l+rVqxMYGGjZzyYnjRo1onr16rz22mukpKTkahjUrfLo7OxMnz59GD9+PI6OjjfcnFNEcsnWy1CJSMl2fdnJmy0DaxiZS596eHjc8PjkyZONxo0bG+7u7oaXl5dRr1494+WXXzbOnTtnGIZhbN++3XjkkUeMSpUqGa6urkZgYKDRuXNnY+vWrZZr/Pzzz0aHDh2MwMBAw8XFxahUqZLx7LPPGufPn89yr23bthnNmjWznPPpp5/ecLnZnJY6NQzDSEhIMEaMGGFUr17dcHFxMUqXLm2EhYUZH3/8sZGammrExsYaTk5OxqxZs274nkeMGGEARlhYWLZj15fJ9PLyynH53F9++cVo2bKl4eHhYXh4eBi1atUyIiIijEOHDlnOudFysx999NENY8pJenq68fXXXxutWrUyfHx8DGdnZ6Ny5crGgAEDsi1Fu337dqNjx46Gp6enUapUKaNt27bG+vXrs13zVvm7Lj/LzV63du1ao3379oaXl5fh4eFh1K9f3xg3bpzl+I2WIM5Nju++++4cl2b9d+4NwzDmzZtn1KlTx3Bycrrl0rOLFy82nnzySaNWrVqGp6en4eLiYlSvXt0YPHiwceHChUKN9csvvzRat25tBAQEGK6urka1atWMl156yYiLi7Ock9PvS1RUlPHAAw8YXl5eBmBZJvZGfy+GYRivvfaaARjVq1fPMQ//Xm7WMG6dx82bNxuA0aFDhxyvKSK5ZzKMApotJiIieTZr1iz69u3L5cuX8fHxsXc4IiXGrl27aNCgAd99912uN3cUkZxpjoWISBHg6+vL2LFjVVSI2NhXX32Fp6cn3bt3t3coIrc9zbEQESkCOnToYO8QREqUBQsWsH//fiZPnsygQYMsE71FJO80FEpERERKnCpVqnDhwgU6duzI9OnTc7VjvIjcnAoLERERERHJN82xEBERERGRfFNhISIiIiIi+abJ24XIbDZz7tw5vLy8ctzwSkRERESkKDMMg4SEBMqXL4+Dw837JFRYFKJz584RHBxs7zBERERERPLl9OnTVKxY8abnqLAoRNdXmDh9+jTe3t42vbfZbCYmJgY/P79bVpeSd8qzbSjPtqE824bybBvKs20oz7ZhzzzHx8cTHBycq5XTVFgUouvDn7y9ve1SWKSnp+Pt7a1f9EKkPNuG8mwbyrNtKM+2oTzbhvJsG0Uhz7kZ1q+fABERERERyTcVFiIiIiIikm8qLEREREREJN9UWIiIiIiISL6psBARERERkXxTYSEiIiIiIvmmwkJERERERPJNhYWIiIiIiOSbCgsREREREck3FRYiIiIiIpJvKixERERERCTfVFgUQxlmg43Hr7DkwGU2Hr9Chtmwd0giIiIiUsw52TsAKVhL9p5n1IL9nI9L/qvlGOV83BjZpQ6dQsvZNTYRERERKb7UY1GMLNl7nudnbP9HUZEpKi6Z52dsZ8ne83aKTERERESKOxUWxUSG2WDUgv3kNOjpetuoBfs1LEpERERECoUKi2Jic2R0tp6KfzKA83HJbI6Mtl1QIiIiIlJiqLAoJi4m3LioyMt5IiIiIiLWUGFRTAR6ueXqvAvxKYUciYiIiIiURCosiom7Qvwp5+OG6Rbnvb/oAG/N38e11AybxCUiIiIiJYMKi2LC0cHEyC51AG5ZXExbf4IHxq1h1+nYQo9LREREREoGFRbFSKfQckx8rBFBPlmHRZXzcWPCo414q0sdXJ0y/8qPX0qk+8T1jFl2mLQMsz3CFREREZFiRBvkFTOdQsvRvk4Qm45f5vj5K1QtF0CzqqVxdMjsx2hZowzDZ+1k95k4MswGn/95hBWHLvJprwZUD/S0c/QiIiIicrtSj0Ux5OhgonnVADrVLk3zqgGWogKgeqAnvzwfxtB7a1jad5+J44Gxa5i2LhKz9rkQERERkTxQYVECOTs6MPTeO5jzfBhVy3gAkJJu5q0F++n3zWbOxV6zc4QiIiIicrtRYVGC3Rnsy2+DW9E/rIqlbe3Ry3T8bDW/7jiLYaj3QkRERERyR4VFCefu4shbXesy/am7CPLOnPSdkJzO0J92MmjmDmISU+0coYiIiIjcDlRYCACtapRh6dDWPNigvKXttz3n6fjZalYcumjHyERERETkdqDCQix8SjnzeZ+GjH+0Ib6lnAG4mJDCgKlbeG3uHhJT0u0coYiIiIgUVSosJJvO9cuzdGhr7r6jjKXt+02nuH/sGradjLFjZCIiIiJSVKmwkByV9XZj2oCmvNstFHdnRwBOXkni4Unr+WjpQVLTtameiIiIiPxNhYXckMlk4rHmlVn0YisaVvIFwGzAFyuO8dCEdRy+kGDfAEVERESkyFBhIbcUUtqD2c+24KWONXH6a1O9fefi6TxuLV+vOa5N9UREREREhYXkjpOjAxFtq/NrRDg1Aj0BSE038+5vB3jkq42ciUmyc4QiIiIiYk8qLMQqoRV8WDC4JQNbhmDK7LxgU2Q0nT5bw+ytp7WpnoiIiEgJpcJCrObm7Mjrneswc2BzKvi6A3A1JZ2Xft7NczO2ceVqip0jFBERERFbU2EhedaiWgCLh7aiZ+OKlral+y7Q8bPVLNt/wY6RiYiIiIitqbCQfPF2c+bjh+9k0mON8fdwAeDy1VSe/m4rL/+8i6vaVE9ERESkRFBhIQWiU2gQS4e25t7agZa2WVvP0Omz1WyOjLZjZCIiIiJiCyospMCU8XLlq35N+KBHPTxcMjfVOxNzjd6TNzB60QFS0jPsHKGIiIiIFBYVFlKgTCYTvZtWYvGLrWlaxQ8Aw4AvVx/nwfHr2H8u3s4RioiIiEhhUGEhhaJSQCl+fKYFI+6rhYtj5o/ZwagEHvxiLRNWHiVDm+qJiIiIFCsqLKTQODqYePbuaswbFE6tIC8A0jIMPlxyiN5fbuDUFW2qJyIiIlJcqLCQQle7nDfzBoXz3N3VLJvqbT0ZQ6fPV/PD5lPaVE9ERESkGFBhITbh6uTIK/fVYtazLQj2z9xULyk1gxFz9jDw261cTEi2c4QiIiIikh8qLMSmmlbxZ/GLrXnkrmBL258HL9JxzGqW7D1vx8hEREREJD9UWIjNebo6Mbp7faY80YTSnq4AxCSl8dyM7Qz/aSfxyWl2jlBERERErKXCQuzmntplWTq0FZ3qBlna5uw4S6cxq1l/9LIdIxMRERERa6mwELsK8HRl4mON+OThO/FydQLgXFwyj369ibcX7Cc5TZvqiYiIiNwO7FpYjB49mqZNm+Ll5UVgYCDdunXj0KFDWc6ZPHkybdq0wdvbG5PJRGxsbJbjK1euxGQy5fjYsmXLDe99q+v+U0pKCg0aNMBkMrFz5858vGPJiclkokfjiiwZ1poWVQMs7d+si6TzuLXsPRtnx+hEREREJDfsWlisWrWKiIgINm7cyLJly0hLS6NDhw4kJiZazklKSqJTp068+uqrOV4jLCyM8+fPZ3kMHDiQkJAQmjRpcsN73+q6//Tyyy9Tvnx569+gWKWCrzvfD2zGG53r4OKU+aN59OJVun2xjnF/HiE9w2znCEVERETkRpzsefMlS5ZkeT5t2jQCAwPZtm0brVu3BmDo0KFAZs9ETlxcXAgK+nuMflpaGvPmzWPw4MGYrm+akINbXfe6xYsX8/vvv/PLL7+wePHim78hyTcHBxNPtQyhdY3SDJu1k71n40k3G3yy7DB/HrzIp73upGoZT3uHKSIiIiL/YlWPxYEDBxg5ciTt2rWjWrVqlCtXjvr16/PEE08wc+ZMUlJS8hVMXFzmkBd/f/88X2P+/PlcuXKFAQMG5CsWgAsXLvD0008zffp0SpUqle/rSe7VKOvFnOfDGdyuOg5/1Yc7T8dy/9g1TN9wQpvqiYiIiBQxueqx2L59Oy+//DJr164lPDycZs2a8dBDD+Hu7k50dDR79+7ltddeY/Dgwbz88ssMHToUV1dXqwIxm80MHTqU8PBwQkND8/RmAKZMmULHjh2pWLFinq8BYBgG/fv357nnnqNJkyacOHHilq9JSUnJUlzFx8cDme/NbLbtMB6z2YxhGDa/b0FycoBh99agzR2l+c/s3Zy4kkRympk35u1j2f4L/K97PYJ83OwaY3HI8+1AebYN5dk2lGfbUJ5tQ3m2DXvm2Zp75qqw6NGjBy+99BI///wzvr6+Nzxvw4YNfP7553zyySe5mrvwTxEREezdu5e1a9da9bp/OnPmDEuXLmXWrFl5vsZ148aNIyEhgREjRuT6NaNHj2bUqFHZ2mNiYkhPT893TNYwm80kJCRgGAYODrf34l+VPWF63zqMXX2K2TsvArD6yGU6fb6aV+4NoUOtgFtcofAUpzwXZcqzbSjPtqE824bybBvKs23YM88JCQm5PjdXhcXhw4dxdna+5XktWrSgRYsWpKVZt8HZoEGDWLhwIatXr85XT8PUqVMJCAiga9eueb7GdcuXL2fDhg3Zel6aNGlC3759+fbbb7O9ZsSIEQwfPtzyPD4+nuDgYPz8/PD29s53TNYwm82YTCb8/PyKzS/6B73K8ECDS7z8yx4uJqQQn5zBqwuPsuFUIqO61sG3lIvNYyqOeS6KlGfbUJ5tQ3m2DeXZNpRn27Bnnp2ccj8lO1dn/rOo+O677+jdu3e2D9ypqan8+OOP9OvXL1dFCGQONxo8eDBz585l5cqVhISE5DrwnK41depUq+5/M2PHjuXdd9+1PD937hwdO3bkp59+olmzZjm+xtXVNcchYA4ODnb5ZTOZTHa7d2FpU6ssvw/z4/Vf97Jw93kAFuw+z+YT0XzU805a31HG5jEVxzwXRcqzbSjPtqE824bybBvKs23YK8/W3M/qyAYMGGCZZP1PCQkJVk+YjoiIYMaMGcycORMvLy+ioqKIiori2rVrlnOioqLYuXMnR48eBWDPnj3s3LmT6OjoLNdavnw5kZGRDBw4MNt9zp49S61atdi8eXOur1upUiVCQ0MtjzvuuAOAatWq5Xv+huSPbykXxj/aiM/7NMDbLbM2vhCfQr9vNvPmvL1cS9WmeiIiIiK2ZnVhYRhGjsu4njlzBh8fH6uuNXHiROLi4mjTpg3lypWzPH766SfLOZMmTaJhw4Y8/fTTALRu3ZqGDRsyf/78LNeaMmUKYWFh1KpVK9t90tLSOHToEElJSVZfV4quBxtUYOmw1rSqUdrS9t2Gkzwwdg07TsXYMTIRERGRksdk5HLdzoYNG2Iymdi1axd169bNMt4qIyODyMhIOnXqVCATp4uL+Ph4fHx8iIuLs8sci+joaPz9/Yt916TZbDBj00neX3SA5LTMlQscHUxEtKnG4Htq4OxYeO+/JOXZnpRn21CebUN5tg3l2TaUZ9uwZ56t+Tyb69kY3bp1A2Dnzp107NgRT8+/NylzcXGhSpUq9OjRI28Ri+SDg4OJfi2qEF69NMNn7WLX6VgyzAZjlx9lxaFLjOl9J9UDvewdpoiIiEixlqvConv37kybNg1vb2+qVKlCnz59rN6nQqSwVSvjyS/PteCLFccYu/wIGWaDPWfjeGDsWv6vUy36h1XBweHGu7GLiIiISN7lqi9l4cKFJCYmAvDkk0/mOHlbpChwcnTgxXtrMPeFMKqV8QAgJd3M2wv389iUTZyNvXaLK4iIiIhIXuSqx6JWrVqMGDGCtm3bYhgGs2bNuuEYq379+hVogCJ5Ub+iL78NacX/Fh9k2voTAKw/doVOn61mVNe6PNSwQo6LEIiIiIhI3uRq8vb69esZPnw4x44dIzo6Gi8vrxw/lJlMpmzLwJZkmrxdNKw7epn/zt7F+bhkS9t9oUG891A9/D3yt6me8mwbyrNtKM+2oTzbhvJsG8qzbdwuk7dzFVlYWBgbN27k0qVLGIbB4cOHiYmJyfZQUSFFUXj10iwZ2pqHGlawtC3eG0XHz1az/OAFO0YmIiIiUnxYXfJERkZSpoztdzcWyQ8fd2fG9G7AhL6N8C2VuTP7pYQUnpy2lRFz9pCYkm7nCEVERERub7kqLE6dOmX5c+XKlW85Nv3s2bP5i0qkkNxfrxy/D21N25p/F8c/bD7FfZ+vYesJ9biJiIiI5FWuCoumTZvy7LPPsmXLlhueExcXx1dffUVoaCi//PJLgQUoUtACvd34pn9T3n+oHqVcHAE4FZ1Ery838MGSg6Smm+0coYiIiMjtJ1erQu3fv5/33nuP9u3b4+bmRuPGjSlfvjxubm7ExMSwf/9+9u3bR6NGjfjwww+5//77CztukXwxmUw82qwSYdUC+M/sXWw7GYPZgIkrj7Hy0CU+692AmkHaVE9EREQkt3LVYxEQEMCnn37K+fPnGT9+PDVq1ODy5cscOXIEgL59+7Jt2zY2bNigokJuK1VKezDr2Ra81LEmzo6ZQ/wOnI+ny7i1TF59jAzzLRdNExERERFy2WNxnbu7Oz179qRnz56FFY+IzTk6mIhoW502Ncsw7KedHL5wldQMM+8vOsgfBy7yycN3Euxfyt5hioiIiBRpWnBY5C91y/swf1BLnmldlevrE2yOjOa+z9cwa+tpcrHli4iIiEiJpcJC5B/cnB159f7a/PB0cyr4ugNwNSWdl3/ezTPTt3H5aoqdIxQREREpmlRYiOSgedUAlgxtxcONK1ralu2/QMcxq/l9X5QdIxMREREpmlRYiNyAl5szHz18J5Mfb0yAhwsAVxJTeWb6Nl6avYuE5DQ7RygiIiJSdKiwELmFDnWDWDqsNffWLmtpm73tDJ0+W8Om41fsGJmIiIhI0ZGnwmL69OmEh4dTvnx5Tp48CcBnn33GvHnzCjQ4kaKitKcrX/VrzIc96+PpmrmY2tnYazw6ZTOfrTxJSlqGnSMUERERsS+rC4uJEycyfPhw7r//fmJjY8nIyPxA5evry2effVbQ8YkUGSaTiV5Ngln8YivuCvEHwDBgxtYoHpywnn3n4uwcoYiIiIj9WF1YjBs3jq+++orXXnsNR0dHS3uTJk3Ys2dPgQYnUhQF+5fih6eb8+r9tXD5a1O9wxeu0u2LdXyx4qg21RMREZESyerCIjIykoYNG2Zrd3V1JTExsUCCEinqHB1MPNO6Gr9GhHNHmczN89IyDD5aeoheX27gxGX9LoiIiEjJYnVhERISws6dO7O1L1myhNq1axdETCK3jVpBXkzrW5fn766Kw1+b6m07GcP9Y9fw/aaT2lRPRERESgwna18wfPhwIiIiSE5OxjAMNm/ezA8//MDo0aP5+uuvCyNGkSLNxcmBlzrW5J7aZRk+axenopNISs3gtbl7+WP/BT7oUZ9Abzd7hykiIiJSqKwuLAYOHIi7uzuvv/46SUlJPProo5QvX57PP/+cPn36FEaMIreFJlX8WfxiK9797QA/bD4FwIpDl+j42Wree6ge99crZ+cIRURERApPnpab7du3L0eOHOHq1atERUVx5swZnnrqqYKOTeS24+HqxOju9fimfxNKe7oCEJOUxgvfb2fojzuIu6ZN9URERKR4ytPk7SNHjgBQqlQpAgMDAThy5AgnTpwo0OBEblftapXl92GtuS80yNL2685zdPpsNeuOXrZjZCIiIiKFw+rCon///qxfvz5b+6ZNm+jfv39BxCRSLPh7uDChbyPG9L4TL7fMUYfn45Lp+/Um3pq/j2RtqiciIiLFiNWFxY4dOwgPD8/W3rx58xxXixIpyUwmEw81rMjSoa0JqxZgaZ+2/gQPjF3D7jOx9gtOREREpABZXViYTCYSEhKytcfFxVl24RaRrMr7ujPjqWa82bkOrk6Zv3bHLiXSfcJ6Pv/jCGkZZjtHKCIiIpI/VhcWrVu3ZvTo0VmKiIyMDEaPHk3Lli0LNDiR4sTBwcSTLUP4bUhL6lXwASDdbDDmj8P0nLieY5eu2jlCERERkbyzernZDz74gNatW1OzZk1atWoFwJo1a4iPj2f58uUFHqBIcVM90Is5L4QxbvlRvlhxlAyzwa4zcTwwdg0j7qvN480r43B9tz0RERGR24TVPRZ16tRh9+7d9OrVi4sXL5KQkEC/fv04ePAgoaGhhRGjSLHj7OjA8PZ38PNzLaha2gOA5DQzI+fv44mpm4mKS7ZzhCIiIiLWsbrHAqB8+fK8//77BR2LSInTsJIfvw1pxejFB/huw0kA1hy5TIcxq3inWygPNqhg5whFREREcidPhQVAUlISp06dIjU1NUt7/fr18x2USEni7uLI2w+Gcm/tsrz08y4uxKcQn5zOiz/uZNn+C7zbLRTfUi72DlNERETkpqwuLC5dusSAAQNYvHhxjse1MpRI3rS+owxLh7bmjXn7WLDrHAALd59nc2Q0H/asT5uagXaOUEREROTGrJ5jMXToUGJjY9m0aRPu7u4sWbKEb7/9lho1ajB//vzCiFGkxPAt5cK4Rxoy9pGG+Lg7A3AxIYX+U7fw+q97SEpNt3OEIiIiIjmzusdi+fLlzJs3jyZNmuDg4EDlypVp37493t7ejB49mgceeKAw4hQpUbreWZ67qvjz8i+7WX34EgAzNp5i3dErfNLrThpV8rNzhCIiIiJZWd1jkZiYSGBg5pAMPz8/Ll3K/NBTr149tm/fXrDRiZRgQT5ufDugKe88WBc358xf1cjLifScuJ5Pfj9Earo21RMREZGiw+rCombNmhw6dAiAO++8ky+//JKzZ88yadIkypUrV+ABipRkJpOJx1tUYdGQVjQI9gXAbMC45UfpPnEdRy4k2DdAERERkb9YXVi8+OKLnD9/HoCRI0eyePFiKlWqxNixY7UErUghqVrGk5+fa8F/2t+B01+b5+09G88D49by9ZrjmM2GnSMUERGRki5Xcyzi4+Px9vYG4LHHHrO0N27cmJMnT3Lw4EEqVapE6dKlCydKEcHJ0YHB99SgTc1Ahs3aydGLV0lNN/Pubwf488BFPu51JxV83e0dpoiIiJRQueqx8PPz4+LFiwC0a9eO2NhYy7FSpUrRqFEjFRUiNlKvog8LB7fkyfAQS9uG41foNGY1v2w7g2Go90JERERsL1eFhaenJ1euXAFg5cqVpKWlFWpQInJzbs6OvNmlDjMHNqO8jxsACSnp/Gf2Lp6fsZ0rV1PsHKGIiIiUNLkaCnXvvffStm1bateuDcBDDz2Ei0vOOwEvX7684KITkZsKq16axUNbM2rBPuZsPwvAkn1RbD0Zwwc96nFP7bJ2jlBERERKilwVFjNmzODbb7/l2LFjrFq1irp161KqVKnCjk1EcsHH3ZlPezWgfe2yvDp3DzFJaVy+msJT326lT9NgXu9cB09Xq7esEREREbFKrj5tuLu789xzzwGwdetWPvjgA3x9fQszLhGx0n31ytG4ih+v/LKH5Qcz50T9uOU0645d5tNeDWhaxZ8Ms8HmyGguJiQT6OXGXSH+OP61ypSIiIhIflj9NeaKFSsKIw4RKQCBXm5MeaIJP245zTsL95OUmsHp6Gv0+nID99Yuy54zsUTF/z3/opyPGyO71KFTqPagERERkfyxeh8LESnaTCYTj9xVicUvtqJJZT8ADAOW7b+QpagAiIpL5vkZ21my97w9QhUREZFiRIWFSDFVOcCDn55twUsda97wnOsL045asJ8MbbInIiIi+aDCQqQYc3Qw0aiS303PMYDzcclsjoy2TVAiIiJSLKmwECnmLiYkF+h5IiIiIjnJ0xqUycnJ7N69m4sXL2I2m7Mc69q1a4EEJiIFI9DLrUDPExEREcmJ1YXFkiVL6NevH5cvX852zGQykZGRUSCBiUjBuCvEn3I+bkTFJXOzWRQxidqtW0RERPLO6qFQgwcP5uGHH+b8+fOYzeYsDxUVIkWPo4OJkV3qAHCzHStemLmDL1YcxTA0iVtERESsZ3VhceHCBYYPH07ZsmULIx4RKQSdQssx8bFGBPlkHe4U5JO5Sd51Hy09xPBZu0hO05cEIiIiYh2rh0L17NmTlStXUq1atcKIR0QKSafQcrSvE5Rt520HE0xYeYyPlh4CYO6Os5yKTuLLxxtT2tPVzlGLiIjI7cLqwmL8+PE8/PDDrFmzhnr16uHs7Jzl+JAhQwosOBEpWI4OJlpUC8jWHtG2OlVLezBs1k6S08xsOxnDg+PXMaV/E2oFedshUhEREbndWF1Y/PDDD/z++++4ubmxcuVKTKa/R22bTCYVFiK3qfvqlSPYvxQDv91KVHwyZ2Ov0WPCesY92pB2tTT0UURERG7O6jkWr732GqNGjSIuLo4TJ04QGRlpeRw/frwwYhQRGwmt4MO8QeHUr+gDQGJqBk99u5Wv1xzXpG4RERG5KasLi9TUVHr37o2Dg/bWEymOynq78dMzLXigXjkADAPe/e0AI+bsITXdfItXi4iISElldXXwxBNP8NNPPxVGLCJSRLi7ODLukYYMaVfd0vbjltP0+2YTMYmpdoxMREREiiqrC4uMjAw+/PBD7r77bgYPHszw4cOzPKwxevRomjZtipeXF4GBgXTr1o1Dhw5lOWfy5Mm0adMGb29vTCYTsbGxWY5fn+eR02PLli03vPetrnvixAmeeuopQkJCcHd3p1q1aowcOZLUVH2okpLBwcHE8A41+bxPA1ycMv+p2Hg8mocmrOPoxat2jk5ERESKGqsLiz179tCwYUMcHBzYu3cvO3bssDx27txp1bVWrVpFREQEGzduZNmyZaSlpdGhQwcSExMt5yQlJdGpUydeffXVHK8RFhbG+fPnszwGDhxISEgITZo0ueG9b3XdgwcPYjab+fLLL9m3bx9jxoxh0qRJNzxfpLh6sEEFfnymuWXp2RNXknhowjrWHLlk58hERESkKDEZRWhG5qVLlwgMDGTVqlW0bt06y7GVK1fStm1bYmJi8PX1veE10tLSqFChAoMHD+aNN9645T1ze12Ajz76iIkTJ+Z6knp8fDw+Pj7ExcXh7W3bJTvNZjPR0dH4+/trPkwhKkl5Pht7jaembeFgVAKQuXTtW13q8HiLKoV+75KUZ3tSnm1DebYN5dk2lGfbsGeerfk8W6R+AuLi4gDw9/e/xZk3Nn/+fK5cucKAAQMKKiyLuLi4fMUmcjur4OvOz8+HcW/tQAAyzAZvzNvHyHl7Sc/QpG4REZGSzup9LAC2bt3KrFmzOHXqVLY5B3PmzMlTIGazmaFDhxIeHk5oaGiergEwZcoUOnbsSMWKFfN8jZwcPXqUcePG8fHHH9/wnJSUFFJSUizP4+Pjgcz3Zjbb9oOX2WzGMAyb37ekKWl5LuXswMS+jfho6SEmr4kE4NsNJ4m8nMjYRxrg7eZ8iyvkTUnLs70oz7ahPNuG8mwbyrNt2DPP1tzT6sLixx9/pF+/fnTs2JHff/+dDh06cPjwYS5cuMBDDz1k7eUsIiIi2Lt3L2vXrs3zNc6cOcPSpUuZNWtWnq+Rk7Nnz9KpUycefvhhnn766RueN3r0aEaNGpWtPSYmhvT09AKN6VbMZjMJCQkYhqGuyUJUUvP8TLNAypaC0ctOkG42WH3kMg+NX8uY7jWp6OtW4PcrqXm2NeXZNpRn21CebUN5tg175jkhISHX51pdWLz//vuMGTOGiIgIvLy8+PzzzwkJCeHZZ5+lXLly1l4OgEGDBrFw4UJWr16dr56GqVOnEhAQQNeuXfN8jX87d+4cbdu2JSwsjMmTJ9/03BEjRmRZGSs+Pp7g4GD8/PzsMsfCZDLh5+enX/RCVJLzPOBuf+oEl+GFmTuISUojMjqZATP3M7FvI+4KKdghgyU5z7akPNuG8mwbyrNtKM+2Yc88OznlvlywurA4duwYDzzwAAAuLi4kJiZiMpkYNmwY7dq1y/Eb+xsxDIPBgwczd+5cVq5cSUhIiLXhZLnW1KlT6devH87OBTMc4+zZs7Rt25bGjRszderUW/5Furq64urqmq3dwcHBLr9sJpPJbvcuSUpynltUL8OvEeE89e1Wjl68SkxSGo9/s5n3HqpHrybBBXqvkpxnW1KebUN5tg3l2TaUZ9uwV56tuZ/Vkfn5+Vm6RCpUqMDevXsBiI2NJSkpyaprRUREMGPGDGbOnImXlxdRUVFERUVx7do1yzlRUVHs3LmTo0ePApnL3e7cuZPo6Ogs11q+fDmRkZEMHDgw233Onj1LrVq12Lx5c66ve/bsWdq0aUOlSpX4+OOPuXTpkiU+Eflb5QAP5rwQRqsapQFIyzB4+efdvL/oABnmIrPonIiIiBQyqwuL1q1bs2zZMgAefvhhXnzxRZ5++mkeeeQR7rnnHquuNXHiROLi4mjTpg3lypWzPP65s/ekSZNo2LChZW5D69atadiwIfPnz89yrSlTphAWFkatWrWy3SctLY1Dhw5lKXxudd1ly5Zx9OhR/vzzTypWrJglPhHJytvNman9m/JEi8qWtsmrj/Ps9G0kpth2fpGIiIjYh9X7WERHR5OcnEz58uUxm818+OGHrF+/nho1avD666/j5+dXWLHedrSPRfGnPGc3fcMJ3lqw39JbUSvIiyn9m1LB1z3P11SebUN5tg3l2TaUZ9tQnm3jdtnHwuo5Fv/cx8HBwYFXXnnF+ghFpNh6vEUVqpT24IXvt5OQnM7BqAQeHL+Oyf0a06iSvngQEREprvJU8hw7dozXX3+dRx55hIsXLwKwePFi9u3bV6DBicjtqVWNMsx9IZzKAaUAuHw1hT6TNzJv51k7RyYiIiKFxerCYtWqVdSrV49NmzYxZ84crl69CsCuXbsYOXJkgQcoIren6oGe/PpCOM2rZvZypqabefHHnXz6+yHMmtQtIiJS7FhdWLzyyiu8++67LFu2DBcXF0t7u3bt2LhxY4EGJyK3Nz8PF757shl9mv699OzY5UcZ/MMOrqVm2DEyERERKWhWFxZ79uzJcYftwMBALl++XCBBiUjx4eLkwOju9Xj9gdqYTJltv+05T+/JG7gQn2zf4ERERKTAWF1Y+Pr6cv78+WztO3bsoEKFCgUSlIgULyaTiYGtqvJ1vyZ4uDgCsPtMHA+OX8fes3F2jk5EREQKgtWFRZ8+ffi///s/oqKiMJlMmM1m1q1bx3//+1/69etXGDGKSDFxT+2y/PJCmGXp2aj4ZHpOWs+Svdm/rBAREZHbi9WFxfvvv0+tWrUIDg7m6tWr1KlTh9atWxMWFsbrr79eGDGKSDFSK8ibeYPCaVTJF4DkNDPPzdjOFyuOYuW2OiIiIlKEWFVYGIZBVFQUY8eO5fjx4yxcuJAZM2Zw8OBBpk+fjqOjY2HFKSLFSGlPV2Y+3ZxuDcpb2j5aeoj/zNpFSromdYuIiNyOrNogzzAMqlevzr59+6hRowbBwcG3fpGISA7cnB0Z07sBNcp68dHSQwDM2XGWk9FJfPl4Y0p7uto5QhEREbGGVT0WDg4O1KhRgytXrhRWPCJSgphMJiLaVmdi30a4OWf+c7TtZAwPjl/Hwah4O0cnIiIi1rB6jsX//vc/XnrpJfbu3VsY8YhICXRfvXL8/FwYZb0zeynOxl6jx4T1LD94wc6RiYiISG5ZXVj069ePzZs3c+edd+Lu7o6/v3+Wh4hIXoRW8GH+oJbUq+ADQGJqBgO/3crXa45rUreIiMhtwKo5FgBjxozBdH2XKxGRAlTW241Zz7bgP7N3smhPFGYD3v3tAEcvXuXFlkH2Dk9ERERuwurCon///oUQhohIJncXR8Y/0ogxZQ4zbvlRAH7ccpojUbFMfuIuAjzd7ByhiIiI5MTqoVCOjo5cvHgxW/uVK1e03KyIFAgHBxP/6VCTz/s0wMXpr0ndpxPoPnEDRy9etXN0IiIikhOrC4sbjXVOSUnBxcUl3wGJiFz3YIMK/PB0cwI8Mv9tOXkliYcmrGPtkct2jkxERET+LddDocaOHQtkLg/59ddf4+npaTmWkZHB6tWrqVWrVsFHKCIlWuPKfvz6QhgDpm7i6OVrJCSn88TUzbzVtS6PN69s7/BERETkL7kuLMaMGQNk9lhMmjQpy7AnFxcXqlSpwqRJkwo+QhEp8Sr4uTPl0bqM+v0kyw9eIsNs8Mavezl28SqvP1AbJ0erO19FRESkgOW6sIiMjASgbdu2zJkzBz8/v0ILSkTk3zxcHPnyscZ89PthJq8+DsC09Sc4fjmR8Y82xNvN2c4RioiIlGxWf823YsWKLEVFRkYGO3fuJCYmpkADExH5N0cHE6/eX5sPe9TH2TFz2evVhy/RfcJ6Tl5JtHN0IiIiJZvVhcXQoUOZMmUKkFlUtG7dmkaNGhEcHMzKlSsLOj4RkWx6NQ1m+lPN8C2V2Utx9OJVun2xjk3Hr9g5MhERkZLL6sJi9uzZ3HnnnQAsWLCAEydOcPDgQYYNG8Zrr71W4AGKiOSkedUA5kWEU62MBwAxSWk8NmUTs7aetnNkIiIiJZPVhcWVK1cICsrcAXfRokU8/PDD3HHHHTz55JPs2bOnwAMUEbmRygEezHkhnFY1SgOQlmHw8s+7Gb3oABnmnJfGFhERkcJhdWFRtmxZ9u/fT0ZGBkuWLKF9+/YAJCUlaYM8EbE5H3dnpvZvSr8Wfy89++Xq4zw7fRuJKel2jExERKRksbqwGDBgAL169SI0NBSTycS9994LwKZNm7SPhYjYhZOjA28/GMrbD9bF0SFzUvcfBy7QY+J6zsZes3N0IiIiJYPVhcVbb73F119/zTPPPMO6detwdXUFwNHRkVdeeaXAAxQRya1+LaowbUBTvNwyV9I+GJXAg+PXsf2UVq0TEREpbLnex+Kfevbsma3tiSeeyHcwIiL51apGGea+EM5T327h5JUkLl9Noc/kjXzUsz4PNqhg7/BERESKrTxtV/vnn3/SuXNnqlWrRrVq1ejcuTN//PFHQccmIpIn1QM9+fWFcJqF+AOQmm7mxR938umyw5g1qVtERKRQWF1YTJgwgU6dOuHl5cWLL77Iiy++iLe3N/fffz9ffPFFYcQoImI1Pw8Xpj/VjN5Ngi1tY/88wuAfdnAtNcOOkYmIiBRPVg+Fev/99xkzZgyDBg2ytA0ZMoTw8HDef/99IiIiCjRAEZG8cnFy4H896lGjrCfvLTqAYcBve85zOiaJr/o1oay3m71DFBERKTas7rGIjY2lU6dO2do7dOhAXFxcgQQlIlJQTCYTA1tV5et+TfBwyVwSe/eZOB4cv469Z/VvloiISEGxurDo2rUrc+fOzdY+b948OnfuXCBBiYgUtHtql+Xn58Oo4OsOQFR8Mg9P2sCSveftHJmIiEjxYPVQqDp16vDee++xcuVKWrRoAcDGjRtZt24d//nPfxg7dqzl3CFDhhRcpCIi+VS7nDe/RoTz7PStbD8Vy7W0DJ6bsZ2XOtbkhTbVMJlM9g5RRETktmUyDMOqJVJCQkJyd2GTiePHj+cpqOIiPj4eHx8f4uLi8Pb2tum9zWYz0dHR+Pv74+CQp8W/JBeUZ9so6Dwnp2Xwyi+7+XXnOUtb94YVGN2jHq5Ojvm+/u1KP8+2oTzbhvJsG8qzbdgzz9Z8nrW6xyIyMjLPgYmIFAVuzo6M6d2AGmW9+GjpIQDm7DjLyegkvny8MaU9Xe0coYiIyO1HpaWIlEgmk4mIttWZ2LcRbs6Z/xRuOxlDty/WcSgqwc7RiYiI3H6s7rF48sknb3r8m2++yXMwIiK2dl+9clT0K8XA77ZwIT6FMzHX6DFxPeMeaUjbWoH2Dk9EROS2YXWPRUxMTJbHxYsXWb58OXPmzCE2NrYQQhQRKVz1KvowL6Il9Sr4AHA1JZ2nvt3C12uOY+U0NBERkRLL6h6LnJaaNZvNPP/881SrVq1AghIRsbUgHzdmPduC/8zeyaI9UZgNePe3Axy7dJVRXUNxcdLIURERkZspkP9TOjg4MHz4cMaMGVMQlxMRsQt3F0fGP9KIwe2qW9p+2Hyaft9sIjYp1Y6RiYiIFH0F9hXcsWPHSE9PL6jLiYjYhYODif90qMlnvRtYeik2Ho+m2xfrOHbpqp2jExERKbqsHgo1fPjwLM8Nw+D8+fP89ttvPPHEEwUWmIiIPXVrWIFg/1I8O30rl6+mcuJKEg99sY4JfRvTskZpe4cnIiJS5FhdWOzYsSPLcwcHB8qUKcMnn3xyyxWjRERuJ40r+/FrRDgDv93KwagE4pPTeWLqZt7qWpfHm1e2d3giIiJFitWFxYoVKwojDhGRIqmiXyl+fj6MF3/YwZ8HL5JhNnjj170cu3iV1x+ojZOjJnWLiIiANsgTEbklT1cnJvdrwjOtq1rapq0/wZPfbiU+Oc2OkYmIiBQdKixERHLB0cHEq/fX5oMe9XByMAGw+vAluk9Yz6krSXaOTkRExP5UWIiIWKF300rMGNgM31LOABy9eJUHv1jLpuNX7ByZiIiIfamwEBGxUvOqAfz6QjjVyngAEJOUxmNTNjFr62kAMswGG45dYd7Os2w4doUMs3bvFhGR4s/qydv/lJycjJubW0HFIiJy26hS2oM5L4QzaOZ21hy5TFqGwcs/72bZ/gvsORNHVHyy5dxyPm6M7FKHTqHl7BixiIhI4bK6x8JsNvPOO+9QoUIFPD09OX78OABvvPEGU6ZMKfAARUSKKh93Z6b2b0q/Fn8vPbts/4UsRQVAVFwyz8/YzpK9520dooiIiM1YXVi8++67TJs2jQ8//BAXFxdLe2hoKF9//XWBBiciUtQ5OTrw9oOhvNW1zg3PuT4QatSC/RoWJSIixZbVhcV3333H5MmT6du3L46Ojpb2O++8k4MHDxZocCIit4uaZb1vetwAzsclM375UQ5GxZOUmm6bwERERGzE6jkWZ8+epXr16tnazWYzaWlaz11ESqaLCcm3PgkY88dhxvxxGICy3q5UDvCgSkCpv/7rQeWAUlQOKIWXm3NhhisiIlLgrC4s6tSpw5o1a6hcuXKW9p9//pmGDRsWWGAiIreTQC/rF7K4EJ/ChfgUNkdGZztW2tOFyn8VGlX+8d8qAR74lFLRISIiRY/VhcWbb77JE088wdmzZzGbzcyZM4dDhw7x3XffsXDhwsKIUUSkyLsrxJ9yPm5ExSVzo1kUvqWc6R9WhVPRSZy8ksTJK4lcvpqa47mXr6Zy+Woq207G5HidrD0df//X38MFk8lUgO9MREQkd6wuLB588EEWLFjA22+/jYeHB2+++SaNGjViwYIFtG/fvjBiFBEp8hwdTIzsUofnZ2zHBFmKi+sf8//XvV62JWcTktP+KjKSOHElkZNXEjnxV9FxIT4lx3vFJqURmxTLrtOx2Y55uTpRufS/C47MP5fxclXRISIihSZP+1i0atWKZcuWFXQsIiK3tU6h5Zj4WCNGLdjP+bi/51wE3WQfCy83Z0Ir+BBawSfbsaTUdE5FJ3HiclKWguPklSTOxV3DyKFrJCElnb1n49l7Nj7bsVIujlTyL0VIaY+shUfpUpTNw1AuERGRf8rXBnkiIpJVp9BytK8TxObIaC4mJBPo5cZdIf44OljfU1DKxYlaQd7UCsq+4lRyWgZnYjKLjhN/FRvX/3smJomcVrVNSs3gYFQCB6MSsh1zdXKgsn8pynk7UyPIlyql/55MXt7XPU/xi4hIyWJ1YeHn55djV7rJZMLNzY3q1avTv39/BgwYUCABiojcbhwdTLSoFlCo93BzdqR6oBfVA72yHUtNN3M29honriRy4nLWouN0dBLpOVQdKelmDl+8yuGLsOpo1nkdzo4mgv2zTiK//t8Kfu44O1q9crmIiBRDeZq8/d5773Hfffdx1113AbB582aWLFlCREQEkZGRPP/886Snp/P0008XeMAiInJzLk4OhJT2IKS0B9TMeiw9w8y52ORs8zlOXEni1JVEUjOyFx1pGQbHLyVy/FJitmOODiYq+rnnOJk82N8dVyfHbK8REZHiyerCYu3atbz77rs899xzWdq//PJLfv/9d3755Rfq16/P2LFjb1lYjB49mjlz5nDw4EHc3d0JCwvjgw8+oGbNv/9POHnyZGbOnMn27dtJSEggJiYGX19fy/GVK1fStm3bHK+/efNmmjZtmuOxW10XIDo6msGDB7NgwQIcHBzo0aMHn3/+OZ6enjd9XyIiRZWTowOVAkpRKaAUUCbLsbT0DA6diiI2w4VT0df+Kjj+7vFITjNnu16G2bBMPl/9r2MmE5T3cadKDpPJK/mXwt1FRYeISHFiMoycpv/dmKenJzt37sy2Sd7Ro0dp0KABV69e5dixY9SvX5/ExOzfbv1Tp06d6NOnD02bNiU9PZ1XX32VvXv3sn//fjw8PAD47LPPSE7OnAQ5YsSIbAVAamoq0dFZ14B/4403+PPPPzl27NgNV0C51XUB7rvvPs6fP8+XX35JWloaAwYMoGnTpsycOfOWeQKIj4/Hx8eHuLg4vL1vvitvQTObzURHR+Pv74+Dg4YpFBbl2TaUZ9u4WZ4Nw+BiQkq2oVXXh1slpmZYfb8gb7e/h1aVzjrEysO1+E4B1M+zbSjPtqE824Y982zN51mr/+X29/dnwYIFDBs2LEv7ggUL8Pf3ByAxMREvr+zjfv9tyZIlWZ5PmzaNwMBAtm3bRuvWrQEYOnQokNkzkRMXFxeCgoIsz9PS0pg3bx6DBw++6bKKt7rugQMHWLJkCVu2bKFJkyYAjBs3jvvvv5+PP/6Y8uXL3/L9iYgUFyaTibLebpT1dqNZ1azzRwzD4EpiamYPx79WsIq8nEh8cnqO14yKTyYqPplNOWwQWMbLNYd9OjyoFFAKH3dtECgiUhRZXVi88cYbPP/886xYscIyx2LLli0sWrSISZMmAbBs2TLuvvtuq4OJi4sDsBQoeTF//nyuXLmS78njGzZswNfX11JUANx77704ODiwadMmHnrooWyvSUlJISXl73Xn4+Mzl3s0m82YzdmHEBQms9mMYRg2v29JozzbhvJsG/nJs38pZ/xL+dIw2Dfbsdik1L96N/5aLteyQWASVxJz3iDwUkIKlxJS2HIi+waB/n9tEFg5oJTlcb23w9fducjv1aGfZ9tQnm1DebYNe+bZmntaXVg8/fTT1KlTh/HjxzNnzhwAatasyapVqwgLCwPgP//5j7WXxWw2M3ToUMLDwwkNDbX69ddNmTKFjh07UrFixTxfAyAqKorAwMAsbU5OTvj7+xMVFZXja0aPHs2oUaOytcfExJCenvM3doXFbDaTkJCAYRjqmixEyrNtKM+2UZh5DvaAYA83WlVyA/7u8biaks6Z2BROxyRzKjaZMzHJnI5N4XRsMlcS03K8VnRSGtFJsezIcYNAR4J93ajo50awr+s//uyGfymnIlF06OfZNpRn21CebcOeeU5IyL5E+Y3kaRBreHg44eHheXnpDUVERLB3717Wrl2b52ucOXOGpUuXMmvWrAKMLPdGjBjB8OHDLc/j4+MJDg7Gz8/PLnMsTCYTfn5++kUvRMqzbSjPtmGPPPsDlbLvGwhAYspfGwT+Y2PAk1eSOBmdlGUDwn9KSMlg/4VE9l/IPsfPw8Xxrx6Ov3s7qvhnPg/0csXBRnt16OfZNpRn21CebcOeeXZyyn25kKszrw/pyY28fIAeNGgQCxcuZPXq1fnqaZg6dSoBAQF07do1z9e4LigoiIsXL2ZpS09PJzo6Osucjn9ydXXF1dU1W7uDg4NdftlMJpPd7l2SKM+2oTzbRlHKs5e7C3UruFC3gm+2Y8lpGX/tSp59Mvm52Gs5bhCYmJrB/vMJ7D+f/ds3N2cHKvv/NXm8dNb9Osr5FPwGgUUpz8WZ8mwbyrNt2CvP1twvV4WFr69vrruPMzJyvzKIYRgMHjyYuXPnsnLlSkJCQnL92pyuNXXqVPr164ezc/4n9rVo0YLY2Fi2bdtG48aNAVi+fDlms5lmzZrl+/oiIpJ3bs6O3FHWizvKZl8oJCU9gzMx13KcTH465hoZOVQdyWlmDl1I4NCF7EWHi6MDwf7ufxUaHlmWz63g646TNggUEQFyWVisWLHC8ucTJ07wyiuv0L9/f1q0aAFkTnT+9ttvGT16tFU3j4iIYObMmcybNw8vLy/L3AUfHx/c3d2BzLkOUVFRHD16FIA9e/bg5eVFpUqVskzyXr58OZGRkQwcODDbfc6ePcs999zDd999Z5lwfqvr1q5dm06dOvH0008zadIk0tLSGDRoEH369NGKUCIiRZirkyPVynhSrUz2PYfSMsyci73298aAlsIjkdPR10jNyD5JMTXDzLFLiRzLYYNAp782CKxS2iPbzuQV/Urh4qSiQ0RKDqv3sbjnnnsYOHAgjzzySJb2mTNnMnny5Bsu35rjzW/QCzJ16lT69+8PwFtvvZXjhOh/ngPw6KOPcvLkSdatW5ft3BMnThASEsKKFSto06ZNrq8bHR3NoEGDsmyQN3bs2FxvkKd9LIo/5dk2lGfbKOl5zjAbnI+7lnVo1T+GWqWkW7cai4MJKvi5/6vg8KCSnxuephTKBZYukXm2lZL+82wryrNt3C77WFhdWJQqVYpdu3ZRo0aNLO2HDx+mQYMGJCUlWR9xMaXCovhTnm1DebYN5fnGzGaDCwnJ2YZWXf9vkpUbBJqAIB83qvxraNX1ieWlXIrvBoG2op9n21CebeN2KSys/pcrODiYr776ig8//DBL+9dff01wcLC1lxMRESnyHBxMlPNxp5yPOy2qZd8g8NLVlGw9HNefJ6RkX27cAM7HJXM+LpkNx69kOx7o5fp3T8e/JpN7uWmDQBEpmqwuLMaMGUOPHj1YvHixZRLz5s2bOXLkCL/88kuBBygiIlKUmUwmAr3cCPRyo2mVrBu8GoZBTFLaX4VG5pyOE1cSOXYhjrNxqcQk5bxXx8WEFC4mpLD5RPZdyQM8XLIMrfpnj4dvKZdCeY8iIrlhdWFx//33c/jwYSZOnMjBgwcB6NKlC88995x6LERERP7BZDLh7+GCv4cLjSr5AVmHNCQkZ3Ay+q8hVZezDrG6fDUlx2teSUzlSmIq20/FZjvm4+5sGVJl+W/pzCLE38MlTxsEZpgNNkdGczEhmUAvN+4K8S/w5XdFpHjI0yDO4OBg3n///YKORUREpETxKeVM/VK+1K/om+3Y1ZR0y8aAJ64kcvLy30OsouJz3iAw7loau87EsetMXLZjXq5OVP7XfI4qf/25jJdrjkXHkr3nGbVgf5YNCcv5uDGySx06hd5gZ0MRKbFyVVjs3r2b0NBQHBwc2L17903PrV+/foEEJiIiUpJ5ujpRt7wPdcv7ZDt2LfWvDQKvD7H6x/K55+KukdOyLAkp6ew9G8/es9k3vXV3dvx7eNVfPRwX4pP57I8j2c6Nikvm+RnbmfhYIxUXIpJFrgqLBg0aEBUVRWBgIA0aNMBkMpHTYlImk8mqDfJERETEeu4ujtQM8qJmUPYNApPT/t4gMPJfk8nPxCTluCv5tbQMDkYlcDAq+waB/2aQuarVqAX7aV8nSMOiRMQiV4VFZGQkZcqUsfxZREREiiY3Z0eqB3pSPTD7nkup6WbOxl77a2jV3z0dJ68kcTomibSM3K1Af31Vq82R0dlWyRKRkitXhUXlypUBSEtLY9SoUbzxxhuEhIQUamAiIiJSsFycHAgp7UFIaQ+omfVYeoaZ83HJnLiSyPxd55i99cwtr3cxIee5HiJSMlm1w4azs7OWlBURESmGnBwdCPYvRasaZejesGKuXlPG07WQoxKR24nVW/d169aNX3/9tRBCERERkaLgrhB/yvm4cavZE1PWRhJ3Lee9OESk5LF6udkaNWrw9ttvs27dOho3boyHh0eW40OGDCmw4ERERMT2HB1MjOxSh+dnbMdE5pyKnPx58CJdxq1l4mONcly9SkRKFpOR0/JON3GzuRUmk4njx4/nO6jiIj4+Hh8fH+Li4vD29rbpvf+5AZODg9UdU5JLyrNtKM+2oTzbxu2U5xvtY9GzcUWmbzxJ7F87h7s6OfBOt1B6NSk6G+XeTnm+nSnPtmHPPFvzedbqHgutCiUiIlIydAotR/s6QTnuvN27aTAR329n15k4UtLNvPzzbrafjOGtrnVxc3a0d+giYgf5KnkMw8hxPwsREREpHhwdTLSoFsCDDSrQolqAZd+Kin6lmPVcCx5rXsly7o9bTtNz0npORyfZK1wRsaM8FRZTpkwhNDQUNzc33NzcCA0N5euvvy7o2ERERKQIc3Vy5N1u9fi01524OWd+pNh7Np4Hxq5h+cELdo5ORGzN6sLizTff5MUXX6RLly7Mnj2b2bNn06VLF4YNG8abb75ZGDGKiIhIEda9UUV+jQjP3B8DiE9O58lpW/l46SEyctrqW0SKJavnWEycOJGvvvqKRx55xNLWtWtX6tevz+DBg3n77bcLNEAREREp+moFeTN/UDgvzd7Nkn1RAIxfcZQdp2MY26chAdrzQqTYs7rHIi0tjSZNmmRrb9y4Menp6QUSlIiIiNx+vNycmfhYI167v7ZlLsa6o1foPG4t20/F2Dk6ESlsVhcWjz/+OBMnTszWPnnyZPr27VsgQYmIiMjtyWQy8XTrqswc2IwyXpm9FOfjkun95QamrYvUoi8ixViuhkINHz7c8meTycTXX3/N77//TvPmzQHYtGkTp06dol+/foUTpYiIiNxWmlUN4LfBLRk0cwebT0STlmHw1oL9bDsVy/+618PD1erR2CJSxOXqt3rHjh1Znjdu3BiAY8eOAVC6dGlKly7Nvn37Cjg8ERERuV0Fervx/dPN+GjpISavztxAd8Gucxw4H8+kxxpTPdDTzhGKSEHKVWGxYsWKwo5DREREiiFnRwdevb82jSr58t/Zu7maks7Ri1d5cPxaPuhZn871y9s7RBEpINp7XURERApdp9ByzB8UTs2yXgAkpmYwaOYO3l6wn7QMs52jE5GCoMJCREREbKJqGU/mRoTxUMMKlrZv1kXyyOSNRMUl2zEyESkIKixERETEZkq5OPFprzt5t1soLo6ZH0O2noyh87g1rD962c7RiUh+qLAQERERmzKZTDzWvDKzn2tBBV93AC5fTeWxKZuYsPIoZu3WLXJbsrqwWL16dY4b4aWnp7N69eoCCUpERESKvzuDfVk4uCWt7ygDgNmAD5cc4pnp24i7lmbn6ETEWlYXFm3btiU6Ojpbe1xcHG3bti2QoERERKRk8PNwYWr/pgy9twamzM26+ePABbqOX8u+c3H2DU5ErGJ1YWEYBqbrv/n/cOXKFTw8PAokKBERESk5HB1MDL33Dqb2b4pvKWcATl5JovuE9czeetrO0YlIbuV628vu3bsDmeMi+/fvj6urq+VYRkYGu3fvJiwsrOAjFBERkRKhTc1AFg5uyQvfb2f3mThS0s289PNutp+KYWSXurg5O9o7RBG5iVz3WPj4+ODj44NhGHh5eVme+/j4EBQUxDPPPMOMGTMKM1YREREp5ir6lWL2cy14rHklS9sPm0/Tc9J6Tkcn2TEyEbmVXPdYTJ06FYAqVarw3//+V8OeREREpFC4Ojnybrd6NKrkx6tz95CcZmbv2Xg6j1vLmN530q5WWXuHKCI5sHqOxciRI1VUiIiISKHr3qgiv0aEUyWgFABx19J4ctpWPvn9EBlaklakyMl1j8U//fzzz8yaNYtTp06Rmpqa5dj27dsLJDARERGRWkHezB/ckpdm72LpvgsAjFt+lB2nYvm8TwMCPF1vcQURsRWreyzGjh3LgAEDKFu2LDt27OCuu+4iICCA48ePc9999xVGjCIiIlKCebs5M+mxxrx6fy0cHTJXplx79DKdx61l+6kYO0cnItdZXVhMmDCByZMnM27cOFxcXHj55ZdZtmwZQ4YMIS5O602LiIhIwTOZTDzTuhrfD2xG6b96Kc7HJdP7yw18t+EEhqGhUSL2ZnVhcerUKcuysu7u7iQkJADw+OOP88MPPxRsdCIiIiL/0LxqAIuGtOSuKv4ApGUYvDlvHy/+uJPElHQ7RydSslldWAQFBVl23q5UqRIbN24EIDIyUt8WiIiISKEL9Hbj+6eb8Uzrqpa2+bvO0e2LdRy9eNWOkYmUbFYXFu3atWP+/PkADBgwgGHDhtG+fXt69+7NQw89VOABioiIiPybs6MDr95fm0mPNcLTNXMtmiMXr/Lg+LX8tvu8naMTKZmsXhVq8uTJmM1mACIiIggICGD9+vV07dqVZ599tsADFBEREbmRTqHluKOsF8/P2M6hCwkkpmYQMXM7T4ZX4Zm7ytg7PJESxerCwsHBAQeHvzs6+vTpQ58+fQo0KBEREZHcqlrGk7kRYbw2dy9zd5wF4Jt1J9h24jITH2tKeb9Sdo5QpGSweiiUiIiISFFTysWJT3vdyTvdQnF2zFySdtfZq3QZv471xy7bOTqRkkGFhYiIiBQLJpOJx5tXZvZzYZT3dQPgSmIqj329iYkrj2mRGZFCpsJCREREipUGwb7MjwineRUfAMwGfLDkIM9M30bctTQ7RydSfKmwEBERkWLH38OFz7vXZEi76pgyR0axbP8Fuo5fy/5z8fYNTqSYynVhcfHixZseT09PZ/PmzfkOSERERKQgODqYGHpvDb7p3xTfUs4AnLySxEMT1jF762k7RydS/OS6sChXrlyW4qJevXqcPv33L+WVK1do0aJFwUYnIiIikk9tawayYFBL6lfMHBqVkm7mpZ93M2LObpLTMuwcnUjxkevC4t8Tnk6cOEFaWtpNzxEREREpCoL9SzH7uRb0bVbJ0vbD5tP0nLSe09FJdoxMpPgo0DkWpuuDGEVERESKGFcnR957qB6fPHwnbs6ZH4H2no2n87i1rDh48yHfInJrmrwtIiIiJUqPxhWZ+0I4VQIyN86Lu5bGgGlb+PT3Q2SYNfpCJK9yXViYTCYSEhKIj48nLi4Ok8nE1atXiY+PtzxEREREbge1y3kzf3BLOtQpa2kbu/wo/aduJjox1Y6Ridy+rJpjcccdd+Dn54e/vz9Xr16lYcOG+Pn54efnR82aNQszThEREZEC5e3mzJePN2bEfbVwdMgczr3myGU6j13DjlMxdo5O5PbjlNsTV6xYUZhxiIiIiNicyWTi2burcWewL4Nm7uDy1RTOxSXT68sNvNm5Do81r6w5pCK5lOvC4u677y7MOERERETspnnVABYNaUnEzO1sORFDWobBG/P2sfVkDKO716OUS64/MomUWLkeCpWenk5KSkqWtgsXLjBq1Chefvll1q5dW+DBiYiIiNhKoLcbM59uztOtQixt83aeo9sX6zh26aodIxO5PeS6sHj66acZMmSI5XlCQgJNmzbliy++YOnSpbRt25ZFixYVSpAiIiIituDs6MBrD9RhQt9GeLpm9lIcvnCVruPWsmjPeTtHJ1K05bqwWLduHT169LA8/+6778jIyODIkSPs2rWL4cOH89FHHxVKkCIiIiK2dH+9cswfFE7Nsl4AJKZm8ML323l34X7SMsx2jk6kaMp1YXH27Flq1Khhef7nn3/So0cPfHx8AHjiiSfYt29fwUcoIiIiYgdVy3gyNyKMbg3KW9q+XhvJo19t5EJ8sh0jEymacl1YuLm5ce3aNcvzjRs30qxZsyzHr17V+EMREREpPkq5ODGmdwPe6RaKs2Pm6lBbTsTwwNg1bDh2xc7RiRQtuS4sGjRowPTp0wFYs2YNFy5coF27dpbjx44do3z58jd6uYiIiMhtyWQy8Xjzysx6tgXlfdwAuHw1lb5fb2TSqmMYhnbrFgErCos333yTzz//nGrVqtGxY0f69+9PuXLlLMfnzp1LeHh4oQQpIiIiYm8NK/mxcEgrWtUoDYDZgP8tPsiz07cRn5xm5+hE7C/XhcXdd9/N1q1bGTJkCFOnTuWrr77KcrxBgwYMGzbMqpuPHj2apk2b4uXlRWBgIN26dePQoUNZzpk8eTJt2rTB29sbk8lEbGxsluMrV67EZDLl+NiyZcsN752cnExERAQBAQF4enrSo0cPLly4kOWcLVu2cM899+Dr64ufnx8dO3Zk165dVr1HERERKT78PVyYNuAuhtzz97zT3/dfoOu4tRw4H2/HyETsL9eFRUpKCnXq1OHFF1+kd+/eODhkfekzzzxDgwYNrLr5qlWriIiIYOPGjSxbtoy0tDQ6dOhAYmKi5ZykpCQ6derEq6++muM1wsLCOH/+fJbHwIEDCQkJoUmTJje897Bhw1iwYAGzZ89m1apVnDt3ju7du1uOX716lU6dOlGpUiU2bdrE2rVr8fLyomPHjqSl6VsJERGRksrRwcTw9ncwtX9TfNydAThxJYmHJqzj521n7BydiP2YjFwODHRzc6NFixa0bduWdu3a0axZM5ydnQs0mEuXLhEYGMiqVato3bp1lmMrV66kbdu2xMTE4Ovre8NrpKWlUaFCBQYPHswbb7yR4zlxcXGUKVOGmTNn0rNnTwAOHjxI7dq12bBhA82bN2fr1q00bdqUU6dOERwcDMCePXuoX78+R44coXr16rd8P/Hx8fj4+BAXF4e3t3cus1AwzGYz0dHR+Pv7ZysCpeAoz7ahPNuG8mwbyrNt2CrPp6OTeOH77ew5G2dpe+SuSozsUgc3Z8dCu29RoZ9n27Bnnq35PJvr/eknTZrEypUr+eabb3jrrbdwd3cnLCyMdu3a0bZtW5o2bYqjY/5+geLiMn8p/f3983yN+fPnc+XKFQYMGHDDc7Zt20ZaWhr33nuvpa1WrVpUqlTJUljUrFmTgIAApkyZwquvvkpGRgZTpkyhdu3aVKlSJcfrpqSkZNmdPD4+s0vUbDZjNtt2zWuz2YxhGDa/b0mjPNuG8mwbyrNtKM+2Yas8V/B1Y9YzzXj7twP8sPk0AD9sPsWes7FMeLQhFf1KFer97U0/z7Zhzzxbc89cFxb9+/enf//+ABw/fpyVK1eyatUqJk2axOuvv46HhwetWrXit99+szpgyAx66NChhIeHExoamqdrAEyZMoWOHTtSsWLFG54TFRWFi4tLtp6PsmXLEhUVBYCXlxcrV66kW7duvPPOOwDUqFGDpUuX4uSUc9pGjx7NqFGjsrXHxMSQnp6ex3eUN2azmYSEBAzD0DcIhUh5tg3l2TaUZ9tQnm3D1nn+T+vy1PR3ZvQfkaSkG+w9G0/ncWt55/7qhFf1LfT724t+nm3DnnlOSEjI9bm5Liz+qWrVqlStWpUnn3ySyMhIpkyZwrhx41iyZEleLgdAREQEe/fuZe3atXm+xpkzZ1i6dCmzZs3K8zWuu3btGk899RTh4eH88MMPZGRk8PHHH/PAAw+wZcsW3N3ds71mxIgRDB8+3PI8Pj6e4OBg/Pz87DIUymQy4efnp1/0QqQ824bybBvKs20oz7Zhjzz3a+1P0xrleOH7HZyMTiI+OYOhcw8xqE01htxTA0cHk03isCX9PNuGPfN8oy/UczzX2oufOnWKFStWsHLlSlauXMnly5dp3rw5//3vf7n77rutvRwAgwYNYuHChaxevfqmPQ23MnXqVAICAujatetNzwsKCiI1NZXY2NgsvRYXLlwgKCgIgJkzZ3LixAk2bNhg+QucOXMmfn5+zJs3jz59+mS7rqurK66urtnaHRwc7PLLZjKZ7HbvkkR5tg3l2TaUZ9tQnm3DHnmuW8GX+YNb8t/Zu1i2/wKGAeNWHGPnmTg+79MQfw8Xm8ViK/p5tg175dma++X6zCeffJKqVatSv359Zs2aRc2aNZk5cyYxMTEsW7aMN954I9uE61sxDINBgwYxd+5cli9fTkhIiFWv//e1pk6dSr9+/W45qbxx48Y4Ozvz559/WtoOHTrEqVOnaNGiBZC5GpWDgwMm09/fLlx/rnGEIiIiciM+7s5Mfrwxr9xXi+udFGuOXKbz2DXsOBVj3+BEClGuC4tp06ZhNpt57bXXeOedd/i///s/WrRoYVX3yL9FREQwY8YMZs6ciZeXF1FRUURFRXHt2jXLOVFRUezcuZOjR48CmSsz7dy5k+jo6CzXWr58OZGRkQwcODDbfc6ePUutWrXYvHkzAD4+Pjz11FMMHz6cFStWsG3bNgYMGECLFi1o3rw5AO3btycmJoaIiAgOHDjAvn37GDBgAE5OTrRt2zbP71lERESKP5PJxHN3V+P7gc0p7Zk5muFcXDK9vtzA9A0ntFu3FEu5LiwOHDjAK6+8wrZt27j//vvx9/enS5cufPzxx2zdujVP3+JPnDiRuLg42rRpQ7ly5SyPn376yXLOpEmTaNiwIU8//TQArVu3pmHDhsyfPz/LtaZMmUJYWBi1atXKdp+0tDQOHTpEUlKSpW3MmDF07tyZHj160Lp1a4KCgpgzZ47leK1atViwYAG7d++mRYsWtGrVinPnzrFkyZIsO46LiIiI3EiLagH8NqQlTav4AZCWYfDGvH0M+2knSam2XdhFpLDleh+Lf9u/fz+rVq1ixYoVrF69muTkZFq2bMnChQsLOsbblvaxKP6UZ9tQnm1DebYN5dk2ilqe0zLMfLD4IF+vjbS03VHWk4mPNaZaGU87RpY/RS3PxdXtso9FniOrU6cO3bt3p3v37jz44IMYhsHixYvzejkRERGRYsvZ0YHXO9dhQt9GeLhk7vt1+MJVHhy/jsV7zts5OpGCYdUEiYsXL7Jy5UrLqlCHDx/GxcWFu+66i2HDhmnugYiIiMhN3F+vHDWDvHh+xjYOX7jK1ZR0nv9+O0+3CuHlTrVwdtS3/nL7ynVhUbt2bQ4fPoyTkxNNmzalZ8+etGnThvDwcNzc3AozRhEREZFio1oZT36NCGfEnD3M23kOgK/WRLLrdBzjH21IoLc+V8ntKdeFRbdu3Wjbti0tW7akVKnivT29iIiISGEq5eLEZ70b0KSyH28v3E9ahsHmE9HcP3Yt4x9tSPOqAfYOUcRque5vGz16NB06dFBRISIiIlIATCYTj7eowqxnW1DOJ7OX4vLVFPp+vYkvVx3TkrRy29FAPhERERE7aljJj4WDW9KqRmkAMswGoxcf5Nnp24hPTrNzdCK5p8JCRERExM4CPF2ZNuAuhrSrbmn7ff8Fuo5by4Hz8XaMTCT3VFiIiIiIFAGODiaGd6jJ1P5N8XF3BuDElSQemrCOX7adsXN0IremwkJERESkCGlbK5CFg1tSr4IPAMlpZv4zexevzt1DclqGnaMTuTGr9rG4Ljk5md27d3Px4kXMZnOWY127di2QwERERERKqmD/Usx+rgWjFuznh82nAJi56RR7z8bxxaONCPbXYjpS9FhdWCxZsoR+/fpx+fLlbMdMJhMZGaqkRURERPLLzdmR0d3r0aiSL6//upeUdDO7z8TRZfxaPuvdgDY1A+0dokgWVg+FGjx4MA8//DDnz5/HbDZneaioEBERESlYDzcJZu4L4VQOyOyliE1KY8C0LXy67DAZZi1JK0WH1YXFhQsXGD58OGXLli2MeERERETkX+qU92b+oJbcWzvz85dhwNg/j9B/6maiE1PtHJ1IJqsLi549e7Jy5cpCCEVEREREbsTH3ZnJjzfm/zrVwsGU2bbmyGU6j13DztOxdo1NBPIwx2L8+PE8/PDDrFmzhnr16uHs7Jzl+JAhQwosOBERERH5m4ODiefbVOPOYB+G/LCDy1dTOReXzMOT1vNml7o81qwSJpPJ3mFKCWV1YfHDDz/w+++/4+bmxsqVK7P88JpMJhUWIiIiIoUsrFppFg5uxaCZ29l6Moa0DIM3ft3L9pMxvPdQKKVc8rTwp0i+WD0U6rXXXmPUqFHExcVx4sQJIiMjLY/jx48XRowiIiIi8i9BPm788ExznmoZYmmbu+MsD32xnuOXrtoxMimprC4sUlNT6d27Nw4O2ltPRERExJ6cHR14o3Mdvni0ER4ujgAcupBA1/HrWLznvJ2jk5LG6urgiSee4KeffiqMWEREREQkDx6oX455g1pSI9ATgKsp6Tz//Xbe+20/aRnmW7xapGBYPQAvIyODDz/8kKVLl1K/fv1sk7c//fTTAgtORERERHKneqAnv0aEM2LOHubvOgfAV2si2XU6jvGPNiTQ283OEUpxZ3VhsWfPHho2bAjA3r17sxzTKgQiIiIi9uPh6sTnfRrQpIof7yzcT1qGweYT0dw/di3jH21I86oB9g5RijGrC4sVK1YURhwiIiIiUgBMJhP9WlQhtIIPEd9v53xcMpevptD360283LEmz7Suqi+DpVBoBraIiIhIMdSokh8LB7ekZfXSAGSYDUYvPshzM7YRn5xm5+ikOLK6x6Jt27Y3rXKXL1+er4BEREREpGAEeLry7ZN38dkfhxm3/CgAS/dd4FDUWiY+1pja5bztHKEUJ1b3WDRo0IA777zT8qhTpw6pqals376devXqFUaMIiIiIpJHjg4m/tOhJt/0b4KPe+aiOyeuJPHQhHXM2X7GztFJcWJ1j8WYMWNybH/rrbe4elWbsYiIiIgURe1qlWXh4JY8//029p6NJznNzPBZu9h2MoY3u9TB1cnR3iHKba7A5lg89thjfPPNNwV1OREREREpYMH+pfj5uTAeuSvY0vb9plM8PGkDZ2KS7BiZFAcFVlhs2LABNzetjywiIiJSlLk5OzK6e30+7FkfV6fMj4K7z8TRedxaVh66aOfo5HZm9VCo7t27Z3luGAbnz59n69atvPHGGwUWmIiIiIgUnl5Ngqlb3pvnZ2znVHQSsUlpDJi2hRfvqcGQdjVwcNCStGIdq3ssfHx8sjz8/f1p06YNixYtYuTIkYURo4iIiIgUgrrlfVgwuCX31i4LgGHAZ38cof+0LUQnpto5OrndWN1jMXXq1MKIQ0RERETswMfdmcmPN+bL1cf5aOlBzAasPnyJLuPWMqFvI+4M9rV3iHKbyNcci6tXrxIfH5/lISIiIiK3FwcHE8+3qcaMgc0o7ekCwNnYazw8aQMzNp7EMAw7Ryi3A6sLi8jISB544AE8PDzw8fHBz88PPz8/fH198fPzK4wYRURERMQGwqqVZuHgVjSunPmZLjXDzOu/7uU/s3ZxLTXDztFJUWf1UKjHHnsMwzD45ptvKFu27E134RYRERGR20uQjxs/PtOc0YsO8s26SADm7DjLvnPxTHysEVXLeNo5QimqrC4sdu3axbZt26hZs2ZhxCMiIiIidubs6MCbXerQqLIv//fzbhJTMzh0IYGu49fx8cP16RRazt4hShFk9VCopk2bcvr06cKIRURERESKkM71yzNvUDjVAzN7Ka6mpPPcjO28v+gA6RlmO0cnRY3VPRZff/01zz33HGfPniU0NBRnZ+csx+vXr19gwYmIiIiIfVUP9GJeRDivzNnDgl3nAJi8+jg7T8cytved1n+YlGLL6p+FS5cucezYMQYMGGBpM5lMGIaByWQiI0MTe0RERESKEw9XJ8b2aUDjSr68t+gAaRkGmyOj6fLFet67vyr3+vvbO0QpAqwuLJ588kkaNmzIDz/8oMnbIiIiIiWEyWSif3gI9Sr6EvH9dqLik7mUkMLzsw7wcryZZ1pX0+fCEs7qwuLkyZPMnz+f6tWrF0Y8IiIiIlKENa7sx29DWjLkxx2sO3qFDANGLz7EjlNxfPhwfbzdnG99ESmWrJ683a5dO3bt2lUYsYiIiIjIbSDA05XvnmxGRJtqlrYl+6J4cPw6DkZpw+SSyuoeiy5dujBs2DD27NlDvXr1sk3e7tq1a4EFJyIiIiJFk6ODif90uIPqfo6MXHyc+OR0Ii8n0u2LdYzuXo+HGla0d4hiY1YXFs899xwAb7/9drZjmrwtIiIiUrK0qubHgkHhvDBzB/vOxZOcZmbYT7vYdjKGNzrXwdXJ0d4hio1YPRTKbDbf8KGiQkRERKTkCfYvxS/Ph9GnabClbcbGU/SatIEzMUl2jExsyerCQkRERETk39ycHflfj/p82KM+rk6ZHzF3nYmj87i1rDp8yc7RiS3kaijU2LFjeeaZZ3Bzc2Ps2LE3PXfIkCEFEpiIiIiI3H56NQ2mTnlvXvh+O6eik4hNSqP/1M28eE8NhrSrgYODlqQtrnJVWIwZM4a+ffvi5ubGmDFjbnieyWRSYSEiIiJSwoVW8GHBoJb8Z/ZO/jhwEcOAz/44wo5TsXzWuwF+Hi72DlEKQa4Ki8jIyBz/LCIiIiKSE59Szkx+vAmTVh/j46WHMBuw6vAlOo9by4S+jbgz2NfeIUoBs3qORXJy8g2PnT9/Pl/BiIiIiEjx4eBg4oU21ZnxVDMC/uqlOBt7jYcnbeD7TScxDMPOEUpBsrqwaNSoETt37szW/ssvv1C/fv2CiElEREREipGw6qX5bUgrGlXyBSA1w8xrc/fyn9m7uJaqVUWLC6sLizZt2tC8eXM++OADABITE+nfvz+PP/44r776aoEHKCIiIiK3vyAfN358pgUDwqtY2uZsP8tDE9YReTnRfoFJgbF6g7wJEybwwAMPMHDgQBYuXMj58+fx9PRk8+bNhIaGFkaMIiIiIlIMuDg5MLJLXRpX9uPln3eTlJrBwagEuo5by0cP30mn0CB7hyj5kKd9LO677z66d+/OunXrOHXqFB988IGKChERERHJlc71yzN/UDjVAz0BSEhJ57kZ2xi96ADpGWY7Ryd5ZXVhcezYMVq0aMHChQtZunQpL7/8Ml27duXll18mLS2tMGIUERERkWKmeqAX8yLC6Vy/nKXty9XHefTrTVxMuPFiQVJ0WV1YNGjQgJCQEHbt2kX79u159913WbFiBXPmzOGuu+4qjBhFREREpBjycHVi3CMNeatLHZz+2jhvc2Q0D4xdy+bIaDtHJ9ayurCYMGECP/74I76+vpa2sLAwduzYQaNGjQoyNhEREREp5kwmE/3DQ/jp2eYEebsBcCkhhUe+2shXq49rSdrbiNWFxeOPP55ju5eXF1OmTMl3QCIiIiJS8jSu7M/CIS0JqxYAQIbZ4L1FB3h+xnYSkjXc/nZg9apQ1+3fv59Tp06RmppqaTOZTHTp0qVAAhMRERGRkqW0pyvTn2rGp8sO8cWKYwAs2RfFoQsJTHqsMTWDvOwcodyM1YXF8ePHeeihh9izZw8mk8nSPWUyZY6Ly8jQJiciIiIikjeODiZe6liLhsF+DJu1k4TkdCIvJ9Lti3WM7l6Pbg0r2DtEuQGrh0K9+OKLhISEcPHiRUqVKsW+fftYvXo1TZo0YeXKlYUQooiIiIiUNPfWKctvg1tRt7w3ANfSMhj6005e/3UPKen6Irsosrqw2LBhA2+//TalS5fGwcEBBwcHWrZsyejRoxkyZIhV1xo9ejRNmzbFy8uLwMBAunXrxqFDh7KcM3nyZNq0aYO3tzcmk4nY2Ngsx1euXInJZMrxsWXLlhveOzk5mYiICAICAvD09KRHjx5cuHAh23nTpk2jfv36uLm5ERgYSEREhFXvUURERETyplJAKX55PozeTYItbTM2nqLXpA2cjb1mx8gkJ1YXFhkZGXh5ZY5vK126NOfOnQOgcuXK2YqCW1m1ahURERFs3LiRZcuWkZaWRocOHUhM/Htb96SkJDp16sSrr76a4zXCwsI4f/58lsfAgQMJCQmhSZMmN7z3sGHDWLBgAbNnz2bVqlWcO3eO7t27Zznn008/5bXXXuOVV15h3759/PHHH3Ts2NGq9ygiIiIieefm7MgHPevzQY96uDhlfnTddSaOzmPXsOrwJTtHJ/9k9RyL0NBQdu3aRUhICM2aNePDDz/ExcWFyZMnU7VqVauutWTJkizPp02bRmBgINu2baN169YADB06FOCGw6xcXFwICvp7+/e0tDTmzZvH4MGDLfM+/i0uLo4pU6Ywc+ZM2rVrB8DUqVOpXbs2GzdupHnz5sTExPD666+zYMEC7rnnHstr69evb9V7FBEREZH86920EnXL+/D899s4HX2NmKQ0+k/dzNB77mBwu+o4OOT8uU9sx+oei9dffx2zOXOr9bfffpvIyEhatWrFokWLGDt2bL6CiYuLA8Df3z/P15g/fz5XrlxhwIABNzxn27ZtpKWlce+991raatWqRaVKldiwYQMAy5Ytw2w2c/bsWWrXrk3FihXp1asXp0+fznNsIiIiIpJ3oRV8WDioFffUCgTAMGDMH4d58tstxCSm3uLVUtis7rH451Cg6tWrc/DgQaKjo/Hz87thD0FumM1mhg4dSnh4OKGhoXm+zpQpU+jYsSMVK1a84TlRUVG4uLhk2eQPoGzZskRFRQGZq1+ZzWbef/99Pv/8c3x8fHj99ddp3749u3fvxsXFJdt1U1JSSElJsTyPj4+3vLfrxZitmM1mDMOw+X1LGuXZNpRn21CebUN5tg3l2TbskWcvN0e+fKwRE1cfZ8yyw5gNWHnoEg+MW8MXjzbkzoq+NovFVuz582zNPfO8j8U/5aeH4bqIiAj27t3L2rVr83yNM2fOsHTpUmbNmpXveMxmM2lpaYwdO5YOHToA8MMPPxAUFMSKFStynGsxevRoRo0ala09JiaG9PT0fMdkDbPZTEJCAoZh4OBgdceU5JLybBvKs20oz7ahPNuG8mwb9szzI/X9qOZTi9cWHiXmWjrnYpPp9eVG/tuuMt3rB+brC++ixp55TkhIyPW5uS4snnzyyVyd98033+T65tcNGjSIhQsXsnr16pv2NNzK1KlTCQgIoGvXrjc9LygoiNTUVGJjY7P0Wly4cMEyX6NcuXIA1KlTx3K8TJkylC5dmlOnTuV43REjRjB8+HDL8/j4eIKDg/Hz88Pb2zuvbytPzGYzJpMJPz8//YNaiJRn21CebUN5tg3l2TaUZ9uwd547+ftzZ9UgBv+wk+2nYknLMBi97ASHLqfxzoN1cXdxtHlMhcGeeXZyyn0/RK7PnDZtGpUrV6Zhw4aWTfHyyzAMBg8ezNy5c1m5ciUhISH5utbUqVPp168fzs7ONz23cePGODs78+eff9KjRw8ADh06xKlTp2jRogUA4eHhlvbrxU50dDSXL1+mcuXKOV7X1dUVV1fXbO3Xl+W1NZPJZLd7lyTKs20oz7ahPNuG8mwbyrNt2DvPFfw8+PGZFry/6ADT1p8AYM6Os+w/H8/ExxoTUtrDLnEVNHvl2Zr75bqweP755/nhhx+IjIxkwIABPPbYY/keAhUREcHMmTOZN28eXl5elvkNPj4+uLu7A5nzIaKiojh69CgAe/bswcvLi0qVKmW5//Lly4mMjGTgwIHZ7nP27FnuuecevvvuO+666y58fHx46qmnGD58OP7+/nh7ezN48GBatGhB8+bNAbjjjjt48MEHefHFF5k8eTLe3t6MGDGCWrVq0bZt23y9bxEREREpOC5ODrzVtS6NKvvxyi+7SUrN4GBUAl3HreXjXnfSsW7QrS8i+ZbrEuSLL77g/PnzvPzyyyxYsIDg4GB69erF0qVL89yDMXHiROLi4mjTpg3lypWzPH766SfLOZMmTaJhw4Y8/fTTALRu3ZqGDRsyf/78LNeaMmUKYWFh1KpVK9t90tLSOHToEElJSZa2MWPG0LlzZ3r06EHr1q0JCgpizpw5WV733Xff0axZMx544AHuvvtunJ2dWbJkyS17RERERETE9rreWZ75g8KpViazlyIhJZ1np29j9OIDpGdoIn9hMxl5rApOnjzJtGnT+O6770hPT2ffvn14enoWdHy3tfj4eHx8fIiLi7PLHIvo6Gj8/f3VBVyIlGfbUJ5tQ3m2DeXZNpRn2yiqeb6aks4rv+xm4e7zlrZmIf6Me7QhgV5udowsb+yZZ2s+z+Y5MgcHB0wmE4ZhkJGRkdfLiIiIiIgUKE9XJ8Y90pCRXerg9NfGeZsio+k8di1bTkTbObriy6rCIiUlhR9++IH27dtzxx13sGfPHsaPH8+pU6fUWyEiIiIiRYbJZGJAeAg/Pducst6Zi+tcTEihz+SNfL3meIEtRiR/y3Vh8cILL1CuXDn+97//0blzZ06fPs3s2bO5//77i1TXl4iIiIjIdY0r+/PbkFaEVQsAIMNs8O5vB3jh++0kJKfZObriJderQk2aNIlKlSpRtWpVVq1axapVq3I8798ToEVERERE7Km0pyvTn2rGp8sO8cWKYwAs3hvFoagEJj7WmJpBXnaOsHjIdWHRr1+/YrWDoYiIiIiUHI4OJl7qWIuGwX4Mm7WThOR0jl9OpNsX6xjdvR7dGlawd4i3Pas2yBMRERERuZ3dW6csCwe35PkZ29l/Pp5raRkM/Wkn207G8Hrn2rg6FY/duu1BkyNEREREpESpHODBnBfC6NWkoqVt+saT9PpyI2djr9kxstubCgsRERERKXHcnB35sOedfNCjHi5OmR+Jd52OpfPYNaw+fMnO0d2eVFiIiIiISInVu2kl5jwfRrC/OwAxSWk8MXUzY/88gtmsJWmtocJCREREREq00Ao+LBzUina1AgEwDPh02WGe/HYLMYmpdo7u9qHCQkRERERKPJ9SznzdrwkvdazJX5t1s/LQJTqPW8vuM7F2je12ocJCRERERARwcDAR0bY63z3ZDH8PFwDOxl6j58QNzNx0Srt134IKCxERERGRf2hZozS/DWlJw0q+AKRmmHl17h7+O3s311Iz7BtcEabCQkRERETkX8r5uPPTMy3oH1bF0vbL9jM8NGEdJy4n2i+wIkyFhYiIiIhIDlycHHira10+79MAd+fMjfMORiXQZdxalu6LsnN0RY8KCxERERGRm3iwQQXmDwqnWhkPABJS0nl2+jZGLz5AeobZztEVHSosRERERERuoUZZL+YNaskD9ctZ2r5cdZzHpmziYkKyHSMrOlRYiIiIiIjkgqerE+Mfacibnevg9NeatBuPR9N57Fq2nIi2c3T2p8JCRERERCSXTCYTT7YM4cdnmlPW2xWAiwkp9Jm8ka/XHC/RS9KqsBARERERsVKTKv4sHNyKFlUDAMgwG7z72wEiZm4nITnNztHZhwoLEREREZE8KOPlyvSn7uKFNtUsbYv2RPHgF+s4fCHBjpHZhwoLEREREZE8cnJ04OVOtfiqXxO83JwAOH4pkQfHr2PezrN2js62VFiIiIiIiORT+zplWTi4JbXLeQNwLS2DF3/cyZvz9pKSXjJ261ZhISIiIiJSACoHeDD3hTB6Nq5oaftuw0l6f7mRc7HX7BiZbaiwEBEREREpIG7OjnzUsz7/614PF6fMj9o7T8fywNg1rDlyyc7RFS4VFiIiIiIiBchkMtHnrkrMeT6Min7uAMQkpdHvm82M+/MIZnPxXJJWhYWIiIiISCEIreDDwsEtaVcrEADDgE+WHeapb7cQm5Rq5+gKngoLEREREZFC4lvKha/7NeG/He7AlLlZNysOXaLzuLXsORNn3+AKmAoLEREREZFC5OBgYlC7Gnz35F34e7gAcCbmGj0mrueHzaeKzW7dKixERERERGygVY0yLBzckoaVfAFIzTAzYs4eXvp5N9dSb/8laVVYiIiIiIjYSHlfd356pgX9w6pY2n7edobuE9dz4nKi/QIrACosRERERERsyMXJgbe61uXzPg1wd3YE4MD5eLqMX8vv+6LsHF3eqbAQEREREbGDBxtUYN6gcKqW8QAgITmdZ6Zv43+LD5KeYQYgw2yw8fgVlhy4zMbjV8gowkvVOtk7ABERERGRkuqOsl7MH9SS//t5N7/tOQ/ApFXH2Hk6hocaVuSzPw5zPi75r7OPUc7HjZFd6tAptJz9gr4B9ViIiIiIiNiRp6sT4x9tyBud6+DkkLkm7cbj0fzfL7v/UVRkiopL5vkZ21my97w9Qr0pFRYiIiIiInZmMpl4qmUIPzzTnDKeLjc87/pAqFEL9he5YVEqLEREREREioimVfx5p1voTc8xgPNxyWyOjLZNULmkwkJEREREpAhJSTfn6ryLCcm3PsmGVFiIiIiIiBQhgV5uBXqeraiwEBEREREpQu4K8aecjxumGxw3AeV83LgrxN+WYd2SCgsRERERkSLE0cHEyC51ALIVF9efj+xSB0eHG5Ue9qHCQkRERESkiOkUWo6JjzUiyCfrcKcgHzcmPtaoSO5joQ3yRERERESKoE6h5WhfJ4hNxy9z/PwVqpYLoFnV0kWup+I6FRYiIiIiIkWUo4OJ5lUDuMPXhL+/Pw5FtKgADYUSEREREZECoMJCRERERETyTYWFiIiIiIjkmwoLERERERHJNxUWIiIiIiKSbyosREREREQk31RYiIiIiIhIvqmwEBERERGRfFNhISIiIiIi+abCQkRERERE8k2FhYiIiIiI5JuTvQMozgzDACA+Pt7m9zabzSQkJODk5ISDg+rHwqI824bybBvKs20oz7ahPNuG8mwb9szz9c+x1z/X3owKi0KUkJAAQPD/t3fvQVGd5x/Av8ttQVxARRbUDXhBiTXEu8NFIKKCRgV70RibqtEmRoyXlABJaiCigrfRTButA5YYq/E2taGKikWgVryBIkIoCkilEUIyooiE676/PxzOz5UV2V1cXPr9zOyM+573nPOcxwOvz77vWVWqLo6EiIiIiEh/Dx48gL29fbt9ZKIj5QfpRa1W486dO1AoFJDJZEY9d01NDVQqFcrLy2FnZ2fUc/8vYZ6Ng3k2DubZOJhn42CejYN5No6uzLMQAg8ePEC/fv2eOVvCGYvnyMzMDAMGDOjSGOzs7PiDbgTMs3Ewz8bBPBsH82wczLNxMM/G0VV5ftZMRSsuhiMiIiIiIoOxsCAiIiIiIoOxsOim5HI5oqOjIZfLuzqUbo15Ng7m2TiYZ+Ngno2DeTYO5tk4TCXPfHibiIiIiIgMxhkLIiIiIiIyGAsLIiIiIiIyGAsLIiIiIiIyGAsLExQXF4dx48ZBoVDAyckJoaGhKCoqeuZ+9+7dQ1hYGFxcXCCXyzF06FCkpKQYIWLTpG+et2/fjmHDhsHGxgYqlQqrV69GfX29ESI2TTt37oSnp6f03dxeXl44ceJEu/scPnwYHh4esLa2xiuvvML7uAN0zXNCQgImTpyIXr16oVevXpg8eTIuXbpkxIhNkz73c6sDBw5AJpMhNDT0+QbZDeiTZ46ButMnzxwDDRMfHw+ZTIZVq1a12+9FHQdZWJigzMxMhIWF4cKFCzh9+jSampowdepUPHz48Kn7NDY2YsqUKSgrK8ORI0dQVFSEhIQE9O/f34iRmxZ98rx//35ERUUhOjoahYWF2L17Nw4ePIiPP/7YiJGblgEDBiA+Ph45OTnIzs7GpEmTEBISgoKCAq39s7KyMG/ePCxevBhXr15FaGgoQkNDkZ+fb+TITYuuec7IyMC8efOQnp6O8+fPQ6VSYerUqfjuu++MHLlp0TXPrcrKyhAeHo6JEycaKVLTpmueOQbqR9c8cww0zOXLl7Fr1y54enq22++FHgcFmbyqqioBQGRmZj61z86dO8WgQYNEY2OjESPrXjqS57CwMDFp0iSNtg8++ED4+Pg87/C6lV69eonExESt2+bMmSNef/11jbYJEyaId9991xihdSvt5flJzc3NQqFQiD179jznqLqfZ+W5ublZeHt7i8TERLFgwQIREhJivOC6kfbyzDGw87SXZ46B+nvw4IFwd3cXp0+fFv7+/mLlypVP7fsij4OcsegG7t+/DwDo3bv3U/skJyfDy8sLYWFhUCqVGDFiBDZs2ICWlhZjhWnyOpJnb29v5OTkSEtGSktLkZKSgunTpxslRlPX0tKCAwcO4OHDh/Dy8tLa5/z585g8ebJGW1BQEM6fP2+MELuFjuT5SXV1dWhqamr3/idNHc3z2rVr4eTkhMWLFxsxuu6jI3nmGGi4juSZY6D+wsLC8Prrr7cZ37R5kcdBi64OgAyjVquxatUq+Pj4YMSIEU/tV1paijNnzmD+/PlISUlBcXExli1bhqamJkRHRxsxYtPU0Ty/+eab+PHHH+Hr6wshBJqbm7F06VJOAz/D9evX4eXlhfr6evTs2RNHjx7F8OHDtfatrKyEUqnUaFMqlaisrDRGqCZNlzw/KTIyEv369evQoPe/Tpc8/+tf/8Lu3buRm5tr3CC7AV3yzDFQf7rkmWOgfg4cOIArV67g8uXLHer/Qo+DXT1lQoZZunSpcHV1FeXl5e32c3d3FyqVSjQ3N0ttW7duFc7Ozs87xG6ho3lOT08XSqVSJCQkiLy8PPHXv/5VqFQqsXbtWiNFapoaGhrEzZs3RXZ2toiKihKOjo6ioKBAa19LS0uxf/9+jbYvvvhCODk5GSNUk6ZLnh8XFxcnevXqJa5du2aEKE1fR/NcU1Mj3NzcREpKitTGpVAdp8v9zDFQf7rkmWOg7m7fvi2cnJw0fr8+aynUizwOsrAwYWFhYWLAgAGitLT0mX39/PxEYGCgRltKSooAIBoaGp5XiN2CLnn29fUV4eHhGm179+4VNjY2oqWl5XmF2O0EBgaKd955R+s2lUoltm3bptH26aefCk9PTyNE1r20l+dWmzdvFvb29uLy5ctGiqr7eVqer169KgAIc3Nz6SWTyYRMJhPm5uaiuLi4C6I1Xe3dzxwDO097eeYYqLujR4+2+T0AQPo98Hgx3OpFHgf5jIUJEkJg+fLlOHr0KM6cOYOBAwc+cx8fHx8UFxdDrVZLbTdu3ICLiwusrKyeZ7gmS58819XVwcxM88fK3NxcOh51jFqtRkNDg9ZtXl5eSEtL02g7ffp0h58VoP/XXp4BYNOmTYiNjcXJkycxduxYI0bWvTwtzx4eHrh+/Tpyc3Ol16xZs/Daa68hNzcXKpWqC6I1Xe3dzxwDO097eeYYqLvAwMA2vwfGjh2L+fPnIzc3V8rf417ocbBr6xrSx3vvvSfs7e1FRkaGqKiokF51dXVSn7feektERUVJ72/fvi0UCoVYvny5KCoqEseOHRNOTk5i3bp1XXEJJkGfPEdHRwuFQiG+/vprUVpaKlJTU8XgwYPFnDlzuuISTEJUVJTIzMwUt27dEnl5eSIqKkrIZDKRmpoqhGib43PnzgkLCwuxZcsWUVhYKKKjo4WlpaW4fv16V12CSdA1z/Hx8cLKykocOXJE4/5/8OBBV12CSdA1z0/iUqiO0TXPHAP1o2ueOQZ2jieXQpnSOMjCwgQB0PpKSkqS+vj7+4sFCxZo7JeVlSUmTJgg5HK5GDRokFi/fr3WKTZ6RJ88NzU1iZiYGDF48GBhbW0tVCqVWLZsmaiurjZ6/Kbi7bffFq6ursLKykr07dtXBAYGSoOWENrv5UOHDomhQ4cKKysr8bOf/UwcP37cyFGbHl3z7OrqqvX+j46ONn7wJkSf+/lxLCw6Rp88cwzUna555hjYOZ4sLExpHJQJwbkpIiIiIiIyDJ+xICIiIiIig7GwICIiIiIig7GwICIiIiIig7GwICIiIiIig7GwICIiIiIig7GwICIiIiIig7GwICIiIiIig7GwICIiIiIig7GwICLqQl9++SUcHBza7RMTE4ORI0caJZ4nubm5Yfv27S/s8XSVkZEBmUyGe/fudVkM7YmJiYFSqYRMJsPf/vY3rW0LFy5EaGhoh45XVlYGmUyG3Nzc5xYzEVErFhZERAZauHAhZDKZ9OrTpw+Cg4ORl5f3zH3nzp2LGzduGCFK07Jo0SL8/ve/7/Tjent7o6KiAvb29p1+bEMVFhbis88+w65du1BRUYFp06Zpbfv888/x5ZdfduiYKpUKFRUVGDFiRKfG+njhQ0TUioUFEVEnCA4ORkVFBSoqKpCWlgYLCwvMmDGj3X2amppgY2MDJycnI0VpGlpaWnDs2DHMmjWr049tZWUFZ2dnyGSyp55brVZ3+nk7oqSkBAAQEhICZ2dnyOVyrW329vbPnOVqZW5uDmdnZ1hYWDyvsImIJCwsiIg6gVwuh7OzM5ydnTFy5EhERUWhvLwcP/zwA4D/X5Jy8OBB+Pv7w9raGvv27dO6FCo+Ph5KpRIKhQKLFy9GfX29xvbm5masWLECDg4O6NOnDyIjI7FgwQKN5TFqtRpxcXEYOHAgbGxs8Oqrr+LIkSPtXkNVVRVmzpwJGxsbDBw4EPv27WvT5969e1iyZAn69u0LOzs7TJo0CdeuXdPo8/e//x3jxo2DtbU1HB0dMXv27KeeMzExEQ4ODkhLS5PasrKyYGlpiXHjxuGXv/wlli9fLm1btWoVZDIZ/v3vfwMAGhsbYWtri3/84x8duu4nl0K15j85ORnDhw+HXC7H7du3tcZaUFCAGTNmwM7ODgqFAhMnTpT+4a9Wq7F27VoMGDAAcrkcI0eOxMmTJzX2Ly8vx5w5c+Dg4IDevXsjJCQEZWVlAB4td5o5cyYAwMzMDDKZTGsbgDZLodRqNTZt2oQhQ4ZALpfjpZdewvr16wFoXwqVn5+PadOmoWfPnlAqlXjrrbfw448/StsDAgKwYsUKREREoHfv3nB2dkZMTIy03c3NDQAwe/ZsyGQy6T0REQsLIqJOVltbi7/85S8YMmQI+vTpo7EtKioKK1euRGFhIYKCgtrse+jQIcTExGDDhg3Izs6Gi4sLduzYodFn48aN2LdvH5KSknDu3DnU1NS0WZYSFxeHr776Cn/6059QUFCA1atX49e//jUyMzOfGvfChQtRXl6O9PR0HDlyBDt27EBVVZVGn1/96leoqqrCiRMnkJOTg9GjRyMwMBB3794FABw/fhyzZ8/G9OnTcfXqVaSlpWH8+PFaz7dp0yZERUUhNTUVgYGBUntycjJmzpwJmUwGf39/ZGRkSNsyMzPh6OgotV2+fBlNTU3w9vbW+7rr6uqwceNGJCYmoqCgQOsM0nfffQc/Pz/I5XKcOXMGOTk5ePvtt9Hc3AwA+Pzzz7F161Zs2bIFeXl5CAoKwqxZs3Dz5k0Aj2angoKCoFAocPbsWZw7dw49e/ZEcHAwGhsbER4ejqSkJACQZr60tWnz0UcfIT4+HmvWrMG3336L/fv3Q6lUau177949TJo0CaNGjUJ2djZOnjyJ77//HnPmzNHot2fPHtja2uLixYvYtGkT1q5di9OnT0s5B4CkpCRUVFRI74mIIIiIyCALFiwQ5ubmwtbWVtja2goAwsXFReTk5Eh9bt26JQCI7du3a+yblJQk7O3tpfdeXl5i2bJlGn0mTJggXn31Vem9UqkUmzdvlt43NzeLl156SYSEhAghhKivrxc9evQQWVlZGsdZvHixmDdvntZrKCoqEgDEpUuXpLbCwkIBQGzbtk0IIcTZs2eFnZ2dqK+v19h38ODBYteuXVL88+fP13oOIYRwdXUV27ZtExEREcLFxUXk5+e36ePu7i6OHTsmhBAiLy9PyGQyUVVVJe7evSusrKxEbGysmDt3rhBCiHXr1glvb+8OX3d6eroAIKqrq4UQj/IPQOTm5j41ZiGE+Oijj8TAgQNFY2Oj1u39+vUT69ev12gbN26c9He5d+9eMWzYMKFWq6XtDQ0NwsbGRpw6dUoIIcTRo0fFk8OytrYFCxZIf9c1NTVCLpeLhIQErXG13ndXr14VQggRGxsrpk6dqtGnvLxcABBFRUVCCCH8/f2Fr69vm2uJjIyU3gMQR48e1XpOIvrfxUWXRESd4LXXXsPOnTsBANXV1dixYwemTZuGS5cuwdXVVeo3duzYdo9TWFiIpUuXarR5eXkhPT0dAHD//n18//33GrMA5ubmGDNmjPRsQHFxMerq6jBlyhSN4zQ2NmLUqFFPPa+FhQXGjBkjtXl4eGgs07p27Rpqa2vbzML89NNP0pKg3Nxc/Pa3v233Grdu3YqHDx8iOzsbgwYNahPHnTt3pBmMESNGoHfv3sjMzISVlRVGjRqFGTNm4IsvvgDwaAYjICBA7+sGHj134enp2W7Mubm5mDhxIiwtLdtsq6mpwZ07d+Dj46PR7uPjIy0Tu3btGoqLi6FQKDT61NfXS7nTR2FhIRoaGjRmfNpz7do1pKeno2fPnm22lZSUYOjQoQDQJh8uLi5tZq+IiJ7EwoKIqBPY2tpiyJAh0vvExETY29sjISEB69at0+j3vNXW1gJ4tCypf//+GtvkcrlBx3VxcdFYmtSqtQCxsbF55nEmTpyI48eP49ChQ4iKitLYlpycjClTpsDa2hrAo28f8vPzQ0ZGBuRyOQICAuDp6YmGhgbk5+cjKysL4eHhUnyA7tdtY2Pz1Ie5H+9jiNraWowZM0brcyt9+/bV+7i6xlVbW4uZM2di48aNbba5uLhIf36ygJLJZF32UDsRmQ4+Y0FE9BzIZDKYmZnhp59+0mm/l19+GRcvXtRou3DhgvRne3t7KJVKjXXtLS0tuHLlivT+8YeQhwwZovFSqVRaz+vh4YHm5mbk5ORIbUVFRRr/38Po0aNRWVkJCwuLNsd1dHQE8OiT7scfxNZm/PjxOHHiBDZs2IAtW7ZobPvmm28QEhKi0db6nEVGRgYCAgJgZmYGPz8/bN68GQ0NDdJMgT7X3VGenp44e/Ysmpqa2myzs7NDv379cO7cOY32c+fOYfjw4QAe5e7mzZtwcnJqE5shX33r7u4OGxubZ+a81ejRo1FQUAA3N7c2cehS9FpaWqKlpUXfsImom2JhQUTUCRoaGlBZWYnKykoUFhbi/ffflz4d1sXKlSvx5z//GUlJSbhx4waio6NRUFCg0ef9999HXFwcvvnmGxQVFWHlypWorq6WPnVXKBQIDw/H6tWrsWfPHpSUlODKlSv4wx/+gD179mg977BhwxAcHIx3330XFy9eRE5ODpYsWaLxifjkyZPh5eWF0NBQpKamoqysDFlZWfjkk0+QnZ0NAIiOjsbXX3+N6OhoFBYW4vr161o/Hff29kZKSgo+++wz6T/Mq6qqQnZ2dpuv6Q0ICMC3336LgoIC+Pr6Sm379u3D2LFjpX8Q63PdHbV8+XLU1NTgjTfeQHZ2Nm7evIm9e/eiqKgIAPDhhx9i48aNOHjwIIqKihAVFYXc3FysXLkSADB//nw4OjoiJCQEZ8+exa1bt5CRkYEVK1bgv//9r95xWVtbIzIyEhEREfjqq69QUlKCCxcuYPfu3Vr7h4WF4e7du5g3bx4uX76MkpISnDp1CosWLdKpUHBzc0NaWhoqKytRXV2td/xE1L1wKRQRUSc4efKktJREoVDAw8MDhw8fltb/d9TcuXNRUlKCiIgI1NfX4xe/+AXee+89nDp1SuoTGRmJyspK/OY3v4G5uTneeecdBAUFwdzcXOoTGxuLvn37Ii4uDqWlpXBwcMDo0aPx8ccfP/XcSUlJWLJkCfz9/aFUKrFu3TqsWbNG2i6TyZCSkoJPPvkEixYtwg8//ABnZ2f4+flJ30IUEBCAw4cPIzY2FvHx8bCzs4Ofn5/W8/n6+uL48eOYPn06zM3N0aNHD4wfP16a/Wj1yiuvwMHBAUOHDpWeDQgICEBLS0ub/Opz3R3Rp08fnDlzBh9++CH8/f1hbm6OkSNHSrMlK1aswP379/G73/0OVVVVGD58OJKTk+Hu7g4A6NGjB/75z38iMjISP//5z/HgwQP0798fgYGBsLOzMyi2NWvWwMLCAp9++inu3LkDFxeXNs/ptGqdWYmMjMTUqVPR0NAAV1dXBAcHw8ys4581bt26FR988AESEhLQv39/6Wtzieh/m0wIIbo6CCIi0p9arcbLL7+MOXPmIDY2tqvD0dusWbPg6+uLiIiIrg6FiIj0wBkLIiIT85///Aepqanw9/dHQ0MD/vjHP+LWrVt48803uzo0g/j6+mLevHldHQYREemJMxZERCamvLwcb7zxBvLz8yGEwIgRIxAfH//UJUdERETGwMKCiIiIiIgMxm+FIiIiIiIig7GwICIiIiIig7GwICIiIiIig7GwICIiIiIig7GwICIiIiIig7GwICIiIiIig7GwICIiIiIig7GwICIiIiIig7GwICIiIiIig/0fZF3Z7GObQ9YAAAAASUVORK5CYII=",
+      "text/plain": [
+       "<Figure size 800x500 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "fig, ax = plt.subplots(figsize=(8, 5))\n",
+    "ax.plot(\n",
+    "    weir_df[\"Weir Coefficient\"],\n",
+    "    weir_df[\"Max WSE At Bridge (ft)\"],\n",
+    "    marker=\"o\",\n",
+    "    linewidth=2,\n",
+    "    color=\"tab:blue\",\n",
+    ")\n",
+    "ax.set_xlabel(\"Bridge deck/weir coefficient\")\n",
+    "ax.set_ylabel(\"Maximum WSE at bridge upstream face (ft)\")\n",
+    "ax.set_title(\"Pressure/Weir Coefficient Sensitivity\")\n",
+    "ax.grid(True, alpha=0.25)\n",
+    "fig.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c3819830",
+   "metadata": {},
+   "source": [
+    "## Summary"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "4ac6d1a3",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-01T18:30:43.097195Z",
+     "iopub.status.busy": "2026-05-01T18:30:43.097027Z",
+     "iopub.status.idle": "2026-05-01T18:30:43.110344Z",
+     "shell.execute_reply": "2026-05-01T18:30:43.109675Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Low-flow method WSE differences in plotted bridge window:\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>Scenario</th>\n",
+       "      <th>Min Delta vs Baseline (ft)</th>\n",
+       "      <th>Max Delta vs Baseline (ft)</th>\n",
+       "      <th>Max Abs Delta (ft)</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>Energy</td>\n",
+       "      <td>0.000</td>\n",
+       "      <td>0.000</td>\n",
+       "      <td>0.000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>Momentum</td>\n",
+       "      <td>0.000</td>\n",
+       "      <td>0.000</td>\n",
+       "      <td>0.000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>Yarnell</td>\n",
+       "      <td>-0.602</td>\n",
+       "      <td>0.009</td>\n",
+       "      <td>0.602</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   Scenario  Min Delta vs Baseline (ft)  Max Delta vs Baseline (ft)  \\\n",
+       "0    Energy                       0.000                       0.000   \n",
+       "1  Momentum                       0.000                       0.000   \n",
+       "2   Yarnell                      -0.602                       0.009   \n",
+       "\n",
+       "   Max Abs Delta (ft)  \n",
+       "0               0.000  \n",
+       "1               0.000  \n",
+       "2               0.602  "
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Weir coefficient sweep WSE range at bridge: 0.102 ft\n"
+     ]
+    }
+   ],
+   "source": [
+    "method_summary = []\n",
+    "base_profile = profile_df[profile_df[\"Scenario\"] == \"Baseline\"][[\"StationNum\", \"WSE\"]].rename(columns={\"WSE\": \"Baseline WSE\"})\n",
+    "for label in [\"Energy\", \"Momentum\", \"Yarnell\"]:\n",
+    "    scenario = profile_df[profile_df[\"Scenario\"] == label][[\"StationNum\", \"WSE\"]]\n",
+    "    joined = scenario.merge(base_profile, on=\"StationNum\")\n",
+    "    diff = joined[\"WSE\"] - joined[\"Baseline WSE\"]\n",
+    "    method_summary.append({\n",
+    "        \"Scenario\": label,\n",
+    "        \"Min Delta vs Baseline (ft)\": float(diff.min()),\n",
+    "        \"Max Delta vs Baseline (ft)\": float(diff.max()),\n",
+    "        \"Max Abs Delta (ft)\": float(diff.abs().max()),\n",
+    "    })\n",
+    "\n",
+    "summary_df = pd.DataFrame(method_summary)\n",
+    "weir_delta = float(\n",
+    "    weir_df[\"Max WSE At Bridge (ft)\"].max() - weir_df[\"Max WSE At Bridge (ft)\"].min()\n",
+    ")\n",
+    "\n",
+    "print(\"Low-flow method WSE differences in plotted bridge window:\")\n",
+    "display(summary_df.round(3))\n",
+    "print(f\"Weir coefficient sweep WSE range at bridge: {weir_delta:.3f} ft\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/ras_commander/geom/GeomBridge.py
+++ b/ras_commander/geom/GeomBridge.py
@@ -321,6 +321,14 @@ class GeomBridge:
         return struct_end_idx
 
     @staticmethod
+    def _find_bridge_deck_line(lines: List[str], bridge_idx: int, struct_end_idx: int) -> Optional[int]:
+        """Find the data line following the bridge Deck Dist Width WeirC header."""
+        for i in range(bridge_idx + 1, struct_end_idx - 1):
+            if lines[i].startswith("Deck Dist Width WeirC"):
+                return i + 1
+        return None
+
+    @staticmethod
     def _parse_wspro_fields(fields: List[str]) -> Dict[str, Any]:
         wspro = {}
         for idx, name in GeomBridge.WSPRO_FIELD_NAMES.items():
@@ -368,6 +376,18 @@ class GeomBridge:
             'use_high_standard_step': high_standard_step,
             'enabled_low_flow_methods': enabled,
             'coefficients': coefficients,
+        }
+
+    @staticmethod
+    def _parse_bridge_deck_fields(fields: List[str]) -> Dict[str, Any]:
+        """Parse common bridge deck fields from the Deck Dist Width WeirC record."""
+        return {
+            'deck_distance': GeomBridge._parse_float_field(fields[0]) if len(fields) > 0 else None,
+            'deck_width': GeomBridge._parse_float_field(fields[1]) if len(fields) > 1 else None,
+            'weir_coefficient': GeomBridge._parse_float_field(fields[2]) if len(fields) > 2 else None,
+            'skew': GeomBridge._parse_float_field(fields[3]) if len(fields) > 3 else None,
+            'max_submergence': GeomBridge._parse_float_field(fields[8]) if len(fields) > 8 else None,
+            'is_ogee': GeomBridge._parse_bool_field(fields[9]) if len(fields) > 9 else None,
         }
 
     @staticmethod
@@ -1201,10 +1221,11 @@ class GeomBridge:
         """
         Read bridge hydraulic method selections from geometry text records.
 
-        This parser reads the bridge ``Bridge Culvert-`` marker plus the selected
-        opening's ``BR Coef=`` and ``WSPro=`` records. The ``BR Coef=`` record
-        stores the selected low-flow method code and high-flow method flag used
-        by the Bridge Modeling Approach editor.
+        This parser reads the bridge ``Bridge Culvert-`` marker, deck/weir
+        coefficient record, and the selected opening's ``BR Coef=`` and
+        ``WSPro=`` records. The ``BR Coef=`` record stores the selected
+        low-flow method code and high-flow method flag used by the Bridge
+        Modeling Approach editor.
 
         Parameters:
             geom_file: Path to geometry file (.g##)
@@ -1220,7 +1241,9 @@ class GeomBridge:
               ``wspro`` or None if no method code is present
             - high_flow_method: ``energy`` or ``pressure_weir`` when available
             - enabled_low_flow_methods: per-method compute flags from BR Coef
-            - coefficients: Momentum, Yarnell, pressure-flow, and audit values
+            - coefficients: Momentum, Yarnell, pressure-flow, deck/weir, and
+              audit values
+            - deck: parsed values from the ``Deck Dist Width WeirC`` record
             - wspro: named WSPRO fields, or None if no WSPro record exists
             - raw: original method records and comma fields for audit
 
@@ -1283,6 +1306,16 @@ class GeomBridge:
             bridge_culvert_fields = GeomBridge._split_comma_fields_from_line(
                 lines[bridge_idx], "Bridge Culvert-"
             )
+            deck_idx = GeomBridge._find_bridge_deck_line(lines, bridge_idx, struct_end_idx)
+            deck_fields = None
+            deck = None
+            if deck_idx is not None:
+                deck_body, _ = GeomBridge._split_line_ending(lines[deck_idx])
+                deck_fields = deck_body.split(',')
+                deck = GeomBridge._parse_bridge_deck_fields(deck_fields)
+                parsed['coefficients']['weir_coefficient'] = deck['weir_coefficient']
+            else:
+                parsed['coefficients']['weir_coefficient'] = None
 
             result = {
                 'river': river,
@@ -1295,6 +1328,7 @@ class GeomBridge:
                 'use_high_standard_step': parsed['use_high_standard_step'],
                 'enabled_low_flow_methods': parsed['enabled_low_flow_methods'],
                 'coefficients': parsed['coefficients'],
+                'deck': deck,
                 'wspro': wspro,
                 'raw': {
                     'bridge_culvert_line': lines[bridge_idx].rstrip('\r\n'),
@@ -1302,6 +1336,11 @@ class GeomBridge:
                     'bridge_culvert_flags': GeomBridge._parse_bridge_header(lines[bridge_idx]),
                     'br_coef_line': lines[br_coef_idx].rstrip('\r\n'),
                     'br_coef_fields': [field.strip() for field in br_coef_fields],
+                    'deck_line': lines[deck_idx].rstrip('\r\n') if deck_idx is not None else None,
+                    'deck_fields': (
+                        [field.strip() for field in deck_fields]
+                        if deck_fields is not None else None
+                    ),
                     'wspro_line': lines[wspro_idx].rstrip('\r\n') if wspro_idx is not None else None,
                     'wspro_fields': (
                         [field.strip() for field in wspro_fields]
@@ -1340,6 +1379,7 @@ class GeomBridge:
                               yarnell_k: Optional[float] = None,
                               pressure_flow_submerged_inlet_cd: Optional[float] = None,
                               pressure_flow_submerged_inlet_outlet_cd: Optional[float] = None,
+                              weir_coefficient: Optional[float] = None,
                               opening_index: int = 0,
                               create_backup: bool = True,
                               validate: bool = True) -> Dict[str, Any]:
@@ -1348,9 +1388,10 @@ class GeomBridge:
 
         Accepted ``low_flow_method`` values are ``energy``, ``momentum``,
         ``yarnell``, and ``wspro``. Accepted ``high_flow_method`` values are
-        ``energy`` and ``pressure_weir``. Existing comma-field spacing is
-        preserved for updated ``BR Coef=`` fields, and a ``.bak`` backup is
-        created by default before writing.
+        ``energy`` and ``pressure_weir``. Momentum and Yarnell selections
+        require an existing or supplied coefficient. Existing comma-field
+        spacing is preserved for updated ``BR Coef=`` and deck/weir fields,
+        and a ``.bak`` backup is created by default before writing.
 
         Parameters:
             geom_file: Path to geometry file (.g##)
@@ -1367,6 +1408,8 @@ class GeomBridge:
             yarnell_k: Optional Yarnell pier coefficient
             pressure_flow_submerged_inlet_cd: Optional pressure-flow Cd
             pressure_flow_submerged_inlet_outlet_cd: Optional pressure-flow Cd
+            weir_coefficient: Optional bridge deck/weir coefficient from the
+                ``Deck Dist Width WeirC`` record
             opening_index: Zero-based bridge opening/coefficient record index
             create_backup: Create ``.bak`` backup before writing (default True)
             validate: Validate method names and unsupported combinations
@@ -1415,8 +1458,12 @@ class GeomBridge:
             yarnell_k,
             pressure_flow_submerged_inlet_cd,
             pressure_flow_submerged_inlet_outlet_cd,
+            weir_coefficient,
         ]):
             raise ValueError("At least one hydraulic method or coefficient must be specified")
+
+        if validate and weir_coefficient is not None and float(weir_coefficient) <= 0:
+            raise ValueError("weir_coefficient must be positive")
 
         backup_path = None
         try:
@@ -1433,6 +1480,11 @@ class GeomBridge:
             )
             br_coef_idx = method_lines['br_coef_idx']
             wspro_idx = method_lines['wspro_idx']
+            deck_idx = GeomBridge._find_bridge_deck_line(lines, bridge_idx, struct_end_idx)
+            if weir_coefficient is not None and deck_idx is None:
+                raise ValueError(
+                    f"Deck Dist Width WeirC record not found for bridge {river}/{reach}/RS {rs}"
+                )
 
             if br_coef_idx is None and method_lines['br_coef_count'] > 0:
                 raise ValueError(
@@ -1466,6 +1518,31 @@ class GeomBridge:
             before = None if inserted_br_coef else GeomBridge.get_hydraulic_methods(
                 geom_file, river, reach, rs, opening_index=opening_index
             )
+
+            if validate and normalized_low == 'momentum':
+                effective_momentum_cd = (
+                    momentum_cd
+                    if momentum_cd is not None
+                    else current['coefficients']['momentum_cd']
+                )
+                if effective_momentum_cd is None:
+                    raise ValueError(
+                        "low_flow_method 'momentum' requires momentum_cd when no "
+                        "existing momentum Cd is set"
+                    )
+
+            if validate and normalized_low == 'yarnell':
+                effective_yarnell_k = (
+                    yarnell_k
+                    if yarnell_k is not None
+                    else current['coefficients']['yarnell_k']
+                )
+                if effective_yarnell_k is None:
+                    raise ValueError(
+                        "low_flow_method 'yarnell' requires yarnell_k when no "
+                        "existing Yarnell K is set"
+                    )
+
             explicit_enabled = {
                 'energy': use_energy,
                 'momentum': use_momentum,
@@ -1552,6 +1629,17 @@ class GeomBridge:
                 "BR Coef=", br_coef_fields, line_ending
             )
             after_line = lines[br_coef_idx].rstrip('\r\n')
+            deck_line_before = None
+            deck_line_after = None
+
+            if weir_coefficient is not None and deck_idx is not None:
+                deck_body, deck_line_ending = GeomBridge._split_line_ending(lines[deck_idx])
+                deck_line_ending = deck_line_ending or '\n'
+                deck_fields = deck_body.split(',')
+                deck_line_before = lines[deck_idx].rstrip('\r\n')
+                GeomBridge._set_comma_field(deck_fields, 2, float(weir_coefficient))
+                lines[deck_idx] = f"{','.join(deck_fields)}{deck_line_ending}"
+                deck_line_after = lines[deck_idx].rstrip('\r\n')
 
             if create_backup:
                 backup_path = GeomParser.create_backup(geom_file)
@@ -1574,6 +1662,8 @@ class GeomBridge:
                 'inserted_br_coef': inserted_br_coef,
                 'br_coef_before': before_line,
                 'br_coef_after': after_line,
+                'deck_line_before': deck_line_before,
+                'deck_line_after': deck_line_after,
                 'backup_path': str(backup_path) if backup_path else None,
                 'before': before,
                 'after': after,

--- a/ras_commander/geom/GeomBridge.py
+++ b/ras_commander/geom/GeomBridge.py
@@ -13,6 +13,8 @@ List of Functions:
 - get_abutment() - Read abutment geometry
 - get_approach_sections() - Read BR U/BR D approach sections
 - get_coefficients() - Read hydraulic coefficients
+- get_hydraulic_methods() - Read bridge low-flow/high-flow method selections
+- set_hydraulic_methods() - Set bridge low-flow/high-flow method selections
 - get_htab() - Read hydraulic table parameters (returns DataFrame)
 - get_htab_dict() - Read hydraulic table parameters (returns dict with invert)
 
@@ -58,6 +60,57 @@ class GeomBridge:
     VALUES_PER_LINE = 10
     DEFAULT_SEARCH_RANGE = 100
     MAX_PARSE_LINES = 200
+
+    LOW_FLOW_METHOD_CODES = {
+        'energy': 0,
+        'momentum': 1,
+        'yarnell': 2,
+        'wspro': 3,
+    }
+    LOW_FLOW_METHOD_NAMES = {value: key for key, value in LOW_FLOW_METHOD_CODES.items()}
+    HIGH_FLOW_METHODS = {'energy', 'pressure_weir'}
+
+    BR_COEF_FIELD_NAMES = {
+        0: 'use_energy',
+        1: 'use_momentum',
+        2: 'use_yarnell',
+        3: 'yarnell_k',
+        4: 'use_wspro',
+        6: 'submerged_inlet_cd',
+        7: 'submerged_inlet_outlet_cd',
+        8: 'use_high_standard_step',
+        9: 'momentum_cd',
+        10: 'low_flow_method_code',
+        11: 'low_chord_weir_check',
+    }
+
+    WSPRO_FIELD_NAMES = {
+        0: 'left_top_elevation',
+        1: 'right_top_elevation',
+        2: 'left_toe_elevation',
+        3: 'right_toe_elevation',
+        4: 'abutment_type',
+        5: 'abutment_slope',
+        6: 'bridge_opening_width',
+        7: 'centroid_station',
+        8: 'wing_wall_type',
+        9: 'wing_wall_width',
+        10: 'wing_wall_angle',
+        11: 'wing_wall_radius',
+        12: 'guide_bank_type',
+        13: 'guide_bank_length',
+        14: 'guide_bank_offset',
+        15: 'guide_bank_angle',
+        16: 'piers_continuous',
+        17: 'friction_slope_geometric_mean',
+        18: 'use_tables',
+        19: 'use_ce_approach',
+        20: 'use_ce_guide_banks',
+        21: 'use_ce_upstream_xs',
+        22: 'use_ce_upstream_bridge',
+        23: 'use_ce_downstream_bridge',
+    }
+    WSPRO_BOOLEAN_FIELDS = set(range(16, 24))
 
     @staticmethod
     def _find_bridge(lines: List[str], river: str, reach: str, rs: str) -> Optional[int]:
@@ -126,6 +179,226 @@ class GeomBridge:
                 flags[name] = None
 
         return flags
+
+    @staticmethod
+    def _split_line_ending(line: str) -> tuple:
+        """Split a text line into body and original line ending."""
+        if line.endswith('\r\n'):
+            return line[:-2], '\r\n'
+        if line.endswith('\n'):
+            return line[:-1], '\n'
+        if line.endswith('\r'):
+            return line[:-1], '\r'
+        return line, ''
+
+    @staticmethod
+    def _split_comma_fields_from_line(line: str, prefix: str) -> List[str]:
+        """Return comma fields after a HEC-RAS keyword while preserving field padding."""
+        body, _ = GeomBridge._split_line_ending(line)
+        return body[len(prefix):].split(',')
+
+    @staticmethod
+    def _parse_float_field(field: str) -> Optional[float]:
+        stripped = field.strip()
+        if not stripped:
+            return None
+        try:
+            return float(stripped)
+        except ValueError:
+            return None
+
+    @staticmethod
+    def _parse_int_field(field: str) -> Optional[int]:
+        value = GeomBridge._parse_float_field(field)
+        if value is None:
+            return None
+        return int(value)
+
+    @staticmethod
+    def _parse_bool_field(field: str) -> Optional[bool]:
+        value = GeomBridge._parse_float_field(field)
+        if value is None:
+            return None
+        return value != 0
+
+    @staticmethod
+    def _format_scalar_field(value: Any) -> str:
+        if isinstance(value, bool):
+            return '-1' if value else '0'
+        if isinstance(value, int):
+            return str(value)
+        if isinstance(value, float):
+            return f"{value:g}"
+        return str(value)
+
+    @staticmethod
+    def _format_bool_field(value: bool, existing_field: str = '') -> str:
+        if value:
+            existing = existing_field.strip()
+            if existing and existing not in {'0', '0.0'}:
+                return existing
+            return '-1'
+        return '0'
+
+    @staticmethod
+    def _set_comma_field(fields: List[str], index: int, value: Any) -> None:
+        """Set one comma field, preserving its surrounding whitespace when present."""
+        while len(fields) <= index:
+            fields.append('')
+
+        old_field = fields[index]
+        new_value = GeomBridge._format_scalar_field(value)
+        if old_field.strip():
+            leading_count = len(old_field) - len(old_field.lstrip())
+            trailing_count = len(old_field) - len(old_field.rstrip())
+            leading = old_field[:leading_count]
+            trailing = old_field[len(old_field) - trailing_count:] if trailing_count else ''
+            fields[index] = f"{leading}{new_value}{trailing}"
+        else:
+            fields[index] = new_value
+
+    @staticmethod
+    def _default_br_coef_fields() -> List[str]:
+        """Return a conservative default BR Coef field list for structures missing the line."""
+        return ['-1 ', ' 0 ', ' 0 ', '', ' 0 ', '', '', '0.8', '0', '', '0', '']
+
+    @staticmethod
+    def _format_comma_line(prefix: str, fields: List[str], line_ending: str = '\n') -> str:
+        return f"{prefix}{','.join(fields)}{line_ending}"
+
+    @staticmethod
+    def _find_bridge_method_lines(
+        lines: List[str],
+        bridge_idx: int,
+        struct_end_idx: int,
+        opening_index: int = 0
+    ) -> Dict[str, Optional[int]]:
+        """Find BR Coef and matching WSPro records for one bridge opening."""
+        if opening_index < 0:
+            raise ValueError("opening_index must be >= 0")
+
+        br_coef_indices = []
+        wspro_indices = []
+
+        for i in range(bridge_idx, struct_end_idx):
+            line = lines[i]
+            if line.startswith("BR Coef="):
+                br_coef_indices.append(i)
+            elif line.startswith("WSPro="):
+                wspro_indices.append(i)
+
+        br_coef_idx = br_coef_indices[opening_index] if opening_index < len(br_coef_indices) else None
+        wspro_idx = None
+
+        if br_coef_idx is not None:
+            next_br_coef_idx = (
+                br_coef_indices[opening_index + 1]
+                if opening_index + 1 < len(br_coef_indices)
+                else struct_end_idx
+            )
+            for idx in wspro_indices:
+                if br_coef_idx < idx < next_br_coef_idx:
+                    wspro_idx = idx
+                    break
+        elif opening_index < len(wspro_indices):
+            wspro_idx = wspro_indices[opening_index]
+
+        return {
+            'br_coef_idx': br_coef_idx,
+            'wspro_idx': wspro_idx,
+            'br_coef_count': len(br_coef_indices),
+            'wspro_count': len(wspro_indices),
+        }
+
+    @staticmethod
+    def _find_br_coef_insert_idx(lines: List[str], bridge_idx: int, struct_end_idx: int) -> int:
+        """Choose a stable insertion point for a missing BR Coef record."""
+        for i in range(bridge_idx + 1, struct_end_idx):
+            if (lines[i].startswith("WSPro=") or
+                    lines[i].startswith("BC Design=") or
+                    lines[i].startswith("BC HTab")):
+                return i
+        return struct_end_idx
+
+    @staticmethod
+    def _parse_wspro_fields(fields: List[str]) -> Dict[str, Any]:
+        wspro = {}
+        for idx, name in GeomBridge.WSPRO_FIELD_NAMES.items():
+            if idx >= len(fields):
+                wspro[name] = None
+                continue
+            if idx in GeomBridge.WSPRO_BOOLEAN_FIELDS:
+                wspro[name] = GeomBridge._parse_bool_field(fields[idx])
+            else:
+                value = GeomBridge._parse_float_field(fields[idx])
+                wspro[name] = value if value is not None else None
+        return wspro
+
+    @staticmethod
+    def _parse_br_coef_fields(fields: List[str]) -> Dict[str, Any]:
+        method_code = GeomBridge._parse_int_field(fields[10]) if len(fields) > 10 else None
+        high_standard_step = (
+            GeomBridge._parse_bool_field(fields[8]) if len(fields) > 8 else None
+        )
+
+        coefficients = {
+            'momentum_cd': GeomBridge._parse_float_field(fields[9]) if len(fields) > 9 else None,
+            'yarnell_k': GeomBridge._parse_float_field(fields[3]) if len(fields) > 3 else None,
+            'submerged_inlet_cd': GeomBridge._parse_float_field(fields[6]) if len(fields) > 6 else None,
+            'submerged_inlet_outlet_cd': (
+                GeomBridge._parse_float_field(fields[7]) if len(fields) > 7 else None
+            ),
+            'low_chord_weir_check': GeomBridge._parse_float_field(fields[11]) if len(fields) > 11 else None,
+        }
+
+        enabled = {
+            'energy': GeomBridge._parse_bool_field(fields[0]) if len(fields) > 0 else None,
+            'momentum': GeomBridge._parse_bool_field(fields[1]) if len(fields) > 1 else None,
+            'yarnell': GeomBridge._parse_bool_field(fields[2]) if len(fields) > 2 else None,
+            'wspro': GeomBridge._parse_bool_field(fields[4]) if len(fields) > 4 else None,
+        }
+
+        return {
+            'low_flow_method_code': method_code,
+            'low_flow_method': GeomBridge.LOW_FLOW_METHOD_NAMES.get(method_code),
+            'high_flow_method': (
+                'energy' if high_standard_step else 'pressure_weir'
+                if high_standard_step is not None else None
+            ),
+            'use_high_standard_step': high_standard_step,
+            'enabled_low_flow_methods': enabled,
+            'coefficients': coefficients,
+        }
+
+    @staticmethod
+    def _normalize_hydraulic_method(method: Optional[str], accepted: set, field_name: str) -> Optional[str]:
+        if method is None:
+            return None
+        normalized = method.strip().lower().replace('-', '_').replace(' ', '_')
+        if normalized not in accepted:
+            accepted_values = ', '.join(sorted(accepted))
+            raise ValueError(f"{field_name} must be one of: {accepted_values}")
+        return normalized
+
+    @staticmethod
+    def _validate_hydraulic_method_selection(
+        low_flow_method: Optional[str],
+        high_flow_method: Optional[str],
+        enabled: Dict[str, Optional[bool]],
+        wspro_idx: Optional[int],
+        require_selected_enabled: bool = True,
+    ) -> None:
+        if (require_selected_enabled and
+                low_flow_method is not None and
+                enabled.get(low_flow_method) is False):
+            raise ValueError(
+                f"selected low_flow_method '{low_flow_method}' cannot be disabled"
+            )
+        if low_flow_method == 'wspro' and wspro_idx is None:
+            raise ValueError("low_flow_method 'wspro' requires an existing WSPro= record")
+        if high_flow_method is not None and high_flow_method not in GeomBridge.HIGH_FLOW_METHODS:
+            accepted_values = ', '.join(sorted(GeomBridge.HIGH_FLOW_METHODS))
+            raise ValueError(f"high_flow_method must be one of: {accepted_values}")
 
     @staticmethod
     @log_call
@@ -917,6 +1190,412 @@ class GeomBridge:
         except Exception as e:
             logger.error(f"Error reading bridge coefficients: {str(e)}")
             raise IOError(f"Failed to read bridge coefficients: {str(e)}")
+
+    @staticmethod
+    @log_call
+    def get_hydraulic_methods(geom_file: Union[str, Path],
+                              river: str,
+                              reach: str,
+                              rs: str,
+                              opening_index: int = 0) -> Dict[str, Any]:
+        """
+        Read bridge hydraulic method selections from geometry text records.
+
+        This parser reads the bridge ``Bridge Culvert-`` marker plus the selected
+        opening's ``BR Coef=`` and ``WSPro=`` records. The ``BR Coef=`` record
+        stores the selected low-flow method code and high-flow method flag used
+        by the Bridge Modeling Approach editor.
+
+        Parameters:
+            geom_file: Path to geometry file (.g##)
+            river: River name (case-sensitive)
+            reach: Reach name (case-sensitive)
+            rs: River station (as string)
+            opening_index: Zero-based bridge opening/coefficient record index
+                when a bridge has multiple ``BR Coef=`` records (default 0)
+
+        Returns:
+            dict with keys:
+            - low_flow_method: one of ``energy``, ``momentum``, ``yarnell``,
+              ``wspro`` or None if no method code is present
+            - high_flow_method: ``energy`` or ``pressure_weir`` when available
+            - enabled_low_flow_methods: per-method compute flags from BR Coef
+            - coefficients: Momentum, Yarnell, pressure-flow, and audit values
+            - wspro: named WSPRO fields, or None if no WSPro record exists
+            - raw: original method records and comma fields for audit
+
+        Raises:
+            FileNotFoundError: If geometry file doesn't exist
+            ValueError: If bridge or opening is not found
+            IOError: If file read fails
+
+        Example:
+            >>> methods = GeomBridge.get_hydraulic_methods(
+            ...     "model.g01", "Beaver Creek", "Kentwood", "5.4"
+            ... )
+            >>> methods["low_flow_method"]
+            'momentum'
+        """
+        geom_file = Path(geom_file)
+
+        if not geom_file.exists():
+            raise FileNotFoundError(f"Geometry file not found: {geom_file}")
+
+        try:
+            with open(geom_file, 'r', encoding='utf-8', errors='replace') as f:
+                lines = f.readlines()
+
+            bridge_idx = GeomBridge._find_bridge(lines, river, reach, rs)
+            if bridge_idx is None:
+                raise ValueError(f"Bridge not found: {river}/{reach}/RS {rs}")
+
+            struct_end_idx = GeomBridge._find_structure_end(lines, bridge_idx)
+            method_lines = GeomBridge._find_bridge_method_lines(
+                lines, bridge_idx, struct_end_idx, opening_index
+            )
+
+            br_coef_idx = method_lines['br_coef_idx']
+            wspro_idx = method_lines['wspro_idx']
+
+            if br_coef_idx is None:
+                if method_lines['br_coef_count'] == 0:
+                    raise ValueError(
+                        f"BR Coef= record not found for bridge {river}/{reach}/RS {rs}"
+                    )
+                raise ValueError(
+                    f"BR Coef= opening_index {opening_index} not found for "
+                    f"{river}/{reach}/RS {rs}; found {method_lines['br_coef_count']}"
+                )
+
+            br_coef_fields = GeomBridge._split_comma_fields_from_line(
+                lines[br_coef_idx], "BR Coef="
+            )
+            parsed = GeomBridge._parse_br_coef_fields(br_coef_fields)
+
+            wspro_fields = None
+            wspro = None
+            if wspro_idx is not None:
+                wspro_fields = GeomBridge._split_comma_fields_from_line(
+                    lines[wspro_idx], "WSPro="
+                )
+                wspro = GeomBridge._parse_wspro_fields(wspro_fields)
+
+            bridge_culvert_fields = GeomBridge._split_comma_fields_from_line(
+                lines[bridge_idx], "Bridge Culvert-"
+            )
+
+            result = {
+                'river': river,
+                'reach': reach,
+                'rs': str(rs),
+                'opening_index': opening_index,
+                'low_flow_method': parsed['low_flow_method'],
+                'low_flow_method_code': parsed['low_flow_method_code'],
+                'high_flow_method': parsed['high_flow_method'],
+                'use_high_standard_step': parsed['use_high_standard_step'],
+                'enabled_low_flow_methods': parsed['enabled_low_flow_methods'],
+                'coefficients': parsed['coefficients'],
+                'wspro': wspro,
+                'raw': {
+                    'bridge_culvert_line': lines[bridge_idx].rstrip('\r\n'),
+                    'bridge_culvert_fields': [field.strip() for field in bridge_culvert_fields],
+                    'bridge_culvert_flags': GeomBridge._parse_bridge_header(lines[bridge_idx]),
+                    'br_coef_line': lines[br_coef_idx].rstrip('\r\n'),
+                    'br_coef_fields': [field.strip() for field in br_coef_fields],
+                    'wspro_line': lines[wspro_idx].rstrip('\r\n') if wspro_idx is not None else None,
+                    'wspro_fields': (
+                        [field.strip() for field in wspro_fields]
+                        if wspro_fields is not None else None
+                    ),
+                },
+            }
+
+            logger.info(
+                f"Read bridge hydraulic methods for {river}/{reach}/RS {rs}: "
+                f"low={result['low_flow_method']}, high={result['high_flow_method']}"
+            )
+            return result
+
+        except FileNotFoundError:
+            raise
+        except ValueError:
+            raise
+        except Exception as e:
+            logger.error(f"Error reading bridge hydraulic methods: {str(e)}")
+            raise IOError(f"Failed to read bridge hydraulic methods: {str(e)}")
+
+    @staticmethod
+    @log_call
+    def set_hydraulic_methods(geom_file: Union[str, Path],
+                              river: str,
+                              reach: str,
+                              rs: str,
+                              low_flow_method: Optional[str] = None,
+                              high_flow_method: Optional[str] = None,
+                              use_energy: Optional[bool] = None,
+                              use_momentum: Optional[bool] = None,
+                              use_yarnell: Optional[bool] = None,
+                              use_wspro: Optional[bool] = None,
+                              momentum_cd: Optional[float] = None,
+                              yarnell_k: Optional[float] = None,
+                              pressure_flow_submerged_inlet_cd: Optional[float] = None,
+                              pressure_flow_submerged_inlet_outlet_cd: Optional[float] = None,
+                              opening_index: int = 0,
+                              create_backup: bool = True,
+                              validate: bool = True) -> Dict[str, Any]:
+        """
+        Set bridge low-flow/high-flow hydraulic method selections.
+
+        Accepted ``low_flow_method`` values are ``energy``, ``momentum``,
+        ``yarnell``, and ``wspro``. Accepted ``high_flow_method`` values are
+        ``energy`` and ``pressure_weir``. Existing comma-field spacing is
+        preserved for updated ``BR Coef=`` fields, and a ``.bak`` backup is
+        created by default before writing.
+
+        Parameters:
+            geom_file: Path to geometry file (.g##)
+            river: River name (case-sensitive)
+            reach: Reach name (case-sensitive)
+            rs: River station (as string)
+            low_flow_method: Optional low-flow method selection
+            high_flow_method: Optional high-flow method selection
+            use_energy: Optional compute flag for the energy method
+            use_momentum: Optional compute flag for the momentum method
+            use_yarnell: Optional compute flag for the Yarnell method
+            use_wspro: Optional compute flag for the WSPRO method
+            momentum_cd: Optional momentum drag coefficient
+            yarnell_k: Optional Yarnell pier coefficient
+            pressure_flow_submerged_inlet_cd: Optional pressure-flow Cd
+            pressure_flow_submerged_inlet_outlet_cd: Optional pressure-flow Cd
+            opening_index: Zero-based bridge opening/coefficient record index
+            create_backup: Create ``.bak`` backup before writing (default True)
+            validate: Validate method names and unsupported combinations
+
+        Returns:
+            dict with before/after method dictionaries, changed line text, and
+            backup path.
+
+        Raises:
+            FileNotFoundError: If geometry file doesn't exist
+            ValueError: If bridge, method value, or combination is invalid
+            IOError: If file write fails
+
+        Example:
+            >>> GeomBridge.set_hydraulic_methods(
+            ...     "model.g01", "Beaver Creek", "Kentwood", "5.4",
+            ...     low_flow_method="yarnell",
+            ...     high_flow_method="energy",
+            ...     yarnell_k=1.05
+            ... )
+        """
+        geom_file = Path(geom_file)
+
+        if not geom_file.exists():
+            raise FileNotFoundError(f"Geometry file not found: {geom_file}")
+
+        normalized_low = GeomBridge._normalize_hydraulic_method(
+            low_flow_method,
+            set(GeomBridge.LOW_FLOW_METHOD_CODES),
+            'low_flow_method'
+        )
+        normalized_high = GeomBridge._normalize_hydraulic_method(
+            high_flow_method,
+            GeomBridge.HIGH_FLOW_METHODS,
+            'high_flow_method'
+        )
+
+        if all(value is None for value in [
+            normalized_low,
+            normalized_high,
+            use_energy,
+            use_momentum,
+            use_yarnell,
+            use_wspro,
+            momentum_cd,
+            yarnell_k,
+            pressure_flow_submerged_inlet_cd,
+            pressure_flow_submerged_inlet_outlet_cd,
+        ]):
+            raise ValueError("At least one hydraulic method or coefficient must be specified")
+
+        backup_path = None
+        try:
+            with open(geom_file, 'r', encoding='utf-8', errors='replace') as f:
+                lines = f.readlines()
+
+            bridge_idx = GeomBridge._find_bridge(lines, river, reach, rs)
+            if bridge_idx is None:
+                raise ValueError(f"Bridge not found: {river}/{reach}/RS {rs}")
+
+            struct_end_idx = GeomBridge._find_structure_end(lines, bridge_idx)
+            method_lines = GeomBridge._find_bridge_method_lines(
+                lines, bridge_idx, struct_end_idx, opening_index
+            )
+            br_coef_idx = method_lines['br_coef_idx']
+            wspro_idx = method_lines['wspro_idx']
+
+            if br_coef_idx is None and method_lines['br_coef_count'] > 0:
+                raise ValueError(
+                    f"BR Coef= opening_index {opening_index} not found for "
+                    f"{river}/{reach}/RS {rs}; found {method_lines['br_coef_count']}"
+                )
+
+            inserted_br_coef = False
+            if br_coef_idx is None:
+                line_ending = '\n'
+                if bridge_idx < len(lines):
+                    _, line_ending = GeomBridge._split_line_ending(lines[bridge_idx])
+                    line_ending = line_ending or '\n'
+                br_coef_fields = GeomBridge._default_br_coef_fields()
+                insert_idx = GeomBridge._find_br_coef_insert_idx(lines, bridge_idx, struct_end_idx)
+                lines.insert(
+                    insert_idx,
+                    GeomBridge._format_comma_line("BR Coef=", br_coef_fields, line_ending)
+                )
+                br_coef_idx = insert_idx
+                inserted_br_coef = True
+                if wspro_idx is not None and wspro_idx >= insert_idx:
+                    wspro_idx += 1
+            else:
+                br_coef_fields = GeomBridge._split_comma_fields_from_line(
+                    lines[br_coef_idx], "BR Coef="
+                )
+
+            before_line = lines[br_coef_idx].rstrip('\r\n')
+            current = GeomBridge._parse_br_coef_fields(br_coef_fields)
+            before = None if inserted_br_coef else GeomBridge.get_hydraulic_methods(
+                geom_file, river, reach, rs, opening_index=opening_index
+            )
+            explicit_enabled = {
+                'energy': use_energy,
+                'momentum': use_momentum,
+                'yarnell': use_yarnell,
+                'wspro': use_wspro,
+            }
+            enabled = dict(current['enabled_low_flow_methods'])
+
+            for method_name, flag_value in explicit_enabled.items():
+                if flag_value is not None:
+                    enabled[method_name] = bool(flag_value)
+
+            if normalized_low is not None:
+                if explicit_enabled.get(normalized_low) is False:
+                    raise ValueError(
+                        f"selected low_flow_method '{normalized_low}' cannot be disabled"
+                    )
+                enabled[normalized_low] = True
+
+            method_to_validate = normalized_low or current['low_flow_method']
+            require_selected_enabled = (
+                normalized_low is not None or
+                (method_to_validate is not None and explicit_enabled.get(method_to_validate) is False)
+            )
+            if validate:
+                GeomBridge._validate_hydraulic_method_selection(
+                    method_to_validate,
+                    normalized_high,
+                    enabled,
+                    wspro_idx,
+                    require_selected_enabled=require_selected_enabled,
+                )
+
+            flag_fields = {
+                'energy': 0,
+                'momentum': 1,
+                'yarnell': 2,
+                'wspro': 4,
+            }
+            for method_name, field_idx in flag_fields.items():
+                if explicit_enabled.get(method_name) is not None or normalized_low == method_name:
+                    existing = br_coef_fields[field_idx] if field_idx < len(br_coef_fields) else ''
+                    GeomBridge._set_comma_field(
+                        br_coef_fields,
+                        field_idx,
+                        GeomBridge._format_bool_field(bool(enabled[method_name]), existing)
+                    )
+
+            if normalized_low is not None:
+                GeomBridge._set_comma_field(
+                    br_coef_fields,
+                    10,
+                    GeomBridge.LOW_FLOW_METHOD_CODES[normalized_low]
+                )
+
+            if normalized_high is not None:
+                high_standard_step = normalized_high == 'energy'
+                existing = br_coef_fields[8] if len(br_coef_fields) > 8 else ''
+                GeomBridge._set_comma_field(
+                    br_coef_fields,
+                    8,
+                    GeomBridge._format_bool_field(high_standard_step, existing)
+                )
+
+            if momentum_cd is not None:
+                GeomBridge._set_comma_field(br_coef_fields, 9, float(momentum_cd))
+
+            if yarnell_k is not None:
+                GeomBridge._set_comma_field(br_coef_fields, 3, float(yarnell_k))
+
+            if pressure_flow_submerged_inlet_cd is not None:
+                GeomBridge._set_comma_field(
+                    br_coef_fields, 6, float(pressure_flow_submerged_inlet_cd)
+                )
+
+            if pressure_flow_submerged_inlet_outlet_cd is not None:
+                GeomBridge._set_comma_field(
+                    br_coef_fields, 7, float(pressure_flow_submerged_inlet_outlet_cd)
+                )
+
+            body, line_ending = GeomBridge._split_line_ending(lines[br_coef_idx])
+            line_ending = line_ending or '\n'
+            lines[br_coef_idx] = GeomBridge._format_comma_line(
+                "BR Coef=", br_coef_fields, line_ending
+            )
+            after_line = lines[br_coef_idx].rstrip('\r\n')
+
+            if create_backup:
+                backup_path = GeomParser.create_backup(geom_file)
+                logger.info(f"Created backup: {backup_path}")
+
+            with open(geom_file, 'w', encoding='utf-8') as f:
+                f.writelines(lines)
+
+            after = GeomBridge.get_hydraulic_methods(
+                geom_file, river, reach, rs, opening_index=opening_index
+            )
+
+            result = {
+                'river': river,
+                'reach': reach,
+                'rs': str(rs),
+                'opening_index': opening_index,
+                'low_flow_method': after['low_flow_method'],
+                'high_flow_method': after['high_flow_method'],
+                'inserted_br_coef': inserted_br_coef,
+                'br_coef_before': before_line,
+                'br_coef_after': after_line,
+                'backup_path': str(backup_path) if backup_path else None,
+                'before': before,
+                'after': after,
+            }
+
+            logger.info(
+                f"Set bridge hydraulic methods for {river}/{reach}/RS {rs}: "
+                f"low={result['low_flow_method']}, high={result['high_flow_method']}"
+            )
+            return result
+
+        except FileNotFoundError:
+            raise
+        except ValueError:
+            raise
+        except Exception as e:
+            logger.error(f"Error writing bridge hydraulic methods: {str(e)}")
+            if backup_path and backup_path.exists():
+                logger.info(f"Restoring from backup: {backup_path}")
+                import shutil
+                shutil.copy2(backup_path, geom_file)
+            raise IOError(f"Failed to write bridge hydraulic methods: {str(e)}")
 
     @staticmethod
     @log_call

--- a/tests/test_geom_bridge_methods.py
+++ b/tests/test_geom_bridge_methods.py
@@ -69,6 +69,8 @@ def test_get_hydraulic_methods_parses_bridge_records(tmp_path):
         "yarnell": False,
         "wspro": False,
     }
+    assert methods["deck"]["weir_coefficient"] == pytest.approx(2.6)
+    assert methods["coefficients"]["weir_coefficient"] == pytest.approx(2.6)
     assert methods["coefficients"]["submerged_inlet_cd"] == pytest.approx(0.34)
     assert methods["coefficients"]["submerged_inlet_outlet_cd"] == pytest.approx(0.7)
     assert methods["wspro"]["abutment_type"] == pytest.approx(1.0)
@@ -82,6 +84,9 @@ def test_set_hydraulic_methods_exact_before_after_file_change(tmp_path):
     expected_after = before_text.replace(
         "BR Coef=-1 , 0 , 0 ,, 0 ,,0.34,0.7,0,,1,",
         "BR Coef=-1 , 0 , -1 ,1.05, 0 ,,0.36,0.72,-1,1.33,2,",
+    ).replace(
+        "30,40,2.6,0, 0, 0, , , 0.95, 0, 0,0,,",
+        "30,40,3.1,0, 0, 0, , , 0.95, 0, 0,0,,",
     )
 
     result = GeomBridge.set_hydraulic_methods(
@@ -95,13 +100,17 @@ def test_set_hydraulic_methods_exact_before_after_file_change(tmp_path):
         momentum_cd=1.33,
         pressure_flow_submerged_inlet_cd=0.36,
         pressure_flow_submerged_inlet_outlet_cd=0.72,
+        weir_coefficient=3.1,
     )
 
     assert geom_file.read_text(encoding="utf-8") == expected_after
     assert result["br_coef_before"] == "BR Coef=-1 , 0 , 0 ,, 0 ,,0.34,0.7,0,,1,"
     assert result["br_coef_after"] == "BR Coef=-1 , 0 , -1 ,1.05, 0 ,,0.36,0.72,-1,1.33,2,"
+    assert result["deck_line_before"] == "30,40,2.6,0, 0, 0, , , 0.95, 0, 0,0,,"
+    assert result["deck_line_after"] == "30,40,3.1,0, 0, 0, , , 0.95, 0, 0,0,,"
     assert result["low_flow_method"] == "yarnell"
     assert result["high_flow_method"] == "energy"
+    assert result["after"]["coefficients"]["weir_coefficient"] == pytest.approx(3.1)
 
     backup_path = Path(result["backup_path"])
     assert backup_path.exists()
@@ -128,6 +137,34 @@ def test_set_hydraulic_methods_rejects_unsupported_combinations(tmp_path):
             "5.4",
             low_flow_method="yarnell",
             use_yarnell=False,
+            yarnell_k=1.05,
+        )
+
+    with pytest.raises(ValueError, match="low_flow_method 'momentum' requires momentum_cd"):
+        GeomBridge.set_hydraulic_methods(
+            geom_file,
+            "Beaver Creek",
+            "Kentwood",
+            "5.4",
+            low_flow_method="momentum",
+        )
+
+    with pytest.raises(ValueError, match="low_flow_method 'yarnell' requires yarnell_k"):
+        GeomBridge.set_hydraulic_methods(
+            geom_file,
+            "Beaver Creek",
+            "Kentwood",
+            "5.4",
+            low_flow_method="yarnell",
+        )
+
+    with pytest.raises(ValueError, match="weir_coefficient must be positive"):
+        GeomBridge.set_hydraulic_methods(
+            geom_file,
+            "Beaver Creek",
+            "Kentwood",
+            "5.4",
+            weir_coefficient=0,
         )
 
 
@@ -153,5 +190,6 @@ def test_get_hydraulic_methods_reads_real_bridge_example():
     assert methods["raw"]["br_coef_line"].startswith("BR Coef=")
     assert methods["low_flow_method"] in {"energy", "momentum", "yarnell", "wspro"}
     assert methods["high_flow_method"] in {"energy", "pressure_weir"}
+    assert methods["coefficients"]["weir_coefficient"] == pytest.approx(2.6)
     assert methods["coefficients"]["submerged_inlet_cd"] == pytest.approx(0.34)
     assert methods["coefficients"]["submerged_inlet_outlet_cd"] == pytest.approx(0.7)

--- a/tests/test_geom_bridge_methods.py
+++ b/tests/test_geom_bridge_methods.py
@@ -1,0 +1,157 @@
+"""
+Regression tests for bridge hydraulic method selection APIs.
+
+These tests cover exact BR Coef text changes, unsupported method combinations,
+and parsing against a real HEC-RAS bridge example.
+"""
+
+import re
+import sys
+from pathlib import Path
+
+import pytest
+
+
+# Ensure we're using local source, not installed package
+repo_root = Path(__file__).parent.parent
+if str(repo_root) not in sys.path:
+    sys.path.insert(0, str(repo_root))
+
+
+from ras_commander import RasExamples
+from ras_commander.geom import GeomBridge
+
+
+BRIDGE_FIXTURE_TEXT = """Geom Title=Bridge Methods Fixture
+River Reach=Beaver Creek,Kentwood
+Type RM Length L Ch R = 3 ,5.4     ,,,
+Bridge Culvert--1,0,0,-1, 0 
+Deck Dist Width WeirC Skew NumUp NumDn MinLoCord MaxHiCord MaxSubmerge Is_Ogee
+30,40,2.6,0, 0, 0, , , 0.95, 0, 0,0,,
+BR Coef=-1 , 0 , 0 ,, 0 ,,0.34,0.7,0,,1,
+WSPro=,,,, 1 ,,,, 0 ,,,, 0 ,,,,-1 ,-1 ,-1 , 0 , 0 , 0 , 0 , 0 
+BC Design=,, 0 ,, 0 ,,,,,,
+Type RM Length L Ch R = 1 ,5.39    ,,,
+"""
+
+
+def _write_bridge_fixture(tmp_path: Path) -> Path:
+    geom_file = tmp_path / "bridge_methods.g01"
+    geom_file.write_text(BRIDGE_FIXTURE_TEXT, encoding="utf-8")
+    return geom_file
+
+
+def _get_geom_file(project_path: Path) -> Path:
+    geom_files = sorted(
+        path for path in project_path.iterdir()
+        if path.is_file() and re.search(r"\.g\d\d$", path.name.lower())
+    )
+    assert geom_files, f"No geometry files found in {project_path}"
+    return geom_files[0]
+
+
+def test_get_hydraulic_methods_parses_bridge_records(tmp_path):
+    geom_file = _write_bridge_fixture(tmp_path)
+
+    methods = GeomBridge.get_hydraulic_methods(
+        geom_file,
+        "Beaver Creek",
+        "Kentwood",
+        "5.4",
+    )
+
+    assert methods["low_flow_method"] == "momentum"
+    assert methods["low_flow_method_code"] == 1
+    assert methods["high_flow_method"] == "pressure_weir"
+    assert methods["enabled_low_flow_methods"] == {
+        "energy": True,
+        "momentum": False,
+        "yarnell": False,
+        "wspro": False,
+    }
+    assert methods["coefficients"]["submerged_inlet_cd"] == pytest.approx(0.34)
+    assert methods["coefficients"]["submerged_inlet_outlet_cd"] == pytest.approx(0.7)
+    assert methods["wspro"]["abutment_type"] == pytest.approx(1.0)
+    assert methods["wspro"]["piers_continuous"] is True
+    assert methods["raw"]["br_coef_line"] == "BR Coef=-1 , 0 , 0 ,, 0 ,,0.34,0.7,0,,1,"
+
+
+def test_set_hydraulic_methods_exact_before_after_file_change(tmp_path):
+    geom_file = _write_bridge_fixture(tmp_path)
+    before_text = geom_file.read_text(encoding="utf-8")
+    expected_after = before_text.replace(
+        "BR Coef=-1 , 0 , 0 ,, 0 ,,0.34,0.7,0,,1,",
+        "BR Coef=-1 , 0 , -1 ,1.05, 0 ,,0.36,0.72,-1,1.33,2,",
+    )
+
+    result = GeomBridge.set_hydraulic_methods(
+        geom_file,
+        "Beaver Creek",
+        "Kentwood",
+        "5.4",
+        low_flow_method="yarnell",
+        high_flow_method="energy",
+        yarnell_k=1.05,
+        momentum_cd=1.33,
+        pressure_flow_submerged_inlet_cd=0.36,
+        pressure_flow_submerged_inlet_outlet_cd=0.72,
+    )
+
+    assert geom_file.read_text(encoding="utf-8") == expected_after
+    assert result["br_coef_before"] == "BR Coef=-1 , 0 , 0 ,, 0 ,,0.34,0.7,0,,1,"
+    assert result["br_coef_after"] == "BR Coef=-1 , 0 , -1 ,1.05, 0 ,,0.36,0.72,-1,1.33,2,"
+    assert result["low_flow_method"] == "yarnell"
+    assert result["high_flow_method"] == "energy"
+
+    backup_path = Path(result["backup_path"])
+    assert backup_path.exists()
+    assert backup_path.read_text(encoding="utf-8") == before_text
+
+
+def test_set_hydraulic_methods_rejects_unsupported_combinations(tmp_path):
+    geom_file = _write_bridge_fixture(tmp_path)
+
+    with pytest.raises(ValueError, match="low_flow_method must be one of"):
+        GeomBridge.set_hydraulic_methods(
+            geom_file,
+            "Beaver Creek",
+            "Kentwood",
+            "5.4",
+            low_flow_method="culvert",
+        )
+
+    with pytest.raises(ValueError, match="selected low_flow_method 'yarnell' cannot be disabled"):
+        GeomBridge.set_hydraulic_methods(
+            geom_file,
+            "Beaver Creek",
+            "Kentwood",
+            "5.4",
+            low_flow_method="yarnell",
+            use_yarnell=False,
+        )
+
+
+def test_get_hydraulic_methods_reads_real_bridge_example():
+    project_path = RasExamples.extract_project(
+        "Bridge Hydraulics",
+        suffix="test_geom_bridge_methods_parse",
+    )
+    geom_file = _get_geom_file(project_path)
+    bridges = GeomBridge.get_bridges(geom_file)
+
+    assert not bridges.empty, "Expected at least one bridge in the example project"
+
+    row = bridges.iloc[0]
+    methods = GeomBridge.get_hydraulic_methods(
+        geom_file,
+        row["River"],
+        row["Reach"],
+        str(row["RS"]),
+    )
+
+    assert methods["raw"]["bridge_culvert_line"].startswith("Bridge Culvert-")
+    assert methods["raw"]["br_coef_line"].startswith("BR Coef=")
+    assert methods["low_flow_method"] in {"energy", "momentum", "yarnell", "wspro"}
+    assert methods["high_flow_method"] in {"energy", "pressure_weir"}
+    assert methods["coefficients"]["submerged_inlet_cd"] == pytest.approx(0.34)
+    assert methods["coefficients"]["submerged_inlet_outlet_cd"] == pytest.approx(0.7)


### PR DESCRIPTION
## Summary
- Adds `get_hydraulic_methods()` and `set_hydraulic_methods()` to `GeomBridge` for reading/writing bridge low-flow and high-flow methods (energy, momentum, yarnell, wspro, pressure/weir)
- Includes coefficient setters for momentum Cd, Yarnell K, pressure-flow Cd, and weir coefficients
- Executed notebook `208_bridge_method_comparison.ipynb` with truncated WSE profile comparison across methods and weir coefficient sensitivity plot

## Test plan
- [x] Notebook executed end-to-end with real HEC-RAS project
- [x] Two matplotlib figures: bridge WSE profile comparison and weir Cd sensitivity
- [x] Unit tests pass

🤖 Reviewed via CLB Symphony issue-review workflow