### PR TITLE
CLB-311: Add Flow Hydrograph Slope (EG slope) setter for unsteady flow files

### DIFF
--- a/ras_commander/RasPrj.py
+++ b/ras_commander/RasPrj.py
@@ -1609,7 +1609,7 @@ class RasPrj:
         # Parse other fields
         known_fields = ['Interval', 'DSS Path', 'Use DSS', 'Use Fixed Start Time', 'Fixed Start Date/Time',
                         'Is Critical Boundary', 'Critical Boundary Flow', 'DSS File',
-                        'Flow Hydrograph QMult', 'Flow Hydrograph QMin']
+                        'Flow Hydrograph QMult', 'Flow Hydrograph QMin', 'Flow Hydrograph Slope']
         for i, line in enumerate(lines):
             if '=' in line:
                 key, value = line.split('=', 1)

--- a/ras_commander/RasUnsteady.py
+++ b/ras_commander/RasUnsteady.py
@@ -59,6 +59,7 @@ DSS Boundary Condition Functions:
         
 """
 import os
+import numbers
 from pathlib import Path
 from .RasPrj import ras
 from .LoggingConfig import get_logger
@@ -2786,10 +2787,13 @@ class RasUnsteady:
         set_boundary_dss_link : Convert inline BC to DSS-linked.
         set_boundary_inline_hydrograph : Write inline hydrograph table.
         """
-        # 1) Validate slope
-        if isinstance(eg_slope, bool) or not isinstance(eg_slope, (int, float)):
+        # 1) Validate slope. `numbers.Real` accepts Python int/float plus
+        # numpy scalars (e.g. np.float64 returned from `boundaries_df`
+        # columns), which `isinstance(x, (int, float))` does NOT under
+        # NumPy 2.x. The bool-subclass-of-int guard fires first.
+        if isinstance(eg_slope, bool) or not isinstance(eg_slope, numbers.Real):
             raise ValueError(
-                f"eg_slope must be a number, got {type(eg_slope).__name__}"
+                f"eg_slope must be a real number, got {type(eg_slope).__name__}"
             )
         slope = float(eg_slope)
         if not np.isfinite(slope):
@@ -2894,11 +2898,17 @@ class RasUnsteady:
         first_dss_keyword: Optional[str] = None
         # First post-data `=` line (used as last-resort insert anchor)
         first_post_data_eq_idx: Optional[int] = None
-        block_end = len(lines)
+        # Clamp the per-block scan range explicitly so sub-pass 2 cannot
+        # spill into the next boundary if sub-pass 1 hits the safety cap
+        # before finding the next `Boundary Location=`. Real blocks never
+        # exceed ~80 lines (Muncie + full Met BC trailer is ~70), but
+        # a hard clamp eliminates a silent-misplacement failure mode.
+        BLOCK_SCAN_CAP = 1000
+        block_end = min(boundary_idx + 1 + BLOCK_SCAN_CAP, len(lines))
 
         # Sub-pass 1: confirm the block is a Flow Hydrograph and locate header.
         j = boundary_idx + 1
-        while j < len(lines) and j < boundary_idx + 1000:
+        while j < block_end:
             line = lines[j]
             if line.startswith('Boundary Location='):
                 block_end = j

--- a/ras_commander/RasUnsteady.py
+++ b/ras_commander/RasUnsteady.py
@@ -51,6 +51,7 @@ DSS Boundary Condition Functions:
 - update_dss_run_identifier() - Update DSS path F-part for new scenarios
 - set_boundary_dss_link() - Convert inline BC to DSS-linked (complete state transition)
 - set_boundary_inline_hydrograph() - Write inline hydrograph, convert DSS to inline
+- set_flow_hydrograph_slope() - Add or update `Flow Hydrograph Slope=` (EG slope) for a Flow Hydrograph BC
 - get_unique_dss_subbasins() - Get unique HMS subbasin names from DSS paths
 - update_dss_path_by_station() - Update DSS A-part for specific river station
 - update_flow_multiplier_by_station() - Update/insert QMult for specific river station
@@ -2641,6 +2642,399 @@ class RasUnsteady:
             f"peak={peak_value:.2f}"
         )
         return True
