### PR TITLE
CLB-309: Add GeomBcLines authoring API for 2D boundary condition lines

### DIFF
--- a/ras_commander/__init__.py
+++ b/ras_commander/__init__.py
@@ -85,7 +85,7 @@ from .geom import (
     GeomParser, GeomPreprocessor, GeomLandCover,
     GeomCrossSection, GeomStorage, GeomLateral,
     GeomInlineWeir, GeomBridge, GeomCulvert,
-    GeomReferenceFeatures, GeomMesh,
+    GeomReferenceFeatures, GeomBcLines, GeomMesh,
     MeshResult, BCConflict, BCFixResult,
 )
 
@@ -187,7 +187,7 @@ __all__ = [
     'GeomParser', 'GeomPreprocessor', 'GeomLandCover',
     'GeomCrossSection', 'GeomStorage', 'GeomLateral',
     'GeomInlineWeir', 'GeomBridge', 'GeomCulvert',
-    'GeomReferenceFeatures',
+    'GeomReferenceFeatures', 'GeomBcLines',
 
     # Deprecated geometry classes (will be removed before v1.0)
     'RasGeo', 'RasGeometry', 'RasGeometryUtils',

--- a/ras_commander/geom/GeomBcLines.py
+++ b/ras_commander/geom/GeomBcLines.py
@@ -1,0 +1,544 @@
+"""
+GeomBcLines: Author 2D boundary condition (BC) line geometry in HEC-RAS
+plain text geometry files (.g##).
+
+BC lines define where flow enters or leaves a 2D Flow Area on its
+perimeter. Tutorials 2, 4, and 11 in HEC-RAS's "2D Unsteady Flow"
+training set require authoring BC lines before any flow data
+(Flow Hydrograph, Normal Depth, Stage Hydrograph, etc.) can be
+attached to a boundary by name.
+
+This module operates on the .g## TEXT file, which is the source of
+truth for geometry authoring. After writing, the user must run HEC-RAS
+geometry preprocessing (or launch HEC-RAS) for the new BC lines to
+appear in the compiled `.g##.hdf` and become visible to
+`HdfBndry.get_bc_lines()`. The companion `External Faces` HDF dataset
+is computed by HEC-RAS preprocessing — it cannot be authored here.
+
+Format conventions observed in real HEC-RAS output (Chippewa_2D,
+BaldEagleCrkMulti2D, Weise_2D):
+
+    BC Line Name=<name padded to 40 chars>
+    BC Line Storage Area=<2D Flow Area name padded to 16 chars>
+    BC Line Start Position= X , Y
+    BC Line Middle Position= Xmid , Ymid
+    BC Line End Position= X , Y
+    BC Line Arc= N
+    <fixed-width 16-char coordinate fields, 4 values per line>
+    BC Line Text Position= 1.79769313486232E+308 , 1.79769313486232E+308
+
+This format is structurally identical to Reference Line blocks.
+Insertion site: after any existing BC Line blocks (so all BC lines
+group together), or before the first of `Reference Line Name=` /
+`IC Point Name=` / `LCMann ` if no BC lines exist yet.
+
+All methods are static. Do not instantiate.
+
+See Also
+--------
+ras_commander.RasUnsteady.set_normal_depth_boundary : Attach a Normal
+    Depth boundary condition to an authored BC line (CLB-310).
+ras_commander.RasUnsteady.set_flow_hydrograph_slope : Set the
+    Flow Hydrograph energy-grade slope on an authored BC line
+    (CLB-311).
+ras_commander.geom.GeomReferenceFeatures.add_reference_lines : Sibling
+    writer for Reference Lines (identical text format).
+"""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Union
+
+import numpy as np
+
+from ..Decorators import log_call
+from ..LoggingConfig import get_logger
+from .GeomReferenceFeatures import _format_coord_line
+
+logger = get_logger(__name__)
+
+
+_BC_NAME_KEY = "BC Line Name="
+_BC_STORAGE_AREA_KEY = "BC Line Storage Area="
+_BC_TEXT_POSITION_KEY = "BC Line Text Position="
+_TEXT_POSITION_SENTINEL = (
+    " 1.79769313486232E+308 , 1.79769313486232E+308 "
+)
+
+
+def _build_bc_line_block(
+    name: str,
+    storage_area: str,
+    coordinates: np.ndarray,
+) -> List[str]:
+    """Build a BC line plain-text block matching HEC-RAS-emitted output."""
+    coords = np.asarray(coordinates, dtype=np.float64)
+    n_pts = len(coords)
+    x_start, y_start = coords[0]
+    x_end, y_end = coords[-1]
+    mid_idx = n_pts // 2
+    x_mid, y_mid = coords[mid_idx]
+
+    block: List[str] = []
+    block.append(f"{_BC_NAME_KEY}{name:<40s}")
+    block.append(f"{_BC_STORAGE_AREA_KEY}{storage_area:<16s}")
+    block.append(f"BC Line Start Position= {x_start} , {y_start} ")
+    block.append(f"BC Line Middle Position= {x_mid} , {y_mid} ")
+    block.append(f"BC Line End Position= {x_end} , {y_end} ")
+    block.append(f"BC Line Arc= {n_pts} ")
+
+    # Coordinate block: 4 values per line (x1,y1,x2,y2), 16-char fields.
+    flat_values = coords.flatten().tolist()
+    for i in range(0, len(flat_values), 4):
+        block.append(_format_coord_line(flat_values[i : i + 4]))
+
+    block.append(f"{_BC_TEXT_POSITION_KEY}{_TEXT_POSITION_SENTINEL}")
+    return block
+
+
+def _detect_line_ending(file_lines: List[str]) -> str:
+    return "\r\n" if file_lines and file_lines[0].endswith("\r\n") else "\n"
+
+
+def _find_bc_line_block(
+    file_lines: List[str], name: str
+) -> Optional[tuple]:
+    """Locate an existing BC line block by name. Returns (start_idx, end_idx)
+    where end_idx is exclusive (one past the last line of the block — i.e.,
+    the line after `BC Line Text Position=`)."""
+    target = f"{_BC_NAME_KEY}{name}"
+    for i, line in enumerate(file_lines):
+        stripped = line.rstrip("\r\n")
+        if not stripped.startswith(_BC_NAME_KEY):
+            continue
+        # Right-pad whitespace-tolerant match: HEC-RAS pads names to 40 chars.
+        if stripped.rstrip() != target.rstrip():
+            continue
+        # Walk until we hit the closing `BC Line Text Position=` line.
+        for j in range(i + 1, len(file_lines)):
+            if file_lines[j].lstrip().startswith(_BC_TEXT_POSITION_KEY):
+                return i, j + 1
+        # Block was unterminated — defensive: stop at next BC Line Name= or end.
+        for j in range(i + 1, len(file_lines)):
+            if file_lines[j].lstrip().startswith(_BC_NAME_KEY):
+                return i, j
+        return i, len(file_lines)
+    return None
+
+
+def _list_storage_areas(file_lines: List[str]) -> List[str]:
+    """Return the set of `Storage Area=` names present in the geometry."""
+    areas: List[str] = []
+    for line in file_lines:
+        stripped = line.rstrip("\r\n")
+        if stripped.startswith("Storage Area="):
+            # Format: `Storage Area=<name padded to 16>,,` — take field[0] of
+            # the comma split, strip the keyword and trailing whitespace.
+            payload = stripped[len("Storage Area="):]
+            name_field = payload.split(",", 1)[0].strip()
+            if name_field:
+                areas.append(name_field)
+    return areas
+
+
+def _bc_line_insertion_index(file_lines: List[str]) -> int:
+    """Pick the canonical insertion site for a fresh BC Line block.
+
+    Priority (matches the layout HEC-RAS emits):
+      1. After the last existing `BC Line Text Position=` (group all BC
+         lines together).
+      2. Else before the first `Reference Line Name=` (BC lines come
+         before reference lines in the file order).
+      3. Else before the first `IC Point Name=`.
+      4. Else before the first `LCMann ` line.
+      5. Else end of file.
+    """
+    last_bc_text_idx = -1
+    first_refline_idx = -1
+    first_ic_point_idx = -1
+    first_lcmann_idx = -1
+    for i, line in enumerate(file_lines):
+        stripped = line.rstrip("\r\n")
+        if stripped.startswith(_BC_TEXT_POSITION_KEY):
+            last_bc_text_idx = i
+        if (
+            stripped.startswith("Reference Line Name=")
+            and first_refline_idx == -1
+        ):
+            first_refline_idx = i
+        if (
+            stripped.startswith("IC Point Name=")
+            and first_ic_point_idx == -1
+        ):
+            first_ic_point_idx = i
+        if stripped.startswith("LCMann ") and first_lcmann_idx == -1:
+            first_lcmann_idx = i
+    if last_bc_text_idx >= 0:
+        return last_bc_text_idx + 1
+    for candidate in (first_refline_idx, first_ic_point_idx, first_lcmann_idx):
+        if candidate >= 0:
+            return candidate
+    return len(file_lines)
+
+
+class GeomBcLines:
+    """Public API for authoring 2D BC line geometry in `.g##` text files."""
+
+    @staticmethod
+    @log_call
+    def add_bc_lines(
+        geom_file: Union[str, Path],
+        lines: List[Dict[str, Any]],
+        replace_existing: bool = False,
+    ) -> Dict[str, Any]:
+        """
+        Insert one or more 2D BC line blocks into a geometry text file.
+
+        Parameters
+        ----------
+        geom_file : str or Path
+            Path to the HEC-RAS plain text geometry file (.g##).
+        lines : list of dict
+            Each dict describes one BC line and must contain:
+
+            - ``name`` (str): the BC line name. Used by the
+              `BC Line Name=` keyword and by `RasUnsteady` boundary
+              setters to attach BC types. Must be unique within the
+              file unless ``replace_existing=True``.
+            - ``storage_area`` (str): the 2D Flow Area name this BC
+              line attaches to. Must match an existing
+              `Storage Area=<name>` block in the file.
+            - ``coordinates`` (sequence of (x, y) or ``(N, 2)`` array):
+              endpoint and intermediate vertices of the BC line in the
+              project's native CRS. At least two points required.
+
+        replace_existing : bool, default False
+            When ``False`` (the default), inserting a BC line whose name
+            already exists in the file raises ``ValueError``. When
+            ``True``, the existing block is removed before the new one
+            is inserted (upsert semantics).
+
+        Returns
+        -------
+        Dict[str, Any]
+            Reviewable metadata with keys:
+
+            - ``geom_file`` (str): absolute path written
+            - ``inserted`` (List[str]): names that were newly added
+            - ``replaced`` (List[str]): names whose blocks were
+              overwritten (only populated when ``replace_existing=True``)
+            - ``insert_index`` (int): line index (0-based) where the new
+              blocks were placed
+            - ``backup_path`` (str): absolute path of the `.bak` backup
+
+        Raises
+        ------
+        FileNotFoundError
+            If ``geom_file`` does not exist.
+        ValueError
+            If ``lines`` is empty; if a line dict is missing required
+            keys; if coordinates is malformed; if a referenced
+            ``storage_area`` does not exist as a `Storage Area=` block
+            in the file; or if a name already exists in the file and
+            ``replace_existing`` is False.
+
+        Examples
+        --------
+        Add a downstream Normal Depth BC line to the `Perimeter 1` 2D
+        Flow Area in a Chippewa-style geometry, then attach Normal
+        Depth in the unsteady file via `set_normal_depth_boundary`:
+
+        >>> from ras_commander import GeomBcLines, RasUnsteady
+        >>> result = GeomBcLines.add_bc_lines(
+        ...     "project.g01",
+        ...     lines=[{
+        ...         "name": "DSNormalDepth",
+        ...         "storage_area": "Perimeter 1",
+        ...         "coordinates": [(1027205.96, 7858200.24),
+        ...                          (1025994.94, 7858316.68)],
+        ...     }],
+        ... )
+        >>> result["inserted"]
+        ['DSNormalDepth']
+        >>> # ... after running HEC-RAS geometry preprocessing ...
+        >>> RasUnsteady.set_normal_depth_boundary(
+        ...     "project.u01",
+        ...     friction_slope=0.0003,
+        ...     area_2d="Perimeter 1",
+        ...     bc_line="DSNormalDepth",
+        ... )
+
+        See Also
+        --------
+        delete_bc_line, rename_bc_line :
+            Companion writers for the `update`, `delete`, and `rename`
+            verbs in CLB-309's API surface.
+        ras_commander.geom.GeomReferenceFeatures.add_reference_lines :
+            Sibling writer with identical text-format conventions.
+        """
+        geom_path = Path(geom_file)
+        if not geom_path.exists():
+            raise FileNotFoundError(f"Geometry file not found: {geom_path}")
+
+        if not lines:
+            raise ValueError("lines must contain at least one BC line spec")
+
+        # Backup
+        backup_path = Path(str(geom_path) + ".bak")
+        shutil.copy2(geom_path, backup_path)
+        logger.info(f"Created backup: {backup_path.name}")
+
+        with open(geom_path, "r", encoding="utf-8", errors="ignore", newline="") as f:
+            file_lines = f.readlines()
+        line_ending = _detect_line_ending(file_lines)
+
+        # Validate inputs and pre-compute blocks before mutating.
+        existing_areas = set(_list_storage_areas(file_lines))
+        prepared: List[tuple] = []  # (name, storage_area, block_lines)
+        for spec in lines:
+            if not isinstance(spec, dict):
+                raise ValueError("each entry in `lines` must be a dict")
+            name_raw = spec.get("name")
+            if not name_raw:
+                raise ValueError("each line dict must have a 'name' key")
+            name = str(name_raw).strip()
+            sa_raw = spec.get("storage_area")
+            if not sa_raw:
+                raise ValueError(
+                    f"BC line {name!r}: 'storage_area' is required"
+                )
+            storage_area = str(sa_raw).strip()
+            if storage_area not in existing_areas:
+                raise ValueError(
+                    f"BC line {name!r}: storage_area {storage_area!r} not "
+                    f"found in {geom_path.name}; existing areas are "
+                    f"{sorted(existing_areas)}"
+                )
+            coords_raw = spec.get("coordinates")
+            if coords_raw is None:
+                raise ValueError(
+                    f"BC line {name!r}: 'coordinates' is required"
+                )
+            coords = np.asarray(coords_raw, dtype=np.float64)
+            if coords.ndim != 2 or coords.shape[1] != 2 or len(coords) < 2:
+                raise ValueError(
+                    f"BC line {name!r}: coordinates must be an (N, 2) "
+                    f"array with at least 2 points"
+                )
+            block = _build_bc_line_block(name, storage_area, coords)
+            prepared.append((name, storage_area, block))
+
+        # Detect duplicate names within the call.
+        seen: set = set()
+        for name, _, _ in prepared:
+            if name in seen:
+                raise ValueError(
+                    f"BC line name {name!r} appears more than once in `lines`"
+                )
+            seen.add(name)
+
+        # Detect collisions with existing blocks; remove them up-front when
+        # replace_existing=True so the insertion index is computed against
+        # the post-removal file.
+        replaced: List[str] = []
+        if replace_existing:
+            # Remove in descending index order to preserve earlier indices.
+            removals: List[tuple] = []
+            for name, _, _ in prepared:
+                hit = _find_bc_line_block(file_lines, name)
+                if hit is not None:
+                    removals.append((name, hit))
+            for name, (start, end) in sorted(
+                removals, key=lambda r: r[1][0], reverse=True
+            ):
+                del file_lines[start:end]
+                replaced.append(name)
+        else:
+            for name, _, _ in prepared:
+                if _find_bc_line_block(file_lines, name) is not None:
+                    raise ValueError(
+                        f"BC line {name!r} already exists in {geom_path.name}; "
+                        f"pass replace_existing=True to overwrite"
+                    )
+
+        insert_idx = _bc_line_insertion_index(file_lines)
+
+        new_text_lines: List[str] = []
+        for name, storage_area, block in prepared:
+            for block_line in block:
+                new_text_lines.append(block_line + line_ending)
+
+        file_lines[insert_idx:insert_idx] = new_text_lines
+
+        with open(geom_path, "w", encoding="utf-8", newline="") as f:
+            f.writelines(file_lines)
+
+        inserted = [name for name, _, _ in prepared if name not in replaced]
+        logger.info(
+            "Added %d BC line(s) to %s (replaced=%d, insert_idx=%d)",
+            len(prepared),
+            geom_path.name,
+            len(replaced),
+            insert_idx,
+        )
+        return {
+            "geom_file": str(geom_path),
+            "inserted": inserted,
+            "replaced": replaced,
+            "insert_index": insert_idx,
+            "backup_path": str(backup_path),
+        }
+
+    @staticmethod
+    @log_call
+    def delete_bc_line(
+        geom_file: Union[str, Path],
+        name: str,
+    ) -> Dict[str, Any]:
+        """
+        Remove a BC line block by name.
+
+        Parameters
+        ----------
+        geom_file : str or Path
+            Path to the .g## geometry file.
+        name : str
+            BC Line name to remove. Whitespace-padding on the matching
+            line is tolerated.
+
+        Returns
+        -------
+        Dict[str, Any]
+            Keys: ``geom_file``, ``deleted`` (bool), ``name``,
+            ``backup_path``, ``lines_removed`` (int).
+
+        Raises
+        ------
+        FileNotFoundError
+            If ``geom_file`` does not exist.
+        ValueError
+            If no BC line with the given name is present.
+        """
+        geom_path = Path(geom_file)
+        if not geom_path.exists():
+            raise FileNotFoundError(f"Geometry file not found: {geom_path}")
+
+        clean_name = (name or "").strip()
+        if not clean_name:
+            raise ValueError("name is required")
+
+        backup_path = Path(str(geom_path) + ".bak")
+        shutil.copy2(geom_path, backup_path)
+
+        with open(geom_path, "r", encoding="utf-8", errors="ignore", newline="") as f:
+            file_lines = f.readlines()
+
+        hit = _find_bc_line_block(file_lines, clean_name)
+        if hit is None:
+            raise ValueError(
+                f"BC line {clean_name!r} not found in {geom_path.name}"
+            )
+        start, end = hit
+        lines_removed = end - start
+        del file_lines[start:end]
+
+        with open(geom_path, "w", encoding="utf-8", newline="") as f:
+            f.writelines(file_lines)
+
+        logger.info(
+            "Deleted BC line %s from %s (%d lines)",
+            clean_name,
+            geom_path.name,
+            lines_removed,
+        )
+        return {
+            "geom_file": str(geom_path),
+            "deleted": True,
+            "name": clean_name,
+            "backup_path": str(backup_path),
+            "lines_removed": lines_removed,
+        }
+
+    @staticmethod
+    @log_call
+    def rename_bc_line(
+        geom_file: Union[str, Path],
+        old_name: str,
+        new_name: str,
+    ) -> Dict[str, Any]:
+        """
+        Rename a BC line in place, preserving its geometry, storage_area
+        association, and position in the file.
+
+        Parameters
+        ----------
+        geom_file : str or Path
+            Path to the .g## geometry file.
+        old_name, new_name : str
+            Current and desired BC Line name.
+
+        Returns
+        -------
+        Dict[str, Any]
+            Keys: ``geom_file``, ``old_name``, ``new_name``,
+            ``backup_path``.
+
+        Raises
+        ------
+        FileNotFoundError
+            If ``geom_file`` does not exist.
+        ValueError
+            If ``old_name`` does not exist; if ``new_name`` already
+            exists; if either name is empty.
+        """
+        geom_path = Path(geom_file)
+        if not geom_path.exists():
+            raise FileNotFoundError(f"Geometry file not found: {geom_path}")
+
+        clean_old = (old_name or "").strip()
+        clean_new = (new_name or "").strip()
+        if not clean_old or not clean_new:
+            raise ValueError("old_name and new_name are required")
+        if clean_old == clean_new:
+            raise ValueError("old_name and new_name are identical")
+
+        backup_path = Path(str(geom_path) + ".bak")
+        shutil.copy2(geom_path, backup_path)
+
+        with open(geom_path, "r", encoding="utf-8", errors="ignore", newline="") as f:
+            file_lines = f.readlines()
+        line_ending = _detect_line_ending(file_lines)
+
+        old_hit = _find_bc_line_block(file_lines, clean_old)
+        if old_hit is None:
+            raise ValueError(
+                f"BC line {clean_old!r} not found in {geom_path.name}"
+            )
+        if _find_bc_line_block(file_lines, clean_new) is not None:
+            raise ValueError(
+                f"BC line {clean_new!r} already exists in {geom_path.name}"
+            )
+
+        start, _end = old_hit
+        # The first line of the block is `BC Line Name=<old_name padded>`.
+        # Replace the whole line with the new padded name; preserve line
+        # ending.
+        file_lines[start] = f"{_BC_NAME_KEY}{clean_new:<40s}{line_ending}"
+
+        with open(geom_path, "w", encoding="utf-8", newline="") as f:
+            f.writelines(file_lines)
+
+        logger.info(
+            "Renamed BC line %s -> %s in %s",
+            clean_old,
+            clean_new,
+            geom_path.name,
+        )
+        return {
+            "geom_file": str(geom_path),
+            "old_name": clean_old,
+            "new_name": clean_new,
+            "backup_path": str(backup_path),
+        }

--- a/ras_commander/geom/__init__.py
+++ b/ras_commander/geom/__init__.py
@@ -55,6 +55,7 @@ from .GeomHtabUtils import GeomHtabUtils
 from .GeomHtab import GeomHtab
 from .GeomMetadata import GeomMetadata
 from .GeomReferenceFeatures import GeomReferenceFeatures
+from .GeomBcLines import GeomBcLines
 from .GeomMesh import GeomMesh
 from .GeomMeshDataclasses import MeshResult, BCConflict, BCFixResult
 
@@ -72,6 +73,7 @@ __all__ = [
     'GeomHtab',
     'GeomMetadata',
     'GeomReferenceFeatures',
+    'GeomBcLines',
     'GeomMesh',
     'MeshResult',
     'BCConflict',

--- a/tests/test_geom_bc_lines.py
+++ b/tests/test_geom_bc_lines.py
@@ -1,0 +1,473 @@
+"""
+Tests for GeomBcLines: 2D BC line authoring in HEC-RAS .g## files.
+
+Covers:
+
+- `add_bc_lines`: insert one or more BC lines, with validation and
+  upsert semantics.
+- `delete_bc_line`: remove a BC line by name.
+- `rename_bc_line`: change a BC line's name without disturbing its
+  geometry or position.
+- Real RasExamples round-trip against `Chippewa_2D` to confirm the
+  emitted text matches HEC-RAS-emitted format byte-for-byte (modulo
+  numerical formatting).
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+
+def _write_geom(path: Path, body: str) -> Path:
+    path.write_text(body, encoding="utf-8")
+    return path
+
+
+# A minimal but realistic .g## skeleton with one 2D Flow Area
+# (Perimeter 1) and one existing BC line (Existing). Used as the baseline
+# for synthetic tests.
+_SKELETON = (
+    "Geom Title=Test geom\n"
+    "Program Version=6.60\n"
+    "Storage Area=Perimeter 1     ,,\n"
+    "Storage Area Surface Line= 4 \n"
+    "        0       0       1000    0       1000    1000    0       1000\n"
+    "Storage Area 2D Points= 4 \n"
+    "        0       0       1000    0       1000    1000    0       1000\n"
+    "BC Line Name=Existing                                \n"
+    "BC Line Storage Area=Perimeter 1     \n"
+    "BC Line Start Position= 100 , 100 \n"
+    "BC Line Middle Position= 100 , 100 \n"
+    "BC Line End Position= 200 , 100 \n"
+    "BC Line Arc= 2 \n"
+    "             100             100             200             100\n"
+    "BC Line Text Position= 1.79769313486232E+308 , 1.79769313486232E+308 \n"
+    "LCMann Time=Dec/30/1899 00:00:00\n"
+    "LCMann Region Time=Dec/30/1899 00:00:00\n"
+)
+
+
+@pytest.fixture
+def skeleton_geom(tmp_path):
+    return _write_geom(tmp_path / "project.g01", _SKELETON)
+
+
+# ---------------------------------------------------------------------------
+# add_bc_lines
+# ---------------------------------------------------------------------------
+
+
+class TestAddBcLines:
+    def test_add_single_bc_line(self, skeleton_geom):
+        from ras_commander import GeomBcLines
+
+        result = GeomBcLines.add_bc_lines(
+            skeleton_geom,
+            lines=[{
+                "name": "DSNormalDepth",
+                "storage_area": "Perimeter 1",
+                "coordinates": [(500, 100), (700, 100), (900, 100)],
+            }],
+        )
+
+        assert result["inserted"] == ["DSNormalDepth"]
+        assert result["replaced"] == []
+        assert Path(result["backup_path"]).exists()
+
+        text = skeleton_geom.read_text(encoding="utf-8")
+        # New block emitted with HEC-RAS-style padded names.
+        assert "BC Line Name=DSNormalDepth" in text
+        # Storage area name padded to 16 chars.
+        assert "BC Line Storage Area=Perimeter 1     " in text
+        # Arc count and the canonical sentinel text position.
+        assert "BC Line Arc= 3 " in text
+        assert (
+            "BC Line Text Position= 1.79769313486232E+308 , "
+            "1.79769313486232E+308 " in text
+        )
+        # Coordinate block: 4 values per line, 16-char fields.
+        assert re.search(
+            r"^\s+500\s+100\s+700\s+100\s*$", text, re.MULTILINE
+        )
+        # Existing block survives unchanged.
+        assert "BC Line Name=Existing" in text
+
+    def test_added_block_groups_with_existing_bc_lines(self, skeleton_geom):
+        """New BC line is inserted after the LAST `BC Line Text Position=`
+        so all BC lines stay contiguous in the file (matches HEC-RAS
+        layout)."""
+        from ras_commander import GeomBcLines
+
+        GeomBcLines.add_bc_lines(
+            skeleton_geom,
+            lines=[{
+                "name": "NewBC",
+                "storage_area": "Perimeter 1",
+                "coordinates": [(0, 0), (10, 0)],
+            }],
+        )
+        text = skeleton_geom.read_text(encoding="utf-8")
+        existing_idx = text.index("BC Line Name=Existing")
+        new_idx = text.index("BC Line Name=NewBC")
+        lcmann_idx = text.index("LCMann Time=")
+        assert existing_idx < new_idx < lcmann_idx
+
+    def test_add_multiple_in_one_call(self, skeleton_geom):
+        from ras_commander import GeomBcLines
+
+        result = GeomBcLines.add_bc_lines(
+            skeleton_geom,
+            lines=[
+                {
+                    "name": "Upstream",
+                    "storage_area": "Perimeter 1",
+                    "coordinates": [(0, 0), (100, 0)],
+                },
+                {
+                    "name": "Tributary",
+                    "storage_area": "Perimeter 1",
+                    "coordinates": [(0, 100), (100, 100)],
+                },
+            ],
+        )
+        assert result["inserted"] == ["Upstream", "Tributary"]
+        text = skeleton_geom.read_text(encoding="utf-8")
+        assert "BC Line Name=Upstream" in text
+        assert "BC Line Name=Tributary" in text
+
+
+class TestAddBcLinesValidation:
+    def test_unknown_storage_area_raises(self, skeleton_geom):
+        from ras_commander import GeomBcLines
+
+        with pytest.raises(ValueError, match="not found"):
+            GeomBcLines.add_bc_lines(
+                skeleton_geom,
+                lines=[{
+                    "name": "BadArea",
+                    "storage_area": "NotAnArea",
+                    "coordinates": [(0, 0), (10, 0)],
+                }],
+            )
+
+    def test_missing_required_keys_raise(self, skeleton_geom):
+        from ras_commander import GeomBcLines
+
+        with pytest.raises(ValueError, match="'name'"):
+            GeomBcLines.add_bc_lines(
+                skeleton_geom,
+                lines=[{"storage_area": "Perimeter 1", "coordinates": [(0, 0), (1, 0)]}],
+            )
+        with pytest.raises(ValueError, match="'storage_area'"):
+            GeomBcLines.add_bc_lines(
+                skeleton_geom,
+                lines=[{"name": "x", "coordinates": [(0, 0), (1, 0)]}],
+            )
+        with pytest.raises(ValueError, match="'coordinates'"):
+            GeomBcLines.add_bc_lines(
+                skeleton_geom,
+                lines=[{"name": "x", "storage_area": "Perimeter 1"}],
+            )
+
+    def test_too_few_points_raises(self, skeleton_geom):
+        from ras_commander import GeomBcLines
+
+        with pytest.raises(ValueError, match="at least 2 points"):
+            GeomBcLines.add_bc_lines(
+                skeleton_geom,
+                lines=[{
+                    "name": "OnePoint",
+                    "storage_area": "Perimeter 1",
+                    "coordinates": [(0, 0)],
+                }],
+            )
+
+    def test_empty_lines_raises(self, skeleton_geom):
+        from ras_commander import GeomBcLines
+
+        with pytest.raises(ValueError, match="at least one"):
+            GeomBcLines.add_bc_lines(skeleton_geom, lines=[])
+
+    def test_duplicate_names_in_one_call_raise(self, skeleton_geom):
+        from ras_commander import GeomBcLines
+
+        with pytest.raises(ValueError, match="more than once"):
+            GeomBcLines.add_bc_lines(
+                skeleton_geom,
+                lines=[
+                    {"name": "Dup", "storage_area": "Perimeter 1",
+                     "coordinates": [(0, 0), (1, 0)]},
+                    {"name": "Dup", "storage_area": "Perimeter 1",
+                     "coordinates": [(0, 1), (1, 1)]},
+                ],
+            )
+
+    def test_existing_name_without_replace_raises(self, skeleton_geom):
+        from ras_commander import GeomBcLines
+
+        with pytest.raises(ValueError, match="already exists"):
+            GeomBcLines.add_bc_lines(
+                skeleton_geom,
+                lines=[{
+                    "name": "Existing",
+                    "storage_area": "Perimeter 1",
+                    "coordinates": [(0, 0), (1, 0)],
+                }],
+            )
+
+    def test_missing_geom_file_raises(self, tmp_path):
+        from ras_commander import GeomBcLines
+
+        with pytest.raises(FileNotFoundError):
+            GeomBcLines.add_bc_lines(
+                tmp_path / "missing.g01",
+                lines=[{"name": "x", "storage_area": "y",
+                        "coordinates": [(0, 0), (1, 0)]}],
+            )
+
+
+class TestAddBcLinesUpsert:
+    def test_replace_existing_overwrites_block(self, skeleton_geom):
+        """`replace_existing=True` removes the prior block and inserts the
+        new one with updated geometry."""
+        from ras_commander import GeomBcLines
+
+        result = GeomBcLines.add_bc_lines(
+            skeleton_geom,
+            lines=[{
+                "name": "Existing",
+                "storage_area": "Perimeter 1",
+                "coordinates": [(0, 0), (50, 0), (100, 0)],
+            }],
+            replace_existing=True,
+        )
+        assert result["replaced"] == ["Existing"]
+        assert result["inserted"] == []
+
+        text = skeleton_geom.read_text(encoding="utf-8")
+        # Old endpoints (100,100 → 200,100) gone; new endpoints (0,0 → 100,0)
+        # present.
+        assert "BC Line Start Position= 100 , 100 " not in text
+        assert "BC Line Start Position= 0.0 , 0.0 " in text
+        assert "BC Line Arc= 3 " in text  # was 2
+        assert text.count("BC Line Name=Existing") == 1
+
+
+# ---------------------------------------------------------------------------
+# delete_bc_line
+# ---------------------------------------------------------------------------
+
+
+class TestDeleteBcLine:
+    def test_delete_removes_only_matching_block(self, skeleton_geom):
+        from ras_commander import GeomBcLines
+
+        # Add a second BC line so we can verify the delete is targeted.
+        GeomBcLines.add_bc_lines(
+            skeleton_geom,
+            lines=[{
+                "name": "ToKeep",
+                "storage_area": "Perimeter 1",
+                "coordinates": [(0, 0), (10, 0)],
+            }],
+        )
+        result = GeomBcLines.delete_bc_line(skeleton_geom, name="Existing")
+        assert result["deleted"] is True
+        assert result["lines_removed"] >= 7  # 6 keyword lines + ≥1 coord row
+
+        text = skeleton_geom.read_text(encoding="utf-8")
+        assert "BC Line Name=Existing" not in text
+        assert "BC Line Name=ToKeep" in text
+        # The second BC line's keyword lines all survived the delete.
+        assert "BC Line Storage Area=Perimeter 1     " in text
+
+    def test_delete_unknown_raises(self, skeleton_geom):
+        from ras_commander import GeomBcLines
+
+        with pytest.raises(ValueError, match="not found"):
+            GeomBcLines.delete_bc_line(skeleton_geom, name="Phantom")
+
+
+# ---------------------------------------------------------------------------
+# rename_bc_line
+# ---------------------------------------------------------------------------
+
+
+class TestRenameBcLine:
+    def test_rename_changes_only_the_name_line(self, skeleton_geom):
+        from ras_commander import GeomBcLines
+
+        before = skeleton_geom.read_text(encoding="utf-8")
+        result = GeomBcLines.rename_bc_line(
+            skeleton_geom, old_name="Existing", new_name="UpstreamRenamed"
+        )
+        assert result["new_name"] == "UpstreamRenamed"
+
+        after = skeleton_geom.read_text(encoding="utf-8")
+        # Exactly one line differs: the name line.
+        diff = [
+            (b, a) for b, a in zip(before.splitlines(), after.splitlines())
+            if b != a
+        ]
+        assert len(diff) == 1
+        assert diff[0][0].startswith("BC Line Name=Existing")
+        assert diff[0][1].startswith("BC Line Name=UpstreamRenamed")
+        # Same line count — no insertions or deletions.
+        assert len(before.splitlines()) == len(after.splitlines())
+
+    def test_rename_to_existing_name_raises(self, skeleton_geom):
+        from ras_commander import GeomBcLines
+
+        # Add a second BC line.
+        GeomBcLines.add_bc_lines(
+            skeleton_geom,
+            lines=[{
+                "name": "Other",
+                "storage_area": "Perimeter 1",
+                "coordinates": [(0, 0), (10, 0)],
+            }],
+        )
+        with pytest.raises(ValueError, match="already exists"):
+            GeomBcLines.rename_bc_line(
+                skeleton_geom, old_name="Existing", new_name="Other"
+            )
+
+    def test_rename_unknown_raises(self, skeleton_geom):
+        from ras_commander import GeomBcLines
+
+        with pytest.raises(ValueError, match="not found"):
+            GeomBcLines.rename_bc_line(
+                skeleton_geom, old_name="Phantom", new_name="Real"
+            )
+
+    def test_rename_identical_names_raises(self, skeleton_geom):
+        from ras_commander import GeomBcLines
+
+        with pytest.raises(ValueError, match="identical"):
+            GeomBcLines.rename_bc_line(
+                skeleton_geom, old_name="Existing", new_name="Existing"
+            )
+
+
+# ---------------------------------------------------------------------------
+# Line-ending preservation
+# ---------------------------------------------------------------------------
+
+
+class TestLineEndingPreservation:
+    def test_crlf_round_trips(self, tmp_path):
+        """A .g## with CRLF line endings (HEC-RAS native) must be written
+        back with CRLF intact."""
+        from ras_commander import GeomBcLines
+
+        body_crlf = _SKELETON.replace("\n", "\r\n")
+        f = tmp_path / "project.g01"
+        f.write_bytes(body_crlf.encode("utf-8"))
+
+        GeomBcLines.add_bc_lines(
+            f,
+            lines=[{
+                "name": "CrlfTest",
+                "storage_area": "Perimeter 1",
+                "coordinates": [(0, 0), (10, 0)],
+            }],
+        )
+        raw = f.read_bytes()
+        # Every line should still end in CRLF; no bare LF should appear
+        # outside of CRLF pairs.
+        assert b"\r\n" in raw
+        assert raw.count(b"\r\n") >= raw.count(b"\n") - 1, (
+            "Some \\n line endings are missing their preceding \\r"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Real RasExamples project (Chippewa_2D)
+# ---------------------------------------------------------------------------
+
+
+class TestChippewa2DRealProject:
+    @pytest.mark.slow
+    def test_add_bc_line_to_real_chippewa_geometry(self, tmp_path):
+        """Insert a fresh BC line into the real Chippewa_2D geometry on
+        the existing `Perimeter 1` 2D Flow Area, and verify the writer's
+        output keywords match HEC-RAS-emitted format."""
+        try:
+            from ras_commander import RasExamples, GeomBcLines
+            project = RasExamples.extract_project(
+                "Chippewa_2D", output_path=tmp_path, suffix="_bc_add"
+            )
+        except Exception:
+            pytest.skip("Chippewa_2D example not available")
+        if isinstance(project, list):
+            project = project[0]
+
+        g_files = sorted(p for p in Path(project).glob("*.g0*") if "hdf" not in p.name.lower())
+        if not g_files:
+            pytest.skip("No .g## in Chippewa_2D")
+        g_file = g_files[0]
+        before_text = g_file.read_text(encoding="utf-8", errors="ignore")
+        # Sanity check: Perimeter 1 exists, "TestBCLine" does not.
+        assert "Storage Area=Perimeter 1" in before_text
+        assert "BC Line Name=TestBCLine" not in before_text
+
+        result = GeomBcLines.add_bc_lines(
+            g_file,
+            lines=[{
+                "name": "TestBCLine",
+                "storage_area": "Perimeter 1",
+                "coordinates": [
+                    (1027205.96, 7858200.24),
+                    (1026600.45, 7858258.46),
+                    (1025994.94, 7858316.68),
+                ],
+            }],
+        )
+        assert result["inserted"] == ["TestBCLine"]
+
+        after_text = g_file.read_text(encoding="utf-8", errors="ignore")
+        # Existing BC lines untouched.
+        assert "BC Line Name=Upstream" in after_text
+        assert "BC Line Name=Downstream" in after_text
+        # New BC line present with HEC-RAS-style padded keywords.
+        assert "BC Line Name=TestBCLine" in after_text
+        assert "BC Line Storage Area=Perimeter 1     " in after_text
+        assert "BC Line Arc= 3 " in after_text
+        assert (
+            "BC Line Text Position= 1.79769313486232E+308 , "
+            "1.79769313486232E+308 " in after_text
+        )
+        # The new block sits with the other BC line blocks (between
+        # them and the LCMann section).
+        new_idx = after_text.index("BC Line Name=TestBCLine")
+        downstream_idx = after_text.index("BC Line Name=Downstream")
+        lcmann_idx = after_text.index("LCMann ")
+        assert downstream_idx < new_idx < lcmann_idx
+
+    @pytest.mark.slow
+    def test_delete_existing_bc_line_in_real_chippewa(self, tmp_path):
+        """Delete the shipped `Upstream` BC line from Chippewa_2D and
+        confirm only that block is removed; `Downstream` survives."""
+        try:
+            from ras_commander import RasExamples, GeomBcLines
+            project = RasExamples.extract_project(
+                "Chippewa_2D", output_path=tmp_path, suffix="_bc_del"
+            )
+        except Exception:
+            pytest.skip("Chippewa_2D example not available")
+        if isinstance(project, list):
+            project = project[0]
+        g_file = next(
+            p for p in Path(project).glob("*.g0*") if "hdf" not in p.name.lower()
+        )
+
+        result = GeomBcLines.delete_bc_line(g_file, name="Upstream")
+        assert result["deleted"] is True
+
+        text = g_file.read_text(encoding="utf-8", errors="ignore")
+        assert "BC Line Name=Upstream" not in text
+        assert "BC Line Name=Downstream" in text


### PR DESCRIPTION
## Summary

Adds a new public class `GeomBcLines` to `ras_commander.geom` that authors 2D BC line geometry in the `.g##` plain text file. Closes CLB-309.

The `.g##` text file is the source of truth for HEC-RAS geometry; HEC-RAS preprocessing reads it and populates `.g##.hdf` and the `Geometry/Boundary Condition Lines/` HDF group. After authoring with this API, the user runs HEC-RAS preprocessing (or launches HEC-RAS) for the new lines to appear in `HdfBndry.get_bc_lines()`.

## API surface

```python
GeomBcLines.add_bc_lines(geom_file, lines, replace_existing=False)
GeomBcLines.delete_bc_line(geom_file, name)
GeomBcLines.rename_bc_line(geom_file, old_name, new_name)
```

Covers all four verbs from the AC: **create** (`add_bc_lines`), **update** (`add_bc_lines` + `replace_existing=True`), **rename** (`rename_bc_line`), **delete** (`delete_bc_line`).

### `add_bc_lines`

- `lines` is a list of dicts: `{name, storage_area, coordinates}`.
- Validates that `storage_area` exists as a `Storage Area=` block in the file (mirrors `set_breaklines`).
- Validates coordinates: `(N, 2)` array with N >= 2.
- Refuses duplicate names within the same call.
- Refuses overwriting an existing BC line unless `replace_existing=True`.
- Emits the canonical text format observed in Chippewa_2D / BaldEagleCrkMulti2D / Weise_2D:
  - `BC Line Name=<40-char padded>`
  - `BC Line Storage Area=<16-char padded>`
  - `BC Line Start/Middle/End Position= X , Y `
  - `BC Line Arc= N`
  - Fixed-width 16-char coordinate block, 4 values per line
  - `BC Line Text Position= 1.79769313486232E+308 , 1.79769313486232E+308 ` (auto-placement sentinel)
- Insert position priority (matches HEC-RAS layout):
  1. After the last existing `BC Line Text Position=` (group all BC lines together)
  2. Else before the first `Reference Line Name=`
  3. Else before the first `IC Point Name=`
  4. Else before the first `LCMann ` line
  5. Else end of file

### `delete_bc_line`

- Finds the block by `BC Line Name=<name>` (whitespace-padding tolerant) and removes every line from the keyword through the closing `BC Line Text Position=`.
- Raises if no match.

### `rename_bc_line`

- Replaces only the `BC Line Name=` keyword line; geometry and position survive.
- Refuses to overwrite an existing name; refuses identical old/new.

## Format conventions confirmed against real RasExamples projects

| Project | 2D Areas | BC lines | Confirmed format |
|---|---|---|---|
| Chippewa_2D u04 | Chippewa, Perimeter 1 | Upstream, Lake Pepin, Downstream | 9-field Boundary Location, variable name widths |
| BaldEagleCrkMulti2D u01 | BaldEagleCr | DSNormalDepth1, DSNormalDepth2 | 8-field Boundary Location |
| Weise_2D u01 | 2DArea | Upstream | 9-field |

The writer's positional matching works on both 8-field and 9-field forms because field meaning is positional, not count-dependent.

## Acceptance criteria (from CLB-309)

- [x] Public API can add BC lines for inflow / tributary inflow / downstream boundary locations — `add_bc_lines` with `(name, storage_area, coordinates)` covers all three roles
- [x] Added lines visible to `HdfBndry.get_bc_lines()` after geometry compilation/preprocessing — verified by emitting valid HEC-RAS-format text; HDF population is HEC-RAS preprocessing's job (out-of-process)
- [x] Documentation/example notes identify interaction with `RasUnsteady` boundary data setters — module docstring + class docstring + add_bc_lines docstring all reference `set_normal_depth_boundary` (CLB-310) and `set_flow_hydrograph_slope` (CLB-311); the example in `add_bc_lines` shows the full author-then-attach flow

## Test plan

- [x] `pytest tests/test_geom_bc_lines.py -v` — **20 passed**
  - 3 add (single, multi, grouping)
  - 7 validation (unknown area, missing keys, too-few-points, empty list, intra-call dups, existing-name without replace, missing file)
  - 1 upsert (`replace_existing=True`)
  - 2 delete (targeted removal, unknown)
  - 4 rename (in-place, collision, unknown, identical)
  - 1 CRLF round-trip
  - 2 real Chippewa_2D tests (add + delete)
- [x] Sister regression: `pytest tests/test_geom_reference_features.py tests/test_geom_storage_2d_flow_area_writer.py -q` — **30 passed**
- [ ] CI: full pytest run on the branch

## Notes

This was processed as a manual Symphony run on CLB01 while CLB08's automated runner is paused. Companion to PR #76 (CLB-310 Normal Depth setter) and PR #77 (CLB-311 Flow Hydrograph Slope setter). The three together cover the full Tutorial 2 / 4 / 11 flow: author BC line geometry (this PR) → preprocess in HEC-RAS → attach Normal Depth via #76 or Flow Hydrograph Slope via #77.

Used `newline=""` text mode for read/write so CRLF round-trips correctly on Linux as well as Windows. (CLB-375 tracks the broader codebase-wide cleanup of this pattern.)