### PR TITLE
Add flow hydrograph optimization API

### DIFF
--- a/docs/api/core.md
+++ b/docs/api/core.md
@@ -294,6 +294,23 @@ The `get_comp_msgs()` method attempts to read computation messages from multiple
         - get_value
         - set_value
 
+### RasFlowOptimization
+
+::: ras_commander.RasFlowOptimization
+    options:
+      show_root_heading: true
+      heading_level: 3
+      members:
+        - copy_plan_with_optimization
+        - enable_plan
+        - set_settings
+        - get_settings
+        - disable_plan
+        - list_flow_hydrographs
+        - compute_plan_and_get_trials
+        - get_trial_results
+        - parse_compute_messages
+
 ### RasGeo
 
 ::: ras_commander.RasGeo

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -9,6 +9,7 @@ Primary classes for project management and execution:
 - [`RasPrj`](core.md#rasprj) - Project management and data structures
 - [`RasCmdr`](core.md#rascmdr) - Plan execution (single, parallel, sequential)
 - [`RasPlan`](core.md#rasplan) - Plan file operations
+- [`RasFlowOptimization`](core.md#rasflowoptimization) - Native HEC-RAS flow hydrograph optimization settings and trial results
 - [`RasGeo`](core.md#rasgeo) - Geometry file operations
 - [`RasUnsteady`](core.md#rasunsteady) - Unsteady flow file management
 - [`RasUtils`](core.md#rasutils) - Utility functions

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -90,7 +90,9 @@ These are the notebooks most directly tied to the April 2026 docs-drift sweep.
 
 ### 300s
 
-`300_unsteady_flow_operations.ipynb`, `310_dss_boundary_extraction.ipynb`,
+`300_unsteady_flow_operations.ipynb`,
+`301_flow_hydrograph_optimization.ipynb`,
+`310_dss_boundary_extraction.ipynb`,
 `311_validating_dss_paths.ipynb`,
 `312_boundary_df_qmult_dss_paths.ipynb`,
 `313_hms_to_ras_boundary_matching.ipynb`,

--- a/docs/user-guide/plan-execution.md
+++ b/docs/user-guide/plan-execution.md
@@ -160,6 +160,41 @@ RasPlan.set_description(new_plan, "Run with finer timestep")
 success = RasCmdr.compute_plan(new_plan)
 ```
 
+## Native Flow Hydrograph Optimization
+
+HEC-RAS native automated flow optimization scales selected flow hydrographs until a stage or flow target is met at a reference point or line. RAS Commander exposes this through `RasFlowOptimization` while keeping execution inside `RasCmdr`.
+
+```python
+from ras_commander import init_ras_project, RasFlowOptimization, RasCmdr
+
+init_ras_project("/path/to/tutorial-13-project", "6.5")
+
+# Copy a plan and enable native HEC-RAS flow optimization on the copy.
+opt_plan = RasFlowOptimization.copy_plan_with_optimization(
+    "01",
+    new_plan_shortid="Native Flow Opt",
+    mode="stage",
+    reference_location="Yosemite Falls Vantage Point",
+    target_value=3963.5,
+    tolerance=0.1,
+    hydrographs=["BCLine: Inflow"],
+    min_ratio=0.5,
+    max_ratio=1.0,
+    max_iterations=10,
+)
+
+# Execute through RAS Commander, not a direct Ras.exe call.
+success = RasCmdr.compute_plan(opt_plan)
+
+# After compute, read native trial output from the plan HDF or compute messages.
+trials = RasFlowOptimization.get_trial_results(opt_plan)
+print(trials[["trial", "ratio", "difference", "target", "computed"]])
+```
+
+Use `RasFlowOptimization.get_settings()` to audit an existing plan and `RasFlowOptimization.list_flow_hydrographs()` to discover flow hydrographs that can be selected for scaling. `RasFlowOptimization.compute_plan_and_get_trials()` is a convenience wrapper around `RasCmdr.compute_plan()` followed by trial extraction. See `examples/301_flow_hydrograph_optimization.ipynb` for the Tutorial 13 workflow and fallback guidance.
+
+`RasCalibrate` remains the ras-commander-native calibration/search API for broader parameter sweeps, arbitrary model edits, and custom objective metrics. Native flow optimization is narrower: it delegates HEC-RAS' built-in flow-ratio trial loop to HEC-RAS and reports the resulting trial table where available. See the [official HEC-RAS flow hydrograph optimization tutorial](https://www.hec.usace.army.mil/confluence/rasdocs/hgt/latest/tutorials/2d-unsteady-flow/flow-hydrograph-optimization) for the corresponding GUI workflow.
+
 ## Checking Results
 
 After execution, verify results were generated and the run completed without errors. This is critical for determining if the simulation succeeded.

--- a/examples/301_flow_hydrograph_optimization.ipynb
+++ b/examples/301_flow_hydrograph_optimization.ipynb
@@ -1,0 +1,1286 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "94ca6ff0",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-01T21:36:02.077792Z",
+     "iopub.status.busy": "2026-05-01T21:36:02.077792Z",
+     "iopub.status.idle": "2026-05-01T21:36:03.555125Z",
+     "shell.execute_reply": "2026-05-01T21:36:03.555125Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "ras-commander 0.96.1\n"
+     ]
+    }
+   ],
+   "source": [
+    "from pathlib import Path\n",
+    "import logging\n",
+    "import os\n",
+    "import shutil\n",
+    "\n",
+    "import h5py\n",
+    "import matplotlib.pyplot as plt\n",
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "from IPython.display import display\n",
+    "\n",
+    "import ras_commander\n",
+    "from ras_commander import (\n",
+    "    RasCmdr,\n",
+    "    RasFlowOptimization,\n",
+    "    init_ras_project,\n",
+    "    ras,\n",
+    ")\n",
+    "from ras_commander.RasUnsteady import RasUnsteady\n",
+    "\n",
+    "logging.disable(logging.CRITICAL)\n",
+    "print(f\"ras-commander {ras_commander.__version__}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3dac5212",
+   "metadata": {},
+   "source": [
+    "## Development Mode\n",
+    "\n",
+    "For local source testing, run this notebook with `PYTHONPATH` pointed at the repository root. The committed import cell intentionally uses normal package imports so the notebook also works for installed ras-commander users."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9c2e9c81",
+   "metadata": {},
+   "source": [
+    "# Native Flow Hydrograph Optimization\n",
+    "\n",
+    "This notebook maps HEC-RAS Tutorial 13 Automated Flow Optimization to `RasFlowOptimization`. It configures a copied native optimization plan and executes through `RasCmdr`. If the command-line HEC-RAS run does not emit native trial rows, the notebook falls back to the ras-commander calibration pattern: parameterize the flow hydrograph multiplier, run candidate plans through `RasCmdr`, evaluate an HDF-derived objective, and compare before/after results."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "179c0259",
+   "metadata": {},
+   "source": [
+    "## Workflow Coverage\n",
+    "\n",
+    "| Tutorial step | ras-commander API |\n",
+    "| --- | --- |\n",
+    "| Read native optimization setup | `RasFlowOptimization.get_settings()` |\n",
+    "| Select scalable hydrographs | `RasFlowOptimization.list_flow_hydrographs()` |\n",
+    "| Enable native optimization on a copied plan | `RasFlowOptimization.copy_plan_with_optimization()` |\n",
+    "| Execute HEC-RAS | `RasFlowOptimization.compute_plan_and_get_trials()` / `RasCmdr.compute_plan()` |\n",
+    "| Fallback search if native trial output is unavailable | `RasUnsteady.update_flow_multiplier_by_station()` + `RasCmdr.compute_plan()` |\n",
+    "| Review results | HDF time-series extraction and plots |"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7f34b340",
+   "metadata": {},
+   "source": [
+    "## Parameters"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "ce80a86b",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-01T21:36:03.557169Z",
+     "iopub.status.busy": "2026-05-01T21:36:03.557169Z",
+     "iopub.status.idle": "2026-05-01T21:36:03.565827Z",
+     "shell.execute_reply": "2026-05-01T21:36:03.565827Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Repository root: C:\\GH\\symphony-workspaces\\ras-commander\\CLB-320\n",
+      "Tutorial project found: True\n",
+      "HEC-RAS executable/version: C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.4.1\\Ras.exe\n"
+     ]
+    }
+   ],
+   "source": [
+    "def find_repo_root(start):\n",
+    "    for candidate in [start, *start.parents]:\n",
+    "        if (candidate / \"pyproject.toml\").exists() and (candidate / \"ras_commander\").exists():\n",
+    "            return candidate\n",
+    "    return start\n",
+    "\n",
+    "\n",
+    "def find_tutorial_project(repo_root):\n",
+    "    env_value = os.environ.get(\"RAS_TUTORIAL_13_PROJECT\")\n",
+    "    candidates = []\n",
+    "    if env_value:\n",
+    "        candidates.append(Path(env_value).expanduser())\n",
+    "    candidates.extend(\n",
+    "        [\n",
+    "            repo_root / \"example_projects\" / \"Example_FlowOptimization\",\n",
+    "            Path(\"H:/Symphony/ras-commander/CLB-320/official_flow_optimization/extracted/Example_FlowOptimization\"),\n",
+    "        ]\n",
+    "    )\n",
+    "    for candidate in candidates:\n",
+    "        if (candidate / \"HydroFlowOptimization.prj\").exists():\n",
+    "            return candidate\n",
+    "    return candidates[0] if candidates else repo_root / \"example_projects\" / \"Example_FlowOptimization\"\n",
+    "\n",
+    "\n",
+    "REPO_ROOT = find_repo_root(Path.cwd())\n",
+    "TUTORIAL_13_PROJECT = find_tutorial_project(REPO_ROOT)\n",
+    "WORK_ROOT = REPO_ROOT / \"working\" / \"flow_hydrograph_optimization\"\n",
+    "TRIAL_HDF_ROOT = WORK_ROOT / \"trial_hdfs\"\n",
+    "\n",
+    "RAS_EXE = Path(os.environ.get(\"RAS_EXE\", \"C:/Program Files (x86)/HEC/HEC-RAS/6.4.1/Ras.exe\"))\n",
+    "RAS_VERSION = str(RAS_EXE) if RAS_EXE.exists() else os.environ.get(\"RAS_VERSION\", \"6.4.1\")\n",
+    "\n",
+    "BASE_PLAN = \"01\"\n",
+    "TARGET_MODE = \"stage\"\n",
+    "TARGET_REFERENCE = \"Yosemite Falls Vantage Point\"\n",
+    "TARGET_VALUE = 3963.5\n",
+    "TARGET_TOLERANCE = 0.1\n",
+    "TARGET_HYDROGRAPHS = [\"BCLine: Inflow\"]\n",
+    "BOUNDARY_LABEL = \"Inflow\"\n",
+    "FLOW_AREA_NAME = \"2DArea\"\n",
+    "\n",
+    "RUN_NATIVE_COMPUTE = os.environ.get(\"RAS_RUN_NATIVE_COMPUTE\", \"1\").lower() not in {\"0\", \"false\", \"no\"}\n",
+    "RUN_FALLBACK_SEARCH = os.environ.get(\"RAS_RUN_FLOW_RATIO_FALLBACK\", \"1\").lower() not in {\"0\", \"false\", \"no\"}\n",
+    "Q_MULT_TRIALS = [1.2, 0.9, 0.6]\n",
+    "\n",
+    "print(f\"Repository root: {REPO_ROOT}\")\n",
+    "print(f\"Tutorial project found: {(TUTORIAL_13_PROJECT / 'HydroFlowOptimization.prj').exists()}\")\n",
+    "print(f\"HEC-RAS executable/version: {RAS_VERSION}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bfeb88ec",
+   "metadata": {},
+   "source": [
+    "## Prepare a Working Copy"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "e3e3c775",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-01T21:36:03.567374Z",
+     "iopub.status.busy": "2026-05-01T21:36:03.567374Z",
+     "iopub.status.idle": "2026-05-01T21:36:03.923339Z",
+     "shell.execute_reply": "2026-05-01T21:36:03.923339Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>plan_number</th>\n",
+       "      <th>Plan Title</th>\n",
+       "      <th>Short Identifier</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>01</td>\n",
+       "      <td>Base</td>\n",
+       "      <td>Base</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "  plan_number Plan Title Short Identifier\n",
+       "0          01       Base             Base"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Working project: C:\\GH\\symphony-workspaces\\ras-commander\\CLB-320\\working\\flow_hydrograph_optimization\\Example_FlowOptimization\n"
+     ]
+    }
+   ],
+   "source": [
+    "project_file = TUTORIAL_13_PROJECT / \"HydroFlowOptimization.prj\"\n",
+    "project_available = project_file.exists()\n",
+    "\n",
+    "if not project_available:\n",
+    "    print(\"Tutorial 13 project not found.\")\n",
+    "    print(f\"Expected project file: {project_file}\")\n",
+    "    print(\"Set RAS_TUTORIAL_13_PROJECT to the extracted Example_FlowOptimization folder.\")\n",
+    "    working_project = None\n",
+    "    ras_project = None\n",
+    "else:\n",
+    "    WORK_ROOT.mkdir(parents=True, exist_ok=True)\n",
+    "    working_project = WORK_ROOT / TUTORIAL_13_PROJECT.name\n",
+    "    if working_project.exists():\n",
+    "        shutil.rmtree(working_project)\n",
+    "    if TRIAL_HDF_ROOT.exists():\n",
+    "        shutil.rmtree(TRIAL_HDF_ROOT)\n",
+    "    TRIAL_HDF_ROOT.mkdir(parents=True, exist_ok=True)\n",
+    "\n",
+    "    shutil.copytree(TUTORIAL_13_PROJECT, working_project)\n",
+    "    ras_project = init_ras_project(working_project, RAS_VERSION)\n",
+    "\n",
+    "    display(ras_project.plan_df[[\"plan_number\", \"Plan Title\", \"Short Identifier\"]])\n",
+    "    print(f\"Working project: {working_project}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "556e92b5",
+   "metadata": {},
+   "source": [
+    "## Inspect Native Optimization Settings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "b0d38693",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-01T21:36:03.923339Z",
+     "iopub.status.busy": "2026-05-01T21:36:03.923339Z",
+     "iopub.status.idle": "2026-05-01T21:36:03.950034Z",
+     "shell.execute_reply": "2026-05-01T21:36:03.950034Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "enabled                                                                   True\n",
+       "mode                                                                     stage\n",
+       "reference                              Ref Point: Yosemite Falls Vantage Point\n",
+       "reference_type                                                       Ref Point\n",
+       "reference_location                                Yosemite Falls Vantage Point\n",
+       "target_value                                                            3963.5\n",
+       "tolerance                                                                  0.1\n",
+       "initial_ratio                                                              1.0\n",
+       "min_ratio                                                                  0.5\n",
+       "max_ratio                                                                  1.0\n",
+       "max_iterations                                                              10\n",
+       "user_selected_hydrographs                                                 True\n",
+       "hydrographs                                                   [BCLine: Inflow]\n",
+       "restart_approach                                                          None\n",
+       "transition_period_hours                                                   None\n",
+       "plan_path                    C:\\GH\\symphony-workspaces\\ras-commander\\CLB-32...\n",
+       "dtype: object"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>river</th>\n",
+       "      <th>reach</th>\n",
+       "      <th>station</th>\n",
+       "      <th>storage_area</th>\n",
+       "      <th>flow_area</th>\n",
+       "      <th>bc_line</th>\n",
+       "      <th>bc_type</th>\n",
+       "      <th>interval</th>\n",
+       "      <th>use_dss</th>\n",
+       "      <th>dss_file</th>\n",
+       "      <th>dss_path</th>\n",
+       "      <th>line_number</th>\n",
+       "      <th>optimization_hydrograph</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td></td>\n",
+       "      <td></td>\n",
+       "      <td></td>\n",
+       "      <td></td>\n",
+       "      <td>2DArea</td>\n",
+       "      <td>Inflow</td>\n",
+       "      <td>Flow Hydrograph</td>\n",
+       "      <td>1HOUR</td>\n",
+       "      <td>True</td>\n",
+       "      <td>.\\Flow_Data\\streamflow.dss</td>\n",
+       "      <td>/MERCED R A HAPPY ISLES BRIDGE/YOSEMITE CA/FLO...</td>\n",
+       "      <td>4</td>\n",
+       "      <td>BCLine: Inflow</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "  river reach station storage_area flow_area bc_line          bc_type  \\\n",
+       "0                                     2DArea  Inflow  Flow Hydrograph   \n",
+       "\n",
+       "  interval use_dss                    dss_file  \\\n",
+       "0    1HOUR    True  .\\Flow_Data\\streamflow.dss   \n",
+       "\n",
+       "                                            dss_path  line_number  \\\n",
+       "0  /MERCED R A HAPPY ISLES BRIDGE/YOSEMITE CA/FLO...            4   \n",
+       "\n",
+       "  optimization_hydrograph  \n",
+       "0          BCLine: Inflow  "
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "if project_available:\n",
+    "    settings = RasFlowOptimization.get_settings(BASE_PLAN, ras_object=ras_project)\n",
+    "    settings_preview = pd.Series({k: v for k, v in settings.items() if k != \"raw_values\"})\n",
+    "    display(settings_preview)\n",
+    "\n",
+    "    hydrographs = RasFlowOptimization.list_flow_hydrographs(BASE_PLAN, ras_object=ras_project)\n",
+    "    display(hydrographs)\n",
+    "else:\n",
+    "    settings = None\n",
+    "    hydrographs = pd.DataFrame()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6514e984",
+   "metadata": {},
+   "source": [
+    "## Configure and Execute a Native Optimization Plan"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "35a52bec",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-01T21:36:03.952544Z",
+     "iopub.status.busy": "2026-05-01T21:36:03.950034Z",
+     "iopub.status.idle": "2026-05-01T21:36:04.048138Z",
+     "shell.execute_reply": "2026-05-01T21:36:04.048138Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Created optimization plan: 02\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "enabled                                                                   True\n",
+       "mode                                                                     stage\n",
+       "reference                              Ref Point: Yosemite Falls Vantage Point\n",
+       "reference_type                                                       Ref Point\n",
+       "reference_location                                Yosemite Falls Vantage Point\n",
+       "target_value                                                            3963.5\n",
+       "tolerance                                                                  0.1\n",
+       "initial_ratio                                                              1.0\n",
+       "min_ratio                                                                  0.5\n",
+       "max_ratio                                                                  1.0\n",
+       "max_iterations                                                              10\n",
+       "user_selected_hydrographs                                                 True\n",
+       "hydrographs                                                   [BCLine: Inflow]\n",
+       "restart_approach                                                          None\n",
+       "transition_period_hours                                                   None\n",
+       "plan_path                    C:\\GH\\symphony-workspaces\\ras-commander\\CLB-32...\n",
+       "dtype: object"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "if project_available:\n",
+    "    optimization_plan = RasFlowOptimization.copy_plan_with_optimization(\n",
+    "        BASE_PLAN,\n",
+    "        new_plan_shortid=\"Native Flow Opt\",\n",
+    "        new_title=\"Native Flow Optimization\",\n",
+    "        mode=TARGET_MODE,\n",
+    "        reference_location=TARGET_REFERENCE,\n",
+    "        target_value=TARGET_VALUE,\n",
+    "        tolerance=TARGET_TOLERANCE,\n",
+    "        hydrographs=TARGET_HYDROGRAPHS,\n",
+    "        min_ratio=0.5,\n",
+    "        max_ratio=1.0,\n",
+    "        max_iterations=10,\n",
+    "        ras_object=ras_project,\n",
+    "    )\n",
+    "    print(f\"Created optimization plan: {optimization_plan}\")\n",
+    "    display(pd.Series(RasFlowOptimization.get_settings(optimization_plan, ras_object=ras_project)).drop(\"raw_values\"))\n",
+    "else:\n",
+    "    optimization_plan = None"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "8c377d26",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-01T21:36:04.048138Z",
+     "iopub.status.busy": "2026-05-01T21:36:04.048138Z",
+     "iopub.status.idle": "2026-05-01T21:36:19.397827Z",
+     "shell.execute_reply": "2026-05-01T21:36:19.397644Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "ComputeResult(SUCCESS, results_df_row=available)\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>trial</th>\n",
+       "      <th>ratio</th>\n",
+       "      <th>difference</th>\n",
+       "      <th>target</th>\n",
+       "      <th>computed</th>\n",
+       "      <th>mode</th>\n",
+       "      <th>units</th>\n",
+       "      <th>reference_location</th>\n",
+       "      <th>converged</th>\n",
+       "      <th>failed</th>\n",
+       "      <th>source</th>\n",
+       "      <th>source_path</th>\n",
+       "      <th>source_dataset</th>\n",
+       "      <th>message</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "Empty DataFrame\n",
+       "Columns: [trial, ratio, difference, target, computed, mode, units, reference_location, converged, failed, source, source_path, source_dataset, message]\n",
+       "Index: []"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Native HEC-RAS command-line compute completed, but no native flow optimization trial rows were written to the plan HDF or compute messages. The next section falls back to a ras-commander search over the inflow QMult.\n"
+     ]
+    }
+   ],
+   "source": [
+    "native_result = None\n",
+    "native_trials = pd.DataFrame()\n",
+    "\n",
+    "if project_available and RUN_NATIVE_COMPUTE:\n",
+    "    native_result = RasFlowOptimization.compute_plan_and_get_trials(\n",
+    "        optimization_plan,\n",
+    "        ras_object=ras_project,\n",
+    "        num_cores=4,\n",
+    "        verify=True,\n",
+    "        force_rerun=True,\n",
+    "    )\n",
+    "    print(native_result[\"compute_result\"])\n",
+    "    native_trials = native_result[\"trial_results\"]\n",
+    "    display(native_trials)\n",
+    "\n",
+    "    if native_trials.empty:\n",
+    "        print(\n",
+    "            \"Native HEC-RAS command-line compute completed, but no native flow \"\n",
+    "            \"optimization trial rows were written to the plan HDF or compute messages. \"\n",
+    "            \"The next section falls back to a ras-commander search over the inflow QMult.\"\n",
+    "        )\n",
+    "elif project_available:\n",
+    "    print(\"RUN_NATIVE_COMPUTE is disabled. Skipping native HEC-RAS execution.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5cdb089f",
+   "metadata": {},
+   "source": [
+    "## HDF Extraction Helpers"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "159246a6",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-01T21:36:19.399859Z",
+     "iopub.status.busy": "2026-05-01T21:36:19.399859Z",
+     "iopub.status.idle": "2026-05-01T21:36:19.407520Z",
+     "shell.execute_reply": "2026-05-01T21:36:19.407520Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "def _as_text(value):\n",
+    "    if isinstance(value, bytes):\n",
+    "        return value.decode(\"utf-8\", errors=\"ignore\").strip()\n",
+    "    return str(value).strip()\n",
+    "\n",
+    "\n",
+    "def plan_hdf_path(plan_number):\n",
+    "    return working_project / f\"{ras_project.project_name}.p{str(plan_number).zfill(2)}.hdf\"\n",
+    "\n",
+    "\n",
+    "def read_inflow_hydrograph(hdf_path):\n",
+    "    dataset_path = (\n",
+    "        \"Event Conditions/Unsteady/Boundary Conditions/Flow Hydrographs/\"\n",
+    "        f\"2D: {FLOW_AREA_NAME} BCLine: {BOUNDARY_LABEL}\"\n",
+    "    )\n",
+    "    with h5py.File(hdf_path, \"r\") as hdf:\n",
+    "        data = hdf[dataset_path][()]\n",
+    "    return pd.DataFrame({\"days\": data[:, 0], \"flow_cfs\": data[:, 1]})\n",
+    "\n",
+    "\n",
+    "def read_reference_wse(hdf_path, cell_index):\n",
+    "    base = \"Results/Unsteady/Output/Output Blocks/Base Output/Unsteady Time Series\"\n",
+    "    with h5py.File(hdf_path, \"r\") as hdf:\n",
+    "        time_days = hdf[f\"{base}/Time\"][()]\n",
+    "        wse = hdf[f\"{base}/2D Flow Areas/{FLOW_AREA_NAME}/Water Surface\"][:, cell_index]\n",
+    "    wse = np.where(wse < -1e20, np.nan, wse)\n",
+    "    return pd.DataFrame({\"days\": time_days, \"wse_ft\": wse})\n",
+    "\n",
+    "\n",
+    "def max_wse_by_cell(hdf_path):\n",
+    "    path = (\n",
+    "        \"Results/Unsteady/Output/Output Blocks/Base Output/Unsteady Time Series/\"\n",
+    "        f\"2D Flow Areas/{FLOW_AREA_NAME}/Water Surface\"\n",
+    "    )\n",
+    "    with h5py.File(hdf_path, \"r\") as hdf:\n",
+    "        data = hdf[path][()]\n",
+    "    data = np.where(data < -1e20, np.nan, data)\n",
+    "    return np.nanmax(data, axis=0)\n",
+    "\n",
+    "\n",
+    "def find_reference_cell(geometry_hdf, baseline_hdf, target_value, tolerance):\n",
+    "    with h5py.File(geometry_hdf, \"r\") as hdf:\n",
+    "        centers = hdf[f\"Geometry/2D Flow Areas/{FLOW_AREA_NAME}/Cells Center Coordinate\"][()]\n",
+    "        min_elev = hdf[f\"Geometry/2D Flow Areas/{FLOW_AREA_NAME}/Cells Minimum Elevation\"][()]\n",
+    "\n",
+    "    baseline_max = max_wse_by_cell(baseline_hdf)\n",
+    "    finite = np.isfinite(baseline_max) & np.isfinite(min_elev)\n",
+    "    candidates = np.where(\n",
+    "        finite\n",
+    "        & (np.abs(min_elev - target_value) <= 0.15)\n",
+    "        & (baseline_max > target_value + tolerance)\n",
+    "    )[0]\n",
+    "    if len(candidates) == 0:\n",
+    "        candidates = np.where(finite)[0]\n",
+    "\n",
+    "    best = min(\n",
+    "        candidates,\n",
+    "        key=lambda idx: (\n",
+    "            abs(float(min_elev[idx]) - target_value),\n",
+    "            abs(float(baseline_max[idx]) - target_value),\n",
+    "        ),\n",
+    "    )\n",
+    "    return {\n",
+    "        \"cell_index\": int(best),\n",
+    "        \"x\": float(centers[best, 0]),\n",
+    "        \"y\": float(centers[best, 1]),\n",
+    "        \"min_elevation_ft\": float(min_elev[best]),\n",
+    "        \"baseline_max_wse_ft\": float(baseline_max[best]),\n",
+    "    }\n",
+    "\n",
+    "\n",
+    "def trial_metrics_from_hdfs(trial_hdfs, reference_cell):\n",
+    "    rows = []\n",
+    "    for trial, (qmult, hdf_path) in enumerate(trial_hdfs.items(), start=1):\n",
+    "        max_wse = max_wse_by_cell(hdf_path)[reference_cell[\"cell_index\"]]\n",
+    "        difference = float(max_wse - TARGET_VALUE)\n",
+    "        rows.append(\n",
+    "            {\n",
+    "                \"trial\": trial,\n",
+    "                \"qmult\": qmult,\n",
+    "                \"hydrograph_scale_vs_base\": qmult / Q_MULT_TRIALS[0],\n",
+    "                \"computed_wse_ft\": float(max_wse),\n",
+    "                \"target_wse_ft\": TARGET_VALUE,\n",
+    "                \"difference_ft\": difference,\n",
+    "                \"objective_ft\": abs(difference),\n",
+    "                \"within_tolerance\": abs(difference) <= TARGET_TOLERANCE,\n",
+    "                \"hdf_path\": str(hdf_path),\n",
+    "            }\n",
+    "        )\n",
+    "    return pd.DataFrame(rows)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3f75009e",
+   "metadata": {},
+   "source": [
+    "## Fallback: ras-commander Flow Multiplier Search\n",
+    "\n",
+    "The native settings remain on the copied plan. The fallback below demonstrates the same calibration/search pattern used by `RasCalibrate`: update a model parameter, run HEC-RAS through `RasCmdr`, calculate an objective from the result HDF, and select the best run. Here the parameter is the inflow `Flow Hydrograph QMult` in the unsteady flow file."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "bf0f2ef2",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-01T21:36:19.409533Z",
+     "iopub.status.busy": "2026-05-01T21:36:19.409533Z",
+     "iopub.status.idle": "2026-05-01T21:37:02.369953Z",
+     "shell.execute_reply": "2026-05-01T21:37:02.369953Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "cell_index             3.140000e+02\n",
+       "x                      6.822427e+06\n",
+       "y                      2.094066e+06\n",
+       "min_elevation_ft       3.963494e+03\n",
+       "baseline_max_wse_ft    3.964547e+03\n",
+       "Name: reference_cell, dtype: float64"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>trial</th>\n",
+       "      <th>qmult</th>\n",
+       "      <th>hydrograph_scale_vs_base</th>\n",
+       "      <th>computed_wse_ft</th>\n",
+       "      <th>target_wse_ft</th>\n",
+       "      <th>difference_ft</th>\n",
+       "      <th>objective_ft</th>\n",
+       "      <th>within_tolerance</th>\n",
+       "      <th>hdf_path</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>1</td>\n",
+       "      <td>1.2</td>\n",
+       "      <td>1.00</td>\n",
+       "      <td>3964.547363</td>\n",
+       "      <td>3963.5</td>\n",
+       "      <td>1.047363</td>\n",
+       "      <td>1.047363</td>\n",
+       "      <td>False</td>\n",
+       "      <td>C:\\GH\\symphony-workspaces\\ras-commander\\CLB-32...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>2</td>\n",
+       "      <td>0.9</td>\n",
+       "      <td>0.75</td>\n",
+       "      <td>3963.494385</td>\n",
+       "      <td>3963.5</td>\n",
+       "      <td>-0.005615</td>\n",
+       "      <td>0.005615</td>\n",
+       "      <td>True</td>\n",
+       "      <td>C:\\GH\\symphony-workspaces\\ras-commander\\CLB-32...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>3</td>\n",
+       "      <td>0.6</td>\n",
+       "      <td>0.50</td>\n",
+       "      <td>3963.494385</td>\n",
+       "      <td>3963.5</td>\n",
+       "      <td>-0.005615</td>\n",
+       "      <td>0.005615</td>\n",
+       "      <td>True</td>\n",
+       "      <td>C:\\GH\\symphony-workspaces\\ras-commander\\CLB-32...</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   trial  qmult  hydrograph_scale_vs_base  computed_wse_ft  target_wse_ft  \\\n",
+       "0      1    1.2                      1.00      3964.547363         3963.5   \n",
+       "1      2    0.9                      0.75      3963.494385         3963.5   \n",
+       "2      3    0.6                      0.50      3963.494385         3963.5   \n",
+       "\n",
+       "   difference_ft  objective_ft  within_tolerance  \\\n",
+       "0       1.047363      1.047363             False   \n",
+       "1      -0.005615      0.005615              True   \n",
+       "2      -0.005615      0.005615              True   \n",
+       "\n",
+       "                                            hdf_path  \n",
+       "0  C:\\GH\\symphony-workspaces\\ras-commander\\CLB-32...  \n",
+       "1  C:\\GH\\symphony-workspaces\\ras-commander\\CLB-32...  \n",
+       "2  C:\\GH\\symphony-workspaces\\ras-commander\\CLB-32...  "
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Selected QMult 0.900; max WSE 3963.494 ft vs target 3963.500 ft.\n"
+     ]
+    }
+   ],
+   "source": [
+    "fallback_trials = pd.DataFrame()\n",
+    "reference_cell = None\n",
+    "best_trial = None\n",
+    "trial_hdfs = {}\n",
+    "\n",
+    "if project_available and RUN_FALLBACK_SEARCH and native_trials.empty:\n",
+    "    unsteady_file = working_project / f\"{ras_project.project_name}.u01\"\n",
+    "\n",
+    "    for qmult in Q_MULT_TRIALS:\n",
+    "        RasUnsteady.update_flow_multiplier_by_station(\n",
+    "            unsteady_file,\n",
+    "            BOUNDARY_LABEL,\n",
+    "            qmult,\n",
+    "            ras_object=ras_project,\n",
+    "        )\n",
+    "        compute_result = RasCmdr.compute_plan(\n",
+    "            BASE_PLAN,\n",
+    "            ras_object=ras_project,\n",
+    "            num_cores=4,\n",
+    "            verify=True,\n",
+    "            force_rerun=True,\n",
+    "        )\n",
+    "        assert compute_result, f\"HEC-RAS compute failed for QMult={qmult}\"\n",
+    "\n",
+    "        source_hdf = plan_hdf_path(BASE_PLAN)\n",
+    "        snapshot_hdf = TRIAL_HDF_ROOT / f\"qmult_{qmult:.3f}.p{BASE_PLAN}.hdf\"\n",
+    "        shutil.copy2(source_hdf, snapshot_hdf)\n",
+    "        trial_hdfs[qmult] = snapshot_hdf\n",
+    "\n",
+    "    geometry_hdf = working_project / f\"{ras_project.project_name}.g01.hdf\"\n",
+    "    reference_cell = find_reference_cell(\n",
+    "        geometry_hdf,\n",
+    "        trial_hdfs[Q_MULT_TRIALS[0]],\n",
+    "        TARGET_VALUE,\n",
+    "        TARGET_TOLERANCE,\n",
+    "    )\n",
+    "    fallback_trials = trial_metrics_from_hdfs(trial_hdfs, reference_cell)\n",
+    "    best_trial = fallback_trials.sort_values([\"within_tolerance\", \"objective_ft\"], ascending=[False, True]).iloc[0]\n",
+    "\n",
+    "    display(pd.Series(reference_cell, name=\"reference_cell\"))\n",
+    "    display(fallback_trials)\n",
+    "    print(\n",
+    "        \"Selected QMult \"\n",
+    "        f\"{best_trial['qmult']:.3f}; max WSE {best_trial['computed_wse_ft']:.3f} ft \"\n",
+    "        f\"vs target {TARGET_VALUE:.3f} ft.\"\n",
+    "    )\n",
+    "elif project_available and not native_trials.empty:\n",
+    "    print(\"Native trial results were available; fallback search was not needed.\")\n",
+    "elif project_available:\n",
+    "    print(\"Fallback search is disabled.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1b5ae539",
+   "metadata": {},
+   "source": [
+    "## Input vs Optimized Hydrograph"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "813ddd1d",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-01T21:37:02.372490Z",
+     "iopub.status.busy": "2026-05-01T21:37:02.372490Z",
+     "iopub.status.idle": "2026-05-01T21:37:02.498971Z",
+     "shell.execute_reply": "2026-05-01T21:37:02.498971Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA/MAAAGbCAYAAACIxMC9AAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjksIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvJkbTWQAAAAlwSFlzAAAPYQAAD2EBqD+naQAAt89JREFUeJzs3Qd4FEUbB/B/eiOdJEBIKKH33ot0kF5UioCKNEHBLoognwW7gqCICqJIlab0Lr230FsgQCCFkN6T+553lgtJCJBAkrvk/r/nWW5vb7M7tzcJ9+7MvGOm0+l0ICIiIiIiIqJCw9zQBSAiIiIiIiKi3GEwT0RERERERFTIMJgnIiIiIiIiKmQYzBMREREREREVMgzmiYiIiIiIiAoZBvNEREREREREhQyDeSIiIiIiIqJChsE8ERERERERUSHDYJ6IiIiIiIiokGEwT0REZGS2b98OMzMz9ZhXfv/9d3XMK1euoCCVLVsWL7zwwiP3k7J99NFHj3WOlJQUvPPOO/Dx8YG5uTl69er1xMfMK3J+KUdYWFi+nkc+VzmPfM6mQN7r2LFjDV0MIiKDYjBPRESZgr1Dhw4ZxRWJi4tTgVBeBrTG5scffzSZ4Cs/zZkzB1999RX69euHefPm4fXXXzd0kYiIiPKdZf6fgoiI6PGC+SlTpqj1p556qsgG88WLF7+v5bpVq1aIj4+HtbV1np1r8ODB6N+/P2xsbGCM5P1aWj7e15KtW7fC29sb3333XZ6Xi4iIyFixZZ6IiMjISFdxW1tb9ZhXLCws1DGl94UxkrI9bjAfEhICFxeXPC9TURQbG1skz0VEZIoYzBMR0QNJi3GxYsVw48YNNQ5Z1j08PPDWW28hNTX1vvG6X3/9tWodLVOmDOzs7NC6dWucPHky0zGllT27lnY5l4yv1h9PziOkdV6O/bDxzzI0QF6XLtZZbdiwQb22evVq9Tw6Ohrjx49X55JWak9PT3To0AFHjhx5ZE04evQounTpAicnJ3Ut2rVrh3379mU7XGHHjh0YOXIk3N3d1f5DhgzBnTt30veT8586dQr//fdf+vvTX5fsxszLazVq1MCJEyfUdbW3t0eFChXw999/q9flOI0bN1bXvXLlyti8efNDx8zrx3Jnt2TsKZCWlobvv/8e1atXVwG3l5eXel8Z34vQ6XT45JNPULp0aVW2Nm3aqPeXU1k/X335Ll68qMojwbqzszNefPFF1WsjY73btm2bOpe+/A8bmvGozzAiIkLd+Jg+fXr6NhnvLjdW5LOU96k3evRolChRIkfvT477oPch5DOtXbt2tj8rn2enTp3uO5YcR443dOhQte1Bv7+XLl3C008/DUdHRwwaNCg90H7zzTdVngH5PZBzyO9vxven7zHx2muvqR4k8vM9evRQfw8e9HmdPn0aAwcOhKurK1q0aKFekzorZSlfvryqQ3LNXnrpJdy+fTvTufTHOHv2LJ599ln1Gck1HzduHBISErK9NitXrlS/F/IepI6uX78+R58HEVFRwG72RET0UBK0SyAhgaJ82Zcg8ZtvvoGfn58KZjL6448/VLA8ZswY9eV72rRpaNu2Lfz9/VUQmFMSyP/000/q+L1790afPn3U9lq1amW7f4MGDVSgsGTJEhXYZLR48WIVWOiDoVGjRqkAWJJnVatWTQUUu3btwpkzZ1CvXr0HlkmCxZYtW6oAQ5KtWVlZ4eeff1ZBtj6QzkiOL4GWBCjnzp1T7+fq1avpgboEyK+++qoKtj744AP1M4+6RhJAd+vWTXWXf+aZZ9QxZf2vv/5SNyjkvUkgpR8/fu3aNRWAZUeuqdwMyOjw4cOqXHKDQ08Cd7kRIMGnBHUBAQGYMWOGCop3796troOYNGmSCuYlaJRFbo507NgRSUlJeBIS1JUrVw5Tp05Vx/z1119V+b744gtVT/788098+umniImJUfuIqlWrPvZnKJ+ZBIdyM0ber5D6IZ9ZeHi4ClYlaBQ7d+5Ux3vS96EfBjF8+HB180vOr3fw4EGcP38eEydOVM8l2O7Zs6cqk3ze8l5XrFhxX73PmBxQ6r4E1vL7Kzda5BgSlMtNkGHDhqFOnTrqptfbb7+tAvWMwxUkCJffKylfkyZN1HXq2rXrA9+n1MuKFSvis88+S78xsGnTJly+fFnVIQnk5XOYPXu2epQbKVl7i8i1kptdcq3kdbmxInVf/r5kJNdg+fLleOWVV1Q9l/369u2LwMBAdROAiKjI0xEREel0urlz58o3b93BgwfTr8fQoUPVtv/973+ZrlHdunV19evXT38eEBCg9rOzs9Ndv349ffv+/fvV9tdffz19W+vWrdWSlZyrTJky6c9DQ0PVz06ePDlHn8+ECRN0VlZWuvDw8PRtiYmJOhcXF91LL72Uvs3Z2Vk3ZsyYXH/mvXr10llbW+suXbqUvi0oKEjn6Oioa9Wq1X3XUa5PUlJS+vYvv/xSbV+1alX6turVq2d7LbZt26b2lUc92U+2LViwIH3b2bNn1TZzc3Pdvn370rdv2LBBbZeyZC2XfFbZkevt6+urq1mzpi4mJkZt27lzp/qZv/76K9O+69evz7Q9JCREXZuuXbvq0tLS0vd7//331X7y2T5K1s9a1mVbxs9O9O7dW+fu7p5pm1wbuZaPOmZOP0OpH15eXunP33jjDfW6p6en7qefflLbbt++rTMzM9NNmzbtoe8rp+8jIiJCZ2trq3v33Xcz7ffaa6/pHBwc0j+TlStXquNJfdJLSUnRtWzZ8r7PXP/7+95772U6pv4Yn3zySabt/fr1U+/p4sWL6vnhw4fVfuPHj8+03wsvvPDAz2vAgAH3XYO4uLj7ti1cuFDtv2PHjvuO0aNHj0z7vvLKK2r78ePH07fJc/ks9WUV8rps/+GHH+47HxFRUcRu9kRE9EjSApiRtEZKS1tW0hVfEpHpNWrUSLV2rl27Nt+v8nPPPYfk5GTVUqe3ceNG1f1YXtOTltf9+/cjKCgoV70T5Fjy/qQHgF7JkiVVS7i0EEZFRWX6mREjRqS3WgvpZSBjwp/kWkgrvrTE60nXaHk/0jqbsWeAfj27z+hB72/AgAGqV4W08jo4OKjtS5cuVV25ZRiCdDXXL/Xr11dlkZZdIb01pAVeehpkbGWV3gL5UfekN0XW652Xn6GcIzg4WPWo0LfAS1JC2S7rQvaXmDKnLfOPeh9ynaXFfeHChekt2lJm6VkiZdZ/JlJ/pB5l7BUjwwLk2j9I1h40cgz5GX3PAz3pdi/nXrdunXqu77IuLd8ZPexcWd+nkKEfetJjR+qQtPKL7Ia3SM+e7M6X9Xenffv2qoeQnvTckV4XOa33RESFHYN5IiJ6KBnjqh+/rifd1rOOmRbSvTarSpUqFcjc5jLeuEqVKir40ZN1GesrXf31vvzyS9WVWcYKy80G6Qb/qC//oaGhanyzBM9ZSSAt48qlS/vDroUEvxI4Psm1kPHoWbskSxAo7yXrNpHdZ5Qd6cItGeEXLFiQKTi6cOECIiMjVXdwqQMZF+nWLonnhAwfyO49y35SV56Er69vpuf64+X0vT3OZ6gP0CVwl7HlMqRAtklArw/m5VECxweNc3+c9yF5FaSLuP4ccpNEbipIF3c9udZSj6Q+ZZTd+xIS+Eu9yUiOUapUqfuGYOiHJ+g/T3mUXAEyPCCjrMMzMsq6r5DhCTLuXYaRSGAv9UK/n9SvrLLWI6mTUo6svztZr+nD/jYRERVFHDNPREQPJS14eUmC0axJtkTGhHqPS1rgZfy0tPxJoPLPP/+oFueMWdJlPK4EZtICLS21Mr5cxi1Li74kRiuMn8WDtmd3nbNLICbv/+OPP0bnzp0zvSYBrgTyMiY/O1lv8uSHJ3lvj0sCXQk2Zdy8jN2WczVt2lS9XwlKJciVgLtZs2Y5nnEgJ+9DxrZLwDt//nx140AeZYy5tEA/LkkMl5ezIjxKxlb4jL9ze/bsUWPyZXy+3IiQuiX1TR4f5UEzMBiibhARGRO2zBMRUZ6RltysJHmXPku9vuUsu8zb+tZAvceZQk2CeUn4tWzZMtVVWLowZ+yWrictm9J1WAJZSegmybLkJsCDSBAnicP03a4zkszbEixlbR3Pei2kJfvmzZuZroWhp4mTz0YSp0k37vfff/++16VFVLqCN2/eXAWUWRd9q7TMXpDde5bWcGNpJc3tZ6jvUi+LBKByc0jer/R6kO7n0j1cAu68JMGpdPmXBI1y3aR+ys2ojEGrXGupR1KfMsrufT2IHEOGmciwiqzXQf+6/lGCbfkdyUhmGMgpeR9btmzBe++9p2amkISWMmwj41CHrLLWIzmflCPj7w4RETGYJyKiPCTBh2TD1jtw4IAan56xxVsCRAkaJNDTO378uMqMnpEEXiK7wP9BpJtwzZo1Vfd6WSRozxhwSet/1m690vIsLbGJiYkPPK4EU5KZfdWqVZm6+koXaOmaLpnCpct1RpKtW8bw60nmebnRkPFayDjo3Ly/vCTBoARWkuNApvTL7saCtKjKNZNW+6zkvejLLoG95Af44YcfMrWKSmZ8Y5Hbz1CCedlP6pG+270E/NIa/+2336rPNqfj5XNDutRLACyzCMhn9Pzzz2d6XWYKkGsv9UlPPiO59jklx5CfkVkJMpIs9lIP9HVUPwPEjz/+mGm/3JxLfyMia2v5w+rGzJkzsz2fsfecISIqaOxmT0REeUbG0kpQJAm3JDiWL+zS6i3TgOnJ/NISDEmgINNiybjrWbNmqem+MiY1k+66MnWcBFMy7t7NzU1N2ZVx2q4Htc7LNGky1l+On7GLsbREyvhhmbZNWlmlu6+MS5bpv2S6vYeRaddkii15f9KqL133ZVozeZ8yDj8rSQgnc5hLQCytphIQyc/KlGB6kkhOgjI5tlw7ubGQcXx/fpJWUplmTcbLS4CbkdxwkW7lMve5BJUyRdixY8dUMCxBu7ScSnI8mXpQrqW0er/11ltqP5k6T4JFGWcuvSMkZ4GxyM1nqA/U5bOTadb05OaQvC/pvt6wYcM8L2PdunVVHZfrKzensk6X2L17d9VTQlq65WaD/I7IEJHsxp4/iByjTZs2akpEOYb8LsiQE6kHkrRQnzdB6qdM9Sa/x9JDQz81nfToyGnPErlBItdMrq/cAJGbR3KurK39Gclr8nsi3fD37t2rhhtIj4Wc5icgIjIVDOaJiCjPSAIvCZ7ly78E6ZJgTlr/pIVcTwIUmS9aAu433nhDBSMyV7i0jsoc7BnJXNySyfr1119XwfHkyZNzFMxLgCrJzjJmsde39ksQJ8GEBEDSdVeCaAm0s2b8zkpuNkiX6wkTJqigVX5WssZLoJF1jnkh71vGmsv7lCBGukvLPNgZAyB5TYYXSKAjNxokeC6oYF7fM0IC3Kyk670E80JutEhQJ0GvdMWXAFi6O0uLsQSVenIcuYEi+0uWe7kmcp0fNid5QcvNZygJ5eTmitRjCf6zBvlStyWgz6/fI7kBljHxnZ78fkkuCAm6pdxSnyTwlZtRciMgJ/THkPonN8vmzp2rPlPJHyEZ7TOS31UZty9Z9iXPhPTCkJ+R6yOfd07I77b8HkuLu7TQy00huSEiPWKyI8eXsskNC6lvY8eOVWUjIqLMzGR+uizbiIiIckVa9yRhmHzhlhZaU/b777/jxRdfVK39DRo0MHRxqBCSHg9yA0t+r7LL2G5o0ktDbhzIzYRBgwbl2XFlZgnpMSI3moypRwcRkbFiAjwiIiIiIyFtLL/99pvqpWEMgXx8fPx926TnjbTu53UCQCIiyh12syciIiIyMJnPXrq+yxAFf3//+/IYGIoMATl8+LAaYy9d3qV7vCwjRoy4bwYHIiIqWAzmiYiIiAxMupZLkjcXFxeVmyBjokRDkuz9kjRQZjSQ7PrSW0C6w0vyPCIiMiyOmSciIiIiIiIqZDhmnoiIiIiIiKiQYTBPREREREREVMhwzHwekblqg4KC4OjomGkOYSIiIiIiIqLczGwSHR2NUqVKqdlDHoTBfB6RQJ5ZXYmIiIiIiCgvXLt2DaVLl37g6wzm84i0yOsvuJOTE4y5B4FkzPXw8HjoXR6igsa6ScaKdZOMFesmGSvWTTJWaYUkFoqKilINxfoY80EYzOcRfdd6CeSNPZhPSEhQZTTmCkymh3WTjBXrJhkr1k0yVqybZKzSClks9Kjh28b/DoiIiIiIiIgoEwbzRERERERERIUMg3kiIiIiIiKiQoZj5omIiIiIKF+m10pOTkZqaiqvLhnNmPnk5GQ1bt6QY+YtLCxgaWn5xFOaM5gnIiIiIqI8JQG8zPIUHx/PK0tGdYMpLS1NzeH+pIH0k7K3t0fJkiVhbW392MdgME9ERERERHlGgqU7d+7A1tYWpUqVUsGKoQMnIn0wn5KSkiet4k9ShqSkJDVFXkBAACpWrPjYvQQYzBMRERERUZ6RQEVIq6ODgwOvLBkNnREE88LOzg5WVla4evWq+n2RG1+PgwnwiIiIiIgozxWGebyJCvPvB3/DiIiIiIiIiAoZBvNEREREREREhQyDeSIiIqI8FhmfjB+3X0RwVAKvLREVCWXLlsX3339v6GKQsQTzO3bsQPfu3VWWS0lAsHLlyvTXZP6/d999FzVr1lSJM2SfIUOGICgoKNMxwsPDMWjQIDg5OcHFxQXDhg1DTExMpn1OnDiBli1bqsQCPj4++PLLL+8ry9KlS1GlShW1j5xz7dq1+fjOiYiIqCj7YIU/vlx/Du8v9zd0UYgoh1544QX06tWrwK/X77//ruKYnJCp/iZPnoxKlSrBxsYGxYsXxzPPPINTp05l2u+jjz5S8VXnzp3vO8ZXX32lXnvqqaeeqNxZ47cH+fTTT9GsWTM1FVtO3mdexoFFnUGD+djYWNSuXRszZ86877W4uDgcOXIEH374oXpcvnw5zp07hx49emTaTz5AqbybNm3C6tWr1Q2CESNGpL8eFRWFjh07okyZMjh8+LCqvFK5Z8+enb7Pnj17MGDAAFUBjh49qn6JZTl58mQ+XwEiIiIqag5eCcfqEzfV+pazIbgcalpfLokofyQmJqJ9+/aYM2cOPvnkE5w/f141QEp29saNG2Pfvn2Z9pfZBLZt24br169n2i4/7+vrW2Afk2RrlxsOo0ePztH+eRUHmgSdkZCirFix4qH7HDhwQO139epV9fz06dPq+cGDB9P3Wbdunc7MzEx348YN9fzHH3/Uubq66hITE9P3effdd3WVK1dOf/7ss8/qunbtmulcjRs31o0cOTLH5Y+MjFRlkUdjlpqaqrt586Z6JDImrJtkrFg3KXf1JU3XbfpOXZl3V+v8JqxRjxNX+KvXIuKSdL/uvKz7cv0Z3febzusuBEezblKRFBsbq/P399fFxcWlb0tLS9PFJiYX+CLnzamhQ4fqevbsmf68devWuldffVX39ttvq3jCy8tLN3ny5Ew/I9//Jd7o3LmzztbWVleuXDnd0qVL01/ftm2b2ufOnTvp244ePaq2BQQEpL+eccl6Dr3PP/9cxTnHjh277/+pBg0a6KpVq5b+fuUYtWvX1nXr1k33ySefpO+7e/duXfHixXWjR49W7y/jex03blym48q1kGuiV6ZMGd13332Xvp6xzPL8UebOnatzdnbWPY7HiQOzI9cnKSkpV/Uiv8THx6v3IY+PG1sWqnnmIyMjVXcOffeMvXv3qvUGDRqk7yN3qyTN//79+9G7d2+1T6tWrWBtbZ2+T6dOnfDFF1/gzp07cHV1Vfu88cYbmc4l+zys24jcGZMlYw8AkZaWphZjJWWTvzvGXEYyTaybZKxYNyk35u+7Cv8bkShmY4lPe1XHuMXH8ffh64hNTMHmM8GISkhJ33falvNoX9ULznZWqODpgIGNfOFgk/OvZqybZKwyfs/U4l0gLikF1SdvLPCynJrSEfbWuQt59GUW8+bNw+uvv65avSVmePHFF1WX8Q4dOqTvIy3IU6dOVePJ//zzT/Tv318N861atWr6seQx47r+sWnTpvjuu+9U1/mzZ8+q7cWKFctUBr0FCxao89aqVSvT6xIfjR8/Hs8//zyOHTuGOnXqpL8u5ZUu6++//756/ttvv2HgwIHZvteMZXzQ9dDvc+DAAXh5ealWfunKb2Fhke3PZnecR+2XnYiICPU+nZ2d1c9Lz2oXFxfUr18//Xjt2rVTcaB8VhIH5kc58pL+WmYXP+Y0Vis0wXxCQoKqiNIdXsZFiFu3bsHT0zPTfpaWlnBzc1Ov6fcpV65cpn2k4ulfk2BeHvXbMu6jP0Z25Bd2ypQp920PDQ1VZTVWUjHkpohUHM79ScaEdZOMFetm0ST/D4bHaYG1i50lLMzNnviYITFJ+Hy99mV8RNOSaFTCApU87HA+NB7Lj95Q28u52aKhrxOuRyRgz5UobDwdnP7zs7ZfQp9aHuhUxQ2+rraPPB/rJhkr6VYt9VPGPst3cyFdwQ1BzpuSw4HF+qBKX1b5OyHjtj/44AP1XGKKGTNmqG7dbdq0Sf+5vn37qvH2QoJyeX369On44YcfkJqaeq8cd4+b8VG+jzs6OqpAVca/Zyx3VtKtvnXr1tm+VrFiRfV45swZ1KhRI/1mnwTa0r1dutvXq1dP5QmTdblJIa9nfK8Zn2d3PfTb5LnEUELKri/3oz5jfYCa27qgjwOfe+45Ne5efl7Gz3t4eNx3LIkD5bUHnUPeo/4zkWtuSFJGuSa3b9+GlZVVpteio6OLTjAvfwieffZZdfF/+uknGIMJEyZkas2XlnlJrieVSn+zwRhJhZGKK+VkME/GhHWTjBXrZtETGp2IMX8dweHACPW8SglHrBrTDFYWmb/xR8QlwdrS/IGtevK95Pj1SPxzLAhHr0UgJDoRcUlpqOPjjNHtq6sbBD8PKYb1p4KRmqZDueIO6FjNK/3GwfHrEdh76TaSUtKw4lgQrt6Ow2/7b6plRMtyeKdTZZg/5CYD6yYZKxnzLN+NJUDRB/OOFhaqlbyg2VlZ5Dhok+/GsujLLD8nreD650KSsYWFhWXaJi31GZ9La/vx48fVNmmxFrKu3yfjoyz67+QZj/Ew2e2n32ZnZ5d+TCm/PJex5dJj4OrVqypxngT1f/zxh3o943vN+Dy766HflvG5vL+clju371MfB0r5xaxZs9J/Vv/+LLM5VtYyZidr8GwI+s/J3d1dJWHPKOvzBx4DhSSQl8q3devWTIFyiRIlEBISct8dDslsKK/p9wkOvnfXW+ifP2of/evZkeyRsmSlr/TGTCp+YSgnmR7WTTJWrJuFV0xiCt5achw66DCpe3WERCXgtUVHcS08Pn2fs7ei8feRG2ha3h3/Hr+Jfg1K43p4HF78/SBKu9ph7WstYXk30JcAf9u5EJwOisKGU8EIDI/LdD5rC3N83rcWrCy1L/DlPBwx+inHbMtW19dNLWJM24pYc+ImVh67ge3nQjF7ZwCuR8RjSo8a8HC8//uGHusmGaOM3zH1gbQ8OtgUju+eGYN/Gaqb8bmsy428rNuyPtc/6oP5jNv1rcb6n8u4/8NI67t0xc9uP30X/cqVK993TEnyLQnyJLn3Sy+9lO059Z9ZxmNLHJZ1W3bvNac3S3L6PjOeX1rj9XGgdLHPmNwvJCQk07H0caC89qBzZPzsDN0yr7922cVlOY3TLAtDIH/hwgXVHUTuWmQkd71k/IRkqZfxEkI+aLlTLRVWv490jZFj6e/ASNcXqej67iGyz5YtW9RYEz3ZR7YTERFR4RKdkKxavN2L2eCL9WdxICBcbZcgOTFF6+ZZxt0ev7/YCP+dC8FH/57G95sv4DvdeYTFJOHXnZeRptMhLikV54Nj8M/xIPSpVxpRCcnoOn0XbkTcuxFgb22BDtW81Nh3BxsLlHF3gJ9HsVyXWXoF9KrrrZYVR6/jnb9PYK3/LWw7G4oxbfzwylMVHtpKT0SGI2O0Zeq0jM/r1q2r1qU3rLh582Z67CHj2jOSGwb6rt8PI8ONJa6RVn+ZEUxPYh8Zdy95xKpVq3bfz1WvXl0tMo4/43j5jKScUkY9KY8E/xmHE2QlsVVOym2oONAUGDSYl3kAL168mP48ICBAVW4Z6yB3VPr166emI5CpBqSi6Mewy+tS6SWphIwDGT58uOp2IR/62LFjVdIJ6QIjpMLK2Ha5IyVjLaRSTps2TVV4vXHjxqnxJ9988w26du2KRYsW4dChQ5mmryMiIiLjJQnmpNv6oSt3MGd3ACLitBYl4WhjiXIeDjhxPRISD0tgPqFLFRXsl3LxxS87A9IDdBtLc0Qnaq1mrvZWuBOXjB+3X0KvOt74Yt1ZtZ+now06VS+BRuXc0K6qZ66Taz1K77ql4etmj//9e1p14/9643nVe+DrZ2rD1upeKx8RGQcZhy6BdIsWLfDXX3+p5HCSaE5UqFBBDcWVqbFlvnUZ9y4xR0Zly5ZVcZE0LkqQLuPCZclKEvGtWrUK3bt3V8eQoFV6E3/22Wcq6JWkcA8iga7ESg+a571t27ZqCPGaNWvg5+eHb7/9VgXLDyPlljI3b95c9VjW36zIKjAwULWYy6PEdPqbGXJtJNmfqFKlispJJonrpJx5EQeaBJ0BZTcVgywyBYJM1ZDda7LIz+ndvn1bN2DAAF2xYsV0Tk5OuhdffFEXHZ15qpfjx4/rWrRoobOxsdF5e3uraR2yWrJkia5SpUo6a2trXfXq1XVr1qzJ1Xvh1HRET4bTf5GxYt00fscC7+jqf7xJTQOnX5pN3aK21ZmyQXcw4LYuOSVVt/ZEkO5iyP3TwS09dE39TPtvtuuCo+J1v+y4pJu86qTuVmS8rsbk9eq1V+YfTj/27ouhBfK+ZOqkRQeupk9x1++n3brwmHtT7bJuUmGamq4wyG5qukdN1yaxycyZM3UdOnRQsUbZsmV1ixcvzvQzu3bt0tWsWVNNXdeyZUs1dZ1+ajq9UaNG6dzd3R86NZ2IiYnRffDBBzo/Pz+dpaWl2r9ChQq6a9euZdpPPzXdg8j7yjg1nUzXJtPVubm56Tw9PXVTp0596NR04p9//lHnlnI8bGo6OcajYjp5LlPXibyMA4v61HRm8o+hbygUBZLkQ8ZxSKZ4Y0+AJ+NLZBYAjpknY8K6ScaKddO4yTjzN5ceQ0Jymmoxr1XaBZ1rlECvOqXUOPesY1sf5NCVcFQu4QhH28xJkb7ecA4ztt3rRfhcAx980a8WCtKei2EYOf8wohNSUL64A2YPqY8Kno6sm2TUCfAuX76sWnglAVtRJn9fVqxYgV69ehnk/OvWrVOt2V9//bVqmaaH02fsl+Rzhh4zL1n6pWe6zJKQNeFdTmNLox4zT0RERJSdO7FJ+GTNGSw7cl09f6qyB2YOrHffPO05/bLWoKyWiC6rMW0qwM7aQo2XL2ZtiZdaZJ7utiA0q1Acy0Y3wwtzDuByWKwat/92p8p4pr53gZeFiIxLly5dVEC/c+dOlWU/4/R2VPQxmCciIqJC1aoye8dlzNh6UY1tlzHwo1r74Y0OldIzzuclCeQloDe0Sl6OWDm2Od5aegI7zoeqGxlfbjiHTpVd8XEfV7g4PDjjPREVbZKk7mGJ6qjoYjBPREREhcb286GYuk6bgqlqSSf8r2d1NHxAq3pR4+loi3kvNsSCA4GYu/sKLobE4N9Tt3Ho+i78MKDuA3sXEFH+4YhlMqTCMdkjEREREYDlR26o6/Bsg9JY82oLkwnkMw4bGNS4DDa93gqLhjdGaWcb3IxMwMBf9uPf40GGLh4RERUgBvNERERUaOaP33hKm57o+SZlTHredQnqZWq8PwZVRcdqXkhKTcOrC49i3KKjuBIWa+jiERFRAWAwT0RERIXChlPBSExJQ3kPB9T0djZ0cYyCvbUFZg6si5fvJuZbdSwIXabtxOmgKEMXjYiI8hmDeSIiIjJ6kk1+wf6rar1XHW+DTylkTCzMzTCxWzWsfrUF6vq6ID45VbXQxyelIjWNMxATERVVTIBHRERERkkC0TM3o7D6xE0sOhiIiLhkWJqbqWCe7lfD2xm/DmmAztN24kJIDJpM3aJugrSoUBxvdayM2j4uvGxEREUIg3kiIiIyKtKiPOLPQzgQEK661ev5eTioFmhfd3uDls+YuRezwTfP1MbQuQcQGZ+stu28EKaWoU3L4L0uVdV0e0REVPixmz0REREZFcnKLsGnBPJ2VhboVN0LPw6qh42vt0abyp6GLp7Ra1XJA/+ObYElI5ti/fiW6FNX68kwb+9VdPthJ/yvRxq6iEQm66OPPkKdOnWe6BhXrlxRQ42OHTuG/PL777/DxcWlSF/HooDBPBERERmVJYeuqcdx7Sri5JRO+HlwAzxds6QaG04573Iv2e6rlHDCt8/VwbyXGsHT0QaXQmPR+8fdmLH1AlJS7/V6ICLNtWvX8NJLL6FUqVKwtrZGmTJlMG7cONy+fTvXl0gC7pUrV2ba9tZbb2HLli1PdLl9fHxw8+ZN1KhRw+Af2+rVq9G6dWs4OjrC3t4eDRs2VDcCsrv5YGFhgRs3tOlF9eR9WFpaqtdlv8f1wgsvoFevXjna96effkK5cuVga2uLxo0b48CBAw/dPzk5Gf/73//g5+enfqZ27dpYv379ffvNnDkTZcuWzfFx8wKDeSIiIjIal0JjcOjqHRW4D2rsywA+j7Su5IEN41vh6ZolkJKmw9cbz+PZn/fiWnhcXp2CqNC7fPkyGjRogAsXLmDhwoW4ePEiZs2apYLvpk2bIjw8/InPUaxYMbi7uz/RMSQoLlGihAqCDemHH35Az5490bx5c+zfvx8nTpxA//79MWrUKHXTIitvb2/88ccfmbbNmzdPbS8oixcvxttvv41JkybhyJEjKjDv1KkTQkJCHvgzEydOxM8//6ze7+nTp9X76927N44ePZrpuG+88QYmT56c4+PmCR3licjISEkXqx6NWWpqqu7mzZvqkciYsG6SsWLdLBhR8Um67edCdK8vPqor8+5q3UtzDxTQmU2rbqalpemWHb6mqzFpvbrO9T/eqDsWeCdfy0mmJzY2Vufv76+Li4u7tzEtTadLjCn4Rc6bQ507d9aVLl06c7l1OvV7Zm9vrxs1alT6tjJlyuj+97//6fr3769eK1WqlG7GjBmZXpfYQL/IczF58mRd7dq10/cbOnSormfPnrpPP/1U5+npqXN2dtZNmTJFl5ycrHvrrbd0rq6uOm9vb92cOXPSfyYgIEAd8+jRo+nHyHgu/bJt2zb1ekJCgu7NN99UZZSyNmrUKP01vblz5+p8fHx0dnZ2ul69eum+/vprVZYHCQwM1FlZWeneeOON+16bPn26Ov++ffsylXfixIm6ihUrZtq3UqVKug8//FC9Lvvpy5L13CtWrFD76GW8jpMnT37ge89K3vvo0aPV30Ihfz/lukydOvWB77VkyZKZPlvRp08f3aBBgzIdd8yYMenPc3Lc+Ph43enTp9Xj48aWTIBHREREBpOQnIo/9l7Bj9svqWz1es808OGnkg+kK2ufeqVVF/wRfxzG6ZtR6D97Hz7qUQ3PNvDhlH+Uf5LjgM9KFfwVfj8IsHZ45G7S6r5hwwZ8+umnsLOzy/SatIIPGjRItb7++OOP6b8nX331Fd5//31MmTJF/ax0x69UqRI6dOiAgwcPwtPTE3PnzkXnzp1Va/qDbN26FaVLl8aOHTuwe/duDBs2DHv27EGrVq1Ui7ecd+TIkeq4sl9W06ZNw+eff57+XNalZ0GVKlXU87Fjx6oW5UWLFqnhAytWrFBl8vf3R8WKFdU55JxTp05VXdWlC7m0MD/M33//rbqfZ9cCL2WV6yJlkO7mej169FA9HXbt2oUWLVqoxzt37qB79+74+OOP8bjeeustnDlzBlFRUep6Czc3t/v2S0pKwuHDh1XLvJ65uTnat2+PvXv3PvD4iYmJqut8RlJHpPwZjzthwoRcHTcvsJs9ERERGcSyw9fR+qtt+GztWRXIe7vYoXZpZ/StVxrtqjLRXX4q7WqPJaOaqu73Mi/9u8v8MXr+EXVzhcgUSdd6nU6HqlWrZvu6bJfAMzQ0NH2bdC9/7733VAD/6quvol+/fvjuu+/Uax4eHupRksjJzQD98+xI4Dl9+nRUrlxZjdeXx7i4OBUQS7AtQaKM39cHj1k5Ozurc8giNwGkS/jy5cvV88DAQBXgLl26FC1btlTjviX4lWBaH/jKzQAJ7t955x31Xl577TXVRfxhzp8/r85bsmTJ+16TspYvX17tk5GVlRWef/55zJkzRz2XR3ku25906IKdnR1sbGzSr4OUIauwsDCkpqbCy8sr03Z5fuvWrQceX67Ft99+q+pIWloaNm3apK6vjPd/kuPmBbbMExERUYHbcykMby49rtYliB/fviJ61/WGpQXbGQpKMRtLzHmhIX7deRlfbzyH9aduYeyCI/jp+fqw4udAec3KXmslN8R5c0EC+pyScfRZn3///ffIrerVq6uW3IxBYMbkdtKqL+PsHzX+WsZwDx48GDNmzFA3GoS0vkugKUF61tZm/dh9adWWMeBZ30t2Sd5yI7uAWm5WNGvWDJ999pm6wSAt1ykpKTBm06ZNw/Dhw1VPB+mVITdEXnzxxfSbEobEYJ6IiIgKlHxZ/mrDObUu06ZN7VsTNpac+9wQJNHgyNZ+qFnaGS/OPYjNZ0Iw+Lf9+ODpamobUZ6Rruk56O5uKBUqVFCBWnaBrZDtrq6uD21hf1xZW6alHNltk1bhB5EWYOnG/vLLL6su83oxMTHqZoB0A8/a1V9atB+X9BiIjIxEUFCQ6rqfkXQ7v3TpUrat+zVr1lRB8YABA1RvB7lpkXWKPbmxkfWminTpf1LFixdX1yA4ODjTdnkurfkPIp+5zEqQkJCgZjWQ9ys9MqT3wZMcNy/w9jcREREVCPlydiMiHiuO3sDRwAjYWpnjvS5VGMgbgWZ+xTFrcH1YW5pj3+VwdJ+xCxOW+yM20bhbzIjyirRSy5h0GRMfHx9/X6D8119/4bnnnsuUV2Lfvn2Z9pPnGbvpS0AureL5TYJMySovQbJ0B8+obt26qgzSqi83LDIu+kBTyizj5rO+l4eRIQWSTf+bb7657zUZFy/DBIYMGZLtz0rr/Pbt29Xjg4Ln6OhoxMbGpm/LGvBn1wsg9RHXWvapX78+tm3blr5NbpDoZyt4FBk3L5n3pSfBsmXL1DXPeNyMUw7m5rhPgi3zREREVCCkNV4S3ekNbVYWnk6ZkwqR4bSp7InNr7fGd5vPqxsuCw8EYt/l21gysik8HG340VCRJ93TpQu4tCh/8sknai7yU6dOqYRpEsRJcryMJFndl19+qZLGyThq6Ta+Zs2a9NdlznEJ6KTLu4znlpb9/CAJ565du6bOlXFMv4zFl+71krxPAmsJvCW4l31k31q1aqFr165qjLyU8euvv1YBqiTze1QXe19fX/XeZfy9BLnSvV9uXqxatUqN9Zfrl3GoQEbSZf2ZZ55R+QSyI0nzZM56OY6UTW40ZJ27PquyZcuqcp87d07dmJHx/NmNxX/99dfVnPQNGzZU55FhEXLTQLrN68m1ks9bEgIKOf+NGzdQp04d9fjRRx+pYF1yDOjJtHRDhw5VUxs2atQo2+PmB7bMExERUb4LiojHrzsD1LqDtQWqlXTC6NZ+vPJGxtfdHt89VwcLhjdGSWdbBITF4qcMN2CIijLpOn7o0CHVffrZZ59VY6NHjBiBNm3aqLHdWTOkv/nmm2p/CZAleJVW8YxdyyV4liDfx8dH7ZNf/vvvP5WMrVq1aiohnX6RZHhCEt1JgCrlleR6cvNBsu1LQC6aNGmCX375RY0Nl/nRN27cqOZWfxQJjCUR3M6dO1UQK639cg4JvCUQfxBp0Zeu6fKYHbnO8+fPx9q1a1W3fMmKLwH0wwwfPly9NymHtOzLjZbsSO+KL774QmXrl+BcWvzlxkXG5HWSNFCf3E7f80Guh1xfGYIhgb4kI8x4M0KOKzdDZP76Bx03P5jJ/HT5egYTIVMhyB0gGTvi5OQEYyV3kaSbjUyVkTHRBpGhsW6SsWLdzBsTlp/AwgPX0LicGxaNaMIp0ApB3dxxPhRD5hyAnZUFdr3bBu7F2DpPOSNdrC9fvqyC4azTvBUV0hI8fvx4tdC96f3atWunYqF169ap1nVjo9PpVDd5uZGQcciEIchNgoCAANUDJOvUdzmNLRnNERERUb6S1t0lh66r9bc7VTb4FyjKmZYVi6NWaWc1dd3c3Vd42YjooaRFffPmzSqgz+/51UnDYJ6IiIjy1dS1Z5CapkObyh5oUDZzN1UyXnLT5ZWnKqj1ObsDsOdimKGLRERGTsarS1dzCegp/zGYJyIionwjAeDG08FqCrT3n76X5ZkKh47VvNDMzx1xSakYOvcAFuwPzNU83ERF1ZUrV9jFngyOwTwRERHli6SUNPxv9Wm1PrhJGVT0cuSVLmTMzc0w54WG6FqrJJJTdXh/hT9G/nkYkfFPPuczERE9GQbzRERElGekO/3JG5EqkJ+06iTO3oqGi70VxrevyKtcSNlaWeCH/nXxXpcqsLIwUz0t3lt2wtDFokKAvTiI8vf3g/PMExERUZ59MRm/+Bj+PR6EYjaWiElMgbkZ1FRnLvbWvMqFvIV+VGs/NCrnhmdn7cW6k7ew8dQtdKxewtBFIyMk83vL3wPJam+MGc2JjIH8fuh/Xx4Xg3kiIiLKEzO3XVSBvJBAXkzoUhVtKnvyChcR9XxdMbxVeTX3/IerTqKJnzucbB//iygVTRYWFmqqrdDQUJVIUQJ6zmJBxkBnBFPT6W90ydSiMle9/L48LgbzRERE9ESkS/20Lecxc9sl9fyTXjVQ3sMBsYmpaF+VgXxRM65dRazzv4krt+Pw5fqz+KRXTUMXiYxQsWLFVNAiAQuRsdDpdEhLS4O5ubnBbzBJIF+ixJP1bmIwT0RERLmWlqaDjPbbcSEUX6w7q8bGixGtyuP5JmV4RYv4GPrP+tTEwF/2Y/6+QPSq480pB+k+Eih5eXmpJTmZCRPJOKSlpeH27dtqCj0J6A1FutY/SYu8HoN5IiIiypUlB69hyr+nEJuUmr5Nktx91rsmnq5ZklfTBDTzK45nG5TGkkPXVXb7fvVLY1jLcvB0tDV00cjISMCSF0ELUV4F81ZWVmoYiCGD+bxS+N8BERERFei88RNW+KcH8jaW5qo1fuubTzGQNzHvP10VZd3tcTs2CT/vuIznf92vhlwQEVHBYMs8ERER5cjFkBi8suCImn6ud11vTOpWDXbWFqrbNZkemaFg/fhW2H4uBB+sOInzwTH4+b9LeLUdpyEkIioIbJknIiKiRwq8HYdBv+5DRFwyapd2xtQ+NeHqYM1A3sTJjZzONUpiUvdq6vkPWy/iYoiWP4GIiPIXg3kiIiJ6qL2XbuO52XsRHJWIip7FMPfFRgziKZMetUvhqcoeSEpNU2PooxKY8IyIKL8xmCciIqJsBUcl4P0V/hj46z7cjExQ08399XJjuDlY84rRfZnLv+xXCyWdbXEpNBbjFh5VMx4QEVH+YTBPRERE2Wasb/3VNizYHwidDhjQyAf/jm0BTydmK6fsSSb72YMbqKSI286FYuWxG7xURET5iME8ERERpdPpdPh6wzm8s+wEEpLTUL+MKxaNaIKpfWrBwYZ5c+nhapZ2xrj2WgK87zdfQHIqs9sTEeUXBvNERESUTqYYm7Htolp/rW0F/D2qKZqUd+cVohx7oVlZFC9mg8DwOCw5dI1XjoioKAbzO3bsQPfu3VGqVCk11mrlypX3tQ5MmjQJJUuWhJ2dHdq3b48LFy5k2ic8PByDBg2Ck5MTXFxcMGzYMMTExGTa58SJE2jZsiVsbW3h4+ODL7/88r6yLF26FFWqVFH71KxZE2vXrs2nd01ERGQYMYkpOBJ4B5tOB6vlVmRC+mvRCclYcfQ6vlh/Vj2Xaefe6FhZ/f9MlBv21pYY08ZPrX+36XymekZERHnHoP3lYmNjUbt2bbz00kvo06fPfa9L0D19+nTMmzcP5cqVw4cffohOnTrh9OnTKugWEsjfvHkTmzZtQnJyMl588UWMGDECCxYsUK9HRUWhY8eO6kbArFmz4O/vr84ngb/sJ/bs2YMBAwZg6tSp6Natm/rZXr164ciRI6hRo0YBXxUiIqK8E5eUgmWHr2PVsSAcunon02vWFuboUaeUmj/+2LWI9O0DG/vixeZl+THQY5M6tOjANZwLjsbIPw9h8cimnAGBiCiPmemk+dsIyJ3/FStWqCBaSLGkxf7NN9/EW2+9pbZFRkbCy8sLv//+O/r3748zZ86gWrVqOHjwIBo0aKD2Wb9+PZ5++mlcv35d/fxPP/2EDz74ALdu3YK1tZZ997333lO9AM6e1VofnnvuOXVjYfXq1enladKkCerUqaNuAOSE3DRwdnZWZZReAsYqLS0NISEh8PT0hLk5R1mQ8WDdJGNlzHVTxiOvOXET18LjYGVpju61S8HbxU69lpiSioX7AzFj2yWExSSm/4yXkw1KOtshPilVBVoZlXCyRduqnvioe3VYWxrXe6XCVTdF4O049Ji5CxFxyRjU2Bef9q5p6CJRATH2ukmmK62Q1M2cxpZGm8kmICBABeDSoq4nb6hx48bYu3evCublUVrY9YG8kP3lg9m/fz969+6t9mnVqlV6IC+kdf+LL77AnTt34OrqqvZ54403Mp1f9sna7T+jxMREtWS84PoKIouxkrLJjRJjLiOZJtZNMlbGWDdT03T493gQvt9yAYHh8enbf915GQteboyj1yIwbcsFBEVo3Zt93ewwuEkZPF2zhArk9XZfDMNa/1uo5FUMXWqUyJSp3pjeLxWeuplRaVdbTO9fB0PmHMSCA4EY0NAH1UoZb4MHmU7dJNOVVkjqZk7LZ7TBvATyQlriM5Ln+tfkUe6qZGRpaQk3N7dM+0gX/azH0L8mwbw8Puw82ZEu+VOmTLlve2hoKBISEoy6YsgdHqnExnw3ikwP6yYZK2Orm0euR+ObbYG4dFv7v8bV3hItyjnjRFAsrt5JQKfvd0Lf5a64gxVealwS3au7w8rCHEiMRkjIvdb4ik7AuOZ3/x9NiEJIgnZjmgoHY6ub2ankBHSo5IpN5+/gwxXH8WO/SszDYAIKQ90k05RWSOpmdHTmnnOFLpg3dhMmTMjUmi8t85Jcz8PDw+i72cuQBimnMVdgMj2sm2SsjKFuRsYn4+SNSGw5E4J5+66qed+dbC0xolV5vNCsjEo4Jl3p+8/ej8thsXCxs8Lop8qr1nhbKwuDlJlMo27mxKRejtjx7Q4cvRGDQ8Fp6FqrpKGLRPmssNRNMj1phaRu6vPDFdpgvkSJEuoxODhYZbPXk+cyll2/j4x5yCglJUVluNf/vDzKz2Skf/6offSvZ8fGxkYtWUmlMOaKIaQCF4Zykulh3SRTqptJKWk4FRSJ5NTsU9ckJKeqxHS7LoZhx/lQpKTd269/Qx9M6FIVzvZW6ds8neywbHQz7LwYhjaVPeBoe+81KroKw99NHzcHjGrtp4Z+/G/NGbSq5Jmp7lLRVBjqJpkms0JQN3NaNqMN5qVrvATTW7ZsSQ/epfVbxsKPHj1aPW/atCkiIiJw+PBh1K9fX23bunWruuMiY+v1+0gCPMl0b2Wl/cchme8rV66sutjr95HzjB8/Pv38so9sJyIiyksSpMv0byuO3lCJwXLK180eVUo4on8jH7StknlomJ6rgzV61C6Vh6Ulyhujn/LDvyeCcDk0Fp+vP4OpfWrx0hIRPSGDBvMyH/zFixczJb07duyYGvPu6+urgutPPvkEFStWTJ+aTjLU6zPeV61aFZ07d8bw4cNV1nkJ2MeOHauS48l+YuDAgWpsu8w//+677+LkyZOYNm0avvvuu/Tzjhs3Dq1bt8Y333yDrl27YtGiRTh06BBmz55tgKtCRERFlYzRe2/ZCaw8FqSeuzlYw+UBLZSW5mYoV9wBNUo5o0vNEqjg6VjApSXKOzLc4/M+tfDsz3ux8MA1tK7kgc412N2eiKjQBvMSMLdp0yb9uX4M+tChQ9X0c++8846aMk7mg5cW+BYtWqip5zKOIfjrr79UAN+uXTvVHaFv375qbvqMGfA3btyIMWPGqNb74sWLY9KkSelzzItmzZqpueUnTpyI999/X908kEz2nGOeiIjy0qz/LqtA3sLcDNP610GXGiXVOpEpaFTODcNalMNvuwLwxpLjKOPugKoljTfPEBGRsTOaeeYLO84zT2Qa836S6cmrurnk0DW88/cJtf5xz+oY3LRsHpaSTFFh/LuZkpqGF+YeVLkgvF3s8M/Y5nAvdn8OIircCmPdJNOQVkjqZk5jS+N9B0REREWAJLqTlkjpXi+kZfL5JmUMXSwig7C0MMeMgXVR1t0eNyLiMfqvI+p3hIiIco/BPBERUT45fDUc7b/9Dx+vPg1JRj+gkS8mdq3KebbJpLnYW+PXoQ1QzMYSBwLCMW3LeUMXiYioUGIwT0RElMdkBNuqYzcw4Jf9CAyPQ/FiNvhfz+r4tFcNBvJEgEro+HnfmupazN8XqGZ5ICKi3DHaqemIiIgKo0UHAvHj9ksqiBcdqnnh++fqwMGG/+USZSQJIEu7nsX1O/H493gQnmngwwtERJQLbJknIiLKI9K6+OGqkyqQt7e2wKjWfpj1fH0G8kTZkJkcBjb2Vevz9wfyGhER5RKDeSIiojxy/FoEklN18HC0waGJ7fFelyqceo7oIZ5t4AMrCzP1u7P7YhivFRFRLjCYJyIiyiOHrt5Rjw3LusLemt3qiR5F8kn0rOOt1l/6/SDW+d/kRSMiyiEG80RERHnkyN1gvn4ZN15TohyS5JDtqngiMSUNry48isDbWr4JIiJ6OAbzREREeSAtTYfDgfpg3pXXlCiHpBfLz4Pro3E5N6Sk6fD34Wu8dkREOcBgnoiIKA9cDotBRFwybK3MUb2UE68pUS5YWphjcNMyav3vw9eRmqbj9SMiegQG80RERHng0BWtVb52aRdYWfC/V6Lcal/VC852VgiKTGAyPCKiHOC3DSIiojzw3/lQ9digLLvYEz0OWysL9KpTSq0vPsSu9kREj8JgnoiI6AlJBu51J2/BzAzoWK0EryfRY3q2oY963HDyFoKjEngdiYgegsE8ERHRQ5y9FY2gyMQHvn4zMh7vLfdX66Nb+6G2jwuvJ9Fjql7KWU3tKInw/th7hdeRiOghGMwTERE9wNHAO+g+YzeGLT6L2MSU+17X6XT4YMVJRMYno3ZpZ7zeoRKvJdETGtainHr8a38g4pNSeT2JiB6AwTwREVE2klLS8N4yf5VV+05cChYe1MbwXr0di7eWHsfQOQfw3abz2Ho2BFYWZvj6mdpMfEf3nF0DfFUROLaQVyWXOlQrAR83OzU7xN9HrvP6ERE9gOWDXiAiIjJls3dcwrngaJibATJL1q87A3A7Ngm/7QxQXYAzJr0b06YCKno5GrjEZDTCLgDLRwBJMcC6d4EK7YFiHoYuVaFhYW6GYc3L4aN/T+PbjefwdI0ScC9mY+hiEREZHbbMExERZZGWpsNvuwLU+me9a8CzmBVCohPx83+XVSDfupIHBjb2haW5GWp4O2H0U368hqRJigWWDNECeZEYCWz+CEiOB85v1IL8v54BFg4EDs0B4sKBlEQZs8ErmMGgJmVQpYQj7sQl45M1Z3htiIiywZZ5IiKiLE7fjFJBhIO1BXrX9UbYnUh8ve0a3BysMbVPTXSqrmWsf//pqqqLvY2lBa8hAWmpwLKXgZDTgIMn0PUbYMlg4Nh8bcnq3Bpg9evaumMpoM5AoHpvwLMaYG7a7S1WFubqd63PT3uw4ugN9KrrrW6iERHRPQzmiYiIsthzKUw9Ni7vroKKvrU8UN+vJCqXdFYBvV4xG/43WihJa/imScClbZLGECjbAug16/4AOj4CsLACrB2yP05qChB0BLj8nxbAx4QAV3cBFjbAc/MB38ZAw+HAwV+0/e1cgVr9gRI1gZhg4PgiIOyc9lp0ELDza21x8ABavQM0fNmkg/q6vq54oVlZzN19BR+s8MfG11vB3pq/c0REevyLSERElMXui7fVYzM/d/VoZmamAntzEw6sCq3Q88Dy4YAuFWg+HogKAvZMB2K1fAfKicVagO1aDji+EKj1LBB/B1j7NuBSBhixHbAppu17ZTdwchkQfhm4fghIir7/nL1+1AJ50fVroP1kQJcGWBcDzDP04mjxOpAYDaSlAAH/acnyruzUyrbubcB/KdBsLFCpC2B57yaSKXmrY2VsPBWM63fiVcLJD7pWM3SRiIiMBoN5IiKiLFnsD14JV+vN/Irz2hQmqcnA7YtacH5pK2DnBlw/eG/8+rJh9/b1qAJ0/BQIOaW10m+SgPvuNGhnV9/b7/YFYNunQOepWgv8/D5a8K1n6wKUawmUbgRY2gIla98L5PVsHpAc0cwMsHXS1qV7vSwpScCRedo4++sHtPH3Lr5A9+mAXxuYGgcbS3zSqwZe/P2gymPRo7Y3apZ2NnSxiIiMAoN5IiKiDI5fj0BcUqrqTi8JuFQ3bDJuIWeANW8BgXu0FvCsyrQAfJsAx/4CnEoB9YYAtQcAljZAhXbA1T3A+fXavtIKLq3jyXFAree0lvr9swArO+Dgr1ogX6EDULU7ULIWUKJW5tb2JyUt8I2GA5WfBg79BhydD0QEAn/20srd8RPA1rSC2TZVPNG9din8ezwI7y0/gVVjmsPSgr1kiIgYzBMREd2l0+lUsi3R1E+61ZupzPZkpKQr/O7pwJ4fgLRkbZu0jpdtCdR8BkhN0oLwar0AC0ug3YfZt473/BH47wugXCugajftuAlRgGsZLamd/xJg5zfa/j6NtfHwVrb5+96cvYF2k4AWbwBbpgAHZgNH/gAubNK2y40GmMFUTOpWDTvOh+JUUJRqoR/ZmjNIEBExmCciIgKQkpqGiStPYtHBa+p6dKtZktfFWIVd1KZ1kwzxCZH3WtQ7fQq4ldcC9NxwcAee/vLec0lUJ4t4+iugmCeQGKUlpms6Nv8D+YxkrL6UoXof4J+x2jCClaPVzQezCh1gVbIV4NkNRZ2How0+6FoV7/x9AjO2XcTzTcqoLvhERKaMfwWJiIgAlTFbAnlzM2BKj+rowmDeON06CfzaDkhJ0J7LNG5tJ2rd0nMbxOeEnYt2k8DQyjQFRu3SWuh3fQfcuQKzg7/AHb9A599a634v3f6LsH71SuOn7ZcQEBaLvw9fx9BmZQ1dJCIig+KAIyIiMnlhMYmYvuWCug4f96qBwU0ZJBitHV9pgXypesDAJVqAW6Vr/gTyxkaGDDQfB4z3B579E7o6z0NnbgUzyYQ/+ylgy/+0IQJFlAx7ebG59rs5d3cAh8AQkcljME9ERCbvm43nEZ2YgprezhjQ0Nfkr4dRTzN3epW23nMmUKlT3iafKywkO361HtD1+AFh/ddDV7WHlolfxvV/UwX45zUg+W7PhSKmb73ScLK1xJXbcdh8JtjQxSEiMigG80REZNIuBEdj8cFAtT6pezXV+kdGSFqcJRGczC5QpRvgxfnGRapTaeiemQc8+4c25EB6LcjUdjKlnQT0ceGS2RFFhYyTH9i4jFqf8u9pRCXcTXxIRGSCOGaeiIhg6q3ykrC+U3UvNCzrZujikF7kDeCWPxB2HriyC5Cu5Ppx8pLhnTKr1hOQFvqLm4HFg4ELG4DPSmpT9RWvrE1rV/8FLaFeITemjR/W+t9EYHgcJq44iWn968DMFIZZEBFlwZZ5IiIyWf7XI7H+1C013PrNjpUNXRzSCz0HTK8LLHwO2PShFphKIO9ZHej7G1C6Pq9VdqQiV+wA9J8PWNhogbwIOwds/ACYVhvY+2Oh74LvaGuF7/vXgYW5Gf45HoTt50INXSQiIoNgyzwREZmkiLgkTFzpr9Z71/FGJS9HQxeJ9LZPBVITASdvwLseULoR4NcG8KphGonunlSF9sD4E9oNEBsn4PRKYM8PQPhlYMMEYO8MoPW7QJ1BgEXh/CpYz9cVLzYri193BeCXnZfRpoqnoYtERFTg2DJPREQmJygiHn1+2oPj1yPhaGuJ1ztUMnSRKOPUc6dWaOuSrf65+UDz14ASNRnI54ZjCcC1LGDvBjR4CRhzAOg+XbtBEnUD+Pc1YGYj4PyGQlv3XmxRTrXO77l0G6eDogxdHCKiAsdgnoiITM5na8/gcmgsSjnb4u9RzeDjZm/oIpm225eAzR8Bv7YH/npG21a9N1CihqFLVnRYWAH1hwKvHgE6TQXsiwPhl4AFzwLLhgNRQShsvF3s0LlGCbU+Z3eAoYtDRFTgGMwTEZFJCYlOwPqTt9T67CENULkEu9cbzLl1wO/dgB/qAbu+A64fBKKDAHMr4KkJhitXUWZlCzR9BRh3HGg6FjAzB/yXANPqaDdUUpJQmAxrUU49/nMsCNfC4wxdHCKiAsVgnoiITMqSg9eQkqZDPV8X1PB2NnRxTDuQX9gfuLJTMrcBFToAvWcDAxYDo3cDHkxImK8kq32nT4FhmwHfplqOArmh8ntXIEKbqrGwjJ1vUaE4klLTVI8bIiJTwmCeiIhMRmqaDgsPXFPrzzfR5qomA4gJBf55VVuv9Rww3h94/m+g9nNA5c4M5AuSzAzw4jotN4GtM3D9gNZKv3AAELgPhcHEblVhbgasO3kL+y7fNnRxiIgKDIN5IiIyGbsvhuFGRDxc7a3wdM2Shi6O6Tn6F/B1JW2KtNhQbaq5Hj8ALj6GLplpkxkCqnYHRmwHyrYEdKnAubXAnE5aUJ9g3MnlqpRwwsDGvmr983VnodPpDF0kIqICwWCeiIhMxu5LYeqxfVUv2FpZGLo4piXkLLDmDSAmGEiOBazsgT4/A5Y2hi4Z6bmVB15YDYw5CNQbCphZaEH9pg+N/hqNb18J1pbmOHYtAkcC7xi6OEREBYLBPBERmYx9l8PVY1M/d0MXxbRIUrUVI7R5z/3aAa/sB8af1KabI+PjUQnoMR0YfHeKwMO/A1d2w5gVL2aD3nW81fpvu5jZnohMg1EH86mpqfjwww9Rrlw52NnZwc/PDx9//HGm7lOyPmnSJJQsWVLt0759e1y4cCHTccLDwzFo0CA4OTnBxcUFw4YNQ0xMTKZ9Tpw4gZYtW8LW1hY+Pj748ssvC+x9EhFR/otJTMHJG5FqvXF5BvMFassU4OZxwM4V6DkT8KwCOPAzMHrlW2st9GLlKODGYRizl+5mtpfZKpjZnohMgVEH81988QV++uknzJgxA2fOnFHPJcj+4Ycf0veR59OnT8esWbOwf/9+ODg4oFOnTkhISEjfRwL5U6dOYdOmTVi9ejV27NiBESNGpL8eFRWFjh07okyZMjh8+DC++uorfPTRR5g9e3aBv2ciIsofh66EqwR4Pm52an5qKiCn/wH2ztDWe8wAnJiroFDp8D/A2UfLcP9re2Dt20BMCIyRTDMpme3TdMCf+64aujhERKYdzO/Zswc9e/ZE165dUbZsWfTr108F3QcOHEhvlf/+++8xceJEtV+tWrXwxx9/ICgoCCtXrlT7yE2A9evX49dff0Xjxo3RokULdTNg0aJFaj/x119/ISkpCXPmzEH16tXRv39/vPbaa/j2228N+v6JiCjvu9g3KccW4QIjXbNXvqKty5zmVbsV3Lkpb9i5aInxaj4D6NKAA7O1bPdnVhvlFX6hWVn1uPTQNSQkpxq6OERE+coSRqxZs2aqdfz8+fOoVKkSjh8/jl27dqUH2QEBAbh165bqWq/n7Oysgva9e/eqoFwepWt9gwYN0veR/c3NzVVLfu/evdU+rVq1grW1dfo+0rovPQHu3LkDV1fX+8qWmJioloyt+yItLU0txkrKJjdBjLmMZJpYNyk/yd+9PXeT3zUu55arv4Gsm7m60DD77wtg7w9apvpbJ2CWmghd2VbQtZ0kFzP3Hx4Zvm7auQG9ZwO1B8Fs68cwCzoM3bJh0A1dDXjXN6pPqHWl4ijlYougiASsORGE3nW1cfRUsPh3k4xVWiGJhXJaPqMO5t977z0VJFepUgUWFhZqDP2nn36qus0LCeSFl5dXpp+T5/rX5NHT0zPT65aWlnBzc8u0j4zLz3oM/WvZBfNTp07FlClT7tseGhqaqYu/MVaMyMhIVYnlhgaRsWDdpPyy/uxtzN4ThKCoJPXczykNISE57ybMuplDKYlw2v0p7M8s1p7fOKgeEsq2Q0T7b4HbzDCe1wq8bharCnT7Ey7rR8M28D+kLeiP232WIs2xFIxJ92pu+HlPEH7fdQnNva0MXRyTxL+bZKzSCkksFB0dXfiD+SVLlqgu8AsWLFDd348dO4bx48ejVKlSGDr0bkIWA5kwYQLeeOON9Ody00ES53l4eKhEe8Zcgc3MzFQ5jbkCk+lh3aT8sOzIdXy0/opat7e2wPONfVG7Qu7mNGfdfITEKODEYpjt/h5mUUHQwQy6jp8ANk4qe711/RfgaW7UXzcKLYPVzQF/Qje3MyxCTsNj0xjoXlynfd5G4qXWzvht303434zF7VRbVC1pPGUzFfy7ScYqrZDEQpKUPSeM+n/Xt99+W7XOS3d5UbNmTVy9elW1ikswX6JECbU9ODhYZbPXk+d16tRR67JP1haYlJQUleFe//PyKD+Tkf65fp+sbGxs1JKVVApjrhhCKnBhKCeZHtZNykvLDl/Hu8v81fqQpmUwoUtV2Fk/3tzyrJtZnN8A7PgKSIoF7lwBkuO07U6lYfb0lzCr0vUJPz0y6rpp5wwMXAL80hZmIadhNq87UKMvUPd5wKE4DM3L2Q4dq3thrf8tLD18Ax/1cDF0kUwS/26SsTIrBLFQTstmvO8AQFxc3H1vRLrb68cQSNd4Cba3bNmSqYVcxsI3bdpUPZfHiIgIlaVeb+vWreoYMrZev49kuE9OTk7fRzLfV65cOdsu9kREZLyk69wPWy7gzaXHVVbr5xr44KPu1R87kKcsjs4HFvYHrh8EQk5rgXzxSkCXr4BXDwMM5E2Diw8wcBFgZa9yI2DzZOC3jkCclmjS0J5toPXAWXnsBhJTmAiPiIomow7mu3fvrsbIr1mzBleuXMGKFStU8jtJWqe/qyLd7j/55BP8888/8Pf3x5AhQ1Q3/F69eql9qlatis6dO2P48OEqC/7u3bsxduxY1dov+4mBAweq5Hcy/7xMYbd48WJMmzYtUzd6IiIqHL7eeA7fbDqv1ke19sPUPjVhbm5m6GIVfqkpwKZJwKoxWlbz2gOAIauAkTuAMQeAxiMAq5x1C6QiQpLfjdkPdP5c9cpA+CVg8WAgRctPYUgtK3qghJMtIuKSsfm0cU6lR0T0pIy6m71MIffhhx/ilVdeUV3lJfgeOXIkJk2alL7PO++8g9jYWDVvvLTAy9RzMhVdxnEGMu5eAvh27dqplv6+ffuquekzZsDfuHEjxowZg/r166N48eLqHBnnoiciIuN15maU6lYfHJ2If49r045O7l4NLzbPnNyUHtP1Q8DGiUDgXu15i9eBdpPlrjovqalz8QWajAbKtdZa5q/uAhYNBJ6dB1g7GKxYFuZm6FvfGzO3XcKSQ9fQtda94ZhEREWFmU76I9ITk+79clNAsiMaewI8uTEiGf6NeZwImR7WTXoSz/68FwcC7nXvff/pKhjRyi9PLqrJ1k1piT+zCjg8Dwj4T9tm5QD0nAHU6GPo0pEx1s1L24CFA4CUeKB0I2DISoMG9FfCYvHU19vV+ryXGqF1JQ+DlcXUGF3dJCpkdTOnsaXxvgMiIqIckHvSp4Oi1PrgJmUwe3D9PAvkTVbwKeC39sDfL2mBvJk5UOd5YMw+BvL0YH5ttADe1hm4fkAblmFAZYs7qOSX4s0lxxEWk2jQ8hARGUU3+8DAQJVVXhLUSVp/mTYuu8zuRERE+S0oMgExiSmwsjDDh92qwdqS96mfyMnlwIqRQGoSYOMMNB6pZSl31YIioofybQI88zvwZ2/g4K9ApS5AxfYGu2jvP10V+y7fxvngGHy8+jSm9a9rsLIQERksmJcEdD/99BMWLVqE69evq5YQPUke17JlSzXGXMajG3OXBSIiKlrO3dJa5csXL8ZA/mHCA4Abh7Wp5OLvaNtK1AKqdgeibwI3jgA3jwF7Z0p/B6BiJ6D7NMCJY40pl/zaAo1HAftnAcuHA8//rSXLMwBbKwt82a82es3cjXX+t/C/HslwtrcySFmIiAwSzL/22muYN28eOnXqpDLHN2rUSCWjs7OzU/O1nzx5Ejt37lRJ46ZMmYK5c+eiYcOGeV5YIiKirM7dilGPlUs4mubFiQkFYoIBCyvAvaJMTnvvtYhA4MifgP8SLYjPziorIO3e1KxKg2HA018B5pzOjx5T+4+AaweAoCPAvB7AgEVAuZYGuZy1SzujspcjzgVHY+3JmxjQyNcg5SAiMkgw7+DggMuXL8Pd3f2+1yR5QNu2bdUyefJklUn+2rVrDOaJiKhAW+ZNKphPTQbObwCOzAMubtamihOlGwJ9fwWCjmmvSUIyaWUX5pZAyTranPAO7toxzq3VAn5zK8C7nnYzoGwLoHZ/ZqqnJ2NlBwz9B1g0SMu7sGQwMHKnNj99AZOpjHvV9cYX689i5dEbDOaJyLSC+alTp+b4gDKnOxERUUE5F3y3Zd7LBIL5pDjgwGytK3xshrmzHTyBxCjg+kFgWu3MPyNThtUbAlTqDNgUy/xap6nA7YuAs7dBs45TEWXjCAxaCszprLXQLx0KvLgesLQu8KL0rFNKBfP7A8JxIyIe3i52BV4GIiKDJ8CLj49X4+Xt7e3Vc0mEt2LFClStWlV1wyciIiooyalpuBRSRLvZpyQBkdeAm8eBgB1A6Fkg5AyQEKG97uAB1BkI1B0CFK+gjYlfPBgI9geKlQDqDgLqDgbcyj34HNIl36NSgb0lMkGWNlpCvJ9baTkb1rwO9JhR4D0/SrnYoXE5NxXM/7DlAj7vW6tAz09EZBTBfM+ePdGnTx+MGjUKERERaNy4MaysrBAWFoZvv/0Wo0ePzpeCEhERZXX1diySUtNgb21ReFraJEjfNxM4t14LbrKOV38UF1/gqQlAzWe0cfJ6ErQP3wIEnwRK1AYsHmvCGqK8JzMh9P0NWPAMcHS+NpyjxfgCv9Jj2lTAgSsHsOjgNVT3dlZTWRIRFWa5Tjt/5MgRlble/P333/Dy8lKt83/88QemT5+eH2UkIiLK1tlb0eqxkpcjzM0LtqXvsSTFAgv7A5slOdi+RwfylnZAiZpAk1e0YOjlrcCrR7QW+YyBfPr+NlrWcAbyZGxkerrOX2jrmyffnTWhYLWq5IG3O1VW61P+OYVTQZEFXgYioryU69v2Mre8o6PWlXHjxo2qlV6momvSpIkK6omIiArKyRta8rsqhaGLfeQNYPHz2thhK3ugw/+0KbxsnLLfXzLJ27kyER0VHY1HAFHXgd3TgA3vA7FhQLtJBVrHR7f2w/FrEdhwKhj/+/c0Fo1oohLkERGZRMt8hQoVsHLlSpWxfsOGDejYsaPaHhISAienB3whISIiygf7Lt9Wjw3Kuhnv9U1OAI4v1sYMSyAvAfrQf4FGwwF3P6CYR/aLvRsDeSp62k8B2k3W1nd9C/zzKpCaUmCnl8B9UvfqsLE0V+Pn15+8VWDnJiIyeDAvc8m/9dZbKFu2rBov37Rp0/RW+rp16+Z5AYmIiLITnZAM/xtaN9mmfvdPnWpwaWnAwV+Bb6sAK0YAcWFal/nh24DSDQxdOiLDkFbwlm8A3acDZubA0T+BjRMLtAiSX2Nkq/Jq/bN1Z5CUcndqRyKiohjMnzhxAmnypQRAv379EBgYiEOHDqk55fXatWuH7777Lv9KSkRElMHBK+FITdOhjLu9cSW/u3NV60b8WwdgzZtA/B3AqTTQ5gNg2KaHZ5cnMhX1h2p5IIRMtxh2oUBPP+opP3g62uBaeDwWHwws0HMTERVoMC8t7pKtXpQvX15lr5dtMlZer1GjRqhSpUqeFYyIiOhh9l7Sutg3LW9ErfLSXXhOJ2DTJODGIcDKAejyJTD+BND6HcDKiG46EBlajT5Apc6ALhXYMqVAT21vbYlX21ZQ69O3XkR8UmqBnp+IqMCCeRcXFwQEBKj1K1eupLfSExERGcoefTBvTF3sr+0Hom8CNs5Ap6nA2INA45FaMjsiul/7j7Tu9mf+BQ78og1PKSDPNfRFaVc7hEYn4pedl/npEFHRDOb79u2L1q1bo1y5cipxSIMGDVQLfXYLERFRfouIS8Lpm1HG1zJ/bq32WOVpoOkrgLO3oUtEZNw8qwINhmnra98C/uoLpCQVyKmtLc3xevtKav27zeex/Mj1AjkvEVGBTk03e/ZsNQXdxYsX8dprr2H48OHp09MREREVNMlCrdMBfh4O8HSyNY4PQAqkD+YrdzF0aYgKjy5faDM7bPkfcGmrlhSv4d0AP5/1qeeNE9cjMG/vVby19DhKONmiWYXiBXJuIqICm2e+c+fO6vHw4cMYN24cg3kiIjL8eHlj6mIfdh4IvwxYWGvzxxNRzsgwlCajte72694Bdn4D1BkEWOX/jTrpcTq5e3VEJaRgxdEb+GTNGax+tQXMzTn3PBEVwanpvv/+eyQnJ9+3PTw8HFFRWpdHIiKiggjmm/kZUQva2dXaY7lWgA17rxHlWr2hgJM3EHUDODKvwC6gBO4fdquGYjaWavjOOs49T0RFNZjv378/Fi1adN/2JUuWqNeIiIjy0+2YRJwLjlbrTYxlvHzgfmDHN9p6la6GLg1R4SQt8S3f1NZ3fAUkRBbYqd0crPFyS23ayG82nUNKKpM9E1ERDOb379+PNm3a3Lf9qaeeUq8RERHlp32Xw9VjlRKO6gt4vo+DP/QbbK5sefA+t/yBv/oBybFa93rpHkxEj6fuYMC9AhAbCvz3ZYFexWEtysHV3gqXQ2Ox8OC1Aj03EVGBBPOJiYlISUm5b7t0vY+Pj3+sQhAREeXUnkthBTde/r8vYb72LbhseFUL2oVMnXV5O3D6H+D2JeCvZ4HEKMC3GfDcX4ClTf6Xi6iosrQGOn+hre+fBYSeK7BTO9paYfzd7PbfbjyHyLj7h5USERXqYL5Ro0Yqu31Ws2bNQv369fOqXERERPfR6XT3kt/ldxd7/7+B7Z+pVTNdKsxWjwP2zQKm1Qb+6AksGQz8UA+IDgKKVwYGLASs7fmpET2piu2Byk8DaSnA38OAxJgCu6aDGvuiomcx3IlLxrQtFwrsvERE+ZrNXu+TTz5B+/btcfz4cbRr105t27JlCw4ePIiNGzc+ViGIiIhyYs+l27gcFgsbS3M0zs9gPjUZWPeuWtXVHQLdqRUwDzoKyCJsnQFbFyDiKmDvDgxcDNi58EMkyitPfwVcPwQE+wPLhgH9F2hZ7/OZpYW5SoY3ZM4B/L4nAF1qlkDDsm75fl4iogJpmW/evDn27t0LHx8flfTu33//RYUKFXDixAm0bNnysQpBRESUEzO3XVSP/Rv6wNnOKv8u2uX/gLgwwL44dF2/QXSz97XtjqWAbt8Bb54DXjsGDNsMjNoFuGmJs4gojziX1nq7WNoC59cDGycW2KVtVckDfep6I00HjF90DJHx7G5PREWkZV7UqVMHf/31V96XhoiI6AGOBN5RLfOW5mYY0dovf6/Tyb+1x+q9AHNLxFfpA8eanWHuVCrz3Nc+Dfl5EeWX0g2AXj8Bf78I7PsRcPcDGr5cINd7Ss/qOHT1DgLD4zDyz0P4eXCD/L2BSESUXy3zsbGxuTpobvcnIiJ6lBlbtVb53nW94e1il38XLDkeOHN3zvga/e5tdy2bOZAnovxXow/Q9kNtfe07wMXNBZYM74cBdeFgbaFm0Oj30x6ERicWyLmJiPI0mJdu9J9//jlu3rz50KREmzZtQpcuXTB9+vQcF4CIiOhRDl8Nx9azIbAwN8MrbSrk7wU7txZIigacSgM+jfnhEBmazD1feyCgSwWWvgiEnCmQ09b2ccGSUU3h5WSDCyEx+HpDwWXWJyLKs27227dvx/vvv4+PPvoItWvXRoMGDVCqVCnY2trizp07OH36tBpHb2lpiQkTJmDkyJE5OjkREdGjyM3iL9drX6KfqV8a5Yo75M9Fkynndn8PbJ+qPa/ZFzA317YTkeGYmQHdv9cSTl7dDSwZAozarU1jl8+ql3LGj4Pqo+9Pe/D3kesY9ZRf/v0NIiLKj5b5ypUrY9myZTh//jyeffZZ3LhxA3///Td++eUXFeh7e3ur9StXruCVV16BhUX+ZxslIiLTsPNCGPYHhMPawhyvtauYfyeSIH7LFCA1CajQXmsNJCLjYGkDPDcfcPAAws4DB34usFPXL+OKdlU8kZqmw3ebzhfYeYmI8jQBnq+vL9588021EBER5beU1DR8ukbrUvt8kzIolV9j5S9sBnZ8pa13+QpoNFxrDSQi42HvBrT/CFg1Btj+BVDzGcCxRIGc+o2OlbDlbAj+OR6EEa3Ko4a3c4Gcl4goT6emIyIiKigLD17DueBouNhb4bV2+TRWPuomsHy4dOgHGgwDGo9gIE9krGTsvHd9La/F3y8BSXEFclrpbt+rTim1PuXfU2r4DxGRoTGYJyIioxSVkIxvN2pj5V9vXwku9vkwPla+kEsrX3w4UKIW0PnueHkiMk6Sx6LHD4CNkzZ+fvHzQEpSgZz6nc5VYGtljoNX7mCN/4OTQhMRFRQG80REZJR+3XEZd+KSUcGzGAY19s2fQF4S3l3aAljaAn1/1cblEpFx86oODFoKWNlrv797CmYWJRnmM6q1n1r/bM0ZxCSmFMh5iYgehME8EREZnbCYRPy6K0Ctv9WxEiwt8vi/q9jbwILngM0fac/bTwE8KuftOYgo//g2Abp9p63v/AaIvFEgV3tkKz/4uNkhKDKBU9URkcExmCciIqNLevfNxnOIS0pFTW9ndKqeDwmu/n0NuLABsLAG2n4INOaUqkSFTq3nAJ/GQHIcsHFigZzSztoCn/aqqdbn7b2Cw1fvFMh5iYjyJJhv1aoVJk2ahC1btiAhISG3P05ERPRAZ25GoeN3O7DwwDX1/K1OlWGW11nlr+4Fzq4GzMyBlzYArd5iwjuiwkj+NnT5UlaAU8uBE0sL5LStKnmgT11vNVJn5J+HcDk0pkDOS0T0xMF8x44dsW/fPvTs2RMuLi5o0aIFJk6ciE2bNiEurmAyihIRUdEk09BdDouFq70VPu5VA60reeTtCeTb96YPtfV6QwDvenl7fCIqWKXqAC3vTpn87zggVEuamd8m96iOaiWdEBaThEG/7kdIFBu4iKgQBPMSuG/cuBERERHYtm0bunXrhkOHDqFr165wc3PLn1ISEVGRl5CcioNXwtX6ohFNMbhJmbw/yaWtwPWDWuKspybk/fGJqOC1eR8o1wpIjgWWvQykpeb7KZ3trPDnsEbw83DAzcgE/HY3xwcRUaEYM3/58mX4+/vj+PHjOHHiBBwdHdGlS5e8LR2AGzdu4Pnnn4e7uzvs7OxQs2ZNdfNAT+b5lG7/JUuWVK+3b98eFy5cyHSM8PBwDBo0CE5OTqo3wbBhwxATk7lLlLyHli1bwtbWFj4+PvjyS+m2RUREBeVI4B0kpqTB09EGlbyK5c9JTi7THmsPABzzYSw+ERU8cwug72+ArTNw6wRw+PcCOa17MRu816WqWl9y6Jq6IUlEZNTB/MCBA+Ht7Y1mzZph/fr1aNKkCdatW4ewsDCsWLEiTwt3584dNG/eHFZWVuocp0+fxjfffANXV9f0fSTonj59OmbNmoX9+/fDwcEBnTp1yjSeXwL5U6dOqaEAq1evxo4dOzBixIj016OiotTwgTJlyuDw4cP46quv8NFHH2H27Nl5+n6IiOjB9ly8rR6b+bnn/Th5IXNRy1h5UaMPPwqioqSYJ9DmA21968dAnNbLJ7+1reKJUs62ahrNdSc59zwRFSzL3P7AokWLULx4cbz88sto27atGjNvb2+fL4X74osvVCv53Llz07eVK1cuU6v8999/r7r+yxh+8ccff8DLywsrV65E//79cebMGXXT4eDBg2jQoIHa54cffsDTTz+Nr7/+GqVKlcJff/2FpKQkzJkzB9bW1qhevTqOHTuGb7/9NlPQT0RE+Wf3pTD12KxC8fw5QcB/QEIk4OAJ+DbNn3MQkeE0GKa1yoecBv77AujyRb6f0sLcDAMa+eKbTecxf18getctne/nJCJ67GD+9u3b2LlzJ7Zv344JEyaoYLlOnTp46qmn1CIt3Hnln3/+Ua3szzzzDP777z/VI+CVV17B8OHD1esBAQG4deuW6lqv5+zsjMaNG2Pv3r0qmJdH6VqvD+SF7G9ubq5a8nv37q32kSz9EsjryXnlZoL0DsjYE0AvMTFRLRlb90VaWppajJWUTW6CGHMZyTSxbpq26IRknLgeqdablnPLl79RZqdWSM5r6Kp2h07WcngO1k0yVqybWcgMFR0/hfn83tAdmgNd49GAi2++fw7PNiiNaVsuqGnq9lwMRZPy7jB1rJtkrNIKSSyU0/LlOpiXwLZHjx5qERcvXsQnn3yiuqZL8JuamnfjhWRc/k8//YQ33ngD77//vmpdf+2111TQPXToUBXIC2mJz0ie61+TR09Pz0yvW1paqmR9GffJ2OKf8ZjyWnbB/NSpUzFlypT7toeGhhr1lH1SMSIjI1UllhsaRMaCddO07bocgdQ0HUo728AqORohIdF5dmzrwP/g4D8f1jf2qud3SrZGUkhIjn+edZOMFetmNopVg6t3E9jc2If4DVMQ1WZqgXwWPWoUx/IToZi80h+/D6yqWuxNGesmGau0QhILRUdH51/LvLSSS8u8LDKOXVq+u3fvjtatWyOvL7a0qH/22Wfqed26dXHy5Ek1Pl6CeUOSXglykyFjy7wMCfDw8FCJ9oyVXFMZiyrlNOYKTKaHddO0HdqtBdetq3jddwP2saWlwmz7VJjt+iZ9k65kHbjUflpLmJXTw/DvJhkp1s0H6PQxMKcD7M6vhG3btwGPKvn+Wbzf3QWbz/+HC2Hx2B6YqLremzLWTTJWaYXk/3RJyp4vwbx8yZIx85L5Xbq7S9d6yTCfHyRDfbVq1TJtq1q1KpYt07IRlyihZSIODg5W++rJc+n6r98nJEsLTEpKispwr/95eZSfyUj/XL9PVjY2NmrJSiqFMVcMIRW4MJSTTA/rpmmSFvnNZ7S/uZ1rlMibv00y1/SqMdo0dKLhy0D9F2DmWR1mj3F81k0yVqyb2fBtBFTpBrOzq2G2/TPgufn5/jkUd7TFuPaV8PHq05jy7xk42Vmje+1SMGWsm2SszApBLJTTsuX6HcgUbhLo/v3333j11VfzLZAXksn+3LlzmbadP39eZZ0X0jVegu0tW7ZkaiGXsfBNm2rJjeQxIiJCZanX27p1q7orI2Pr9ftIhvvk5OT0fSTzfeXKlbPtYk9ERHlHxpmGxSTBydYyb8aaSgKsWS20QN7aEejzK9D1G6BETfnfMS+KTETGru1E+coOnPkXuHHvO2B+GtK0DDpXL4Gk1DS8uvAo5u25UiDnJSLTletvNZLpXT82fNeuXWqR9fzw+uuvY9++faqbvYzNX7BggZoubsyYMel3VcaPH6/G7EuyPJn3fsiQISpDfa9evdJb8jt37qx6ERw4cAC7d+/G2LFjVXI82U8/3Z6Mw5f552UKu8WLF2PatGmZutETEVH+WH9Sy1/SvpoXrCweM9g+vwH4oxfwSzvg33FAahJQoQMwZh9Q65m8LTARGT/PqkDt/tr6pslq2E1+k79fMwfVw4vNy6rnk/85hcUHA/P9vERkunL9rSk2NhYvvfSS6tYuGeBlkaBYAuG4uLg8LVzDhg3V3PULFy5EjRo18PHHH6up6GTeeL133nlH9RCQKeRk/5iYGDUVXcZxBjL1XJUqVdCuXTs1JZ1Mp5dxDnnJgL9x40aVHb9+/fp48803MWnSJE5LR0SUzyQBzYZTWjDfqXr2w5pyZPNHwOVtwI1DWkbrdpOAgUsAZ04TRWSynpoAWFgDV3YCq1+XPzj5fkpJfDepWzUMb6klVn5vuT92X9Sm3SQiymtmOvkmlQsjR47E5s2bMWPGDNUNXkjrvGSZ79Chg8o+b4qke7/cFJDsiMaeAE9yCEjuA2MeJ0Kmh3XTNB2/FoGeM3fDzsoCRz7sADvrnCemSxd/B/hCawlDz5lAqXqAV+Z8K0+CdZOMFetmDpxcDiwbBujSgNbvAW0mFNiNynf+PoGlh6/D180eG8a3ery/b4UU6yYZq7RCEgvlNLbM9TuQ5HO//fYbunTpog4si7R2//LLL2ocPRERUU6tOHpDPXao5vX4X3Sv3U1y5+YH1H0+TwN5IirkavQBuk/T1nd/D8Tkz9DQrGQo6OQe1VHS2RaB4XH4fvP5AjkvEZmWXAfz0pU+67zuQu5u5HU3eyIiKrpSUtOw+kSQWu9d1/vxD3Rtn/bo2ySPSkZERUrdwYB3fSAlAdj3Y4GdtpiNJT7uWUOt/7zjMt5bdgIxiSkFdn4iKvpyHcxL5vfJkycjISEhfVt8fDymTJmSnkGeiIjoUXZdDFNZ7N0drNGiYvHHv2CBd4N5H22GEiKiTMzMgJZvausHfwXiIwrsAkliz9faVlBFWHTwGgb9sg8JyfmfjI+ITEOug3nJ8i4Z4UuXLq0Sysni4+ODPXv2qNeIiIhyYuXdLvYyF/NjZ7FPSbo37RRb5onoQSp1ATyrAYlRwMpXgOR7jVL57Y2OlbFweBO42lvh+PVI1UKfy5RVRETZyvW3J8kqf+HCBUydOhV16tRRy+eff6626aetIyIiepi0NB22ng1JD+Yf260TWtdZOzegeCVedCLKniS66jwVsLABzq0B5vcFkgpueGiT8u74cVB9WJqbYeWxIPy2K4CfFBE9McvH+SF7e3s1bzsREdHjCLgdi6iEFNhYmqNWaefHv4hXdt3rYi/9WImIHqT8U8Dzy4CFA4Cru4C1bwO9ZhbY9Wrq544Pu1VT889/sf6sCvBreD/B3z8iMnk5Cub/+eefHF+oHj16mPxFJSKihzsWqI1Zrent/Phd7MWZu/8/VWjHS05Ej1auJTBgAfBHT+DYfG14Tr3BBXblhjQto+ad33g6GCP/PIyGZV1Rr4wrhjS9O70mEVFeB/O9evXK8TQcqalM6kFERA93/LoWzNf2cXn8S3XnijZe3swcqNaTl5yIcqZcK6DN+8DWT7TWeQnoi1cskKsn35W/6FsLx6/vwI2IeNw4Fq+63fu42aNNZc8CKQMRFR05ag5JS0vL0cJAnoiIcuL4tTwI5k+t0B7LtgCK8UswEeVCize1bvcp8cDyEUBqcoFdPlcHaywa0VR1ue9So4TaNnHFScRy2joiyo9g3s3NDbdv31brL730EqKjo3N7HiIiIkWmZTp9M0qt132SYP7kcu2xeh9eWSLKfUK8Xj8Bti5A0BGthT614OaAL1fcAcNalMM3z9ZGaVc71Ur/4aqTSE1jlnsiyuNgPikpCZGRkWp93rx5meaYJyIiyo0zN6OQnKqDm4O1+hL7WG5f0jLZm1kAVZmrhYgeg1MpoNt32vrhudo4+rjwAr2U9taW+Kx3TZW/c/mRGxj55yHEJRXcTQUiMoEx802bNlXj5uvXr6/mxXzttddgZ5f9F7A5c+bkdRmJiKgodrEv7azGjz5Rq7x0k3Vwz8PSEZFJqdEHMLfQ5p6XDPf/vAo8N79AZ8doVckDPw6sh/GLj2HzmRBM+ec0vuhXq8DOT0RFvGV+/vz5ePrppxETE6O+eEkr/Z07d7JdiIiIHuZwYF6Ml19+74s4EdGTkASaL6wGzK2As6uBYwsK/Hp2qVkSc15oqNYXH7qGvZe04a1ERE/cMu/l5YXPP/9crZcrVw5//vkn3N3ZEkJERLkjvbv0X1Ibl3vM/0dCzgIhp7Uv3lW68iMgoidXqi7Q9gNg80fAune0DPfufgV6ZZtXKI6BjX2xYH8g3l/hj9WvtoCDTY6+qhORicr15L4BAQEM5ImI6LGcD45BWEwibK3MUa+My5O1ysvc8nau/CSIKG80ew0o0xxIigGWDAGS4wv8yr7XpQq8nGwQEBaLEX8eUglDiYge5LFu923ZskUtISEhakq6jDhmnoiIHmTPpTD12LCsG2wsLXJ/oSTbtP9SbZ1Z7IkoL8nY+b6/AT+3BIJPAqtf1zLeF+D4eSdbK8x6vj6e/3U/dl+8jVHzD+PHQfVUojwioidumZ8yZQo6duyogvmwsDCOmSciohyTL6eimV/xx7tq+34Ewi9r00lV7sIrT0R5y6kk0PdXwMwcOL4Q2PCBjA8q0Ktc19cVv73QUPVg2n4uFP1n70NodGKBloGICodc3+abNWsWfv/9dwwePDh/SkREREVSSmoa9l/WB/OPMV4+PADY9pm23ulTwNYpj0tIRHR3lozu04F/xgL7ZgKJUUCnzwr0b06T8u746+XGeHneIZy4HonBv+3HstHNOIaeiJ6sZV7mnG/WrFluf4yIiEyc/41IRCemwMnWEjW8nXP3wzKkS6aMSokHyrUC6gzKr2ISEQH1BgNdvtKuxNE/gR+bAqHnC/TK1C/jhuWvNEfxYjY4eysaby09jrS0gu0lQERFLJh/+eWXsWBBwU/ZQUREhdu2syHqsamfOyzMczkGdf9PwJWdgJU90O37Ah3DSkQmqvEIYOi/gGtZIOo6sOwlICWpQItQrrgDfh5cD1YWZlh38hZGzj+M2zHsck9Ej9nNPiEhAbNnz8bmzZtRq1YtWFlZZXr922+/ze0hiYjIBGw4FaweO1UvkbsfDD4NbJ6irUtX1wKeLoqITJj0BHppg9Yyf8sf2D4VaD+5wFvov+pXG2//fRybTgfj2LUILHi5MSp6ORZoOYioCATzJ06cQJ06ddT6yZMnM71mxpYSIiLKhkyzdC44GpbmZmhXxSvn1ygxWpsiKjURqNgJqP8Cry8RFSzHEkD3acCSwcCu74DyrbVx9QWoV11vVPJyxLhFR3EhJAaDft2PHwbUhZuDNcp7FMt9byciMs1gftu2bflTEiIiKrI2nLqV3sXe2T5zj64HkgzS/7wG3L4AOJYCev3I7vVEZBjVegB1B2vj55e9DIzcATiVKtgilHLC0lFNVXZ7GUP/3Ox9anuP2qUwrX8dNqoRmaBcj5knIiJ63GA+V13sj84HTi0HzC2BZ34HHB5zOjsiorzw9FeAVw0gNhRY+gKQUvBj113srfHnsMZoWbG4SownDfL/HA/C0sPXC7wsRFSIWub79OmTo/2WL1/+JOUhIqIiJC4pBZ+tPYOjgREqZ13Hal45n4Zu/XvaetuJgG/jfC0nEdEjWdkBz/4BzG4DXNsPrBoL9Jld4D2GPBxtVEAvZm67iK82nMNH/5yCn0cx1C/jWqBlIaJCEsw7O+dyGiEiIjJpQRHxeOn3g6o7qBjXriI8nWwf/kPJCcChOcCBn4GkGMC3GdDstYIpMBHRo0gCzmfnAfP7Av5LtLnnO38OWORw+FAeG9XaD7suhGHv5dt49ue9eLVtBfW3lnmsiExDjoP5uXPn5m9JiIioyLgQHI3nf9uP4KhE1Yr03bN10KJiDrrJr3sbOPKHtu7gAfT+CTC3yPfyEhHlmF8boNt3wL+vAQd/BYJPAQMXA7YF3/Alie9+HlIfH648iVXHgvD95guIik/Bh92qMqAnMgEcM09ERHkqLU2Ht5YeV4F8Ja9iWDmmec4C+aRYwP9vbb39FODVw9r8zkRExqb+UKD/AsDaEQjcC2ybarCiONlaYVr/uvisd031fM7uAHyy5gySU9MMViYiKhgM5omIKE+tOHoDx69HwsHaAvOHNYa3i13OfvDcOiA5DnAtBzQfZ5BWLiKiHKvSVetyL6SFPvyyQS/ewMa++LhndbX+264A9PtpD66Fxxm0TESUvxjMExFRngmPTcKXG86q9bFtczBGPiN9q3yNvpyCjogKhwrtAL+2QFoysOVjQ5cGg5uWVfPPO9laqpuqg3/bj8i4ZEMXi4jyCYN5IiLKEzvOh6LT9ztU93pfN3u81CIXXeTjwoGLm7X1mv34iRBR4SHDgmCmTaV5ZrWhS4PutUth/fhWqlfUldtxGLPgCPyvRyIhOdXQRSOiPMZgnoiIntj1O3F4ed4hhEYnooJnMfwypAFsLHORuO70Sq1ly7M64FmVnwgRFR4lawFNx2jrK1/RptY0sFIudurvsJ2VBXZdDEP3GbvQ6NPNaio7mTKUiIoGBvNERPTEfv7vMpJS09CwrCtWv9oClUs45vyHdTrgwC/aep2B/DSIqPBp/xHg0xhIjATmdQcubTV0iVCtlBN+G9oATcu7w9XeClEJKWpO+v6z9yExha30REUBg3kiInoiIdEJWHzomlp/vUMl2Frlciq5q7uBkNOAlT1Q93l+GkRU+Mg88/3mAi5lgMhrwJ+9gXXvAqmGHa/erEJxLBzRBIcmdsD3z9WBi70VTlyPxNcbzhm0XESUNxjMExHRE5GsyUkpaajr66JagHJt/8/aY63nADsXfhpEVDg5ewOj9wCNRmrP98/SWunj7xi6ZGo++l51vfFVv9rq+S87A7Dq2A1DF4uInhCDeSIiemySUGnRAa1V/pWnKsDMzCx3B4gIBM6u0dYbjeAnQUSFm00x4OkvgQGLABsnbQ76xYOBlCQYgw7VvDC4SRm1Pm7RMbyx5BjO3ooydLGI6DExmCciose2+UwwIuOTUdLZFm2reOb+ALunA7pUoPxTgFc1fhJEVDRU7gK8uBawLgZc2QmsGgMkRMIYTOpeDaOf8oPce11+5AY6f78Tz8zag4g447jhQEQ5x2CeiIge25JD19Vjv/qlVTfOXIkOBo78oa23fJOfAhEVLSVqauPozcwB/yXA97WAI38aulSwsjDHu52rYOnIpuhYzQvWFuY4eOUOhs45gOgEzklPVJgwmCcioscSFBGPnRdC04P5XNs3E0hNBEo3Asq25KdAREVPpY7AwCVA8cpAQgTwz1hg++faLB4G1qCsG2YPaYDVr7VQ2e6PX4/Esz/vw/ngaEMXjYhyiME8ERE9lsUHr6nvo43LuaGMu0PufjgtNUOr/BtQ/T2JiIqiih2AV/YCrd7Rnm+fCmz60CgCelHJyxF/DmsMNwdrnLkZhW4/7FKJTdPSjKN8RFREgvnPP/9cJVcaP358+raEhASMGTMG7u7uKFasGPr27Yvg4OBMPxcYGIiuXbvC3t4enp6eePvtt5GSkpJpn+3bt6NevXqwsbFBhQoV8PvvvxfY+yIiKmxiE1Mwb+8VtT7objKlXLlxRMvwbOsMVOiQ9wUkIjIm5hZA2w+ALl9pz/f8AGycCJxbB0TfMnTpUMPbGevHtcRTlT3U7CQfrz6NwXP242ZkvKGLRkRFIZg/ePAgfv75Z9SqVSvT9tdffx3//vsvli5div/++w9BQUHo06dP+uupqakqkE9KSsKePXswb948FahPmjQpfZ+AgAC1T5s2bXDs2DF1s+Dll1/Ghg0bCvQ9EhEVFgsPBCIiLhll3e3RtWbJ3B/g4ibtsXwbwMIyz8tHRGSUGo8AOn+hre+dASzsD0yvBwQdM3TJ4Olki7kvNMTHvWrA1socuy/eRqfvduCf40GGLhoRFeZgPiYmBoMGDcIvv/wCV1fX9O2RkZH47bff8O2336Jt27aoX78+5s6dq4L2ffv2qX02btyI06dPY/78+ahTpw66dOmCjz/+GDNnzlQBvpg1axbKlSuHb775BlWrVsXYsWPRr18/fPfddwZ7z0RExjwd3ewdl9W6ZETOdeI7cXHzve6nRESmpMkooPt0LV+Isy+QHKsF9VGGD5qlB6xMXbfmtZaoXdoZUQkpeG3hUYxbdBSRcUyOR2RsCkVziHSjl5bz9u3b45NPPknffvjwYSQnJ6vtelWqVIGvry/27t2LJk2aqMeaNWvCy8srfZ9OnTph9OjROHXqFOrWrav2yXgM/T4Zu/NnlZiYqBa9qChtjs60tDS1GCspm06nM+oykmli3Sw8fv7vEkKiE9V0dD1rl8r935PYMJjdOAK5BZAmLfNG/veIdZOMFetmIVZ3sLYkRMJsTieYhZ2D7pe20HX9FqjU2dClQzl3eywZ2QQzt13CzO2XsOpYEA4EhOOrfrXQzM/9kT/PuknGKq2QxEI5LZ/RB/OLFi3CkSNHVDf7rG7dugVra2u4uLhk2i6Bu7ym3ydjIK9/Xf/aw/aRAD0+Ph52dnb3nXvq1KmYMmXKfdtDQ0PVOH5jrhjSo0Eqsbl5oeiYQSaCdbNwuBKegBnbLqr1UU1LIiI8LNfHsL3wL1ygQ7J7FdyOtwDiQ2DMWDfJWLFuFg0WHWfCdc3LsIy8ArNFAxDd+C3E1h0OYzCwljNqeVTGRxsCcD0iAc//dgD963pidHNv2Fg++Hsk6yYZq7RCEgtFR0cX/mD+2rVrGDduHDZt2gRbW1sYkwkTJuCNN95Ify6Bv4+PDzw8PODk5ARjrsDShUrKacwVmEwP66bxS0xJxVcrDiI5VYfWlTzwfMvK6u9Jbpnt3KMeLSt3UklJjR3rJhkr1s0iQv4OvrIHuq2fwGz/j3Dc/zUcfGoA1XrCGLT1BJpU9cGna89i4YFrWHQ0BHuuRqNhWTc0r+CO7rVK3TfcinWTjFVaIYmFchr7GnUwL93oQ0JCVJb5jAntduzYgRkzZqgEdTLuPSIiIlPrvGSzL1GihFqXxwMHDmQ6rj7bfcZ9smbAl+cSlGfXKi8k670sWUmlMOaKIaQCF4Zykulh3TReKalpGL/4OA5fvQMHawt82rsGLCwscn+gpFjg/Hq1alatJ8wKyd8h1k0yVqybRYSNA9BlqoQawP5ZMF85CoAOqHEvqbMhFbO1xtQ+tdChmhfe+dsfgeHxCAy/gWVHbuDH7ZfxRodK6Fy9BMwzBPWsm2SszApBLJTTshnvOwDQrl07+Pv7qwzz+qVBgwYqGZ5+3crKClu2bEn/mXPnzqmp6Jo2baqey6McQ24K6ElLvwTq1apVS98n4zH0++iPQURkysJiEjH8j0PYcCoY1pbmmD2kAUq72j/ewWQapuQ4wLUc4H3vRi0REUnSps+Ayl2BlATg7xeBde8BycYzPVzbKl7Y8mZr/DSoHl55yg8u9la4GBKDV/46gh4zd+H4tQhDF5HIpBh1MO/o6IgaNWpkWhwcHNSc8rLu7OyMYcOGqe7u27ZtUy35L774ogrCJfmd6NixowraBw8ejOPHj6vW/IkTJ6qkevqW9VGjRuHy5ct45513cPbsWfz4449YsmSJmvaOiMiUnbgegc7f78C2c6GwtjDHjwProXmF4o9/wJPLtMcafeXWeJ6Vk4ioyMxH/+wfQPO7SZj3/wT81Ay4fgjGwtnOCl1qlsQ7natgxzttMK5dRdVj6+SNKPT5aQ+mbb6AtDSdoYtJZBKMOpjPCZk+rlu3bujbty9atWqluswvX748/XXpBrp69Wr1KEH+888/jyFDhuB///tf+j4yLd2aNWtUa3zt2rXVFHW//vqrymhPRGSqohKSVWtLWEwSKns5YtXY5mhfLXOy0FyJvwNcuDu/fM1+eVZOIqIixcIS6DAFGLgEcCwFhF8Gfu8KnNOGKBkTJ1srvN6hkgrqu9UqidQ0Hb7bfB6vLjqGhBTjzhZOVBSY6SSVHz0xSYAnPQUkO6KxJ8CTIQeSdMqYx4mQ6WHdND7jFx3FymNBKO1qh7XjWqovbU/k4K/AmjcBz+oq2VNhwbpJxop10wQkRALLhgMXNgBmFkCT0UCLNwCHR08PV9AkpPj78HV8sOIkklLTUNrFBs828EUTv+KoXMJRtegTGVpaIYmFchpbGu87ICIig9l1IUwF8pKheFr/uk8eyMt94wO/auv1BudJGYmIijxbZ6D/X0DtAYAuFdg7A5heFzi7FsaYVOyZBj74Y1gjuNhZ4XpEIr7dfAHP/rwXDT7ZhN92BRi6iERFDoN5IiK6z4xtF9Tj4CZlUL+M65NfoYAdQOgZwMoBqDOQV5yIKKcsrIBePwGD/gZK1AQSI4FFA4A/egGLB2t/X41Ik/Lu2P52a0zsUAbtq3qilLOtmtL049WnMWG5P67ejjV0EYmKDAbzRESUyeGr4dh3ORxWFmYY2bp83lydA7O1x9r9tZYmIiLKOUkYWrEDMHwb0FimrQNweRtw5h9gfl/g0jajuprSm6tb9eKYPbg+dr/XFu8/XUVtX3ggEK2/2o4Bs/ep/2uI6MkwmCciokxmbL2oHvvWK42SznZPdnVu+QN/9gbOrtaeNxrBq01E9CSt9F2+AF7aAPSYAVTqDKQmAQsHAPt+AlISjbL7/YhWfvj9xYZoWbE4ZCr6vZdvo+9Pe1Vulsj4ZEMXkajQsjR0AYiIyHhsPRuspqGTsfIjW/s9/oHkC+V/XwC7vtfGeZpbAq3eATy11hkiInoCvk20pdazwKJBwMVNwPr3tID+mbmAd32ju7xPVfZUS1BEPH7YegGLD15TuVl2X7qN5n7uaOrnjn71fdT/P0SUM2yZJyIiJSYxBRNXnFTrL7coh3LFHR4/2d2KUcDOb7RAvlpPYOwh4Kl3eaWJiPKSpQ0wYCHQ7XttGruIq8Cczndb6ZOM8lqXcrHD1D618PfoZijjbo/Q6EQV1L+7zB8DftmHI4F3EJ+UauhiEhUKDOaJiAingiIxfN4hBEUmwMfNDuPbV3qy8fGnlmut8c/MA579A3Arx6tMRJRfXe8bvAiM2QdU7qp1u5dW+pkNgcv/Ge01r+frivXjWuGXIQ3wWtsKcLC2wIGAcPT5cQ9qfLQBX204i7Q0zqBN9DAM5omITNzvuwPQdfouNYZRkt590acW7Kwtcn+g+Ahg6yfAhg+05x0/Aar3yvPyEhFRNiS56HPzga7fAA6ewJ0rWnI8/7+1HlNGSP6v6VDNC290rIx141qhYzUvuDtYIzVNh5nbLuHVRUeZ/Z7oIThmnojIhC06EIiP/j2t1rvWKom3O1ZG2cfpXh8XDvzcCoi8pj2v+cy9jMtERFQwzM2Bhi9r89KvGgOcWgEsGwasGqtNaydTg8rfZ5tiRveJ+LrbY/aQBmp92eHreHfZCaw5cVMtlbyKoWpJJ/Sq4402VTwNXVQio8FgnojIBF0MicFna89g69kQ9Xx4y3J4/+mqKuvwY9n4oRbIO/sAnacCVbppUykREVHBs3YA+v4GOHkD+2cBKfHA9QPaIuPpX1gDFPMw2k+mb/3S8HGzx/QtF7DnUhjOB8eoZdWxIDzXwAcDGvuqAN/emqEMmTb+BhARmZiU1DQ8/+t+3IpKUFmDh7csj3c7V378QF7GZB6bLxMQaV8efRvndZGJiCi3zC2ATp8C7SZrN1vPrQX2zADCzgF/9gIGrzTqgL5ROTfMf7kxwmIScSwwAjsvhOKPfVex+NA1tciwsNaVPNGwrKv6v6xJeXfU8HY2dLGJChSDeSIiE7PvcrgK5F3trbBsdDOU93iC7pZpqcDat7X1hsMYyBMRGRtLa8DdD2j2KlD5aWBuFyD4JDC9LtBkFFC1O+BVU+uib4SKF7NB+2peaulSsyRmbruIMzejVZC/+UywWvSerlkCb3SohAqejrgWHgdbKwt4ONoYtPxE+YnBPBGRiVl38qZ67FS9xJMF8uLkMq2Vx9YFaDcpbwpIRET5Q4L6If8Ay18GbvkDO77SFvcKQL+5QMlaRn3lpfVdFnE+OBqrjwfh+p14RMQnY9u5EKz1v4X1J2/Bz6MYLoTEwM7KAh92q4YBjXwev/cZkRFjME9EZEIkQ/CGU7fUurRwPNnBUoDtn2vrzV/TMikTEZFx86wCjNgBnF4JHF8IXN0D3L4I/NYB6PCxNs2dTHdn5Cp5Oaos+HrnbkXjm43nsPF0sArkRXxyKt5f4Y9vN51H1ZKOKnN+5+ol4Olka8CSE+UdBvNERCbk4JVwhMUkwdnOCs38tNaNx3Z8ARB+CbB3BxqNzKsiEhFRfpMu9TX6aIvMRrJ8OHBxM7DubWDfTOCp94Ga/bRx94VE5RKOKhv+yRuRuBQag6Z+7vjnWBC+2nBOdcnfeUGWMExadUp13Zex9t1rl0K7qp6wsSw875MoIwbzREQmZJ2/1sVeWiesLJ5gfGRsGLBpsrbe4g2jnOaIiIhywN4NGLgEOPgbsONLbX76FSOAXd8BbScCVboWqtlJJAmePhHeyy3LY2BjX5UJ/9CVcPx7PAjHr0eq4H7dyVtq8Xaxw6ttK6BFxeJqnd3xqTBhME9EZCLS0nTqi4s+SdATWT8BiA/XkiY1Zqs8EVGhJi3wjUdo89Af+BnYPQ0IPQMsHgR41wfafgj4tUFhJNPX1fFxUYsE97GJKTh7K0p1x19+5AZuRMTjveX+al93B2s8XbMknqrsoVr6GdyTsWMwT0RkIo4E3kFIdCIcbSzRvELxxz/QiaWA/xLAzBzoMb1QjK0kIqIckF5WLd8EGrwE7PlBm5P+xmFtKruyLbVEpz6NCvWldLCxRP0ybmp5vX0l/Ln3KpYdua665t+OTcKf+66qRfh5OKBrrVKoXdoZNUs7w9ORY+3JuDCYJyIyEZLlV8j0Po89PjBwP7DqFW29xeuAd708LCERERkFO1ctcG88Ctj5DXBoDnBlp5Ykr1IXoNVbgFd1wMoOhZlMXTe8VXm1JKWkYe/l21hzIggnrkfiYkgMLoXGYvqWC2pfGWnQqKyb6rbfrVYpNbc9kaExmCciMgE6nQ7r705J17nGY3axv7AJWDYMSE0CqnQD2kzM20ISEZFxKeYJdPkCaDoW+O8L4NhfwPl12iK8agB1nwdqPaeNvS/ErC3N0bqSh1pEVEIyNp4Kxo7zoSpT/rngaOwPCFfLjK0XVTd8+ZkKnsVQ18cVjcq5McCnAsdgnojIBEjCn6DIBNhbW6R/UclVsrsdXwP7Z8ltAcCnMdBntpYNmYiIij4XH6DnDKD5OGD7VO3mbmIUEHwSWP+elhC1anegxXigRE0UBU62VuhXv7RahIytX3b4On7deVlNfaef/k7Pw9EGzf3cUbmEE3rVLYWSzoW71wIVDgzmiYhMwMqjN9Rj2yqeqlthjp1dAywfASTd/dLSYBjQeSpgaZNPJSUiIqNVvCLQb45099Ju9Mpc9UfmAbf8gZN/a0vNZ7T56lG0uqFLMrzX2lXE0GZlVU+3+KRUxCSm4FxwDHZeCEVodCJWHgsCEITvNp9Hrzql4OpgDRc7a1QuUQyNyrmjmA1DL8pbrFFEREVcQnIqVtwN5vUtDDlyYTOwZCiQlgyUrK2Nn6zQPv8KSkREhYMMIC/mATQari1BR4Hd04FTywH/pTC7sAn2dYYDdXoBHlUAi6ITcjjbWeG5hr6Ztsl4+32Xb8P/RiS2nwvBwSt3sOTQ9Uz7uNhbYXRrP/Rv6AtneyaOpbxhppOBlPTEoqKi4OzsjMjISDg5ORntFU1LS0NISAg8PT1hzi6yZERYN/PP6hNBGLvgKEo42WL3e21zNqYv5Aww+ykgJQGo3hvo+5s2dZEJYt0kY8W6SUZHgvp/xwE3j9/bZm4JuPkBrd8BavQtVHPWPw4JrXZeCMOui2FITdOpFnuZTeb6nXj1urWFOZpXcEcNb2fUK+OKFhWKw8qCw9YKSlohiYVyGlsWndtkRESULX3rgLTK5yiQT0sFVo3VAnm/tkCfX0w2kCciolwoVRd4eSvSDs1Bsv8qWN86DLOUeCDsnJZA9eif2tj6Sp0B51z0FCtEzMzM0KqSh1r0UlLTVA+5X3cGqER6286FqkXfYi9d+C3NzVCuuAN83ezVMdyLWavkeo42VrCxMkcFj2IwZwZ9yoLBPBFRESUtArN3XFZj+XLVxf7gr8CNQ4CNE9BzJueRJyKinJMu9Q1fxp0yPeDpURxmMcHA0fnAjq+Ay9u1Zc1bQIV2QLNXgfJPFfmra2lhjmca+Kjl7K0o7Ll4Wz1uPRuKsJhERMQlpyerfRAJ+DtU80L1Uk4oXsxGdXCoXdpFjcsn08VgnoioCIqMT8Yrfx3G7ou31fMBjXxRtrhDzrpIbv5IW28/GXAqlc8lJSKiIsvMHHD2Bp56V+tif2oFcHEzcG2f9iiLb1OgdAOgVD2gao8iNb4+O1VKOKlF32IvAbwk0pP8NjK3/a3IBOigU4/yPDElTQX7kk3/9z1XMh1LWvObVyiO2j4u8HaxVS36wsrCDC0reqign4q2ov3bQkRkgm5GxmPIbwfUtDkyFd1H3avjmQY5aJW/cwVY0B9IjtMS3dV/qSCKS0REpqB4BaD129py+xKw/2fg8FwgcK+2qH0qAbX7a2PsK3YArHNwE7qQt9jXL+Oa/rxT9ez3k0B/29kQNcf9+eBoRCekqBsAAWGx+O98qFqykv//n2voo6bM0/NytEVFr2Kws7KAk50VvJxs8+eNUYFhME9EVMRMWnVKBfKS8G7OCw1RrdQjknKGXwY2fgicWwfoUgHPakC/uZxHnoiI8oe7H/D0l0CzscDZtUD4JZUFH2HngS3/0/Zx8QW6fa/lbiniSfMeRaaU7VKzpFoyuhgSje3nQnHuVrTqrq93MzIBZ29FY+7uzC35WT1ds4TKzC8t+cLCzEz14vN0lG78pn3NCwsG80RERYh0w9tyJlitz3upESqXcHzwzjKZiQTwK0cBCXfH6Ul3xz6zAVvjnZWDiIiKCAnYm4zS1ttOBI78oc1Zf2UXEBEIzO8DFPMCSjcEXMsClToB5VoZutRGo4Kno1qyy6i/8XSwmiZP8ucIebgWHofLYbFq2524JKz1v6WWrGwszVXC3NKuduhWqxSa+bmrZHzWlveyv9taWjAhnxFgME9EVIQsOhCo/sNuWt794YH8ufVa60fIKe156UZA92mAV7UCKysREVE6W2ctIZ5IjNb+j5LgXhLonV2tbd87AyjbEvBrA7hXAMo0BxyK8yJmIa3qnaqXUMuDSGv+9K0XcCE4On2bjM+XgF8exfngGHy76Ty+3XT/z0tX/UpexdCiYnF0rl4SznZW2mJvxc+jADGYJyIqIpJT07Do4DW1/nyTMg/eMSYUWDIESE0ELG1V1mG0mwxYMiMuEREZARtH4OmvgI6fANcOACGngZsngBOLgSs7tUXPwUNLtOfdAKg3RMv5UsST6OUFueE/c2C9bMfnh0QlIk2nw6Grd7D+5E2cvBGFW1EJmfaLT05VyftkmbntktomM+c19XNHTW+X9JER0oLfpooHano7s+t+PmBNJyIqItb630RodKLKXivT1zyQJBySQL5kHWDIKsDOpSCLSURElDOWNkC5ltoiJCv+8UVaAj3pji+9y2LvJn87t0ZbHEsB3vWAG4cB++JAqzeBKt0Z4OdifL6vu71al/Hz+mltJciX0XlCsu3LuHz/65FY438T+y7fVl3345JS1Sw6+pl09L7bfB4lnW1RraQT3BysYW5mBh83O1Qu4YTKXo4odTcTv3Ttp9xhME9EVATI9Dbfb76g1oc2LZNpXFvmHRO1eeSFdGdkIE9ERIVpjH3rd+49jw0Dom9ps7CcXgUcWwBEBwFng7TXo28CS18AzC0BlzKAbxMtN4xbecCzKmDvZrC3UhiD/Iz8PIqppVdd7/RtgbfjsPbkTdWyr3crKh5bz4ao4F+Wh5Fx+d1rlUKDsq7qRoJMvedoawl7a4asD8IrQ0RUBCw7cl1NUSN3vF9sUe7BO8ocvzL+UFouqvUsyCISERHlLRkvrx8z79MIaDcJOLtGm2pV5q6/shvY9xOQGKllzJfl2F93f9gMKFlL+7+wziDA8cHjyylnpEV/VGu/+7bHJqbA/0akmlZPptRLTtEhICwG54JjcCkkBkmp2hj9iyExqhX/vuO62atcQE/XKgl3B2t1Y6GMuz2sLB7QcGFCGMwTERVy0QnJmHa3Vf6Vp/xQzOYBf9qlf9zemdp6o+GABZPUEBFREeuWX6PPveeS+b71u1oLfegZIGAHcPM4EB4ARFzV1mWRZHsOnoBHZaBsC6BUPS17vkyhZ565RZpyz8HGEk3Ku6slu3w/MQkp6nHHhTBsPh2MM7eicONOvBq3L0l9A8Pj1LL4kJYXSMh0en4exdTYf1mqlnBSx7ezNq3Pi8E8EVEhJmPUxi86hqDIBHi72D088V3gXuDWCcDSDqj/QkEWk4iIyDDMzQFnb22R5Hh60j3/wibg6Hzg2j4gNkRbMibXs3XRMuYXrwAUr6yN3Zeu/pRnpHXd1UFLwCvj8/Vj9PVuxyTiZFCUSsS380KYCvqjE1LU+Pyzt6LVomdvbYHG5dxgY6mN++9WqyTKuDnA0sJM3VAoiormuyIiMgEyj+xna89gy9kQNUb+x0H17hvTlsm+H7XH2s9xnCAREZk26VZfb7C2xEcAdwKAoGNa633YeSD8MpAQcTexXoafK1ETqPM84OIDWFgDzqUB13KAla0B30zR5V7MBq0reahFLy1NhxsR8Wp6vXPB0erx8NU7atu2c3cTIgKYveNy+rqnow1Ku9qpRHtmaSlYMtoTRQGDeSKiQigpJQ3vLjuBFUdvqOdf9q2F2j4PyUov4wdlHKFoPLqASklERFQISDJYu7pAqbpAgxe1bakpQNBR4PpB7f/QoCPAjSNaFv3172b+eQsbbcx+ydqAWzmgUmctyKd8YW4u2fDt1dL+7uw90sBxJDACZ25GqV6LB66EY8uZYCQka+PxQ6IT1SJsH5QkuBAy6mB+6tSpWL58Oc6ePQs7Ozs0a9YMX3zxBSpXrpy+T0JCAt58800sWrQIiYmJ6NSpE3788Ud4ed2blikwMBCjR4/Gtm3bUKxYMQwdOlQd29Ly3tvfvn073njjDZw6dQo+Pj6YOHEiXniB3VCJyPhExiVj5PxD2Hc5XE3j8lnvGpmyyWZr9zRAlwb4tQU8qxRUUYmIiAonmavep6G26MWFA/5LgbOrgeQEIDkeiAjUEuxJ93x9F/01bwE+jQFrB8DGEXAto43fL9+GY/DziZmZGeqXcVWLGNqsrGrBl3H38cmpuBASg5CoBLUtJjoKRYVRB/P//fcfxowZg4YNGyIlJQXvv/8+OnbsiNOnT8PBwUHt8/rrr2PNmjVYunQpnJ2dMXbsWPTp0we7d+9Wr6empqJr164oUaIE9uzZg5s3b2LIkCGwsrLCZ599pvYJCAhQ+4waNQp//fUXtmzZgpdffhklS5ZUNweIiIxFWEwiBszep/5TcrC2wI/P18/U9Sxbd64CR/7U1lu+VSDlJCIiKnJkKrvGI7UlY3LZ2xe17vnyKF31A/do4/Cz3lR39gEqddKmx5PkesUraQE/5VsLvjnM4Ghhjnq+WpCflpaGkJCi0zJvppM+CYVEaGgoPD09VZDfqlUrREZGwsPDAwsWLEC/fv3UPtKKX7VqVezduxdNmjTBunXr0K1bNwQFBaW31s+aNQvvvvuuOp61tbValxsCJ0+eTD9X//79ERERgfXr1+eobFFRUepmgpTJyckJxkqrwCHqOppLQhAiI8G6+Wjy5/ql3w+q8WAlnGwx54WGqFYqB39vVo0Fjv4JlH8KGLIqLz4uk8K6ScaKdZOMlcnXzduXtO750iNOxuOHngVOr9LG4Gdkbgl41weKeWnrkqRP1s3MAVtnLdmelb02Nt+zKmehMaG6GZXD2NKoW+azkjcj3Nzc1OPhw4eRnJyM9u3vZaasUqUKfH1904N5eaxZs2ambvfS2i7d7qVLfd26ddU+GY+h32f8+PEPLIt06Zcl4wXXVxBZjJWUTQICYy4jmSbWzUebt+eKCuQl2d3cFxqgcoliD/9djgiE2X+fA8cXyWy6SGs9QS50Xn5sJoF1k4wV6yYZK5Ovm5IQT5aMOk0FLm2FWcB/Wut9xBWYxYYC1/bn6JrqrItpgb9MmSeBvpk5dF7VgTIt7t4AkP/pqajUzZyWr9AE8/KGJLhu3rw5atSoobbdunVLtay7uGRO+iSBu7ym3ydjIK9/Xf/aw/aRAD0+Pl6N189KxtxPmTLlvu3S2i/j+I35OspNEanExnw3ikwP6+bDrTl9G59tvqLWX23hDVfzeISExD/gYqbC/uSfKHbge5ilaPvE1hiMaJuyQEhIXn90RR7rJhkr1k0yVqybD+DWUFvqa08toq7B6uZhmCXHwiw1GRYxQTBPCFdd980TImARcwNITYZ5UjTMZVy+3AiQ5S59+J5m5YA0u+L3AnpzCyR6N0VChW7aTQD9frauSLNzN+nAP62QxELR0fem3CsSwbyMnZdu8Lt27YIxmDBhgkqYpyeBvyTOk27/xt7NXhJESDmNuQKT6WHdfDCZWuXzjVog37tuKbzSobr6PX4Qs40TYbZvplrX+TaDrsPHsPOuh/tvSxLrJhVm/LtJxop1M4c8PYEKdyP7h9GlIS34FHDrBMwkD05yHCA3668dgFnwSZgnx6olI8s7l+Bwcv79h7K01brrS2K+an2gk8S45nentZXu/U6ltGn7ZF2y9BexwD+tkMRCtra2RSeYl6R2q1evxo4dO1C69L1pHiSpXVJSkhrbnrF1Pjg4WL2m3+fAgQOZjiev61/TP+q3ZdxHgvLsWuWFjY2NWrKSSmHMFUNIBS4M5STTw7p5v7X+N/H5em2C21ee8sNbHSurhC4PFHYROPCztt7lS5g1HA4z/q6zblKRxb+bZKxYN/OSOfD/9u4EPqrq7v/4d7LvYQkJIAgiKpuAsom4oKColaKiReujoGifulXK42NLn1bFpaitC8qitv+itlqhWlCpighq3XABUUBAQRQqkECAkBCyTv6v37kkJGQmoCxzh3zer9d9ZZY7M3dm7ivJ95zfOad1D2/bU/WM+ju31p11//PnpG8/8MbtGzd+f6sCFSWSbaWF0oJJCiyYFP5lk5tK7U+VWnb3ltqzRoBqiRleyb9N5FfdGBAlAlGQhfb12Hwd5q384aabbtLMmTPd0nFHHVV37EmvXr3crPQ2+/zw4cPdbStXrnRL0fXv399dt5/33HNPzUQHZu7cuS6od+nSpWafV155pc5z2z7VzwEAkbBsfYH+Z8Zn7vLoU47Srefsw5Jy88ZLwQrpmCF1Z9sFAACHn/hkqcXuZbtrdDqv/m0VpVLhBjccT5tWSoufkbZ8vfv+yjKp4Duv199YA8Hyl7wtnMRMqW1fKSFFSmoitT9FatZh9yCAuASphU3e5+vYGbXi/F5abzPVv/jii0pPT68Z424z+1mPuf0cPXq0K3e3SfEsoFv4txBuk98ZW8rOQvsVV1yh+++/3z2HrSFvz13ds25L0k2aNEm33nqrrr76as2fP18zZsxwM9wDQKSWoPvZ0wvd2qinHpOlcefuQ5D/9n3vD66Vxg2+41AcJgAAiBZxiV5vurEe9VCB3xY6Kyvyflrg/+YdactqL+RX9/Kryuv937JGsrH8q+bufvyip+o/p/Xi2+R9zY7yLtv/KemtpKbtvONJ2TXe3xoDfNxb7ke+DvNTp051PwcOHFjn9mnTpmnUqFHu8kMPPeTKEKxn3maXt1nop0yZUrNvbGysK9G32est5Nv69CNHjtSdd95Zs4/1+FtwtzXrJ06c6Er5//znP7PGPICIKK2o1HV/W6jvtu3UUVmpmnTZiYqL3csfNyuXm3Wdd/mEK6Qcr/IIAABgn1motvH0pm0fbwunskLa8Jm0YbEX9K3c38J/cf7ufXYWeIH/6ze9rSGurP8Uryc/o5UUiJUSUr2VAbI7eZcRvevM+xnrzAONY93Pg628Mqgbnlmk17/IVXpinGbeMEAds3fPRBuS/Rp/6SZvLfnMI6Xr3vWWrcEBwbkJv+LchF9xbmL3yVDpJu7TxqXS1m+8Mf42HHD7d9K2byWb0K/UW+K7QTHx0hEnej37VmGQ2dbr1a/u3W/Sziv1P0zOzcNynXkAOJxVBqt0yz8+c0He1pJ/7Ipeew/ytg7p3N95Qd7Gp104lSAPAAD8wSbHa32CtzX0v0xwVy//2ve98v2iXZOT79wm5a+SduRJ6z5s4IUCUiubJPAEb6I+m5W//WlSWrYUE7frZ3RN1LcvCPMA4ANWJPV/M5foxcXrFRcT0NTLT9SAjlkNP2jHZmn2L3dPTHPOBK88DQAAIFpYD3lMQviyfqtAtIn6vlsoVZZ7S/NZL/+2XT37rne/wCv3ty3ka8S5sfmBQIyyAvHSmDD7RRnCPAD4IMiPf/kLPffxOtmqcxMvPUGDOuc09ABp2T+lV/7XG5dmY8qGTZZ6XnYoDxsAAODQjOO3CftsC2f7BmnNv6X8r7z/k/KWS2s/8IK/NQBYz3/RRjfHfkxc6KXHoxFhHgAi7I+vr9ST73/jLt9/cQ/9qHur8DuXbPcmulsx27ue3UUaNsmbJRYAAKAxymgl9RgRfty+LclXnK9gsEpbtm5TMx0eCPMAECH2B+X+OSv12Nur3fW7hnXVxb3ahH9A2Q7pmUukdQu8iWBOu0U6Zay3hisAAADqs7HymW28LRhURWyeDheEeQCIgB2lFfrVC59r9ucb3PX/O6+zrui/a+3XULavl1641gvyNlP9FbO8WV0BAADQKBHmAeAQ+3TtVv1y+mJ9k1/sJru7b3h3DW+oR37J89Lssd7kLglp0uUvEOQBAAAaOcI8ABxCH6zO16hpH6m0IqjWmUl6cERPndShefgHvPeIt/ScsXHxNtFddudDdrwAAADwJ8I8ABwiH63ZotFPfeyC/MDjWrhZ6zOT40PvbDOxvnG79N5E73r/G6Wz7jws10gFAADA90eYB4CDrKIyqEfmr9LkN1epMlilUzpm6bH/6qWk+DDB3JZQeXmMtPhv3nUL8QNu5nsCAABADcI8ABxERaUVuuGZRXr7y03u+rCerTXhouPDB/nCjdI/RnlrowZipB8/Kp3wX3xHAAAAqIMwDwAHyYKv83XHS8u0YmOhkuNjde/w4zWs5xHhH7B2gTTjSqkoV0rMkC56QjruXL4fAAAA1EOYB4ADLL+oVL96YYneWJ7rrmelJegvo/qoe5sm4cfHf/SENOc3UrBCatFZGvE3Kasj3w0AAABCIswDwAGerX7M9E+Vu73ULTt3Wd8jddOgjspOTwr9gNIiafYvpSUzvOtdL/JK6xPT+F4AAAAQFmEeAA4Am9jukXlf6dH5XylYJR3dIlWTLz9RnVpmhH/Q6jell38hbVsrBWKls++WTrpOCgT4TgAAANAgwjwA7KeNBSW6+blP9eGaLe76Jb3aaPywrkpJCPMrNneZ9MZ46as53vXMttKFj0vtB/BdAAAAYJ8Q5gFgP7y5Ik//84/PtGVHmVITYnXPhcfrghOOCD82fuE06dVfSZVlXm98n2ukQb+TEtP5HgAAALDPCPMA8AOUVQT1hzkr9Kd31rjrXVplaNJPT1CHFmHGuud+Ic2/S1r5inf92HOlIfdIzY/m8wcAAMD3RpgHgO/pm807dPP0xfps3TZ3fWT/dhp3XufQa8fbBHcW4j983LrmvbXjB90mDRjD2HgAAAD8YIR5APgevfFT3lqlKW+tdpczkuJ0/8U9dE63lvV3LsyVPn1a+mSatP0777bOQ6Uzfitld+IzBwAAwH4hzAPAPli5sVBjpi/W8g3b3fVTOmbp3uHHq03TlLo7lu+U3p8kvfugVF68e4K7oQ9LHQfzWQMAAOCAIMwDQANyt5e4Jeemf7xOFcEqNU2J1/hh3TS0eysFai8hV1kuffo36e37pcL13m1H9JL6XCt1GSYl7BH6AQAAgP1AmAeAEILBKj370Vrd9+oKFZZWuNsGd87R7y/qpuz0pNo7Sl/MlObfI21ZvbsnfvAdUrfhjIsHAADAQUGYB4A9QvxbX+bpgde/1LL1Xkl9j7ZN9JtzO6lfh+Z1l5lbNU+aN17a+Ll3W0qWdNotUu+rpbhEPlcAAAAcNIR5AI2eBXgL7nOX52rmp//Rui073WeSlhinsWcdq5Ent1dsTK2S+rUfeiH+2/e86wnp0sk3Sf2vZ714AAAAHBKEeQCN0o7SCr27arPeXJGn+SvylFdYWnNfemKcLut3pH5++tFqlpoQfq342ESp77XSKWOl1Fq99gAAAMBBRpgH0CjkFZZo4Tdb9cm33rbsuwI3oV211IRYnXpMCw3plqNzurZSckLs7nL6tR9IH/8/aekLu9eK73m5NPDXUmabyL0pAAAANFqE+UakYGe5nv9knYqKCpWWVlx3Ju5a7GbrjcxKS1RMmH3iYwNuErCM5DgFFHofC0MJcTEH9D0Ae9pZVunWfK8IBrWpqFS520uVW1CiotIKVQartHzjdi38dqu+zd+1TFwtbZsla1CnHA3qnK2+RzVTYtyuAG8qK6TlL0nvPCDlLt19u81Mb2vFtziWLwMAAAARQ5hvRLYVl+mufy0/ZK9n7QAt0hKVUt3DGUKTlAS1SE9UXO3xyLXExATcczRJia/XaBAXG3CPzUy2+xS2QSEnI0nJ8eGPITMl3pVVh2vcwN5VVVW5Gd8LisvD7rOzvNIt82bhO9R9Gwt2avPW7UpNLVAgEKOyykrlbS91oXxPpRVBbSgo0fptO10j1b6wr/e4nHT1atdUvds3Ve92zdSmaXLd7z1YKa1f7JXRL3529xJz8alSt4ukPtdIrXtySgAAACDiCPONSEpCnM7v3kqlJSVKTEoKG15tMrDNRaXaWlzmKoxDsTBlwcx+hmOPrT0OOaQQvaWRkBQfo7iYhqsIrMogOz3RTYq2p8T4GOWkJyk1xH212UfeJDlemSkJCtN+sV/sM7ex4FuKy5SaEOcaQWzitpLyoPKLSsN+X1Wq0tbicm0qLHXffzUL0vYdWs93Q6xX3F4j0mwNeGu8sS09yWugad88xQX4E45s6hp+6igpkHKXeZuV0q+eL+3cuvv+5GZSv//2tuSmh/z9AAAAAOEQ5hsR68V+5NKeysvLU3Z2tmL2El73pTfWyphD3rerrH/DthLXwxqKPTS/qEz5O0rd5VDKK4IuTBaW1O99tYCZW1iqohD3VdtRWqmN20vChtFgVZULuF4Q3UsYLZW27ChreJ9GLjEuJuzQDGsMaZlhDR71qySsvD07I1ExlWVKTvZ6y61ao7rywrWC1BIfE1BOZpJaZyarZWaSG+9uj6kz43xt1uO+5Wvp66W7w/vGpVLB2hBvIkPqcLrU9UKp0/ksMQcAAABfIsw3JkV5Csz5jTJLShRISrJ+4tD7WXBKyvQ2m+grlJg4BZKbKi4hNezzZMUnKyu1hRRnrxVGywwpqYkUE6YM3l7fwtV+Njw0pLiswjUqWLBviFcKXqKS8vqNE8VlXqNB6V56p+01thWXa9s+lob/EBZsbfjCzrIK19tu7yohNkZZaQlKamC4QUZyvAvPCbG7v0/b38JyQ8MUjAX45mkJrvrjhwoGg/UbmspLpPIQ1RuVZdKOPKl4s7Rps1RZLlVVSju3ScX53la+07ttyxopb7lUsTPMGz9CyukmteohHX2m1Ka3FLtHDz4AAADgM4T5xqSsSIEl/1CyoowF+oS0+o0GFvisDNoaFMKNd7eGBNsnLjHs06ckpivFSqjDNSjUvF68OqU0l+JDfIKxCVJruy9pb29GSkzz1iU/WGP0LfyWbvHeuzWE2OtY+LWScvsZijVklBV5JeYVtRorinZK3+VLwb00PljPtz22tDD8PhWl0s4tUkVJyPsCxfnKLi/ZNfwj4L1mqCD/Q8UlSzldpJyuXnh3P7tSPg8AAICoRJhvTJKbKXj2PSoqLFJaelrYcmhVBb3gZ1u43moLhRbMrPczbDjc4fWe2qzg4V6ndLu3NaR6v1Bqj29GVNsV4fd9b2tYscqP1KxdjTUBL5jb7dWNLnaOV/e8Nztq7w02AAAAQJQgzDcmyU2kk65XcV6e0rKzD2rp+vdivbrhWPm0BXZrGKj3uAbuq2Y9u8VbvOcJqcprKLDy7L2U2bseZSvfDtW7bY0arte5bB8aJgq9XvCDxfXIp3s94a6nvMoNi3Dff2z4CgVXMeAqFOLqVhxYMG5oqISx0GzPb5UA4SK5la6nNJPiU0LeF0xqqvztxWrevLlirBqjpvIiLUQVQ8A/5y8AAAAQAYR5RF5DvaV2X3yrQ3k0iJRgUJUxeVJzHzU0AQAAAD7Ff8wAAAAAAEQZwjwAAAAAAFGGMA8AAAAAQJQhzAMAAAAAEGUI83uYPHmy2rdvr6SkJPXr108fffRRZL4ZAAAAAADCIMzXMn36dI0dO1a33367Fi1apB49emjIkCHKy8sL9/kBAAAAAHDIEeZrefDBB3XttdfqqquuUpcuXfTYY48pJSVFf/nLXw79NwMAAAAAQBisM79LWVmZFi5cqHHjxtV8ODExMRo8eLA++OCDeh9caWmp26pt377d/QwGg27zKzu2qqoqXx8jGifOTfgV5yb8inMTfsW5Cb8KRkkW2tfjI8zvsnnzZlVWVionJ6fOB2TXV6xYUe+DmzBhgsaPH1/v9k2bNqmkpER+PjEKCgrcSWyNFYBfcG7Crzg34Vecm/Arzk34VTBKslBhYeE+7UeY/4GsB9/G19fumW/btq1atGihjIwM+fkEDgQC7jj9fAKj8eHchF9xbsKvODfhV5yb8KtglGQhm4x9XxDmd8nKylJsbKxyc3PrfEB2vWXLlvU+uMTERLftyU4KP58Yxk7gaDhOND6cm/Arzk34Fecm/IpzE34ViIIstK/H5t93cIglJCSoV69emjdvXp2WG7vev3//iB4bAAAAAAC10TNfi5XNjxw5Ur1791bfvn318MMPa8eOHW52+72xcRe1J8LzK2ugsDEYVrrh59YoND6cm/Arzk34Fecm/IpzE34VjJIsVJ0pqzNmOIT5WkaMGOEmsLvtttu0ceNG9ezZU6+99lq9SfEamqTAxs0DAAAAALA/LGNmZmaGvT9Qtbe4j31u5Vm/fr3S09PdOAy/qp6ob926db6eqA+ND+cm/IpzE37FuQm/4tyEX22PkixkEd2CfOvWrRusIKBn/gCxD7lNmzaKFnby+vkERuPFuQm/4tyEX3Fuwq84N+FXGVGQhRrqka/m34ECAAAAAAAgJMI8AAAAAABRhjDfyCQmJur22293PwE/4dyEX3Fuwq84N+FXnJvwq8TDLAsxAR4AAAAAAFGGnnkAAAAAAKIMYR4AAAAAgChDmAcAAAAAIMoQ5gEAAAAAiDKE+UZk8uTJat++vZKSktSvXz999NFHkT4kQP/+9781dOhQtW7dWoFAQLNmzeJTgS9MmDBBffr0UXp6urKzs3XBBRdo5cqVkT4sQFOnTlX37t2VkZHhtv79++vVV1/lk4Gv3Hvvve7v+pgxYyJ9KIDuuOMOdz7W3jp16hT1nwxhvpGYPn26xo4d65ZiWLRokXr06KEhQ4YoLy8v0oeGRm7Hjh3ufLTGJsBP3n77bd1www1asGCB5s6dq/Lycp199tnunAUiqU2bNi4oLVy4UJ988onOPPNMDRs2TMuWLeOLgS98/PHHevzxx12jE+AXXbt21YYNG2q2d999V9GOpekaCeuJtx6mSZMmuevBYFBt27bVTTfdpF//+teRPjzAsVbSmTNnuh5QwG82bdrkeugt5J922mmRPhygjmbNmukPf/iDRo8ezSeDiCoqKtKJJ56oKVOm6O6771bPnj318MMP860g4j3zs2bN0uLFiw+rb4Ke+UagrKzMtd4PHjy45raYmBh3/YMPPojosQFAtCgoKKgJTYBfVFZW6rnnnnMVI1ZuD0SaVTT96Ec/qvN/J+AHX331lRvW2aFDB11++eVau3atol1cpA8AB9/mzZvdH/ucnJw6t9v1FStW8BUAwF5YNZON+xwwYIC6devG54WIW7JkiQvvJSUlSktLc1VNXbp0ifRhoZGzhiUbzmll9oDfqpSffPJJHXfcca7Efvz48Tr11FO1dOlSNzdOtCLMAwCwDz1N9gf/cBhfh8OD/UNq5aJWMfL8889r5MiRbggIgR6Rsm7dOt18881ujhGbbBnwk3PPPbfmss3lYOG+Xbt2mjFjRlQPTyLMNwJZWVmKjY1Vbm5undvtesuWLSN2XAAQDW688UbNnj3brbxgE48BfpCQkKCOHTu6y7169XI9oRMnTnSTjgGRYEM6bWJlGy9fzSpD7XenzdlUWlrq/h8F/KBJkyY69thjtWrVKkUzxsw3kj/49od+3rx5dUpG7Trj6wAgtKqqKhfkrXx5/vz5Ouqoo/io4Fv2d93CEhApgwYNcsM/rGKkeuvdu7cbm2yXCfLw20SNq1evVqtWrRTN6JlvJGxZOivBs1+qffv2dbOK2mQ5V111VaQPDY2c/TKt3Sq6Zs0a90ffJhk78sgjI3psaNystP7ZZ5/Viy++6MbTbdy40d2emZmp5OTkSB8eGrFx48a5klH7HVlYWOjO07feektz5syJ9KGhEbPfk3vOKZKamqrmzZsz1wgi7pZbbtHQoUNdaf369evdct3WwHTZZZcpmhHmG4kRI0a4ZZVuu+029w+pLRPy2muv1ZsUDzjUbI3kM844o07Dk7HGJ5uoBIiUqVOnup8DBw6sc/u0adM0atSoCB0VIFfKfOWVV7pJnKxxycZ/WpA/66yz+HgAIIT//Oc/Lrjn5+erRYsWOuWUU7RgwQJ3OZqxzjwAAAAAAFGGMfMAAAAAAEQZwjwAAAAAAFGGMA8AAAAAQJQhzAMAAAAAEGUI8wAAAAAARBnCPAAAAAAAUYYwDwAAAABAlCHMAwAAAAAQZQjzAAAcBgKBgGbNmnXQX6d9+/Z6+OGHffM839eTTz6pJk2aHPLXBQDgQCPMAwDgc5s2bdJ1112nI488UomJiWrZsqWGDBmi9957r2afDRs26Nxzz5XfhAvPH3/8sX72s59F5JgAADgcxEX6AAAAQMOGDx+usrIyPfXUU+rQoYNyc3M1b9485efn1+xjAT+atGjRItKHAABAVKNnHgAAH9u2bZveeecd3XfffTrjjDPUrl079e3bV+PGjdOPf/zjkGX233zzjbs+Y8YMnXrqqUpOTlafPn305Zdfuh7x3r17Ky0tzfXkW69/tYEDB2rMmDF1Xv+CCy7QqFGjwh7fgw8+qOOPP16pqalq27atrr/+ehUVFbn73nrrLV111VUqKChwx2PbHXfcEbLMfu3atRo2bJg7royMDP3kJz9xjRbV7HE9e/bUX//6V/fYzMxMXXrppSosLNxrZYBVNKSkpOjCCy+s0wBiVq9e7V43JyfHvbZ9Tm+88UbN/Xfeeae6detW73ntWH73u981+NoAABxMhHkAAHzMAqZtFtRLS0u/12Nvv/12/fa3v9WiRYsUFxenn/70p7r11ls1ceJE10CwatUq3Xbbbft1fDExMXrkkUe0bNkyVzkwf/589xrm5JNPdoHdwrkNA7DtlltuqfccwWDQBeotW7bo7bff1ty5c/X1119rxIgR9YK3fQ6zZ892m+177733hj22Dz/8UKNHj9aNN96oxYsXu8aQu+++u84+1vBw3nnnuUqHTz/9VOecc46GDh3qGhfM1VdfreXLl7tGkGq23+eff+4aKgAAiBTK7AEA8DEL4da7fO211+qxxx7TiSeeqNNPP931Snfv3r3Bx1pwtrH15uabb9Zll13mQuuAAQPcbRZ07bn3R+2efOsxt7D885//XFOmTFFCQoLrQbce+YaGAdgxLVmyRGvWrHG9++bpp59W165dXYi23vLq0G/Hm56e7q5fccUV7rH33HNPyOe1RgsL59WNC8cee6zef/99vfbaazX79OjRw23V7rrrLs2cOVMvvfSSawRo06aN+wynTZtWcxx22b4DG/IAAECk0DMPAEAUjJlfv369C5gWTq183UL93oJ47bBvZeTGSuJr35aXl7dfx2Yl6YMGDdIRRxzhQrYFbCtlLy4u3ufnsJ5vC/HVQd506dLFTZxn99VuLKgO8qZVq1YNHr89tl+/fnVu69+/f72eeWv06Ny5s3s9q4Kwx1X3zBtrSPn73/+ukpISN3fBs88+63rsAQCIJMI8AABRICkpSWeddZYbp229yzaO3croGxIfH19z2XrHQ91mvd21S+arqqrqPEd5eXnY57ex+eeff75rNHjhhRe0cOFCTZ482d1nofdAq33soY7/h7Agbz3xv//9793QAyvHtwaP2sdvZfe2ioDt9/LLL7vP5OKLL96v1wUAYH9RZg8AQBSynusDva68zTBv49qrVVZWaunSpW6seSgW3i1MP/DAA64hwNike7VZqb09T0OsV3zdunVuq+6d/+KLL9zkf/Y+fyh7Xhs3X9uCBQvqXLfl/axhxCbHq+6pt0aKPYc6jBw50pXX2/uxIQ42qSAAAJFEmAcAwMesZP2SSy5xZd3WA25l5p988onuv/9+N2ncgXTmmWdq7Nix+te//qWjjz7azVRvgTqcjh07ul7qRx991PVeWzC2cf21WWm8BWQb225j021WedtqGzx4sOsNv/zyy92EeRUVFW5WfBuXbjPv/1C/+MUv3PwAf/zjH91nNWfOnDrj5c0xxxyjf/7zn+74raffKh9C9fZfc801rnHA2PsEACDSKLMHAMDHbAy3jft+6KGHdNppp7ll0ixw2jjuSZMmHdDXsgYD64G+8sorayZ4C9crbyycW+C3ZfPsuJ555hlNmDChzj42o71NiGcz01vPvzVC7MlC9IsvvqimTZu692jh3l57+vTp+/V+TjrpJP3pT39yE+HZsb7++utudv/a7Pjtde04LdDbZHc2H8GeLPTbPp06dao3Dh8AgEgIVO05OA4AAAB12L9LFuitYsCqFwAAiDTK7AEAABqwadMmPffcc9q4cSNrywMAfIMwDwAA0IDs7GxlZWXpiSeecCX5AAD4AWEeAACgAYxIBAD4ERPgAQAAAAAQZQjzAAAAAABEGcI8AAAAAABRhjAPAAAAAECUIcwDAAAAABBlCPMAAAAAAEQZwjwAAAAAAFGGMA8AAAAAgKLL/wfvjdL8D469ZgAAAABJRU5ErkJggg==",
+      "text/plain": [
+       "<Figure size 1000x400 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>metric</th>\n",
+       "      <th>input</th>\n",
+       "      <th>optimized</th>\n",
+       "      <th>optimized/input</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>peak flow cfs</td>\n",
+       "      <td>12120.000000</td>\n",
+       "      <td>9090.000000</td>\n",
+       "      <td>0.75</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>volume proxy cfs-days</td>\n",
+       "      <td>24975.386719</td>\n",
+       "      <td>18731.541016</td>\n",
+       "      <td>0.75</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                  metric         input     optimized  optimized/input\n",
+       "0          peak flow cfs  12120.000000   9090.000000             0.75\n",
+       "1  volume proxy cfs-days  24975.386719  18731.541016             0.75"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "if project_available and not fallback_trials.empty:\n",
+    "    baseline_hydrograph = read_inflow_hydrograph(trial_hdfs[Q_MULT_TRIALS[0]])\n",
+    "    optimized_hydrograph = read_inflow_hydrograph(Path(best_trial[\"hdf_path\"]))\n",
+    "\n",
+    "    fig, ax = plt.subplots(figsize=(10, 4), constrained_layout=True)\n",
+    "    ax.plot(baseline_hydrograph[\"days\"], baseline_hydrograph[\"flow_cfs\"], label=f\"Input QMult {Q_MULT_TRIALS[0]:.2f}\")\n",
+    "    ax.plot(optimized_hydrograph[\"days\"], optimized_hydrograph[\"flow_cfs\"], label=f\"Optimized QMult {best_trial['qmult']:.2f}\")\n",
+    "    ax.set_xlabel(\"Simulation day\")\n",
+    "    ax.set_ylabel(\"Inflow (cfs)\")\n",
+    "    ax.set_title(\"Input vs optimized inflow hydrograph\")\n",
+    "    ax.grid(True, alpha=0.3)\n",
+    "    ax.legend()\n",
+    "    plt.show()\n",
+    "\n",
+    "    comparison = pd.DataFrame(\n",
+    "        {\n",
+    "            \"metric\": [\"peak flow cfs\", \"volume proxy cfs-days\"],\n",
+    "            \"input\": [\n",
+    "                baseline_hydrograph[\"flow_cfs\"].max(),\n",
+    "                np.trapezoid(baseline_hydrograph[\"flow_cfs\"], baseline_hydrograph[\"days\"]),\n",
+    "            ],\n",
+    "            \"optimized\": [\n",
+    "                optimized_hydrograph[\"flow_cfs\"].max(),\n",
+    "                np.trapezoid(optimized_hydrograph[\"flow_cfs\"], optimized_hydrograph[\"days\"]),\n",
+    "            ],\n",
+    "        }\n",
+    "    )\n",
+    "    comparison[\"optimized/input\"] = comparison[\"optimized\"] / comparison[\"input\"]\n",
+    "    display(comparison)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a51373fe",
+   "metadata": {},
+   "source": [
+    "## Objective Function Convergence"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "59ca4271",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-01T21:37:02.498971Z",
+     "iopub.status.busy": "2026-05-01T21:37:02.498971Z",
+     "iopub.status.idle": "2026-05-01T21:37:02.621177Z",
+     "shell.execute_reply": "2026-05-01T21:37:02.621177Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAysAAAGbCAYAAADEAg8AAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjksIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvJkbTWQAAAAlwSFlzAAAPYQAAD2EBqD+naQAAdxZJREFUeJzt3QdYk9fbBvCbvWSogIjinrgFB1j/Wne1WrV1tu6J2mrtsHY4alu1rdZa9x51a7V2adWqrYIi7r23DHEAgoBCvus5/ULDUkAgIbl/1xUlb94kJycnb94n55znmGk0Gg2IiIiIiIgMjLm+C0BERERERJQRBitERERERGSQGKwQEREREZFBYrBCREREREQGicEKEREREREZJAYrRERERERkkBisEBERERGRQWKwQkREREREBonBChERERERGSQGK0Rkcvbs2QMzMzP1v1bfvn1RpkyZlOvXrl1T+3z77bf5WrZly5ap5w0JCcnz179x48bn7pu2XvKLtv6lPoiIyHQxWCGiAkN7Ip/R5aOPPtJ38SgHVq9ejRkzZrDuiIgoQ5YZbyYiMlyff/45ypYtm2pb9erV9VYeY7Zw4UIkJyfnabBy6tQpjBo1KtX20qVL4/Hjx7Cyssqz5yYiIsPHYIWICpxXXnkFvr6++i6GSdBXsCC9Zba2tnp5bmMVGxsLBwcHfReDiChbOAyMiIzG9evXMWzYMFSuXBl2dnYoWrQounTpouY/vIjvvvtO/dIvj9mkSRPVE6DrxIkTam5HuXLl1Am2h4cH+vfvj3v37qV7rNu3b2PAgAHw9PSEjY2N6iEKCAhAYmJips//4MED1K9fHyVLlsT58+efWdYrV66o11ykSBHY29ujYcOG+O233zLcNykpCR9//LEqr5zEdujQATdv3nzunBXpaZGhW9WqVVOvt1ixYhgyZIgqZ1p//PGHqjNHR0c4OTmhXr16qjdFNG3aVJVN3jftcD7tc6WdsyJzh+S67JvW2LFjYW1tner5Dx48iDZt2sDZ2VnVg5Rh//79yIr4+HhMmDABlSpVUq+vePHi6Ny5My5fvpzqxP+9996Dl5eXeh+lzUkZNRpNqseSMo8YMQJbtmxRvX+yr9Tbtm3bUvaRuUOy3969e9OVZf78+eo23TZ37tw5vPHGG+o9lvJJ4L5169YMh0zKY8pnwt3dXbUfrdmzZ6v2Km1a2tY///yj3g+56EpISMD48eNRoUIFVXZ5vR9++KHant3XmZ3PwMOHD1Vvm7Z+5fmnTp2ap718RGSY2LNCRAVOVFQUIiMjU21zdXXFoUOHEBgYiO7du6sTMznhnTt3rjoBO3PmjDppza4VK1YgJiYGw4cPVyex33//PZo1a4aTJ0+qk3SxY8cOFST069dPnfifPn0aCxYsUP8fOHBAnciJO3fuqBNDOREbPHgwqlSpok7c5GQ1Li5OnXCnJa+zZcuWuH//vjrxLF++fKZlDQ8Ph7+/v3qsd955RwVry5cvV0GIPEenTp1S7f/ll1+qso0ZMwYREREqAGnRogWOHTumTmIzI4GJnAzL65XnuXr1KmbNmoWjR4+qgEDbGyP7SNAmJ60SULi4uKh95AS2Z8+e+OSTT9R7eevWLRUQikKFCmX4nF27dlUnyevXr8cHH3yQ6jbZ1qpVKxQuXFhd/+uvv1Tvm4+PjzrRNjc3x9KlS9X7Jifl8h5kRgK4V199Fbt27VLtaOTIker9l/dYAgapfwlIpE53796tTrpr166N7du3q3LJ+6l9LVr79u3DTz/9pIIGCdpmzpyJ119/HTdu3FDvUbt27dTrltchQZWudevWqfrTDnOUNtWoUSOUKFFCzdOSIFPu17FjR2zatCndeyzP6ebmhnHjxqkAS8hnQgKLxo0b491331WfE7m/1J9uQCOBgbxOKb+016pVq6p2L6/vwoULKjDJzuvM6mdA/pd6kO3S1kqVKqU+19KGQkNDOceJyNRoiIgKiKVLl8rP1hleRFxcXLr7BAUFqdtXrFiRsm337t1qm/yv1adPH03p0qVTrl+9elXtY2dnp7l161bK9oMHD6rt7777bsq2jJ53zZo1ar+///47ZVvv3r015ubmmkOHDqXbPzk5OdVrlH1CQ0M11apV05QrV05z7dq159bPqFGj1H3/+eeflG0xMTGasmXLasqUKaNJSkpK9fpLlCihiY6OTtl3/fr1avv333+fab3IY8s+q1atSvXc27ZtS7X94cOHGkdHR02DBg00jx8/zvC1inbt2qV6/LT1L/Wh5efnp/Hx8Um1X3BwcKr3Vx67YsWKmtatW6d6HnmPpB5atmz5zDpcsmSJerzp06enu037eFu2bFH7fPHFF6luf+ONNzRmZmaaS5cupWyT/aytrVNtO378uNr+ww8/pGzr0aOHxt3dXfP06dOUbfL+S3v5/PPPU7Y1b95cU6NGDU18fHyqcvn7+6vXraVtRy+99FKqx0xISNAULVpUU69ePc2TJ09Sti9btkzt36RJk5RtK1euVM+v257EvHnz1L779+/P9uvMymdg0qRJGgcHB82FCxdS3f7RRx9pLCwsNDdu3Eh3XyIyXhwGRkQFjgxhkV+6dS9CtzfgyZMnahiWDB+RX/SPHDmSo+eSX5zlV2wt+VW4QYMG+P3331O26T6v9L5Ib4gMvxLa55VfqeWX6Pbt22c430bb+6IlvQ3y67K8jr///lsNQ3seKZOU76WXXkrZJr/Yyy/Y8uu59C7p6t27t/oFXEuGFsmQJ93XltaGDRvU0Crp7ZHXqb1IL4Y8l/Q2CHlPpEdCfv1PO/ck7WvNqm7duuHw4cOphmNJz4MME3rttdfUdekVunjxouq5kfdfWz7pVWjevLmqy2cNJZLeCemle/vtt9Pdpi231I+FhYXqVdIlw8LkvF2GvumS3irdHrGaNWuqIXHSG6f72qR3SzedtvQ2SFnlNiG9a9JrJL1MUrfa1yavs3Xr1up1S2+ErkGDBqmyaklKbNlftlta/je44s0330zpmdJ9r6U3RXo/dN9r6aES2vc6q68zq58BeV7p9ZHy6D6vPL70fMl7SESmg8PAiKjAkRPyjE52JHvU5MmT1ZAfOWnTnT8gw41yomLFium2yVwGGXqjJSeREydOxNq1a9UJpy7t8969exfR0dFZzlrWq1cvdTJ59uxZNbQsK2Q+hwRSackJp/Z23edP+9rkZFGCu2fN8ZETYnlNMgciI9rXrw0ocjNLm8zFGT16tApQZK6NvL9yYitDvuSkWFs+0adPn0wfR8qf9sRcS8ot8090T+TTknqU+Ra6gV7aetYlw5jSkufXnWOjnV8jr02CKiF/yxAzaW/i0qVL6jV/9tln6pJZ/esG12mz5mnLJu+zLnm9aecmSV1K+5NhZJk9V3ZeZ1Y/A/K8Mg8sq89LRMaNwQoRGQ35NVwCFZmY6+fnp07+5ARc5h7k5cRc+aVbxtTLnAU5uZQeBnk+OQHN6fPKhG6ZLyNzZCQAMxTyeiRQWbVqVYa3Z3aCmRskQJBf3CVQlGBF5gPJfAiZeK1bPvHNN9+o9yIjmc2LySu6PRu6dINp6R2SXrzNmzdjzpw5av6RzP/56quv0r22999/X/WkZCRtEPKsuUfPI89Xo0YNTJ8+PcPbZfJ7dl9nVp9Xeu5kjlJGtMEbEZkGBitEZDRk2Iz8oj5t2rRUw7JkMm9OaX+p1yWTi7W/QsuvxjIZW3pWZBJzZveTk3j59T9tJrFnBV5y4imPKUFXVha9lKFiGWULk+xR2tuf9drkpFJ+vZfhO5mRYT47d+5Uk7yfdSKsHQ4krzftCfSLDAmTIVEygVtep/Q8SNIEGVaU9nmlrmXYUHbJ/SWTmAy/yyxts9Sj1IEMxdLtXcmsnrPz2iQhgrQn6dGQ90M7BExI9i4h5crJa9Mtm7zPL7/8csr2p0+fqh413fde6uL48eOqpyenQ/dy8hmQ53306FGOXyMRGRfOWSEioyG/7Kb9FfeHH35Q49xzSsbY684DCA4OViezMvRI+5wi7fOmXZVdMlLJL+e//PKLmjeQlV+fZaiP/IouWZAkg9PztG3bVpUvKCgoZZvM1ZDMZBJceXt7Z5jpTDfYk2xL2teWWS+S1OekSZPS3SYnvNrAULJzyYm89ApJwJjZa5VsVtkZoifZpaTO16xZo4aASeYu3bVDZO6MnOxKGmE54U1LhiI97/FlfoRkN0tLW26pZ6mDtPtIliw5qX9W/T2LnJxLOmIJwuQiwx11h3FJj5ZktpN0xvI+Zfe1CRk+KZm5ZLFPeb+0pKcsbeppea+l7cu+GQ251GYXy6qsfgbkeaUNS4a1tKR96ZabiIwfe1aIyGjIievKlStVT4ScmMsJj/wCrk2bmhPSKyAT1mUdCFlbQoIQeTztEBX5pfh///sfvv76a/VrvMwX+PPPP1U637RkSI/cJhPntalg5aRTTrol7askAkhLhjPJybykTpaT/7feeivTskrvi5zEy8myTP6WE1/5pV7KIhPH5WRRl9wur01SEMuwI3lt8npl8nVmpOySTlaCEJnMLkGJ/NIvvTTyOmTYmkzUl3qRk/eBAweqtVVkwrvMX5Bf6iU1rZRLG1zIibnMRZH9ZIiWbk9JWnLCLj0CMjRJAi3dngchr3HRokWqDiTlr7w2eU/kpFsmhEu55GQ5M5J0QII4KY8EfjLsTE7KpR1Jj45M5JfySRkk9bL0RtSqVUu9rz///LMagvis9NLPIvUow/9k7pM8pwRcGSWXkPdMhmfJ+yS9LfLeSVuXpAxSv88iqYFlDRnpuZOJ8hIYyGuQNNNSbt0eFJk3JUPuhg4dqupOetMkSJMeJNkuwUR2F2fNymdAhlPKujHyeZZ1fqSNSH1I2mQJqKW8kgSBiEyEvtORERFllW5a34w8ePBA069fP42rq6umUKFCKn3tuXPnVGpcScGbk9TF33zzjWbatGkaLy8vjY2NjaZx48YqJasuSW3cqVMnjYuLi8bZ2VnTpUsXzZ07d9T9x48fn2rf69evq/Stbm5u6vEkLfHw4cNVStnMXqOkHJbUtpaWlipt7rNcvnxZpdCVstja2mrq16+v+fXXX1Pto339kl557NixKmWupGiWNMJSPl1p60VrwYIFKo2w3E9SFEs63Q8//FC9bl1bt25VaXVlPycnJ1UeeV6tR48eaXr27KnKK2XSPldGqYu1Fi5cqG6T502bFlnr6NGjms6dO6s0vVLP8rhdu3bV7Nq1S/M8kub4k08+UamOraysNB4eHqpOpW51U0JL+mpPT0+1j6QNlraimy5ZSDnl/U0rbZvU2rFjh7qPpEC+efNmhuWTckgbknLJc0sK6ldffVWzcePGLH9WZs6cqcogdSPviaQhlvezTZs2qfZLTEzUTJ06VaXQln0LFy6s9ps4caImKioqR6/zeZ8Bbf1K26xQoYJKiSyfaWlH3377rSoTEZkOM/lH3wETEREZJvl1XX61lzkOZLxkUrvMKZGenYyGfRER6QvnrBARUaZkiA6H3BgXmUOU9ndKGfomKbhlTgwRkSHhnJV8IONrZZLk0aNHM02lSURkSGSdC0kuIAvwyRwCMh6S8vndd99V69bI/CtZuHTx4sVq/RPZRkRkSEyqZ+XmzZvo37+/ytUvkwwlhePIkSPVar665JclmWQ4ZcqUdI/Rrl07dZtMUMwpWaFYHuN56VTl1y+ZXCgTKWXBLsmikpXAaMCAASo4krSiMmFy/PjxSExMTHciIhNHZWVpyZUvk4OJiLR++uknNVle1qiRbGRkPCQznBz3Z86cqSbaS2IASSwgKZPlu5GIyJCYTM/KlStX1CJxspiUZMuRk/nTp0+rXwz/+OMP9UuTZMbRkgO5ZEfRXdtAssnIwbx48eL5UmbJuiIBh2T1kUw+WSFZWmTssaS2lKw+ks9eMsboZpaRFYQlg4+kyZw3b57KsCJBnGRhkewsRETyg8yL/ChDhh2sSLYtIqKCwGR6ViTtp/xipE2ZWKpUKZXaUtJRShAiKSh1ScpEybUvKwhrSapNOcmX1Jm6pJdEhkvokhN/CXYy6vnQLsQlaTzlvtJ7khFZO0DWVpBgw8PDI0uvU1bMlhW8pZyS0rJDhw5qnQb5lVQ3n770tCxZskSl9pRfTiUgymyVYiIiIiIifTCJYEUmDUo+eMmRn3bFZQkC3nzzTZXnX3fCoQQ2sl1O/LUk+JAeiBchPTbaXhJZgVkmr8pQi7wkazTo9hpJZh9ZF0K3u79169aqPGkXBSMiIiIi0heTGAYmi5VJICKLT8kQqTt37qjF1bSLX8mQMDlJl6FikrpRhl9Jz4MEK9L7Iis1y+JnMsdETvLlMWRxOBlOpSWLnOle167wK9u0K0TLasoyHMvGxkZdl/ki9vb26u+0901LFpuTVXuft19aly9fVit4y2vQ3lcWDpP5OrqPpV0BWtKTVq5cOVvPQURERESUGTkPl/NhmTeedoHi5zGJdVYOHjyIhg0bqqFQskKy9G4QEREREVH+JrsqWbJktu5jEj0rMtFcelHOnj2LZs2apVSWk5OT+lvma/z222+qF0Kb8UsycEk2MFkca/Xq1WqI1F9//YUqVargpZdeUvtoM+TI/JSVK1eiffv2Kc8pk/BlQrv0zly/fh01a9bEP//8k/K/zIkJCQlR2bqyEmEGBASo4VxSlqyQ4WVSRgnOZN6L7nMMGTJERbe6jyXpSaX8MqdG5tIUJNLTdffuXdUrlt1onVifeYltk/VpyNg+WZeGim3T+OoyOjpadRbIyKbsMolgRfLIt2zZEnPmzFFpfYUEKnIJCwvDhg0b1AR8bfBiYWGh5nPIdZmj8umnn6JWrVqoX7++ul3ebBnKpd1fGoAEEtrrMuxMhoXJ/BjZpn1jChUqpK5rgwHt7VlpPFZWVip9sfY5nkUSBkjgIYHKjz/+qF6PLhnKJgkF5PnlcUVgYKAa/iXDwwriB1HSPGe1Lon1mV/YNlmfhoztk3VpqNg2jbcuzf5/CkZ26L/U+WTWrFlqnknnzp1T5m1s27ZNBTGSznjcuHEZ3k8CC+mlkJTFmZHeGnl8WfRRekuGDh2aEgRkRAICebMkE5lEuzKXJTNnzpxR82UkSYAERPK3XLSCg4NVb48EKEL+l3ViJNuZ9OzI40tAJhetnj17qmBMAjdJ3yzJBWSS/+jRo59Ti0RERERE+cdkgpWKFSvi0KFDKr+8kJV6ZfK8BCqSnlh6PTIjw7y0E9AzMm3aNNW1JYssSiAgqYK1E+czUqJECbV+wZdffqmGi40YMSLTfdu2bYs6dergl19+UYtJyt9y0ZIeHBmiJhPwxY4dO9QkeQmuZEygPL72ouXs7KxSOF+9ehU+Pj547733VLDGNVaIiIiIyJCYxAT7tGPm5GRdeikkyJC1ReQEXybg53e3XEREhFqzxRC65Qoy1iXr01CxbbI+DRnbJ+vSULFtGl9dRuucf2dlSoPJzVnJzMSJE1VPi6xeL/NRGDQQERER5S9ZMkI7QkR7gi3XZa4Fz81eTH7VpcyPlrnVOZmT8jwmHayIfv366bsIRERERCZJ5u3KPGLdgT7yt5xkS+bSvDj5NSWafKxLmQIh0w50Fx3PDSYfrBARERGRfnpUJFCRk1zJrKo9mZYTbFkIO69+qTclmnyoS3kOWUxdkjrJfGiZJ56bvTgMVvQgKVmDg1fu4dKt+6jwyAINyrnCwpwfRiIiIjIdMjxJTnQlUJHlFLQYrOQeTT4FftrlMGRtQQlcbG1tc+2xGazks22nQjHxlzMIjYr//y1XUdzZFuPbe6NN9f8ydhERERGZAvaeGAfzPJoTwzRU+RyoBPx4RCdQ+VdYVLzaLrcTEREREdG/GKzk49Av6VHJKE+0dpvcLvsRERERERGDlXwTfPV+uh4VXRKiyO2yHxEREREZl2vXrqkhb8eOHdN3UQoU9qzkk4iY+Fzdj4iIiIjylwQbz7pMmDCBb0ku4wT7fOLuaJur+xERERFR/goN/W9+8bp16zBu3DicP38+ZVuhQoXy9PkTExNzfR0TQ8eelXxSv2wRlfXrWUnj5HbZj4iIiMhUxT2Jw+Onj9X/aS8JSQnp9s3sEv809WiVzPbLDg8Pj5SLs7Oz6k3RXnd3d8f06dNRsmRJ2NjYoHbt2ti2bdszH+/UqVN45ZVXVJBTrFgx9OrVC5GRkSm3N23aFCNGjMCoUaPg6uqK1q1bq+3yPDVq1ICDgwO8vLwwbNgwtcCm1rJly+Di4oLt27er/RwdHdGmTZtUwZZYsmQJqlWrpsorCzrKc2k9fPgQAwcOVKmlnZyc0KxZMxw/fhz5jT0r+UTWUZH0xJL1SwKWjKbRl3Cxw9PkZFiYW+RXsYiIiIgMSsM1DTO9rXGJxpjTYk7K9abrm6rAJiO+xXyxtM3SlOttNrXBg4QH6fY72eckcsP333+PadOmYf78+ahTp44KBDp06IDTp0+rhRLTkmBAAgAJCL777js8fvwYY8aMQdeuXfHXX3+l7Ld8+XIEBARg//79qdIEz5w5E2XLlsWVK1dUsPLhhx9izpz/6iYuLk6VRwIXWQNFAqH3338fq1atUrfPnTsXo0ePxpQpU1TAFBUVleo5unTpotZP+eOPP1RgJq+refPmuHDhAooUyb8f1xms5CNZR2XuW3XTrLMCuNhZITr+CUKuP0CfJcGY38sXznZW+Vk0IiIiInoB3377rQo2unfvrq5PnToVu3fvxowZMzB79ux0+8+aNUsFNV999VXKNglwpKdEAoJKlSqpbRLofP3116nuKz0tWmXKlMEXX3yBoUOHpgpWZNFNCUhKly6tFoWUXpPPP/885Xa5z3vvvYeRI0embKtXr576f9++fQgODkZERITqddG+vi1btmDjxo0YPHhwvrUVBit6CFhaenvg4JVIXLp1FxVKuqkV7IMu38PQHw/jwJX76DovCEv71YOny3+ruRIRERGZggM9DiApKQkWFhbpFoxMO/pkT9c9mT6OuVnq2Q7bXn/2kKwXER0djTt37qBRo0aptsv1zIZOyXYJZjKa53L58uWUYMXHxyfd7Tt37sTkyZNx7tw59dyySn18fLzqTbG3t1f7yP/ly5dXtwkZ5iXBh5D/pbzSU5JZ2WRYWdGiRVNtl94fKVt+YrCipyFhDcsVRblCSXB3LwpzczO8VNEV64Y0RL+lh3A+PAad5wRiWf96qOLhpI8iEhEREemFvZU9npo9Vb0Bz1vdXvbNzuMaEgkG2rdvr3pg0pLAQsvBwSFdCuRXX31VDQ378ssv1ZAs6QkZMGCAmoCvDVZk6JcuqUuN5t+JCDK863llkzLs2ZM+GJS5MPmJE+wNSDVPZ2we3ggV3AshLDoeXeYGIfDyf5OsiIiIiMjwyAR0T0/PVHM+hFz39vbO8D5169ZV81lkGFeFChVSXdIGKLoOHz6M5ORkNR+lYcOGqgdGekmyQybcy/Pu2rUr07KFhYWpgDFt2WSif35isGJgZJL9xqF+qF+mCGISnqo5LFuPZ68BEhEREVH++uCDD1QviaQ0lnTGH330kVoAUndOiK7hw4fj/v376NGjBw4dOqSGV0n2rn79+qlhcJmpUKGCmo/yww8/qMn1K1euxLx587JdXlkTRgIemah/8eJFHDlyRD2maNGiBfz8/NCxY0f8+eefqjcnMDAQn3zyCUJCQpCfGKwYIBd7a6wYUB9ta3jgSZIG76w5igV/X07puiMiIiIiw/LOO++o7FoyaV3SBUva4q1bt2aYCUxoe2IkMGnVqpW6j0ycl2FWku0rM7Vq1VKpiyUwql69usruJfNXsqtPnz5q8r9Mypf0xTK0TIIW7ZCx33//Hf/73/9U8CS9N5I44Pr16yrFcn4y0+jxDPjvv//GN998o7qzJO/z5s2bVQT3LDJ2ThqCdJtJtoRPP/0Uffv2zfJzyiQkSb8m6dmky05fpPtOJjdJTu7MGmRysgaTfjuDpfuvqet9/cvgs1e91ZwXyl5dUu62TWJd6gPbJuvTULFt5oxMCL969apKv2tr+9+i2HJqKpPCszJnhZ4tP+sys/fzRc+/9XomEhsbq6LDjNK5ZUQqoF27dnj55ZdVt5pEn5KbWrrMjJFMvB/fvho+bVdVXV8WeA0jVh9B/JPMuwaJiIiIiIyFXrOByQI0cskqGY8n0ZqMrxNVq1ZV2Q9kIR3tip7GaGDjcnB3ssX764/jj1NhiHx0EAt7+6rhYkRERERExqpApS4OCgpSE350SZCiuzBOWgkJCeqi2w2l7bKVi77Ic0vXXFbL8GoND7g6WGHIj0dw6NoDvDE3EEv71kOJwlyLJbt1SbnbNol1mV/YNlmfhopt88XqTXvRpb3O+bovLr/qUvs+ZnSO/SLnFAUqWJEUamkn9ch1CUBkkZqMckbLhKOJEyem23737l01tk5f5E2TcXvypmZ1XkC5QsC8Nyrh3S0XceluLDrO3ofvOlZEJXfDyhteEOqSWJ/5gW2T9WnI2D5Zl/omGa2kHcqcCu3ChUK+z7XZsDhn5cXkZ13Keyjv571799Kt8RITE2MawUpOjB07Vk3I15LARibmu7m56X2CvTQaKUd2TrDd3YHNJdzRf/lhnA+LQcDGC5jzZl00rpi/Oa8NSU7rklifeY1tk/VpyNg+WZf6Jj8ay0msrFQvE8DTSnvCSzmXH3Up76Och8mq92kn2Ke9brTBioeHB8LDw1Ntk+sSdGS2EqeNjY26pCWVqe8TWznBzkk5ShR2wIahfhiy4jCCrtzDgOUh+PqNmuhctyRMVU7rklifeY1tk/VpyNg+WZf6PoGWNig9LNpV17W9AdpeAPasvJj8rEsZ5STPIefdac/HXuT8rEAFK7I4jeR81rVjxw613dQ42VphWf96eH/DCfxy/A5Grz+O0Kh4DGtanh9sIiIiMnjSmyJBigzNl8BFe0LL1MW5R5MPqYvlOeLi4tSyB7JGjPSw5Ca9BiuPHj3CpUuXUqUmlpTERYoUQalSpdQQrtu3b2PFihXq9qFDh2LWrFn48MMP0b9/f/z1119Yv349fvvtN5giG0sLfN+tNjydbTH/7yv4Zvt5hEY9xsQO1bkWCxERERk0OXkuXry4Ov+TxQa1tJO0JXhhz8qLyc+6lEBFRkHlNr0GKyEhIWrNFC3t3BJZUXPZsmVqocgbN26k3C5piyUweffdd/H999+jZMmSWLRokVGnLc7KWixj21ZFcWdbTPz1DH48cANhUQn4oUcd2FnnbmRLRERElJusra3VCu+JiYkp27STtGXuA4d3v5j8qkvpGcvtHhWDCFaaNm36zDRqErBkdJ+jR4/mcckKnr6NyqKYky1GrjuGnWfD0XPRASzuUw9FHLgWCxERERkuOYnWnYAtJ9hy8ivbGKy8GGOoy4JZasrQKzWKY9XABnC2s8LRGw/x+txA3LgXx9oiIiIiogKJwYqRqVemCDYF+KGEix2uRsai89z9OHHrob6LRURERESUbQxWjFAFd0dsHuYP7+JOiHyUiO4LDmD3+Qh9F4uIiIiIKFsYrBgpdydbrBvSUC0WGZeYhIHLQ7D+0E19F4uIiIiIKMsYrBgxR1srNcm+c90SSErW4MNNJzBj54VnJjUgIiIiIjIUDFaMnLWlOaZ1qYXhL5dX12fsvIixP53E06RkfReNiIiIiOiZGKyYAFkE6IPWVfBFx+owNwPWHrqJQStCEJvwVN9FIyIiIiLKFIMVE/JWw9KY38sXtlbm2H3+LnosPIDIRwn6LhYRERERUYYYrJiYlt7FsHpQQxS2t8KJW1HoPCdQpTgmIiIiIjI0DFZMUN1ShbEpwB9eRexw436cWjzy6I0H+i4WEREREVEqDFZMVDm3QvgpoBFqlnTG/dhENSRsx5lwfReLiIiIiCgFgxUT5uZogzWDGqJpZTfEP0nGkJUhWHXwur6LRURERESkMFgxcQ42lljY2xddfUsiWQN8svkUvt1+nmuxEBEREZHeMVghWFmYY+rrNTGqRUVVG7N2X8L7G07gCddiISIiIiI9YrBCKWuxjGpRCVNfrwELczNsOnIL/ZcdwiOuxUJEREREesJghVLpVq8UFvX2hZ2VBf65GIlu84MQER3PWiIiIiKifMdghdJ5uYo71g5uiKIO1jh9Jxqd5gTiUsQj1hQRERER5SsGK5ShWl4u+GmYP8q6OuD2w8d4Y14gQq7dZ20RERERUb5hsEKZKl3UARuH+qG2lwsexj1Bz0UHse1UKGuMiIiIiPIFgxV6pqKF/l2LpUXVYkh8moyAVUewPPAaa42IiIiI8hyDFXouO2sLzHurLno2KAWNBhi/9TQm/3EWybIwCxERERFRHmGwQlliaWGOLztWxwetK6vr8/dewbvrjyHhaRJrkIiIiIjyBIMVytZaLMNfroBpXWrB0twMPx+7g75LDiE6/glrkYiIiIhyHYMVyrbXfUpiSd96cLC2QNCVe+g6LwhhUVyLhYiIiIhyF4MVypH/VXLDuiF+cHO0wbmwGHSasx8XwmNYm0RERESUaxisUI5VL+GMnwL8Ud7NAaFR8Xh9biAOXLnHGiUiIiKiXMFghV6IVxF7bArwh2/pwoiJf4rei4Pxy/E7rFUiIiIiemEMVuiFudhb48eBDdCmmgcSk5Lx9pqjWPTPFdYsEREREb0QBiuUK2ytLDD7zbro619GXf/it7P4/JczXIuFiIiIiHKMwQrlGgtzM4xv742xr1RR15fsv6p6WeKfcC0WIiIiIso+BiuU62uxDGlSHt93rw0rCzP8djIUvZcEIyqOa7EQERERUfYwWKE88VrtEljerz4cbSwRfPU+3pgXiNsPH7O2iYiIiCjLGKxQnvGv4Ir1Q/3g4WSLixGP0HnOfpy5E80aJyIiIqIsYbBCeapqcSf8NMwflYoVQnh0ArrOD8L+S5GsdSIiIiJ6LgYrlOc8XeywYag/GpQtgkcJT9F3aTC2HL3NmiciIiKiZ2KwQvnC2c4KKwbUR7uaxfEkSYNR645h7p7L0Gg0fAeIiIiIKEMMVijf2Fha4IfudTDwpbLq+tRt5zB+62kkJTNgISIiIqL0GKxQvjI3N8Onr3rjs1e9YWYGrAi6jmGrDnMtFiIiIiJKh8EK6cWAl8piVo+6sLY0x/bT4ei58AAexCby3SAiIiKiFAxWSG9k/srK/vXhZGuJIzce4vV5gbh5P47vCBEREREpDFZIrxqUK4qNAf7wdLbFlbux6DQnEKduR/FdISIiIiIGK6R/lYo5YvPwRqji4YjIRwnoNj8Iey/c1XexiIiIiEjP2LNCBqGYky02DPVDowpFEZuYhP7LDmFDyE19F4uIiIiI9IjBChkMR1srLO1bHx1re6p0xh9sPIEfdl3kWixEREREJorBChkUyQ42vWttBDQtr65P23EBH28+hadJyfouGhERERHlMwYrZJBrsYxpUwWfv1ZNrcWyJvgGhqw8jLjEp/ouGhERERGZUrAye/ZslClTBra2tmjQoAGCg4Ofuf+MGTNQuXJl2NnZwcvLC++++y7i4+PzrbyUf3r7lcG8t3xgY2mOXeci0GPhQTUBn4iIiIhMg16DlXXr1mH06NEYP348jhw5glq1aqF169aIiIjIcP/Vq1fjo48+UvufPXsWixcvVo/x8ccf53vZKX+0ruaB1YMawMXeCsdvPsTrcwNxLTKW1U9ERERkAvQarEyfPh2DBg1Cv3794O3tjXnz5sHe3h5LlizJcP/AwEA0atQIPXv2VL0xrVq1Qo8ePZ7bG0MFm0/pItgU4I+She1w/V6cCliO3Xyo72IRERERUR6zhJ4kJibi8OHDGDt2bMo2c3NztGjRAkFBQRnex9/fHz/++KMKTurXr48rV67g999/R69evTJ9noSEBHXRio6OVv8nJyeri77Ic2s0Gr2WoSApW9Qem4b6YcDyEJy6E40eCw5gZo/aaF7FnXWZy9g2WZeGim2T9Wmo2DZZn4Yq2UDON1/k+S2z+0R79+7FP//8g+vXryMuLg5ubm6oU6eOCjJkDklWRUZGIikpCcWKFUu1Xa6fO3cuw/tIj4rc76WXXlIV//TpUwwdOvSZw8AmT56MiRMnptt+9+5dvc51kbqMiopSr0OCNMqa7zuWwye/XcGB69Fq0v2HzUqhQ7WirEu2TYPEzznr05CxfbIuDRXbpvHVZUxMTN4GK48fP8a0adMwd+5c3L9/H7Vr14anp6ea5H7p0iVs2bJFDeeSYVnjxo1Dw4YNkRf27NmDr776CnPmzFGT8eW5R44ciUmTJuGzzz7L8D7ScyPzYnR7ViSokiDLyckJ+mw8ZmZmqhwMVrJn+cBiKp3xpiO3MWXXDTxKskTPms5wd3dnXbJtGhR+zlmfhoztk3VpqNg2ja8ubW1t8zZYqVSpEvz8/LBw4UK0bNkSVlZW6faRnhaZAN+9e3d88sknKnh5FldXV1hYWCA8PDzVdrnu4eGR4X0kIJEhXwMHDlTXa9SogdjYWAwePFg9Z0Zvgo2NjbqkJfvqO0iQxmMI5ShobMzN8W2XWijhYoeZf13CrD1XcC2iKKb1cIcl6zJXsG3mHtZl7mJ9sj4NFdsm69NQmRnA+eaLPHeW7vnnn39i/fr1aNu2bYaBiihdurTqxbh48SKaNWv23Me0traGj48Pdu3alSr6k+sSGGVEhp2lfbES8Ajp3iLT+uCNblUZX3WqAXMz4Ncz9zB45WHEJnAtFiIiIiJjkaVgpWrVqil/37hxI8PAQLbJbRLMlC//7+rjzyPDs6S3Zvny5SoVcUBAgOopkexgonfv3qkm4Ldv314NRVu7di2uXr2KHTt2qN4W2a4NWsi09GxQCvN7+cDW0hx7L0Si24IgRMRw3R0iIiIik8wGVrZsWYSGhqr5AbpkLovcJpPms6pbt25qorvMcwkLC1NzYbZt25Yy6V6CH92elE8//VT9oi7/3759W42/k0Dlyy+/zO7LICMiGcFmv1EJH2y9jFO3o9F5TiCW96+P8m6F9F00IiIiInoBZppsjp+S4EHmlUigkHbOiqyVIj0jhkwm2Ds7O6vMCPqeYC+LX3JSeO7VZZyFA/otC1FrsRS2t8KiPvXgU7pwLjyDaWHbZF0aKrZN1qehYttkfRqqZAM533yR8+8s96xoM2pJz4YMvZLFG7WkN+XgwYOqZ4RIX8oUdVCLRw5YdgjHb0Wh50JZi6UOWlfLOGEDERERERm2LAcrR48eVf9LR8zJkyfVBHkt+btWrVp4//3386aURFnkWsgGawY3xNurj2LXuQgE/HgYEztUQy+/MqxDIiIiImMMVmbOnKlWipd1VWTy+/fff6/XIVREz2Jvbakm3X/28ymsCb6Jz34+jTtR8fiwdWXVM0hEREREBYN5VoeAaVeeXLFihV5XfifKCksLc5XWeHTLSur63D2XMXr9cSQ+TWYFEhERERlTz4qsVr9p0ya1zooMA7t161amAUupUqVyu4xEOSK9KO80rwgPZ1uM/ekkNh+9jbsxCZj7Vl042ma8XhARERERFbBgRVIFv/322xgxYoQ6AaxXr166fSSIkduyk7qYKD909fVCMSdbNX9l36VIdJkXpFIbyzYiIiIiKuDByuDBg9GjRw+VnrhmzZrYuXMnihYtmvelI8olTSq5Yd1gP/RbdgjnwmLUWizL+tVDxWKOrGMiIiKigp4NzNHREdWrV8fSpUvRqFEj2NjY5G3JiHJZjZLO2DzMH32WBONKZCxenxuo1mKpX7YI65qIiIiooE6w1103sk+fPgxUqMDyKmKPjQH+qFvKBdHxT/HW4oP4/WSovotFRERERDkNVqpVq4a1a9ciMTHxmftdvHgRAQEBmDJlSlYelkgvijhYY/WghmjlXUxlBxu++ggW77vKd4OIiIioIA4D++GHHzBmzBgMGzYMLVu2hK+vr8oQZmtriwcPHuDMmTPYt28fTp8+rSbhS8BCZMhsrSww9y0fTNh6GisPXMekX88gLOoxxr5SFebmXIuFiIiIqMAEK82bN0dISIgKSNatW4dVq1apyfaPHz+Gq6sr6tSpg969e+PNN99E4cKF877URLnAwtwMn79WDZ4udpi67RwW/nMVYdEJ+LZLTdhYWrCOiYiIiArKBHvx0ksvqQuRsZB02wFNy8PD2QYfbjyBX47fQUR0PBb09oWzHddiISIiIjL4OStExq5TnZJY1q8+CtlY4uDV++gyLxB3Hj7Wd7GIiIiITBqDFaL/16iCK9YP8YO7ow0uhD9Sa7GcC4tm/RARERHpCYMVIh3enk7YPLwRKrgXQlh0PLrMDULg5UjWEREREZEeMFghSqOEix02DfVH/TJFEJPwVC0i+fOx26wnIiIiIkMOVp4+fYoVK1YgPDw870pEZACc7a2wYkB9tKtRHE+SNBi59hjm772caoFUIiIiIjKgYMXS0hJDhw5FfHx83pWIyIDWYvmhRx30b1RWXZ/8xzlM/OUMkpIZsBAREREZ5DCw+vXr49ixY3lTGiIDIwtEjmvvjU/bVVXXlwVew4jVRxD/JEnfRSMiIiIyetlaZ0XIKvajR4/GzZs34ePjAwcHh1S316xZMzfLR2QQBjYuh2JOtnhv/XH8cSoMd2MOYlEfX7jYW+u7aERERERGK9vBSvfu3dX/77zzTqqF9WQsv/yflMRfnMk4ta/lCddCNhi8MgQh1x/g9bmBam0WryL2+i4aERERkVHKdrBy9erVvCkJUQHgV74oNg71R9+lwbh8NxadVcBSD9U8nfVdNCIiIiKjk+1gpXTp0nlTEqICorKHI34a5o9+Sw/hXFgMus4LwrxePmhc0U3fRSMiIiIyKjlaZ+Xy5ct4++230aJFC3WRIWGyjchUFHe2w/qhfvArVxSxiUkqcNl0+Ja+i0VERERk2sHK9u3b4e3tjeDgYDWZXi4HDx5EtWrVsGPHjrwpJZEBcrK1wrL+9dChlieeJmvw3objmL37EtdiISIiItLXMLCPPvoI7777LqZMmZJu+5gxY9CyZcvcKhuRwbOxtMCMbrVR3NkW8/++gm+2n8edh4/x+WvVYWFupu/iEREREZlWz8rZs2cxYMCAdNv79++PM2fO5Fa5iArUWixj21bFhPbeMDMDVh28gSErD+NxIjPjEREREeVrsOLm5pbhopCyzd3d/YUKQ1SQ9W1UFnN61oW1pTl2ng1Hz0UHcD82Ud/FIiIiIjKdYWCDBg3C4MGDceXKFfj7+6tt+/fvx9SpU9VikUSm7JUaxeHmaIMBy0Nw9MbD/1+LpR5KF029eCoRERER5UGw8tlnn8HR0RHTpk3D2LFj1TZPT09MmDAh1UKRRKbKt0wRbArwQ58lh3A1MlYFLEv61kPNki76LhoRERGR8Q4De/r0KVauXImePXvi1q1biIqKUhf5e+TIkWoFeyICKrg7YvMwf3gXd0Lko0R0X3AAu89HsGqIiIiI8ipYsbS0xNChQxEfH6+uSw+LXIgoPXcnW6wb0hCNK7oiLjEJA5eHYN2hG6wqIiIioryaYF+/fn0cPXo0u3cjMkmOtlZqCFjnuiWQlKzBmE0nMWPnBa7FQkRERJQXc1aGDRuG9957Tw398vHxgYND6onDskgkEf3HysIc07rUgqezHWbtvoQZOy8iLCoeX3SsDkuLbP9eQERERGQysh2sdO/eXf2vO5le5qpoNBr1f1IS15YgSks+G++3rgwPZ1uM+/kU1h66ifDoeMzqWRcONtn+GBIRERGZhGyfJV29ejVvSkJkAt5qWBrFnGzx9poj2H3+LnosPIDFfeqpdMdERERElFq2xqA8efIEzZo1Q1xcHEqXLp3hhYieraV3Mawe1BBFHKxx4laUSm0sKY6JiIiI6AWCFSsrq5RMYESUc3VLFcamAH+UKmKPG/fjVMBy9MYDVikRERGRjmzP7h0+fLharV7WXCGinCvr6qAClpolnXE/NlENCdtxJpxVSkRERJTTOSuHDh3Crl278Oeff6JGjRrpsoH99NNP2X1IIpMlc1XWDGqIEav/ncMyZGUIPn+tuprbQkRERGTqsh2suLi44PXXX8+b0hCZIMkGtrC3Lz7ZfArrQm7i0y2nVGrj91pVUlnEiIiIiExVtoOVpUuX5k1JiEyYrLcy5fUaKO5iq9ZhkfVYQqPi1TZZp4WIiIjIFOXoLEjmq+zcuRPz589HTEyM2nbnzh08evQot8tHZDKkF2VUi0qY+noNWJibYdORW+i/7BAeJXB+GBEREZmmbAcr169fV3NVXnvtNTXZ/u7du2q7TLp///3386KMRCalW71SWNTbF3ZWFvjnYiS6zgtCRDSz8BEREZHpyXawMnLkSPj6+uLBgwews7NL2d6pUyc18Z6IXtzLVdyxbkhDuBayxpnQaHSaE4hLEey5JCIiItOS7WDln3/+waeffgpra+tU28uUKYPbt29nuwCzZ89W97W1tUWDBg0QHBz8zP0fPnyoenSKFy8OGxsbVKpUCb///nu2n5fI0NUs6YKfAhqpFMe3Hz7GG/MCEXLtvr6LRURERGS4wUpycjKSkpLSbb916xYcHR2z9Vjr1q3D6NGjMX78eBw5cgS1atVC69atERERkeH+iYmJaNmyJa5du4aNGzfi/PnzWLhwIUqUKJHdl0FUIJQqao+NQ/1Q28sFD+OeoOeig9h2KlTfxSIiIiIyzGClVatWmDFjRqpJwTKxXgKOtm3bZuuxpk+fjkGDBqFfv37w9vbGvHnzYG9vjyVLlmS4v2y/f/8+tmzZgkaNGqkemSZNmqggh8hYFS3071osLaoWQ+LTZASsOoJl+6/qu1hEREREhpe6eNq0aar3Q4KL+Ph49OzZExcvXoSrqyvWrFmT5ceRXpLDhw9j7NixKdvMzc3RokULBAUFZXifrVu3ws/PTw0D+/nnn+Hm5qaef8yYMbCwsMjwPgkJCeqiFR0dndJDJBd9kefWaDR6LYOxMIW6tLE0w5yetTHhlzNYHXxT/X/n4WN82LoyzM1zdy0WU6jP/MK6ZH0aMrZP1qWhYts0vrpMfoHnz3awUrJkSRw/flwN4ZL/pVdlwIABePPNN1NNuH+eyMhINZysWLFiqbbL9XPnzmV4nytXruCvv/5SzyXzVC5duoRhw4bhyZMnqmcnI5MnT8bEiRPTbZcsZhJs6fNNi4qKUg1IgjRiXWbF235ucLJMwrzAO1jwz1Vci4jCpy1Lw9oy99oQ22buYV3mLtYn69NQsW2yPg1VsoGcb2qXOsmXYEXdydJSBQxyye8Kd3d3x4IFC1RPio+Pj5rU/80332QarEjPjcyL0e1Z8fLyUr0yTk5O0Bd5LTKETsrBYIV1mR0fvloMFTxd8dFPJ/Hn+fuIeQLMfasunGyt2DYNDD/nrE9DxvbJujRUbJvGV5e2trb5G6zkBhk2JgFHeHh4qu1y3cPDI8P7SAYwKyurVEO+qlatirCwMDWsLG2GMiEZw+SSlrxh+g4SpPEYQjmMganV5Ru+XnB3skXAj4cRdOU+ui84iKX96qG4c9Z7N5/F1OozL7EuWZ+GjO2TdWmo2DaNqy7NX+C59VZqCSykZ0R3bRaJ/uS6zEvJiEyql6FfuuPeLly4oIKYjAIVImP2v0puWD/UD26ONjgXFoPOcwJxITzn3axEREREhkavP5vK8CxJPbx8+XKcPXsWAQEBiI2NVdnBRO/evVNNwJfbJRuYLEwpQcpvv/2Gr776Sk24JzJF1Tyd8VOAP8q7OSA0Kh6vzw3EgSv39F0sIiIiolyht2Fgolu3bmqi+7hx49RQrtq1a2Pbtm0pk+5v3LiRqttI5pps374d7777LmrWrKnWV5HARbKBEZkqryL22BTgj4HLQxBy/QF6Lw7GtK610L6Wp76LRkRERJQ/wYqsLC/Dtp6VIljSCXft2jVbBRgxYoS6ZGTPnj3ptskQsQMHDmTrOYiMnYu9NX4c2ACj1h7DttNheHvNUYRHx2Ng43L6LhoRERFR3g8DkyDh3r3/hpdIJi1JJaz18OFD9OjRI+clIaIXYmtlgdlv1kVf/zLq+he/ncXnv5xBcrKGNUtERETGHaxIfuZnXc9sGxHlHwtzM4xv742P21ZR15fsv6p6WeKfJPFtICIiItOeYC+p0YhIv+RzOPh/5fF999qwsjDDbydD0XtJMKLinvCtISIiogKFiygQGanXapfA8v714WhjieCr9/H6vEDcfvhY38UiIiIiyptsYGfOnFFZu7RDvs6dO4dHjx6p65GRkdl5KCLKB/7lXbEhwA99lxzCpYhH6DxnP5b2rQ9vTyfWPxERERlXsNK8efNU81JeffXVlGEnsp3DwIgMTxUPJ/w0zB99lwbjQvgjdJ0fhPm9fNCogqu+i0ZERESUO8HK1atXs7orERkYTxc7bBjqj8ErQnDw6n0VuHzzRi10rFNC30UjIiIievFgpXTp0lndlYgMkLOdFVYMqI/31h/HrydCMWrdMdyJeoyAJuXZK0pEREQFe4K9zEm5fv16qm2nT59Gv3791EKQq1evzovyEVEusrG0wMzudTCocVl1/ett5zF+62kkcS0WIiIiKsjByttvv42ZM2emXI+IiEDjxo1x6NAhtXp93759sXLlyrwqJxHlEnNzM3zSzhvjXvWGZBtfEXQdw1Yd5losREREVHCDlQMHDqBDhw4p11esWIEiRYrg2LFj+Pnnn/HVV19h9uzZeVVOIspl/V8qi1k96sLa0hzbT4ej58IDeBCbyHomIiKighesSMriMmXKpFz/66+/0LlzZ1ha/jvtRQKZixcv5k0piShPtKtZHD8OaAAnW0scufEQr88NxM37caxtIiIiKljBipOTEx4+fJhyPTg4GA0aNEi5LmmLZTgYERUs9csWwaYAf5RwscOVyFi8Pi8I5yIYsBAREVEBClYaNmyo5qwkJydj48aNiImJQbNmzVJuv3DhAry8vPKqnESUhyoWc1RrsVTxcETko0QM23Aef1+4yzonIiKighGsTJo0CVu3boWdnR26deuGDz/8EIULF065fe3atWjSpElelZOI8lgxJ1tsGOoH//JFEfckGQNWHMaGkJusdyIiIjL8dVZq1qyJs2fPYv/+/fDw8Eg1BEx0794d3t7eeVFGIsonjrZWWNLHF6NWH8K2c/fxwcYTCI2Kx9vNKnAtFiIiIjLsFezLli2L1157LcPb27Vrl5vlIiI9kexg41uXQZliLpi39wqm77iA0KjHmPRadVhaZLkzloiIiOiFZfnMo3z58ipY6d+/v1pP5datWy/+7ERkkCRhxoetK2PSa9XUWixrgm9iyMrDiEt8qu+iERERkQnJcrAiqYr79OmDK1euYPDgwShdujQqVqyIIUOGqPkq4eHheVtSIsp3vfzKYN5bPrCxNMeucxHosfAgIh8x6x8REREZWLDStGlTTJgwAXv27MGDBw+wY8cO9OjRQ81jkdXrPT09Ua1atbwtLRHlu9bVPLB6UAO42Fvh+M1/12K5FhnLd4KIiIjyXI4GoNva2qq0xZ9++ikmTpyId955B4UKFcK5c+dyv4REpHc+pf9di8WriB2u34tTAcuxm/+tu0RERESk92AlMTERf//9twpQXn75Zbi4uGDo0KGqp2XWrFlqEj4RGafyboVUwFK9hBPuxSaix4ID2HWWwz+JiIjIALKBSU/KwYMH1SR7WU9F5qqsXr0axYsXz8PiEZEhcXe0xdrBfhi26ohaNHLQihB82akGetQvpe+iERERkSn3rPzzzz8oWrSoClqaN2+Oli1bMlAhMkGFbCyxuI8vuviURLIGGPvTSUz/8zw0Go2+i0ZERESmGqw8fPgQCxYsgL29PaZOnaom1NeoUQMjRozAxo0bcffu3bwtKREZDCsLc3z9Rk2807yiuj7zr0v4cOMJPElK1nfRiIiIyBSDFQcHB7Rp0wZTpkxRw8EiIyPx9ddfq+BF/i9ZsiSqV6+et6UlIoNai2V0y0qY3LkGzM2ADYdvYeDyEMQmcC0WIiIiyh05Xo5agpciRYqoS+HChWFpaanSGBORaZH5Kgt7+8LOygJ7L9xFtwVBiIiJ13exiIiIyJSCleTkZAQHB6telFdeeUVlAvP398ecOXPg4eGB2bNnqwUjicj0NK9aDGsGN0RRB2ucuh2NznMCcfnuI30Xi4iIiEwlG5gEJ7GxsSowkbTF3333nVoosnz58nlbQiIqEGp7uajUxn2XBuPa/6/FsrhPPfiULqzvohEREZGxByvffPONClIqVaqUtyUiogKrjKuDClj6Lw9Rq933XHgAM3vUQetqHvouGhERERnzMDBZV4WBChE9T9FCNlgzqAGaV3FHwtNkBPx4GCuDrrHiiIiIKP8m2BMRZcbe2hLze/moyfeyFstnP5/GlD/OIVmuEBEREWURgxUiyhOWFub4qlN1vNfy36Gj8/ZexnsbjiPxKddiISIioqxhsEJEeboWy9vNK+KbN2rCwtwMm4/eRv9lhxAT/4S1TkRERM/FYIWI8lwXXy8s6VsP9tYW2HcpEl3mBSE8mmuxEBERUR4EKytXrkSjRo3g6emJ69evq20zZszAzz//nJOHIyIT0KSSG9YP8YNrIRucC4tBp9n7cTE8Rt/FIiIiImMKVubOnYvRo0ejbdu2ePjwIZKSklLWYZGAhYgoM9VLOGPzMH+Uc3PAnah4tRZL8NX7rDAiIiLKnWDlhx9+wMKFC/HJJ5/AwsIiZbuvry9OnjyZ3YcjIhPjVcQem4b6o24pF0THP8Vbiw/i95Oh+i4WERERGUOwcvXqVdSpUyfddhsbG7XCPRHR8xR2sMbqQQ3RyruYyg42fPURLN53lRVHRERELxaslC1bFseOHUu3fdu2bahatWp2H46ITJStlQXmvuWD3n6lodEAk349gy9+PcO1WIiIiCiFJbJJ5qsMHz4c8fHx0Gg0CA4Oxpo1azB58mQsWrQouw9HRCZM0hlP7FANxZ3tMHXbOSzadxVh0fGY1rUWbCz/G2ZKREREpinbwcrAgQNhZ2eHTz/9FHFxcejZs6fKCvb999+je/fueVNKIjLqtVgCmpZHcWdbfLDxOH49EYq7MQlY0NsXznZW+i4eERERFbTUxW+++SYuXryIR48eISwsDLdu3cKAAQNyv3REZDI61imBZf3qo5CNJQ5evY8u8wJx5+FjfReLiIiIClKw0qxZM5WyWNjb28Pd3V39HR0drW4jIsqpRhVc1VosxZxscCH8ETrPCcS5sGhWKBERkYnKdrCyZ88eJCYmptsuc1j++eef3CoXEZkob08n/DSsESq6F1LzV7rMDULg5Uh9F4uIiIgMec7KiRMnUv4+c+aMGv6lJQtDSjawEiVK5H4JicjklHCxw8ah/hi0IgTB1+6jz5JgfNulFl6rzWMMERGRKclyz0rt2rXV+ioyGVaGe8l17cXHxwdffPEFxo0bl6NCzJ49G2XKlIGtrS0aNGigMoxlxdq1a1V5OnbsmKPnJSLD5WxvhRUD6qNdjeJ4kqTByLXHMH/vZZWFkIiIiEyDZXYWg5SThHLlyqlgws3NLeU2a2trNXdFd0X7rFq3bp1Khzxv3jwVqMyYMQOtW7fG+fPnU+bDZOTatWt4//330bhx42w/JxEVnLVYfuhRB8WcbLFk/1VM/uMcQqPi8dmr3irtMRERERm3LPeslC5dWvV+JCcnw9fXV13XXooXL56jQEVMnz4dgwYNQr9+/eDt7a2CFpm4v2TJkkzvI8POJCPZxIkTVfBERMbL3NwM49p749N2/y46uyzwGoavOoL4J0n6LhoREREZ2jorK1aseObtvXv3zvJjyUT9w4cPY+zYsSnbzM3N0aJFCwQFBWV6v88//1z1uki65OdN6k9ISFAXLclaJiTokou+yHNLT5U+y2AsWJemUZ/9G5WBu6MN3t9wHNtOh+HNRQexsFdduNhbw1AZal0WVKxP1qehYttkfRqqZAP5HnqR5892sDJy5MhU1588eaIWh5ShYNIjkp1gJTIyUvWSFCtWLNV2uX7u3LkM77Nv3z4sXrwYx44dy9JzTJ48WfXApHX37l2VwUyfb1pUVJRqQBKgEevSUBhy26zvYYHvOlbEmF8u4/D1B+g0ez++61gBns42MESGXJcFEeuT9Wmo2DZZn4Yq2UC+h2JiYvIvWHnw4EG6bbJAZEBAAD744APk9Qvt1asXFi5cCFdX1yzdR3ptZE6Mbs+Kl5eXmnPj5OQEfTYeSQ4g5eBJDOvSkBh623zF3R3lS7qj37IQXH8QjyEbL2JJHx9U83SGoTH0uixoWJ+sT0PFtsn6NFTJBvI9JEm08i1YyUjFihUxZcoUvPXWW5n2iGREAg6Z6xIeHp5qu1z38PBIt//ly5fVxPr27dun61aytLRUk/LLly+f6j42Njbqkpa8Yfo+eZDGYwjlMAasS9OqzyrFnbF5WCP0XRqMc2Ex6L7gIOb18kHjiv8l/jAUhl6XBQ3rk/VpqNg2WZ+GyswAvode5LlzrdQSLNy5cydb95GhY5L2eNeuXamCD7nu5+eXbv8qVarg5MmTagiY9tKhQwe8/PLL6m/pMSEi0+DhbIv1Q/3gV64oYhOT0G/pIWw6fEvfxSIiIqJclO2ela1bt6a6LmPgQkNDMWvWLDRq1CjbBZAhWn369FEZxurXr69SF8fGxqrsYELmwMhikzL3RLqQqlevnur+Li4u6v+024nI+DnZWmFZ/3r4YMMJbD1+B+9tOK5WvR/WtLz6JYmIiIhMLFhJuwCjdhycLBQ5bdq0bBegW7duarK7LCgZFhamFpnctm1byqT7GzducPgEEWXKxtICM7rVRnEXW8zfewXfbD+POw8fY2KHarC04NArIiIikwpW8iL12YgRI9QlI3v27HnmfZctW5br5SGigrcWy9hXqsLT2Q4TfjmNVQdvIDw6QS0oaWedszWgiIiISP/4syMRGY0+/mUw9826sLY0x86z4ei56ADuxybqu1hERESUlz0ruql/s7IiPRGRvrSpXhyrB9pgwPIQHL3xEK/PDcSyfvVQuqgD3xQiIiJjDFaOHj2apQfjhFYiMgS+ZYpgU4A/+iwJxtXIWBWwLO5TD7W8/k3IQUREREYUrOzevTvvS0JElIsquBfC5mH+6LfsEE7fiUb3BQcw5826eLmKO+uZiIjIFOas3Lp1S12IiAyRu5Mt1g3xQ+OKrnj8JAkDV4Rg3aEb+i4WERER5VWwItnAPv/8czg7O6N06dLqImudTJo0KU8yhRERvYhCNpZY0rceOtctgaRkDcZsOonvdlxQa0QRERGRkaUu/uSTT7B48WJMmTIlZRHIffv2YcKECYiPj8eXX36ZF+UkIsoxKwtzTOtSS6U2nrX7Er7fdRFhUfH4olN1dRsREREZSbCyfPlyLFq0CB06dEjZVrNmTbXK/LBhwxisEJFBkgQg77eurBaP/GzLKawLuYnwmHjM7lkXDjbZPhQSERFRPsj2T4r3799HlSpV0m2XbXIbEZEhe7NBaczv5QtbK3PsOX8XPRYewN2YBH0Xi4iIiHIjWKlVqxZmzZqVbrtsk9uIiAxdS+9iWD2oIYo4WOPErSiV2vjK3Uf6LhYRERGlke2xD19//TXatWuHnTt3ws/PT20LCgrCzZs38fvvv2f34YiI9KJuqcIpa7HcuB/371osfeup7URERFRAe1aaNGmCCxcuoFOnTnj48KG6dO7cGefPn0fjxo3zppRERHmgrKuDClhqlnTGg7gn6LnwAHacCWddExERGYgczSr19PTkRHoiMgpujjZYM6ghRqw+gt3n72LIyhB8/lp1vNWwtL6LRkREZPKy3bOybds2lapYa/bs2ahduzZ69uyJBw8emHyFElHBI9nAFvb2RTdfLyRrgE+3nMI3289xLRYiIqKCFqx88MEHiI6OVn+fPHkSo0ePRtu2bXH16lX1NxFRQWRpYY4pr9fAqBYV1fXZuy/jvQ3HkfiUi90SEREVmGFgEpR4e3urvzdt2oT27dvjq6++wpEjR1TQQkRUkNdiGdWiklo8cuzmk/jpyG2V1njuWz4oxLVYiIiIDL9nxdraGnFxcepvyQjWqlUr9XeRIkVSelyIiAqyrvW8sKiPL+ysLPDPxUh0nReEiOh4fReLiIjI5GQ7WHnppZfUcK9JkyYhODhYpTEWkiGsZMmSeVFGIqJ893Jld6wb0hCuhaxxJjQaneYE4lJEDN8JIiIiQw5WZPFHS0tLbNy4EXPnzkWJEiXU9j/++ANt2rTJizISEelFzZIu+CmgkUpxfPvhY7w+NwiHrt3nu0FERGSoc1ZKlSqFX3/9Nd327777LrfKRERkMEoVtVdrsQxYfghHbzzEm4sOYmb32mhTvbi+i0ZERGT0crTOSlJSEjZv3oyzZ8+q61WrVkXHjh1VjwsRkbEp4mCN1QMb4u01R7HzbDgCVh3B+Fe90bdRWX0XjYiIyKhlexjY6dOnUbFiRfTp00cFLHLp27ev2nbq1Km8KSURkZ7ZWVtg3lt18WaDUtBogAm/nMHk388iWRZmISIiIsMIVgYOHIjq1avj1q1bKl2xXG7evImaNWti8ODBeVNKIiIDWYvli47V8UHryur6/L+vYNS6Y0h4mqTvohERERmlbI/bOnbsGEJCQlC4cOGUbfL3l19+iXr16uV2+YiIDG4tluEvV0BxZ1t8uPEEth6/o9Zimd/bB062VvouHhERkWn3rFSqVAnh4eHptkdERKBChQq5VS4iIoPWuW5JLO1XDw7WFgi6ck+txRIa9VjfxSIiIjK9YEUWe9ReJk+ejHfeeUelLpahYHKRv0eNGoWpU6fmfYmJiAxE44puWD/UD26ONjgXFoPOcwJxPoxrsRAREeXrMDAXFxc19EFLo9Gga9euKdvkumjfvr3KFEZEZCqqeTpj8zB/9FkSjMt3Y/HGvEAs6OULv/JF9V00IiIi0whWdu/enfclISIqoEoW/nctlkErQnDo2gMVuEzrWgvtanjou2hERETGH6w0adIkSw/G1MVEZKpc7K2xckADvLvuGP44FabWZAmNqoIOlRz0XTQiIiLTmWCfVkxMDBYsWID69eujVq1auVMqIqICyNbKArN61kVf/zLq+le/n8OMvTe5FgsREVF+Byt///23WhiyePHi+Pbbb9GsWTMcOHAgpw9HRGQULMzNML69Nz5uW0VdX3s0Am+vPYb4J5zPR0RElKfrrISFhWHZsmVYvHixygwmk+wTEhKwZcsWeHt7Z/vJiYiMkSQfGfy/8nB3tMH7G06oYWH3HgVjYW9fONtzLRYiIqJc71mRTF+VK1fGiRMnMGPGDNy5cwc//PBDlp+IiMjUdKjlie87VUQhG0sEX7uP1+cF4vZDrsVCRESU68HKH3/8gQEDBmDixIlo164dLCwssvwkRESmysfLEeuHNISHky0uRTxCp9n7ceZOtL6LRUREZFzByr59+9Rkeh8fHzRo0ACzZs1CZGRk3paOiMgIVPFwxE/D/FGpWCFExCSg6/wg7LvI4ycREVGuBSsNGzbEwoULERoaiiFDhmDt2rXw9PREcnIyduzYoQIZIiLKmKeLHTYM9UfDckXwKOEp+i4Nxuajt1hdREREuZkNzMHBAf3791c9LSdPnsR7772HKVOmwN3dHR06dMjuwxERmQxnOyss718fr9YsjqfJGry77jjm7LkEjUaj76IREREZ3zorMuH+66+/xq1bt7BmzZrcKxURkZGysbTAzO51MKhxWXX9623nMe7n00hKZsBCRESU64tCCpls37FjR2zdujU3Ho6IyKiZm5vhk3beGPeqN8zMgJUHriPgx8Nci4WIiCgvghUiIsq+/i+VxeyedWFtaY4/z4Sj58IDeBCbyKokIiL6fwxWiIj0qG2N4vhxQAM42VriyI2HeH1uIG7ej+N7QkRExGCFiEj/6pctgk0B/ijhYocrkbHoNCcQJ29F6btYREREeseeFSIiA1Cx2L9rsVQt7oTIRwnotiAIe85H6LtYREREesVghYjIQBRzslWr3b9UwRVxiUkYsDwEG0Ju6rtYREREesNghYjIgDjaWmFJ33roVKeESmf8wcYTmLnrItdiISIik8RghYjIwEh2sOldayGgaXl1ffqOC/h480k8TUrWd9GIiIhML1iZPXs2ypQpA1tbWzRo0ADBwcGZ7rtw4UI0btwYhQsXVpcWLVo8c38iooLIzMwMY9pUwaTXqsHcDFgTfBNDVh5GXOJTfReNiIjIdIKVdevWYfTo0Rg/fjyOHDmCWrVqoXXr1oiIyHhi6Z49e9CjRw/s3r0bQUFB8PLyQqtWrXD79u18LzsRUV7r5VcG897ygY2lOXadi0CPhQfVBHwiIiJToPdgZfr06Rg0aBD69esHb29vzJs3D/b29liyZEmG+69atQrDhg1D7dq1UaVKFSxatAjJycnYtWtXvpediCg/tKrmgdWDGqKwvRWO3/x3LZZrkbGsfCIiMnqW+nzyxMREHD58GGPHjk3ZZm5uroZ2Sa9JVsTFxeHJkycoUqRIhrcnJCSoi1Z0dLT6XwIcueiLPLdGo9FrGYwF65L1aQpts46XMzYMaYh+y0Jw/V6cClgW9fZBLS8XmAp+1lmfhoptk/VpqJIN5HzzRZ5fr8FKZGQkkpKSUKxYsVTb5fq5c+ey9BhjxoyBp6enCnAyMnnyZEycODHd9rt37yI+Ph76fNOioqJUA5IAjViXhoJt03DrshCAeW9UxHs/X8K5iDg1JOyLtmXxUjnTCFjYNlmfhoptk/VpqJIN5HwzJiamYAYrL2rKlClYu3atmscik/MzIr02MidGt2dF5rm4ubnByckJ+mw8MoFWysFghXVpSNg2Dbsu3QFsCCiGEWuOYu+FSHz4y2V80bE6utfzgrFj22R9Giq2TdanoUo2kPPNzM7TDT5YcXV1hYWFBcLDw1Ntl+seHh7PvO+3336rgpWdO3eiZs2ame5nY2OjLmnJG6bvIEEajyGUwxiwLlmfptQ2He2ssahPPXz800lsOHwLH28+hbCoeLzbspJ6PmPGzzrr01CxbbI+DZWZAZxvvshz6/Us2draGj4+Pqkmx2sny/v5+WV6v6+//hqTJk3Ctm3b4Ovrm0+lJSIyHFYW5vj6jZp4p3lFdX3mX5fUApJPuBYLEREZEb3/pC9DtGTtlOXLl+Ps2bMICAhAbGysyg4mevfunWoC/tSpU/HZZ5+pbGGyNktYWJi6PHr0SI+vgohIP7+WjW5ZCZM714CFuRk2Hr6FActDEJvAtViIiMg46D1Y6datmxrSNW7cOJWO+NixY6rHRDvp/saNGwgNDU3Zf+7cuSqL2BtvvIHixYunXOQxiIhMUY/6pbCwtw/srCzw94W76LYgCBEx+ksgQkRElFsMYoL9iBEj1CUjMnle17Vr1/KpVEREBUezKsWwdnBD9F92CKduR6PznEAs718f5d0khxgREVHBpPeeFSIiyh2y5sqmAH+UKWqPWw8eq7VYDl+/z+olIqICi8EKEZERKePqoAIWCVwexj1Bz4UHsf10mL6LRURElCMMVoiIjEzRQjZYM6gBmldxR8LTZAT8eBgrgziEloiICh4GK0RERsje2hLze/moyffJGuCzn09jyh/nkCxXiIiICggGK0RERsrSwhxfdaqO91pWUtfn7b2M0euPIfFpsr6LRkRElCUMVoiIjHwtlrebV8Q3b9SEpbkZthy7g37LghET/0TfRSMiInouBitERCagi68XFvetBwdrC+y/dA9d5gUhPJprsRARkWFjsEJEZCKaVHLDuiF+cC1kg3NhMeg0ez8uhsfou1hERESZYrBCRGRCqpdwxuZh/ijn5oA7UfFqLZaDV+7pu1hEREQZYrBCRGRivIrYY9NQf/iULozo+KfotTgYv50I1XexiIiI0mGwQkRkggo7WGPVwAZo5V0MiUnJGLHmCBbvu6rvYhEREaXCYIWIyETZWllg7ls+6O1XGhoNMOnXM/ji1zNci4WIiAwGgxUiIhNmYW6GiR2qYUybKur6on1X8c7ao0h4mqTvohERETFYISIydbIWS0DT8pjRrTasLMzw64lQ9F4cjKjHXIuFiIj0iz0rRESkdKxTAsv61UchG0scvHofXeYF4s7Dx6wdIiLSGwYrRESUolEFV6wf4odiTja4EP4InecE4lxYNGuIiIj0gsEKERGl4u3phJ+GNUJF90IIi45Hl7lBCLwUyVoiIqJ8x2CFiIjSKeFih41D/VG/bBHEJDxFn6XB+PnYbdYUERHlKwYrRESUIWd7K6zoXx/tahTHkyQNRq49hvl7L0MjeY6JiIjygSVMVNyTOFg+Sf/yLcwtYGNhk2q/zJibmcPW0jZH+z5++lhd5D7m5ubpMvPYWdql2jezk4O0+8Y/jUeyJjnTcthb2edo34SkBCQlJ+XKvlJeKbdITErE0+SnL7RvcnKyqiN5Leb/H38/SXqCJ8mZZzKS90Lek6zsK+1B2kW2901+ovbPjLWFNSzNLbO9r9SB1EVmrCysYGVule195T2T905bn2nbpuwn++vum+nj6uwr74u0tdzYV+pA6kLIZ0LKmRv7Zudzn519keZjm91jRFY/93l6jEAypr5RGUUdgRVB1zF52wncfPgQH7WpgkI2Dvl6jMiobWbneJKdz72pHCPkfcjoeyizfbP6uTe1Y4Ru27SytMq38wiDOEbk0XlEZudIeXEeYczHiOT/b5vyuq3NrfPlPCIjz/yufA6TDVaabWgGC7t/G4OuxiUaY06LOSnXm65vmukBzLeYL5a2WZpyvc2mNniQ8CDDfasVrYa1r65Nud55a2fcib2T4b7lnctjS8ctKdd7/NoDl6MuZ7ivp4Mntr+xPeV63219cfre6Qz3LWxTGH93/zvlesDOAISEh2T64Q5+Mzjl+ru738U/t/9BZk72OZny99h/xmLH9R2Z7nuw58GUg9LEoInYenlrpvvu7bYXRWyLqL+/PvQ11p1fl+m+v3f6HV5OXurvmUdnYtnpZZnuu7nDZlQoXEH9vfDkQsw9PjfTfde0W4PqrtXV3z+e/RHTD0/PdN8lrZegnkc99ffGCxvx1cGvMt13dvPZ+F/J/6m/f7vyGz7b/1mm+37b5Fu0LtNa/b3rxi68v/f9TPed1GgSOlboqP4OvBOI4buGZ7rvxw0+Ro8qPdTfRyKOoP/2/pnuO9pnNPpV76f+Pnv/LHr89u/9MhJQKwDDag9Tf195eAWdtnbKdN++1friPd/31N+hsaHqc5SZbpW74dOGn6q/5bPWZF2TTPftUL4DvnzpS/W3fIYbrG6Q6b4tS7fE9Kb/va/P2je7x4jJtSfn6BjRcUtHgztGOP67FAt+fgj8stYaB3sGq4UlC8oxYtvr21CiUAn1N48R/x4jQu6F4NMd/36mMsJjRN4fI3J6HmGIx4jcOo/4ZN8n2HGDx4jcPI/45n/foE3ZNno7j0h6nPO1uzgMjIiIsi0pWYO3Fh3Ew7jMf3EjIiJ6UWYaExt8HB0dDWdnZ4RGhsLJyUlvw8BiE2MREREBNzc3DgPLhWFgd+/ehVdxL1haWBpV962+hoFJfaZtm6Y8xONFhoFF34+Gu7u7qktjGeJx6Np9jFh9BDGPLVDezUGtzeLubJEvw8DStk1TH+KR0b5Z/dxLfYaGhcK5qDOHgeXCMDBt2+QwsBcfBvb4yWOEhYdleI4kOAwse8PApG2W8CgBa0v9DQOT8+/irsURFRWV4fn3s5hssJKTyspN0ngkWNGexBDr0lCwbbIus+JCeAz6LAlGaFQ83BxtsLRvPVQv4cy2WYDws866NFRsm8ZXl9EvcP7Ns2QiIsq2SsUcsXlYI1TxcMTdmAR0mx+Evy/cZU0SEVGuYrBCREQ54uFsi/VD/eBfvihiE5PQf9khbDp8i7VJRES5hsEKERHlmJOtlZqz8lptTzxN1uC9Dccxe/clrsVCRES5gsEKERG9EGtLc3zXtTaGNCmnrn+z/Tw+3XIKT5Myn8j/PNeuXVMT548dO8Z3h4jIhI+bDFaIiChTN2/eRP/+/eHp6Qlra2uULl0aI0eOxL1791Lt16zZy/i4rTfqRf0NSc616uANDP3xMB4nJqFdu3bqC3TChAk5ruk9e/bAwsJCTc58nhMnTqBx48awtbWFl5cXvv766+feZ9euXfD394ejoyM8PDwwZswYPH369IUfl4hMT1aPm02bNlXHxilTpqR7jIJw3BTLli1DzZo11f1kEv/w4cMzfFy5TcyYMQPZxWCFiIgydOXKFfj6+uLixYtYs2YNLl26hHnz5qkTez8/P9y/fz/V/vIFd3L3z5j7Zl3YWJpj59kIdPzmF7V/8eLF8y3jTKtWrdTJweHDh/HNN9+oL/sFCxZkep/jx4+jbdu2aNOmDY4ePYp169Zh69at+Oijj17ocYnI9OTkuCkn/Lpu375t8MdNMX36dHzyySfqWHn69Gns3LkTrVv/u4B12sfdu3ev2iaBWbaPmxoTExUVJama1f/6lJSUpAkNDVX/E+vSkLBtsi612rRpoylZsqQmLi4uVaXIscve3l4zdOjQlG1NmjTRBAQEaIoWLarZt2+f5tDVe5qaE7ZrXP7XW1PU219TtXoNzfjx41P2l+Pw5s2bUz2us7OzZunSpervq1evqn2OHj2a8rfupU+fPhm+UXPmzNEULlxYk5CQkLJtzJgxmsqVK2f6xo4dO1bj6+ubatvWrVs1tra2mujo6Bw/rqHjZ511aagKctt8keOm1pdffqlp3769platWgZ73Lx//77Gzs5Os3Pnzkz30X1c7fn3qFGjsn3cZM8KERGlI7/+bd++HcOGDYOd3X+LSgoZJvXmm2+qHgjdpbpkuINsX7p0KXzLFMGmAH/En94F88ov41pkLMKiMl/w81nkl8dNmzapv/ft26d+dfz+++8z3DcoKAj/+9//VFm05Je+8+fP48GDBxneJyEhQQ1h0CWvOT4+Xv3KmNPHJSLT8qLHTS3paZFhZC/CK4+Pmzt27FBruMjjVq1aFSVLlkTXrl3VELhnPW7z5s2zfdxksEJEROnIEAb5QpUvoYzIdvmykZWRdckX7Pr16xEbG4s7546gkPkT+DRurjKFbTx8C7vPRWS7tmXMdZEiRdTfrq6u6ktfFhfLSFhYGIoVK5Zqm/a63JYR+VIODAxUQzaSkpLUl+/nn3+ubgsNDc3x4xKRacmN4+bff/+t5pi8+uqrL1QWizw+bspwNwlWvvrqKzUPZePGjSpYa9myJRITEzN9XO3clewcNxmsEBFRpnR/AcyI7i9molatWqhYsaL64lqyZAn69O6FDcMao5CNJZ4mJ2PgihCsO3TDoGpcxlTLGO2hQ4fCxsYGlSpVUnNYhD5XfCYi0zxu9urVC5aWljBkycnJePLkCWbOnKl+8GnYsKH6wUcCtt27d+fqc/EoTERE6VSoUEFlojl79myGtSPb3dzc4OLiku42+ZVw9uzZ6otX/pZAxauIPaoWd0JSsgZjNp1Ujy1fdrrki+9Fya+H4eHhqbZpr8ttmRk9ejQePnyIGzduIDIyEq+99praXq5cuRd6XCIyHbl53MyImZlZukBIX8dN7eR/b2/vlG3y2qQXR46jmT1uREREto+bDFaIiCidokWLqu78OXPm4PHjx6luk+77VatWoW/fvhnWXM+ePXHy5ElUr1495YvMTHowvIthxMsV/r1u54x5fxzGk/9fi0V+jYuLi3vuL5EyTOtZJNuODKPQ/QKXsdWVK1dG4cKFn3lfORGQVKMy1lx+IZQx33Xr1n3hxyUi05Dbx8203NzcUoam6vu42ahRI/W/zD/RkmFg8mOPZP/K7HGl1yW7x00GK0RElKFZs2apyefSxS9fODJxctu2berLWIZKjRs3LsP7yZeQfKFK6s20wcD7rSvjy07VYVe6JvZsXonOk1bhn8ADagiWlZVVpu+EfPnJ/SU1poz3fvToUaZf+PIFPWDAAJVKUyazyqRS6TnR2rx5M6pUqZLqfjIMTE4U5D6TJk1S6TVleIOM+87q4xIR5fZxU1ezZs3U40uK9ZCQEL0eN+W1SA+0rB8jc/5OnTqFPn36qH1efvnldI+r7W2SNM7ZPm5qTAxTFxufgpzi0BCxPlmXuiT9paS7LFasmMbMzEylnuzcubMmNjY21X6SgnPkyJGZVl7aFJxrdh/T2JerqzGzstU4uJXUrNn4c6YpOLUmTpyocXd3V+XILAWnOH78uOall17S2NjYaEqUKKGZMmVKqtvlOdJ+/b388svq+SVdcYMGDTS///57th+3oOFnnXVpqAp628yr4+bt27c1rVq10jg4OGgqVqyojlP6PG7KOXX//v01Li4umiJFimg6deqkuXHjRqaPK/efMGGCJrvM5B+YEFmgRrIhSKYFJycnvZVDxmrLuD3JisAJnKxLQ8K2ybp8lvHjx6uFwGSIgEyofBFHbzzAgOUhuB+biFJF7LGsXz2UcyvEtplP+FlnXRoqY2ubuXncLKh1+SLn3wW/BRARUb6ZOHGiGh514MCBdBPks6tOqcJqLRYJVG7cj8PrcwNx5AbXLCEi45Kbx01TZNh50YiIyOD069cv1x6rrKuDClgGLD+EE7ei0HPhAfzQoy5aeqfOzU9EVJDl5nHT1LBnhYiI9MrN0QZrBzfEy5XdEP8kGUNWhuDHA9f5rhAREYMVIiLSP3trSyzs7Yvu9byQrAE+3XIK32w/99zF1YiIyLixZ4WIiAyCpYU5JneugVEtKqrrs3dfxnsbjiPxabJaTPLAlXv489x99b9cJyKizBnLcZNzVoiIyGDImgCjWlSCp7Mdxm4+iZ+O3MbZ0GiVMSw8OuH/97qK4s62GN/eG22q/7uKMhER/WfbqVBM/OUMQqPiC/xxkz0rRERkcLrW88KiPr6wtjTH2dAYnUDlX2FR8Qj48Yj6QiYiov/IcVGOj/8FKgX7uGkQPSuzZ89WqweHhYWhVq1a+OGHH1C/fv1M99+wYQM+++wzXLt2DRUrVsTUqVPRtm3bfC0zERHlrf9VdIOjrSXuPUpMd5t2MMO4n0+jorsjLMzN+HZkU7ImGfcexiPOIhbmZvzt8kWwLnMX6zPnkpI1+GzL6ZRjpC7ZJkdK6XFp6e1RYI6beg9W1q1bh9GjR2PevHlo0KABZsyYgdatW+P8+fNqAZu0AgMD0aNHD0yePBmvvvoqVq9ejY4dO+LIkSOoXr26Xl4DERHlvuCr9zMMVHRFxCSg+fS9rH4ioiyQgEV6XOT46le+KAoCva9gLwFKvXr1MGvWLHVdFsvx8vLC22+/jY8++ijd/t26dUNsbCx+/fXXlG2yGmjt2rVVwJNWQkKCuuiuoCmP/+DBA72vYH/37l24ubkZxeqs+sS6ZH0aKrbNF7P1+B2MWnf8ufvZWJrDyoLH0ZzQaJJhxl6VXMG6zF2sz5x5kpSMhKfPX3hyRrda6FDLE/lFzr8LFy6coxXs9dqzkpiYiMOHD2Ps2LEp2+TEvUWLFggKCsrwPrJdemJ0SU/Mli1bMtxfemBk5dC0JFCIj089li+/T2LkDZNYkcEK69KQsG2yLg2F1dPHWdpv+msV4OPlmOflMdbPurOzM7+HWJcGhW0z5w7fjMHwTReydHyNiIhAfomJicnxffUarERGRiIpKQnFiqVeqViunzt3LsP7yLyWjPaX7RmRQEg3uNH2rEiPhr57ViTrDXtWWJeGhm2TdWkoWrm6wWPHDYRHx2c4/lpGW3s426JVnXIFZuy1IeFnnXVpqNg2je+4aWtrW3DnrOQ1GxsbdUlLejP03aMhwYohlMMYsC5Zn4aKbTPn5NA4oYO3yl4jX6m6X7zar1hJw2llafGC75LpYvtkXRoqtk3jOm6av8C5rl7Pkl1dXWFhYYHw8PBU2+W6h4dHhveR7dnZn4iICi5ZD2DuW3XVL4G65LpsL2jrBRAR5bU2Rnbc1GvPirW1NXx8fLBr1y6V0Uvb9SfXR4wYkeF9/Pz81O2jRo1K2bZjxw61nYiIjI98sUqazYNXInHp1l1UKOmGBuVcOfSLiMgEjpt6HwYm80n69OkDX19ftbaKpC6WbF/9+vVTt/fu3RslSpRQE+XFyJEj0aRJE0ybNg3t2rXD2rVrERISggULFuj5lRARUV6RL9iG5YqiXKEkuLsXhXkB/MIlIspPFkZy3NR7sCKpiCUz17hx49QkeUlBvG3btpRJ9Ddu3Eg1zs3f31+trfLpp5/i448/VotCSiYwrrFCRERERGRc9B6sCBnyldmwrz179qTb1qVLF3UhIiIiIiLjxTRURERERERkkBisEBERERGRQWKwQkREREREBonBChERERERGSQGK0REREREZJAMIhtYftJoNOr/6OhovZZDFr+MiYmBra1tqtTMxLrUN7ZN1qWhYttkfRoqtk3Wp6FKNpDzTe15t/Y8PDtMLliRN0x4eXnpuyhERERERCZ1Hu7s7Jyt+5hpchLiFPAI886dO3B0dISZmZleI0wJmG7evAknJye9lcMYsC5Zn4aKbZP1acjYPlmXhopt0/jqUqPRqEDF09Mz2z08JtezIhVUsmRJGAppOAxWWJeGiG2TdWmo2DZZn4aKbZP1aaicDOB8M7s9KlqcLEFERERERAaJwQoRERERERkkBit6YmNjg/Hjx6v/iXVpSNg2WZeGim2T9Wmo2DZZn4bKxgjON01ugj0RERERERUM7FkhIiIiIiKDxGCFiIiIiIgMEoMVIiIiIiIySAxWiIiIiIjIIDFYyQV///032rdvr1blNDMzw5YtW557nz179qBu3boqO0OFChWwbNmydPvMnj0bZcqUga2tLRo0aIDg4GAYu+zW5U8//YSWLVvCzc1NLXbk5+eH7du3p9pnwoQJ6rF0L1WqVIEpyG59SrtMW1dyCQsLg6m3zZzUZ9++fTOsz2rVqsHU2+fkyZNRr149ODo6wt3dHR07dsT58+efe78NGzao+pG2V6NGDfz++++pbpecMePGjUPx4sVhZ2eHFi1a4OLFizBmOanLhQsXonHjxihcuLC6SD2l/Rxn1H7btGkDY5eT+pTv8LR1JW1UF9tm1uqyadOmGR4327VrB1Nvm3PnzkXNmjVTFniUc54//vjD6I+ZDFZyQWxsLGrVqqVO4LLi6tWr6kP38ssv49ixYxg1ahQGDhyY6iR73bp1GD16tEo3d+TIEfX4rVu3RkREBIxZdutSTh4lWJEP3+HDh1Wdysnk0aNHU+0nJ4ehoaEpl3379sEUZLc+teTLRLe+5Avb1NtmTurz+++/T1WPN2/eRJEiRdClSxeYevvcu3cvhg8fjgMHDmDHjh148uQJWrVqpeo4M4GBgejRowcGDBigPuNy4iOXU6dOpezz9ddfY+bMmZg3bx4OHjwIBwcH1T7j4+NhrHJSl/LDhNTl7t27ERQUBC8vL3Wf27dvp9pPTgB12+aaNWtg7HJSn0JOHnXr6vr166luZ9vMWl3Kj5C69SifbwsLi3THTVNsmyVLlsSUKVPU+U5ISAiaNWuG1157DadPnzbuY6akLqbcI1W6efPmZ+7z4YcfaqpVq5ZqW7du3TStW7dOuV6/fn3N8OHDU64nJSVpPD09NZMnTzaZtysrdZkRb29vzcSJE1Oujx8/XlOrVi2NqctKfe7evVvt9+DBg0z3YdvMen2mJfubmZlprl27lrKN7fNfERERqk737t2baf117dpV065du1TbGjRooBkyZIj6Ozk5WePh4aH55ptvUm5/+PChxsbGRrNmzRqNqchKXab19OlTjaOjo2b58uUp2/r06aN57bXXNKYuK/W5dOlSjbOzc6a3s21mvS7T+u6771TbfPToUco2ts3/FC5cWLNo0SKNMR8z2bOiB/IrlnSz6ZIoVraLxMREFTXr7mNubq6ua/ehjCUnJyMmJkb9eq1LujRl6E65cuXw5ptv4saNG6zCZ6hdu7bqEpZeq/3796dsZ9t8MYsXL1af49KlS7N9phEVFaX+T/vZzc6xU3qtZcii7j7Ozs5qqKIpHTuzUpdpxcXFqV+9095HemCkZ7Vy5coICAjAvXv3YGqyWp+PHj1Sn23ppUr7azfbZvbqMu1xs3v37uoXf12m3jaTkpKwdu1a1Uslw8GM+ZjJYEUPpGEUK1Ys1Ta5Hh0djcePHyMyMlI1woz2STt3gFL79ttv1RdG165dU7bJh07GE2/btk2N95QPp4zVlqCGUpMARbqCN23apC7ypSvjh2W4l2DbzLk7d+6oscUy5FMX2+e/PzLIcNhGjRqhevXq2T52ao+L2v9N+diZ1bpMa8yYMeoHHd2TFhlms2LFCuzatQtTp05Vw6NeeeUV9f1kKrJan3LCvGTJEvz888/48ccf1f38/f1x69YtdTvbZs7apsyjkiFLaY+bptw2T548iUKFCqk5z0OHDsXmzZvh7e1t1MdMS30XgCi3rF69GhMnTlRfFrpzLOQApiUT0+TkUH79Wr9+vRrHSam/cOWiJV+2ly9fxnfffYeVK1eyql7A8uXL4eLiosYL62L7hJofICckpjBXxxDrUsbAyy+08ku17qRw+TVbSybmyvGzfPnyar/mzZvDFGS1PuWXbd1ft+XYWbVqVcyfPx+TJk3Kh5IaZ9uUXhVpe/Xr10+13ZTbZuXKldV8Z+ml2rhxI/r06aOCtcwCFmPAnhU98PDwQHh4eKptcl0m50kmBldXVzWZLKN95L6UnnzRyi8vEoCk7fJMS04YK1WqhEuXLrEqs0C+JLR1xbaZMzLFRX517dWrF6ytrdk+dYwYMQK//vqrmugtk0dzcuzUHhe1/5vqsTM7danbGy3Byp9//qlO+J5FhtHKMcBUjp05qU8tKysr1KlTJ6Wu2DazX5cyvEm+27Pyo6IptU1ra2uVRdbHx0dlrpOkL5LMxZiPmQxW9EB+fZGuS12ScUT7q4w0RGmEuvtI96lcz2xcoimTDCD9+vVT/+umNsyMDBOT3gIZ8kTPJ7/gaOuKbTNn5Fcv+RLNypeuqbRPCeDkZFCGMPz1118oW7bsCx875THkC1Z3HxleKxlujPnYmZO61GYBkl/9ZYisr6/vc/eXIU0yL4Bt8/lkOJIM19HWFdtm9tqmNuVuQkIC3nrrLbbNZ5DzQ6knoz5m6nuGvzGIiYnRHD16VF2kSqdPn67+vn79urr9o48+0vTq1Stl/ytXrmjs7e01H3zwgebs2bOa2bNnaywsLDTbtm1L2Wft2rUqG8OyZcs0Z86c0QwePFjj4uKiCQsL0xiz7NblqlWrNJaWlqoOQ0NDUy6SzULrvffe0+zZs0dz9epVzf79+zUtWrTQuLq6qqwkxi679SlZV7Zs2aK5ePGi5uTJk5qRI0dqzM3NNTt37tSYetvMSX1qvfXWWyoDS0ZMtX0GBASo7Eny2nU/u3FxcSn7SF1KnWpJ/cjn/dtvv1XHTsmkZmVlpdqq1pQpU1R7/PnnnzUnTpxQ2azKli2refz4scZY5aQupZ6sra01GzduTHUfaeNC/n///fc1QUFBqm3KMaBu3bqaihUrauLj4zXGLCf1KRkot2/frrl8+bLm8OHDmu7du2tsbW01p0+fTtmHbTNrdan10ksvqUypaZly2/zoo49UJjV53XJ8k+uSYfLPP/806mMmg5VcoE33mvYiqfWE/N+kSZN096ldu7b6sihXrpxKe5jWDz/8oClVqpTaR9LFHjhwQGPssluX8vez9hdysCtevLiqxxIlSqjrly5d0piC7Nbn1KlTNeXLl1dfskWKFNE0bdpU89dff6V7XFNsmzn9rEvgbGdnp1mwYEGGj2mq7TOjepSL7rFQ6lL3syzWr1+vqVSpkqovSQH/22+/pbpdUnF+9tlnmmLFiqmgunnz5prz589rjFlO6rJ06dIZ3kdOZoScTLZq1Urj5uamTm5k/0GDBpnEjxI5qc9Ro0alHBOl7bVt21Zz5MiRVI/Ltpn1z/m5c+fUftqTcF2m3Db79++vXq+0M3n9cnzTrSNjPWaayT/67t0hIiIiIiJKi3NWiIiIiIjIIDFYISIiIiIig8RghYiIiIiIDBKDFSIiIiIiMkgMVoiIiIiIyCAxWCEiIiIiIoPEYIWIiIiIiAwSgxUiIiIiIjJIDFaIiKhAmDBhAmrXrp2t+5iZmWHLli15ViYiIspbDFaIiCjfSRDxrIsEJmm9//772LVrF98tIiITYqnvAhARkekJDQ1N+XvdunUYN24czp8/n7KtUKFCKX9rNBokJSWpbbrbiYjI+LFnhYiI8p2Hh0fKxdnZWfWmaK+fO3cOjo6O+OOPP+Dj4wMbGxvs27cv3TCwQ4cOoWXLlnB1dVWP0aRJExw5coTvJhGREWGwQkREBumjjz7ClClTcPbsWdSsWTPd7TExMejTp48KZA4cOICKFSuibdu2ajsRERkHDgMjIiKD9Pnnn6uek8w0a9Ys1fUFCxbAxcUFe/fuxauvvpoPJSQiorzGnhUiIjJIvr6+z7w9PDwcgwYNUj0qMgzMyckJjx49wo0bN/KtjERElLfYs0JERAbJwcHhmbfLELB79+7h+++/R+nSpdXcFj8/PyQmJuZbGYmIKG8xWCEiogJp//79mDNnjpqnIm7evInIyEh9F4uIiHIRgxUiIiqQZPjXypUr1XCx6OhofPDBB7Czs9N3sYiIKBdxzgoRERVIixcvxoMHD1C3bl306tUL77zzDtzd3fVdLCIiykVmGllti4iIiIiIyMCwZ4WIiIiIiAwSgxUiIiIiIjJIDFaIiIiIiMggMVghIiIiIiKDxGCFiIiIiIgMEoMVIiIiIiIySAxWiIiIiIjIIDFYISIiIiIig8RghYiIiIiIDBKDFSIiIiIiMkgMVoiIiIiICIbo/wAAXZIAhwABBgAAAABJRU5ErkJggg==",
+      "text/plain": [
+       "<Figure size 800x400 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>trial</th>\n",
+       "      <th>qmult</th>\n",
+       "      <th>computed_wse_ft</th>\n",
+       "      <th>target_wse_ft</th>\n",
+       "      <th>difference_ft</th>\n",
+       "      <th>objective_ft</th>\n",
+       "      <th>within_tolerance</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>1</td>\n",
+       "      <td>1.2</td>\n",
+       "      <td>3964.547363</td>\n",
+       "      <td>3963.5</td>\n",
+       "      <td>1.047363</td>\n",
+       "      <td>1.047363</td>\n",
+       "      <td>False</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>2</td>\n",
+       "      <td>0.9</td>\n",
+       "      <td>3963.494385</td>\n",
+       "      <td>3963.5</td>\n",
+       "      <td>-0.005615</td>\n",
+       "      <td>0.005615</td>\n",
+       "      <td>True</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>3</td>\n",
+       "      <td>0.6</td>\n",
+       "      <td>3963.494385</td>\n",
+       "      <td>3963.5</td>\n",
+       "      <td>-0.005615</td>\n",
+       "      <td>0.005615</td>\n",
+       "      <td>True</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   trial  qmult  computed_wse_ft  target_wse_ft  difference_ft  objective_ft  \\\n",
+       "0      1    1.2      3964.547363         3963.5       1.047363      1.047363   \n",
+       "1      2    0.9      3963.494385         3963.5      -0.005615      0.005615   \n",
+       "2      3    0.6      3963.494385         3963.5      -0.005615      0.005615   \n",
+       "\n",
+       "   within_tolerance  \n",
+       "0             False  \n",
+       "1              True  \n",
+       "2              True  "
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "if project_available and not fallback_trials.empty:\n",
+    "    fig, ax = plt.subplots(figsize=(8, 4), constrained_layout=True)\n",
+    "    ax.plot(fallback_trials[\"trial\"], fallback_trials[\"objective_ft\"], marker=\"o\")\n",
+    "    ax.axhline(TARGET_TOLERANCE, color=\"tab:green\", linestyle=\"--\", label=\"Tolerance\")\n",
+    "    for _, row in fallback_trials.iterrows():\n",
+    "        ax.annotate(f\"QMult {row['qmult']:.2f}\", (row[\"trial\"], row[\"objective_ft\"]), textcoords=\"offset points\", xytext=(0, 8), ha=\"center\")\n",
+    "    ax.set_xlabel(\"Trial\")\n",
+    "    ax.set_ylabel(\"Absolute WSE error (ft)\")\n",
+    "    ax.set_title(\"Fallback objective convergence\")\n",
+    "    ax.grid(True, alpha=0.3)\n",
+    "    ax.legend()\n",
+    "    plt.show()\n",
+    "\n",
+    "    display(fallback_trials[[\"trial\", \"qmult\", \"computed_wse_ft\", \"target_wse_ft\", \"difference_ft\", \"objective_ft\", \"within_tolerance\"]])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "149eabe0",
+   "metadata": {},
+   "source": [
+    "## Before/After WSE Comparison"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "f523c791",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-01T21:37:02.624183Z",
+     "iopub.status.busy": "2026-05-01T21:37:02.624183Z",
+     "iopub.status.idle": "2026-05-01T21:37:02.843004Z",
+     "shell.execute_reply": "2026-05-01T21:37:02.842712Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAABLsAAAGbCAYAAAAskpJqAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjksIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvJkbTWQAAAAlwSFlzAAAPYQAAD2EBqD+naQAArDpJREFUeJzs3Qd8U2X3wPHT3dLSQaHsIUOGyFYE8RVUBAcK8jpAGYIojv/rK04cDCfuvQduxa2vuEGmbMTB3nuWUrpn/p/ztDcmadqm0DRN8/t+PmnGvbm5eZImT849z3mCbDabTQAAAAAAAIAaINjXOwAAAAAAAABUFoJdAAAAAAAAqDEIdgEAAAAAAKDGINgFAAAAAACAGoNgFwAAAAAAAGoMgl0AAAAAAACoMQh2AQAAAAAAoMYg2AUAAAAAAIAag2AXAAAAAAAAagyCXUANsnHjRjn33HMlLi5OgoKC5KuvvvL1LtUYc+bMMW2q55bRo0dLixYtJBAE0nN19Pbbb5vXfdu2bb7eFQBANfP4449Ly5YtJSQkRLp06SL+hn5jzTFlyhTTX/GErqfre1Pfvn3NCfAlgl2AD39AW6fQ0FBp3LixCSjs3r37mLc7atQo+euvv+Shhx6S9957T3r06FGp+42KO//88yUhIUFsNpvT7b///rt57Zs3b17iPrNnzzbLXnvtNfttGmy5+uqrpVWrVhIZGSkNGjSQf/3rXzJ58mSn+2rHwvG95Xhq165dmfu6Z88e0/lZtWoVLzUAoEb2ufSUlJQk/fr1k++///6Yt/vTTz/JHXfcIaeffrpMnz5dHn74YfGVW2+9VTp06FAp/cYPP/xQnnnmGalKL730knmd/IW/7S8QqEJ9vQNAILv//vvlhBNOkOzsbFm8eLH54lywYIH8/fffJqBREVlZWbJo0SK555575KabbvLaPqNi+vTpYzrT+pqefPLJ9tsXLlxogpw7duyQXbt2SZMmTZyWWfdVmzZtklNOOUWioqJkzJgxJsNq7969snLlSnn00Udl6tSpTo+p23rkkUdK7Itm/JUX7NJt6fZdj1C//vrrUlhYGHAv/4gRI+SKK66QiIgIX+8KAKAS+lx68Gn//v2mz6UHpP73v//JhRdeWOHt6YGp4OBgefPNNyU8PNynr83MmTNl0KBBldJv1GCX9ln++9//SlUGj+rWrWsO+vqD6ri/9957r9x1112+3g2gWiHYBfjQeeedZ8++uuaaa8wXpwYvvvnmG7nssssqtK2DBw+a8/j4+ErbPw3CaQdOO3M4NlbASoOYrsEu7WRrZ1mXaUDFotcTExOlffv25vrTTz8t6enpJuPKNRPswIEDboNaV111VaW+ZGFhYRJIMjIyJDo62gxN0RMAoOb0udTYsWOlfv368tFHHx1TsEu/f/UgVGUFujQIp/0u3WZFbNmyRdavXy+vvPKKz/uNpdGDZbm5uRU+kFtT+7D5+fmmTSozSKoHUPUE4B/V778fCGBnnHGGOd+8ebPT7evWrZN///vfUqdOHdNR0M6aBsQsOvTMCoLcfvvtJkXfsb6SDo3UjCDt1GmGykknnSRvvfWW25pUH3/8sTk6pMMqa9WqJUePHjXLlyxZIgMHDjSBFL39zDPPtGcgOe6HbkMzkfRol3agdH0dfpeZmVni+b7//vty6qmnmu3pUD8dlqfDAhxpVpS2iwYeateuLRdccIGsXr3a4zbV/baGEuo2OnXqJM8++2yF2vd46PPTzoxrW+l1fb663HGZdn40y69379722gv6ftBsLXdDHnUoRmXQ11+zx5S+XtZQDytN37Vmlw6r1OVPPPGEvPjii6Zmib6OWjNu586dptP+wAMPmP3WjvvFF18shw8fLvG4x/r65uXlmSy0Nm3amNdMg4MaWPz5558r/NpaQ1zmzp0rN9xwg2lTK9OutJpdnuz3vn37TFvqtvT/rmHDhqYdqP8FAL6nfRT9fnINEOj3sA7j076Sfm9o3+m6666TlJQU+zr6vaBDF/XAiOv3pQYy9PtPyw7oZ79+d959992Sk5Pj9Dh6uwbZfvzxR/PdpPvy6quvmmVHjhwxmVVNmzY122jdurU5GOouw1qzurSvZR1c2759u/kua9u2rdmmfj9eeumlTt89pfUbtRSCbk+3YT0vx+9+fQ5aPkH3R/dL90+Hcro+N72fZot98MEHph113R9++MHt66Db1+9P/Q62HtOq9aT9httuu80cLIyJiZHY2FgTtPzjjz8q1If99NNPzTBPfT07duwoX375pdtapJ689mXtrzuO/SXdtvW+WLNmjcf9FE/6PO5qdunrcsstt0i9evVMX+Wiiy4yowk8rcvqbpv6vj/rrLNMX0mfh7bryy+/XOrzB3yJ8C9QjVgdEQ3MWPQLVetB6Be3pifrj+tPPvlEBg8eLJ9//rkMGTJELrnkEtNp0y+0YcOGmeCOdgqUpuqfdtpp9o6HfuHpD3U9oqmdANc0de2gaXBGOxf6JamXNftIOxfdu3c3nRw9SmZ92c2fP98EbBxpVpoOFdChdDrU7o033jBfitpRs+iXtn6JalBHhxbo42hgSh9LAyZK60doPYkBAwaY+2rATL9Q9Qtea16VVzBdOwHakdQgw80332zqXK1du1a+/fZbc93T9j0e2inRdtNsLYsGg/Skz107tNqxtGjtDH1drE6r0g7pL7/8YtpG27w8BQUFcujQoRK3a6dXn587mkWmr8OkSZPk2muvtQdedR/Loh1ZPVr7f//3f6ZT+thjj5nXX/dTO5933nmnCX4+//zz5j3lGGQ9ntdX3zv6/tKMSH3/aZstX77cvN/69+9/TK+t/jjQ/w9tA/0BUxpP93vo0KFmH7Rt9DbNAtD3pA5dDcRi/wDgS6mpqea7UQ/G6Oexfi9p1rRrJrQGNzRwpQcr/vOf/8jWrVvlhRdeMJ/venBKM531e0Drai5dutT0cRy/L/V76Z133jEBDK2lpX0b/b7S/ocGWRxpRpb22/Qxx40bZwJU+p2iBxT1QKXe3qxZM/ntt99k4sSJpoSBaz2t7777znzvWUG7ZcuWmfU1Y1wPtmjfUr+jNCCjARYNApXWb9TvSW0nDYhoVrmy+pMaCNJgifZntJ+g/Qbts+h6GzZsKDEpkvZZ9DtX+546cqG07z19Pvo9qY+jQyqVBpmsrDXdrgbrtF+pfVoNCGr76HNp1KhRuX1Y7WNdfvnlJmCmr4MGrrQPrH0DV5689mXtb1m036zZZtp2GiTS4Jan/RRP+jzu6Pp6YHn48OHm/amviR6cOx76XtJgoL4X9D2nw4C1/6TvjxtvvPG4tg1UOhuAKjd9+nStVm775ZdfbAcPHrTt3LnT9tlnn9nq1atni4iIMNctZ599tu3kk0+2ZWdn228rLCy09e7d29amTRv7bVu3bjXbfPzxx50ea+zYsbaGDRvaDh065HT7FVdcYYuLi7NlZmaa67/++qu5f8uWLe23WY+ljzNgwABz2aLrnHDCCbb+/fvbb5s8ebLZxpgxY5wea8iQIbbExET79Y0bN9qCg4PN7QUFBU7rWo+RlpZmi4+Pt40bN85p+b59+8x+u97uKj8/3+xf8+bNbSkpKW4foyLta7WPnltGjRpltl+e22+/3dx3165d5vpHH31ki4yMtOXk5Ni+++47W0hIiO3o0aNm2QsvvGDWXbhwof3+f//9ty0qKsrc3qVLF9vNN99s++qrr2wZGRklHuvMM88067k7XXfddWXu57Jly8x6+v505fpcrfebvmePHDliv33ixInm9s6dO9vy8vLstw8bNswWHh5ub+fjfX11+xdccEGZ63j62lr/j3369DHvG0fWMn2+Fdlvfc+5+38EAFQt63Pc9aT9rbfffttp3fnz55tlH3zwgdPtP/zwQ4nb9XsxOjraab1Vq1aZ9a655hqn22+77TZz++zZs+236Xeq3qbbdvTAAw+Y7W7YsMHp9rvuusv0F3bs2GG/TfsB2p9w/N527MNZFi1aZB7r3XffLbffqN+t7vo27733num7aRs5euWVV0r0W/S6rrt69WqbJ0466STTf3Gl39+u/UTdb33t7r//fvttpfVhlfYDmjRpYr6/LXPmzDHrOz7Pirz2pe2vO1Y7x8bG2g4cOHBM/RRP+jxWH9z1vXjDDTc4rTd8+HBzu65fXn/WdZulvb/0N4K2vSNtH0/bCPAWhjECPnTOOeeYTBJNA9cjgHpER1OXrSFUmimjR2E0UyYtLc0ckdRTcnKyySrRKaPLmr1R+xt6ZEiLlupl6/560vvr0Ts9KuRIM1Yc60VonSh9HD0qpI9r3V8zX84++2yZN29eibT68ePHO13XLCG9r5VOrkfp9D6aQeNaS8FKl9YMGM160iOOjvut9ZN69uwpv/76a5ltq0fh9IicZq651qOwHuN429dTVpaWZsEpPTqo2V56xLFXr172oYvWMiuN3aJH0PR10KPPeoRWh2HqUT89kqiF413p0VNtP9eTN4rN6tFWx8L3+too3VfHoSF6u2aAWe15vK+vvqZ6RFRfI3eO5bXVo+rl1efydL+tOi6a3eY4/AEA4Bs65N76PtRsF52NUTNfvvjiC/s6OtxNv9M0W8bxM16/szWTp7zvJs2yUhMmTHC6XTO8lGMmt9JsJf1OcqT7oP0mzfJ33AftM2rmtva7LPo9pxlMmn1vcezD6fA3/d7TYYf6vena56sI3S/N5tKZnR33y8o4d20bzb46lhkiHWkGlNVP1Oeuz0VfB82Ac/dcXPuwOvGOZp+NHDnSnqFm7ZtjHdXKeO3Lo9ne2uc/ln5KeX2est6LmqHm6Hj7go7ta2VLantqFp5eB6oThjECPu54nXjiiebLQYd3aQfGcdY3Hf6lQar77rvPnNzRVHx3qdhW8VH9Ya6p9noq7f6uHS9H1herdiBKo/vvOPRSU+4dWcv0R7/WW9AaVNp5KasTZD1uacP2dDvWbEKuX646XNGqe6a1GUpzvO3rKU1R1wCbBrJ0WIGeW2nn2oHRdrBu03OtneVatFTfJzpsQjt7mrqvQzF1yKCmw+trpp1giwZNHa97k+trbQW+NIDr7nYr8OPp61saHXKp9a+0XfQ11npyOnOi1mQ71tfW9b3vjqf7rf/HOsRRf+BoUFKHEuuQWu1w6/sTAFC1dPiX44EkPWjRtWtXM8xOP5/1e1c/47VPUVo9THeTwjjSWlfav9HgkiP93Nfve13uyN33ju7Dn3/+6RQYKW0fNHimz8lxGJ32i3TImw6b02BJUaJVkeMJRuh+6VBMT/bL0+/U8ujBQD3Ap7Mf6gFM7QNZtG6VK9fHtNrb9fWwbnMMmB3va18e132rSD+lvD5PWe9FrRHmSAOFx0P7qVrSRGfydK3Hq+1X3szfQFUi2AVUk46XZupoBpBmUGkNBz2KZGVMae0B1yN/Fndf4Bbr/pplU1qwyvWL0nUWIGsbjz/+uHTp0sXtNhyPlqnSsmMcO1zlsR5XAzzuggNW1tCMGTNMbYVjeZzjbV9PaYdMj4RqnQutD6KdWO0oWLSOgi7TGhlaz+nKK68sdVvatno0Uk+aFaZHprVuVlUFt9ztT0Vut14bT1/f0mhxfw1ofv3112ZSA62ZonVDdDYqPVJ/LK+tJzNgVWS/9eipZlVqJqMWINbOrP4A0SO5+gMLAOA7GgjQ71ANpmigQ7Oo9TNegx36vepOaYEeV65FvUvj7ntH90EPfmnhd3c04OGYvePaB9J6Uhro0u8g7Sdo8EH3Rw+2uStw7ym9r/Y9nnrqKbfLXQ9yVXRWSXcefvhh892pkyxpPS6tc6Wvmz43d8/leB6zsl770pTWv/akn1Jen+d4lfZ+dQwuKt0HHdWhfVp9H+hrrkFifR/q/hzP+wvwBoJdQDWhwQH9IawdLy2GqYUqdYY7pQUxjyWYYc2+ol9WxxoMsY4IacZKZQVUdJv6hagZSqUF0KzH1Y5HWY+rHQTXGfgc7//333+Xev/jbd+K0ECmZu9pJ0VfD8fC73pZpz7XIW/Wup6wAqVasLYyeNo5rwyevr5l0U6vdvL1pEFE7QxqEVft+Hnrta3ofuv6mt2lJ/0xpe/3J5980gyhAQD4ls6cqPQ7xPrM1glhNCP7WAInOqGM9m/0816H/Fm0sLpm2rubVdmV7oPuT3nfMdq/0QNkrgXHP/vsM3OAU79rLFoYXR//ePoCul86C6IGOyq7v1Da9vS5aL/4zTffdLpdn4sWvS+P1d6aReXK9baKvPaV8fwr2k8pq89T1ntRA1SO2Vx6QN2VjsBw9/5wzUTUYvQ6bFZLrjhm9h/vEE/AW6jZBVQjOlOOZnvpTC/aMdEf1HqbzjzjLqChwxTLC6BpjQCt26WdooreX2mtAu0A6JTJVmewottwpVlsemRO07JdjwJZmT8axNIAmx7V05oTpT2uzrSonQTHk+rWrZtJGde2dP0Ctx7jeNu3IjSApUEubUedOtrxCKEGu7RtNU1f28V1BkSt9eWuDax6DMebkm6xZmr0tEN8PDx9fUujNS1cswv1CKg1/bm3XltP91tT+/V/2JH+H2nw2XWKdgBA1dPPcD0ApZkpVmBK6yfpd7VmEbkLjJX3/aizGirXGROtbChPZsLTfdAhYpoR7Eof3wrQaR9Ahy86Ds20+n6uGe4686Rrlk5prBkZ3e2XDot0VytUh06WNYuxJ4/prm3dPRetreVpPVWdrVGH/b377rtOfdi5c+eaWl6OKvLal7a/FVGRfkp5fR53rDpuzz33nNPtru9Nq3+ir7mOPLDoPrnOHmpl7bsOjdVMQqA6IrMLqGZuv/12U/Rbpz7WQu9a10sDJZo6rgW09UiQHiHUjpAOe9OjbGWZNm2aOeKixbP1/lofSotiap0CPYKll8uiwRdNl9YvTU3x1yNKWj9AOxq6Xf3hr0d6KkK/oHW6Zu1QaBFWnQJbaxzpdNnaMdEMN92uTm+sNQk0cKXp9xog0qOYWqNCj7xpBlxZ+63312Fkmk2j+62BsXXr1pkin1Yn8njb11NWtpZud/To0SWGJOgRSl2m++FaUF9rP61YscK0kzXsVF8/7bzpkT7XYqPa8Sgtc8h1inXXzo4+tqbFa1BGO3P6vqmMuhuujvf11fexdhI1GKttoFNw6xFgrb1i8cZr6+l+6zTsevRbO8+6rzq8UTuN+vh6HwBA1fr+++9NH8CqhfThhx+aDCzNpLfqLWqh7euuu870Q3RimHPPPddk3uh6GmTRIY86oVBpOnfubLKqtE6qBkN0e0uXLpV33nnHHOjTLCVP+oGaOaN1xLS/oN9zGkjS4Ix+z+lENdpn0O8c7Zu5Zhnp/XSovQ5f1O8f/c7T/p67Glfu6ONpiQgtsq81RDWwon0p/d775JNPTN9U+3/6fafBIW1TvV37Va6BN0/pY+p364MPPmj6iBoI0tqY+lz0wKj24fRAoLaBDjO0sqI8oQentN6V7q9uR2uH6ve0BsEcA2AVee1L29+K8rSf4kmfx5X2fbUunR5I1X6htt+sWbPcZrlpv+TOO++UIUOGmIL2esBOn5/2Tx3rmmmbaHBY3w/aVtp+GvzU519ZowyASuW1eR4BlDsN9rJly0os0ymWW7VqZU75+fnmts2bN9tGjhxpa9CggS0sLMzWuHFj24UXXmj77LPPyp1CWu3fv99244032po2bWrur9vR6Y5fe+21EtM2f/rpp273+ffff7ddcskltsTERDPls05RfNlll9lmzZpVYorigwcPun2+uo+O3nrrLVvXrl3N9hISEswUxT///LPTOrpfOqVxXFycmV5b22X06NG25cuXe/QOW7Bgga1///622rVrm6m8O3XqZHv++eed1vGkfa320fPypmouTaNGjcw2HNvdctFFF5ll119/fYllOp23vn4dO3Y07aD72KxZM9MOuu+OtA3dTbFuncrz9ddf2zp06GALDQ0161vTmbs+19Leb6W9j0p7zx/r6/vggw/aTj31VFt8fLwtKirK1q5dO9tDDz1ky83NrfBrW9b/Y2nv3fL2+9ChQ+Y10/3S952u17NnT9snn3xS5vMCAFQu63Pc8aSf2126dLG9/PLLtsLCwhL30e/p7t27m+8X7T+cfPLJtjvuuMO2Z88e+zr6vaif767y8vJsU6dOtZ1wwgnme0f7XhMnTrRlZ2c7raffqRdccIHbfU5LSzP3ad26tS08PNxWt25dW+/evW1PPPGE+Z47cuSI+Z52952SkpJiu/rqq819YmJizHfVunXrzOPpPpf3PZ6enm4bPny4+X7V5Y7f/frYjz76qO2kk06y9920nfT5pqam2tfT++l3oKf27dtn2kLbWu+rfRmlbXbrrbfaGjZsaF6L008/3bZo0SKz3FrHkz7sxx9/bL6PdZ+1L/XNN9/Yhg4dam47lte+tP11p6z+uaf9FE/6PFYf3FFWVpbtP//5j+m763t10KBBtp07d5r1dH1HP/30k2kbfb+1bdvW9v7777vdprad9qX1f6hFixbm/aD9ede+kutrBPhCkP6p3PAZAAAAAMAbNJNKJ7M5dOgQs98dI8180sxsd3VfAdQM1OwCAAAAAD+hJQe0FpMOVUT5tdmsOmcWnRBIhwjq0EAANReZXQAAAACAGkdrnOnkRVqzVOvCao0xrU2qgUKdvMnTWmYA/A8F6gEAAAAANU5CQoIp7K6TLekMhzr5js6KqRM4EegCajafDmPUWR50ZjGdAUVPvXr1MjOlWDZv3mxmhdDx1LpcZ7XSGSpc6WwkOmNYVFSU+UDT2U7c0WlbmzRpYmYt8WS6WE+3CwAAAACoXjSDS2eX1NkNc3JyzCzkOruizkANoGbzabBLA08aVV+xYoWZQlWnbNWpYVevXm2m2NXpTTUwNXv2bFm4cKHk5uaaqU4LCwvt2/j888/NVLg6layOvdb1hg8f7vbxxo4da4JrnqjIdgEAAAAAAFA9VLuaXXXq1JHHH39cmjZtKuedd56kpKSYrC6VmppqMqx++uknM/Zaiw22aNFCpk6dagJZ5WWRaVR/0qRJcvbZZ5vtanFHdyqyXQAAAAAAAFQf1aZmV0FBgUkp1YwuHc6oQxg1qysiIsK+TmRkpAQHB8uCBQtMsGvlypWye/duc1vXrl1l3759ZhpZDZZ17NjRfr81a9bI/fffL0uWLJEtW7aUuy+ebteVpsbqyaIZaJoqq+PB9bkAAAC4o8ce09LSTAFl7X8EEu0v7dmzR2rXrk1/CQAAVE6fyeZjf/75py06OtoWEhJii4uLs82cOdPcfuDAAVtsbKzt5ptvtmVkZNjS09NtN910k2ah2a699lqzzkcffWSuN2vWzPbZZ5/Zli9fbhs2bJgtMTHRlpycbNbJzs62derUyfbee++Z67/++qu5T0pKSqn75Ml23Zk8ebK5HyfagPcA7wHeA7wHeA/wHjiW98DOnTttgUafM/8v/L/wHuA9wHuA9wDvAd4DUol9Jp9ndrVt21ZWrVplhih+9tlnMmrUKJk7d6506NDBZHpdf/318txzz5mI3bBhw6Rbt2726J1Vu+uee+6RoUOHmsvTp083tcD0vtddd51MnDhR2rdvb6ab9ZQn23VHH2vChAn26/qcmjVrJtu3b7cPxaxMup+HDh2SunXrBtxRYF+j7Wn/QMV7n/YPVN5+7x89elSaN29uspsCjfWcd+7c6ZX+EgAAqDm0z6Rlr8rrM/k82BUeHi6tW7c2l3Va2GXLlsmzzz4rr776qilQr8MZtXMZGhpqamw1aNBAWrZsadZv2LChOdfAmEWHPeryHTt2mOta3P6vv/4ygTRllSjTzqoGs7QulytPtuuOruM47NKi++2tYJcW7dftE+yqWrS9b9H+tH2g4r1fc9ve2mYglj2wnrM1OzcAAEB5yusz+TzY5a4z6Vj3ygpMWYGrAwcOyEUXXWQPjmlwaf369dKnTx9zW15enmzbts0cHbVmVczKyrJvS4NpY8aMkfnz55c65awn2wUAAAAAAED149Nglw770xkXdaifFhj78MMPZc6cOfLjjz/ahw7qEMR69erJokWL5Oabb5ZbbrnFDH1UevRv/PjxMnnyZJPGpoEoLSKvLr30UnPuGtDSLDGl27VmY1y6dKmMHDlSZs2aJY0bN/ZouwAA/6WTouhBDH+jB4R0v7Ozs8no9dO2DwkJMdnqgZjBBQAAEBDBLs3S0iDT3r17JS4uTjp16mQCXf379zfLNbNKA2I6o2GLFi3MsEMNdjnSIJR2GkeMGGEyuHr27GkywBISEjzej8zMTPNYjj98KmO7AIDqJz09XXbt2mUf1u5PdJ816KIHiAiW+G/b16pVy5RM0FIOAAAAqHxBWqXeC9tFceE0DeJpoXpv1ezSgGFSUhJH+KsYbe9btD9tfzwZXRs3bjTBBs0a9reAkX5l5+fnkxnkp22v29C6XwcPHjTvxTZt2ti/v73dZ6jOAvm5AwAA7/Qbql3NLgAAvEUzeDXgoIGuqKgov2togl3+3/b6vgsLCzMzNWvgKzIyslL3EwAAACKVP50QAADVnL9ldKFmYQZlAAAA7yLYBQAAAAAAgBqDYBcAAD6kE7CsWrXKa9vXWY5/+OGHMtf59ttv5ZRTTjGzHbds2VLGjRsnR44csS/v27evKaaudSItW7ZsMRlKgwcPLncftm3bZp8BWU2ZMsXMaliaf//739KoUSOTgee4H64+/vhj6dKli3Ts2NGcnnzySaflb775pqmLpTMz63Pyxxk4AQAAUHEEuwAAqMHKC3bpsuuuu05ee+01MzPxhg0bTB2p8847z0wGYdEZk9977z379bfeeku6d+9+TPs0derUMoNd48eP9ygA2LRpU7P/f//9tyxcuFBefvll83zV1q1b5b777pP58+fLpk2bZP/+/eY5AgAAoOYj2AUACNiC45m5+V49VXTCY82guu222+SMM84w2Uga9LGMHj1axowZI//6179MBtaoUaMkKyvLvuyZZ56xr6vb0OwpDRi98sor8sEHH5gMqPvvv7/EYz744INyzz33SNeuXc11LcCuGVI7d+6Un3/+2b6ePt4777xjLmsQbMaMGTJ8+HD7cg0y6WNYNAClWWuurOekz1HXd8wWs5xzzjlmpuHynH766dKgQQNzWWfladeunckiU5999plcdNFFZrlmiOnjfvTRR+VuEwAAAP6P2RgBAG4dycyVr1ftkf1Hs6VPm7rSu1XdGtVSWXkF0mHSj159jDX3D5Ba4RX7qt28ebP8+uuvZshdhw4dZNGiRdKrVy+zbOnSpSZTSadZHjJkiDz99NNy9913l7otDSZpkEeHAjoGwxytXLlSnn/+eafbdMiiZm1psGzAgAH2LCoNHC1ZskRSUlKkR48ekpCQIBWlwbdXX33VPA/HoY3Ha82aNaatdPtqx44d0rx5c/tyDbzpbQAAAKj5CHYBAEpYuSNFxr69TFIyi2ocvTRns4zs1Vzuu6A9reVll19+ucmu0pMGqzT4ZQW7Lr30Uqldu7aEhITI2LFj5bnnnisz2HW8oqKinK5rZpnWwdJg17XXXiu7d++W6mDXrl1y8cUXm0BXkyZNfL07qIZa3DXT17sA1Bjbpl3g610AgHIR7AIAONl5OFPGvL1MjmTmSZukGGnXMFa+/XOPvLtou8RGhspVnSsvG8eXosJCTOaVtx+jorRelkWDWvn5+aWuq8PzlAbGCgoK7LdrPayYmBiPHq9bt24mI8oaxqhyc3NlxYoVpuaVIy1Gf+edd0pERIScffbZ8u6779qXuduHqrBnzx4z7PHee+81wUBLs2bNTKDQosMb9TYAAADUfNTsAgDY5eQXyLXvrTCBrs5N4uTrm06X54d1lSf+3dksf3nuFtmaXFQnyt9poEiHGHrzZAWjKsvnn38u6enpJqg0ffp0E+RRrVu3NkMcVXJysnz33Xf2++iQx9TU1FK3qZlhWrfLKgivwbVbb73V1A/ToYqugTgdOqkZZToToyOdxXH79u1y8OBBc92xmL0rzU4ra588tXfvXhN00wCc1hRzNHToUPnmm29k3759pnaaZn1dccUVx/2YAAAAqP4IdgEA7N75bZus3XtUEqPD5ZUR3e31poZ2byLndqgvBYU2eWPxXlrMRzT4dMEFF5haXlrv6r///a+5XYcUapCpffv2MnLkSDnttNPs99HaXhrIKq1A/fnnn28CQddcc42ceOKJpg6XDlN0zNpydMkll8jAgQNL3N6oUSO544475NRTTzWPX6dOnVKfhwbT+vfvX2qBen2O1nDEk046yQTeHPd3+fLl5vKkSZNMHa5nn33WbEtPGgS0gm8666MWsddgYL169cyskwAAAKj5gmwVnSoKHjt69KiZHUqPXuuR9cqms2HpjwSdscr1CDu8i7b3LdrfO1IycuVfj/8qadn58ti/O8llPZo6LV+376gMfGa+BAeJzLntTGmW6NkwuepEh9Zt3bpVTjjhBKfhgv5AZ1zs3Lmz3HTTTWbIYGVnjTnOqnjllVfKG2+8Ieedd55XHsMfaXdJs94qo+3dvQ+93WeozqriuVOzC6g81OwC4A/9BiIkAADj2VkbTaCrfcNYGdqtZJHvdg1ipXerRCm0iXz1+x5arYbSLCotPE+gCwAAAP6KYBcAQHYfyZL3F283LXHP+e0lRNO33BjStZE5/2rVHpPpgqrz9ttv24ctAgAAACgdwS4AgLy3aLvkF9qkV8tE6dOmbqktonW7IkKDZMuhDPl791FaDgAAAEC1Q7ALAAJcVm6BfLxsh7k8ps8JZa5bOzJMzmgZby5/88fuKtk/AAAAAKgIgl0AEOD+9+ceOZKZJ00SouSsdknlrn9WmwRzPmttyVn0APi3efPmyaBBg8zsmlqI/6uvvvJoUoNu3bpJRESEmflSh9wCAAD4EsEuAAhw3/+115xf3qNpqbW6HPVsFithIUVDGTcfTK+CPQRQVTIyMsysny+++KJH6+uskhdccIH069dPVq1aZerKXXPNNfLjjz96fV8BAABKE1rqEgBAjZeeky8LNyWbywM7NvDoPtERIXJay0SZv/GQzFq7X1rVi/HyXgKoKjoLZ0Vm4nzllVfkhBNOkCeffNJcb9++vSxYsECefvppGTBggBf3FAAAoHRkdgFAAJu34aDkFhRKi8Ra0jrJ86DV2cXDHX9hKONxy83NlTvvvNMM/9JAwcknnyzvvPOOR/fdtm2bCTY4Ov/882X9+vUV3o9jvV9p6tata/bPnbVr15psoFatWpmTBldWr15tXz5lyhQzhO7LL7+036azf2pQJT6+qGZceVq0aGEyjZQOq1u3bl2p6x44cEAGDhwobdq0kY4dO5qhfKV5/PHHzTodOnSQIUOGyJEjR+zLlixZYrKiTjzxRDnrrLNk9+6aX9du0aJFcs455zjdpkEuvb00OTk5cvToUaeTKiws9NopWGycaAPeA5X0HvDm/yon2oD3AO+BQg/awBNkdgFAAPtp9T5zfu5JDUxwwVP92taTKf8TWbk9xWSHxUT44deJzSaSl+ndxwirJVJOu44ePdr8+P/jjz8kOjraBIg0+JOfny9jx471KNg1fvx4+23ffffdMe3qsd6vovbs2SNnnnmmPPPMMzJ8+HBz20cffSR9+/Y1wanGjRub27p37y5vvfWWCSipWbNmmQBaSkpKhR9Tg10aJGvXrp3b5XfddZecdtpp8sMPP8iyZcvMY+rwvLCwMKf1fvnlF7MtDWrVrl1bHnzwQbnnnnvMkD/teF155ZXy+uuvmyF9TzzxhBnS9+mnn0pNtm/fPqlfv77TbXpdA1hZWVkSFRVV4j6PPPKITJ06tcTtBw8elOzsbK/sZ/sEm1e2CwQiPUAAAL6Slpbm0Xp++OsEAFAZ8goKZfa6og5r/w7OP1bL07ROLWlWp5bsOJwpS7cmy1ntKnb/akEDXQ838u5j3L1HJDy61MUbN240BcB37txpAl1WRpIOCdMAlga7tPj3TTfdZAqAr1y5UsLDw+XNN9+Url27mnW2b98uXbp0kWbNmsk333xj7q/b1Ns0gKRBIw3gaGBs1KhR0qtXL3n44Ydl165d8p///EcmTJhgf1y9nxYmP/fcc+37qOtpwfLp06eb/dUAjv7Q0QDdtddea/ZN6WNrhpoGiDRLqjQvvfSS2S8r0KWGDRtmsrheeOEFEwhRffr0kZ9++skEUxo0aGACX2PGjJGJEyfa76cBWg1+WdleGgxbvny5eS6WN954w9x2yy23mIwxfe6axebok08+kU2bNpnLp5xyimmDuXPnlshY+vPPP+X00083gS6l29HnosGuFStWSGhoqAl0qeuuu07uvfdeE7yJjIws400SePQ1tN53SgNjTZs2lXr16klsbKxXHnNtiufBfABlS0oqfzIbAPAWT/tVBLsAIEAt3XpYjmbnS2J0uHRrVjTDYkWc3jpRdizNNDW//DLYVQ38/vvvZuhcYmKi0+0akNIAmGa6KB3i9+yzz5rhjZoFpcEhHQqoWV0afLKG67mjwbBff/3VBBQ0CKTBofnz55sMq7Zt25oAkuPQQP0RY21PH1eHG956661SUFBgHvf99983GVKZmZkmG6pnz57SvHlzufrqq812dXjfa6+9JsnJRbXgXGnArn///iVu1+eswS1HV111lXnOGjjSgJ1mUjkGuzyhxdJ1n7WdBg8eXGK57mdeXp4JqFm0nXbs2FFiXQ04vvrqq/Zspg8++MAcXTx8+LBZX9vBogExDdxoO7ds2VJqKm23/fv3O92m1/W5u8vqUjpro55cBQcHm5M3FArBLqCyeOv/FAAq8zOIYBcABKhvVu0x5+e0r+/RLIyuTm9dVz5aulMWbjokfkmHGGrmlbcfoxJo8OXss882dasuvfRSueGGG0wwzBP//ve/JSQkRBISEkzQ5cILLzQZUTpcUDNpNONLs8BcaZDm4osvNhlVWqNqzZo1Jvh1xRVX2NfRQI/evnfvXunUqZMJdCnNSPu///u/Cj9P1+CIZqJpYCwmJkYuu+wyn//A0iwuDfxpG2qbWkMsNaMrUGmQ0nUI7M8//2xuBwAA8JXA7Z0BQADLyMmXmX/tNZcHdy2qkVRRvVoWZSOt25cmh9JzpG5MyUyNak1raZUxxLAq6FBEHRqo2UWO2V1a3Nsa1uWOBqs8rbHmmOqtARrX61obzJUGsTSgo8P+tNC60kBbnTp13GaR6RBG1/0rjWZH6fPTYYWO9LbevXs73aYBOc2W0vpOv/32W4lt6f5rxpnlWOo9abtrsMoaLqk0AKjDQt3RQOONN95oLi9evFiaNGlisph0fc2ic2zD1NRUMyTSn6Snp9uHdCqtXaavub72+hw1s04L77/77rtmuQ6l1eGnd9xxh8kSnD17thkWOnPmTB8+CwAAEOjIQQWAAPTBku2msHzzxFrS84Q6x7SNxJgIad+wqL7Ob5vdD1lD2XQIo9bD0tpXOizQCrRo9tB9991nX09v06GI6vPPPzdD6KwgiwZUKpMGvzQbTE86jNCiQx718bR2l0WDIjqET7N4tJ6VNeOhZoPpLJPuXH/99ea5fPjhh/bbdGimZohpO7h64IEHzPBFna3Sld6mxeLVF198IRkZGW4fs7x20mw5a1ZLHS6pwRwtou+OZrEpfb0mTZpkgjxKa6PpcEjrddLhjvra+lu9Lq1vpkFYPSmtraWX9blaz99xiKfOkKmBLc3m0pkotd6c1knTGRkBAAB8hcwuAAgwWbkF8tq8LebyjX1bS/AxDGG09GmdKGv3HpWFGw/JRZ39K4OlutAMGS1kfvLJJ5vi85qtdPvtt5ssGctJJ51kZgHUgvJaAF4DRZo9pUMHdZkOM9Qhiq4ZVsdi4cKFZtZBrbukGTrqoosukvvvv1++/fZbU/vq6aefNhlVWhBe90UzsKyZE/U5aIF61zpkFl1Xi+7rc9SAnmYS6RBLDVq5K07eo0cPc3JH90PbRNtPa4uV9pgaRNMAoq7vrkD9o48+KiNGjDDBR91/rfFlzcSoQR7NztK6YUqDODrzogbz9D5WgX4dYqn30/U0w0zv895774m/0aGamsVXGn0furuP1p8DAACoLoJsZfVocFy0GHBcXJw5muyN2YW0s60zYmkxYV/XMQk0tD3t789emrNJHvthvTStEyWzb+0rYSHBx/ze/3X9Abl6+jIzM+O8O4pmoavONAihw7I0G8VfMm40MGQVodevbM280mF3ng5jrO609pjWBtNhkxpQq64qs+3dvQ+93Weozqriube4i2GVQGXZNu0CGhNAte83kNkFAAFk/9FseXF2UT2e/559YoUCXe70aJ5gSl/tOJwpB9NypF5tP6vbBZ/T2mQ6QyMAAABQWUgHAoAAoZkpD3y7RjJyC6RL03gZcoyF6R3VjgyTE5Nqm8srd6RUwl7C3RAxd0XhAQAAALhHsAsAAsSnK3bJt3/ulZDgILn/4pOOq1aXo27N4805wS4AAAAA1QHBLgAIAD+v2S/3ffW3uTyh/4nSqUlRgKoydG2WYM5/336k0rYJAAAAAMeKYBcA1HAfLd0h1723XHLyC+XcDvXl+jNbVer2uxUHu/7cfUTyCgorddsAAAAAUFEEuwCgBvtp9T6Z+MVfUmgTuaxHE3npym6VNnzR0rJutMRFhUl2XqGs3Xu0UrcNAAAAABVFsAsAaqj0nHy5+8uioYtXndZMHh3aSUKPc/ZFdzR41rVZcd2u7RSpr4guXbqYU4cOHSQkJMR+/fLLLxdve+aZZ2Tfvn1efxwAAACgqoVW+SMCAKrE2wu3yqH0HGmRWEsmXXiSBAVVbkaX61DGOesPysodR2T06V57mBrHmmVx27ZtJshV0VkX8/PzJTQ09JiDXTrTY4MGDY7p/gAAAEB1RWYXANRAOfkF8vZv28zl/55zooSHevfj3qrb5Y8zMmbmZZZ6yinI8Xjd7PzsStkfDWANGDBAevToISeddJIMHz5cMjIyzLI5c+ZI586dZezYsSY49uWXX8pvv/1mLp988skyZswYs1zXU5q5ddlll8mpp55qlt97773m9vvvv1/27NljMsiOJcgGAAAAVGdkdgFADfTT6v1yKD1XGsRGygWdGnr98To3jRNNHNuVkiUH0rIlqXak+IueH/YsddkZjc+Ql855yX697yd9JSs/y+26Per3kOkDpx/3/uhwxg8//FASExPFZrPJDTfcIM8//7zcddddZvm6devkpZdekrfeektyc3OlVatW8u6770q/fv3k119/lenT/9mHUaNGyd133y1nnnmmCaJdeOGF8umnn8qkSZPM/WfMmGGCXQAAAEBNQrALAGqgT5bvNOf/7t5EwrxQp8tV7cgwaZMUIxv2p8uqHUfk3JMYGnesNMD19NNPy8yZM02AKjU1VXr37m1f3rJlSxO8sgJfOoxRA11KzzX4pTQbbNasWbJ//377fdPT02X9+vXH8UoDAAAA1R/BLgCoYXalZMqCTYfM5ct6NK2yx+3aNMEEu37f6V/BriXDl5S6LCQ4xOn6nMuKhge6ExxUOUFFzeqaPXu2zJ07V2JjY+W5554z1y3R0dFl3t+qzaZBM7V48WKJjPSfTDsAAADgeFGzCwBqmG//3Csa5+jVMlGaJdaqsse1ZmTUzC5/UiusVqmniJAIj9eNDK2cgFJKSorUrVvXBLrS0tLk7bffLnXdtm3bSl5engmMKT3ftGmTuRwTE2MyvaZNm2ZfX+t07dq1y1zW7WvWGAAAAFDTEOwCgBrm13UHzPnAjlWbXdW1uEj9H7uOSEFhUVYRKm7kyJGSmZlpAlnnnXeenHHGGaWuGxERIR9//LH85z//MQXotV6X3i8+vijw+MEHH5jgV8eOHc3ySy65RJKTk80yvc+4ceMoUA8AAIAah2GMAFCDHM3OkxXbi2ZE7Nc2qUofu3VSjMREhEp6Tr5s2J8m7RvGVunj+7MWLVrIkSNFGXFxcXHyyy+/uF2vb9++snz5cqfbdPbFP/74w1xetmyZ/Pjjj3LiiSea60lJSfL++++73dY111xjTgAAAEBNQ7ALAGqQhRsPSX6hTVrWi67SIYwqJDjIzMq4cFOy/L7jCMGuKvL555+bgvZao0uL1b/33ntSq1bVvvYAAABAdUKwCwBqkF/XFw1h7Hti1WZ1ORapLwp2pcjwns18sg+BZvTo0eYEAAAAoBrU7Hr55ZelU6dOpkiunnr16iXff/+9ffnmzZtlyJAhUq9ePbP8sssuc5pC3aLTs/fs2VOioqIkISFBBg8e7PbxtE5JkyZNzExV1nCR8uTk5Jh6JnqfVatWHcezBQDvW7r1sDk/48S6Pmluq0i9zsgIAAAAAAEX7NLAk84StWLFClOD5KyzzpKLL75YVq9eLRkZGXLuueeaIJNOub5w4ULJzc2VQYMGSWFhodPwjREjRsjVV19tapboesOHD3f7eGPHjjXBtYq44447pFGjRsf9XAHA25LTc2Rbcqa53K1pUbH4qtalaVGwa9OBdEnNypPqSof8Ab7i2I8BAABADRvGqIErRw899JDJ9lq8eLHs3r1btm3bJr///rvJ6lLvvPOOydzS4Nc555wj+fn5cvPNN8vjjz9uAlmWDh06lHgs3a5mc02aNMkpe6wsut5PP/1kAmqe3gcAfEXrZFmF4uNqhflkHxJjIqR5Yi3Znpwpf+w8Iv86sZ5UJ2FhYeYgysGDB03WsF72Jxqk0+8+rc3lb/vu7yqj7XUbeuBO33/BwcESHh5e6fsJAACAalSzq6CgQD799FOT0aXDGXUIo3YmdVp1S2RkpOkcLliwwAS7Vq5caYJielvXrl1l3759ZsihBr90mnXLmjVr5P7775clS5bIli1bPNofHS6pU7J/9dVXHhf61SGPerIcPXrUfgTXG0dxdZvaceYIcdWj7X2L9ndv5Y6iWRi7No332ueCJ22v2V0a7Fq5/bD0aZ0o1Yl+rzRu3Nh8d2zdulX8kba9fu/Bf9te+xWa3W5t0/EcAAAANSDY9ddff5ngVnZ2tsTExMiXX35pMrP0iHt0dLTceeed8vDDD5sfV3fddZcJiu3du9fc1wpcTZkyRZ566ikzdfuTTz5ppmbfsGGD1KlTxwSfhg0bZgJgzZo18yjYpY+lxX7Hjx8vPXr0MBlmnnjkkUdk6tSpJW7XI7j6/CqbdoxTU1PN/vLDp2rR9r5F+7u3ZFNRcfrWCSFy4MABn7V96/iQov3ZfEAOnBwn1ZFmDOv3ib/Rdk9LSzPfl2R2+Wfb6/+Nnlxrh+q2AQAAUEOCXW3btjWF3/XH02effSajRo2SuXPnmoCXZnpdf/318txzz5mOoQatunXrZv+BZR0Fveeee2To0KHm8vTp083RUr3vddddJxMnTpT27dvLVVdd5fE+Pf/886bTqfetCF1/woQJTpldTZs2tRfYr2z6/LXDrdsn2FW1aHvfov1LKii0ydoDRZNo/KtDU0lKqu2ztu/TIVyenLNT1uzP8suhgtWZtr81BJPP/ZrV9pq9DgAAgBoS7NJ6Fa1btzaXu3fvLsuWLZNnn31WXn31VVOgXoczHjp0yNTIiI+PlwYNGkjLli3N+g0bNixRo0uHPeryHTt2mOta30uzxzSQ5liUuG7duiZI5i4TS++zaNEipyGUSrO8rrzySlM7zB1d3/U+jkdxvUF/RHpz+6Dtqyve+842HUyTzNwCiQ4PkRMbxEpwcJDP2v6kRvESHhpsCtRvP5wlLevFeG1fAhHv/ZrZ9nyPAwAA1KBgl7sjp451r6zAlBWE0qE5F110kT04psGl9evXS58+fcxteXl5Zthh8+bNzXUtLp+VlWXflgbTxowZI/Pnz5dWrVq53QfNJHvwwQft1/fs2SMDBgyQGTNmSM+ePb3wrAHg+KzZU1QjsH3DWAnxYqDLExroOrlxnKzYnmKK5hPsAgAAABAwwS4d9nfeeeeZWlo6bPDDDz+UOXPmyI8//mgfkqhDEHXIgGZa6cyLt9xyixn6qHRooNbVmjx5shkuqAEurc2lLr30UnPuGtDSLDGl29VMMbV06VIZOXKkzJo1yxQu1v1xpPU5rG1ZBWUBoDpZvSfVnJ/UqPKHTB8LLZJvgl07U2Rodz43AQAAAARIsEuztDTIpAXn4+LipFOnTibQ1b9/f7NcM7Y0IHb48GFTfF6HHWqwy5EGt3SI44gRI0wGl2ZeaQZYQkKCx/uRmZlpHkuzwgDAH60uzuw6qVH1KAjftZl+Bm81mV0AAAAAEDDBrjfffLPM5dOmTTOnsoSFhckTTzxhTp7QmRqtul1l3eZIA21lLQcAX9LPJyvY1aGaZHZ1bloUdFu/L02y8wokMqxohkYAAAAA8DaqmgOAn9t9JMsUgw8NDpI29atHMfjG8VFSJzpc8gttsm5fmq93BwAAAEAAIdgFADWkOH2b+rUlIjSk2sxa16lJUXbXX7sYyggAAACg6hDsAoAaU6+regxhtHRqXBTs+mNXUfF8AAAAAKgKBLsAwM/Z63U1rF7BrpObFM14+xfBLgAAAABViGAXAPi5NXtSq2dmV/Ewxo0H0iQzN9/XuwMAAAAgQBDsAgA/lpqZJ3tSs83l9tUs2FU/NlLqx0ZIoe2fumIAAAAA4G0EuwDAj2nWlGoUFymxkWFS3ZzcuGgoI3W7AAAAAFQVgl0A4Mc2HUg3562SYqQ6YkZGAAAAAFWNYBcA1IBgV5uk2lIdnVxct+uv3czICAAAAKBqEOwCAD+2sTjY1bqaZnZZM0RuS86U7LwCX+8OAAAAgABAsAsAakJmV/3qGexKqh0hcVFhUlBok80Hi/YVAAAAALyJYBcA+KmMnHzZfSTLXG5dr3oGu4KCgqRtg6Ihlhv2FxXTBwAAAABvItgFAH5qy8EMc143JlwSosOlumpbvyjYtW4fwS7AX7z44ovSokULiYyMlJ49e8rSpUvLXP+ZZ56Rtm3bSlRUlDRt2lRuueUWyc7OrrL9BQAAcESwCwD81KaDRcGjVtU0q8tyopXZRbAL8AszZsyQCRMmyOTJk2XlypXSuXNnGTBggBw4cMDt+h9++KHcddddZv21a9fKm2++abZx9913V/m+AwAAqFCaAQD809bizK6W9aKlOmtXHOxaT7AL8AtPPfWUjBs3Tq6++mpz/ZVXXpGZM2fKW2+9ZYJarn777Tc5/fTTZfjw4ea6ZoQNGzZMlixZ4nb7OTk55mQ5evSoOS8sLDQnbwgWm1e2CwQib/2fAkBlfgYR7AIAP7U1OdOct0is3sGuE5OKgl17UrPlaHaexEaG+XqXAJQiNzdXVqxYIRMnTrTfFhwcLOecc44sWrTI7X169+4t77//vhnqeOqpp8qWLVvku+++kxEjRrhd/5FHHpGpU6eWuP3gwYNeG/rYPoFgF1BZSsvyBICqkJbmWWkUgl0A4Ke2HSrK7GpRt3oHu+JqhUnDuEjZm5otG/enSffmdXy9SwBKcejQISkoKJD69es73a7X161b5/Y+mtGl9+vTp4/YbDbJz8+X8ePHlzqMUQNpOkzSMbNL63zVq1dPYmNjvfLarE0J8sp2gUCUlJTk610AEMAiIyM9Wo9gFwD4If1BaQW7TqjmwS51Yv3aJtilReoJdgE1y5w5c+Thhx+Wl156yRSz37Rpk9x8883ywAMPyH333Vdi/YiICHNypRlkevKGQiHYBVQWb/2fAkBlfgYR7AIAP5SckStpOfkSFCTSrE4tqe7aNqgtczccpEg9UM3VrVtXQkJCZP/+/U636/UGDRq4vY8GtHTI4jXXXGOun3zyyZKRkSHXXnut3HPPPfwwBgAAVY6wPAD4ISurq1FclESGhUh117Z+Ud0uzewCUH2Fh4dL9+7dZdasWU6FYPV6r1693N4nMzOzREBLA2ZWFioAAEBVI7MLAPzQVnu9ruqf1WVldqkN+9PMj98gTUkDUC1pPa1Ro0ZJjx49TMH5Z555xmRqWbMzjhw5Uho3bmwKzatBgwaZGRy7du1qH8ao2V56uxX0AgAAqEoEuwDAD21LzvCLmRgtrZNiJDhIJCUzTw6m5UhSrGeFJQFUvcsvv9zMjDhp0iTZt2+fdOnSRX744Qd70fodO3Y4ZXLde++9JoCt57t37zaF5jXQ9dBDD/HyAQAAnyDYBQB+aFtypl8Fu3Sope7rlkMZsn5/GsEuoJq76aabzKm0gvSOQkNDZfLkyeYEAABQHVCzCwD80K7DRcGuZon+MYzRmpFRraduFwAAAAAvItgFAH5oV0qWOW+SECX+wqrbRbALAAAAgDcR7AIAP5OVWyDJGbnmcpN4/8nscixSDwAAAADeQrALAPzM7iNFQxhrR4RKbFSo3w1j3LA/XQoLbb7eHQAAAAA1FMEuAPDTIYyNE6LMDGj+okViLQkPDZasvALZmVIUsAMAAACAykawCwD8jD/W61KhIcHSsm7R7JGbDqT7encAAAAA1FD+M/4FAGDsPlKc2RXvX8Eu1SopRtbtS5PNB9Pl7Pb1fb07gN9bu3atfPzxxzJ//nzZvn27ZGZmSr169aRr164yYMAAGTp0qERERPh6NwEAAKoUmV0A4LeZXf5TnN7Sql6MOSezCzg+K1eulHPOOccEtRYsWCA9e/aU//73v/LAAw/IVVddJTabTe655x5p1KiRPProo5KTk0OTAwCAgEFmFwD4md3F9a60Zpe/aZ1UFOzafDDD17sC+DXN2Lr99tvls88+k/j4+FLXW7RokTz77LPy5JNPyt13312l+wgAAOArBLsAwM/4a80u1arePzW7NPPEnwrsA9XJhg0bJCwsrNz1evXqZU55eXlVsl8AAADVAcMYAcCP5OQXyIG0HL+t2dWyboxofCs1K0+SM3J9vTuA33IMdL377rtuhynm5uaaZa7rAwAA1HQEuwDAj+w5km3Oo8JCpE50uPibqPAQe5COul1A5bj66qslNTW1xO1paWlmGQAAQKAh2AUAfmRXcb0uHcLor0MA/6nble7rXQFqhNKGBO/atUvi4uJ8sk8AAAC+RM0uAPAju4vrdfljcXrHGRnnrD9IZhdwnHQmRg1y6enss8+W0NB/unUFBQWydetWGThwIO0MAAACDsEuAPAj/lyc3sKMjEDlGDx4sDlftWqVDBgwQGJiirImVXh4uLRo0cLM2ggAABBoCHYBgB/ZfaQ4syu+lvhzZpfafIBhjMCxuuSSS+Ttt9+W2NhYE9S64oorJCIiggYFAACgZhcA+G/NLn/P7NLAXWZuvq93B/BL3377rWRkZJjLY8aMcVugHgAAIFCR2QUAfqQm1OzSWSQTaoVJSmaebDmYIR0bU0AbqKh27drJxIkTpV+/fqZA/SeffGKyvNwZOXIkDQwAAAIKwS4A8BN5BYWy72i232d2Wdldy7almBkZCXYBFffKK6/IhAkTZObMmaZA/b333ut2Rka9jWAXAAAINAS7AMBP7EvNlkKbSHhosNSN9u/aPFq3S4Ndm6jbBRyT3r17y+LFi83l4OBg2bBhgyQlJdGaAAAA1OwCAP+x06rXFR8lwcElMzj8c0ZGitQDx2vr1q1Sr149GhIAAKBYsHUBAFC91YR6Xa4zMpLZBRybHTt22C83b97c7RBGR7t376apAQBAwPBpsOvll1+WTp06mYKqeurVq5d8//339uWbN2+WIUOGmKOVuvyyyy6T/fv3l9iO1qvo2bOnREVFSUJCggwePNjt4yUnJ0uTJk1Mh/DIkSOl7te2bdtk7NixcsIJJ5httmrVSiZPniy5ubmV9MwBoOJ2FQe7/L1el2Nm17ZDmZJfUOjr3QH8zimnnCLXXXedLFu2rNR1dIbG119/XTp27Ciff/55le4fAABAwNbs0sDTtGnTpE2bNmYmoXfeeUcuvvhi+f3336VFixZy7rnnSufOnWX27Nlm/fvuu08GDRpkalRofQqlnbdx48bJww8/LGeddZbk5+fL33//7fbxNIClwbXyjm6uW7dOCgsL5dVXX5XWrVub7elj6BTfTzzxhBdaAgDKt/tIcWZXvP8HuxrFR0lEaLDk5BfKzpQsOaFutK93CfAra9askYceekj69+8vkZGR0r17d2nUqJG5nJKSYpavXr1aunXrJo899picf/75vt5lAACAwAh2aeDKkXbaNNtLg1kakNIMKw18WVNpazBMM7c0+HXOOeeYwNbNN98sjz/+uAlkWTp06FDisXS7ms01adIkp+wxdwYOHGhOlpYtW8r69evNNgh2AfCVXVbNroRafv8ihAQHSct6MbJ271HZfCCdYBdQQYmJifLUU0+ZvpNmuC9YsEC2b98uWVlZUrduXbnyyitlwIABJqsLAAAg0FSb2RgLCgrk008/NdlTOpxRhzDqcMOIiH9mHNOjlZrRpR06DXatXLnSBMX0tq5du8q+ffukS5cuJvjl2LnTo5v333+/LFmyRLZs2XJM+6dDAerUqVPmOjk5OeZkOXr0qDnXLDE9VTbdpmbEeWPboO2rs0B971vDGBvFR/rsuVdm27eqG22CXZsOpMlZ7SiuXdXtj+rV9se6XS238O9//9ucAAAAUE2CXX/99ZcJbmVnZ0tMTIx8+eWXJjNL63RFR0fLnXfeaYYoagfzrrvuMkGxvXv3mvtagaspU6aYo5s69PHJJ5+Uvn37mim4NTilwadhw4aZAFizZs2OKdi1adMmef7558vN6nrkkUdk6tSpJW4/ePCgeX7e6BhrEE7bxhrWiapB2/tWILZ/fqFN9qYWBbsi8zPkwIE8v2/7xEibOd+w57AcOFBUwwtV1/6oXm2flpbGSwIAAFBTgl1t27aVVatWmQ7kZ599JqNGjZK5c+eagJdmel1//fXy3HPPmY6lBq209oTVybSOgt5zzz0ydOhQc3n69OmmFpjeVwu3Tpw4Udq3by9XXXXVMe2fZo7pkMZLL73U1O0qiz7WhAkTnDK7mjZtai+wX9n0+Wv2m26fHz1Vi7b3rUBsf63XpXXcw0KCpP0Jjc0wQH9v+7ZNckSW7ZPkbJGkpKRK28eaLBDf+4HS9pq9DgAAgBoS7AoPDzdF4JUWV9VZhZ599llTHF4L1OtwxkOHDkloaKjEx8dLgwYNTA0t1bBhwxI1unTYoy63puTW+l6aPaaBNKVHZJXWs9AgmbtMLMuePXukX79+0rt3b3nttdfKfS762I7DLi3aKfbWjxLteHtz+6Dtq6tAe+/vTS0aIt0wLkrCQkNqRNs3qxNtD+QFyutYGQLtvR8obc/rCQAAUIOCXe6OnDrWvbICU1bg6sCBA3LRRRfZg2MaXNLi8X369DG35eXlmcL2zZs3t8/WqMVaLRpMGzNmjMyfP19atWpVZkaXBrr0MTRbjE4ogOpRnN7/Z2K0WM9Fn5seiNBAAgAAAAD4dbBLh/2dd955ppaW1qr48MMPZc6cOfLjjz+a5Rpk0iGIOmRg0aJFZubFW265xQx9VDo0cPz48TJ58mQzXFADXFqbS+mwQ+Ua0NIsMaXb1UwxtXTpUhk5cqTMmjVLGjdubAJdWvdLt6d1urTmlkUzywCgqu0uLk7fOL7mBLsaxkeKxrey8wrlUHqu1KtdMjMWQPnmzZtnstA1C96Rzlr922+/yb/+9S+aEQAABBSfBrs0S0uDTFpwPi4uTjp16mQCXf379zfLNWNLA2KHDx82xed12KEGuxxpcEs7dyNGjDAZXD179jQZYAkJCR7vR2ZmpnkszQpTP//8sylKryet/+XIGgYJAL6YibFJQq0a0/ARoSHSIDZS9qZmm+wugl3AsdFMdO1Luda+03qoukwn9wEAAAgkPg12vfnmm2UunzZtmjmVJSwszGRflTdTokUztlwDVq63jR492pwAoLrQulaqcQ0axmgNZdRg186ULOnazPODFAD+Udow4OTkZDOzNQAAQKCpdjW7AACBUbNLNU2oJcu2pdifHwDPXXLJJeZcA116kM5xkhzN5vrzzz/N8EYAAIBAQ7ALAKq5wkKb7DmSXeNqdjkG73Ye/mciEQCe0RIQVmZX7dq1JSoqymm269NOO03GjRtHcwIAgIBDsAsAqrmD6TmSW1AoIcFB0jAuUmoSqwYZmV1AxelEPkrrmt52220MWQQAACgWbF0AAFTv4vRazD00pGZ9bDepE+U02ySAitNZqXUI4y+//CKvvvqqmeFa7dmzR9LT02lSAAAQcMjsAoBqzsp6qmnF6a2aXVZAT4drBgeXLLINoGzbt2+XgQMHyo4dOyQnJ8fMaq3DGh999FFz/ZVXXqEJAQBAQKlZKQIAUINnYqxpxelVg7hI0fiWDtPU4ZoAKu7mm2+WHj16SEpKilPdriFDhsisWbNoUgAAEHDI7AIAPxnG2KSGFadXYSHB0jAuygT0NIOtfmzNqkkGVIX58+fLb7/9ZorSO9JaXrt37+ZFAAAAAYfMLgDwl2BX8ZC/moYZGYHjU1hYKAUFBSVu37VrlxnOeCxefPFFEyyLjIyUnj17ytKlS8tc/8iRI3LjjTdKw4YNTf2wE088Ub777rtjemwAAIDjRbALAKq53TW4ZpdiRkbg+Jx77rnyzDPP2K8HBQWZwvRauP7888+v8PZmzJghEyZMMPdfuXKldO7cWQYMGCAHDhxwu35ubq6pE7Zt2zb57LPPZP369fL6669L48aNj+t5AQAAHCuGMQJANWaz2Wp0zS7VOL5o6OKe1Gxf7wrgl5588kkTjOrQoYNkZ2fL8OHDZePGjVK3bl356KOPKry9p556SsaNGydXX321ua4F7mfOnClvvfWW3HXXXSXW19sPHz5shlKGhYWZ2zQrDAAAwFcIdgFANZackSvZeYUSFCSmtlVN1LC4Ftne4qAegIpp0qSJ/PHHH/Lxxx/Ln3/+abK6xo4dK1deeaVTwXpPaJbWihUrZOLEifbbgoOD5ZxzzpFFixa5vc8333wjvXr1MsMYv/76a6lXr54JuN15550SEhJSYn2dIVJPlqNHj9qHY+rJG4LF5pXtAoHIW/+nAFCZn0EEuwDAD+p11a8dKeGhNXPkecO4osyuvWR2AccsNDRUrrrqquNuwUOHDpn6X/Xr13e6Xa+vW7fO7X22bNkis2fPNsE1rdO1adMmueGGGyQvL88MhXT1yCOPyNSpU0vcfvDgQZOZ5g3tEwh2AZWltCHNAFAV0tLSPFqPYBcAVGO7i4NdNbVel2pcnNllDdcEUDGaWeWO1u7SAvOtW7eWE044watHWJOSkuS1114zmVzdu3c3s0A+/vjjboNdmjWmNcEcM7uaNm1qMsJiY2O9so9rU4K8sl0gEOn/OwD4ivZtPEGwCwCqsV3Fxelrar0ux2GMadn5kp6TLzERfDUBFTF48GAT2NIaf46s2/S8T58+8tVXX0lCQkKZ29I6Xxqw2r9/v9Pter1Bgwbu/4cbNjS1uhyHLLZv31727dtnhkWGh4c7ra+zNerJlQ6X1JM3FArBLqCyeOv/FAAq8zOITyoAqMasbCcr+6km0uBW7ciiABd1u4CK+/nnn+WUU04x56mpqeakl3v27CnffvutzJs3T5KTk+W2224rd1samNLMrFmzZjllbul1rcvlzumnn26GLjrW0NiwYYMJgrkGugAAAKoCwS4AqMZ2HrYyu2pJTWYF85iREai4m2++2cygePbZZ0vt2rXNSS/rMMLbb7/dBKOeeeYZEwDzhA4xfP311+Wdd96RtWvXyvXXXy8ZGRn22RlHjhzpVMBel+tsjLofGuTSmRsffvhhU7AeAADAFxgrAgDV2PbiYFfzxJod7NIi9ev2pcke6nYBFbZ582a3ta70Ni0er9q0aWOKz3vi8ssvN8XiJ02aZIYidunSRX744Qd70fodO3Y4DSHQels//vij3HLLLdKpUydp3LixCXzpbIwAAAC+QLALAKqpgkKbPbOrxge7ijO7GMYIVJwOO9QMrnfffdcUeVcarLrjjjvM8Ea1ceNGE5Ty1E033WRO7syZM6fEbTrEcfHixbx8AADAP4NdW7dulfnz58v27dslMzPTdKq6du1qOjmeVsUHAJRvb2qW5BXYJCwkSBrG1dyaXYphjMCxe+ONN0yR+iZNmtgDWjt37pSWLVvK119/ba6np6fLvffeSzMDAICA4HGw64MPPpBnn31Wli9fbtLYGzVqJFFRUaZGg6bPa6DryiuvNCnrzZs39+5eA0AA2JFclNXVNKGWhAQH1fhhjIphjEDFtWvXTtasWSM//fSTqZml2rZtK/3797cPN9RgGAAAQKDwKNilmVs6m87o0aPl888/L5EGn5OTI4sWLZKPP/5YevToIS+99JJceuml3tpnAAioel3NavgQRmVlru1Nzfb1rgB+JS8vzxx8XLVqlQwcONCcAAAAAp1Hwa5p06bJgAEDSl0eEREhffv2NaeHHnpItm3bVpn7CAABaVtyhjlvkRgtNZ19GOORLLHZbBIUVLMz2YDKEhYWJs2aNZOCggIaFQAAoNg/U+mUoaxAl6vExERTKBUAUDnDGJvVqfmZXfXjIsx5Tn6hHM7I9fXuAH7lnnvukbvvvtuUlgAAAMAxFKgPCQmRvXv3SlJSktPtycnJ5jaOLAJA5dieHBgzMaqI0BCpGxMhh9JzzFDGxJii4BeA8r3wwguyadMmU09V66ZGRztng65cuZJmBAAAAaXCwS4dXuKO1u3Sul4AgOOnn7U7imt2NQ+AYYyqcXykCXbpUMaOjeN8vTuA36D4PAAAwDEGu5577jlzrnVUdIrrmJgY+zLN5po3b56ZDQgAcPx0KF96Tr5o6aomCUX1rAKhSP0fu1IpUg9U0OTJk2kzAACAYwl2Pf300/Zsg1deecUMZ7RoRleLFi3M7QCA42dldTWIjZTIsH8+b2uyhvGR5lwzuwAAAADAq8Gub775RtavX2+CWv369ZMvvvhCEhISjvlBAQCeBbuaBkBx+hIzMqZm+3pXAL+iGfZ6UPKTTz6RHTt2SG6u8yQPFK4HAACBxqPZGIcMGSKpqanmsg5XzMvL8/Z+AUBAs2ZibB5AwS4dxqj2ktkFVMjUqVPlqaeekssvv9z01yZMmCCXXHKJBAcHy5QpU2hNAAAQcDwKdtWrV08WL15sH8aodbsAAN7P7GoWSMEuhjECx+SDDz6Q119/XW699VYJDQ2VYcOGmfqqkyZNsvffAAAAAolHwa7x48fLxRdfbOp0aaCrQYMG5rK7EwCgEoNdiYE3jHF/Wo4UFLqf+RdASfv27ZOTTz7ZXNYJhKxs/AsvvFBmzpxJkwEAgIDjUc0uTYG/4oorZNOmTXLRRRfJ9OnTJT4+3vt7BwABKhBrdtWNiZDQ4CDJL7TJgbRs+7BGAGVr0qSJ7N27V5o1ayatWrWSn376Sbp16ybLli2TiIgImg8AAAQcj2djbNeunTnp9NaXXnqp1KoVOD/AAKAqZecVyL6j2QFXsyskOEiSakeYAvX7j+YQ7AI8pLVVZ82aJT179pT/+7//k6uuukrefPNNU6z+lltuoR0BAEDA8TjYZdFgFwDAe3YfyRKbTSQ6PETqRIcHVFMnxUYWB7uYkRHw1LRp0+yXtUh98+bN5bfffpM2bdrIoEGDaEgAABBwPKrZNXDgQI8KnKalpcmjjz4qL774YmXsGwAE9EyMOoQx0CYEqR9bNOTqAMEuwGM6U3Z+fr79+mmnnWZmZDzvvPPMMgAAgEDjUWaXDlscOnSoxMXFmSOEPXr0kEaNGklkZKSkpKTImjVrZMGCBfLdd9/JBRdcII8//rj39xwAaqidKYFXr8tSPzbSnFvDOAGUr1+/fqZmV1JSktPtWqhelxUUFNCMAAAgoHgU7Bo7dqyp//Dpp5/KjBkz5LXXXrPP9KNZBx06dJABAwaYQqjt27f39j4DQI22KyXLnDdNCNxgl9bsAuAZm83mNgs0OTlZoqOjaUYAABBwPK7ZpbP5aMBLT0qDXVlZWZKYmChhYWHe3EcACCi7ijO7miREBXCwi8wuoDyXXHKJOddA1+jRo51mXtRsrj///FN69+5NQwIAgIBT4QL1Fh3SqCcAQOXaeTgrgIcxWjW7yOwCymP1wzSzq3bt2hIV9U+APDw83NTuGjduHA0JAAACzjEHuwAA3kFmFzW7AE9Mnz7dnLdo0UJuu+02hiwCAAAUI9gFANVIek6+pGTmBe4wxtpFwxhTs/IkO69AIsNCfL1LQLU3efJkX+8CAABAtRLs6x0AAJTM6oqvFSa1IwOvHmJsVKhEhhV9NTGUEQAAAMCxINgFANXIruJ6XYGY1WUV2rYXqU+jSD0AAAAALwa7li5damb2KU1OTo588sknx7ALAADLzuLMrqYJgVec3nUoIzMyAgAAAPBqsKtXr16SnJxsvx4bGytbtmyxXz9y5IgMGzbsmHYCAFBkV0pgZ3appOIZGfelktkFVNSuXbuksLCQhgMAAAHN42CXTmtd1vXSbgMAHMtMjIGb2dWgeBjjgbQcX+8K4Hc6dOgg27Zt8/VuAAAA1JyaXVprpSJefvll6dSpk8kS05Nmj33//ff25Zs3b5YhQ4ZIvXr1zPLLLrtM9u/fX2I7M2fOlJ49e0pUVJQkJCTI4MGD3T6eZqY1adLE7KdmopXl8OHDcuWVV5rHjY+Pl7Fjx0p6enqFnh8AVNTO4ppdTesEbmaXvWbXUTK7gIriwCMAAICPC9Rr4GnatGmyYsUKWb58uZx11lly8cUXy+rVqyUjI0POPfdcE5iaPXu2LFy4UHJzc2XQoEFO6fmff/65jBgxQq6++mr5448/zHrDhw93+3gasNLgmic00KX78fPPP8u3334r8+bNk2uvvbbSnjsAuENm1z/DGAl2AQAAADgWoRVZec2aNbJv3z77kcN169bZs50OHTpU4QfXwJWjhx56yGR7LV68WHbv3m3S8H///XeTXaXeeecdk7mlwa9zzjlH8vPz5eabb5bHH3/cBLIcU/hd6XY1m2vSpElO2WPurF27Vn744QdZtmyZ9OjRw9z2/PPPy/nnny9PPPGENGrUqMLPFQDKk5qVJ0ez8yXQa3b9k9nFMEagou6++26pU6cODQcAAAJahYJdZ599tlN6/IUXXmjONftKb6/oMEZHOtPjp59+ajK6dDijDmHU7UVEFB3hV5GRkRIcHCwLFiwwwa6VK1eaoJje1rVrVxOI69Kliwl+dezY0SlId//998uSJUuciuqXZtGiRWboohXoUvp4+ji6DR1aWdqMlHqyHD161JxrJpo3isXqNrXdKURb9Wh736qp7b8zOcOcJ0aHS2RocLV8flXR9vViwu2ZXfrdcDzfLTVNTX3v+wNvt31lbXfixImVsh0AAICACHZt3brVKzvw119/meBWdna2xMTEyJdffmkys7ROV3R0tNx5553y8MMPmw7mXXfdZX747N2719zXClxNmTJFnnrqKWnRooU8+eST0rdvX9mwYYM5sqnBJ50lUgNgzZo18yjYpUGzpKQkp9tCQ0PN9qzMNnceeeQRmTp1aonbDx48aJ6fNzrGqamppm00EIeqQ9v7Vk1t/9XbimoJ1o8JlQMHDkigtn1wXoE5z8wtkG279kl0RIhXHscf1dT3vj/wdtunpaVV+jYBAAAClcfBrubNm3tlB9q2bSurVq0yHcjPPvtMRo0aJXPnzjUBL830uv766+W5554zHUsNWnXr1s3eybSOgt5zzz0ydOhQc3n69OmmFpje97rrrjNHONu3by9XXXWVeJs+1oQJE5wyu5o2bWovsF/Z9PlrxoNunx89VYu2962a2v5HNxRldp2QFFsi4B5obV878m9Jy86XwojakpQU47XH8Tc19b3vD7zd9pq9DgAAgCoOdmlNLh1i6Bj00gLuWsNKb9cZEEsrDF+W8PBwad26tbncvXt3Uyfr2WeflVdffdUUqNfhjPrYmlmlQwsbNGggLVu2NOs3bNiwRI0uHfaoy3fs2GGua30vzR7TQJqyhmHWrVvXBMncZWLpY7hmVWh9MJ2hUZeVRh/bcdilRTvF3vpRoh1vb24ftH11VRPf+7uPFGWANqlTq1o/r6poe63blZadLgfSc6VNg+rbFr5QE9/7/sKbbc/rCQAA4INg1//93/+Zwuw6TFBpMOiMM84wt7Vq1UpGjx5thhjqzIjHe+TUse6VFZiyAlf6uBdddJE9OKbBpfXr10ufPn3MbXl5eaawvRWU09kas7Ky7NvSYNqYMWNk/vz5Zr/d0WGVWsxeZ4nUx7AeW/etZ8+ex/X8AKC8mRibJtQK+EaqHxshmw6kMyMjAAAAgArz+NCkzpBoBZnUu+++a2pY6RDEr7/+2tTVevHFFys87G/evHkmOKXZV3p9zpw5cuWVV9qHJOrjanbX+++/L5deeqnccsstZuij0qGB48ePl8mTJ8tPP/1kgl467FHpukoDWlqs3jqdcMIJ5nYd2mgNE1q6dKm0a9fOFLu3lg0cOFDGjRtnli1cuFBuuukmueKKK5iJEYDX7EopCswH8kyMFmZkBMr32GOPOR3Q0/6K4wFDrQN2ww030JQAACDgeBzs0sLsWgDeoplOl1xyiRleqDQQtnHjxgo9uGZpjRw50gSvdKZHzbr68ccfpX///ma5Bq90eKQGn3Q2RR12qMMmHWnheQ1CaUbZKaecItu3bzf7lpCQ4PF+ZGZmmsfSrDDLBx98YAJgul/nn3++yRx77bXXKvT8AMBTOsT6n2AXmV3/BLsqf3IPoKbQg4SOhe3PO+88+4E7q3+jZSEAAAACjcfDGDWLSof2WcMDNeNp7NixTnUsXIcflufNN98sc/m0adPMqSxhYWEmAOYaBCuNztRo1e0q6zbNWvvwww892iYAHK8jmXmSnpNvLpPZJVK/dlH9Q4JdQOlc+y6u1wEAAAKVx5ldp512mpkVUetWabF3PZJ41lln2Zdv2LDBzDwIAKi4ncX1upJqR0hkWEjANyGZXQAAAAC8ntn1wAMPmCF9WjtLZya8++67nYYKfvzxx3LmmWce844AQCDbeZh6XY7qFWd2HUrP9dErAgAAAKDGB7s6deoka9euNcVPGzRoUGJWQq2b1aFDB2/sIwAEzkyMdajX5RjsOpiWY4Zm6VB5ACW98cYbEhMTYy7rwci3337bPou1Yz2vitJJh7QuqtZs7dy5szz//PNy6qmnlns/Pfg5bNgwufjii+Wrr77iJQMAANU72LV161Yzk6F2Xty54IILKnO/ACAghzE2pTi9UTemKNiVlVcgGbkFEhPh8dcVEDCaNWsmr7/+uv26Hox87733SqxTUTNmzJAJEybIK6+8Yg5uPvPMMzJgwAAzmY81k7U7Orv2bbfdJmeccUaFHxMAAKAyefzroVWrVqY4fb9+/eynJk2aVOrOAECgYhijs+iIUIkODzGBrkNpOQS7gFKCS97w1FNPybhx4+Tqq6821zXoNXPmTHnrrbfkrrvucnufgoICufLKK2Xq1Kkyf/58M6kRAABAtQ92zZ49W+bMmWNOH330keTm5krLli1NkXor+FW/fn3v7i0A1FAMYyypbu0IyUjOlIPpOdKibrQPXhUg8Gj/bsWKFTJx4kT7bcHBwXLOOefIokWLSr3f/fffb7K+dKZuDXaVRWfvdpzB++jRo+ZcJ0HSkzcECzNVApXFW/+nAFCZn0EeB7v69u1rTio7O1t+++03e/DrnXfekby8PGnXrp2sXr3a000CAERMTapdKUUF6hnG+I96MRGyXYNdaf/8KAbwDw0+JScny4UXXmi/7d1335XJkydLRkaGDB482NTaiogoGhbsiUOHDpksLdcDmHp93bp1bu+zYMECefPNN2XVqlUePcYjjzxiMsBcHTx40PQxvaF9AsEuoLIcOHCAxgTgM57WJD2mIiiRkZEmo6tPnz4mo+v777+XV199tdROEACgdBrMyckvlOAgkYbxkTSVmyL1ANxnU+mBSCvY9ddff5nMqtGjR0v79u1NgflGjRrJlClTvNrhHDFihKkdZhXGL49mjWlNMMfMrqZNm0q9evUkNjbWK/u5NoVJLoDKUlbtPgDwNo1HVXqwS1PbFy9eLL/++qvJ6FqyZInpnPzrX/+SF154Qc4888xj3V8ACFg7i7O6GsZFSVhIsK93p9og2AWUTTOpHnjgAaeZELWgvFW0XvtomuVVkWCXBqxCQkJk//79TrfrdS2A72rz5s2mdtigQYNKDC8IDQ01Re217qsjzTRzl22mwyX15A2FQrALqCze+j8FgMr8DPI42KWZXBrc0hkZNah13XXXyYcffigNGzb0dBMAgDLqdTVJiKJ9XIYxqkPpZHYB7qSkpDgNN5w7d66cd9559uunnHKK7Ny5s0KNFx4eLt27d5dZs2aZYZBW8Eqv33TTTSXW1xIWmlHm6N577zUZX88++6wJuAEAAFQ1j4NdWmxUA1sa9NKUeQ14JSYmenfvACAA7DxcFOxqWqeWr3el2hWoVwxjBNzTQNfWrVtNQEmz71euXOlUC0sDTmFhYRVuPh1iOGrUKOnRo4eceuqp8swzz5gaYNbsjCNHjpTGjRub2ls6lKBjx45O94+PjzfnrrcDAABUu2CXTiGtAS8dvvjoo4/KsGHD5MQTTzRBLyv4pbUWAAAVs/Nw0TBGMrvcZ3bpbIwASjr//PPlrrvuMv2yr776SmrVqiVnnHGGffmff/5ZYgihJy6//HJTLH7SpEmyb98+6dKli/zwww/2LLIdO3YwjAkAANSMYFd0dLQMHDjQnKyjhTr7jtbveuyxx+TKK6+UNm3ayN9//+3N/QWAGmfXkeLMrgQyuxxRswsom9bruuSSS8wBx5iYGDM7tg5DtLz11lty7rnnHlMz6pBFd8MWlR74LMvbb799TI8JAABQWY5pNkYr+FWnTh1zSkhIMEVI165dW2k7BgCBltnFMEb3wS6t2VVYaJNgna4SgFMx+Xnz5klqaqoJdmlheUeffvqpuR0AACDQeBzs0uKky5cvN0fzNJtr4cKFpn6D1mzo16+fvPjii+YcAOC5gkKb7DnCMEZ3EmOKMlTyCmySmpUnCdH/ZKwAEJk+fbqcffbZ0qxZM7fNoQckAQAAApHHwS4tNqrBLZ12WoNaTz/9tKnVdSy1IAAARfYfzZb8QpuEhQRJ/dhImsVBRGiIxNcKkyOZeSa7i2AX4OyGG24whembN29u+mbWSQ9EAgAABDKPg12PP/646UBpUXoAQOXOxNgoPkpCGKZXQt2YCBPs0hkZ29SvzdsOcJk86LfffpO5c+earPsPP/zQBL9at25tD3zpgUmrsDwAAECg8DjYdd1113l3TwAgAO1KYQhjeTMybjqQzoyMgBsRERH2oNaUKVMkOztbFi1aZAJfWnZCC9bn5eVJfn4+7QcAAAJKsK93AAACmT3YFc9MjO4wIyPgueDgYHMKCgoyJ5vNVmo9LwAAgJrsmGdjBAAcv10pRcMYm9aJojndINgFlE6HLC5evNhkcc2ePVuWLFli6nf961//knHjxsn7778vTZs2pQkBAEDAIdgFAD60szjY1SSBzK4yg13pOVX6ugD+IC4uTpKSkmTQoEFy4403yscff2wmEgIAAAh0BLsAwIeo2VV+gXqlBeoBOOvcubP8/vvvMm/ePPsQRi1In5iYSFMBAICARs0uAPCR/IJC2ZuabS6T2eVe3Zhwc56cnluFrwzgH3QIY3Jysjz22GMSFRVlzhs2bCgdO3aUm266ST799FM5cOCAr3cTAACgypHZBQA+su9othQU2iQsJEiSiofrwX1mV3IGmV2AOzExMTJw4EBzUmlpaTJ//nz5+eefTd2u9PR0ZmMEAAABh2AXAPh4CGPj+CgJDg7idXCjTnRRZtfhjFwzs5zOMAegpMLCQlm2bJkpVv/rr7/KwoULJSMjwxSsBwAACDQEuwDAR3YetmZipDh9ecGuvAKbHM3Ol7iosCp7fYDqbunSpSa4pacFCxaYLK4mTZqYul3PPfec9OvXT1q0aOHr3QQAAKhyBLsAwEcoTl++yLAQqR0RKmk5+ZKcnkOwC3Bw2mmnmdkXNaj11FNPmfNWrVrRRgAAIOAR7AIAnwe7yOwqS52Y8KJgV0autKxXRS8O4AfWrl0rbdu29fVuAAAAVDvMxggAPrIrpWgYY5OEKF6DMiQWD2VkRkbAGYEuAAAA9wh2AYCPMIzRM4nMyAgAAACgAgh2AYAP5OYXyt7UomGMTRnGWCYyuwAAAABUBMEuAPDREMZCm0hUWIjUqx3Ba1CGxJiiYYyHM3JpJwAAAADlItgFAD6w/XBRva7mibUkKCiI16AMidFFwcBD6Tm0E+BGdnZ2qe2yd+9e2gwAAAQcgl0A4APbD2XYg13wLLOLAvWAe926dZNVq1aVuP3zzz+XTp060WwAACDgEOwCAJ9mdkXT/h5mdjGMEXCvb9++ctppp8mjjz5qrmdkZMjo0aNlxIgRcvfdd9NsAAAg4IT6egcAIBBtT/5nGCM8zOzKYBgj4M5LL70kF1xwgVxzzTXy7bffmqGLMTExsnTpUunYsSONBgAAAg7BLgDwgW3JRcMYW5DZ5fFsjJrZVVhok+BgapwBrs477zy55JJL5OWXX5bQ0FD53//+R6ALAAAELIYxAkAVKyi0ya7DWeZyszpkdpUnoTjYpbNXHsnK8/rrA/ibzZs3S69evUxW148//ih33HGHXHTRReY8L4//GQAAEHgIdgFAFdubmiW5BYUSFhIkjeKjaP9yhIUES3ytMHM5mRkZgRK6dOkiJ5xwgvzxxx/Sv39/efDBB+XXX3+VL774Qk499VRaDAAABByCXQDgo3pdTRNqSQhD8jxSpzi761B6rjdfGsBva3Z9/PHHEh8fb7+td+/e8vvvv5uZGgEAAAINwS4AqGLr96WZ89ZJMbS9h+oyIyNQKp110Z3atWvLm2++ScsBAICAQ4F6AKhi6/YdNeftGsbS9h5iRkagfGvWrJEdO3ZIbu4/GZBBQUEyaNAgmg8AAAQUgl0AUMXWFWd2tWtQm7avYLCLYYxASVu2bJEhQ4bIX3/9ZYJbNpvN3K6XVUFBAc0GAAACCsMYAaCKZ2LcsJ9gV0XVsQ9jzPHCqwL4t5tvvtkUqD9w4IDUqlVLVq9eLfPmzZMePXrInDlzfL17AAAAVY7MLgCoQtuTMyQ7r1Aiw4KleWI0be+husWZXckUqAdKWLRokcyePVvq1q0rwcHB5tSnTx955JFH5D//+Y8pVA8AABBIfJrZ9fLLL0unTp0kNjbWnHr16iXff/+9ffnmzZtNWn69evXM8ssuu0z2799fYjszZ86Unj17SlRUlCQkJMjgwYPty5KTk2XgwIHSqFEjiYiIkKZNm8pNN90kR48W1cwpzYYNG+Tiiy82HUd9bO006jTeAFAZQxjb1q/NTIwVkFic2UWwCyhJhylqMXql/ZY9e/aYy82bN5f169fTZAAAIOD4NNjVpEkTmTZtmqxYsUKWL18uZ511lgkwafp9RkaGnHvuuabehB6tXLhwoSm4qkVWCwsL7dv4/PPPzSxEV199tfzxxx9mveHDh9uX69FN3eY333xjAlhvv/22/PLLLzJ+/Pgy9+3CCy+U/Px889i6f507dza37du3z6ttAqBmW7e3uDh9A4rTV0Sd6OLMLoYxAiV07NjR9IGUHvx77LHHTH/o/vvvl5YtW9JiAAAg4Ph0GKPr7EAPPfSQyfZavHix7N69W7Zt22ZS7zWzSr3zzjsmc0sDUOecc44JRmmdiscff1zGjh1r306HDh3sl3X966+/3n5dj3LecMMN5j6lOXTokGzcuNFM162ZZ0qDci+99JL8/fff0qBBg0ptBwCBY61VnL4hxemPaRhjxj+zzAEocu+995qDhEoDXHpw7owzzpDExESZMWMGzQQAAAJOaHVKwf/0009NZ02HM+oQRs3q0qGHlsjISJOptWDBAhPsWrlypQmK6W1du3Y1WVddunQxgSw9yumOpvZ/8cUXcuaZZ5a6L9o5bNu2rbz77rvSrVs3sw+vvvqqJCUlSffu3Uu9X05OjjlZrKGSmonmmI1WWXSbOuOSN7YN2r468+f3vpXZdWJSjF/uv6/aPqFWmDk/kpknOXn5EhYSmPOr+PN73995u+2PZ7sDBgywX27durWsW7dODh8+bA74WTMyAgAABBKfB7t0mmwNbmVnZ0tMTIx8+eWXJjNL63RFR0fLnXfeKQ8//LDpYN51110mKLZ37177VNtqypQp8tRTT0mLFi3kySeflL59+5ohi3Xq1LE/zrBhw+Trr7+WrKwsk1H2xhtvlLpP2jHUoY5a+0trYGgwTQNdP/zwg+k4lkYLwU6dOrXE7QcPHjTPzxsd49TUVNM2uo+oOrS9b/lr+2fkFsjOlCxzOTE0x8yc5m981faF+nhBei6yacdeSYwuCn4FGn9979cE3m77tLSirM/K4tgHAgAACDQ+D3ZpBtWqVatMB/Kzzz6TUaNGydy5c03ASzO9dAjic889ZzqWGrDSTCurk2kdBb3nnntk6NCh5vL06dNNLTC973XXXWd/nKefflomT55sgmATJ06UCRMmmGGJ7mhH9sYbbzQBrvnz55vC9xoc0yDZsmXLpGHDhm7vZ23XMbNLC+JbBfYrmz5/Dczp9vnRU7Voe9/y1/ZfuSPFnNePjZATmzcSf+TLtk+oFV40jDGytiQlBWbNM39979cE3m57zV6vqDFjxni03ltvvXUMewQAAOC/fB7sCg8PNyn3SocIajDp2WefNcMGtUC9DmfUGlqhoaESHx9v6mVZxVatoJNjjS4dcqjLd+zY4fQ4ej89tWvXzhzt1FoW9913n9vAldYE+/bbbyUlJcUepNLA2M8//2zqhmmGmTv62I7DLi3WNODeoB1vb24ftH115Y/v/fX70+3F6f1pv6tL29eNiTDBrpTMfL9uv0B879cU3mz7Y9mmTrqjtUi1lIMeqAMAAEA1CXa5O3LqWPfKmkbbCkLpsJ+LLrrIHhzT4JJOq92nTx9zW15enilsr52/sh5DuT6OJTMz023HU69TJwXAsVq3l+L0x4MZGQFnmv3+0UcfydatW82s1FdddRXDFwEAADR+48tW0GF/8+bNM8Eprd2l1+fMmSNXXnmlfUiizsyo2V3vv/++XHrppXLLLbeYoY9Ks67Gjx9vhif+9NNPJuhlzbyo66rvvvvObEdnUdTHmTlzprnP6aefbmp8qaVLl5qMLy12r7SGmNbm0iGVOpW3Dn28/fbbTWfyggsu8FFrAfB36/YVFadv3yAwh+Adr0RrRsZ0ZmQE1IsvvmjqmN5xxx3yv//9z5ROuOyyy+THH38k0wsAAAQ0nwa7NEtr5MiRJnh19tlnmyGM2kHr37+/Wa7BKy0S3759ezOVttbmeuKJJ5y2oTMvXnHFFTJixAg55ZRTZPv27SYDzCokr/W2Xn/9dZP5pdvRYJlmhukwRcdMLn0szQqzMsm0GH16erqcddZZ0qNHDzMDpBa479y5c5W2EYCaQYcYWZldbRvU9vXu+CUdxqiSM9xn5QKBSDPctaapllpYs2aNnHTSSXLDDTeYA3rajzmeQJpuQ2uJ9ezZ0xwYLI32s7Q8hPa99KQzZpe1PgAAQI0exvjmm2+WuXzatGnmVJawsDATAHMNgln69esnv/32W5nb0NkbXWtdaIBLA28AUBl2H8mStJx8CQ0Oklb1YmjU4xjGeFiL1AMoQcstaF0x7dPo7NXHasaMGWbCnVdeecUEup555hkZMGCAOTCok/e40qx8Dbj17t3bBMceffRRU3d19erV0rhxY14pAABQ5apdzS4AqInW7yvK6mqdFCPhoRQWP55hjIcYxgjYaf3RL774wsy4qFnoF154obzwwgsycODAYy6k/9RTT8m4ceNMHTClQS8tA6GP4W6Sng8++MDpus5g/fnnn8usWbNMBr+7fXasm6qzVyuti+qt2qjBQgF/oLJQwxiAP3wGEewCgCqwrjjY1Y4hjMcsMbp4GGM6wxgBpcMVP/74Y1Ora8yYMaZYvTWpz7HKzc2VFStWmDqqFg2a6dDERYsWebQNLQ+hpSF09mt3HnnkEZk6dWqJ2w8ePCjZ2dniDe0TCHYBlVmKBgB8JS2t6HdVeQh2AUAVWLu3KHOhXUOK0x9vZhfDGAGxZ1w1a9ZMWrZsKXPnzjUndzTzy1OHDh0yQyDr16/vdLteX7dunUfbuPPOO6VRo0YmQOaOBtJ0mKRjZpcG7OrVq2cmH/KGtSlBXtkuEIjcDWcGgKqiJRM8QbALAKoAmV3HL7G4ZhezMQJFdIig1uiqTrTWqmabaR2v0jqjWlRfT640g+xYh16Wp1CqVzsB/sxb/6cAUJmfQQS7AMDLsvMKZMvBolnR2jUgs+tYJRbPxqiF/rVNI8NCKu01AvzR22+/Xenb1GGQISEhsn//fqfb9XqDBg3KvK9OFqTBrl9++UU6depU6fsGAADgKcLyAOBlmw6kS6FNJL5WmNSPLZnNAM/ERoaa2SzVkcw8mg3wgvDwcOnevbspLu9YCFav9+rVq9T7PfbYY/LAAw/IDz/8YGa0BgAA8CWCXQBQhUMYq9uQI3+ibRdfq2goY0pmrq93B6ixtJ7W66+/Lu+8846sXbtWrr/+esnIyLDPzqjDJx0L2D/66KNy3333mdkaW7RoIfv27TOn9PSijFYAAICqxjBGAPCydVZxeoYwHreEWmFyKD1HUjIIdgHecvnll5uZESdNmmSCVl26dDEZW1bR+h07djjVy3j55ZfNLI7//ve/nbYzefJkmTJlCi8UAACocgS7AKCKMrvaN6xNWx+nBHtmF8MYAW+66aabzMkdLT7vaNu2bbwYAACgWmEYIwB42bp9ZHZVloToMHPOMEYAAAAApSHYBQBedDAtRw6l54qW6jqxPpldlZbZxTBGAAAAAKUg2AUAVZDV1SIxWqLCQ2jr4/RPgXqGMQIAAABwj2AXAHjRur3/zMSI41eHYYwAAAAAykGwCwCqoDg9MzFWdmYXszECAAAAcI9gFwBURXF6ZmKsFMzGCAAAAKA8BLsAwEvyCwpl4/50c7l9g1jauTKHMVKgHgAAAEApCHYBgJdsPZQhuQWFEh0eIk0SomjnSsAwRgAAAADlIdgFAF6yZm/REMYTG9SW4OAg2rkShzGmZedLXkEhbQoAAACgBIJdAOAla4tnYmzfkCGMlSUuKkyCiuOGRzLzKm27AAAAAGoOgl0A4CVrizO7OhDsqjQhwUEm4KWOMCMjAAAAADcIdgGAl4NdZHZ5ZyjjYYrUAwAAAHCDYBcAeMGh9Bw5kJZjhty1a1CbNq5ECbWKZ2RkGCMAAAAANwh2AYAXs7qa16kl0RGhtLEXMrsYxggAAADAHYJdAOAFDGH0nnhrGCM1uwAAAAC4QbALALw4EyPF6StfnWirQD2zMQIAAAAoiWAXAHgBmV3ez+xKoUA9AAAAADcoJAMAlSwnv0A2HUg3l9s3iqV9vVSzK4VhjECNsu7wOonJi7Ffjw2PlSa1m0hOQY5sPrK5xPodEjuY862pWyUrP8tpWeOYxhIXESeHsw/Lvox9Ehy5277MVhAhtry6IlIowZF7S2y3MLuBiIRIUFiyBIVkOy2z5cWKraC2SHCmBIenuNwxTApzk8zF4IjdIkEui3OSRGxhEhSaIkGhmc7bzY8RW36cSHCOBIcfcr6jLUQKcxoUb3efSFCB83Zz64oURkhQaKoEhaa7bLeW2PITRILyJDjigMt2dZ8aF203/IBIsHO2bGFugkhhLQkKSZOgsKI6lP+0YaTY8hJFpECCI/e5acOG5ph6UNghCQrJcWnDOLEVxLhtQ1thuNhy6xXtk8NrVqINww5LUIjza27Lry22/FiR4GwJDk92uWOoFObWL27DvSJBhS7brStiK60No8WWHy8SlCvBEQdd2jBICnMaFbfhfpHgfJc2rCNSGFVOG+ZLcOT+0tsw/KAEBee6tGG82AqiJSgkQ4LCjpTShqW9v7UdQst5f2dJcPjhUttQ/1cLbc5teELcCRIVGiV70/dKSo7z61onso40iG4gmXmZsu3oNqdlIUEh0rZOW3N5U8omyS10fq7NajeTmPAYOZh5UA5mObd/ZX5GOIoOi5bmsc2loLBA1qesL7HdNgltJCw4THYe3SlpeUWZ/JakWklSN6qupOakyu505/dwZEiktIxvaS6vTV4rNv0ndNAyrqVEhkbKnvQ9ciTH+XVNjEyU+tH1JSMvQ7Yf3e60LDQ4VE5MONFc3pCyQfILnd+H+lz0Oe3P2C/J2c7/G/ER8dIoppFk52fLltQtTsuCJEjaJ7Y3l7cc2SLZBdlu2/BQ1iE5kOn8+VI7rLY0jW0qeYV5sjFlY4k2bJvQVkKCQ8xz0efkSN8r+p5x14b6HtP3mlqTvKbEdlvFt5KIkAjZlbZLjuY6/8/Vi6on9WrVk/TcdNmRtsNpWXhwuLROaG0urz+8Xgpszp+zLWJbSK2wWua9ou8ZRwkRCdIwpqF5j+l7zVFwULC0q9POXNb3qL5XHen7V9/HbtswvLY0rd1U8gryZOORkm2o29Xtb0vdJpn5zt8pDaMbSkJkgqRkp8jeDOfPgVqhtaRFXAvzP6z/y67axLeRsJAw2Zm2U9Jy3b+/tW21jR1pu2v7V8VnRHqa8+d0aQh2AUAl27g/XfILbRIbGSqN4iJpXy8NY2Q2RqBmGf3DaAmJCrFfv6DlBTLtjGnmB9rl315eYv2/Rv1lzu9deK/8efBPp2UP93lYBrUaJD9u+1EeXvKwRBf9NjLy09tI1s6xIsG5En3C8yW2m77hXhOMiaz/rYTWXuu0LHv/BZJ3+AwJjd4kUU0+dFpWkN1IMrf+x1yu1eIlCQp2/rGUsfkWEywIrzdLwuOXOy3LOdRXcg8OlJDIXVKr+etOywrzYiVj093mclTTtyTYJWiSuX2cFGS2krCERRJRd47TstwjPSRn778lOOxwiedqKwyR9PUPmcuRjT+WkMg9Tsuzdg2X/LROEhq3SiLrz3Ralp/WXrJ2jTIBJ3dtmLZ+ikhhpEQ2+FpCY5x/pGXvu1jyUnpJaMx6iWo8w7kNM5tJ5vYbzGW3r82m20ygMqLeTxIWt8q5DQ+eLbmH+ktI1A6p1ewt5zbMTZSMzbcXtWGzNyQ41PnHdca266Uwq7mE15kv4YkLnNvw8GmSs3+wCXSVaMOCCEnfMLWoDZt8ICEuAcXMnSOlIL2DhMUvl4ikH52W5R09WbJ3XylBoRnu23DdgyK2YIls8IWERjv/gM7ee4nkHTlVQmuvlsiGXzgty884QbJ2XGcCem7bcONEE1iNSPpBwmL/cm7DAwMkN7mfhNTaKrWavuu0rCAnSTK3TLD/r7oGKGZcOMMEl978+02Zsd75dR3RYYTcccodJhAz4vsRJQIF866YZy7/59f/mB/Yjl455xU5vfHp8umGT+XlP152WlaZnxGOejfqLa/2f9UEL9xtd+7lc82P88eWPSZzdjn/z93W4zYZddIoWbx3sdw29zanZe3rtJdPBn1iLl/53ZUmEOToy4u+NAGXV/98Vb7Y6Py6ju04Vv7b/b8mwDPmxzElAhCzLp1lLl//y/UlgiZvDXhLTmlwiny07iPz+ji6pM0lMrX3VBO4cH2uGtBbOWKluXzX/Ltk7WHnz8MnznxCBrQYIDO3zJQnlj/htKxvk77y/NnPm2CJuzZcNGyRCWJq2/+25zenZXf3vFuGtRsm83bNk7sXFH32WTrV6yQfnP+BuexuuzOHzJRmsc3khVUvmP1ydH3n6+WGLjfIHwf/kPG/jHdapkGl7y75zlwe99O4EsGY9857T7okdZF317wr7615z2nZ5W0vl3tPu9cEulz3SYOMi4cvNpdvnXOrbE51Dso+1+856desn3y16St5duWzTsv6N+8vT/V9ygQo3T3XFVetkPCQcJm6aKos3+/8nTKl1xQZeuJQmb1jtkxZNMVpWY/6PWT6wOkmKOpuuz//+2cTeHp6xdPy8/afnZbd3O1muebka2TFvhXm/9VRq7hW8tXgr6rkM6Igy/n7tTRBNpvNOaSMSnP06FGJi4uT1NRUiY2t/OyOwsJCOXDggCQlJUlwMCNSqxJt71vVvf0/WLJd7vnybzm9daJ8cM1pUpNUh7ZfvCVZrnhtsbSsGy2zb+srgaQ6tH+g8nbbe7vPUJ1Zz33J1iUSU9s7mV0XPv9PAIPMLqshyOyykNlVscyuH+5oRWYXmV1kdhUjs8s3mV09T+hZbp+JYJcXEeyqufjBSfuX5dZP/pDPV+6S/zurtdx6btGHc01RHd776/elyYBn5klCrTD5fdK5EkiqQ/sHKoJd3lMVgb4Wdzkf4Qdw7LZNu4DmA1Dt+w30lAGgkv2+o+hoRbdmCbStFyQUD2NMzcqTgkKSkwEAAAA4I9gFAJVIZwjccqhojHrXZvG0rRfERxUVqNc419Es53oXAAAAAECwCwAq0e87i7K6WtaLlvjiWQNRucJDgyU6PMSe3QUAAAAAjgh2AUAlWrm9aKrork0ZwuhNViDxCMEuAAAAAC4IdgFAJVq6tWj2olNaEOzypvhaRXW7jmTmevVxAAAAAPgfgl0AUEmycgtk1c6izK5erRJp1yoIdjGMEQAAAIArgl0AUImzMOYWFErDuEhpVqcW7VoFRep1QgAAAAAAcESwCwAqyaItyeb8tJaJEhQURLt6UZw1jJGaXQAAAABcEOwCgEqy2B7sqkObell8lFWzi9kYAQAAADgj2AUAleBwRq6s3FFUr6t3q7q0qZdRswsAAABAaQh2AUAl+HH1PikotEnHxrHSlHpdVVazi9kYAQAAALgi2AUAlWDmn3vN+fknN6Q9qwA1uwAAAACUhmAXAByn5PQce3H6Cwh2VYmEWkWZXanU7AIAAADggmAXABynT5bvMkMYOzWJk+aJ0bRnFdbsYjZGAAAAAK4IdgHAccgrKJR3F20zl0ec1py2rPLZGHOlsNBGuwMAAACoHsGul19+WTp16iSxsbHm1KtXL/n+++/tyzdv3ixDhgyRevXqmeWXXXaZ7N+/v8R2Zs6cKT179pSoqChJSEiQwYMH25clJyfLwIEDpVGjRhIRESFNmzaVm266SY4ePVru/pW1XQCwCtPvTc2WxOhwGdS5EY1SRWKLg10a50rLyafdAQAAAFSPYFeTJk1k2rRpsmLFClm+fLmcddZZcvHFF8vq1aslIyNDzj33XAkKCpLZs2fLwoULJTc3VwYNGiSFhYX2bXz++ecyYsQIufrqq+WPP/4w6w0fPty+PDg42Gzzm2++kQ0bNsjbb78tv/zyi4wfP77MfStvuwCgpi8syuq6smcziQwLoVGqiLZ1VHF7U7cLAAAAgKNQ8SENXDl66KGHTLbX4sWLZffu3bJt2zb5/fffTVaXeuedd0yGlQa/zjnnHMnPz5ebb75ZHn/8cRk7dqx9Ox06dLBf1vWvv/56+/XmzZvLDTfcYO5TGk+2CwB/7joiK7anSFhIkFzFEEaf1O3KSi2QI1m50kxq8YYEAAAA4Ptgl6OCggL59NNPTUaXDmfUIYya1aVDDy2RkZEmU2vBggUm2LVy5UoTFNPbunbtKvv27ZMuXbqYIFXHjh3dPs6ePXvkiy++kDPPPLPUfTmW7aqcnBxzslhDJTUTzTEbrbLoNm02m1e2Ddq+Oqsu7/23Fmy1z8BYNybc5/sTSG2v4qLCzBDSlIycarE/gdb+gcbbbc9rCgAAUIOCXX/99ZcJbmVnZ0tMTIx8+eWXJoNK63RFR0fLnXfeKQ8//LDpYN51110mKLZ3715z3y1btpjzKVOmyFNPPSUtWrSQJ598Uvr27WuGLNapU8f+OMOGDZOvv/5asrKyTEbZG2+8Ueo+VWS7jh555BGZOnVqidsPHjxonp83OsapqammbTQwh6pD2/tWdWj/9JwC+e6vos+iQe1i5cCBAxIIqkPbW6KLv8F27EuWA3GBUaS+OrV/oPF226elpUl18uKLL5qDfHrAr3PnzvL888/LqaeeWur6esDyvvvuM1n5bdq0kUcffVTOP//8Kt1nAACAahPsatu2raxatcp0ID/77DMZNWqUzJ071wS8tOOkQxCfe+4507HUgFW3bt3snUzrKOg999wjQ4cONZenT59uaoHpfa+77jr74zz99NMyefJkE6yaOHGiTJgwQV566SW3+1SR7TqytuuY2aUF8a0C+5VN91Oz33T7/OipWrS9b1WH9p+7YpfkFtikTVKM9D25hdmfQFAd2t5SL26XyK40KQyLkqSkJAkE1an9A423216z16uLGTNmmP7MK6+8YibqeeaZZ2TAgAGyfv16t/9rv/32m+mj6UG/Cy+8UD788EMzqY9mypeVEQ8AAFBjg13h4eHSunVrc7l79+6ybNkyefbZZ+XVV181Bep1OOOhQ4ckNDRU4uPjpUGDBtKyZUuzfsOGDUvU0tJhj7p8x44dTo+j99NTu3btTGbWGWecYY5AWttwVJHtOtJ1HIddWrRT7K0fJdrx9ub2QdtXV75+73/zxx5zPrhrYwkJCazC9L5ue0tCdLg5P5qV7/N9CcT2D0TebPvq9HpqVvu4cePMJD1Kg146Q/Vbb71lsuxdab9NZ76+/fbbzfUHHnhAfv75Z3nhhRfMfQEAAAIu2OXuyKlj3StVt25dc66F6XWo0EUXXWQPjmlwSY809unTx9yWl5dnUui1EH1Zj6FcH8dyrNsFEBgOHM2W3zYnm8sXdW7k690JWHFRRcGulMw8X+8KUGPozNc6S7ZmqzsG4rRW6qJFi9zeR293zGxXmgn21VdfVajGqWaCaUkLb8jbt9Er2wUC0fLly329CwACWHp6evUPdmlH6rzzzpNmzZqZWhWa9j5nzhz58ccf7UMH27dvb4YMaEdKZ0i85ZZbzNBHpUMDx48fb4Yn6nBBDURZsyxeeuml5vy7776T/fv3yymnnGI6UKtXrzZHHk8//XRTi0stXbpURo4cKbNmzZLGjRt7tF0AgWv2ugNis4l0aRovTeswC6AvZ2NUOhsjgMqh2fRaH7V+/fpOt+v1devWub2P1vVyt77eXpEap/369TuufQdQNU55h5YGUP35NNilWVoaZNKC83FxcdKpUycT6Orfv79ZrplVGhA7fPiwCUxpDS0NdjnSIJQOcRwxYoQpPq+1JTQDLCEhwSyPioqS119/3dxPjyJq8OqSSy5xSsPPzMw0j6XZW55uF0DgmrvhoDnv1zYw6kRVV/FRRcGuVDK7AL9SWo3TX3/91WuZXQBQrtcJuAOVZtyv4s3MLk8OkPk02PXmm2+WuXzatGnmVJawsDB54oknzMkdbQQtnFoWnWVRZ1eqyHYBBKa8gkJZsPGQuXxm23q+3p2A9k9mF8MYgcqipSO0DqFmxTvS61r71B29vSLrl1bjVCch8saEPgDgkR7Va1ZcAO5Z5Q/KU32qoQKAH1i5PUXScvKlTnS4dGoc5+vdCWhWza4jmQxjBCpz4iCtXaqlHRxrner1Xr16ub2P3u64vtIC9aWtDwAAEHAF6gHAH4Yw/qtNXQkODvL17gS0hOjiYYxkdgGVSocYjho1Snr06CGnnnqqPPPMM5KRkWGfnVFLUGiNU629pbSm6plnnilPPvmkXHDBBfLxxx+bAtavvfYarwwAAPAJgl0AUAFz1hcFu/pSr8vn4u2ZXXlmKHpQEMFHoDJcfvnlcvDgQZk0aZIpMt+lSxf54Ycf7EXod+zYYWZotPTu3dtMMnTvvffK3XffLW3atDEzMXbs2JEXBAAA+ATBLgDw0IGj2bJm71HRmMoZberSbtWkZld+oU2OZudLXHHBegDH76abbjInd3TmbFc6WzUzVgMAgOqCml0A4KFFW5LN+UmNYiUxpmRxZVStyLAQe8BrX2o2zQ8AAADAINgFAB5aXBzs6tUykTarJhrERprzvalZvt4VAAAAANUEwS4A8NDiLYfN+WkEu6qNhnFFwS4yuwAAAABYCHYBgAc0mLL1UIboBIynnFCHNqsmGsRFmfO9DGMEAAAAUIxgFwB4YMnWoiGMHRvHSWwkhdCrCzK7AAAAALhiNkYA8MDybSnm/NQWZHVVJ80Ta5nzGct3SkZuvoSHBktwUJCEBAVJcLBIUFCQhAYHSVRYiESEBktIcLCEhgRJSHDR7bXCQyUyLLj4etF5VHiI1AoPMcvDQoLNNvV6RGiIhIcU3V+3FRrC8SIAAACgOiLYBQAe+HN3qjnv3DSe9qpGBpzUQFonxcimA+ny7Z97q/SxNQimQS8NgOnMkBoQ0+BYmLktyH5beKjeroE1vR5q1tf1oiNCzDq6TANtuj29TYNqYQ5BtejwULNNXS8kSCQnv1BsNluVPlcAAADAnxDsAoBy5BUUytq9R83lkxvH0V7ViAaL3ht7qvy0er95nQptNikoFHNeWGiTQptIQWGhZOYWSG5BoeQX2qSgwCYFNptZPyOn+PbiZXqenafr50tegU3yCwvNeXpOvuTmFzo9tl53va2qBAWJhBVnqZkgWXhoceZaUdaaBss0Q80E04pv03UjQ0PM7brcym7Tcw2wmWw2E3jTdYuCeEW3BZvbgnVdzZorzn7TbDlNbtNMOg3WaSadnteKKMqAs7av2XUAAABAVSLYBQDl2LA/zQQ1akeG2ofNofpoGBclo3q38PrjaDZVUUDMJtl5BWbYpAl4WQGynHzJK7RJXr4GyIoCbJl5BeZ6bvH1rOIgmmZn6WW9Tbep6+u2dJt5+UXX8wpdtlugGV3WvojZZm6BmG0cycyT6kpjXRokKxoOGmoPsGlwzAw31WCZyXwrynozt+vy4sCarq9BOw3IaXAtpDiAZgXedL2o8ODi5db9ioJw1jbMMNSwEDPBhHW7/XKwmOCftW/WbY7r6eMFB9nEpg0OAACAao9gFwCU4+/iIYya1UWWSuDS116HEoaFiMlsSogOr/J9yM3Ll+2790nt+DpSIEEmE02DZJp5ZgXNCorPNQiWk1d8vbDQHqTT2zXzzWS5Fa+rQTVd9s/9bUUBuuLtFhSfrPtl5RaY9TVDzlqmJ2tdRxqYy9f7afCvBgSL3hgZIud0aODr3QAAAEAZCHYBQDn+3PVPsAvwJR1SqBmGSbGREqzpR9WMZr9p1poZUlooZhioBsT0ck5+gRk2WjTUtGgoaaFDkCzDIbBmX6f4lJVXYLZrllnDU4vvXxR8yzfBuaL7SvE6+hgOw1jzi4a56r6Y8+Llus9WVp3TssKiZUXXi4Yz63aSakf4upkBAABQDoJdAOBpZlcTgl1AedlvOuRQTzVNYWGhbNu1V5o0qO3rXQEAAEA5qt9hYQCoRjTjY+3eNHOZzC4gsFkF+wEAAFC90WMDgPKK0xcUSmxkqDSrQ3F6AAAAAKjuCHYBgIdDGClODwAAAADVHzW7qkBmXqaE5pVs6pDgEIkIiXBarzTBQcESGRrptK7WD8nKzzKXHQsVu66r62iRXXf0x3tUaNQxrZudny2FtsJS97lWWK1jWjenIEcKCgsqZV3dXytAkVuQK/mF+ZWybnjwP7Ow5RXkSV5hXqnr6muhr4kn6+r7Qd8XFV63MM+sX+r+hoRLaHBohdfVNtC2KE1YSJiEBYdVeF19zfS1K3Xd4DCzfmnrOr73I0Ij7Ovqe0zfa55st7x1tQ20LZZuO6xlt6VD48hS/0etdZX+/+i+laYi//fH+xnh6boV/Yxw97njbt1A/oyoyP99RdYNCyp6/3qybiB/RpS27vF8Rrh+51bk/96Tdcv6nwUAAEDFEOyqAmd9epaERJUs1ntG4zPkpXNesl/v+0nfUjvLPer3kOkDp9uvD/x8oKTkpLhd96TEk+TjCz+2Xx/81WDZk7HH7bqt4lrJV4O/sl8f9u0w2Zy62e26jaIbyY///tF+ffQPo2V18mq36yZEJMi8K+bZr1//y/WyfP/yUn9ALr1yqf36Lb/eIvN3z5fS/DXqL/vlifMnys/bfy513SXDl9h/+E5dNFW+2fxNqevOvXyu1ImsYy4/tuwxmbF+RqnrfjfkOwmToh9Ez/3+nLy9+u1S1/3yoi+ldUJrc/n1v16Xl/94udR1P7rgI+lYt6O5/P7a9+WpFU+Vuu5bA96SUxqcYi5/tuEzeXjJw6Wu++LZL8q/mvzLXJ65Zabct/C+Utd94swnZECLAebyrB2z5La5t5W67gOnPyCDWw82l3/b85vcOOvGUte9u+fdMqzdMHN55YGVMubHMaWuO6H7BLm649Xm8trDa2XYzKL7uXN95+vlhi43mMtbjmyRId8MKXXd0SeNllt73Gou783Ya/6PSnN528vlnp73yIKNhyQoJEM+PjBCPv7Q/boXtbpIHurzkLms/8M9P+xZ6nb7N+8vT/X953Uta93q+Bkx/LvhsiV1i9t1+Yz4xw9Df5DGMY0r/TPig/M+kCRJMpf5jPD9Z8S9p91rLuv/2pkzzix1XU8+IwqySg/KAgAAoGIIdvkpm7jPwlC5efmyfe9B+/X8gtI70Hn5zuvq9dLodhzX1ccpjU717rhudm7pWQI6Rbzjulk5pR/5V47rZmaXfjRf7dx3SCKLM00yssped9f+ZEkLL2qr9MzSj/yr3QcPS1hWmGQVBsnR9LKPxu85dFjCsov2+UhaRpnr7j2UIrXzitZNOZpe5rr7ko/IdlvRuodTy173wOFU2R5StG7ykaJi66U5lHJUtkcctF8ui27Lej30Mcqi+2itu+/wkTLX1edurbs31X3AxqJtaq27J12zsEqnr5W17v6sstfV98Dni9dLWlqqxEbkSek5R/omzhfJLX5ty8juKFq34J91y2NzWbeU7Cu365bxGSGaQeW0bqHn65a1D+K6blmtZnNZt4wf+rYKrKsc1y0jq8vQbBrrOZWRqVW03UyR4AjP17X2o4wsKft7xr5u2Z9/kpclQYXF2/Zg3X/el+Wtm+2wbtmflWb5sayrj1HmurkO65bzf1RwjOuW9/+pr5W1rr6GAAAA8EtBttLGruC4HT16VOLi4mTvob0SGxtbqUOUPly4Sgb/0tf9ujosxuFlzQoKKvVnrw7IiTrGdbODgsoMANQ6xnVzgkQKzKMd/7q6v9ZS/amXH1Q562r7WgO49GdsXiWtG2GzSYgX1g232eyR7Yqsqz/nc8tYN8xmK85vq9i6Gn7I8cK6hcXvtcpYN9RmE2uwqq34f6My1g0Rm0Q4/JNlVtK6rv/3FVmXz4gifEYU4TOi7M+Iwls3SHBETKUPY9Q+Q8O6DSU1NdVtnyEQ+ktLti6RmNox9ttjw2OlSe0mZpjq5iMls847JHYw51tTt5ZoU82sjIuIk8PZh2Vfxj6nZdFh0dI8trkZArs+ZX2J7bZJaGOGtO48ulPS8pwPECXVSpK6UXUlNSdVdqfvdloWGRIpLeNbmstrk9eWODDZMq6l6cvtSd8jR3KcD/okRiZK/ej6kpGXIduPbi/x/jkx4URzeUPKhhJDqPW56HPan7FfkrOTnZbFR8RLo5hGZkiua1ZukARJ+8T29qzH7IJst214KOuQHMg84LSsdlhtaRrb1Ax73piysUQbtk1oa/q5+lz0OTlqEN3AZNK7a0PN9j8h7gRzeU3ymhLbbRXfyvSdd6XtkqO5zgfk6kXVk3q16kl6brrsSNtRovyElUG7/vB6KXA5aNIitoUZCaDvFX3PuI5WaBjT0LzH9L3m2j9vV6eduazvUdch1fr+1fex2zYMry1Nazc1w8Y3HinZhrpd3f621G2Sme/8G6FhdENJiEyQlOwUk4XqqFZoLWkR18IMxV53eF2J7baJb2OGa+9M2ylpue7f39q22saOtN21/ZVu17X0gL5u+vrtTd9bIrNcX2993fW3zraj25yWhQSFSNs6bc3lTSmbJLfQ+eBMs9rNJCY8Rg5mHpSDWf8c8FZ8RhThM+IffEYExmdEelq69DyhZ7l9JjK7qoB+eTrWkClrPY+3GVrLKehTFscAVWWuG+mldYt+3Nsqfd3w4kBOZa8bVhxEqYnrhhYHcip7XQ3S1fLCusFeWjfIS+tKNVmXz4gifEYU4TOi7M+IwtAoCXb5vtZabp5+h5e2bn5YOdmCAUDLIziWfbig5QUy7YxpJohz+beXl1rW4N6F98qfB/90WvZwn4dlUKtB8uO2H0sM8+/dqLe82v9VE7xwt12rrIGWNJiza47Tstt63CajTholi/cuLjHMv32d9vLJoE/M5Su/u7JETT1ryPKrf74qX2z8wmnZ2I5j5b/d/2sCPK7D/PXHxaxLZ9nLQrgGTayyBh+t+0je/PtNp2WXtLlEpvaean6UuD5XDeitHLHSXL5r/l1mSLC7sgZa/uCJ5U84LevbpK88f/bz5oeQuzZcNGyRCVBo22uZA3dlDebtmid3L7jbaVmnep3kg/M/MJfdbXfmkJnSLLaZvLDqBbNf7oYs/3HwDxn/y3inZRpU+u6S78zlcT+NK/FD673z3pMuSV3k3TXvyntr3nM7ZFkDXa77pEHGxcMXm8u3zrm1RCmQ5/o9J/2a9ZOvNn0lz6581m1ZAw1QunuuK65aYYLkWobDtRTIlF5TZOiJQ2X2jtkyZdEUt2UNNCjqbrs///tn86Py6RVPlygFcnO3m+Wak6+RFftWyH9+/U+pZQ30f9U1iDnjwhkmAK3vQddSICM6jJA7TrnDBGtHfD+i1NIn+pj6A9vRK+e8Iqc3Pl0+3fBpiWH+fEYU4TPiH3xGBMZnRIGHpR/I7KqCI5VeOUprs0lhTrocPHhQ6tWrV6JQNLxLCxXT9r5D+9P2gYr3fjVo+0bNJTikZB3Oat1nqObI7CKzy0Jm1z/I7CpCZlcRsj/5jHAVyJ8R6R5mdhHs8iJvd1y1433gwAFJSkoi2FXFaHvfov1p+0DFe7/mtj3BrsAM9AEAAO/0mUgHAgAAAAAAQI1BsAsAAAAAAAA1BsEuAAAAAAAA1BgEuwAAAAAAAFBjEOwCAAAAAABAjUGwCwAAAAAAADUGwS4AAAAAAADUGAS7AAAAAAAAUGMQ7AIAAAAAAECNQbALAAAAAAAANQbBLgAAAAAAANQYob7egZrMZrOZ86NHj3pl+4WFhZKWliaRkZESHEzcsirR9r5F+9P2gYr3fs1te6uvYPUdAom3+0sAAKDm8LTPRLDLi7RTrJo2berNhwEAADWo7xAXFyeBhP4SAACo7D5TkC0QDyFW4VHgPXv2SO3atSUoKMgrEU0NpO3cuVNiY2Mrffug7asr3vu0faDivV9z2167Y9ppa9SoUcBla3u7vwT/wOcbAD4nUJl9JjK7vEgbvkmTJuJt2ukm2OUbtL1v0f60faDivV8z2z7QMrqqur8E/8DnGwA+J1AZfabAOnQIAAAAAACAGo1gFwAAAAAAAGoMgl1+LCIiQiZPnmzOQdsHEt77tH2g4r1P2wM1FZ9vAPicQGWiQD0AAAAAAABqDDK7AAAAAAAAUGMQ7AIAAAAAAECNQbALAAAAAAAANQbBLgAAAADHrW/fvvLf//6XlgRQIS1atJBnnnnmuFptypQp0qVLF6+2PJ9x/oVgl5968cUXzYdCZGSk9OzZU5YuXerrXQoI8+bNk0GDBkmjRo0kKChIvvrqK1/vUsB45JFH5JRTTpHatWtLUlKSDB48WNavX+/r3QoYL7/8snTq1EliY2PNqVevXvL999/7ercC0rRp08znDz8oq4Z2nrW9HU/t2rWrokcH/MsXX3whDzzwQJU+ZlX8wAVQOd5++22Jj48vcfuyZcvk2muvPa5t33bbbTJr1qzj2gZqFoJdfmjGjBkyYcIEmTx5sqxcuVI6d+4sAwYMkAMHDvh612q8jIwM094abETVmjt3rtx4442yePFi+fnnnyUvL0/OPfdc85rA+5o0aWKCLCtWrJDly5fLWWedJRdffLGsXr2a5q9C2hl89dVXTeARVeekk06SvXv32k8LFiyg+QE36tSpYw5KAUBF1KtXT2rVqnVcjRYTEyOJiYk0POwIdvmhp556SsaNGydXX321dOjQQV555RXz4fDWW2/5etdqvPPOO08efPBBGTJkiK93JeD88MMPMnr0aPOjUwOOemRox44dJvgC79OMxvPPP1/atGkjJ554ojz00EOmU6HBR1SN9PR0ufLKK+X111+XhIQEmr0KhYaGSoMGDeynunXr0v5AOUN8dATCww8/LGPGjDEBsGbNmslrr71mX3fbtm0mU/Ljjz+W3r17m9EKHTt2NAe3ysoC0ax6vZ+1fOrUqfLHH3/YMy/1NgDekZOTI//5z3/MKAv9n+3Tp485EKfmzJlj/gdnzpxpDsrp8tNOO03+/vtv+3L9/Zqammr/f9XMTHfDGHWZHty78MILze/c9u3by6JFi2TTpk3mcyY6Otp8bmzevLnULE/XrGw96eNYdL/0t532Z+vXry8jRoyQQ4cO2ZfrAfWRI0ea5Q0bNpQnn3ySt5WfIdjlZ3Jzc82P+3POOcd+W3BwsLmuHwBAoNAvSusoMqpWQUGB+XGinQAdzoiqoZmNF1xwgdPnP6rGxo0bzfD1li1bmoCjBtoBlE9/HPbo0UN+//13ueGGG+T6668vUYLg9ttvl1tvvdWso98penAlOTnZo+a9/PLLzX0dsy/1NgDecccdd8jnn38u77zzjhlh1Lp1azPC6PDhw07/0/q/r0EwzdjS/2kdkaHBKQ1oaTkM6/9Vhx6WRodEa7Bp1apVpnzA8OHD5brrrpOJEyeaUQY2m01uuummUu/vmJGtQTLd13/9619m2ZEjR8woha5du5pt6UH1/fv3y2WXXeb0PDT4/vXXX8tPP/1kgnX6nOE/Qn29A6gYjTbrD02NPjvS6+vWraM5ERAKCwvNkePTTz/dHAVG1fjrr7/MD5Hs7GxzlOvLL7802aXwPg0uagfLOnqKqqN1MTVTpG3btqbDrFkkZ5xxhjkizHAtoGyaEaxBLnXnnXfK008/Lb/++qv5f7Loj9WhQ4fa60Pqj84333zT/KguT1RUlPk+srIvAXiPHuTU/1H9TtSMKKXZ5lpeRP9ntbau0lI7/fv3N5c1KKalMLTPqIGkuLg4k2Hlyf+rZoFZwSf9/NA+6H333WeCa+rmm28265TGegwNiulnjD62ZoupF154wQS6NPvUoqOkmjZtKhs2bDAHuPQ5vf/++3L22Wc7PRf4D4JdAPwyw0V/aFI3p2rpjxM9uqZZdZ999pmMGjXKHPEi4OVdO3fuNB067UzqkABULatDr3RYhga/mjdvLp988omMHTuWlwMog2N9QesHrmuNWccMYQ1aaSbY2rVraVegmtEhg5qhpQebLWFhYXLqqaea/1kr2OX4P60jMLT/eCz/046fH1aix8knn+x0mx6APXr0qMkWK83dd99tRkBpBpcGyJUOfdbAuwbL3T3PrKwsM6JKv/Ndnwv8B8EuP6N1QkJCQkyapSO9zhEtBAI9Avztt9+amTE5ulK1wsPDTQq46t69u8kyevbZZ+1HyeAdOnRdfxx269bNfptm+Or/gB6Z1PoZ+r2AqqH1g7RunQ6JAFA2/SHsSANemp3tKS3VoVkZjvTHNoDA+vyw6vS5u62szxTNzNKMUh2C2LhxY6c6qDq88tFHHy1xH63PxXd8zUDNLj/8sak/Mh2nVdV/cL1O7RzUZNa4fE2Dnj17tpxwwgm+3qWAp589GmiBd2n6vA4h1aw666SZD1o7Si8T6Kpa2kHWo77aGQZw/BwnOsnPzzcBfi1GrbTeT1pamtPMy/q559o31gMAALyrVatW5v9t4cKFTsFnPfjpmOXv+D+dkpJihgVa/9NV+f+q2VzXXHONOSirhfId6QFEnVFcC9brgVzHkxa/1+eqgbUlS5aUeC7wH2R2+aEJEyaY4UP6Y0fTRrXQn3YCyhqzjMr7keMY6d+6davpdGlaq84yBO8OXfzwww9NkUitk7Nv3z5zu46/t1KS4T1aDFSHc+n7XH946GuhR8l+/PFHmt3L9P3uWptOO2I6vTY167xPi+fq0V8durhnzx5Ti0QDjMOGDauCRwdqvhdffNHM9Ks/hjUDQ39Q6gyOSocQ6UxsOgxJZ4DTH56usy3qj1WrP6YZ3/qZGRER4aNnA9Rc2vfQSSa0cLv12+exxx6TzMxMM6xfhwaq+++/3/RRdJjhPffcY0YmDR482P7/qr+nNFFDZ1fX/289VTb9nTBkyBC54oorTI0v63eDfn9rEF1/V2i9Mf0u1/qA+nz0N57WSH3jjTfM8EZ9Tvpc9bno7JP6XDTbFP6DV8sP6SwzTzzxhEyaNMlMr6pf7lrM07VoPSqfjvXWYoZ6sgKPellfC3iXFsTUWlE63bBmVFinGTNm0PRVQIfR6Yw4WqtAM430KJ4GuqwCpEBNtWvXLtMZ1ve+FsrVTq8etdbOMoDjN23aNHPSH75ai/Obb74xP46V/gDVYUjfffedqdXz0UcfyZQpU5zur4WnBw4cKP369TP/l7oOAO/Q/1X9nxsxYoTJjtIAkfYHExISnNbRWqM6GkmDTP/73/9MRpfSGRnHjx9vfs/q/6sGy7xBJ27TMj9aVN7xd4NVV0wL0GuGmmaZnXvuuebzRSe/0lIFVkDr8ccfNxPS6AEvnQm7T58+5jnBfwTZXAfCAwAAAIAXbdu2zZQk+P33383BWwD+TTP+Neis2ZkaNAJ8jcwuAAAAAAAA1BgEuwAAAAAAAFBjMIwRAAAAAAAANQaZXQAAAAAAAKgxCHYBAAAAAACgxiDYBQAAAAAAgBqDYBcAAAAAAABqDIJdAAAAAAAAqDEIdgGoMYKCguSrr77y+uO0aNFCnnnmmWqznYp6++23JT4+vsofFwAAAACqAsEuAH7h4MGDcv3110uzZs0kIiJCGjRoIAMGDJCFCxfa19m7d6+cd955Ut2UFlxatmyZXHvttT7ZJwAAAACoqUJ9vQMA4ImhQ4dKbm6uvPPOO9KyZUvZv3+/zJo1S5KTk+3raADMn9SrV8/XuwAAAAAANQ6ZXQCqvSNHjsj8+fPl0UcflX79+knz5s3l1FNPlYkTJ8pFF13kdhjjtm3bzPVPPvlEzjjjDImKipJTTjlFNmzYYDKqevToITExMSYTTLPGLH379pX//ve/To8/ePBgGT16dKn799RTT8nJJ58s0dHR0rRpU7nhhhskPT3dLJszZ45cffXVkpqaavZHT1OmTHE7jHHHjh1y8cUXm/2KjY2Vyy67zAT1LHq/Ll26yHvvvWfuGxcXJ1dccYWkpaWVm1mmGXG1atWSIUOGOAUI1ebNm83j1q9f3zy2ttMvv/xiX37//fdLx44dS2xX9+W+++4r87EBAAAAoKoR7AJQ7WkARk8ayMrJyanQfSdPniz33nuvrFy5UkJDQ2X48OFyxx13yLPPPmsCaJs2bZJJkyYd1/4FBwfLc889J6tXrzaZZ7NnzzaPoXr37m0CWhq80mGWerrttttKbKOwsNAEnA4fPixz586Vn3/+WbZs2SKXX355icCUtsO3335rTrrutGnTSt23JUuWyNixY+Wmm26SVatWmWDhgw8+6LSOBubOP/98kyn3+++/y8CBA2XQoEEm+KbGjBkja9euNUFCi673559/mkAeAAAAAFQnDGMEUO1pkEqzk8aNGyevvPKKdOvWTc4880yT1dSpU6cy76uBJa3tpW6++WYZNmyYCeqcfvrp5jYNBOm2j4djJphmXGkwafz48fLSSy9JeHi4ycDSjK6yhlnqPv3111+ydetWkx2m3n33XTnppJNMkEmzraygmO5v7dq1zfURI0aY+z700ENut6tBPQ1eWcG3E088UX777Tf54Ycf7Ot07tzZnCwPPPCAfPnll/LNN9+YIFmTJk1MG06fPt2+H3pZXwMdUgrg/9u7d5a41jAKwPsUgq0ggliqoGKvNhZeOstYBRQhdQp/hKIYLKKN1vFSJCBikfQBC9MF/4Agor0IRjysDyaMxugh8cA4PA8IOo77Mo2weN+1AQBoJCa7gBfT2XV6eloCmIQ3WQ9M6PVUUFUfhmVNL7JyWP/a+fn5X11bVv7Gx8errq6uEkIlgMqq4OXl5X8+RianEnLVgq4YGBgoxfb5XX2YVgu6orOz89Hrz98ODQ3deW1kZOSXya6Egv39/eV8maLL39UmuyJB4/b2dnV1dVW607a2tsrEFwAAQKMRdgEvRmtrazU5OVl6ojKdlB6trCk+pqWl5ef3ma566LVMS9WvJN7e3t45xvX19W+Pn26wqampEqp9/Pix+vbtW7W+vl5+l1DoudVf+0PX/ycSdGWSa2Fhoax2Zt0xgWD99WetMU/BzPv29/fLZ/Lq1au/Oi8AAMD/wRoj8GJl8qlWSP+cT0hMr1bNzc1N9f3799J19ZCEWwmb3r17V4KySCl+vawy5jiPyVTVyclJ+apNdx0fH5dy/tznn8px09tV7/Dw8M7PX79+LcFhyutrk14J8e6vks7Ozpb1xdxPVkhT+g8AANBohF1Aw8tK4PT0dFmbywRV1viOjo6q5eXlUur+nMbGxqr5+fnq4OCg6u7uLk9aTOD0Oz09PWXK6f3792X6KcFResXqZfUwAVK6tdKNlaci5qvexMREmaZ6/fp1KbT/8eNHeapjerHy5Mg/9fbt29JPtrKyUj6rz58/3+nrit7e3urTp0/l+jMplsm5h6bF3rx5U8KzyH0CAAA0ImuMQMNLh1R6p1ZXV6vR0dFqcHCwBDLpkVpbW3vWcyVQywTTzMzMzwL23011RcKrBGJLS0vluj58+FAtLi7eeU+eyJjC+jxZMZNjCenuS8i0t7dXtbW1lXtM+JVz7+7u/tX9DA8PV5ubm6WoPtf65cuX8nTKern+nDfXmcArZfTpQ7svoVje09fX90sPGAAAQKP45/Z+OQ0APCD/LhJ4ZeIs028AAACNyBojAE+6uLiodnZ2qrOzs2pubs4nBgAANCxhFwBP6ujoqNrb26uNjY2y8ggAANCohF0APMnGOwAA8FIoqAcAAACgaQi7AAAAAGgawi4AAAAAmoawCwAAAICmIewCAAAAoGkIuwAAAABoGsIuAAAAAJqGsAsAAACAqln8Cz3f+PhUl9NPAAAAAElFTkSuQmCC",
+      "text/plain": [
+       "<Figure size 1200x400 with 2 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>run</th>\n",
+       "      <th>max_wse_ft</th>\n",
+       "      <th>difference_from_target_ft</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>input</td>\n",
+       "      <td>3964.547363</td>\n",
+       "      <td>1.047363</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>optimized</td>\n",
+       "      <td>3963.494385</td>\n",
+       "      <td>-0.005615</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "         run   max_wse_ft  difference_from_target_ft\n",
+       "0      input  3964.547363                   1.047363\n",
+       "1  optimized  3963.494385                  -0.005615"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Executed flow hydrograph optimization workflow with before/after WSE comparison.\n"
+     ]
+    }
+   ],
+   "source": [
+    "if project_available and not fallback_trials.empty:\n",
+    "    baseline_wse = read_reference_wse(trial_hdfs[Q_MULT_TRIALS[0]], reference_cell[\"cell_index\"])\n",
+    "    optimized_wse = read_reference_wse(Path(best_trial[\"hdf_path\"]), reference_cell[\"cell_index\"])\n",
+    "\n",
+    "    fig, axes = plt.subplots(1, 2, figsize=(12, 4), constrained_layout=True)\n",
+    "    axes[0].plot(baseline_wse[\"days\"], baseline_wse[\"wse_ft\"], label=f\"Input QMult {Q_MULT_TRIALS[0]:.2f}\")\n",
+    "    axes[0].plot(optimized_wse[\"days\"], optimized_wse[\"wse_ft\"], label=f\"Optimized QMult {best_trial['qmult']:.2f}\")\n",
+    "    axes[0].axhline(TARGET_VALUE, color=\"tab:green\", linestyle=\"--\", label=\"Target\")\n",
+    "    axes[0].set_xlabel(\"Simulation day\")\n",
+    "    axes[0].set_ylabel(\"WSE (ft)\")\n",
+    "    axes[0].set_title(\"Reference-cell WSE time series\")\n",
+    "    axes[0].grid(True, alpha=0.3)\n",
+    "    axes[0].legend(fontsize=8)\n",
+    "\n",
+    "    before_after = pd.DataFrame(\n",
+    "        {\n",
+    "            \"run\": [\"input\", \"optimized\"],\n",
+    "            \"max_wse_ft\": [baseline_wse[\"wse_ft\"].max(), optimized_wse[\"wse_ft\"].max()],\n",
+    "        }\n",
+    "    )\n",
+    "    before_after[\"difference_from_target_ft\"] = before_after[\"max_wse_ft\"] - TARGET_VALUE\n",
+    "    axes[1].bar(before_after[\"run\"], before_after[\"difference_from_target_ft\"], color=[\"tab:blue\", \"tab:orange\"])\n",
+    "    axes[1].axhline(0, color=\"black\", linewidth=1)\n",
+    "    axes[1].axhline(TARGET_TOLERANCE, color=\"tab:green\", linestyle=\"--\", linewidth=1)\n",
+    "    axes[1].axhline(-TARGET_TOLERANCE, color=\"tab:green\", linestyle=\"--\", linewidth=1)\n",
+    "    axes[1].set_ylabel(\"Max WSE - target (ft)\")\n",
+    "    axes[1].set_title(\"Before/after target residual\")\n",
+    "    axes[1].grid(True, axis=\"y\", alpha=0.3)\n",
+    "    plt.show()\n",
+    "\n",
+    "    display(before_after)\n",
+    "\n",
+    "    assert best_trial[\"objective_ft\"] <= TARGET_TOLERANCE\n",
+    "    print(\"Executed flow hydrograph optimization workflow with before/after WSE comparison.\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/ras_commander/RasFlowOptimization.py
+++ b/ras_commander/RasFlowOptimization.py
@@ -1,0 +1,1320 @@
+"""
+RasFlowOptimization - Native HEC-RAS flow hydrograph optimization helpers.
+
+This module configures HEC-RAS Automated Flow Optimization using the native
+``Flow Ratio ...`` plan-file parameters and extracts trial summaries from HDF
+results or computation messages after execution.
+
+All methods are static and are designed to be used without instantiation.
+"""
+
+from __future__ import annotations
+
+import re
+from numbers import Number
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional, Tuple, Union
+
+import h5py
+import numpy as np
+import pandas as pd
+
+from .Decorators import log_call
+from .LoggingConfig import get_logger
+from .RasPlan import RasPlan
+from .RasPrj import ras
+from .RasUtils import RasUtils
+
+logger = get_logger(__name__)
+
+
+class RasFlowOptimization:
+    """
+    Static helpers for HEC-RAS native Automated Flow Optimization.
+
+    HEC-RAS stores flow hydrograph optimization setup in plan files using
+    ``Flow Ratio ...`` keys and reports trial progress in compute messages.
+    This API keeps execution in the standard ras-commander path: configure a
+    copied plan, run it with :class:`RasCmdr`, then extract the trial summary.
+    """
+
+    PLAN_KEYS = {
+        "target_value": "Flow Ratio Target",
+        "tolerance": "Flow Ratio Tolerance",
+        "initial_ratio": "Flow Ratio Initial Ratio",
+        "min_ratio": "Flow Ratio Min Ratio",
+        "max_ratio": "Flow Ratio Max Ratio",
+        "max_iterations": "Flow Ratio Max Iterations",
+        "reference": "Flow Ratio Reference",
+        "user_selected_hydrographs": "Flow Ratio User Selected Hydrographs",
+        "hydrograph": "Flow Ratio Optimization Hydrograph",
+        # These keys are not present in every HEC-RAS plan. The writer preserves
+        # and updates them when callers need the non-default restart behavior.
+        "restart_approach": "Flow Ratio Restart Approach",
+        "transition_period_hours": "Flow Ratio Transition Period",
+    }
+
+    RESTART_APPROACH_VALUES = {
+        "reuse_initial_conditions": "Re-use Initial Conditions",
+        "reuse": "Re-use Initial Conditions",
+        "default": "Re-use Initial Conditions",
+        "recompute_each_trial": "Recompute Each Trial",
+        "recompute": "Recompute Each Trial",
+    }
+
+    TRIAL_RESULT_COLUMNS = [
+        "trial",
+        "ratio",
+        "difference",
+        "target",
+        "computed",
+        "mode",
+        "units",
+        "reference_location",
+        "converged",
+        "failed",
+        "source",
+        "source_path",
+        "source_dataset",
+        "message",
+    ]
+
+    @staticmethod
+    @log_call
+    def get_settings(
+        plan_number_or_path: Union[str, Number, Path],
+        ras_object=None,
+    ) -> Dict[str, Any]:
+        """
+        Read native flow optimization settings from a HEC-RAS plan file.
+
+        Args:
+            plan_number_or_path: Plan number (``"01"``) or explicit ``.p##``
+                path.
+            ras_object: Optional RAS project object. If None, uses global
+                ``ras``.
+
+        Returns:
+            Dict with normalized keys including ``enabled``, ``mode``,
+            ``reference_location``, ratio limits, and selected hydrographs.
+        """
+        ras_obj = ras_object or ras
+        plan_path = RasFlowOptimization._resolve_plan_file_path(
+            plan_number_or_path,
+            ras_obj,
+        )
+        lines = RasFlowOptimization._read_text_lines(plan_path)
+        raw_values, hydrographs = RasFlowOptimization._read_flow_ratio_values(lines)
+
+        reference = raw_values.get(RasFlowOptimization.PLAN_KEYS["reference"])
+        reference_type, reference_location = RasFlowOptimization._split_reference(
+            reference
+        )
+        mode = RasFlowOptimization._infer_mode(reference_type, raw_values)
+
+        settings = {
+            "enabled": any(key.startswith("Flow Ratio ") for key in raw_values),
+            "mode": mode,
+            "reference": reference,
+            "reference_type": reference_type,
+            "reference_location": reference_location,
+            "target_value": RasFlowOptimization._parse_float(
+                raw_values.get(RasFlowOptimization.PLAN_KEYS["target_value"])
+            ),
+            "tolerance": RasFlowOptimization._parse_float(
+                raw_values.get(RasFlowOptimization.PLAN_KEYS["tolerance"])
+            ),
+            "initial_ratio": RasFlowOptimization._parse_float(
+                raw_values.get(RasFlowOptimization.PLAN_KEYS["initial_ratio"])
+            ),
+            "min_ratio": RasFlowOptimization._parse_float(
+                raw_values.get(RasFlowOptimization.PLAN_KEYS["min_ratio"])
+            ),
+            "max_ratio": RasFlowOptimization._parse_float(
+                raw_values.get(RasFlowOptimization.PLAN_KEYS["max_ratio"])
+            ),
+            "max_iterations": RasFlowOptimization._parse_int(
+                raw_values.get(RasFlowOptimization.PLAN_KEYS["max_iterations"])
+            ),
+            "user_selected_hydrographs": RasFlowOptimization._parse_ras_bool(
+                raw_values.get(
+                    RasFlowOptimization.PLAN_KEYS["user_selected_hydrographs"]
+                )
+            ),
+            "hydrographs": hydrographs,
+            "restart_approach": raw_values.get(
+                RasFlowOptimization.PLAN_KEYS["restart_approach"]
+            ),
+            "transition_period_hours": RasFlowOptimization._parse_float(
+                raw_values.get(
+                    RasFlowOptimization.PLAN_KEYS["transition_period_hours"]
+                )
+            ),
+            "plan_path": str(plan_path),
+            "raw_values": raw_values,
+        }
+        return settings
+
+    @staticmethod
+    @log_call
+    def set_settings(
+        plan_number_or_path: Union[str, Number, Path],
+        mode: str,
+        reference_location: str,
+        target_value: Union[int, float],
+        tolerance: Union[int, float] = 0.1,
+        initial_ratio: Union[int, float] = 1.0,
+        min_ratio: Union[int, float] = 0.5,
+        max_ratio: Union[int, float] = 4.0,
+        max_iterations: int = 10,
+        hydrographs: Optional[Union[str, Iterable[str]]] = None,
+        user_selected_hydrographs: Optional[bool] = None,
+        restart_approach: Optional[str] = None,
+        transition_period_hours: Optional[Union[int, float]] = None,
+        update_observed_timeseries: bool = True,
+        target_units: Optional[str] = None,
+        ras_object=None,
+    ) -> bool:
+        """
+        Write native flow optimization settings into a plan file.
+
+        Args:
+            plan_number_or_path: Plan number or explicit plan path.
+            mode: ``"stage"``, ``"flow"``, or ``"none"``.
+            reference_location: Existing HEC-RAS reference point/line name. A
+                full value such as ``"Ref Point: LowPoint"`` is accepted; if no
+                prefix is supplied, the prefix is inferred from ``mode``.
+            target_value: Target stage or flow value.
+            tolerance: Allowed target tolerance.
+            initial_ratio: Flow ratio used by trial 1.
+            min_ratio: Minimum trial flow ratio.
+            max_ratio: Maximum trial flow ratio.
+            max_iterations: Maximum number of trials.
+            hydrographs: Exact optimization hydrograph labels, a single label,
+                or ``None`` to auto-discover flow hydrographs where possible.
+                Plain names are written as ``"BCLine: <name>"``.
+            user_selected_hydrographs: Override the native user-selected flag.
+                Defaults to ``True`` when hydrograph labels are written.
+            restart_approach: Optional restart approach. Accepted shorthands:
+                ``"reuse_initial_conditions"`` or ``"recompute_each_trial"``.
+            transition_period_hours: Optional restart transition period.
+            update_observed_timeseries: Also write the constant observed stage
+                or flow target in the referenced unsteady flow file.
+            target_units: Units for the observed target series. Defaults to
+                ``"ft"`` for stage and ``"cfs"`` for flow.
+            ras_object: Optional RAS project object.
+
+        Returns:
+            True when the plan file was written successfully.
+        """
+        mode_key = RasFlowOptimization._normalize_mode(mode)
+        if mode_key == "none":
+            return RasFlowOptimization.disable_plan(
+                plan_number_or_path,
+                ras_object=ras_object,
+            )
+
+        RasFlowOptimization._validate_ratio_bounds(
+            min_ratio=min_ratio,
+            max_ratio=max_ratio,
+            initial_ratio=initial_ratio,
+            max_iterations=max_iterations,
+        )
+
+        ras_obj = ras_object or ras
+        plan_path = RasFlowOptimization._resolve_plan_file_path(
+            plan_number_or_path,
+            ras_obj,
+        )
+        reference = RasFlowOptimization._format_reference(
+            mode_key,
+            reference_location,
+        )
+        hydrograph_labels = RasFlowOptimization._resolve_hydrograph_labels(
+            hydrographs,
+            plan_path,
+            ras_obj,
+        )
+        if user_selected_hydrographs is None:
+            user_selected_hydrographs = bool(hydrograph_labels)
+
+        restart_value = None
+        if restart_approach is not None:
+            restart_value = RasFlowOptimization._normalize_restart_approach(
+                restart_approach
+            )
+
+        requested = {
+            RasFlowOptimization.PLAN_KEYS["target_value"]: target_value,
+            RasFlowOptimization.PLAN_KEYS["tolerance"]: tolerance,
+            RasFlowOptimization.PLAN_KEYS["initial_ratio"]: initial_ratio,
+            RasFlowOptimization.PLAN_KEYS["min_ratio"]: min_ratio,
+            RasFlowOptimization.PLAN_KEYS["max_ratio"]: max_ratio,
+            RasFlowOptimization.PLAN_KEYS["max_iterations"]: max_iterations,
+            RasFlowOptimization.PLAN_KEYS["reference"]: reference,
+            RasFlowOptimization.PLAN_KEYS[
+                "user_selected_hydrographs"
+            ]: user_selected_hydrographs,
+        }
+        if restart_value is not None:
+            requested[RasFlowOptimization.PLAN_KEYS["restart_approach"]] = (
+                restart_value
+            )
+        if transition_period_hours is not None:
+            requested[
+                RasFlowOptimization.PLAN_KEYS["transition_period_hours"]
+            ] = transition_period_hours
+
+        lines = RasFlowOptimization._read_text_lines(plan_path)
+        updated_lines = RasFlowOptimization._upsert_flow_ratio_lines(
+            lines,
+            requested,
+            hydrograph_labels,
+        )
+        RasFlowOptimization._write_text_lines(plan_path, updated_lines)
+
+        if update_observed_timeseries:
+            unsteady_path = RasFlowOptimization._resolve_unsteady_file_from_plan(
+                plan_path,
+                ras_obj,
+            )
+            if unsteady_path and unsteady_path.exists():
+                units = target_units or ("ft" if mode_key == "stage" else "cfs")
+                RasFlowOptimization._set_observed_target_timeseries(
+                    unsteady_path=unsteady_path,
+                    mode=mode_key,
+                    reference=reference,
+                    target_value=target_value,
+                    target_units=units,
+                    plan_lines=updated_lines,
+                )
+            else:
+                logger.warning(
+                    "Unsteady flow file could not be resolved; skipped observed "
+                    "target time-series update"
+                )
+
+        RasFlowOptimization._refresh_plan_dataframe(ras_obj)
+        logger.info("Updated flow optimization settings in %s", plan_path.name)
+        return True
+
+    @staticmethod
+    @log_call
+    def enable_plan(
+        plan_number_or_path: Union[str, Number, Path],
+        mode: str,
+        reference_location: str,
+        target_value: Union[int, float],
+        **kwargs,
+    ) -> bool:
+        """
+        Enable native Automated Flow Optimization for an existing plan.
+
+        This is an alias for :meth:`set_settings` with intent-focused naming.
+        """
+        return RasFlowOptimization.set_settings(
+            plan_number_or_path=plan_number_or_path,
+            mode=mode,
+            reference_location=reference_location,
+            target_value=target_value,
+            **kwargs,
+        )
+
+    @staticmethod
+    @log_call
+    def disable_plan(
+        plan_number_or_path: Union[str, Number, Path],
+        ras_object=None,
+    ) -> bool:
+        """
+        Remove native ``Flow Ratio ...`` settings from a plan file.
+
+        Args:
+            plan_number_or_path: Plan number or explicit plan path.
+            ras_object: Optional RAS project object.
+
+        Returns:
+            True when the plan file was updated.
+        """
+        ras_obj = ras_object or ras
+        plan_path = RasFlowOptimization._resolve_plan_file_path(
+            plan_number_or_path,
+            ras_obj,
+        )
+        lines = RasFlowOptimization._read_text_lines(plan_path)
+        updated_lines = [
+            line
+            for line in lines
+            if not line.lstrip().startswith("Flow Ratio ")
+        ]
+        RasFlowOptimization._write_text_lines(plan_path, updated_lines)
+        RasFlowOptimization._refresh_plan_dataframe(ras_obj)
+        logger.info("Disabled flow optimization in %s", plan_path.name)
+        return True
+
+    @staticmethod
+    @log_call
+    def copy_plan_with_optimization(
+        template_plan: Union[str, Number],
+        mode: str,
+        reference_location: str,
+        target_value: Union[int, float],
+        new_plan_shortid: Optional[str] = None,
+        new_title: Optional[str] = None,
+        ras_object=None,
+        **settings_kwargs,
+    ) -> str:
+        """
+        Clone a plan and enable native flow optimization on the copy.
+
+        Args:
+            template_plan: Existing plan number to copy.
+            mode: ``"stage"`` or ``"flow"``.
+            reference_location: Existing reference point/line.
+            target_value: Target stage or flow value.
+            new_plan_shortid: Optional new Short Identifier.
+            new_title: Optional new Plan Title.
+            ras_object: Optional RAS project object.
+            **settings_kwargs: Additional :meth:`set_settings` options.
+
+        Returns:
+            New plan number.
+        """
+        ras_obj = ras_object or ras
+        new_plan = RasPlan.clone_plan(
+            template_plan=template_plan,
+            new_plan_shortid=new_plan_shortid,
+            new_title=new_title,
+            ras_object=ras_obj,
+        )
+        RasFlowOptimization.set_settings(
+            new_plan,
+            mode=mode,
+            reference_location=reference_location,
+            target_value=target_value,
+            ras_object=ras_obj,
+            **settings_kwargs,
+        )
+        return new_plan
+
+    @staticmethod
+    @log_call
+    def list_flow_hydrographs(
+        plan_number_or_path: Union[str, Number, Path],
+        ras_object=None,
+    ) -> pd.DataFrame:
+        """
+        List flow hydrograph boundary labels available to a plan.
+
+        The returned ``optimization_hydrograph`` values are suitable for the
+        ``Flow Ratio Optimization Hydrograph=`` plan-file lines when HEC-RAS
+        uses 2D boundary condition line labels.
+        """
+        ras_obj = ras_object or ras
+        plan_path = RasFlowOptimization._resolve_plan_file_path(
+            plan_number_or_path,
+            ras_obj,
+        )
+        unsteady_path = RasFlowOptimization._resolve_unsteady_file_from_plan(
+            plan_path,
+            ras_obj,
+        )
+        if not unsteady_path or not unsteady_path.exists():
+            raise FileNotFoundError(
+                f"Unsteady flow file could not be resolved from {plan_path}"
+            )
+
+        lines = RasFlowOptimization._read_text_lines(unsteady_path)
+        rows = []
+        index = 0
+        while index < len(lines):
+            if lines[index].startswith("Boundary Location="):
+                block_end = index + 1
+                while (
+                    block_end < len(lines)
+                    and not lines[block_end].startswith("Boundary Location=")
+                ):
+                    block_end += 1
+                row = RasFlowOptimization._parse_unsteady_boundary_block(
+                    lines[index:block_end],
+                    line_number=index + 1,
+                )
+                if row.get("bc_type") in {
+                    "Flow Hydrograph",
+                    "Lateral Inflow Hydrograph",
+                    "Uniform Lateral Inflow Hydrograph",
+                }:
+                    rows.append(row)
+                index = block_end
+            else:
+                index += 1
+
+        df = pd.DataFrame(rows)
+        logger.info("Found %s flow hydrograph boundary rows", len(df))
+        return df
+
+    @staticmethod
+    @log_call
+    def get_trial_results(
+        plan_number_or_path: Union[str, Number, Path],
+        ras_object=None,
+    ) -> pd.DataFrame:
+        """
+        Extract native flow optimization trial results after compute.
+
+        The extractor first looks for flow optimization result datasets in the
+        plan HDF. If HEC-RAS stores the trials only in compute messages, it
+        falls back to parsing ``.computeMsgs.txt`` / ``.comp_msgs.txt`` or the
+        HDF compute-message text dataset.
+
+        Returns:
+            DataFrame with one row per parsed trial. Empty when no native flow
+            optimization output is available.
+        """
+        ras_obj = ras_object or ras
+        plan_path, hdf_path = RasFlowOptimization._resolve_plan_and_hdf_paths(
+            plan_number_or_path,
+            ras_obj,
+        )
+
+        hdf_df = pd.DataFrame()
+        if hdf_path is not None and hdf_path.exists():
+            hdf_df = RasFlowOptimization._extract_trial_results_from_hdf(hdf_path)
+            if not hdf_df.empty:
+                return RasFlowOptimization._finalize_trial_results(hdf_df)
+
+        messages = RasFlowOptimization._read_compute_messages(plan_path, hdf_path)
+        if not messages:
+            return pd.DataFrame(columns=RasFlowOptimization.TRIAL_RESULT_COLUMNS)
+
+        message_df = RasFlowOptimization.parse_compute_messages(messages)
+        if not message_df.empty:
+            source_path = hdf_path if hdf_path and hdf_path.exists() else plan_path
+            message_df["source_path"] = str(source_path) if source_path else None
+        return RasFlowOptimization._finalize_trial_results(message_df)
+
+    @staticmethod
+    @log_call
+    def parse_compute_messages(messages: str) -> pd.DataFrame:
+        """
+        Parse HEC-RAS flow optimization trial lines from compute messages.
+
+        Args:
+            messages: Raw compute message text.
+
+        Returns:
+            DataFrame with one row per ``Optimization trial #`` message.
+        """
+        if not messages:
+            return pd.DataFrame(columns=RasFlowOptimization.TRIAL_RESULT_COLUMNS)
+
+        header_re = re.compile(
+            r"Hydro\s+Flow\s+Optimization\s+"
+            r"(?P<mode>Stage|Flow)\s*,\s*Target\s+"
+            r"(?P<target>[-+]?\d*\.?\d+(?:[Ee][-+]?\d+)?)"
+            r"(?:\s+(?P<units>[A-Za-z0-9_/^.-]+))?\s+at\s+"
+            r"(?P<reference>.+)",
+            re.IGNORECASE,
+        )
+        trial_re = re.compile(
+            r"Optimization\s+trial\s*#\s*(?P<trial>\d+)\s+"
+            r"Ratio\s+(?P<ratio>[-+]?\d*\.?\d+(?:[Ee][-+]?\d+)?)\s+"
+            r"Difference\s+(?P<difference>[-+]?\d*\.?\d+(?:[Ee][-+]?\d+)?)\s+"
+            r"Target\s+(?P<target>[-+]?\d*\.?\d+(?:[Ee][-+]?\d+)?)\s+"
+            r"Computed\s+(?P<computed>[-+]?\d*\.?\d+(?:[Ee][-+]?\d+)?)",
+            re.IGNORECASE,
+        )
+        converged_re = re.compile(
+            r"Hydro\s+Flow\s+Optimization\s+Converged\s+Trial\s*#\s*"
+            r"(?P<trial>\d+)\s+Ratio\s+"
+            r"(?P<ratio>[-+]?\d*\.?\d+(?:[Ee][-+]?\d+)?)",
+            re.IGNORECASE,
+        )
+        failed_re = re.compile(
+            r"Hydro\s+Flow\s+Optimization.*"
+            r"(failed|not\s+able\s+to\s+converge|did\s+not\s+converge)",
+            re.IGNORECASE,
+        )
+
+        mode = None
+        units = None
+        reference = None
+        rows: List[Dict[str, Any]] = []
+        converged_trial = None
+        failed = False
+
+        for raw_line in messages.splitlines():
+            line = raw_line.strip()
+            if not line:
+                continue
+
+            header_match = header_re.search(line)
+            if header_match:
+                mode = header_match.group("mode").lower()
+                units = header_match.group("units")
+                reference = header_match.group("reference").strip()
+                continue
+
+            trial_match = trial_re.search(line)
+            if trial_match:
+                rows.append(
+                    {
+                        "trial": int(trial_match.group("trial")),
+                        "ratio": float(trial_match.group("ratio")),
+                        "difference": float(trial_match.group("difference")),
+                        "target": float(trial_match.group("target")),
+                        "computed": float(trial_match.group("computed")),
+                        "mode": mode,
+                        "units": units,
+                        "reference_location": reference,
+                        "converged": False,
+                        "failed": False,
+                        "source": "compute_messages",
+                        "source_path": None,
+                        "source_dataset": None,
+                        "message": line,
+                    }
+                )
+                continue
+
+            converged_match = converged_re.search(line)
+            if converged_match:
+                converged_trial = int(converged_match.group("trial"))
+                continue
+
+            if failed_re.search(line):
+                failed = True
+
+        if not rows:
+            return pd.DataFrame(columns=RasFlowOptimization.TRIAL_RESULT_COLUMNS)
+
+        df = pd.DataFrame(rows)
+        if converged_trial is not None:
+            df.loc[df["trial"] == converged_trial, "converged"] = True
+        if failed:
+            df["failed"] = True
+        return df
+
+    @staticmethod
+    @log_call
+    def compute_plan_and_get_trials(
+        plan_number: Union[str, Number, Path],
+        ras_object=None,
+        **compute_kwargs,
+    ) -> Dict[str, Any]:
+        """
+        Execute a plan through :class:`RasCmdr` and return native trials.
+
+        This method is a convenience wrapper only; it does not invoke HEC-RAS
+        directly.
+        """
+        from .RasCmdr import RasCmdr
+
+        compute_result = RasCmdr.compute_plan(
+            plan_number,
+            ras_object=ras_object,
+            **compute_kwargs,
+        )
+        trial_plan = RasFlowOptimization._resolve_trial_plan_after_compute(
+            plan_number,
+            ras_object=ras_object,
+            dest_folder=compute_kwargs.get("dest_folder"),
+        )
+        trial_results = RasFlowOptimization.get_trial_results(
+            trial_plan,
+            ras_object=ras_object,
+        )
+        return {
+            "compute_result": compute_result,
+            "trial_results": trial_results,
+        }
+
+    @staticmethod
+    def _resolve_plan_file_path(
+        plan_number_or_path: Union[str, Number, Path],
+        ras_object=None,
+    ) -> Path:
+        if isinstance(plan_number_or_path, (str, Path)):
+            path = Path(plan_number_or_path)
+            if path.is_file():
+                return path
+
+        ras_obj = ras_object or ras
+        ras_obj.check_initialized()
+        plan_path = RasPlan.get_plan_path(plan_number_or_path, ras_obj)
+        if plan_path is None or not Path(plan_path).exists():
+            raise FileNotFoundError(f"Plan file not found: {plan_number_or_path}")
+        return Path(plan_path)
+
+    @staticmethod
+    def _resolve_plan_and_hdf_paths(
+        plan_number_or_path: Union[str, Number, Path],
+        ras_object=None,
+    ) -> Tuple[Optional[Path], Optional[Path]]:
+        if isinstance(plan_number_or_path, (str, Path)):
+            path = Path(plan_number_or_path)
+            if path.is_file():
+                if path.suffix.lower() == ".hdf":
+                    plan_path = Path(str(path)[:-4])
+                    return (plan_path if plan_path.exists() else None, path)
+                return path, Path(str(path) + ".hdf")
+
+        ras_obj = ras_object or ras
+        ras_obj.check_initialized()
+        plan_path = RasPlan.get_plan_path(plan_number_or_path, ras_obj)
+        hdf_path = RasPlan.get_results_path(plan_number_or_path, ras_obj)
+        if hdf_path is None and plan_path is not None:
+            hdf_path = Path(str(plan_path) + ".hdf")
+        return plan_path, hdf_path
+
+    @staticmethod
+    def _resolve_trial_plan_after_compute(
+        plan_number: Union[str, Number, Path],
+        ras_object=None,
+        dest_folder: Optional[Union[str, Path]] = None,
+    ) -> Union[str, Number, Path]:
+        if dest_folder is None:
+            return plan_number
+
+        ras_obj = ras_object or ras
+        if isinstance(dest_folder, str):
+            project_folder = getattr(ras_obj, "project_folder", None)
+            if project_folder is None:
+                return plan_number
+            dest_path = Path(project_folder).parent / dest_folder
+        else:
+            dest_path = Path(dest_folder)
+
+        if isinstance(plan_number, (str, Path)):
+            plan_path = Path(plan_number)
+            if plan_path.is_file() or plan_path.suffix.lower().startswith(".p"):
+                return dest_path / plan_path.name
+
+        if isinstance(plan_number, Number) or str(plan_number).isdigit():
+            project_name = getattr(ras_obj, "project_name", None)
+            if project_name:
+                plan_num = RasUtils.normalize_ras_number(plan_number)
+                return dest_path / f"{project_name}.p{plan_num}"
+
+        return plan_number
+
+    @staticmethod
+    def _resolve_unsteady_file_from_plan(
+        plan_path: Path,
+        ras_object=None,
+    ) -> Optional[Path]:
+        flow_file = None
+        for line in RasFlowOptimization._read_text_lines(plan_path):
+            if line.startswith("Flow File="):
+                flow_file = line.split("=", 1)[1].strip()
+                break
+        if not flow_file or not flow_file.lower().startswith("u"):
+            return None
+
+        unsteady_number = RasUtils.normalize_ras_number(flow_file[1:])
+        ras_obj = ras_object or ras
+        try:
+            if getattr(ras_obj, "project_folder", None):
+                unsteady_path = RasPlan.get_unsteady_path(
+                    unsteady_number,
+                    ras_obj,
+                )
+                if unsteady_path is not None:
+                    return Path(unsteady_path)
+        except Exception:
+            logger.debug("Could not resolve unsteady path from ras_object")
+
+        match = re.match(r"(?P<base>.+)\.p\d{2,3}$", plan_path.name, re.IGNORECASE)
+        if not match:
+            return None
+        return plan_path.parent / f"{match.group('base')}.u{unsteady_number}"
+
+    @staticmethod
+    def _read_text_lines(path: Path) -> List[str]:
+        return path.read_text(encoding="utf-8", errors="ignore").splitlines(
+            keepends=True
+        )
+
+    @staticmethod
+    def _write_text_lines(path: Path, lines: List[str]) -> None:
+        path.write_text("".join(lines), encoding="utf-8")
+
+    @staticmethod
+    def _read_flow_ratio_values(
+        lines: List[str],
+    ) -> Tuple[Dict[str, str], List[str]]:
+        raw_values: Dict[str, str] = {}
+        hydrographs: List[str] = []
+        for line in lines:
+            if "=" not in line:
+                continue
+            key, raw_value = line.split("=", 1)
+            key = key.strip()
+            if not key.startswith("Flow Ratio "):
+                continue
+            value = raw_value.strip()
+            if key == RasFlowOptimization.PLAN_KEYS["hydrograph"]:
+                hydrographs.append(value)
+            else:
+                raw_values[key] = value
+        return raw_values, hydrographs
+
+    @staticmethod
+    def _upsert_flow_ratio_lines(
+        lines: List[str],
+        requested: Dict[str, Any],
+        hydrograph_labels: List[str],
+    ) -> List[str]:
+        original_keys = set(requested.keys())
+        updated_keys = set()
+        output: List[str] = []
+
+        for line in lines:
+            if "=" not in line:
+                output.append(line)
+                continue
+            key = line.split("=", 1)[0].strip()
+            if key == RasFlowOptimization.PLAN_KEYS["hydrograph"]:
+                continue
+            if key in requested:
+                output.append(
+                    f"{key}={RasFlowOptimization._format_plan_value(requested[key])}\n"
+                )
+                updated_keys.add(key)
+            else:
+                output.append(line)
+
+        missing = [
+            key
+            for key in requested
+            if key in original_keys and key not in updated_keys
+        ]
+        new_lines = [
+            f"{key}={RasFlowOptimization._format_plan_value(requested[key])}\n"
+            for key in missing
+        ]
+        new_lines.extend(
+            f"{RasFlowOptimization.PLAN_KEYS['hydrograph']}={label}\n"
+            for label in hydrograph_labels
+        )
+
+        insert_index = RasFlowOptimization._find_flow_ratio_insert_index(output)
+        output[insert_index:insert_index] = new_lines
+        return output
+
+    @staticmethod
+    def _find_flow_ratio_insert_index(lines: List[str]) -> int:
+        insert_index = None
+        for index, line in enumerate(lines):
+            if line.startswith("Flow Ratio "):
+                insert_index = index + 1
+        if insert_index is not None:
+            return insert_index
+
+        for index, line in enumerate(lines):
+            if line.startswith("Computation Interval="):
+                return index
+            if line.startswith("CheckData="):
+                insert_index = index + 1
+        return insert_index if insert_index is not None else len(lines)
+
+    @staticmethod
+    def _format_plan_value(value: Any) -> str:
+        if isinstance(value, bool):
+            return "-1" if value else "0"
+        if isinstance(value, (int, np.integer)):
+            return f" {int(value)} "
+        if isinstance(value, (float, np.floating)):
+            return RasFlowOptimization._format_float(float(value))
+        return str(value)
+
+    @staticmethod
+    def _format_float(value: float) -> str:
+        return f"{value:.12g}"
+
+    @staticmethod
+    def _normalize_mode(mode: str) -> str:
+        mode_key = str(mode).strip().lower()
+        if mode_key not in {"stage", "flow", "none"}:
+            raise ValueError("mode must be one of: 'stage', 'flow', 'none'")
+        return mode_key
+
+    @staticmethod
+    def _format_reference(mode: str, reference_location: str) -> str:
+        reference = str(reference_location).strip()
+        if not reference:
+            raise ValueError("reference_location cannot be empty")
+        if ":" in reference:
+            return reference
+        prefix = "Ref Point" if mode == "stage" else "Ref Line"
+        return f"{prefix}: {reference}"
+
+    @staticmethod
+    def _split_reference(reference: Optional[str]) -> Tuple[Optional[str], Optional[str]]:
+        if not reference:
+            return None, None
+        match = re.match(r"(?P<kind>Ref\s+(?:Point|Line)):\s*(?P<name>.*)", reference)
+        if not match:
+            return None, reference
+        return match.group("kind"), match.group("name").strip()
+
+    @staticmethod
+    def _infer_mode(
+        reference_type: Optional[str],
+        raw_values: Dict[str, str],
+    ) -> Optional[str]:
+        explicit_mode = raw_values.get("Flow Ratio Mode")
+        if explicit_mode:
+            lowered = explicit_mode.strip().lower()
+            if lowered in {"stage", "flow", "none"}:
+                return lowered
+        if reference_type:
+            if "point" in reference_type.lower():
+                return "stage"
+            if "line" in reference_type.lower():
+                return "flow"
+        return None
+
+    @staticmethod
+    def _normalize_restart_approach(restart_approach: str) -> str:
+        key = str(restart_approach).strip().lower().replace("-", "_").replace(" ", "_")
+        return RasFlowOptimization.RESTART_APPROACH_VALUES.get(
+            key,
+            str(restart_approach).strip(),
+        )
+
+    @staticmethod
+    def _validate_ratio_bounds(
+        min_ratio: Union[int, float],
+        max_ratio: Union[int, float],
+        initial_ratio: Union[int, float],
+        max_iterations: int,
+    ) -> None:
+        min_value = float(min_ratio)
+        max_value = float(max_ratio)
+        initial_value = float(initial_ratio)
+        if min_value > max_value:
+            raise ValueError("min_ratio cannot exceed max_ratio")
+        if not min_value <= initial_value <= max_value:
+            raise ValueError("initial_ratio must be between min_ratio and max_ratio")
+        if int(max_iterations) < 1:
+            raise ValueError("max_iterations must be at least 1")
+
+    @staticmethod
+    def _resolve_hydrograph_labels(
+        hydrographs: Optional[Union[str, Iterable[str]]],
+        plan_path: Path,
+        ras_object=None,
+    ) -> List[str]:
+        if hydrographs is None:
+            try:
+                df = RasFlowOptimization.list_flow_hydrographs(
+                    plan_path,
+                    ras_object=ras_object,
+                )
+                if "optimization_hydrograph" in df.columns:
+                    return [
+                        str(value)
+                        for value in df["optimization_hydrograph"].dropna().tolist()
+                        if str(value).strip()
+                    ]
+            except Exception as exc:
+                logger.debug("Auto-discovery of hydrographs failed: %s", exc)
+                return []
+
+        if isinstance(hydrographs, str):
+            if hydrographs.strip().lower() == "all":
+                return RasFlowOptimization._resolve_hydrograph_labels(
+                    None,
+                    plan_path,
+                    ras_object=ras_object,
+                )
+            hydrograph_iterable = [hydrographs]
+        else:
+            hydrograph_iterable = list(hydrographs)
+
+        return [
+            RasFlowOptimization._format_hydrograph_label(label)
+            for label in hydrograph_iterable
+            if str(label).strip()
+        ]
+
+    @staticmethod
+    def _format_hydrograph_label(label: Any) -> str:
+        text = str(label).strip()
+        if ":" in text:
+            return text
+        return f"BCLine: {text}"
+
+    @staticmethod
+    def _parse_unsteady_boundary_block(
+        block_lines: List[str],
+        line_number: int,
+    ) -> Dict[str, Any]:
+        location_line = block_lines[0].split("=", 1)[1]
+        fields = [field.strip() for field in location_line.split(",")]
+        row = {
+            "river": fields[0] if len(fields) > 0 else "",
+            "reach": fields[1] if len(fields) > 1 else "",
+            "station": fields[2] if len(fields) > 2 else "",
+            "storage_area": fields[4] if len(fields) > 4 else "",
+            "flow_area": fields[5] if len(fields) > 5 else "",
+            "bc_line": fields[7] if len(fields) > 7 else "",
+            "bc_type": "",
+            "interval": "",
+            "use_dss": "",
+            "dss_file": "",
+            "dss_path": "",
+            "line_number": line_number,
+        }
+
+        for raw_line in block_lines[1:]:
+            line = raw_line.strip()
+            if line.startswith("Interval="):
+                row["interval"] = line.split("=", 1)[1].strip()
+            elif line.startswith("Flow Hydrograph="):
+                row["bc_type"] = "Flow Hydrograph"
+            elif line.startswith("Lateral Inflow Hydrograph="):
+                row["bc_type"] = "Lateral Inflow Hydrograph"
+            elif line.startswith("Uniform Lateral Inflow Hydrograph="):
+                row["bc_type"] = "Uniform Lateral Inflow Hydrograph"
+            elif line.startswith("Use DSS="):
+                row["use_dss"] = line.split("=", 1)[1].strip()
+            elif line.startswith("DSS File="):
+                row["dss_file"] = line.split("=", 1)[1].strip()
+            elif line.startswith("DSS Path="):
+                row["dss_path"] = line.split("=", 1)[1].strip()
+
+        if row["bc_line"]:
+            row["optimization_hydrograph"] = f"BCLine: {row['bc_line']}"
+        else:
+            parts = [row["river"], row["reach"], row["station"]]
+            row["optimization_hydrograph"] = ", ".join(
+                part for part in parts if part
+            )
+        return row
+
+    @staticmethod
+    def _set_observed_target_timeseries(
+        unsteady_path: Path,
+        mode: str,
+        reference: str,
+        target_value: Union[int, float],
+        target_units: str,
+        plan_lines: List[str],
+    ) -> None:
+        series_type = "Stage" if mode == "stage" else "Flow"
+        prefix = f"Observed Time Series={series_type}|"
+        start_datetime = RasFlowOptimization._simulation_start_datetime(plan_lines)
+        block = [
+            f"{prefix}TS Name={reference}\n",
+            f"{prefix}TS Used=-1\n",
+            f"{prefix}TS Source=Constant\n",
+            f"{prefix}TS Table Mode=0\n",
+            f"{prefix}TS Table Use Fixed Start=0\n",
+            f"{prefix}TS Table StartDateTime={start_datetime}\n",
+            f"{prefix}TS Table Interval=1 Hour\n",
+            f"{prefix}TS Table Data Units={target_units}\n",
+            f"{prefix}TS Table Data Type=INST-VAL\n",
+            (
+                f"{prefix}TS Constant Value="
+                f"{RasFlowOptimization._format_float(float(target_value))}\n"
+            ),
+            f"{prefix}TS Constant Units={target_units}\n",
+        ]
+
+        lines = RasFlowOptimization._read_text_lines(unsteady_path)
+        start_idx, end_idx = RasFlowOptimization._find_observed_timeseries_block(
+            lines,
+            prefix,
+            reference,
+        )
+        if start_idx is not None and end_idx is not None:
+            lines[start_idx:end_idx] = block
+        else:
+            insert_idx = RasFlowOptimization._find_unsteady_observed_insert_index(lines)
+            lines[insert_idx:insert_idx] = block
+
+        RasFlowOptimization._write_text_lines(unsteady_path, lines)
+        logger.info("Updated observed %s target in %s", series_type, unsteady_path.name)
+
+    @staticmethod
+    def _find_observed_timeseries_block(
+        lines: List[str],
+        prefix: str,
+        reference: str,
+    ) -> Tuple[Optional[int], Optional[int]]:
+        target_name = f"{prefix}TS Name={reference}"
+        for index, line in enumerate(lines):
+            if line.strip() != target_name:
+                continue
+            end = index + 1
+            while end < len(lines):
+                if (
+                    lines[end].startswith("Observed Time Series=")
+                    and "|TS Name=" in lines[end]
+                ):
+                    break
+                if not lines[end].startswith(prefix):
+                    break
+                end += 1
+            return index, end
+        return None, None
+
+    @staticmethod
+    def _find_unsteady_observed_insert_index(lines: List[str]) -> int:
+        for index, line in enumerate(lines):
+            if line.startswith("Non-Newtonian Method="):
+                return index
+        return len(lines)
+
+    @staticmethod
+    def _simulation_start_datetime(plan_lines: List[str]) -> str:
+        for line in plan_lines:
+            if not line.startswith("Simulation Date="):
+                continue
+            value = line.split("=", 1)[1].strip()
+            parts = [part.strip() for part in value.split(",")]
+            if len(parts) < 2:
+                return ""
+            date_part = parts[0]
+            time_part = parts[1].zfill(4)
+            day = date_part[:2]
+            month = date_part[2:5].title()
+            year = date_part[5:]
+            return f"{day}{month}{year} {time_part[:2]}:{time_part[2:]}:00"
+        return ""
+
+    @staticmethod
+    def _extract_trial_results_from_hdf(hdf_path: Path) -> pd.DataFrame:
+        rows = []
+        with h5py.File(hdf_path, "r") as hdf_file:
+            def visitor(name: str, obj: Any) -> None:
+                if not isinstance(obj, h5py.Dataset):
+                    return
+                lowered = name.lower()
+                if not (
+                    ("flow" in lowered and "optimization" in lowered)
+                    or "flow ratio" in lowered
+                ):
+                    return
+                candidate = RasFlowOptimization._dataset_to_dataframe(obj)
+                if candidate.empty:
+                    return
+                normalized = RasFlowOptimization._normalize_hdf_trial_dataframe(
+                    candidate,
+                    hdf_path,
+                    name,
+                )
+                if not normalized.empty:
+                    rows.append(normalized)
+
+            hdf_file.visititems(visitor)
+
+        if not rows:
+            return pd.DataFrame(columns=RasFlowOptimization.TRIAL_RESULT_COLUMNS)
+        return pd.concat(rows, ignore_index=True)
+
+    @staticmethod
+    def _dataset_to_dataframe(dataset: h5py.Dataset) -> pd.DataFrame:
+        data = dataset[()]
+        if isinstance(data, (bytes, str)) or np.isscalar(data):
+            return pd.DataFrame()
+
+        if getattr(data, "dtype", None) is not None and data.dtype.names:
+            df = pd.DataFrame.from_records(data)
+        elif isinstance(data, np.ndarray) and data.ndim == 2:
+            columns = RasFlowOptimization._get_dataset_column_names(
+                dataset,
+                data.shape[1],
+            )
+            df = pd.DataFrame(data, columns=columns)
+        elif isinstance(data, np.ndarray) and data.ndim == 1:
+            df = pd.DataFrame({"value": data})
+        else:
+            return pd.DataFrame()
+
+        for column in df.columns:
+            if df[column].dtype == object:
+                df[column] = df[column].map(RasFlowOptimization._decode_hdf_value)
+        return df
+
+    @staticmethod
+    def _get_dataset_column_names(
+        dataset: h5py.Dataset,
+        width: int,
+    ) -> List[str]:
+        for attr_name in (
+            "Column Names",
+            "Column names",
+            "Columns",
+            "Variable Names",
+            "Variables",
+        ):
+            if attr_name not in dataset.attrs:
+                continue
+            raw = dataset.attrs[attr_name]
+            values = np.atleast_1d(raw).tolist()
+            columns = [
+                str(RasFlowOptimization._decode_hdf_value(value)).strip()
+                for value in values
+            ]
+            if len(columns) == width:
+                return columns
+        return [f"column_{index}" for index in range(width)]
+
+    @staticmethod
+    def _decode_hdf_value(value: Any) -> Any:
+        if isinstance(value, bytes):
+            return value.decode("utf-8", errors="ignore").strip()
+        return value
+
+    @staticmethod
+    def _normalize_hdf_trial_dataframe(
+        df: pd.DataFrame,
+        hdf_path: Path,
+        dataset_name: str,
+    ) -> pd.DataFrame:
+        normalized_columns = {
+            column: RasFlowOptimization._normalize_column_name(str(column))
+            for column in df.columns
+        }
+        rename_map = {}
+        for column, normalized in normalized_columns.items():
+            if normalized in {"trial", "trial_number"}:
+                rename_map[column] = "trial"
+            elif normalized in {"ratio", "flow_ratio", "hydrograph_ratio"}:
+                rename_map[column] = "ratio"
+            elif normalized in {"difference", "diff", "error"}:
+                rename_map[column] = "difference"
+            elif normalized == "target":
+                rename_map[column] = "target"
+            elif normalized in {"computed", "computed_value"}:
+                rename_map[column] = "computed"
+
+        result = df.rename(columns=rename_map)
+        required = {"trial", "ratio"}
+        if not required.issubset(set(result.columns)):
+            return pd.DataFrame(columns=RasFlowOptimization.TRIAL_RESULT_COLUMNS)
+
+        result = result.copy()
+        result["source"] = "hdf"
+        result["source_path"] = str(hdf_path)
+        result["source_dataset"] = dataset_name
+        result["message"] = None
+        result["converged"] = False
+        result["failed"] = False
+        return result
+
+    @staticmethod
+    def _normalize_column_name(name: str) -> str:
+        normalized = name.strip().lower()
+        normalized = normalized.replace("#", "number")
+        normalized = re.sub(r"[^a-z0-9]+", "_", normalized)
+        return normalized.strip("_")
+
+    @staticmethod
+    def _read_compute_messages(
+        plan_path: Optional[Path],
+        hdf_path: Optional[Path],
+    ) -> str:
+        if hdf_path is not None and hdf_path.exists():
+            try:
+                with h5py.File(hdf_path, "r") as hdf_file:
+                    path = "Results/Summary/Compute Messages (text)"
+                    if path in hdf_file:
+                        data = hdf_file[path][()]
+                        return str(RasFlowOptimization._decode_compute_message_data(data))
+            except Exception as exc:
+                logger.debug("Could not read HDF compute messages: %s", exc)
+
+        candidate_paths: List[Path] = []
+        if hdf_path is not None:
+            candidate_paths.extend(
+                [
+                    Path(str(hdf_path).replace(".hdf", ".computeMsgs.txt")),
+                    Path(str(hdf_path).replace(".hdf", ".comp_msgs.txt")),
+                ]
+            )
+        if plan_path is not None:
+            candidate_paths.extend(
+                [
+                    Path(str(plan_path) + ".computeMsgs.txt"),
+                    Path(str(plan_path) + ".comp_msgs.txt"),
+                ]
+            )
+
+        for candidate_path in candidate_paths:
+            if candidate_path.exists():
+                return candidate_path.read_text(encoding="utf-8", errors="ignore")
+        return ""
+
+    @staticmethod
+    def _decode_compute_message_data(data: Any) -> str:
+        if isinstance(data, bytes):
+            return data.decode("utf-8", errors="ignore")
+        if isinstance(data, np.ndarray):
+            values = data.ravel().tolist()
+            return "\n".join(
+                str(RasFlowOptimization._decode_hdf_value(value))
+                for value in values
+            )
+        return str(data)
+
+    @staticmethod
+    def _finalize_trial_results(df: pd.DataFrame) -> pd.DataFrame:
+        if df.empty:
+            return pd.DataFrame(columns=RasFlowOptimization.TRIAL_RESULT_COLUMNS)
+        result = df.copy()
+        for column in RasFlowOptimization.TRIAL_RESULT_COLUMNS:
+            if column not in result.columns:
+                result[column] = None
+
+        for column in ("trial",):
+            result[column] = pd.to_numeric(result[column], errors="coerce").astype(
+                "Int64"
+            )
+        for column in ("ratio", "difference", "target", "computed"):
+            result[column] = pd.to_numeric(result[column], errors="coerce")
+        for column in ("converged", "failed"):
+            result[column] = result[column].fillna(False).astype(bool)
+
+        return result[RasFlowOptimization.TRIAL_RESULT_COLUMNS]
+
+    @staticmethod
+    def _parse_float(value: Optional[str]) -> Optional[float]:
+        if value in (None, ""):
+            return None
+        try:
+            return float(str(value).strip())
+        except ValueError:
+            return None
+
+    @staticmethod
+    def _parse_int(value: Optional[str]) -> Optional[int]:
+        if value in (None, ""):
+            return None
+        try:
+            return int(float(str(value).strip()))
+        except ValueError:
+            return None
+
+    @staticmethod
+    def _parse_ras_bool(value: Optional[str]) -> Optional[bool]:
+        if value is None:
+            return None
+        text = str(value).strip().lower()
+        if text in {"-1", "true", "yes", "1"}:
+            return True
+        if text in {"0", "false", "no"}:
+            return False
+        return None
+
+    @staticmethod
+    def _refresh_plan_dataframe(ras_object=None) -> None:
+        ras_obj = ras_object or ras
+        try:
+            if getattr(ras_obj, "project_folder", None):
+                ras_obj.plan_df = ras_obj.get_plan_entries()
+        except Exception:
+            logger.debug("Skipped plan_df refresh")

--- a/ras_commander/__init__.py
+++ b/ras_commander/__init__.py
@@ -64,6 +64,7 @@ from .RasCalibrate import (
     make_steady_profile_calibration_points,
     make_xsec_mannings_apply_fn,
 )
+from .RasFlowOptimization import RasFlowOptimization
 
 # Validation framework - core validation infrastructure
 from .RasValidation import ValidationSeverity, ValidationResult, ValidationReport
@@ -179,7 +180,7 @@ __all__ = [
     'extract_steady_profile_modeled', 'extract_steady_profile_observations',
     'make_composite_apply_fn', 'make_infiltration_apply_fn',
     'make_mannings_apply_fn', 'make_steady_profile_calibration_points',
-    'make_xsec_mannings_apply_fn',
+    'make_xsec_mannings_apply_fn', 'RasFlowOptimization',
 
     # Geometry handling (new in v0.86.0)
     'GeomParser', 'GeomPreprocessor', 'GeomLandCover',

--- a/tests/test_rasflowoptimization.py
+++ b/tests/test_rasflowoptimization.py
@@ -1,0 +1,274 @@
+"""Tests for native HEC-RAS flow hydrograph optimization helpers."""
+
+from pathlib import Path
+
+import h5py
+import numpy as np
+
+from ras_commander import RasFlowOptimization
+
+
+class _DummyRas:
+    project_folder = None
+
+    def check_initialized(self):
+        return None
+
+
+def _write_plan(path: Path) -> None:
+    path.write_text(
+        "\n".join(
+            [
+                "Plan Title=Base",
+                "Program Version=6.40",
+                "Short Identifier=Base",
+                "Simulation Date=31dec1996,0000,05jan1997,0000",
+                "Geom File=g01",
+                "Flow File=u01",
+                "Subcritical Flow",
+                "CheckData=True",
+                "Computation Interval=1MIN",
+                "Output Interval=10MIN",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+def _write_unsteady(path: Path) -> None:
+    path.write_text(
+        "\n".join(
+            [
+                "Flow Title=Flood",
+                "Program Version=6.40",
+                "Use Restart= 0 ",
+                (
+                    "Boundary Location=                ,                ,        ,"
+                    "        ,                ,2DArea          ,                ,"
+                    "Inflow                          ,"
+                ),
+                "Interval=1HOUR",
+                "Flow Hydrograph= 0 ",
+                "DSS File=.\\Flow_Data\\streamflow.dss",
+                "DSS Path=/MERCED/FLOW/01DEC1996/15MIN/USGS/",
+                "Use DSS=True",
+                "Non-Newtonian Method= 0 ,",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+def test_set_and_get_native_flow_optimization_settings(tmp_path):
+    plan_path = tmp_path / "Project.p01"
+    unsteady_path = tmp_path / "Project.u01"
+    _write_plan(plan_path)
+    _write_unsteady(unsteady_path)
+
+    assert RasFlowOptimization.set_settings(
+        plan_path,
+        mode="stage",
+        reference_location="LowPointOnRoad",
+        target_value=3967.0,
+        tolerance=0.1,
+        initial_ratio=1.0,
+        min_ratio=0.5,
+        max_ratio=4.0,
+        max_iterations=10,
+        hydrographs=["Inflow"],
+        ras_object=_DummyRas(),
+    )
+
+    content = plan_path.read_text(encoding="utf-8")
+    assert "Flow Ratio Target=3967\n" in content
+    assert "Flow Ratio Reference=Ref Point: LowPointOnRoad\n" in content
+    assert "Flow Ratio User Selected Hydrographs=-1\n" in content
+    assert "Flow Ratio Optimization Hydrograph=BCLine: Inflow\n" in content
+    assert content.index("Flow Ratio Target=") < content.index("Computation Interval=")
+
+    settings = RasFlowOptimization.get_settings(plan_path, ras_object=_DummyRas())
+    assert settings["enabled"] is True
+    assert settings["mode"] == "stage"
+    assert settings["reference_location"] == "LowPointOnRoad"
+    assert settings["target_value"] == 3967.0
+    assert settings["max_iterations"] == 10
+    assert settings["hydrographs"] == ["BCLine: Inflow"]
+
+    unsteady_content = unsteady_path.read_text(encoding="utf-8")
+    assert "Observed Time Series=Stage|TS Name=Ref Point: LowPointOnRoad\n" in unsteady_content
+    assert "Observed Time Series=Stage|TS Constant Value=3967\n" in unsteady_content
+
+
+def test_list_flow_hydrographs_from_plan_unsteady_file(tmp_path):
+    plan_path = tmp_path / "Project.p01"
+    unsteady_path = tmp_path / "Project.u01"
+    _write_plan(plan_path)
+    _write_unsteady(unsteady_path)
+
+    df = RasFlowOptimization.list_flow_hydrographs(
+        plan_path,
+        ras_object=_DummyRas(),
+    )
+
+    assert len(df) == 1
+    assert df.loc[0, "bc_type"] == "Flow Hydrograph"
+    assert df.loc[0, "flow_area"] == "2DArea"
+    assert df.loc[0, "bc_line"] == "Inflow"
+    assert df.loc[0, "optimization_hydrograph"] == "BCLine: Inflow"
+
+
+def test_observed_target_update_preserves_other_observed_series(tmp_path):
+    plan_path = tmp_path / "Project.p01"
+    unsteady_path = tmp_path / "Project.u01"
+    _write_plan(plan_path)
+    _write_unsteady(unsteady_path)
+    content = unsteady_path.read_text(encoding="utf-8")
+    content = content.replace(
+        "Non-Newtonian Method= 0 ,\n",
+        (
+            "Observed Time Series=Stage|TS Name=Ref Point: LowPointOnRoad\n"
+            "Observed Time Series=Stage|TS Used=-1\n"
+            "Observed Time Series=Stage|TS Source=Constant\n"
+            "Observed Time Series=Stage|TS Constant Value=3900\n"
+            "Observed Time Series=Stage|TS Name=Ref Point: PreserveMe\n"
+            "Observed Time Series=Stage|TS Used=-1\n"
+            "Observed Time Series=Stage|TS Source=Constant\n"
+            "Observed Time Series=Stage|TS Constant Value=4000\n"
+            "Non-Newtonian Method= 0 ,\n"
+        ),
+    )
+    unsteady_path.write_text(content, encoding="utf-8")
+
+    RasFlowOptimization.set_settings(
+        plan_path,
+        mode="stage",
+        reference_location="LowPointOnRoad",
+        target_value=3967.0,
+        hydrographs=["Inflow"],
+        ras_object=_DummyRas(),
+    )
+
+    unsteady_content = unsteady_path.read_text(encoding="utf-8")
+    assert "Observed Time Series=Stage|TS Constant Value=3967\n" in unsteady_content
+    assert "Observed Time Series=Stage|TS Name=Ref Point: PreserveMe\n" in unsteady_content
+    assert "Observed Time Series=Stage|TS Constant Value=4000\n" in unsteady_content
+
+
+def test_parse_compute_message_trial_summary():
+    messages = """
+Unsteady Input Summary:
+Hydro Flow Optimization Stage, Target 3967.00 ft at LowPointOnRoad
+Hydro Flow Optimization Trial # 1
+Optimization trial # 1 Ratio 1.000 Difference 1.765 Target 3967.00 Computed 3968.76
+Hydro Flow Optimization Trial # 2
+Optimization trial # 2 Ratio 0.833 Difference 1.037 Target 3967.00 Computed 3968.04
+Hydro Flow Optimization Trial # 3
+Optimization trial # 3 Ratio 0.500 Difference -0.532 Target 3967.00 Computed 3966.47
+Hydro Flow Optimization Trial # 4
+Optimization trial # 4 Ratio 0.613 Difference 0.062 Target 3967.00 Computed 3967.06
+Hydro Flow Optimization Converged Trial # 4 Ratio 0.613
+"""
+
+    df = RasFlowOptimization.parse_compute_messages(messages)
+
+    assert df["trial"].tolist() == [1, 2, 3, 4]
+    assert df.loc[0, "mode"] == "stage"
+    assert df.loc[0, "units"] == "ft"
+    assert df.loc[0, "reference_location"] == "LowPointOnRoad"
+    assert np.isclose(df.loc[2, "difference"], -0.532)
+    assert bool(df.loc[3, "converged"]) is True
+
+
+def test_get_trial_results_reads_hdf_dataset(tmp_path):
+    hdf_path = tmp_path / "Project.p01.hdf"
+    dtype = np.dtype(
+        [
+            ("Trial", "<i4"),
+            ("Ratio", "<f8"),
+            ("Difference", "<f8"),
+            ("Target", "<f8"),
+            ("Computed", "<f8"),
+        ]
+    )
+    data = np.array(
+        [
+            (1, 1.0, 1.765, 3967.0, 3968.765),
+            (2, 0.833, 1.037, 3967.0, 3968.037),
+        ],
+        dtype=dtype,
+    )
+    with h5py.File(hdf_path, "w") as hdf_file:
+        hdf_file.create_dataset(
+            "Results/Unsteady/Flow Optimization/Trials",
+            data=data,
+        )
+
+    df = RasFlowOptimization.get_trial_results(hdf_path, ras_object=_DummyRas())
+
+    assert df["source"].unique().tolist() == ["hdf"]
+    assert df["trial"].tolist() == [1, 2]
+    assert np.isclose(df.loc[1, "ratio"], 0.833)
+    assert df.loc[0, "source_dataset"] == "Results/Unsteady/Flow Optimization/Trials"
+
+
+def test_get_trial_results_falls_back_to_compute_messages(tmp_path):
+    plan_path = tmp_path / "Project.p01"
+    _write_plan(plan_path)
+    Path(str(plan_path) + ".computeMsgs.txt").write_text(
+        (
+            "Hydro Flow Optimization Flow, Target 5000 cfs at RefLine1\n"
+            "Optimization trial # 1 Ratio 1.200 Difference -100 "
+            "Target 5000 Computed 4900\n"
+        ),
+        encoding="utf-8",
+    )
+
+    df = RasFlowOptimization.get_trial_results(plan_path, ras_object=_DummyRas())
+
+    assert len(df) == 1
+    assert df.loc[0, "source"] == "compute_messages"
+    assert df.loc[0, "mode"] == "flow"
+    assert df.loc[0, "units"] == "cfs"
+    assert df.loc[0, "computed"] == 4900.0
+
+
+def test_compute_plan_and_get_trials_reads_dest_folder(monkeypatch, tmp_path):
+    project_folder = tmp_path / "Project"
+    project_folder.mkdir()
+    ras_object = _DummyRas()
+    ras_object.project_folder = project_folder
+    ras_object.project_name = "Project"
+
+    dest_folder = tmp_path / "Project Optimized"
+
+    def fake_compute_plan(plan_number, ras_object=None, **kwargs):
+        dest_folder.mkdir()
+        plan_path = dest_folder / "Project.p01"
+        _write_plan(plan_path)
+        Path(str(plan_path) + ".computeMsgs.txt").write_text(
+            (
+                "Hydro Flow Optimization Stage, Target 3963.5 ft at Vantage\n"
+                "Optimization trial # 1 Ratio 0.900 Difference 0.1 "
+                "Target 3963.5 Computed 3963.6\n"
+            ),
+            encoding="utf-8",
+        )
+        return True
+
+    from ras_commander import RasCmdr
+
+    monkeypatch.setattr(RasCmdr, "compute_plan", fake_compute_plan)
+
+    result = RasFlowOptimization.compute_plan_and_get_trials(
+        "01",
+        ras_object=ras_object,
+        dest_folder=dest_folder,
+    )
+
+    assert result["compute_result"] is True
+    assert result["trial_results"].loc[0, "ratio"] == 0.9
+    assert result["trial_results"].loc[0, "source_path"] == str(
+        dest_folder / "Project.p01"
+    )


### PR DESCRIPTION
## Summary
Adds RasFlowOptimization for native HEC-RAS flow hydrograph optimization. Notebook 301 with 3 figures showing optimization convergence and results.

## Test plan
- [x] Notebook executed end-to-end
- [x] 3 matplotlib figures
- [x] Unit tests included

🤖 Reviewed via CLB Symphony issue-review workflow