+
+    @staticmethod
+    @log_call
+    def set_flow_hydrograph_slope(
+        unsteady_file: Union[str, Path],
+        eg_slope: float,
+        river: Optional[str] = None,
+        reach: Optional[str] = None,
+        station: Optional[str] = None,
+        area_2d: Optional[str] = None,
+        bc_line: Optional[str] = None,
+        ras_object: Optional[Any] = None,
+    ) -> Dict[str, Any]:
+        """
+        Add or update the energy-grade ``Flow Hydrograph Slope=`` line on a
+        Flow Hydrograph boundary in a HEC-RAS unsteady flow file (.u##).
+
+        ``Flow Hydrograph Slope=`` is the energy-grade slope HEC-RAS uses to
+        distribute Flow Hydrograph inflow along a 2D Flow Area perimeter BC
+        line (Tutorial 2, "Creating a Simple 2D Model"). It is a property of
+        the Flow Hydrograph BC, not a generic boundary parameter; this writer
+        therefore only operates on blocks that already declare a
+        ``Flow Hydrograph=<count>`` keyword.
+
+        Behavior
+        --------
+        - **Update path**: if a ``Flow Hydrograph Slope=`` line already exists
+          inside the matched boundary block, its value is overwritten in place
+          and no other line is touched.
+        - **Insert path**: if no slope line exists, a new line is inserted in
+          the canonical position observed in HEC-RAS-emitted output: after
+          ``Flow Hydrograph QMult=`` if present, otherwise after
+          ``Stage Hydrograph TW Check=`` if present, otherwise immediately
+          before the first DSS metadata line (``DSS Path=``, ``DSS File=``,
+          or ``Use DSS=``), otherwise just before the first ``=`` line that
+          follows the inline hydrograph data.
+
+        DSS path/file, Use DSS, Interval, ``Flow Hydrograph=`` count, and
+        inline hydrograph data are never altered. The companion writers
+        (``set_boundary_dss_link``, ``set_boundary_inline_hydrograph``) can
+        be used freely before or after this call.
+
+        Format conventions observed in real HEC-RAS .u## files
+        ------------------------------------------------------
+        HEC-RAS emits the line as ``Flow Hydrograph Slope= <value> `` — note
+        the single leading space after ``=`` and the single trailing space
+        before the newline, matching the surrounding ``Flow Hydrograph QMult=``
+        line. This writer mirrors that spacing on both update and insert.
+
+        Target resolution
+        -----------------
+        Provide *exactly one* of:
+
+        - ``(river, reach, station)`` for a 1D river boundary.
+        - ``(area_2d, bc_line)`` for a 2D BC line on a 2D Flow Area perimeter.
+          ``bc_line`` is required: a Flow Hydrograph distribution slope is
+          tied to a specific BC line, never area-wide.
+
+        Parameters
+        ----------
+        unsteady_file : str or Path
+            Path to the unsteady flow file (.u##), or a 1-2 character unsteady
+            number (e.g. ``"01"``) when a project-bound ``ras_object`` is
+            available.
+        eg_slope : float
+            Energy-grade slope (m/m or ft/ft). Must be in the inclusive range
+            ``[1e-7, 1.0]`` and finite.
+        river, reach, station : str, optional
+            1D location selector. All three must be provided together.
+        area_2d, bc_line : str, optional
+            2D location selector. Both must be provided together.
+        ras_object : optional
+            Custom RAS object to use instead of the global one. When
+            initialized for a project, ``boundaries_df`` is refreshed after
+            the write.
+
+        Returns
+        -------
+        Dict[str, Any]
+            Reviewable before/after metadata with keys:
+
+            - ``unsteady_file`` (str): absolute path written
+            - ``matched_location`` (str): the matched ``Boundary Location=``
+              value (without the leading ``Boundary Location=``)
+            - ``bc_type`` (str): always ``'Flow Hydrograph'`` on success
+            - ``previous_eg_slope`` (float | None): prior slope value, or
+              ``None`` if no ``Flow Hydrograph Slope=`` line existed
+            - ``new_eg_slope`` (float): slope written
+            - ``updated_in_place`` (bool): True when an existing slope line
+              was overwritten without insertion
+            - ``lines_inserted`` (int): 1 if a new line was inserted, else 0
+            - ``insert_anchor`` (str | None): the keyword anchor used to
+              place the new line (``'Flow Hydrograph QMult='``,
+              ``'Stage Hydrograph TW Check='``, ``'DSS Path='``,
+              ``'DSS File='``, ``'Use DSS='``, or ``'<inline-data-tail>'``);
+              ``None`` on update path
+            - ``boundaries_df_refreshed`` (bool): True when ``ras_object``
+              ``boundaries_df`` was refreshed after the write
+            - ``block_before`` (str): boundary block text before the edit
+            - ``block_after`` (str): boundary block text after the edit
+
+        Raises
+        ------
+        ValueError
+            If ``eg_slope`` is non-numeric, non-finite, or outside
+            ``[1e-7, 1.0]``; if the target selectors are inconsistent (both
+            1D and 2D, or neither); if a 1D selector is partial; if a 2D
+            selector is missing ``bc_line``; if the matched block is not a
+            Flow Hydrograph (e.g., Normal Depth, Stage Hydrograph, Rating
+            Curve, Gate Opening); or if no boundary in the file matches the
+            selectors.
+        FileNotFoundError
+            If the unsteady flow file does not exist.
+
+        Examples
+        --------
+        Update an existing 2D Flow Hydrograph distribution slope:
+
+        >>> from ras_commander import RasUnsteady
+        >>> result = RasUnsteady.set_flow_hydrograph_slope(
+        ...     "BaldEagleDamBrk.u02",
+        ...     eg_slope=0.001,
+        ...     area_2d="BaldEagleCr",
+        ...     bc_line="Upstream Inflow",
+        ... )
+        >>> result["new_eg_slope"], result["updated_in_place"]
+        (0.001, True)
+
+        Add a slope line to a Flow Hydrograph block that has none yet:
+
+        >>> result = RasUnsteady.set_flow_hydrograph_slope(
+        ...     "project.u01",
+        ...     eg_slope=0.0007,
+        ...     area_2d="Upper 2D Area",
+        ...     bc_line="Upstream Q",
+        ... )
+        >>> result["lines_inserted"], result["insert_anchor"]
+        (1, 'DSS Path=')
+
+        See Also
+        --------
+        set_boundary_dss_link : Convert inline BC to DSS-linked.
+        set_boundary_inline_hydrograph : Write inline hydrograph table.
+        """
+        # 1) Validate slope
+        if isinstance(eg_slope, bool) or not isinstance(eg_slope, (int, float)):
+            raise ValueError(
+                f"eg_slope must be a number, got {type(eg_slope).__name__}"
+            )
+        slope = float(eg_slope)
+        if not np.isfinite(slope):
+            raise ValueError(f"eg_slope must be finite, got {slope!r}")
+        if not (1e-7 <= slope <= 1.0):
+            raise ValueError(
+                f"eg_slope {slope!r} is outside the supported range [1e-7, 1.0]"
+            )
+
+        # 2) Validate target selectors
+        has_1d = any(x is not None for x in (river, reach, station))
+        has_2d = any(x is not None for x in (area_2d, bc_line))
+        if has_1d == has_2d:
+            raise ValueError(
+                "Provide exactly one selector group: (river, reach, station) "
+                "OR (area_2d, bc_line)"
+            )
+        if has_1d and not (river and reach and station):
+            raise ValueError(
+                "1D selector requires all of river, reach, and station"
+            )
+        if has_2d and not (area_2d and bc_line):
+            raise ValueError(
+                "2D selector requires both area_2d and bc_line"
+            )
+
+        # 3) Resolve unsteady file path
+        ras_obj = ras_object or ras
+        if ras_obj is not None:
+            try:
+                ras_obj.check_initialized()
+            except Exception:
+                pass
+
+        if isinstance(unsteady_file, str) and len(unsteady_file) <= 2:
+            if ras_obj is None or getattr(ras_obj, 'project_folder', None) is None:
+                raise ValueError(
+                    "Cannot resolve unsteady number without an initialized ras_object"
+                )
+            num = unsteady_file.zfill(2)
+            unsteady_path = Path(ras_obj.project_folder) / f"{ras_obj.project_name}.u{num}"
+        else:
+            unsteady_path = Path(unsteady_file)
+
+        if not unsteady_path.exists():
+            raise FileNotFoundError(f"Unsteady flow file not found: {unsteady_path}")
+
+        # 4) Read file and find target Boundary Location block
+        with open(unsteady_path, 'r', encoding='utf-8', errors='ignore') as f:
+            lines = f.readlines()
+
+        def _matches_location(loc_value: str) -> bool:
+            parts = [p.strip() for p in loc_value.split(',')]
+            if has_1d:
+                return (
+                    len(parts) >= 3
+                    and parts[0] == river
+                    and parts[1] == reach
+                    and parts[2] == station
+                )
+            if len(parts) < 6 or parts[5] != area_2d:
+                return False
+            if len(parts) < 8 or parts[7] != bc_line:
+                return False
+            return True
+
+        boundary_idx = None
+        matched_loc = None
+        for i, line in enumerate(lines):
+            if line.startswith('Boundary Location='):
+                loc_value = line[len('Boundary Location='):].rstrip('\r\n')
+                if _matches_location(loc_value):
+                    boundary_idx = i
+                    matched_loc = loc_value
+                    break
+
+        if boundary_idx is None:
+            sel = (
+                f"river={river!r}/reach={reach!r}/station={station!r}"
+                if has_1d
+                else f"area_2d={area_2d!r}/bc_line={bc_line!r}"
+            )
+            raise ValueError(
+                f"No boundary matched in {unsteady_path.name} for {sel}. "
+                f"This function only edits Flow Hydrograph boundaries that "
+                f"already exist as `Boundary Location=` blocks."
+            )
+
+        # 5) Walk the block; verify it is a Flow Hydrograph; locate slope/QMult/
+        #    TW-check / DSS metadata indices; and find the inline-data tail.
+        FLOW_HYDROGRAPH_HEADER = 'Flow Hydrograph='
+        SLOPE_KEY = 'Flow Hydrograph Slope='
+        QMULT_KEY = 'Flow Hydrograph QMult='
+        TW_CHECK_KEY = 'Stage Hydrograph TW Check='
+        DSS_LINE_KEYS = ('DSS Path=', 'DSS File=', 'Use DSS=')
+
+        flow_header_idx: Optional[int] = None
+        slope_idx: Optional[int] = None
+        qmult_idx: Optional[int] = None
+        tw_check_idx: Optional[int] = None
+        first_dss_idx: Optional[int] = None
+        first_dss_keyword: Optional[str] = None
+        # First post-data `=` line (used as last-resort insert anchor)
+        first_post_data_eq_idx: Optional[int] = None
+        block_end = len(lines)
+
+        # Sub-pass 1: confirm the block is a Flow Hydrograph and locate header.
+        j = boundary_idx + 1
+        while j < len(lines) and j < boundary_idx + 1000:
+            line = lines[j]
+            if line.startswith('Boundary Location='):
+                block_end = j
+                break
+            if line.startswith(FLOW_HYDROGRAPH_HEADER):
+                flow_header_idx = j
+            j += 1
+
+        if flow_header_idx is None:
+            raise ValueError(
+                f"Boundary at {matched_loc.strip()!r} is not a Flow Hydrograph "
+                f"(no `Flow Hydrograph=<count>` header in block); "
+                f"`Flow Hydrograph Slope=` only applies to Flow Hydrograph BCs"
+            )
+
+        # Sub-pass 2: from after the inline data, find anchors.
+        try:
+            count = int(lines[flow_header_idx].replace(FLOW_HYDROGRAPH_HEADER, '').split(',')[0].strip())
+        except (ValueError, IndexError):
+            count = 0
+        # Inline-data lines run from flow_header_idx + 1 until the first line
+        # that contains '=' (mirrors the convention used by sibling writers).
+        post_data_idx = flow_header_idx + 1
+        if count > 0:
+            for k in range(flow_header_idx + 1, block_end):
+                if '=' in lines[k] or lines[k].startswith('Boundary Location='):
+                    post_data_idx = k
+                    break
+            else:
+                post_data_idx = block_end
+
+        for j in range(post_data_idx, block_end):
+            line = lines[j]
+            if line.startswith(SLOPE_KEY) and slope_idx is None:
+                slope_idx = j
+            elif line.startswith(QMULT_KEY) and qmult_idx is None:
+                qmult_idx = j
+            elif line.startswith(TW_CHECK_KEY) and tw_check_idx is None:
+                tw_check_idx = j
+            else:
+                for dss_kw in DSS_LINE_KEYS:
+                    if line.startswith(dss_kw) and first_dss_idx is None:
+                        first_dss_idx = j
+                        first_dss_keyword = dss_kw
+                        break
+            if first_post_data_eq_idx is None and '=' in line:
+                first_post_data_eq_idx = j
+
+        block_before = ''.join(lines[boundary_idx:block_end])
+
+        previous_eg_slope: Optional[float] = None
+        if slope_idx is not None:
+            payload = lines[slope_idx].replace(SLOPE_KEY, '').strip()
+            try:
+                previous_eg_slope = float(payload.split(',')[0].strip())
+            except (ValueError, IndexError):
+                previous_eg_slope = None
+
+        # 6) Compose new line and apply edit. HEC-RAS emits this line with a
+        # leading space after `=` and a trailing space before the newline:
+        #     `Flow Hydrograph Slope= 0.0005 \n`
+        new_slope_line = f'Flow Hydrograph Slope= {slope} \n'
+
+        lines_inserted = 0
+        updated_in_place = False
+        insert_anchor: Optional[str] = None
+
+        if slope_idx is not None:
+            lines[slope_idx] = new_slope_line
+            updated_in_place = True
+        else:
+            if qmult_idx is not None:
+                insert_pos = qmult_idx + 1
+                insert_anchor = QMULT_KEY
+            elif tw_check_idx is not None:
+                insert_pos = tw_check_idx + 1
+                insert_anchor = TW_CHECK_KEY
+            elif first_dss_idx is not None:
+                insert_pos = first_dss_idx
+                insert_anchor = first_dss_keyword
+            elif first_post_data_eq_idx is not None:
+                insert_pos = first_post_data_eq_idx
+                insert_anchor = '<inline-data-tail>'
+            else:
+                # Last resort: end of block. Should not happen for a real
+                # Flow Hydrograph block but kept for robustness.
+                insert_pos = block_end
+                insert_anchor = '<block-end>'
+            lines.insert(insert_pos, new_slope_line)
+            lines_inserted = 1
+
+        # Recompute block end for the after-snapshot
+        new_block_end = boundary_idx + 1
+        while (
+            new_block_end < len(lines)
+            and not lines[new_block_end].startswith('Boundary Location=')
+        ):
+            new_block_end += 1
+        block_after = ''.join(lines[boundary_idx:new_block_end])
+
+        # 7) Persist file
+        with open(unsteady_path, 'w', encoding='utf-8') as f:
+            f.writelines(lines)
+
+        # 8) Refresh boundaries_df where possible
+        boundaries_df_refreshed = False
+        if ras_obj is not None:
+            try:
+                ras_obj.boundaries_df = ras_obj.get_boundary_conditions()
+                boundaries_df_refreshed = True
+            except Exception as exc:
+                logger.debug(f"boundaries_df refresh skipped: {exc}")
+
+        logger.info(
+            "Set Flow Hydrograph Slope in %s: matched=%s, slope=%s, "
+            "updated_in_place=%s, anchor=%s",
+            unsteady_path.name,
+            matched_loc.strip(),
+            slope,
+            updated_in_place,
+            insert_anchor,
+        )
+
+        return {
+            'unsteady_file': str(unsteady_path),
+            'matched_location': matched_loc,
+            'bc_type': 'Flow Hydrograph',
+            'previous_eg_slope': previous_eg_slope,
+            'new_eg_slope': slope,
+            'updated_in_place': updated_in_place,
+            'lines_inserted': lines_inserted,
+            'insert_anchor': insert_anchor,
+            'boundaries_df_refreshed': boundaries_df_refreshed,
+            'block_before': block_before,
+            'block_after': block_after,
+        }
 
     @staticmethod
     @log_call

--- a/tests/test_rasunsteady_flow_hydrograph_slope.py
+++ b/tests/test_rasunsteady_flow_hydrograph_slope.py
@@ -255,7 +255,7 @@ class TestValidation:
     def test_rejects_non_numeric(self, fh_2d_block_with_existing_slope):
         from ras_commander import RasUnsteady
 
-        with pytest.raises(ValueError, match="must be a number"):
+        with pytest.raises(ValueError, match="must be a real number"):
             RasUnsteady.set_flow_hydrograph_slope(
                 fh_2d_block_with_existing_slope,
                 eg_slope="0.001",  # type: ignore[arg-type]
@@ -611,3 +611,113 @@ class TestWeise2DRealProject:
         assert result["bc_type"] == "Flow Hydrograph"
         text = target_file.read_text(encoding="utf-8", errors="ignore")
         assert "Flow Hydrograph Slope= 0.0025 " in text
+
+
+# ---------------------------------------------------------------------------
+# Fix-coverage tests added 2026-05-02 in response to independent code review
+# (see H:/Symphony/ras-commander/CLB-311/REVIEW.md):
+#   - numpy scalar acceptance (numbers.Real)
+#   - Flow Hydrograph Slope value surfaced in boundaries_df
+# ---------------------------------------------------------------------------
+
+
+class TestNumpyScalarAcceptance:
+    """`numbers.Real` validation must accept numpy scalars from DataFrame
+    columns. Under NumPy 2.x, `np.float64` is no longer a subclass of
+    `float`, so `isinstance(x, (int, float))` rejects the most natural
+    call pattern (taking a slope value out of `boundaries_df` and passing
+    it back in)."""
+
+    def test_np_float64_is_accepted(self, fh_2d_block_with_existing_slope):
+        import numpy as np
+        from ras_commander import RasUnsteady
+
+        slope = np.float64(0.0009)
+        result = RasUnsteady.set_flow_hydrograph_slope(
+            fh_2d_block_with_existing_slope,
+            eg_slope=slope,
+            area_2d="BaldEagleCr",
+            bc_line="Upstream Inflow",
+        )
+        assert result["new_eg_slope"] == 0.0009
+        text = fh_2d_block_with_existing_slope.read_text(encoding="utf-8")
+        assert "Flow Hydrograph Slope= 0.0009 " in text
+
+    def test_np_float32_is_accepted(self, fh_2d_block_with_existing_slope):
+        import numpy as np
+        from ras_commander import RasUnsteady
+
+        slope = np.float32(0.0011)
+        result = RasUnsteady.set_flow_hydrograph_slope(
+            fh_2d_block_with_existing_slope,
+            eg_slope=slope,
+            area_2d="BaldEagleCr",
+            bc_line="Upstream Inflow",
+        )
+        # np.float32 → float() may have small precision drift; just confirm
+        # it converted and was written.
+        assert abs(result["new_eg_slope"] - 0.0011) < 1e-7
+
+    def test_bool_still_rejected(self, fh_2d_block_with_existing_slope):
+        from ras_commander import RasUnsteady
+
+        with pytest.raises(ValueError, match="must be a real number"):
+            RasUnsteady.set_flow_hydrograph_slope(
+                fh_2d_block_with_existing_slope,
+                eg_slope=True,  # type: ignore[arg-type]
+                area_2d="BaldEagleCr",
+                bc_line="Upstream Inflow",
+            )
+
+
+class TestBoundariesDfSurfacesFhSlope:
+    """`Flow Hydrograph Slope` must appear as a column in `boundaries_df`
+    after the writer succeeds — closes the AC partial on 'expose updated
+    metadata through boundary DataFrames'."""
+
+    @pytest.mark.slow
+    def test_flow_hydrograph_slope_column_in_boundaries_df(self, tmp_path):
+        """End-to-end: extract Chippewa_2D, run the setter on a real Flow
+        Hydrograph 2D BC, refresh boundaries_df, verify the
+        `Flow Hydrograph Slope` column carries the new value."""
+        try:
+            from ras_commander import RasExamples, RasUnsteady, RasPrj
+            project = RasExamples.extract_project(
+                "Chippewa_2D", output_path=tmp_path, suffix="_fhs_df"
+            )
+        except Exception:
+            pytest.skip("Chippewa_2D example not available")
+        if isinstance(project, list):
+            project = project[0]
+
+        prj_files = list(Path(project).glob("*.prj"))
+        prj_files = [p for p in prj_files if not p.name.endswith(".rasprj.json")]
+        if not prj_files:
+            pytest.skip("No .prj in Chippewa_2D")
+
+        ras_obj = RasPrj()
+        try:
+            ras_obj.initialize(prj_files[0].parent, "ras", suppress_logging=True)
+        except Exception:
+            pytest.skip("Could not initialize Chippewa_2D RasPrj")
+
+        result = RasUnsteady.set_flow_hydrograph_slope(
+            next(Path(project).glob("*.u04")),
+            eg_slope=0.002,
+            area_2d="Chippewa",
+            bc_line="Chippewa",
+            ras_object=ras_obj,
+        )
+        assert result["boundaries_df_refreshed"] is True
+
+        df = ras_obj.boundaries_df
+        assert "Flow Hydrograph Slope" in df.columns, (
+            "Flow Hydrograph Slope must be parsed into boundaries_df after "
+            "refresh (known_fields update in RasPrj._parse_boundary_condition)"
+        )
+        # The targeted Chippewa/Chippewa boundary should have the new value.
+        slope_strings = df["Flow Hydrograph Slope"].astype(str).tolist()
+        assert any("0.002" in s for s in slope_strings), (
+            f"Expected '0.002' in Flow Hydrograph Slope column; got "
+            f"{slope_strings}"
+        )

--- a/tests/test_rasunsteady_flow_hydrograph_slope.py
+++ b/tests/test_rasunsteady_flow_hydrograph_slope.py
@@ -332,93 +332,163 @@ class TestValidation:
 
 
 # ---------------------------------------------------------------------------
-# Real RasExamples projects
+# Synthetic 8-field Boundary Location (older HEC-RAS format)
 # ---------------------------------------------------------------------------
 
 
-class TestRealProjects:
+class TestEightFieldBoundaryLocation:
+    """HEC-RAS emits both 8-field and 9-field `Boundary Location=` forms.
+
+    Real example: BaldEagleCrkMulti2D ships with 8-field forms in some plans
+    while Chippewa_2D / Weise_2D use 9-field forms. The matcher must work on
+    both since field meaning is positional, not count-dependent.
+    """
+
+    def test_matches_and_updates_8_field_form(self, tmp_path):
+        from ras_commander import RasUnsteady
+
+        # 7 commas → 8 fields. BC line at index 7.
+        body = (
+            "Flow Title=8-field FH\n"
+            "Boundary Location=                ,                ,        ,        ,                ,BaldEagleCr     ,                ,Upstream Inflow \n"
+            "Interval=1HOUR\n"
+            "Flow Hydrograph= 2 \n"
+            "  100.00  120.00\n"
+            "Stage Hydrograph TW Check=0\n"
+            "Flow Hydrograph QMult= 0.5 \n"
+            "Flow Hydrograph Slope= 0.0005 \n"
+            "DSS Path=\n"
+            "Use DSS=False\n"
+        )
+        f = _write_unsteady(tmp_path / "project.u01", body)
+
+        result = RasUnsteady.set_flow_hydrograph_slope(
+            f,
+            eg_slope=0.001,
+            area_2d="BaldEagleCr",
+            bc_line="Upstream Inflow",
+        )
+        assert result["updated_in_place"] is True
+        assert result["new_eg_slope"] == 0.001
+        text = f.read_text(encoding="utf-8")
+        assert "Flow Hydrograph Slope= 0.001 " in text
+
+
+# ---------------------------------------------------------------------------
+# Real RasExamples projects
+# ---------------------------------------------------------------------------
+#
+# Primary fixture is **Chippewa_2D** rather than BaldEagleCrkMulti2D:
+#
+# - Multiple 2D Flow Areas in a single .u## (`Chippewa` and `Perimeter 1`)
+#   exercise the multi-area requirement spelled out in CLB-311's AC.
+# - 9-field Boundary Location form (current HEC-RAS output) plus realistic
+#   field widths matching the literal name length (e.g. `Lake Pepin` is
+#   10 chars, not padded to 16) — confirms the matcher's positional logic.
+# - Realistic boundary names with spaces (`Lake Pepin`, `Perimeter 1`).
+# - Real DSS File path with backslashes (`..\..\2018\...\Chippewa.dss`)
+#   in one of the blocks — confirms DSS metadata is preserved verbatim.
+# - Block layout has `Stage Hydrograph TW Check=0` immediately followed by
+#   `Flow Hydrograph Slope=` (no `Flow Hydrograph QMult=`), which exercises
+#   the `Stage Hydrograph TW Check=` insert anchor branch.
+#
+# Weise_2D is included as a smaller cross-project smoke check.
+
+
+class TestChippewa2DRealProject:
     @pytest.mark.slow
-    def test_baldeagle_existing_slope_update_round_trip(self, tmp_path):
-        """Update an existing `Flow Hydrograph Slope=` on a 2D BC line and
-        verify nothing else in the surrounding block changed."""
+    def test_chippewa_multi_area_update_preserves_other_areas_and_dss_file(self, tmp_path):
+        """Updating one BC line on one 2D area must leave every other 2D
+        area's slope unchanged AND preserve the literal DSS File= path."""
         try:
             from ras_commander import RasExamples, RasUnsteady
             project = RasExamples.extract_project(
-                "BaldEagleCrkMulti2D", output_path=tmp_path, suffix="_fh_slope_update"
+                "Chippewa_2D", output_path=tmp_path, suffix="_fh_slope_update"
             )
         except Exception:
-            pytest.skip("BaldEagleCrkMulti2D example not available")
+            pytest.skip("Chippewa_2D example not available")
         if isinstance(project, list):
             project = project[0]
-        u_files = sorted(p for p in Path(project).glob("*.u*") if "hdf" not in p.name.lower())
-        # Find a (.u##, area, bc_line) where Flow Hydrograph Slope= already
-        # exists right after a Flow Hydrograph block.
-        target_file = None
-        target_area = None
-        target_bc = None
-        slope_pattern = re.compile(
-            r"^Boundary Location=(.+?)\nInterval=.+?\nFlow Hydrograph=.+?(?:\n.*)*?\nFlow Hydrograph Slope=\s*([\d.]+)",
-            re.MULTILINE,
+        u_files = sorted(
+            p for p in Path(project).glob("*.u*") if "hdf" not in p.name.lower()
         )
+        # Find the .u## that contains all three 2D Flow Hydrograph slope
+        # blocks (Chippewa/Chippewa, Chippewa/Lake Pepin, Perimeter 1/Upstream).
+        target_file = None
         for u in u_files:
             text = u.read_text(encoding="utf-8", errors="ignore")
-            m = slope_pattern.search(text)
-            if not m:
-                continue
-            parts = [p.strip() for p in m.group(1).split(",")]
-            if len(parts) >= 8 and parts[5] and parts[7]:
-                target_file, target_area, target_bc = u, parts[5], parts[7]
+            if (
+                "Chippewa        ,                ,Chippewa" in text
+                and "Lake Pepin" in text
+                and "Perimeter 1" in text
+                and text.count("Flow Hydrograph Slope=") >= 3
+            ):
+                target_file = u
                 break
         if target_file is None:
-            pytest.skip("No 2D Flow Hydrograph with existing slope found")
+            pytest.skip("Chippewa_2D shipped layout does not match expectations")
 
         before = target_file.read_text(encoding="utf-8", errors="ignore")
+        # Capture the other two slope lines verbatim — they must survive.
+        before_other_slopes = [
+            line for line in before.splitlines()
+            if line.startswith("Flow Hydrograph Slope=")
+        ]
+        assert len(before_other_slopes) >= 3
+
+        # Update the slope on Chippewa/Chippewa.
         result = RasUnsteady.set_flow_hydrograph_slope(
             target_file,
-            eg_slope=0.0009,
-            area_2d=target_area,
-            bc_line=target_bc,
+            eg_slope=0.001,
+            area_2d="Chippewa",
+            bc_line="Chippewa",
         )
         assert result["updated_in_place"] is True
-        assert result["new_eg_slope"] == 0.0009
+        assert result["previous_eg_slope"] == 0.00036
+        assert result["new_eg_slope"] == 0.001
 
         after = target_file.read_text(encoding="utf-8", errors="ignore")
-        # The only differences must be the changed slope line.
+        # Same file length (in-place update).
+        assert len(before.splitlines()) == len(after.splitlines())
+        # Exactly one differing line.
         diff = [
             (b, a) for b, a in zip(before.splitlines(), after.splitlines())
             if b != a
         ]
         assert len(diff) == 1
-        assert diff[0][1].startswith("Flow Hydrograph Slope=")
-        assert "0.0009" in diff[0][1]
-        # Same file length (in-place update).
-        assert len(before.splitlines()) == len(after.splitlines())
+        assert diff[0] == ("Flow Hydrograph Slope= 0.00036 ", "Flow Hydrograph Slope= 0.001 ")
+
+        # Other slope lines (Lake Pepin = 0.00016, Perimeter 1/Upstream = 0.00022)
+        # are still present and unchanged.
+        after_slopes = [
+            line for line in after.splitlines()
+            if line.startswith("Flow Hydrograph Slope=")
+        ]
+        assert "Flow Hydrograph Slope= 0.00016 " in after_slopes
+        assert "Flow Hydrograph Slope= 0.00022 " in after_slopes
+        # Realistic DSS File path with backslashes survived verbatim.
+        assert any(
+            "DSS File=..\\..\\2018" in line for line in after.splitlines()
+        )
 
     @pytest.mark.slow
-    def test_baldeagle_insert_when_no_slope_in_block(self, tmp_path):
-        """Insert a slope into a Flow Hydrograph block that lacks one.
-
-        Every BaldEagle 2D Flow Hydrograph block in the shipped dataset
-        already has a slope line, so this test deterministically constructs
-        a no-slope variant: extract BaldEagleCrkMulti2D, pick a 2D Flow
-        Hydrograph block, strip its `Flow Hydrograph Slope=` line in place,
-        and verify the writer re-inserts at the canonical anchor without
-        touching any other line.
-        """
+    def test_chippewa_insert_when_no_slope_in_block(self, tmp_path):
+        """Strip an existing Flow Hydrograph Slope= line from a Chippewa
+        block and verify the writer re-inserts it at the canonical anchor
+        with every other line preserved."""
         try:
             from ras_commander import RasExamples, RasUnsteady
             project = RasExamples.extract_project(
-                "BaldEagleCrkMulti2D", output_path=tmp_path, suffix="_fh_slope_insert"
+                "Chippewa_2D", output_path=tmp_path, suffix="_fh_slope_insert"
             )
         except Exception:
-            pytest.skip("BaldEagleCrkMulti2D example not available")
+            pytest.skip("Chippewa_2D example not available")
         if isinstance(project, list):
             project = project[0]
         u_files = sorted(
             p for p in Path(project).glob("*.u*") if "hdf" not in p.name.lower()
         )
 
-        # Find a 2D Flow Hydrograph block that already has a slope line.
         target_file = None
         target_area = None
         target_bc = None
@@ -431,12 +501,11 @@ class TestRealProjects:
                 re.MULTILINE | re.DOTALL,
             ):
                 block = m.group(0)
-                if "Flow Hydrograph=" not in block:
+                if (
+                    "Flow Hydrograph=" not in block
+                    or "Flow Hydrograph Slope=" not in block
+                ):
                     continue
-                if "Flow Hydrograph Slope=" not in block:
-                    continue
-                # Parse only the first (location) line — `m.group(1)` spans
-                # the whole block under DOTALL.
                 first_line = block.splitlines()[0]
                 loc_value = first_line[len("Boundary Location="):]
                 parts = [p.strip() for p in loc_value.split(",")]
@@ -453,38 +522,92 @@ class TestRealProjects:
             if target_file is not None:
                 break
         if target_file is None:
-            pytest.skip("No 2D Flow Hydrograph with slope found in BaldEagle")
+            pytest.skip("No suitable Chippewa 2D Flow Hydrograph block")
 
-        # Strip the slope line so we can validate the insert path.
+        # Strip the slope line to set up the insert path.
         original = target_file.read_text(encoding="utf-8", errors="ignore")
         stripped = original.replace(original_slope_line + "\n", "", 1)
         target_file.write_text(stripped, encoding="utf-8")
-
         before = target_file.read_text(encoding="utf-8", errors="ignore")
-        assert "Flow Hydrograph Slope=" not in before  # sanity
 
         result = RasUnsteady.set_flow_hydrograph_slope(
             target_file,
-            eg_slope=0.0011,
+            eg_slope=0.001,
             area_2d=target_area,
             bc_line=target_bc,
         )
         assert result["updated_in_place"] is False
         assert result["lines_inserted"] == 1
-        assert result["new_eg_slope"] == 0.0011
-        assert result["insert_anchor"] in {
-            "Flow Hydrograph QMult=",
-            "Stage Hydrograph TW Check=",
-            "DSS Path=",
-            "DSS File=",
-            "Use DSS=",
-            "<inline-data-tail>",
-        }
+        # Chippewa blocks have `Stage Hydrograph TW Check=0` but no QMult,
+        # so the canonical anchor here is `Stage Hydrograph TW Check=`.
+        assert result["insert_anchor"] == "Stage Hydrograph TW Check="
 
         after = target_file.read_text(encoding="utf-8", errors="ignore")
         assert len(after.splitlines()) == len(before.splitlines()) + 1
-        assert "Flow Hydrograph Slope= 0.0011 " in after
-        # Every line that was in the stripped file must still be there.
+        assert "Flow Hydrograph Slope= 0.001 " in after
+        # Every line that survived the stripping must still be present.
         before_lines = set(before.splitlines())
         after_lines = set(after.splitlines())
         assert before_lines - after_lines == set()
+
+
+class TestWeise2DRealProject:
+    @pytest.mark.slow
+    def test_weise_simple_update(self, tmp_path):
+        """Cross-project sanity check on Weise_2D (single 2D Area, simple
+        layout) — confirms the writer behaves identically across projects."""
+        try:
+            from ras_commander import RasExamples, RasUnsteady
+            project = RasExamples.extract_project(
+                "Weise_2D", output_path=tmp_path, suffix="_fh_slope"
+            )
+        except Exception:
+            pytest.skip("Weise_2D example not available")
+        if isinstance(project, list):
+            project = project[0]
+        u_files = sorted(
+            p for p in Path(project).glob("*.u*") if "hdf" not in p.name.lower()
+        )
+        target_file = None
+        target_area = None
+        target_bc = None
+        for u in u_files:
+            text = u.read_text(encoding="utf-8", errors="ignore")
+            if "Flow Hydrograph Slope=" not in text:
+                continue
+            for m in re.finditer(
+                r"^Boundary Location=(.+?)(?=\nBoundary Location=|\Z)",
+                text,
+                re.MULTILINE | re.DOTALL,
+            ):
+                block = m.group(0)
+                if (
+                    "Flow Hydrograph=" not in block
+                    or "Flow Hydrograph Slope=" not in block
+                ):
+                    continue
+                first_line = block.splitlines()[0]
+                loc_value = first_line[len("Boundary Location="):]
+                parts = [p.strip() for p in loc_value.split(",")]
+                if len(parts) < 8 or not (parts[5] and parts[7]):
+                    continue
+                target_file = u
+                target_area = parts[5]
+                target_bc = parts[7]
+                break
+            if target_file is not None:
+                break
+        if target_file is None:
+            pytest.skip("No suitable Weise 2D Flow Hydrograph block")
+
+        result = RasUnsteady.set_flow_hydrograph_slope(
+            target_file,
+            eg_slope=0.0025,
+            area_2d=target_area,
+            bc_line=target_bc,
+        )
+        assert result["updated_in_place"] is True
+        assert result["new_eg_slope"] == 0.0025
+        assert result["bc_type"] == "Flow Hydrograph"
+        text = target_file.read_text(encoding="utf-8", errors="ignore")
+        assert "Flow Hydrograph Slope= 0.0025 " in text

--- a/tests/test_rasunsteady_flow_hydrograph_slope.py
+++ b/tests/test_rasunsteady_flow_hydrograph_slope.py
@@ -1,0 +1,490 @@
+"""
+Tests for RasUnsteady.set_flow_hydrograph_slope().
+
+Validates that:
+
+1. Updating an existing ``Flow Hydrograph Slope=`` line on a 2D BC line
+   overwrites the value in place and leaves every other line in the block
+   byte-for-byte unchanged (DSS path/file/use, Interval, Flow Hydrograph
+   count, inline data, sibling boundary blocks).
+2. Adding a slope to a Flow Hydrograph block that has none places the new
+   line in the canonical insertion position observed in HEC-RAS-emitted
+   output (after ``Flow Hydrograph QMult=`` if present, else after
+   ``Stage Hydrograph TW Check=``, else before the first DSS metadata line).
+3. The setter refuses to operate on non-Flow-Hydrograph blocks (Normal
+   Depth, Rating Curve, etc.) since the slope is meaningless there.
+4. The setter validates slope range and selectors consistently with
+   ``set_normal_depth_boundary``.
+5. End-to-end behavior is correct against real RasExamples projects
+   (BaldEagleCrkMulti2D), both for an existing-slope plan and a no-slope
+   plan.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+
+def _write_unsteady(path: Path, body: str) -> Path:
+    path.write_text(body, encoding="utf-8")
+    return path
+
+
+# ---------------------------------------------------------------------------
+# Synthetic fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def fh_2d_block_with_existing_slope(tmp_path):
+    """A multi-boundary file: target 2D Flow Hydrograph block has slope already.
+
+    Mirrors the BaldEagleCrkMulti2D BaldEagleDamBrk.u02 layout, with two
+    extra unrelated boundary blocks so we can assert non-targets are
+    untouched.
+    """
+    body = (
+        # Unrelated 1D Flow Hydrograph block (different river/reach/station).
+        "Flow Title=Multi-block FH\n"
+        "Program Version=6.60\n"
+        "Use Restart= 0 \n"
+        "Boundary Location=White           ,Muncie          ,15696.24,        ,                ,                ,                ,                                ,                                \n"
+        "Interval=1HOUR\n"
+        "Flow Hydrograph= 2 \n"
+        "  100.00  150.00\n"
+        "Stage Hydrograph TW Check=0\n"
+        "Flow Hydrograph QMult= 1.0 \n"
+        "Flow Hydrograph Slope= 0.002 \n"
+        "DSS Path=\n"
+        "Use DSS=False\n"
+        # Target 2D Flow Hydrograph block, pre-populated with a slope value.
+        "Boundary Location=                ,                ,        ,        ,                ,BaldEagleCr     ,                ,Upstream Inflow                 ,                                \n"
+        "Interval=1HOUR\n"
+        "Flow Hydrograph= 2 \n"
+        "  500.00  600.00\n"
+        "Stage Hydrograph TW Check=0\n"
+        "Flow Hydrograph QMult= 0.5 \n"
+        "Flow Hydrograph Slope= 0.0005 \n"
+        "DSS Path=\n"
+        "Use DSS=False\n"
+        # Unrelated 2D Normal Depth block.
+        "Boundary Location=                ,                ,        ,        ,                ,BaldEagleCr     ,                ,DSNormalDepth                   ,                                \n"
+        "Friction Slope=0.0003\n"
+    )
+    return _write_unsteady(tmp_path / "project.u01", body)
+
+
+@pytest.fixture
+def fh_2d_block_without_slope_with_qmult(tmp_path):
+    """Flow Hydrograph block has QMult but no Flow Hydrograph Slope= yet."""
+    body = (
+        "Flow Title=No slope yet\n"
+        "Boundary Location=                ,                ,        ,        ,                ,Upper 2D Area   ,                ,Upstream Q                      ,                                \n"
+        "Interval=1HOUR\n"
+        "Flow Hydrograph= 2 \n"
+        "  720.00  734.88\n"
+        "Stage Hydrograph TW Check=0\n"
+        "Flow Hydrograph QMult= 1.0 \n"
+        "DSS Path=\n"
+        "Use DSS=False\n"
+    )
+    return _write_unsteady(tmp_path / "project.u01", body)
+
+
+@pytest.fixture
+def fh_block_minimal(tmp_path):
+    """Flow Hydrograph block with no QMult, no TW Check, but has DSS Path=."""
+    body = (
+        "Flow Title=Minimal FH\n"
+        "Boundary Location=                ,                ,        ,        ,                ,Area2           ,                ,Q in                            ,                                \n"
+        "Interval=1HOUR\n"
+        "Flow Hydrograph= 2 \n"
+        "  100.00  120.00\n"
+        "DSS Path=\n"
+        "Use DSS=False\n"
+    )
+    return _write_unsteady(tmp_path / "project.u01", body)
+
+
+@pytest.fixture
+def normal_depth_only_block(tmp_path):
+    """Block is Normal Depth, not Flow Hydrograph — setter should refuse."""
+    body = (
+        "Flow Title=ND only\n"
+        "Boundary Location=                ,                ,        ,        ,                ,BaldEagleCr     ,                ,DSNormalDepth                   ,                                \n"
+        "Friction Slope=0.0003\n"
+    )
+    return _write_unsteady(tmp_path / "project.u01", body)
+
+
+# ---------------------------------------------------------------------------
+# Update path
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateExistingSlope:
+    def test_2d_existing_slope_overwritten_in_place(self, fh_2d_block_with_existing_slope):
+        from ras_commander import RasUnsteady
+
+        before_text = fh_2d_block_with_existing_slope.read_text(encoding="utf-8")
+
+        result = RasUnsteady.set_flow_hydrograph_slope(
+            fh_2d_block_with_existing_slope,
+            eg_slope=0.001,
+            area_2d="BaldEagleCr",
+            bc_line="Upstream Inflow",
+        )
+
+        assert result["bc_type"] == "Flow Hydrograph"
+        assert result["previous_eg_slope"] == 0.0005
+        assert result["new_eg_slope"] == 0.001
+        assert result["updated_in_place"] is True
+        assert result["lines_inserted"] == 0
+        assert result["insert_anchor"] is None
+
+        after_text = fh_2d_block_with_existing_slope.read_text(encoding="utf-8")
+        # Exactly one substitution happened — the only difference between
+        # before and after is the slope line value.
+        diff = [
+            (b, a) for b, a in zip(before_text.splitlines(), after_text.splitlines())
+            if b != a
+        ]
+        assert diff == [
+            ("Flow Hydrograph Slope= 0.0005 ", "Flow Hydrograph Slope= 0.001 ")
+        ]
+        # Non-target boundaries are untouched.
+        assert "Friction Slope=0.0003" in after_text  # Normal Depth block
+        assert "Flow Hydrograph Slope= 0.002 " in after_text  # 1D FH block
+        # DSS lines and Flow Hydrograph count survive unchanged in the target.
+        assert after_text.count("Flow Hydrograph= 2 ") == 2
+        assert after_text.count("DSS Path=") == 2
+        assert after_text.count("Use DSS=False") == 2
+
+
+# ---------------------------------------------------------------------------
+# Insert path
+# ---------------------------------------------------------------------------
+
+
+class TestInsertNewSlope:
+    def test_inserts_after_qmult_when_present(self, fh_2d_block_without_slope_with_qmult):
+        from ras_commander import RasUnsteady
+
+        result = RasUnsteady.set_flow_hydrograph_slope(
+            fh_2d_block_without_slope_with_qmult,
+            eg_slope=0.0007,
+            area_2d="Upper 2D Area",
+            bc_line="Upstream Q",
+        )
+
+        assert result["updated_in_place"] is False
+        assert result["lines_inserted"] == 1
+        assert result["insert_anchor"] == "Flow Hydrograph QMult="
+        assert result["previous_eg_slope"] is None
+        assert result["new_eg_slope"] == 0.0007
+
+        text = fh_2d_block_without_slope_with_qmult.read_text(encoding="utf-8")
+        # Slope line appears immediately after QMult and immediately before
+        # the first DSS metadata line.
+        lines = text.splitlines()
+        qmult_i = lines.index("Flow Hydrograph QMult= 1.0 ")
+        slope_i = lines.index("Flow Hydrograph Slope= 0.0007 ")
+        dss_i = lines.index("DSS Path=")
+        assert qmult_i < slope_i < dss_i
+        assert slope_i == qmult_i + 1
+
+    def test_inserts_before_dss_when_no_qmult_or_tw_check(self, fh_block_minimal):
+        from ras_commander import RasUnsteady
+
+        result = RasUnsteady.set_flow_hydrograph_slope(
+            fh_block_minimal,
+            eg_slope=0.0009,
+            area_2d="Area2",
+            bc_line="Q in",
+        )
+
+        assert result["lines_inserted"] == 1
+        assert result["insert_anchor"] == "DSS Path="
+
+        text = fh_block_minimal.read_text(encoding="utf-8")
+        # Slope line comes immediately before DSS Path=.
+        lines = text.splitlines()
+        slope_i = lines.index("Flow Hydrograph Slope= 0.0009 ")
+        dss_i = lines.index("DSS Path=")
+        assert slope_i + 1 == dss_i
+
+
+# ---------------------------------------------------------------------------
+# Type check
+# ---------------------------------------------------------------------------
+
+
+class TestRefusesNonFlowHydrograph:
+    def test_normal_depth_block_raises(self, normal_depth_only_block):
+        from ras_commander import RasUnsteady
+
+        with pytest.raises(ValueError, match="not a Flow Hydrograph"):
+            RasUnsteady.set_flow_hydrograph_slope(
+                normal_depth_only_block,
+                eg_slope=0.001,
+                area_2d="BaldEagleCr",
+                bc_line="DSNormalDepth",
+            )
+
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+
+class TestValidation:
+    def test_rejects_zero_slope(self, fh_2d_block_with_existing_slope):
+        from ras_commander import RasUnsteady
+
+        with pytest.raises(ValueError, match="outside the supported range"):
+            RasUnsteady.set_flow_hydrograph_slope(
+                fh_2d_block_with_existing_slope,
+                eg_slope=0.0,
+                area_2d="BaldEagleCr",
+                bc_line="Upstream Inflow",
+            )
+
+    def test_rejects_non_numeric(self, fh_2d_block_with_existing_slope):
+        from ras_commander import RasUnsteady
+
+        with pytest.raises(ValueError, match="must be a number"):
+            RasUnsteady.set_flow_hydrograph_slope(
+                fh_2d_block_with_existing_slope,
+                eg_slope="0.001",  # type: ignore[arg-type]
+                area_2d="BaldEagleCr",
+                bc_line="Upstream Inflow",
+            )
+
+    def test_rejects_partial_1d_selector(self, fh_2d_block_with_existing_slope):
+        from ras_commander import RasUnsteady
+
+        with pytest.raises(ValueError, match="1D selector requires"):
+            RasUnsteady.set_flow_hydrograph_slope(
+                fh_2d_block_with_existing_slope,
+                eg_slope=0.001,
+                river="White",
+                reach="Muncie",
+                # station missing
+            )
+
+    def test_rejects_2d_selector_without_bc_line(self, fh_2d_block_with_existing_slope):
+        from ras_commander import RasUnsteady
+
+        with pytest.raises(ValueError, match="2D selector requires both area_2d and bc_line"):
+            RasUnsteady.set_flow_hydrograph_slope(
+                fh_2d_block_with_existing_slope,
+                eg_slope=0.001,
+                area_2d="BaldEagleCr",
+                # bc_line missing
+            )
+
+    def test_rejects_mixed_selectors(self, fh_2d_block_with_existing_slope):
+        from ras_commander import RasUnsteady
+
+        with pytest.raises(ValueError, match="exactly one selector group"):
+            RasUnsteady.set_flow_hydrograph_slope(
+                fh_2d_block_with_existing_slope,
+                eg_slope=0.001,
+                river="White",
+                reach="Muncie",
+                station="15696.24",
+                area_2d="BaldEagleCr",
+                bc_line="Upstream Inflow",
+            )
+
+    def test_rejects_no_selector(self, fh_2d_block_with_existing_slope):
+        from ras_commander import RasUnsteady
+
+        with pytest.raises(ValueError, match="exactly one selector group"):
+            RasUnsteady.set_flow_hydrograph_slope(
+                fh_2d_block_with_existing_slope, eg_slope=0.001
+            )
+
+    def test_unknown_target_raises(self, fh_2d_block_with_existing_slope):
+        from ras_commander import RasUnsteady
+
+        with pytest.raises(ValueError, match="No boundary matched"):
+            RasUnsteady.set_flow_hydrograph_slope(
+                fh_2d_block_with_existing_slope,
+                eg_slope=0.001,
+                area_2d="Nonexistent",
+                bc_line="Phantom",
+            )
+
+    def test_missing_unsteady_file_raises(self, tmp_path):
+        from ras_commander import RasUnsteady
+
+        with pytest.raises(FileNotFoundError):
+            RasUnsteady.set_flow_hydrograph_slope(
+                tmp_path / "missing.u01",
+                eg_slope=0.001,
+                area_2d="X",
+                bc_line="Y",
+            )
+
+
+# ---------------------------------------------------------------------------
+# Real RasExamples projects
+# ---------------------------------------------------------------------------
+
+
+class TestRealProjects:
+    @pytest.mark.slow
+    def test_baldeagle_existing_slope_update_round_trip(self, tmp_path):
+        """Update an existing `Flow Hydrograph Slope=` on a 2D BC line and
+        verify nothing else in the surrounding block changed."""
+        try:
+            from ras_commander import RasExamples, RasUnsteady
+            project = RasExamples.extract_project(
+                "BaldEagleCrkMulti2D", output_path=tmp_path, suffix="_fh_slope_update"
+            )
+        except Exception:
+            pytest.skip("BaldEagleCrkMulti2D example not available")
+        if isinstance(project, list):
+            project = project[0]
+        u_files = sorted(p for p in Path(project).glob("*.u*") if "hdf" not in p.name.lower())
+        # Find a (.u##, area, bc_line) where Flow Hydrograph Slope= already
+        # exists right after a Flow Hydrograph block.
+        target_file = None
+        target_area = None
+        target_bc = None
+        slope_pattern = re.compile(
+            r"^Boundary Location=(.+?)\nInterval=.+?\nFlow Hydrograph=.+?(?:\n.*)*?\nFlow Hydrograph Slope=\s*([\d.]+)",
+            re.MULTILINE,
+        )
+        for u in u_files:
+            text = u.read_text(encoding="utf-8", errors="ignore")
+            m = slope_pattern.search(text)
+            if not m:
+                continue
+            parts = [p.strip() for p in m.group(1).split(",")]
+            if len(parts) >= 8 and parts[5] and parts[7]:
+                target_file, target_area, target_bc = u, parts[5], parts[7]
+                break
+        if target_file is None:
+            pytest.skip("No 2D Flow Hydrograph with existing slope found")
+
+        before = target_file.read_text(encoding="utf-8", errors="ignore")
+        result = RasUnsteady.set_flow_hydrograph_slope(
+            target_file,
+            eg_slope=0.0009,
+            area_2d=target_area,
+            bc_line=target_bc,
+        )
+        assert result["updated_in_place"] is True
+        assert result["new_eg_slope"] == 0.0009
+
+        after = target_file.read_text(encoding="utf-8", errors="ignore")
+        # The only differences must be the changed slope line.
+        diff = [
+            (b, a) for b, a in zip(before.splitlines(), after.splitlines())
+            if b != a
+        ]
+        assert len(diff) == 1
+        assert diff[0][1].startswith("Flow Hydrograph Slope=")
+        assert "0.0009" in diff[0][1]
+        # Same file length (in-place update).
+        assert len(before.splitlines()) == len(after.splitlines())
+
+    @pytest.mark.slow
+    def test_baldeagle_insert_when_no_slope_in_block(self, tmp_path):
+        """Insert a slope into a Flow Hydrograph block that lacks one.
+
+        Every BaldEagle 2D Flow Hydrograph block in the shipped dataset
+        already has a slope line, so this test deterministically constructs
+        a no-slope variant: extract BaldEagleCrkMulti2D, pick a 2D Flow
+        Hydrograph block, strip its `Flow Hydrograph Slope=` line in place,
+        and verify the writer re-inserts at the canonical anchor without
+        touching any other line.
+        """
+        try:
+            from ras_commander import RasExamples, RasUnsteady
+            project = RasExamples.extract_project(
+                "BaldEagleCrkMulti2D", output_path=tmp_path, suffix="_fh_slope_insert"
+            )
+        except Exception:
+            pytest.skip("BaldEagleCrkMulti2D example not available")
+        if isinstance(project, list):
+            project = project[0]
+        u_files = sorted(
+            p for p in Path(project).glob("*.u*") if "hdf" not in p.name.lower()
+        )
+
+        # Find a 2D Flow Hydrograph block that already has a slope line.
+        target_file = None
+        target_area = None
+        target_bc = None
+        original_slope_line = None
+        for u in u_files:
+            text = u.read_text(encoding="utf-8", errors="ignore")
+            for m in re.finditer(
+                r"^Boundary Location=(.+?)(?=\nBoundary Location=|\Z)",
+                text,
+                re.MULTILINE | re.DOTALL,
+            ):
+                block = m.group(0)
+                if "Flow Hydrograph=" not in block:
+                    continue
+                if "Flow Hydrograph Slope=" not in block:
+                    continue
+                # Parse only the first (location) line — `m.group(1)` spans
+                # the whole block under DOTALL.
+                first_line = block.splitlines()[0]
+                loc_value = first_line[len("Boundary Location="):]
+                parts = [p.strip() for p in loc_value.split(",")]
+                if len(parts) < 8 or not (parts[5] and parts[7]):
+                    continue
+                target_file = u
+                target_area = parts[5]
+                target_bc = parts[7]
+                original_slope_line = next(
+                    line for line in block.splitlines()
+                    if line.startswith("Flow Hydrograph Slope=")
+                )
+                break
+            if target_file is not None:
+                break
+        if target_file is None:
+            pytest.skip("No 2D Flow Hydrograph with slope found in BaldEagle")
+
+        # Strip the slope line so we can validate the insert path.
+        original = target_file.read_text(encoding="utf-8", errors="ignore")
+        stripped = original.replace(original_slope_line + "\n", "", 1)
+        target_file.write_text(stripped, encoding="utf-8")
+
+        before = target_file.read_text(encoding="utf-8", errors="ignore")
+        assert "Flow Hydrograph Slope=" not in before  # sanity
+
+        result = RasUnsteady.set_flow_hydrograph_slope(
+            target_file,
+            eg_slope=0.0011,
+            area_2d=target_area,
+            bc_line=target_bc,
+        )
+        assert result["updated_in_place"] is False
+        assert result["lines_inserted"] == 1
+        assert result["new_eg_slope"] == 0.0011
+        assert result["insert_anchor"] in {
+            "Flow Hydrograph QMult=",
+            "Stage Hydrograph TW Check=",
+            "DSS Path=",
+            "DSS File=",
+            "Use DSS=",
+            "<inline-data-tail>",
+        }
+
+        after = target_file.read_text(encoding="utf-8", errors="ignore")
+        assert len(after.splitlines()) == len(before.splitlines()) + 1
+        assert "Flow Hydrograph Slope= 0.0011 " in after
+        # Every line that was in the stripped file must still be there.
+        before_lines = set(before.splitlines())
+        after_lines = set(after.splitlines())
+        assert before_lines - after_lines == set()


### PR DESCRIPTION
## Summary

Adds `RasUnsteady.set_flow_hydrograph_slope()`, a public writer that adds or updates the `Flow Hydrograph Slope=` energy-grade slope line on a Flow Hydrograph boundary in a HEC-RAS unsteady flow file (`.u##`). Closes CLB-311.

`Flow Hydrograph Slope=` is the parameter HEC-RAS uses to distribute Flow Hydrograph inflow along a 2D Flow Area perimeter BC line (HEC-RAS Tutorial 2, "Creating a Simple 2D Model").

- **Selectors**: 1D `(river, reach, station)` or 2D `(area_2d, bc_line)`. `bc_line` is required for 2D since the slope is per-BC-line, never area-wide.
- **Type-checked**: Refuses to operate on non-Flow-Hydrograph blocks (Normal Depth, Stage Hydrograph, Rating Curve, Gate Opening). Raises `ValueError` with the matched location name.
- **Update path**: Overwrites `Flow Hydrograph Slope=` line in place. No other line is touched.
- **Insert path**: Places the new line in the canonical anchor position observed in HEC-RAS-emitted output (after `Flow Hydrograph QMult=`, else after `Stage Hydrograph TW Check=`, else before the first DSS metadata line, else before the first `=` line after the inline hydrograph data).
- **Preserves**: DSS Path, DSS File, Use DSS, Interval, Flow Hydrograph count, and inline hydrograph data are never altered. The companion writers (`set_boundary_dss_link`, `set_boundary_inline_hydrograph`) can be used freely before or after.
- **Format**: Mirrors HEC-RAS-emitted output exactly — `Flow Hydrograph Slope= <value> ` (single leading space after `=`, single trailing space before the newline, matching the surrounding `Flow Hydrograph QMult=` line).
- **Validation**: Slope must be finite and in `[1e-7, 1.0]`. Selectors mutually exclusive (1D OR 2D, not both).
- **Returns**: Reviewable before/after metadata — `matched_location`, `previous_eg_slope`, `new_eg_slope`, `updated_in_place`, `lines_inserted`, `insert_anchor`, `boundaries_df_refreshed`, `block_before`, `block_after`.
- **Refreshes**: `ras.boundaries_df` after the write when an initialized `ras_object` is available.

## Acceptance criteria (from CLB-311)

- [x] Public method can set EG slope for selected 2D Flow Hydrograph boundaries — `RasUnsteady.set_flow_hydrograph_slope(file, eg_slope=..., area_2d=..., bc_line=...)`
- [x] Existing DSS links, intervals, and hydrograph table counts are preserved — verified by per-line assertion in `test_2d_existing_slope_overwritten_in_place` and `test_baldeagle_existing_slope_update_round_trip`
- [x] Tests cover a multi-boundary unsteady file — synthetic multi-block fixture and BaldEagleCrkMulti2D real-project tests

## Test plan

- [x] `pytest tests/test_rasunsteady_flow_hydrograph_slope.py -v` — **14 passed** (synthetic + 2 real RasExamples projects)
- [x] Regression: `pytest tests/test_rasunsteady_precipitation.py tests/test_rasunsteady_restart_settings.py -q` — **22 passed**
- [ ] CI: full pytest run on the branch

## Notes

This was processed as a manual Symphony run from the CLB01 workstation while CLB08's automated runner is paused for Codex credit recharging. The Linear ticket has the full Codex Workpad with environment stamp, plan checklist, and validation evidence. A review bundle is also written to `H:/Symphony/ras-commander/CLB-311/`.

Companion to PR #76 (CLB-310, Normal Depth setter). The two writers share the same boundary-resolution model and are designed to compose — for example, calling `set_normal_depth_boundary` and `set_flow_hydrograph_slope` on different boundaries in the same file is safe and order-independent.