### PR TITLE
CLB-279: Add polygon multipoint terrain modification writer API

### DIFF
--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -49,7 +49,7 @@ Classes for terrain creation, modification writing, and terrain-modification
 analysis:
 
 - `RasTerrain` - Terrain HDF creation from rasters
-- `RasTerrainModWriter` - Channel, high-ground, and fill-surface terrain modification HDF/.rasmap writing
+- `RasTerrainModWriter` / `RasTerrainModification` - Line and polygon terrain modification HDF/.rasmap writing
 - `RasTerrainMod` - Terrain profile and volume comparison with modifications applied
 
 ## Fixit Module

--- a/examples/316_terrain_modifications.ipynb
+++ b/examples/316_terrain_modifications.ipynb
@@ -32,10 +32,10 @@
    "id": "b195b626",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-02T00:32:52.448945Z",
-     "iopub.status.busy": "2026-05-02T00:32:52.448945Z",
-     "iopub.status.idle": "2026-05-02T00:32:54.016305Z",
-     "shell.execute_reply": "2026-05-02T00:32:54.016305Z"
+     "iopub.execute_input": "2026-05-05T21:10:51.806424Z",
+     "iopub.status.busy": "2026-05-05T21:10:51.806424Z",
+     "iopub.status.idle": "2026-05-05T21:10:53.288283Z",
+     "shell.execute_reply": "2026-05-05T21:10:53.288283Z"
     }
    },
    "outputs": [
@@ -43,8 +43,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Repository: C:\\GH\\symphony-workspaces\\ras-commander\\CLB-324\n",
-      "Artifacts:  H:\\Symphony\\ras-commander\\CLB-324\\316_terrain_modifications\n"
+      "Repository: C:\\GH\\symphony-workspaces\\ras-commander\\CLB-279\n",
+      "Artifacts:  H:\\Symphony\\ras-commander\\CLB-279\\316_terrain_modifications\n"
      ]
     }
    ],
@@ -59,6 +59,7 @@
     "\n",
     "import h5py\n",
     "import matplotlib.pyplot as plt\n",
+    "from matplotlib.path import Path as MplPath\n",
     "import numpy as np\n",
     "import pandas as pd\n",
     "\n",
@@ -68,13 +69,13 @@
     "    sys.path.insert(0, str(REPO_ROOT))\n",
     "\n",
     "from ras_commander import HdfMesh, HdfResultsMesh, RasCmdr, RasExamples, init_ras_project\n",
-    "from ras_commander.terrain import RasTerrainMod, RasTerrainModWriter\n",
+    "from ras_commander.terrain import RasTerrainMod, RasTerrainModification, RasTerrainModWriter\n",
     "\n",
     "logging.getLogger('ras_commander').setLevel(logging.WARNING)\n",
     "warnings.filterwarnings('ignore', category=UserWarning)\n",
     "pd.options.display.max_columns = 20\n",
     "\n",
-    "ARTIFACT_ROOT = Path('H:/Symphony/ras-commander/CLB-324/316_terrain_modifications')\n",
+    "ARTIFACT_ROOT = Path('H:/Symphony/ras-commander/CLB-279/316_terrain_modifications')\n",
     "ARTIFACT_ROOT.mkdir(parents=True, exist_ok=True)\n",
     "print(f'Repository: {REPO_ROOT}')\n",
     "print(f'Artifacts:  {ARTIFACT_ROOT}')"
@@ -86,10 +87,10 @@
    "id": "2a74dbad",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-02T00:32:54.016305Z",
-     "iopub.status.busy": "2026-05-02T00:32:54.016305Z",
-     "iopub.status.idle": "2026-05-02T00:33:02.365175Z",
-     "shell.execute_reply": "2026-05-02T00:33:02.365175Z"
+     "iopub.execute_input": "2026-05-05T21:10:53.290299Z",
+     "iopub.status.busy": "2026-05-05T21:10:53.290299Z",
+     "iopub.status.idle": "2026-05-05T21:10:56.542894Z",
+     "shell.execute_reply": "2026-05-05T21:10:56.542894Z"
     }
    },
    "outputs": [
@@ -124,33 +125,43 @@
        "    <tr>\n",
        "      <th>0</th>\n",
        "      <td>base</td>\n",
-       "      <td>H:\\Symphony\\ras-commander\\CLB-324\\316_terrain_...</td>\n",
-       "      <td>H:\\Symphony\\ras-commander\\CLB-324\\316_terrain_...</td>\n",
+       "      <td>H:\\Symphony\\ras-commander\\CLB-279\\316_terrain_...</td>\n",
+       "      <td>I:\\Symphony\\ras-commander\\CLB-279\\316_terrain_...</td>\n",
        "      <td>NaN</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
-       "      <td>proposed</td>\n",
-       "      <td>H:\\Symphony\\ras-commander\\CLB-324\\316_terrain_...</td>\n",
+       "      <td>high-ground proposed</td>\n",
+       "      <td>H:\\Symphony\\ras-commander\\CLB-279\\316_terrain_...</td>\n",
        "      <td>NaN</td>\n",
-       "      <td>H:\\Symphony\\ras-commander\\CLB-324\\316_terrain_...</td>\n",
+       "      <td>I:\\Symphony\\ras-commander\\CLB-279\\316_terrain_...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>polygon proposed</td>\n",
+       "      <td>H:\\Symphony\\ras-commander\\CLB-279\\316_terrain_...</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>I:\\Symphony\\ras-commander\\CLB-279\\316_terrain_...</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
        "</div>"
       ],
       "text/plain": [
-       "  condition                                            project  \\\n",
-       "0      base  H:\\Symphony\\ras-commander\\CLB-324\\316_terrain_...   \n",
-       "1  proposed  H:\\Symphony\\ras-commander\\CLB-324\\316_terrain_...   \n",
+       "              condition                                            project  \\\n",
+       "0                  base  H:\\Symphony\\ras-commander\\CLB-279\\316_terrain_...   \n",
+       "1  high-ground proposed  H:\\Symphony\\ras-commander\\CLB-279\\316_terrain_...   \n",
+       "2      polygon proposed  H:\\Symphony\\ras-commander\\CLB-279\\316_terrain_...   \n",
        "\n",
        "                                            geom_hdf  \\\n",
-       "0  H:\\Symphony\\ras-commander\\CLB-324\\316_terrain_...   \n",
+       "0  I:\\Symphony\\ras-commander\\CLB-279\\316_terrain_...   \n",
        "1                                                NaN   \n",
+       "2                                                NaN   \n",
        "\n",
        "                                         terrain_hdf  \n",
        "0                                                NaN  \n",
-       "1  H:\\Symphony\\ras-commander\\CLB-324\\316_terrain_...  "
+       "1  I:\\Symphony\\ras-commander\\CLB-279\\316_terrain_...  \n",
+       "2  I:\\Symphony\\ras-commander\\CLB-279\\316_terrain_...  "
       ]
      },
      "execution_count": 2,
@@ -159,7 +170,7 @@
     }
    ],
    "source": [
-    "# Extract isolated base/proposed project copies\n",
+    "# Extract isolated base/proposed/polygon project copies\n",
     "template = RasExamples.extract_project(\n",
     "    'BaldEagleCrkMulti2D',\n",
     "    output_path=ARTIFACT_ROOT,\n",
@@ -167,25 +178,35 @@
     ")\n",
     "base_project = ARTIFACT_ROOT / 'BaldEagleCrkMulti2D_base'\n",
     "proposed_project = ARTIFACT_ROOT / 'BaldEagleCrkMulti2D_proposed'\n",
-    "for project in (base_project, proposed_project):\n",
+    "polygon_project = ARTIFACT_ROOT / 'BaldEagleCrkMulti2D_polygon_multipoint'\n",
+    "for project in (base_project, proposed_project, polygon_project):\n",
     "    if project.exists():\n",
     "        shutil.rmtree(project)\n",
     "    shutil.copytree(template, project)\n",
     "\n",
     "base_ras = init_ras_project(base_project, '6.6', ras_object='new', load_results_summary=False)\n",
     "proposed_ras = init_ras_project(proposed_project, '6.6', ras_object='new', load_results_summary=False)\n",
+    "polygon_ras = init_ras_project(polygon_project, '6.6', ras_object='new', load_results_summary=False)\n",
     "\n",
     "plan_number = '18'\n",
     "plan_row = base_ras.plan_df.loc[base_ras.plan_df['plan_number'] == plan_number].iloc[0]\n",
     "geom_number = str(plan_row['Geom File'])\n",
     "base_geom_hdf = Path(base_ras.geom_df.loc[base_ras.geom_df['geom_number'] == geom_number, 'hdf_path'].iloc[0])\n",
     "proposed_geom_hdf = proposed_project / base_geom_hdf.name\n",
+    "polygon_geom_hdf = polygon_project / base_geom_hdf.name\n",
     "terrain_value = proposed_ras.rasmap_df['terrain_hdf_path'].iloc[0]\n",
     "proposed_terrain_hdf = Path(terrain_value[0] if isinstance(terrain_value, list) else terrain_value)\n",
+    "polygon_terrain_value = polygon_ras.rasmap_df['terrain_hdf_path'].iloc[0]\n",
+    "polygon_terrain_hdf = Path(\n",
+    "    polygon_terrain_value[0]\n",
+    "    if isinstance(polygon_terrain_value, list)\n",
+    "    else polygon_terrain_value\n",
+    ")\n",
     "\n",
     "summary = pd.DataFrame([\n",
     "    {'condition': 'base', 'project': str(base_project), 'geom_hdf': str(base_geom_hdf)},\n",
-    "    {'condition': 'proposed', 'project': str(proposed_project), 'terrain_hdf': str(proposed_terrain_hdf)},\n",
+    "    {'condition': 'high-ground proposed', 'project': str(proposed_project), 'terrain_hdf': str(proposed_terrain_hdf)},\n",
+    "    {'condition': 'polygon proposed', 'project': str(polygon_project), 'terrain_hdf': str(polygon_terrain_hdf)},\n",
     "])\n",
     "summary"
    ]
@@ -196,10 +217,10 @@
    "id": "39d9f96a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-02T00:33:02.365175Z",
-     "iopub.status.busy": "2026-05-02T00:33:02.365175Z",
-     "iopub.status.idle": "2026-05-02T00:33:04.893902Z",
-     "shell.execute_reply": "2026-05-02T00:33:04.893902Z"
+     "iopub.execute_input": "2026-05-05T21:10:56.544968Z",
+     "iopub.status.busy": "2026-05-05T21:10:56.544968Z",
+     "iopub.status.idle": "2026-05-05T21:10:58.332625Z",
+     "shell.execute_reply": "2026-05-05T21:10:58.332625Z"
     }
    },
    "outputs": [
@@ -326,10 +347,10 @@
    "id": "dd6e12a5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-02T00:33:04.895910Z",
-     "iopub.status.busy": "2026-05-02T00:33:04.895910Z",
-     "iopub.status.idle": "2026-05-02T00:33:05.102919Z",
-     "shell.execute_reply": "2026-05-02T00:33:05.102919Z"
+     "iopub.execute_input": "2026-05-05T21:10:58.332625Z",
+     "iopub.status.busy": "2026-05-05T21:10:58.332625Z",
+     "iopub.status.idle": "2026-05-05T21:10:58.558611Z",
+     "shell.execute_reply": "2026-05-05T21:10:58.558159Z"
     }
    },
    "outputs": [
@@ -412,7 +433,7 @@
     {
      "data": {
       "text/plain": [
-       "WindowsPath('H:/Symphony/ras-commander/CLB-324/316_terrain_modifications/terrain_profile_difference.png')"
+       "WindowsPath('H:/Symphony/ras-commander/CLB-279/316_terrain_modifications/terrain_profile_difference.png')"
       ]
      },
      "execution_count": 4,
@@ -469,10 +490,10 @@
    "id": "f39b3677",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-02T00:33:05.105583Z",
-     "iopub.status.busy": "2026-05-02T00:33:05.105583Z",
-     "iopub.status.idle": "2026-05-02T00:33:05.902921Z",
-     "shell.execute_reply": "2026-05-02T00:33:05.902394Z"
+     "iopub.execute_input": "2026-05-05T21:10:58.558611Z",
+     "iopub.status.busy": "2026-05-05T21:10:58.558611Z",
+     "iopub.status.idle": "2026-05-05T21:10:59.168009Z",
+     "shell.execute_reply": "2026-05-05T21:10:59.168009Z"
     }
    },
    "outputs": [
@@ -557,7 +578,7 @@
     {
      "data": {
       "text/plain": [
-       "WindowsPath('H:/Symphony/ras-commander/CLB-324/316_terrain_modifications/terrain_profile_readback_validation.png')"
+       "WindowsPath('H:/Symphony/ras-commander/CLB-279/316_terrain_modifications/terrain_profile_readback_validation.png')"
       ]
      },
      "execution_count": 5,
@@ -672,13 +693,538 @@
   {
    "cell_type": "code",
    "execution_count": 6,
+   "id": "de436196",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-05T21:10:59.170322Z",
+     "iopub.status.busy": "2026-05-05T21:10:59.170322Z",
+     "iopub.status.idle": "2026-05-05T21:10:59.653746Z",
+     "shell.execute_reply": "2026-05-05T21:10:59.653746Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-05 17:10:59 - rasterio._env - WARNING - CPLE_AppDefined in PROJ: proj_create_from_database: C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.6\\GDAL\\common\\data\\proj.db lacks DATABASE.LAYOUT.VERSION.MAJOR / DATABASE.LAYOUT.VERSION.MINOR metadata. It comes from another PROJ installation.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-05 17:10:59 - rasterio._env - WARNING - CPLE_AppDefined in PROJ: proj_create_from_name: C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.6\\GDAL\\common\\data\\proj.db lacks DATABASE.LAYOUT.VERSION.MAJOR / DATABASE.LAYOUT.VERSION.MINOR metadata. It comes from another PROJ installation.\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>dataset</th>\n",
+       "      <th>count</th>\n",
+       "      <th>min_elevation_ft</th>\n",
+       "      <th>max_elevation_ft</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>boundary vertices</td>\n",
+       "      <td>5</td>\n",
+       "      <td>738.21875</td>\n",
+       "      <td>1038.40625</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>interior controls</td>\n",
+       "      <td>2</td>\n",
+       "      <td>925.00000</td>\n",
+       "      <td>930.00000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>profile values</td>\n",
+       "      <td>5</td>\n",
+       "      <td>738.21875</td>\n",
+       "      <td>1038.40625</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "             dataset  count  min_elevation_ft  max_elevation_ft\n",
+       "0  boundary vertices      5         738.21875        1038.40625\n",
+       "1  interior controls      2         925.00000         930.00000\n",
+       "2     profile values      5         738.21875        1038.40625"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "WindowsPath('H:/Symphony/ras-commander/CLB-279/316_terrain_modifications/polygon_multipoint_control_points.png')"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAwsAAAJOCAYAAAD4RJvRAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjksIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvJkbTWQAAAAlwSFlzAAAPYQAAD2EBqD+naQAAzAJJREFUeJzsnQd0FAXXhi9dqoUOIiIIohR7xa5YAUVERBEFsSMWLNhAxUqxIHYUe0EFFURRQbCAIoIioljoKE16J8l/nus3+TdhA5tks/V9zpmTZHcyMzu7O3Pre4tlZWVlmRBCCCGEEELkonjuB4QQQgghhBBCzoIQQgghhBAiT5RZEEIIIYQQQoRFzoIQQgghhBAiLHIWhBBCCCGEEGGRsyCEEEIIIYQIi5wFIYQQQgghRFjkLAghhBBCCCHCUjL8w0IIIYQQQsSOjRs32ubNm2O2v9KlS9tOO+0Us/0lK3IWhBBCCCFE3B2FevXq2T///BOzfdaoUcNmz54th2EHyFkQQgghhBBxhYwCjsL8+fOtUqVKRb6/1atXW506dXy/yi5sHzkLQgghhBAiIahQvrwvRU1mRkaR7yNVUIOzEEIIIYQQIizKLAghhBBCiIQgMzPTl1jsR0SGMgtCCCGEEEKIsMhZEEIIIYQQQoRFZUhCCCGEECIhoPE4Fs3HanCOHGUWhBBCCCGEEGFRZkEIIYQQQiQEmZkZvsRiPyIylFkQQgghhBBChEWZBSGEEEIIkRBkZmT6Eov9iMhQZkEIIYQQQggRFmUWhBBCCCFEQqCehcRDmQUhhBBCCCFEWOQsCCGEEEIIIcKiMiQhhBBCCJFADc6xGMqmBudIUWZBCCGEEEIIERZlFoQQQgghREKQmZVpmZkxkE7NUmYhUpRZEEIIIYQQQoRFmQUhhBBCCJEQ0K8Qm56Fot9HqqDMghBCCCGEECIsyiwIIYQQQoiEICtGmQX2IyJDmQUhhBBCCCFEWJRZEEIIIYQQCQFKSDFRQ4rBPlIFZRaEEEIIIYQQYZGzIIQQQgghhAiLypCEEEIIIURCIOnUxEOZBSGEEEIIIURYlFkQQgghhBAJQWZmhi+x2I+IDGUWhBBCCCGEEGFRZkEIIYQQQiQEmRmZMRnKxn5EZCizIIQQQgghhAiLMgtCCCGEECIhyMyK0VC2LGUWIkWZBSGEEEIIIURY5CwIIYQQQgghwqIyJCGEEEIIkRBoKFviocyCEEIIIYQQIizKLAghhBBCiIRAmYXEQ5kFIYQQQgghRFiUWRBCCCGEEAkBsqkxkU6NwT5SBWUWhBBCCCGEEGFRZkEIIYQQQiQEWRkZ3rcQi/2IyFBmQQghhBBCCBEWOQtCCCGEEEKIsKgMSQghhBBCJASZmRm+xGI/IjKUWRBCCCGEEEKERZkFIYQQQgiREGRmZFlmRgykUzOyinwfqYIyC0IIIYQQQoiwKLMghBBCCCESgsysGPUsZKlnIVKUWRBCCCGEEEKERZkFIYQQQgiREGTGaChbLPaRKiizIIQQQgghhAiLMgtCCCGEECIhyMzM9CUW+xGRocyCEEIIIYQQIixyFoQQQgghhBBhURmSEEIIIYRICNTgnHgosyCEEEIIIYQIizILQgghhBAiIVBmIfFQZkEIIYQQQggRFmUWhBBCCCFEQiDp1MRDmQUhhBBCCCFEWJRZEEIIIYQQCUFWRqb3LcRiPyIylFkQQgghhBBChEXOghBCCCGEECIsKkMSQgghhBAJQWZWhmVmZsRkPyIylFkQQgghhBBChEWZBSGEEEIIkRBkeoNz0Tcfx2IfqYIyC0IIIYQQQuyACRMmWKtWraxWrVpWrFgxGzFiRI7ns7Ky7K677rKaNWta2bJl7aSTTrLff/89xzr//vuvXXDBBVapUiXbZZddrGvXrrZ27doc6/z000929NFH20477WR16tSxhx9+OK7vjZwFIYQQQgiRENCvEKslv6xbt86aN29ugwcPDvs8Rv3jjz9uTz/9tH377bdWvnx5O+WUU2zjxo3Z6+AozJgxwz799FMbOXKkOyCXXXZZ9vOrV6+2li1bWt26dW3KlCnWr18/69Onjz377LMWL4pl4QYJIYQQQggRJzCSd955Z/vo9ZetfLlyRb6/devX2+kdL7JVq1Z5lD+/FCtWzIYPH25nnXWW/405TcbhxhtvtJ49e/pjbLt69eo2dOhQ69Chg82cOdP23Xdfmzx5sh188MG+zscff2ynn366LViwwP//qaeesttvv93++ecfK126tK9z6623ehbj119/tXigzIIQQgghhEgIGMgWqyWazJ492w18So8CcH4OO+wwmzhxov/NT0qPAkcBWL948eKeiQjWOeaYY7IdBSA78dtvv9mKFSssHqjBWQghhBBCpG1GI5QyZcr4kl/++ecf/0kmIRT+Dp7jZ7Vq1XI8X7JkSdttt91yrFOvXr1tthE8t+uuu1qsUWZBCCGEEEIkBJmZmTFbgAZiMgDB8sADD8T7FCQcchaECMNxxx3ni4icOXPmeA0ntZmRwLo0bRUleh//H8415zyV2HPPPe3iiy/O/vuLL77w18jPUF555RXbZ599rFSpUl4CEM/PBt8PjpHvS7zPlxDCbP78+d5bECy9evUq0GmpUaOG/1y8eHGOx/k7eI6fS5YsyfH81q1bXSEpdJ1w2wjdR6yRsyBSguAGHCzIjTVs2NCuueaabb50InZ89NFHRe4QFBWvv/66PfrooxGvf//9928joyfiDw2BGMj169e35557LmaKIvo87Jgnn3wy4uCCEEUFzc2hS0FKkIDSIYz5zz//3EJLnOhFOOKII/xvfq5cudJVjgLGjh3rWQ56G4J1UEjasmVL9jooJzVq1CguJUggNSSREnDDueSSS+yee+7xLywyZV999ZVHFJEf+/nnn61cPtQVgohj7gilyBsipZz7F198MTt6ibOGxFw40TXeI2o1WYqKzZs3+8/QRrFIOfPMM/1zE2kEuEKFCtauXbuENX6IXrHgSKcKRMr5rgbnnBsu7znvNw2DgIThlVde6VrnDRo0iMpnozCfh4yMDDcCMEhinenZtGmTnxcyLIlAkyZNrEqVKrrOihxqSCNeeDZmakhndbksX2pIa9eutT/++MN/P+CAA2zgwIF2/PHHe8/BHnvsYQ899JA9+OCD9tJLL/n98M477/SZCb/88kv2tfe0007zICbXJq4F2C40PBOgAo4HxwD51FtuucXvQ126dLFHHnkkh8RqLFGDs0gp+BIGKgOXXnqpVa5c2b/M77//vp1//vnxPjwRQiyM1qIyBGMFDlWo4Ztb7xsN70gpascsEeA85f5cBSn/oPwo3p+NEiVK+BIPChoxFUL8x/fff+/OQcANN9zgPzt37uyBgZtvvtmvzRj1ZBBatGjh0qih16XXXnvNA2knnniiX7POOeccn80QgMM0ZswYu/rqq+2ggw5yh5pBb/FyFEBlSCKlOeGEE7IlzYDI6r333uslCdw4iUzedtttHnHbXiQBo6xHjx7bPIcuMjf+0IYoogjHHnusT2/cfffdrW/fvh5tD1enTBp+v/3282NBX5mLAxeYUIicEoEjMsFFigxJ7dq1I57oyH65MA0bNsz1nTku0pzTp0/355955hmPuHIxY1+5jzGvOucd1XzzP8HgmtASsdDjCi1RCmrqKRtp3769R3pw9jjvoQNt8vM+5j7GoKb97bfftvvuu8/fH143F+0gWhT836hRo2zu3LnZx80+tneOuUEQTQrWDz1nCxcu9MgQihYcL+/5Cy+8kGMbwbG9+eabdscdd/h7zHtNtI1tEan+888/XY+7YsWKPtgHvvzySzv33HM9qsW2ada7/vrrbcOGDTvsWQg+G5RP8RkLjo2b244IPZd33323Hy/HRTSdyBjvxXXXXefKHxw70bPc70+k7yOZKb5HvF+cE74HDDXK65iCjCDb6927t/9etWrVHJ+5cJ9fPmc8TwkjnwumsLZt29bPe0D//v3tyCOP9M8m3yVu5u+8807En4e8ehZicS3I/V0OjuXrr792o4dzxLXu7LPPtqVLl27zv2TbMGL2339/Pz9cT957772IemNyv262x3s4fvz47HMUvB9EW/lM7b333r4fzjVGF6UYIvXJzMiMkXTqfw3O+eG4447z61HuJcgg8jmmwgHVIq4nn332mV9PQiELQRZhzZo1fq3kXsA1MpRmzZr5tZ1tYGeQYYgnqR1mEmlPcJPnZhNkG7iBY9AwOIVaQgx9BqUwXCUcfIm5eb711luepQiNCr7xxht+oQgMN4xCbuJcMGiS4sb7/PPPh43ocVPlhojGMmUSaCgzjIVhLdy8Q0sF0FY+9dRT3XDBkMY44eLRtGlTz6bsCC46H3zwgRsgwGvmxk8UBCPlqquu8n1gdGDUUkNZWC6//HJbtGiR3+ApB4sUXh+GBMc4adIkj7hwbC+//HL2OgV5H0MhTUxEh8E5XKx53byHgc41A3F4nIs0qV/IfTEPhdfHMR166KHZ0R8MYCDdfPjhh2cb5hhko0ePtq5du7ojgEEdCsYzUW+ODaM5iIBjWKO1jdGEwRqU1eEErl+/3j9DfM6/++47GzRokB87z+0IyvUw+PgMYOxzvol0zZs3L/t7sz047xjNDA3C4WLffHY5v7xvfM55H7mZkpYnQpbf95H/wVnAUWL54YcfPEUflBLlBT0nfG7YFt8t3kNuwuGgPIjvBPXGDE/CSeVmzueXMoDg/XzsscesdevW/nlh/zh3OGtMYj3jjDN2+HkIRyyvBeHo3r2710LjWGHMc974rHLNC4VSrvPOO8+uuOIKj6QSBOG141yefPLJ+don+2C/vCd830LlITkffA6Cc8j3hIgu73t+9yOEiAJMcBYi2XnxxRcpis/67LPPspYuXZo1f/78rDfffDOrcuXKWWXLls1asGBB1rRp03ydSy+9NMf/9uzZ0x8fO3Zs9mPHHnusLwGffPKJrzN69Ogc/9usWbMc63Xv3j2rWLFiWVOnTs1+bPny5Vm77bab///s2bP9sSVLlmSVLl06q2XLllkZGRnZ6z7xxBO+3gsvvJDjWHjs5Zdfzn5s06ZNWTVq1Mg655xzdnhu+N8yZcpk7xueeeYZf5xtrF69OvvxXr165ThOqFu3blbnzp232W7uc8T/8L+8FwFXX321P5bXcfXu3Tv7b37nsdatW+dY76qrrvLHf/zxR/+7MO/juHHjfJ3GjRv7OQx47LHH/PHp06dnP3bGGWf4a4+U8uXLhz1PXbt2zapZs2bWsmXLcjzeoUOHrJ133jlr/fr1OY5tr732yn4sgO3y3K233rrN9nOvCw888IB/DufOnbvN+Q2Fv/kc/vHHH9mPcZ55fNCgQdt9vcHxNmnSJGvz5s3Zj59//vm+79NOOy3H+kcccUSO8xnp+xh8V3g/MjMzs9e77bbbfL3Qcx4cEz9zv26uC6Hk/mzwnWO9gQMHbvNaQ/eb+3zz2jkHJ5xwQkSfh+BaFY9rQe7vcnAsJ510Uo7XeP3112eVKFEia+XKlTn+l3Xffffd7MdWrVrln+0DDjhgu5+zcK8b9ttvvxzvQUDz5s39/RbpBZ8nPiPvPPtk1uhXXizyhf2wP/Yrto/KkERKQWSOyC2lGEQHiVoRVSRVjzJPaI1hABFNoOxke9ulNIBawwCijZQcXXjhhdmPEWGjxIc0fWjKMcg8BJCaJCpJVDm0Hr1bt25efpP7WHgdofsh2kzE7a+//orovFBmE1pGE6guEEEmmpz78Ui3WxQE2Y8Aoo8QvH+FeR8DKIkJrVk/+uiji+R1Y4+/++671qpVK/992bJl2QtZArIXREtDIWJLpD4cRJ1zE7oupS9smzIZ9jd16tQdHiOf7dCoN5F3PoORnouLLrooR+SbzxD7JkMVCo8jUUiGJD/vY/Bd4XMQWt6SOyNTWHifqA0OPm+hhO439HwT5ec95POT+32MlFhfC8JB9iP0NfJ6yLRQhhcK10CyrAEcH+8/n7NgoFQ0oL+EEiUyGUKI+KMyJJFSUCNPfSCNnKS0URQIbsDc+Pg9VBEFkDrj5pT7xhgK/4fBT2kAJR+UgOA4UE9LGj6AbQQSaaHk3mewL44vFG78e+211zbHQq127jpgygZwViKBevZQaKACnKpwj8drpDxQpxwKhiznP6h1Lsz7mNf5COToov26qfum7hy5zrwkO3Nrbuee3BnAZ5rPQW4oF6JMhzKz3MePIZvfcxGcj0jPRX4+W6gVcUyUN0X6PgY/c38uCApEU0aQkkW+jztqAqfciJKoadOm5eitKKiyUayvBYX5PvBe5d53UI/N9zNaGvDUfLdp08a3TY8GZVedOnXKs4RMpBZZ/+spiMV+RGTIWRApBRG2QA0pLwp6UyeC1q9fP28GRVmJBiVqnAPjqCjJSz0lnCRpfv4/ku3mdb6IPMZC1SWv/RdGdrKw5zNSggmhRILJGIQjtwGUV1aBvpfcqki8B9RwM9CHunUGj9EnQ+8MjazB/hP1swXJNCiO3h/6FY455hjv9aEBmqwKtfuB7GFRUxSf3Whuc3vXi0jh/OK8oWJHQzV9X/QOITVJH4MQIrbIWRBpA/MWMJ5IbTdu3Dj7cRpQif7y/PYgwoWuMhkFontEdGnmzL2PUFWdgNyPBfuikZHoYQDlCCg3URqSKBBlzK3KAkQ8Q489HAUxBHl/QqPrnDvet6CMqrDvY6Tk99jDrU/0mzIvDKWieE9RtJo1a5Y3CePMBiSDakyk72Pwk/VCP29kbaKZCSKDRYM1Sjx5zSGgVIls4ieffJJDtABnoaCfn2S6FvBdxIEIfW18/iD4fgZZCd7DULnacBm/7Z0jyjcpF2RBkQ4HgsZnOQtCxB71LIi0ARUVyD2VF4UjCJRMtgepcCJdbINSitzqI9ShT5w40UsUAoj6hvY6AAYAZQYoz4RG74YMGeJlGpEcS6zAiELNJlR5hlIM6s93RDAHIJyzkReB3GpA4JAF5zoa72MkcOyRlPGErp/7dRKxpS8EI5Mel9zklqcsaEQ49DPE7yj2JDqRvo98VzDe+RyEvs78TNeOBN4n+j2eeOKJbZ4L9sv5xsANjZJTfhNucne4z0M4kulagLpZqEoVKkWoTdGjFZQgBf0vTKANCGRkIz1Hy5cv36ZPgxKo7Ulci9QhMzMjZouIDGUWRNrQvHlzLwWhdpwbFLMQkJnkJnbWWWflGLSSFx07dnS5UW6YNJvmjkDy3KuvvuqlITRKBtKp1ATjNASRNCLOSKsil0g9LqUNRBYpbTjkkENyNDDGGyJ5yDNynEg1Uh7Aa9yeFGQAGvRw7bXXuiOFsUXj+fYgmsr5YH84XuyL8877F633MRI4dqQjacDlPcFgoVF5e+vTrIqxSyMo2RGaepFpHTdunP9O0yra9HwWaIhlfX4vKJQd8T4gs0rpEQ2nOCbx7DmJlEjfR74rvL5A7hcng4Za5GdpSI4WZGYwfHm/OQ6afDFyeY+QlaWGHsOd95fPJp9J+k1wbjFkc/cM5PV5yE0yXQvoIUDyF0lXesLQhycTFJpZQdKW6x3r3XTTTf6dZz1eJ9nY3OeIPjB6QDiHzORgNg7fEfTseZ4MA7KpXIOQcxVCxB45CyKtwHAn1Y/mOwY/0TBu1MHgph3BDZKbIUouZBlyQ1MnhiHG8f333+83SNR9cBp4LHSKIyl1nieSyRAtboqokvB/eZVBxAOM/AEDBrjRg2ILPSFkFgLVmu2BFjxOE1r0GP1ETnfkLGCg07CLbj/NphgI9IpE832MBAxEMkQYQtRLUy6yPWeB88P7x0A1BqJhCGMc8pnB+KRpk3kGGIFkpRjA9dBDDxXqGPmcfPjhh/7Zwpjm84VaDecscK4SmUjfR4xJXhs164HjRYYvmlF3jFq+1wzro/8ApysYBsYMA8CQJeKPA8h3AQeA95DsQm5nIa/PQziS5VpAkzkZHpwAHBpeP99XrhEBHC/vJd+fO++8099TzhXlSZQUhcL3nPIk5pww0wKHkXPM55mGfd5jsgl89/gMsF+R+gRD02KxHxEZxdBPjXBdIYSZG2PUiofrTcgLbpZMSqb2NhZNwclIMJiK0pxoRoyFEIWHngT6tggUCFEUUNaGYMgbjw+wcnkIPUST9Rs22PnX3ujlfmRlRd4osyBEPvj7779d9zyYOBoOooihijbU3zLRlQilHAUhhBAibxA+iETJrbDEYh+pgpwFISKAOvqvv/7ayyZIs19++eV5rsucBeptUXihnpeyBSImpOSFEEIIIZIJOQtCRMD48eO93pbGPRowtzd8iAZMmvFo3KSh+cADD3SHAek/IYQQQuRNZkZmjHoWlFmIFPUsCCGEEEKIhOhZeGXAQ1au7P+LgRQV6zdstE433qKehQjQnAUhhBBCCCFEWFSGJIQQQgghEgJJpyYechZiCJ33TMCsWLHidsfcCyGEEEIUNajnM+OCwYHFi6vYRIRHzkIMwVFgaJcQQgghRKIwf/5823333S0RyMyKkXRqlhqcI0XOQgwhoxB8KTUARAghhBDxbiomiBnYJ0KEQ85CDAlKj3AU5CwIIYQQIhFIpNJo9SwkHipQE0IIIYQQQoRFmQUhhBBCCJEQZGZm+BKL/YjIUGZBCCGEEEIIERZlFoQQQohcoMayefNmnReR9JQuXTqpZFGzMjItMyMzJvsRkSFnQQghhAgBJ2H27NkxkW8UoqjBUahXr547DUIUBDkLQgghRMiQqr///ttKlCjhkpLJFJEVIq9hsHym99hjj4RSPRLJg5wFIYQQ4n9s3brV1q9f7xNty5Urp/Mikp6qVau6w8Bnu1SpUpboqME58VDIRAghhPgfGRn/KaSoZEOkCsFnOfhsC5FflFkQQgghcqFyDZEqJNtnmeZmBrPFYj8iMpRZEEIIIYQQQoRFzoIQQgghijy6PWLEiEJt4+KLL7azzjorz+eHDh1qu+yyiyUqffr0sf333z/eh5EUTdmxWkRkqAxJCCGEiAK/r8yyNZuzdrhexdLFbO9dolsasnTpUrvrrrts1KhRtnjxYtt1112tefPm/thRRx0V1X0JIdILOQtCCCFEFByFxq9uiXj9mReWiqrDcM455/h8iJdeesn22msvdxg+//xzW758edT2IeLPli1bkkLRqNBqSLHoWchUw3ekqAxJCCGEKCSRZBQKs/72WLlypX355Zf20EMP2fHHH29169a1Qw891Hr16mWtW7fOXm/gwIHWtGlTK1++vM+QuOqqq2zt2rXblPGMHDnSGjVq5NKx7dq1cylZnJA999zTMxbXXnttDmUdHr/33nvt/PPP923Xrl3bBg8evN1jnj9/vrVv3973t9tuu1mbNm1szpw52c+z/RtuuMGfr1y5st18880+AyMSKHfae++9baeddrJTTjnF9xXKU089ZfXr13eVIF7nK6+8kv0cx0DJ1LRp03KcXx774osv/G9+8jfO2MEHH+zn6cgjj7Tffvstx34efPBBq169ulWsWNG6du1qGzduzPH85MmT7eSTT7YqVarYzjvvbMcee6z98MMPOUpk2A/Hy/vIue3bt681aNDA+vfvn2NbHC/r/vHHHxGdIyGSxlngC9CsWTOrVKmSL0cccYSNHj06xxc23DJs2LDsbcybN8/OOOMM/7JWq1bNbrrpJtcSDoUv9oEHHmhlypTxLxkXxNxwYeOCx8XlsMMOs++++y7H83zJr776ar9oVahQwaM4RG6EEEKIeMI9iQUjedOmTXmux4C5xx9/3GbMmOHG/9ixY90IDwXHgHXefPNN+/jjj/3+efbZZ9tHH33kC4b1M888Y++8806O/+vXr5+XPU2dOtVuvfVW69Gjh3366ad5Rscx4jGicXK+/vprP/5TTz3VsyMwYMAAv1e/8MIL9tVXX9m///5rw4cP3+G54Pjvu+8+e/nll327GPodOnTIfp5tcGw33nij/fzzz3b55ZfbJZdcYuPGjbP8cvvtt/txfv/991ayZEnr0qVL9nNvv/229yjcf//9/nzNmjXtySefzH4exyc4tuDc4mRxXjiuuXPnZtsYbIf3YPr06e50sJ8XX3wxx7Hw9zHHHOM2jhAp5Szsvvvu7nlPmTLFv0wnnHCCRxe4kBH1YOJg6HL33Xf7BeW0007LjjzgKHBx+eabb/zix8WFGs2A2bNn+zpEW/C8r7vuOrv00kvtk08+yV7nrbfe8ghG79693avngscXdsmSJdnrXH/99fbhhx+6ozJ+/HgfcNK2bdsYnzEhhBAiJxiq3Pu4BxKJp0fhtttus59++inHetz/uBcSGON+S5Qaoza3IU8g74ADDnDjk8wCxvqQIUNs3333tTPPPNO3kdu4Zp84CQ0bNrTu3bv7/z3yyCNh3yruuUTOn3/+ec90NG7c2I1dgn9B9P7RRx/1zAj3WZ5/+umnPfq+Izj+J554woOPBx10kJ8T7IMgAEhEnkZpsiocK/d+9pE7Uh8JOCVkAzgvvHb2E2QPOH6cELInZBewIch2cHxkOgiIkt1o2bKlT1bmNXLecfawWxgKGGQXOnbs6NuivIx1OX6yGMFrYpuvv/56DmclmaEEKVaLSAJnoVWrVnb66af7F4gvLV88nIFJkyZZiRIlrEaNGjkWIgJ88VgHxowZY7/88ou9+uqrrjCAE0EqlCxBEJ3gAlOvXj33/vkyXnPNNdtcxEjNduvWzb+MfOn5HzIVRDRg1apVfqFkPS6wXIC4sHFh4FiFEEKIeEK2myDWBx984BH6IKMemkn/7LPP7MQTT/QINlH9Tp06eU8D0fgA7n0YsQEYujgXwX03eCw0mAYY57n/njlzZthj/fHHH71chmMIsiKUImFo//nnn37PJUBIlj/UIaLkZ0ew3iGHHJL99z777OMOVHAs/Mzd8M3feR3r9qAyIoDMAZANWLdundsmnMfVq1dnZ3t4Pdg2lB3xHpQtW9buueceO/roo91O4THKwhYuXOiVEFRcQO7XjSNBEDSwUQhkso9zzz03369BiKTqWSBLQNqTL1nuiw6QfSAzQAouYOLEiR6V4MIVQEaALyfZiWCdk046Kce2WIfHAaeCbYeuQ6qWv4N1eB7PPXQdLkB4+ME6QgghRDyhjJYa+DvvvNODWUSgyZgDkWyyAhi47777rt/Xgr6CILgGuZtnKf0N91hhZCcxiAm6cU8PXWbNmuVR9HjC/R9C+yO4/4cj9LwEg89QpVq2bJn/TtkyDgA2Cr/jALB9nAT6JQhQ8rofe+wxf7/4nfWC9yPYJr0KuaFCAptpw4YNHrw877zz3NFLBSSdmnjE3VmgBo+oAl+iK664wrMHRPdzQ2SfzABNRAH//PNPDkcBgr95bnvr4FDwJeNLjaMSbp3QbfDFzq3fHLpOOPD02U/oIoQQQsQC7qUE4ADnACOMLPvhhx/u2XwyEdEid5adv7lnh4OMx++//+59htTYhy6UGrEQqf/222+z/4deRF7DjmA9ypqBTAXboDeA7WHIsw96Kchc8PpXrFjhfROB3VG1alX/yfMBoc3OeRE0fONY4CCwveA48jpH9FTQLE6FxX777ed2UOBohG4zHPwPTgSlS/SWpEoJkkhM4u4soETAF5Ev9JVXXmmdO3f29F0oGPXU44VmFZKBBx54IPvCx0IfhhBCCBFNKCWiRJaSXPoUqHmnv+7hhx/2PkDASMaQHTRokP3111/eqEzJbbTA8GV/ZAfIWLB/GonDccEFF3gpDseGoc7xUjaF4bxgwQJfh/+lp5Gm7V9//dV7DDD6dwTRfsqNEUuhVBlhEsp4yGRQAsR26dN44403vGSIqD77wPbAmSCqj5IU929sEXoU77jjju06J5RN8b9BEJFSKPZDmRBRf84JGZ6g4iGAEmzeB0qgsIE4L2QdQredF7wWMkf0dbCdcBUZyYp6FhKPuDsLROy5iPFF5stJczFf3lBQXaCm8qKLLsrxOH0MuRWJgr95bnvrUAvIl5ILFl+6cOuEboMLSO4LVeg64eBLzEUkWHLLtwkhhBCFhew89fD04tGU3KRJEy9FohePZl/g3krfHfKqPP/aa6/5PTdaoC5EJJ3GaBqn2Rclv+GgXGbChAleyhs0MAfSokGdPtujpwIjHkOY/gYUgbYHmRPu60TZCT7S44jUK2VXlPfQF4FBjo2BQ8M5w2mgcoE+D0qECE5yXrA5sEtwNmiCBrI0HGMQ8aeygKZsHg96OoIyJsqCeA9Qm2I7qBtxTKGwXzIbZFp4rThLZFsiySwA5wzbhHImIYqSYlmRChfHCKIjXEBCm7KOO+44N+pzS7UROaAGk3Rh8AV79tlnXT6V5itSerfccotLklHuFEBNJDJspO6ACwaRBCIuwQWHYyA6gcIBhj6pSS4qNJEBSgT0LdCzQEo3EihDIsPA9oILohBCiMQBY5BINw2n9ABEyg9LMu3Qt/OOBOfmu/Yl7cBqcY/XRQUaoFFaYokHQckvvRDc93EQQiP0BQHTiMg+2RgWjPLgd4x4Ap04CJQCFdWQNBqdsRVwlMJBVoaGdQKRuUupI/1MJ5JdEhzLw9debmXLlCny/W3YtMlufvyZhHjtiU5cJzgTeUfBCMN8zZo1XmpEKjJU1hTFBCIQGPy5QXKMukA8ctKfePmkC4kEcMEA+iCIrODdE21AV5oU5KhRo7K3Q9SA6AWpSpwGJM+IFATeOh9ePHjWIzLBhwppOKIdkToKQgghUpeKpYsV6fpiW2Oe+3SgNoThjkpQcO8vLEFjdzhHgIBikEEoKnBIeF3hnB4ep+yJ+QsoIG3PURAi6Z0Fov+UFpEZwCBHpQFHATWHAGr+mMeAY5AbyoeYNElqD8MdDx+jHymyADxpHAM0jkk9si20nUPTo6QL+eIxnwGHAxlWsg6hX0DSu1wcyCzwReX/QwesCCGESF/23qWYzbywVESTmXEUWF8UDIx17Aei/QTvuFdjD8SKonYUgmwAjgr9D7mhyoEAJrYKw+dSjayMLMvMyIzJfkSSliGlMomU7hNCCBG9MiQRGygNol+QyH+snYRYQgCT10gJdmFJtjKkh66+zHYqU7rI97dx02a7ZfCzCfHaE53UKJgUQgghRMpD9p+IO+IiqeooBAZ+qsxNEMlPXMuQhBBCCCHyU8tPFDgWpUDxfI00Uker/yLZyMzM8CUW+xGRkbrfNiGEEEKkFDgJhZkenUwEE5yFiDfKLAghhBAiKYiFElGiOAnp2lLqmYUdzJiI1n5EZKT2N04IIYQQKVOewxJOISiVSHdnQSQeqf2NE0IIIeIAE4AXLVrkteeo9jCjRxQcDGcUgmj6TeXGZkh3Z4HsUSxKzdKlnC0aKLMghBBCRIlp06ZZt27drGrVyrb33nv74FDkL08//VSf+ZOqBgoDVTFyV65cWSTbZ3ArM46qVq2a8LX8Q4cOtV122aVQ2+A1pquzIBIPOQtCCCFEIcGw6927tx1wwAH28Uev2C1Xl7PP361tXwzf3Z56uKotWfilnXnmme40YPhGm4svvtjOOuusfBukI0aMiMr+jzzyyOwBq0UhI7p8+XKrVq1akWUV9txzT3v00UctUUhnZ4F+hVgtIjJUhiSEEEIUkrvvvtvuuece63trZbvp6l2tZMn/j34ffXhZ63bhzjb683XW8covrE2bM+3jjz+10qWLfvBULKDUitfC7IPCwETm3OcER4HZCpUrV7ayZctaPKFfAiM+Fg3W6ewsiMRDmQUhhBCiEPz888/uLNx7S2Xr1WO3HI5CKKedWN7ef6m6ffnlV/b0008X6Tk/7rjj7Nprr7Wbb77Z+yUw5Pv06ZMjkg5nn322G6bB3/D+++/bgQce6NN+99prL39tTE4OYP2nnnrKWrdubeXLl7f77rsvbBnSu+++a/vtt5/PC2D7AwYMyHGMPHbvvffaRRdd5LMTLrvsshzPU3aEo0C2gvPVoEED39Yee+zh+wyYPn26nXDCCe5M4FSwnbVr126Tdenfv7/VrFnT17n66qvdyQnO1dy5c+3666/31xCUOQXlRB988IGXk7HvefPm2YoVK/yYd911V++hOO200+z333/P87348ccf7fjjj7eKFSv66zzooIPs+++/3+77J2dBJBJyFoQQQohC8OSTT1qNamU8o7AjjjmirJ19enl78snHizxy/NJLL7kx/+2339rDDz/smY9PP/3Un5s8ebL/fPHFF718KPj7yy+/dEO4R48e9ssvv9gzzzzjRnOocQ44HjgaGOpdunTZZt9Tpkyx9u3bW4cOHXwd1r/zzjt9W6FgwDdv3tymTp3qz4dmGXAUMNYffPBBX3ieY3r99de9aRzWrVtnp5xyihvuvIZhw4bZZ599Ztdcc02O/YwbN87+/PNP/8l54TiCY3nvvfds99139/PDuWAJbVR/6KGH7Pnnn7cZM2Z4KRTOB8Y+TsTEiRP9fTz99NOznY/cXHDBBb59jo/zcuutt/oU6u2Rzs6CypASD5UhCSGEEAWE6Pcrr7xk13Urb6VKRdZ4e0XnSnbiOX/a119/bS1atCiyc9+sWTPvowCarZ944gn7/PPP7eSTT/ZGYcAYDy0fIouAMdu5c2f/m8wC0X8yFMG2oGPHjnbJJZdk//3XX3/l2PfAgQPtxBNPzHYAGjZs6IZ+v3793NgOICNw44035vhfHAUMdqLw9Cg89thjfuzBMdWvXz/7vOE4UKr08ssvu2MErNuqVSs38gOnAmeCx9nePvvsY2eccYafC5rRybzwOJH/3KVUOAA4gzg0QAYBJ4H3jj4NeO2116xOnTre/3Huuedu8z6Qjbjpppt8v8F7sSMSvYlbpBfKLAghhBAFZPHixbZ27Xo78pCdIv6fIw/+r/b+jz/+KNLzjrMQCiU4S5Ys2e7/UDJDhL1ChQrZCwY1xjtR9oCDDz54u9uZOXOmHXXUUTke42+MbWr/w20HpSjKmNgXhjuODNvBIcPxyGs/GPKBoxDsh2399ttv2Y9RDhXaHB3JuQB6KELPI/tjzsNhhx2W/RhlTY0aNfLnwnHDDTfYpZdeaieddJJnSMhwREK6S6fGYhGRIWdBCCGEKCCB4VuiROSR4MBmDTWai4LcpS5Eq3dkIFHrT3YBCdhgoYwII58ehoBQ47wwYIzjIOB0EYGnrAipWTIBHG+0mpoLci6A/Rc2yk8JFiVMZDPGjh3r/Q/Dhw8Puy7HhBPDZ2NHpUpCxAo5C0IIIUQBoZynRIni9stvmyL+n19mbc6ObscTjNHcDguNzUTkaSbOveRHBahx48ZeqhMKf1OCs3r1aluwYIE3TSMjSxlRoKZUq1Ytd0QCA531MdgpGcprP2RDcDJC98OxEu2PFPYfifPG/jhu+kACkHXlnOEE5AVlWDRQjxkzxtq2beu9Irkhg7Jw4UI/jtq1a6eMWlZ+yczIjFHfgjILkSJnQQghhCgglOmgtPPsq+siLht59pVVVq1aZS9LiSeoEWGE00iMwg/cddddXv9PdoFoOKU1b775pt1xxx352jZ9CGybfodZs2bZc889Z4MGDfK+A4xiSowo5wmUmsgkkLnIHcXnsVtuucV7JjguSngmTZpkQ4YMyW4eZh22iyoVDczdu3e3Tp06ZfcrRHouJkyY4Mb6smXL8lwP56VNmzZemvXVV1+5o3LhhRe6cc/judmwYYM3W6MWheISjgyNzjgdAXxuyK4w8Tvom+DcCJEoyFkQQgghCsFVV11tM2dtsHdH/b9cZ17MnrfFXhm2zrp1uyLukWOkTFFHojmXYXKAstDIkSM9An7IIYfY4Ycfbo888ojVrVs3X9smQ/H222+7o9GkSRMvxenVq5fX72MM42RFCk3SOB84MhjZ5513Xna/AdKln3zyif37779+vO3atfP+BpqZ8wN9GnPmzPHm6aD5Oy/ICiB/ypC9I444wo39jz76KGzZEH0SZB5QmCK7gEIUUqs4Y/wffSD0aJBtIdOEE5Xuzc2ZmRkxW0RkFMtK1w6aOMDFAL3oVatWucqDEEKIxIKSmNmzZ1u9evVy1OhvD26j7dq1tdGjP7R3nq9up55QPk9H4bTz/7EMq27ffvu91+anOkTWyVxggOfHQUhlgvIrFj47ZBOwDYpqOvX2PtOJZJcEx9Krw9m2U+mi79fYuHmLPfDm8IR47YmOMgtCCCFEISAS/Oqrr9uJJ55iZ164yFpf9LdPa16zNtM2bMi0qdM32lW3LLHmJyywzGI1bMyYz9PCUcBIpXGZ1ypH4b+ZDThONHJTioWKEgPmAulWIRIVFcUJIYQQhYQm3OHD3/dBX4MHP25nXjg9x/M1a1azm2663uvXMRJTnWD6MoYwkfN0J3CcKDPCeVJPQt5kZWb6UtTEYh+pgpwFIYQQIho31JIlXU+/a9eu9sMPP7jcKEO9qEU/9thj00YKMxiqRtOyyjv+K1OjaRpHgXMiRLIhZ0EIIYSIclkSDbAs6Vpug3SpMgr/gdIR4CyIHVO8RHFfippY7CNV0JkSQgghwkSDGZBFlJwmXYaV0ZgqdgxNqmRRkAIls5LO8PpxFig9SneVI5G8KLMghBAi7UABhTIhfrJg0PET4+6oo47ykiKaTjHwgp8s6OnL6Ns+nB/kUZEMZW4BEXV6OpCKTbdzR5YFBaJIlbWKgmQTvSxeopgvsdiPiAw5C0IIIdKGn376yWcLTJs2zacFU0OOMUs0nN4CfqLdj7Pw33Tm/xwFsgw07GIAS9knMjhPnDskQjlvgMPA+cV5yM9E6GQFOdAyZcp4g3O8HIWlS5f6+5AuPTMi+shZEEIIkTYwrOvggw/2gWTVqlULuw4lRwsWLLD58+dvo/BDaQ0ORjoYutE2WinjIoPDecT5wojGaUhV2VBeM04SzmjgLMUDHIXdd989ac5z8eLFfInFfkRkyFkQQgiRNuy7775eP56XoxBExPfee+9t6u0x/p5++mk3vFq1ahWDo01NOI/MGvjmm29s+vTp2ZOQU61EiTI3JjszeTqer42MQrI4CiIxkbMghBAibdh///1t7Nix1rZt2+2uh3EVzsA655xz7M4777QWLVp42ZIoGI0aNfIFZ+GZZ56xH3/80a677rqUchhmzJhhdevW9eyJiBz1LCQeyqMKIYRIGw488EAvL/rrr78K9P9M3D3mmGPstddei/qxpSNNmza1Bx980GbOnOnGdar1x/D6hEh25CwIIYRIGxgSdvLJJ9uwYcMKvI1zzz3XfvvtN5s4cWJUjy1doeyLoXVfffWVpVJj89y5c61JkybxPhQhCo2cBSGEEGkFNfIY+7NmzSqww3HFFVfY888/75OKReFBLSiVVKZ+/vlnL0FCXUsUrME5FotIAmfhqaeesmbNmvmFl4UGp9GjR+dYh8jNCSecYOXLl/d1SP8yICfg33//tQsuuMCfQ3Gga9eurmSROxV49NFHu85xnTp17OGHH97mWIgy7bPPPr4OaUOaknI3ZNGkRI0q9YcnnXSSNy8JIYRILrhfnHLKKfbOO+8UeBtMZz7++OPt8ccf98FtouDMmTPHswqHHnpoypxGlSCJVCKuzgKKEtQqTpkyxb7//nt3Ctq0aZNdt4ijcOqpp1rLli3tu+++s8mTJ9s111yTQ7IOR4H10c0eOXKkTZgwwS677LIcqUD+Hw+f/fTr18/69Oljzz77bPY6KDKcf/757mhMnTrVzjrrLF+IDATgYHBTQAnj22+/deeFm028tJOFEEIUnNNPP90zC6jyFJQOHTq40syrr76qt6IArFixwu/FBOK45zZs2DAlziM2AsshhxwS70NJ6gbnWCwiMoplJdhov912280Negz3ww8/3GtL77333rDr0hCFDB5OBLrZ8PHHH/tNAI1sBu6Qvbj99tt9mA7DYODWW2+1ESNG2K+//up/n3feebZu3Tp3NgLYN6oZOAecIrZ14403Ws+ePf15Jn1Wr17dhg4d6jeMSMBxISXJ/xLZEkIIET8oI0LvPzTAlF8YeHXbbbdZly5dPDsutg8zFrh3MxRv/PjxdsABB3gPSKooS1EdQaUCgU2a6ROdRLJLgmPpe1l726l00Q+Q27h5i93x7NsJ8doTnYTpWcjIyLA333zTjXYuuEuWLHHPHC3sI4880g3z3A1QZB4oPQocBaA8iMwD/xusQ+lS4CgAGQHqVYlqBOvwf6GwTtC8Nnv2bHc2QtfhA33YYYepwU0IIZIUMtdff/21GwsFhSnP2+tfoFQWI0iYS9bimL3wwgt+z8fJuvbaa1PCUcDpJMP0/vvv++tKBkchUaGVICY9C0osJI+zgMYyTU1McuSCO3z4cM8WBLJ2lAx169bNMwZ8+U488cTsXgEM+NyDdUqWLOnZCZ4L1sHRCCX4e0frhD4f+n/h1skrgsJNInQRQgiRGFAKS6/a559/XqjtBP0LTIUOndRLoKlHjx529dVXb9NLl26sX7/e3njjDY+4P/bYY149wOC7VICeFSaDU+p89913W4MGDeJ9SEKklrPAUBbSkWQCrrzySuvcubP98ssv7qXD5ZdfbpdccomnKh955BFfn6hEMvDAAw94BiJYaK4WQgiRWNmFzz77zLZu3Vqo7dD3Rs09xiIZBspXmcVwxhlneI/b9gJL6QANv9wHqQRIpcFrOIH0Xi5btszf+9xBRZF/1LOQeMTdWaA8CC+cyAzGdfPmzT3qEKQlyTKE0rhx4+yGtBo1ani5Uihc8En78lywzuLFi3OsE/y9o3VCnw/9v3DrhKNXr16e3g4WBgEJIYRIHLjnoHA3adKkQm2Hac9kwel3w2h8++23/ZrfunVr73lL15kMBP7oTXj55Ze9JDiVHAUETrBbcAbpjVTdu0hV4u4shLuwUL6z5557+gWW3oJQUK9A2QjobVi5cqWn/kJrItkG/QTBOigkbdmyJXsdlJPIUOy6667Z6+ROQ7NO0KxWr149dwpC16GkiGzI9hraKK0KZGGDRQghROJAjxs9apS6FlbvA0O4Y8eO1rZtW8+Qo9ZXrlw5u/jii/3+gURousC5ROUQQZH33nvPzwvzLVIF7IxBgwa5o0mpGfd7IVKVuDoLRN4x5LmA0rvA31988YVfYLno3nTTTS5Xihb2H3/8YXfeeacrGFHrGGQZSCETzUFalUY16iFRJ8LRAC5QZC/4HyRW33rrLc9c3HDDDdnHwRedGwX1pmyfPgkucmwLOJbrrrvO+vbtax988IEf60UXXeT7QO5NCCFE8kLEmzKhgg5pyw1y3WQX2C7sscceLpDx7rvvWjo4CZQccb8eMmSI9xlyb23RokUO2fNkf40vvfSSVzZcf/313ispokexGA1kYz/5Zc2aNW4PErTGUUSAB0XOAAID2IyhC3ZqKJHMB0s04voJ54uG0U19J7WMDGj75JNPXC4VeENI8/Fl5OSSLibiX79+/extUBOKUc8FiQvROeec4w5GANsdM2aMN5hR6lSlShXXdA6VyuPNfv311+2OO+5wFQOarpBWDR3TfvPNN7tSE/9HNoMLHw4GQ9yEEEIkL1zHaVDmmk7WuSgaYKllD+S6YwH3PQRDKIuinyJUEbCo4PVRfoV0eatWrfxenor3SIa2EqC85557vARJpA+XXnqpz+B65ZVXPGCMAhaBADKJtWvX9nVwDl588cXs/8mddcJRwO7FnqXqhb5cbEvs0EQl4eYspDKJpGcshBAi57wEZukMHDjQg0rRAMMZox0lIHoaGDrarl27Ij/tGCJk6jFscBj22msvD5gVFX/++ae/VioAmHN02mmneflVKoKTwPwlgouc12QnkeyS4Fj69TjfypYpeud2w6bNdtNjb0T82jds2GAVK1Z0eVyECwIIRPOZp/qEzAIBZQLOBZ0PlogodyaEECLtYV4CqntE+4jERwPKbIkiIvuNkRHtMhycEHoh6NtjbtBDDz3kUUwUA8mUkCXncTLhRQHOAc4IUVVKr8jy8zpTFWTbGfTK60wFR0Hkj61bt/p8kNzZMsqRQmeAUU6PrD99sSeccII7EZUrV45oPtjZZ5+dkG+LnAUhhBDif+UD1Ndzw45G+Qx1zRj0REujDb1+SHYSiWRgKU4DErDsa9GiRV6+i9z40Ucf7SW80S43wkmgx4NSI0ooiuI1JhKoH/LZoCeSSLIoeunUoibYR+4ZWDjc4RrWK1as6KI29957r/fMUlrI7BAcgGC2BtcQBA4QxiHjRmk7WQfWIbsYyXywRETOghBCCGHmA9q4kRMlJNoXje1hUIeWLEQLjBn66Ch7oIGa4abUSRP5pGGSjAJqgjgNhVH8wdmh/IKfzBIYPXq0D5sjk0BpU7xLV2IBTa0PP/ywHXXUUa6cJVKL3DOwevfu7UI34XjllVesS5cu3p+A8U/WkExkoMqJMxnQtGlT78Wlz5ZsA721yYqcBSGEEOJ/yndEBj/88MOoOAs0S48aNcrVc6I9X4BZRAh63H///a7xT7Qb0RAM20MOOSR7LtD2egcoqyCaSa002YiFCxd6vwORVpwDBEaAY6fUgmZeMhWIj+CcpAN//fWXl3Ux7ZuSMlH0BGpFsdgPMA8l1Ondngxu/fr1fW4IjjrfE76H5513Xp5laTxODxQlezgLkcwHS0TkLAghhBD/g3IaIunRgFIEDAGkuDHgow3S3UT/cRhQ5gnNYGD8EPnE0AWaODFwcAKCnyyoJFHKRKSUCCsziqipxsnAQeAnJVmpNEwt0jIvpG5RvqHUCscsVaRfRU4KMgerfPnyvpDBQ8WTzFM4cMSXL1+ePWg4dD5YUM6Wez5YIiJnQQghhPiffv6XX36Zo/mwMJQqVcpLFp577jmPTAcGQzShvwJHoF+/fl46EWQS+EnGAUOEWmvqq/nJ48HC3zRhygj+r+SKrMrcuXO90fTHH3/0SDB9HzhPInV7FvLDJ5984tcJsoZkC5gHRrkh8qfMSmC+Co4lWQJ6FpDdp58hKF8LnQ+GqhbSqbnngyUichaEEEKkPRgANCsyvJNZPNGCOT7z5s3zbSLNimGBwUHUnsbjwjYGE/FnXhHbp4kytC4aIyVovBTh3/Nhw4Z59oD3iL/p/+A9wknAkRIiFBxzZInJGNCUjGNw3333eWCALCIDCRnYR/YA45/eHhqiQ0ubdjQfLBGRsyCEEMLSParMDf6HH35wozvaGQCihkTxn3nmGTv33HPtnXfecalWJhyzFHYCMOVGlDwlsppKIkLTKfK2NKiiXMX7zrkUIi/at2/vSzgIABAI2BE4GYk8gC0cKsATQgiR1qDwM23atCJxFAIoPYAnn3zSpUZREiIrEA3jlIgmMwCIiovIoNacCC/KUagcUSYmRyExKF6suEfci3wpJhM4UpRZEEIIkdZG43vvveclQkT7iwoMUSYqB2pFKA9Fg02bNtmjjz7q2Qnp/0cG5UY0fu+///4+iE8IsX3kLAghhEhbKAmid2Dfffct8n3tt99+2b8jp0hzIzKKNB8XxOBF1vPVV1/1DAXNzNuTSRX/QS05w+uYf0FTuEg8ErnBOV2RsyCEECJtwcDOPcE1FtDwiFQiQ56uuOKKiOcWIHv69ddf27hx49zRaNGihXXs2HG72vDpDlK4kydP9vP2yy+/WMOGDa1Hjx5pMVBOiGggZ0EIIUTacvrpp9sNN9zgcwrQQD/++OML3XAcKZ06dfKm5549e3oJETMP2DcZh82bN/tCmRHzEJBlpISJhWZmpBgPP/xwn4EgwvdxIH+Kg0DjOlKW9CbQL1K5cmWdsgQm1kPZxI6RsyCEECJtQR6zf//+3uD88ccf28iRI13KkIh9Uc8fYN+33HKLD22bPXu2OwkYucgwkmnAeWAJZiLwGJr/RdlbkeyqVpQX4SAwKwFHCulapCsZOCeEKBhyFoQQQqQ1RJrRPCer8NVXX/nk3g8//NAHJ1GyUpTQb0DDc1FMeE4X0Lznffvmm2+85IiMC9ki3jsNnEs+1LOQeMhZEEIIIbwsobgdc8wxHo0mwzBw4EB74IEHNJwrAVm+fLk7ByyLFi3yMq7OnTt7s3qsysiESBf0jRJCCCFCb4wlS1qbNm3cCB08eLDddtttilAnAPRv0Kg8fvx4+/XXX13B6rTTTrODDz5YSlBCFCFyFoQQQogw5UFdunSxO+64w55//nkvU6K5OCMjw+rXr++9A6LoQSKWgXM4CJMmTfLpt2R/rrrqKmV8UpRiMZJOZT8iMuQsCCGEEGGgQfb666+3N9980+6//353EChV+ueff7yfAaNVFN2wvC+//NImTJjgsxFQqurVq5c7ajhyQojYIWdBCCGEyIPatWv7dOdQfv75ZxswYIDtvvvuttdee+ncRQkkYpE5pQ9h+vTpXmbUtm1bLzNCFUqkB5JOTTzkLAghhBD5oEmTJj7nANWkm266SeeukA7ClClTXOr0p59+slq1armaESVgTLkWQsQfOQtCCCFEPqB3ATUeUfA+hJkzZ9pHH33kDgLZG6ZZX3DBBVazZk2d1jRH0qmJh5wFIYQQacHChQt9+BnTfBs0aJCv/2Vg2owZM1yNZ+LEibb33nvbhRdeWGTHmqpOAiVcw4cPt3nz5nl2Rg6CEImPnAUhhBApDTKbDFnDUKXHYM6cOW6oUg+/vVp4pDqZ7IyDMHXqVJfnpH4eKdX8OhvpDE4CGQScBORoTz/9dOvZs6fkTkVYihcr5n0LsdiPiAw5C0IIIVKOzMxMN/BxEubPn28nnXSSXXrppS63ycRf5id89tlnbvwzhG2//fazEiVK2NatW+3HH3/07AG19Eh1HnrooXb77bdbvXr1pMSTDziX9CKMHj3alixZYmeeeabdcsstVrZs2aJ744UQUUfOghBCiJRh8+bNLrmJgUrzLEO7br755hxRbFSMkEL9888/3Sl4+umn3blo1KiRlxqxLlKdvXv3trp168pByCerV6+2sWPH2qeffuqZm1NPPdWOPfZYl6IVYkeoZyHxkLMghBAi6Vm1apUbpyzMQ2jVqpVnDEqVKhV2fbT6KSVioW6ehtvffvvNzjjjDO9HkJZ/wZwESo3GjRvn57Br1662//77a/q1EEmOnAUhhBBJCyVGZBG+/vpr1+W/5pprXNo0P8Y+g9YoQ2IR+Wfjxo3+HowcOdL22Wcf69Onj+255546lUKkCHIWhBBCJBUZGRk+vGvMmDE2a9Ysa9Gihd13331eXiRiy3fffWdDhw61ypUre9Ny48aN9RaIQqGhbImHnAUhhBBxh54BGmK3p05EqRElLp9//rn/TdNy9+7drVKlSjE8UgFr1651J4Fm8M6dO9tRRx2l0i0hUhQ5C0IIIeIKqkWvv/66y2rSUEy9O9N7KSVioUyI+Qgo6zRs2NAuuugiO/DAA129SMTn/XruuedcHerhhx92hSkhokXxEv81OcdiPyIy5CwIIYQoUtatW+dZg5133jmsetETTzxh55xzjh1yyCGuUERp0dy5cz3bwIJOP2UuKBgx7VfEh3///ddeffVVzyZ06tTJFY7UCC5E6lM8njt/6qmnrFmzZp5CZkGqjiapgOOOOy47shQsV1xxRY5tMAUS9Qqk7qpVq2Y33XST35RC+eKLLzwKVaZMGVe+IHWaGzS3achC2o2x89Rh5m7guvrqq/2GVaFCBb+xLV68OOrnRAghUgmupTQdX3vttdtcM//55x8bMGCAX7uROK1ataodfvjhnjkI/ue6666z66+/3h+ToxAfuKeOGjXKexLI5vTv3z/7/ixEUfUsxGIRSZBZoBntwQcf9JQzkaOXXnrJ2rRp4ynOQJWiW7duds8992T/T6hWNk1uOAo1atSwb775xv7++2+/oSCVRwQKSF2zDk7Ga6+95rWuDOapWbOmT/CEt956y2644QbX2sZRePTRR/05ZPS4iQE3Ky6Ww4YN8+gYNzKmf6LAIYQQIryR+fzzz/t1nPkFXEe5PtepU8evo0xUpjm5R48eMjwTlF9++cUDbNyjcRZQnBJCpBfFsrgCJBBMy+zXr5/rMxO5QKMZ4z0cZCGYCEmda/Xq1f0xDH4mRC5dutQb5fgdI5+bUkCHDh1s5cqV9vHHH/vfOAikv0mFA2lvbmY0zt16663eVEfEi5radu3a+Tq//vqrqz4w0IdIWKQa1Nwg2Z4a8oQQqc7ChQs920sD7PHHH+8BnZIlS3oQh5IWrr3BtVskFpSDvf322/bHH3/YWWed5Zkf3juRWiSSXRIcy9tPXmXlypYp8v2t37DJ2l/1ZEK89kQnrmVIoZAlePPNN722lXKkALIBNLqhm92rVy+fyBmAod60adMcNxsyAnzgiGIF66CYEQrr8HhQLztlypQc69BMx9/BOjy/ZcuWHOugJb3HHntkrxOOTZs2+bGELkIIkS7UqlXLS4k+++wzDwIRhKGUiGxC69at5SgkGNyHp0+f7qVhffv29dJcgnUMuJOjIET6EvcwARcmnAN6AugFYPpjkObs2LGjK2Nww/npp588S0Bp0HvvvZdd75o7KhX8zXPbWwfDfcOGDbZixQq/QIZbh+xBsA2yFEwFzb1OsJ9wPPDAA3b33XcX4uwIIUTyQk07mdfmzZt7KeiCBQs8yCISBzLp3FcnTZrkalMEy5BBJbuf+54nhEhP4u4sNGrUyKZNm+ZpoHfeecfT1ePHj3eH4bLLLstejwwCfQYnnniip0fr169viQ6ZEHohAnBQiKwJIUQ6MWHCBCtfvryXmYr4Q4ae7Dv3XhZ6Sw499FDPApE1x2EQIl4gmxob6VQ1OCeNs0DEHoUiOOigg2zy5Mn22GOP2TPPPLPNutS3AjWUOAs0NudWLQrUNngu+JlbgYO/qU8rW7asKzuwhFsndBuUK9HnEBppCV0nHKgvsQghRLrCtRO5zdtuu82zxyL20Jo4f/58lzxlIZNAZjzI+BCc08wKIUTCOgvhUqLU+oeDCAiQYQDKl+677z5bsmRJtmrRp59+6o5AUMrEOh999FGO7bBO0BeBs4KTgkoSTVzBMfA3ikfA8yh48BiSqcDFFtnW0P4KIYQQOSFrzDU1CAqJ2EFDOf0ilBfRD4jKIEE3svbBPVOIROO/QYxFH/WX9G+SOAuU6aCwQA3rmjVrXG2ImQiffPKJlxrx9+mnn+6zDehZQHbvmGOO8dkM0LJlS3cKGA7DFEn6B+644w6fhxBE9ImaoHJ08803W5cuXWzs2LGu8IBCUgClQpQ/HXzwwZ6KpaGLC+sll1ziz9OdT/0m65FGxxlBKQlHIVIlJCGESEdQosNRIOAiih4cM+THCYohe8o97fLLL/fyIr0HQqQHW7ZscZuYkkPUPAtbAhpXZ4GMAHMRiH5gkOME4CicfPLJnjIlIhIY7tT6E9XHGQggbTpy5Ei78sor3XCnJhajP3QuA+PocQxwNChvYrYDut/BjAU477zzXGr1rrvu8pOLXCuyqqFNz4888ojXcXIMZD74/yeffDKGZ0sIIZILrpUjRoxw5SMRm/PNwDTuqfT3ESxTk7JINtSzUDAIulPyibIoJfqUgFKCSAYF25cAO1lFRgUk/ZyFVCaR9IyFEKKo4aZFdLtPnz5qmi1iUBRE8hR1PzLpO+20U1HvUqQAiWSXBMcyfEh3K1+u6Ps9163fZGd3HZQQr72wDBw40Mvy6edF6piMIkqi9OYy04YM75dffunBG0oRBw0a5AORk7ZnQQghRPKzfPlyz9D27t1bjkIRQHkBzcrIj6NmRDae7LocBZHs0K8Qi56FWOwjViAOhOocfUnhwHmgFP+pp57yiew4DnIWhBBCxBV6zugDoxRURA+KAbjRU26w6667uqJRuXLlvMzg1FNPddEOIUR68cYbb0S0HhlHyhPzizILQgghCm3AIh5BX1fDhg1duQ5RCoQnRPRArnvIkCG2cOFC69atW4Fqj4UQqU2XLl28R7dixYo5Hqf/F3GeF154Id/bVM9CmtYGCiFEtKAvoW/fvq5sR3MtspzcsBo3bqyTHAXoQxg9erS9++671qJFCzv//PM9myBEKtklwbF8+HKPmPUstLrosYR47dEE8Z/gOhzKsmXLfDYYZYv5RZkFIYQQhYKbEgPXTjjhBFfcENHJ1syePdu++eYbmzhxopcP3HLLLS6BKoQQ4ZwtrhssKCOFihwQcGDmWEHnq8hZEEIIUSiqVKliPXv2tAceeMD23HNPL0USBWPRokXuILAQ8aTvA7nDJk2aaMqySAvU4FwwkElGJpUl3DWYx+++++4CbVvOghBCiELDzal9+/Y2ePBgl/AsWVK3l/woR5E9wEGgH4FZP8z/OeCAA9SwLISIiHHjxnlWgQwvJYuhg9gQPqhbt67LqRYEXc2FEEJEBUqQUOVguCXqPCLvcoE//vjDl19//dV+//1323ffff380bSMBKoQ6YqGsuUfHINZs2Z5lpfhxCeddNI2Dc6FQc6CEEKIQkNEa9SoUd54SxOd+A+mqM6ZMyfbOfjzzz9t6dKlVrNmTWvQoIEdeeSRdu2112rSshCiUNcZghA4Cy+//LIr0clZEEIIkTBwk3r22Wdt3rx5dsMNN6R1CdKWLVs8wod0LFNTOSdkCpisinNw3HHH2V577eUN4UKIbVHPQv454ogj7KyzzrKDDjrIAzcEIJjeHI6CSKem7xVdCCFEoZk5c6b3KWAM33///WlpBFN2xTRlHARkZLlJN2vWzE477TTv5ahatao3FwohRFHAkMZHHnnEM5dcaxBH2LhxY9S2L2dBCCFEvsnMzLT33nvPS486duzoNbLpZBBTWjR+/HibOnWq/fvvv9aoUSN3EGhMrlOnTlqdCyGiiXoW8k/16tXtwQcf9N/r1atnr7zyilWuXNmihZwFIYQQ+VbvIZtA9KpPnz6uspEOrF+/3r7++mtXHWHo0WGHHebNhAyfC9U0F0KIeMF8lmgjZ0EIIUTETJkyxZ555hnX/7/55pvTwkimD2HMmDE2YsQIb94mi3L44YdrirIQIiF48803rUOHDhGtO3/+fO+lOuqooyLevpwFIYRIM2jA/e233+zoo492FR4a4tD3r127dp7lMxjMyKJSetOlS5d83WiSudRq0qRJ9tZbb3kfQvfu3b3USAhRxA3OJYrFZD+pwlNPPeUD1y655BJr1aqVZztDIQtMVpTehk8//dSGDBmSr+3LWRBCiDQC2c6HHnrIJfYwglHmwVmgMe6CCy6wM844Y5v/oeRm0KBB7kjcd999aSGNSuP2a6+9ZitXrrRzzz3XHavixYvH+7CEEGIbCOJ88MEHfp3u1auXK7DRx0Dmd8WKFS7CwDX/4osvdpU2nssPchaEECKNIP1MlByjf926dfbDDz9YRkaGS+99+eWXruATahTz2NChQ30qKM27qS6LunjxYo++oWpEhI7zUaZMmXgflhBpQzEyCzGI+rOfVKJ169a+LFu2zL766iubO3eubdiwwZ0EpsGzFDTgkdpXfSGEEDmgjKZSpUr24osvWteuXe3444/3xzdt2mSjR4/2m8wxxxzjsnusM23aNLvmmmv8RpPKbN261T766CMbPny4D0obOHCg7bzzzvE+LCGEyBc4B8xciCZyFoQQIo0oVaqUD04jszBgwAC78sorfTYC0fNOnTp5LSsNcN9//71L7yHHt+uuu1oqw2Tl559/3jMst9xyi+2zzz7xPiQh0hZJpyYechaEECINI0/33nuvN8VR34r8KY7BIYccYmvWrLG//vrLzj77bGvRokVK1+kjhTps2DCXQm3Tpo2XHaV6mZUQQuSXYll0tomYsHr1ak9r05VOGYAQQsQTLv9PP/209y707Nkzrd6MyZMn20svveTN2pRj1axZM96HJERa2yXBsUwYdatVKF/0fUJr122yY854MCFee6KjEIoQQqQpqBsRTWdeAj0L6dDIy0A5nIRff/3V1Z/oz9C0ZSGEyBs5C0IIkaZQq88kZpqeS5cubekwUO7JJ5+0gw46yPr3769oohBCRICcBSGESDNQ/nn//fdt5MiR1rZtW5+tkMrRdcqtUDp655137PLLL/fpy0KIxKR4if+anGOxn1QkIyPD5a4///xzW7JkiQ+XDGXs2LH53qacBSGESCOY3IziEc5B7969bc8997RUd4yQgJ06dardcccdVr9+/XgfkhBCFBk9evRwZ4EgUJMmTaISCJKzIIQQacDatWvtzTfftK+//tqzCQwbS3XlH17zY4895j9Rf0LxSQiR2BSP0VC2WOwjHnCdf/vtt+3000+P2jZT+04hhBBpDiU4kyZNspdfftnq1q3rcxOqV69uqQ6TmB9++GGrVauW3XjjjbbTTjvF+5CEEKLIof+sQYMGUd2mnAUhhEhRqFelBGf27Nl20UUX2RFHHJHSvQkBZBJwFEjBd+7cOaVnRQiRamgoW+EgOEJG9Yknnoja9V7OghBCJEnt/aeffmrlypXbodwn644ePdree+89O/LII+3qq6/2Kc3pwpgxY3zqtBwFIUS68dVXX/mgSe4B++23n5UqVSrH89wX8oucBSGESAJeeOEFmzlzpm3ZssWmT59ul112WVi5U+RQaWDGYbjllltsn332sXRj0aJFnlVQRkGIJO1ZiIUaUor2LOyyyy529tlnR3WbchaEECLBWbFihU2YMMEeffRRjxINGDDA7rvvPs8YVKtWzddZv369N7V98cUX1qZNGx+2luoNzHmxYcMG9SgIIdKSF198MerbjGsh51NPPeXDgBizzUI9LWmTcA16KHeQdh8xYkSO5+bNm+fyUKTmuWnedNNNHlELhZvngQce6NNJafpAUio3DCZCQpAmuMMOO8y+++67HM9v3LjRb8yoaZDOP+ecc7yBTgghihoyCFybqEP95ZdfXAJ0jz32sFtvvdWnETNorGfPnrZw4UJ74IEHPKqUro4C1KlTx+8NQojkVUOKxZLKLF261EuSWPi9MMT1brL77ru7Msfee+/tDgE3PSJi6GFTZxVANC1cfS6DJ3AUatSoYd988439/fff3sRH5O3+++/3dWjsY50rrrjCXnvtNR9Scemll1rNmjXtlFNO8XXeeustu+GGG+zpp592R4H98Rx65EHU7vrrr7dRo0bZsGHDbOedd7ZrrrnG5QeRIRRCiKKkfPnyPnF48uTJ9sorr9gPP/xg3bp18+sVU4lRNzrqqKM8+JKKDcybN2/2AA43PQI3VapUyX69JUpsO1mpUaNGrv4khBDpxrp166x79+5+DQwGsnGdxD4eNGiQB9fzS7EsrPQEYrfddrN+/fpZ165d/e9p06bZmWeead9//70b+MOHD7ezzjrLnyMLwXPUpwZSgBj81OniRRGN43eM/J9//jl7Hx06dLCVK1faxx9/7H9zwz3kkEO8cxw4uUSmONlE7latWmVVq1a1119/3dq1a+fr/Prrr9a4cWObOHFixNNAV69e7Y4G2yOTIoQQ+YVr18CBA10SlCBIKkNp1SeffOLXajK6J5xwgjcuz5071wM13L5OPfVUO/HEE3PcAPk/ejoI/OBYCCES3y4JjuX78XdYhQpFL3W8du1GO/jYvgnx2qMJU+o/++wzt2kJqgCBlmuvvdZOPvlkr+rJLwmjJ0eWgEESeESUIwUX/I4dO3qJENmD3GCoN23aNIdmOBkBPnAzZszIXuekk07K8X+sw+NBxIrIXOg6NMXxd7AOz9NUGLoOTYOUAQTrhGPTpk1+LKGLEEIUtnmNzCbZ1H///TclTybX5Q8++MCuu+46+/HHH70ElMwKWWLUnc4//3x7/PHHrUuXLn595ibI+QjAcWjYsKFnYIQQySmdGoslFXn33Xdd5ILy/aDMnwFtzz33nL3zzjsF2mbci1pR9cA5ILVM5IjMwb777ptd+sONgdKkcPzzzz/bDBcK/ua57a2D4U4THI2DOCrh1iF7EGyDLAU36dzrBPsJB7XDd999dz7OhhBC7BiuRZRbcv0iG5tKoOb0zDPP+Osju4uqUbjSKoI6Bx10kC+UZ3Ej/OmnnzzAFPTAIR9INiKd+zeEEOnF+vXrww7epKye5wpC3DML1JZSavTtt9/alVde6brYNPARVRo7dqynkZOVXr16eXorWObPnx/vQxJCpMhkYsoy69WrZ6mUTXjjjTesb9++1qJFC7v33ns9cxxJDwZlpARnCALRB4fIBdugTAknIsGqbYUQ26FYjJqb2U8qcsQRR1jv3r09CB9AcJzgdVC5k19KJtJY6iBChOJH2bJl7c8//9wmmo8K0dFHH+0KR5Qm5VYtChSKgrIlfuZWLeJvIk/sg6YPlnDrhG6DGxm1wqHHE7pOOFBfYhFCiMJCLxV9WqSRuQbSe5UqcwR+//13zyag+ISzgPhFfkGpjmw0SlEMryMFf/PNN1ufPn08LR/0mwkhRCrz2GOPebk919HmzZv7Y5Rzcn2lB6wgFE/EGyK1/jQWk1Im6xAs8Mgjj2RryOIhUca0ZMmS7P/nJoEjEJQysQ4KSKGwTuBd4azgpISuwzHwd7AOz5MSD10HpSSk+QrqpQkhRKRwrbnrrrs824oBTK1+QRQtEg2CMAhHoF7HVGoiXwVxFAK4TrMdstNAMzSNzjT7CSGSA/UsFA5KNwnAkG3df//9fSHjymOhSqNJk1mgTIfoD43Ca9as8ZsGGQM8HyL24aL2rBuk3lu2bOlOQadOnTwtT/8AUSWa4YKIPmohdIQHN1hutgwuQiEpANlUyp8OPvhgO/TQQ730iUbrSy65xJ+nOx91JtajPhhnhFpaHIVIlZCEECK/IKzAbBmuV6j+INccbmpzMjJr1izPJuD0UHJUGCchFLYT6hzUr1/fr+fcH1BGWr58uVWsWDElnK1QZv+zwdZuzNjhehV2KmH1apQN+xzniPspzeI4XmTTI6Uw/yuEiC5c35DXjhZxdRbICKD7ynwEDHI0s3EUkHaKBMqHRo4c6b0OGO5okWP033PPPdnr4FhwoyU9TWqGG8nzzz+fPWMBzjvvPJdaJXLHBQ8vDKm+0AYRMhqk/CmDIvPB/zMISQghisqYpt4ew4tSGoZGpgJkE5hXg0GP84NKR7hZCQWlbt26tmzZMpfURl6W1Dv3Fq7v1PDSz8D+XnjhBT+3iQaBszvvvNPFPrhHHnDAAX7voi8jgM8D6oH0weE87tv0APu9UkcrtcuetvqH52zDvPGWsXGFFS9Z1jK3brRixUtZ2T2Ps50PvsbWTH/Fam2dZgvmzfb7Lip/RB05V9znuB+TkWHAX2i/CFFKMv55EfwvVQBsl8Df8ccf7034ucuJhdgesRqYlkpD2T744AMPvnNN4/ft0bp16+Sfs5DKJJKesRAiMcGgZVAkxhaTmDGmU0XNJ8gmENhBC7x27dpFsh9kA1H9IAMMGLH0LdBnxu+ogtAbkYg9HwSvmAuEFjoG/KuvvuqGOKVVwfkiC89r2Guvvbxx8c57HrYRw9+1MjUOtK1rFtiuh/e0VVOfs62r5lnW1g2269F32ervB1vJ3RpY1uZ11ve2a6zVyYe5Id+jRw9XBGSWEX0dvDfjx4/3bDolCwTIUAYk0MZzeRH8L8NVQc5CcpBIdklwLNMn97GKMZizsGbtRmt6SJ+EeO2FhWsZwW6uC9u7rhEA4PueX+QspOmXUgiReNCnReaTchlSyCgepQJkY8km0PeF8YkDVJSGOpninj17esScc4iTwIBOFJKOO+44N7IT0VHA8KdE6v333/eZEgH0zRE1xMEJx8Tpi+zIZrWRkbHKJzxkJSvWtsUjOlq1M4fYiokP2061D7cy1Zrbss9utJrtR9gnD51gTfes4P+LqAjltzgiZBMCyGTwXChk7ocOHbrN/sl6MSgvdL3AadjR/4r4kkh2iZyFxCU1wlVCiLhBWQelBwwoJFJJRBcFBnqKKGcIohmRSGCmK2vXrvUIMsYZA8eYDZCIxmxBICr97LPPuhGMsVtU2YRwSnQMrcNZYHYD5UmXXnqpJfp3iagfpVOhoNzHBNa8yrreeeNFs5Llzbaus2IlytjmpT9bsdIVrXSVxv73psU/WaX9u7ozsXkpzd8nZP8/RiLfzQkTJni/HwYjfQcY/8w+4rN50003+eA73sNw8LmlpJj/DdQMKXXAMUQMJFAfFCISYjUwLVWHsr388sueocytxsm1gvJFvqv5Rc6CEKLAYIQNHDjQy2SQ86S+mppJDA+Mi6DKEVnLVq1aeVQ3VRp0owXyz9TP04iLUAPnKlWyCYhJICpBiQqR8Vg4QJRxIVJBCU3jxo2zjyVan7tRP/1tAz/9zdZtyn8qPxIq7LGvnd3tBmvQ/jYrVWFXW/7TOPvzm4m2U+Vadvj9/6/It+LXSfbHW30tc8smK1VhN6t+Xl9bMe4ZW/PLc1a6ZiMrXq6ibVj8njsOJSvubsWKl7TiZSpaxoblOc4VGRccVLItGBcY9fT4HXjggS5fjoOFs4cjw3c9HFWrVs3+30CYJBgWSFmEehaEiB2I8yCIwXcvdz8Uz8lZEELE3NDFKENkINQQPOyww7ykIhgKQ3SRhk2Ufc4880w78cQT034GCRFbyjIoPaJEg2n1qZJ9IZtAbwLlDffdd5/X3scKMjTsn9IYMhlExRG64HHKkcJNNs0POAp/Ll1nRUWlU6+35aMfs6kPdfBMQOka9a1842Ns0z9/2D+r/3/IUmaVfazGxY9b5vrVtubHT2zZyAetauubbcUXL9qaye/4OmumvW/l9jnWNi/6K6zSVvv27d2hpz8iFJT/QuE84kDQ5KzZQaKoKV4sRg3OKXK9zQ3f6XD3kgULFvg1uSAosyCEKDBcfFCaCRcxJsoYlB4gMUxd9JQpU9xpoCabyAea+EQgU8VIjpSpU6e60hFGLNmEVIm8hjZnn3vuuf4ex7qciuwVUfC9997bj2X27NmeYaC067bbbvOIOc/xucVxyO9nL8goYMtUq1gETZiV6lmdKx61jM0bLGPjeitdqbL9/ua9VqpKLatRKXR/O5lV+e9zs6VhM/tp4MW2Yc5PVv28h2zN1FG24ssXreZFj9jSEfQw1LKszK2WuWmNlShb+X+OQicvNSLzs6NadXomOKdz5syxRo0aRf81CyEKDZn9oOSXgFyoMAbljVwLuSYXBDkLQogCg7GFRGUkYDTSNMk8E6LpH374oU8jxqFAaQUDjlKleDfZFSX0c7z22ms2adIkTwXjLKWKozRjxgxvziZyxZC1eDVnN2jQwBdAAps6Xc7xhRde6A4rSkPU2JNpoCaf40STnBst70ekylM4CpNuO7GIX415H1C9h6e5U3nZZeH3N33OWjugn1nm6hKWuWxXK12xhdnmJ23D3J9sw5wfbOcDr7ZNf08xy8q0UpUb2k3XXGSLF862cePGbbfsLSjdYvor39/cZQ3bI/jfgiiviPRGPQsF46yzzvKf9BAi78/1LfT7SLaVPqKCIGdBCFFgMLAGDRqUrTATCRhuNECzUEuOs0GGgpImyh+QC+VClypyoaHGNKU5OFgPPfSQKx6lAgw8Q8qTBneyCbx3idKcjaEa+jlq2LChL4ATQU0+Mxlo8h09erQ7sJTbMPwzXjBriDICIvj0BFFGtc8++2QPCeV8U9pFAzGODsff96FHLWPdMitRroptXDDJSu68h5WqvrctfaePldy5hpWsVNdWTnzQdtrzBFv57SM2Y+ts+2T0KD8/yC2G9hgw24GeD2YkBDDUlL6T/MyloKGc7zqzkFC/IigQarwIIaJL7969/SdOAQ3OuYUSCkNiXNGFEEkJpRxEMzBeKDHKL9Q/U4pDc/SNN97omu9ovNN0Sco0FcAhQp2if//+3q/B5PpUcRTQ5seQxGDFAYpVE3OkUDqTl9NJpI3yJD57vC8cP+U2NPPGExwXVIlwEMg+IfeKAxEY6gyUoyeDCCGOD9m4lSv+tWqnP2nFS1e0Fd/2t3+Gn28Za5ZaiYpVbMuqJbZ87M1Wulozq9T8Ets4/ytb/PdCHz6KsxEsKCAF20cx5dhjj/VSBpqXcV5oVr/mmmsifh2oXt19990+yA0HOT//K9Kb4iWKx2zJL2vWrLHrrrvOnWEcYHrNQiWG+a4wAJLvFM8z9PD333/PsQ1U2i644ALPolOCykwTetiiBT1w0XQUQHMW0lTPWIhoQlkNUXOMRSKehblQEe0kwktfQ4cOHVyCNVlLdbhJPP300x5RveKKK1JmbgLXMHT0p0+fbp06dXKDO9HeI27anHMi80FZ0o6YN2+eG7gMdQvdDg36X375pTtCz/y9hy1Zu9n7ByIpQ6I/gFp/StAwDMhaRHqu2DdTmilFwvAgYhhO1Wn2PxvsmF7TcjxWvMoKK1Yiy7IyinlpUigTHtjf6tWQlKlILLskOJbfZ9xnFYuiHygXa9ZstL33uz1fr/28HQxNJOiAEADXRwJhTGPnOsnzwX2R+yTDIblncn0ga0iJLhnaaMA9lGPCweeaRhY1t7OSX1Irzy+EiAs0MCOZiJH12WefeRPVySefnKcu+/Ygskm2gsjqE0884eU7l112WVKVMHADYGIwNfNEgBmwlUgR94KC8YrRzA0SFSyyJQVV1yhqKK+h4bpOnToR/w/1+2QjKIvjxj9z5kyPslMqh0PENtetp8Z/x+U4GPkYA88997QtWfL/cqX77tvIrrzymuy5BOGg1IhzPOjxQTbjlxnZj++6y2522eXd3AnCcQjA8McBWLvx//sDLn5loi1ft9mqVCplQ69umv14hZ1KyFEQogBs2LDBr+sEsuhvgj59+nhwC+fh3nvv9RK+O+64w9q0aePPk1Ums4YSIMEvrincF8hG0L8HlPJSqsf1NBrKcQQ86B8jW8+x3H777R6w4BjIehQEZRbS1IMXoqiMSaIuH3zwgddbk4LFUC6o2g8pXyLzGF7du3f3JuhEB4UZbhw4B0jK5sdYTWSYiswNiPciiIQlMpTuUBqHAlJ+QKWKEjjeP5wDbuIsRAVRV7p7amlbb6W3m1nAmDj//POsZIkM63RueTvrtApWsUJx+3vxVnv1nbX2/sdrrVatmjZ69Bh3unJno1qe3NLmzptrVYvVshqZe1gZK2sZttWW2iJbXGK+ZRXPdCME4yMvmMmA1GqkGRCRniSSXRIcy58z749ZZqF+49sifu1r1qzx9QiIUaIXQKkg5Y7BvBzU7ijzC6Ckj78ZWMg6GPFkCwMIUHB9Yco9PXuFhWN4/PHH/d5LwI6G5+AxqgAKksFQZkEIETUor2jatKkvNI8SyaC+k2ZJ6sLzO3CMC13Pnj3to48+coUdovQYbokYpQ/Kp4JZEmRHUqFJOzMz08aMGeMp7SOOOMKH7ZUvX94SHRrmC+LQMKAMp4BMGQZBUDpAnwAOSLl659n6dVvz/P//sklt7azTytuQR6q5kxBKm1Mr2Jz5W+zsi5fYCScca5MmTfZyBVi4cKEde8yxtnbZejs8q6WVt4pmIRVLu1k1a5DRxH7NnGodO3b0np9oGBdCpDM4KeEmwIe7Hx1xxBGeQaDfiYzBG2+84eIOlDoGYgG5Z7nwd/AcP3OrinGfQGAgWKewsB3uwUBGHmcIuC9RFlUQEu+OK4RICYhkEEEhTUsUBaWjF198MXtQW34cECIkpFI//fRTT9XmvrjHG4w8lCi+/vprT/OiHJMKjgLlOKS0MZJ5L7t165YUjgI1ubNmzfLyuPzCzZWGQz5zob03OIMYEJTJ5QW1wV26dLaTjy1nrz9VfRtHIWDPOqVszFvVrfxO66xHj+7Zj+MYr1q22vbf2sLKFwtfwleiWEnbN+tgq2a17ZKLL/FeCCFSUTo1FguQ/SWjESz0HOTFK6+84hl0yhS5HhCtJ8CQSAEspMjpiQjuwwR7gNKngg5VTJxXJ4RISaitJruAYhIlLPfcc4+tXLky39shckN2AVUYFIWo/UyEqDuSm9SFEmniNUYqIZvIkBZ/7733/HWhuPPggw9uUy6TyHz77bfe8xLNYXdImZIZW7tmbZ71zAwc/PvvJfbQnbtZyZLbb2KuWqWk3dK9ko0c+ZHXExMNZO7I7lsbWJliZXfoQNfPauJOM1kQIUTB4b5E9D1YuL/kRf369V2xD/Ui/o8MJj1qXPfJRgKT4kPh7+A5fiJPnPt6S4AjWKewkG38/PPP/XfKd8kmUMJLn1SXLl0KtM3kD30JIZICoh3UjyNNSbSa35FlzA9EtXE8yDAwpArlJRrJ4hHV4YJPA+vy5ctd6hXjNBWg14S6fSBLkozOD2UBzP6IJmSK+My+d+8n/ndm5n/NxBj6OIzsE5nc009pbnV3R30k71KlgI5tK9rN96ywoUOH/tfAn1nMalrdiI6nXLEKVqVYDXvm6WeyZzAIkQoUK17MijMiPQb7AfoQ8tuvUb58eV/ImpN55X5EOSEGP4Z60LOAQ0/wgv41oIyJYBn9VEg1A1PUCTwddthhUXldBHdC1ZuQeUUaORh8WhDkLAghYgYGF0ouGEdkGCgtym80hagqcqpEvGkYQ5KOaEmsZElJQXNxZxLzUUcd5dKc0da0jgeUh9GXwGuj34L61mQspaJ0igZl3pdow6Rn6pbXr95kq1avdvWvr776yhscySq1bdvamjSubtfes6sd0myFHdhkpTVtuNrKlws/xbh8ueLWbN8y9tdff7nhUbFEJSuVta00al5UzNzV/vzjzyi+QiFEQYcmFitWzINZffv2dcM8kE5F4SiYrkwGGrVASjoR7yArwQwSxAqioYQUXMtD70mUYxakJDOU5LsTCCGSGrIAQSQUYwuHoaDlTZQloezA4CccCNKvGHRFBaliou6knxkgxxTqZIeIFlEuanEZFsc5jdZNK9agKU5ULVABKQqK/a/jmLkH//zzm2dfggblZcuWWo1d5tqVXXa3LydXsRFjatpTr9azy86fY0cdFF7bvETxLO+H4H3I0c0c4bFk/C/DIUSqENpPUNT7yS+r/lemRFCCpmRENwgUBEMTGVKJ9DFy32QQCCQgehBqvBNowkFAQIH7Idug9yFa0EDNvfDCCy/M3kdhkbMghIg5RGAYTMOFlShNQQd6YbDRjMpMB6QkaaJu3769l6BEszSJY6R5mYwIqWMG7yRDo+/2wDil3pY6eyQBuWGhWpVIjXr5AbWiYEp2oHFe2OgcBgHNj+GaAncqs5PdfltOR7d27Tr2828/2+41Ntr5rRbY+a3MfpxZyR5/qb7VqrbR6tXJ2Yy8ZUuW/frHVjvkqFpehrQ+c61lZGVYiWJ5N1GHsq7Yam+0FELEhvbt2/uSF9zLyJqz5AVORrQGsIWDgXBsn+sgDduUIuE4BHMdCoKcBSFEXNh11/+mygYGWWFgKi4Ziu+//96jNvQ0UF8ejegyNadkQJjie/nllyf8fIFIHB9qaGmmRb2HGlZ0wMNNBk4WkOmlZviCCy7IoX9eUFASQRGFCCFO4cUXX2wHHnjgDv/vwgs729VXX2XzF26xOrX/izQ2b7zaS5JGj69uV104O8f6H3yy1hYv3eQ3cjJiKIcttgVWK4K+hc1ZG21p8UXW85IehXilQiQetBLEomchBruIC2QVWAgCcZ1H3pUyJPrPuNYUZDBbvoayEYmiC5wJngweQrKNBsUDDjjAhy+lyvChdBh+IkQiQKQeZ4EyomjVx1MD2q9fPy8NQdKuMCA1h6NAfSoZjGT/3nLtYSgQjg/RJqYSJ2NfQu7rKo7iKaec4lmFSOH+xQBBPi+UEJClQj2J/gGicmSnOEdffPGF32z33Xdfrys+68UZtnj1phzDzlAzobmZY2nadD8765QSdv/t1W3Kz7vYhMlV7J+lZeyai/6yA/b9T+8cNm7MtGPaLLKdKja3r76a6I+RIftu3Pd2UMZxLpG6PWZl/WiLS8+zhYsWhp1foqFsItnskuBYFsx5yCpVKhuD/W2w3fe8JSFee1FDbx/BlJ9++snLHvNLRHcJJOEGDBjgU0mp2aXLm5pWLq40eDCEiGYNaobxWArbSCGESA9I5zLghsnARO0LWo4UCoYfRh3bpQGZrEN+QRaPsqYffvjB+yuOPPLIqBxbPKHkCEeBZjyi8Klyc8SwJ2JGn0J+hswxLRUjm8wBDgP3OWqMKQfiPUeZhPf8hBNO8NIzMlY+ebXW2WYly9mKlSu87hinI3R2SMuWp9r6LLPr+po1rLfGWrZYbIc2X2Fld6In4T/Wrc+0DpcvthmzMuyLLx7NfpwyqiOPONJ+2jTRmmYebiWL/ZedCIX43hz7zebZ79b//v75HnQohEgPNm7caB988IFfI+mbYDhcQYUfInIWUB1B7onGPiIfQSNHKGQaOCBu0kR5cB6EEGJ7UHpB3wINY4yh5zoTDTAe6YkYNGiQOw35USv68ccf/VpHphSjmvrSZAbHhwwOESXKaTjHye74BBDRJ/vDPSeS18R9CuleHAP6W8LNjgjXQ0O086qrrvL72lEPf2FL1mz2ErfuXbtnSyjyGaPfg/995JFH/DO9X6OyVrVieWu4ZwXLzCxufy/eaq8MW2PPv7bO1qwrbiNGfJBDLpGG+Y9Gf2StzmxlkzaOsRpb97CatqftZGVtq221ZbbI/i4511ZuXe5DAHkNQqQaidzgnCyKTdjjBPLJHDMklADJMcccU+BtRuQssBPknrYHOq5cHJlAiSKFEEJE2rvAsBjUeJo1axa1xmEadml6JUOAMsWOILrMMdDITLqWZt9kN6rJjJC1wXmiKTvoE0kV0DgnehaoEe0InEcMcsqL8urR2N57TqCseLH/GsBLlijp5WnhYO4GTtljjz1iPe74wK7ptTT7uQoVylmnTl1cYpFAXG7oH5n24zRXR3lhyAs2Z+1vOY7t9FNO9/+l9FcIIXJDvwIlmdz7Tj/99LAB/iJxFkIdBRwBIm65L6hEY5ATJOXPhDshhIgUDCv6oZhGW9AJk7kpUaKEXX311f9FePfbz0uS8oLBakSDgcZWpOeSGUpjuFHQ8I0jRm9Csjs+4SBDQOQsktfGPWrp0qX5bub+dF6mLd3w/61967dmZf98/bf/r/2tWraYnbzH/ytJEcVjoScHaVqapemJQEpxRyVgOHePPvqoSzLSI4hTRNkv/YEE5sIxb94qW79+S/bfW7dmZP/89ddl2Y+XK1fK9thj54hfvxCxhubmmDQ4p2iH8+LFi6MuHZ3vzjYiOChF5L6Z0svAcwVpnBBCpDcYezgJNDpj2DLQJhpQz80QOCLKOARkC6hJZ3/Urv/zzz/2+++/ewMrdemdO3dOalUgoNyIUhskNckmpGpNO/chysUiVafiPSfwRVNzpH0sOAqnfZBzEnONTf/dOP/dZHbRpznvd6Nbl8zhMASTy1kKAlk2BjjtCByFtm3fyvHYvy1qmO1Uwv79d6NdeOF7OZ57773z5DAIkaJUrFjRFeJefPFF/8nwUmx2Js1z7QtXfhl1ZyEvTXTqYlNhiqkQIj7QfIUuNAYgGtXRup4geUl5JFmLN9980zMOXEyJSuMwkCml1wr1m2SG10Od6jfffGMdO3b0xtxUzCYQkOKm9+6772YrFkVKkyZNbObMmZ6aj4TQjEJRrB8tQjMKRbG+ELFEPQuFgyw9PXtk0ydMmOAZSpwF+vFQ90NOtcichaCRipsP46tDp6Ry8Ua3G5UkIYQoKNRZzpgxw5544gm/5kRrQBiRlLvvvtsNarSnkejDGUHVDechFWTxnnnmGZeyZoIxP1M1vT548GAv6SELlVfPQF6wPuoghRkEKIQQiQzXxr59+/o9NLQciQAS99aCELGzMHXqVP/JRXb69Ok5UvX8TtMY0TshhCgo1J/TvMlwKpqNKQuKFhiHBDlYyGKkAmj7ky1hFgDZEdTqknUC8/bgvvPVV1+5qhNlamROClIuRqks52zRokWafCxEgqLMQuHARg83IZrswrJl/9+/FHVnAVWGjz76yBus0J+m/ilVNLqFEIkFddpoQTOzBaM+kprtdGTWrFn29NNP+7X4/vvvt5o1a1qqgUIVZVU4CghoMNeAJt9wkJFCgIPUe173J5xR+hYGDhzoN04ajulVIdgVqWJIyYxN2T9r/D0hx3MPvmX2eMnYZyxoYvYehRAyy6Se0yiE2DFc1+jpyq0SR9CfXrYicxZIZRC1wllAYYOmOTkLQoiiAkOOTCW1lsw5OPTQQ3Wy/8fmzZu95vTTTz91eVjq71Mxm4BzQMkRZa4oGOEoMO8gN/Sd0L/A0CGauZnAjApWXlx77bUeeaPPbsmSJZ7Bwuni88bAuvwQOA4Bq9ebrbY4sVP4crpiGf8/DE4Ikfp06NDB5ZsZPBmIeSAJzjUOdbwicxao6+VizE2JdDBScKETK0MpyLRUIYTITYMGDdxApMaSGnWUjNIdDOGnnnrKypQp48PmCqqyk+gQASOjTZNe27ZtPSMQDnpQnnzySb8n0ZPC+aG5b3tQhhY6CI0bKw3TfM6Qzc2P5ODWEmVy/L1bGbNy8cos/LsxrKNQ7s+4uS9CFAhJpxYOMs0ETBDvINiy7777+k/KN++4446icxbYePfu3f3GjZcSTqouaBjLj3QqNz2WOXPmZDchUnrADQIuv/xy++yzz7y+FLnDI4880rMaodEf0s5XXnmljRs3ztehxpkLfujNhXpesiOkqTl5vB4mmYZCBKtfv34upUhKGqnF0GgmztGNN97o9cHUvJ5yyil+k0qV2mchEhFKRJjwPGDAAFu5cqWdddZZadmYyqTi9957z8tBOQetWrVKicbscBAFQ7GDa/n2FKqYmcDnAuMex4nrP/eKvAJZecHniXsOA/xee+01l9rdHgt2PznP5x4+uYR1bBT794U5CrnlUYUQ6Unp0qVdVRAxIqSiyaJSvlkYSfKInAWmn55//vk2d+5cn7CKAR8N7W6iYih38AJwNl566SWXTiSqhOOAocAkVbIVzHGg6bFly5Y2e/Zsv1HimJxxxhlWo0YNr2ulRosUC7WneFbAuqzDDYAbweeff26XXnqp1/di8AOSijgTpKKJODEMh+d+++237HkS119/vY0aNcrTOqTCcZyIeJHaEUIUHdSYE0QgUEANe/v27dPqdC9cuNCDGVwjiZ7nNZQrVcB4p9QqXNYER4Kb39ixY306Nc4E1/wgOMRNks9IQfZJ5op5G0KI+KIG5+iA7Rytap+I1ZCI3qBRzZAHGshIgxcWomOhUJ9MpmHSpEnuLOCkBOy5554uBUXUn0wEU6LHjBnjkoE4L0T4kW4lwkStFo4FNw4cAJo8iEAFhgfNckxrDZwFmt26devmzdvA/+AYvPDCCy5BtWrVKo900V2O9BRwHtgWx3r44YcX+lwIkagQcWWwC44z3794DC3jgsck5ttvv92vPwVt0komcA64tnHdIUhy7rnn5lmOk0pguB988MFe+ko2l9dMZAznANlTStLoYSATnDuzixwu06sLQpUqVVwpRLKqQohk44b/jTeIBGze/BLRnSf04hlNKcNQyBIQtedGcMQRR2zzPI9joGP4U0oEEydOtKZNm+a4YeAAUJZEyRFpF9Y56aSTcmyLdZBnBCJYU6ZMcUMkgGZB/of/BZ4nWhW6HUqhMGBYJy9ngXIllgC03YVIFvje4zDzGafmkYZaHGm+V0RzYy1yQKSZSDJGJE2qqQwBCqYwU2aJMhTnP50go9y7d2/P4BKYouSI3jmyxEin5uU04USShaZkDUWQ/DoLXK/pfwjuMVXL5q/kLb/rR4ty5UoV6fpCxJKsYsV8icV+UoWp/xtvsCMKWsYbkbMQ9BJQdrO9qOLvv//uHgtpciLykYAqBc4BdabUnA4fPjzHjZG+AGqWcRYYqIPBEhwD/QW5I0vB3zy3vXUw3GmOW7FihTsq4dYhohpsg33mvvmwTrCfcNA7QdmAEMkIgxYnT57s5T+UHeI8UNaHsc73/Lbbbot5lgGD8aeffrJUhos+A9a4DnIN4bqYjvK5Dz/8sJeC0q9BZjmSxmPWoXyVLPWJJ57o55CmZ0q5uIcEC0EinAOyycF2Ufsj281nO+iBOHmP4ja6dcmIJjPjKLB+PNhjj53tvffOi2gyM44C6wshUodx48YV6fYjchZo9qW056qrrvKhP6SIuWmT8sXYphSI0h6i+USCiOxHCg7AtGnTPJKGHCCZC9QsAoeBCBP7pB+hf//+Xq9MnwD7TnTIVoSmhnBQgoiVEIkOo+Epuwv6k4hI7LXXXtajRw83xlCPQSgAadNYgfGYWzs6VSCqTckR11LOa4sWLdKymTs0w0upZ37hHsQ9goUeBD4vOBt8Trn+4ojg5BKYotctKEcF7i84FswSQtSD7Fm8HID8IgdApApbs7J8icV+Upk//vjDS4iPOeYYD4YUpsQyImeBCM3333/vNzGagWkUptmZyDzRmaAsAcN+1113zdcBcNFGIhGICBHJ5EJNZA1oJmahCZpyH7bPRZ6Gaxqbv/vuuxzbW7x4sf/kueBn8FjoOtwEOHk0SrOEWyd0G0Sicqe2Q9cJB+nzaPR2CBEP+H6HazLlO0stOd9RHAdED2gOpWeoKGvqqVsnq4CEc6pBHxbOF9FssgmBsILIP1xzcXJZtndzJHgzYcIE7wcJ1sFBISiGyAXSg2TVUeEjQIbkqhBCJDrLly/3wAfZBq5tVP0Q6Ovatavb0EEPb37IV8iESBdZBjIBZBQoHaK+88MPP/RoTn4dhXCgdhFa5x8KF36W4HnKlyhjYrBOAGVKOAJBZoJ1UEAKhXWCvggMH5yU0HU4Bv4O1uF5FJZC1yHCST1xuP4KIVIByj/ymmrLd4xaeoQCEBtgWCN9BEHpXlH1TzRs2ND3lypwreH6SbkiRilSd3IUosf2omj0PlBGShCMz1cAQSSywpQj4Swwg4Fs+YgRI/w7IYSITWYhFksqcv311/u9Gxs1NMhx3nnn+fDKghBXaQ0uyOhb0yi8Zs0aT8EzE+GTTz7xOlOyGER9qlat6k4JMqtcyIPIIs/hFHTq1MnrW7nwM0OBiFAQ0UcylYgdfQ9dunRxyb23337b1Y4CKBWi/InoEbMViCpR1xqoI5HZwCNjPVLZGEqkqHEUpIQkUtnQCjWiwkFmkV4mtP/ff/9913amxyGaGQYMtOeff95TqtSSp0ppDtEf1N/4icpTkGEVsYF7CTLaOKEEv1q3bp3jee479DCwEJmj4ZzMFvetvJxoIYSINyiFYkfnrgygQoeqoIIQ12JMMgKUL9G3QKkTJUi8QHoU6En48ssv3THgJopHRCMaNaZB5I3yoZEjR/pPDPcLL7zQt3fPPfdk74N6VRwDsgnIPpJ+wfAIrVNl2/RD0MRNKQWZE7yv0KZnIqhnnnmmnXPOOV7/RfkRQ5KESFVwuPPK8uWG8g2MLZwEBodFC2QwCQRwgSP6juOeCiC5jAgE1zJmwshRiA8Ee3gfKG2lRycvuMnSp0M5Kqp8O3KihRAiXhDsDlc2iVJcQUvji2XpqhczqJHF2KGZO9ayk0Lkl6FDh3qZHiPiI4UyJDILlHAUtiyRCxuOAn1C9EYQCU52cH4o2WJmAFHt0CnxIn5Q20vwh6DR9m6mQRaIBnRllUUqkEh2SXAs8/8dYJUqFf31fvXqDVZntxsT4rVHE4LslM+TiSfITkYUldIOHTp46StiQkWWWVi0aFG+Ny6ESF5otqWpPz8wfwTBA0oIC8P8+fM900dTVs+ePVPCUZg1a5aXsGBwUlIpRyFxYMgbzi39I9sDZTDKkhiWJ4QQiQhBNsomKfMnG0oZPkOVEXQgmFcQInYWaPSip0AIkR4ceOCBrjaGlGR+QKmMMhv6jgoC5SCUHKFmw2T1ZJ9aTCSH5lhUjuizwmGIpdysiKyMjt43Sla5ue5I6AOBC5w+IUT0UYNz4cAxIDjFtapNmzZelkRvITN8CioQEvFdmHrNyy+/3Gs7kUzUzU6I1IaoPlPLaVomyo9BFQk0hp566qn26quvurpPpA3JGF/8DylTBAfoDUp2aJwdPHiwl1RxDlN1RkQqQN8IpQgo7JHCzwucVxzASL8PQggRayjnomQyWkR8tUN7mps4N3QUiHaUrhVCJD/t2rVzgze/ZRdEMxAwoBxpR21RqB198MEHLsWKygwiBKngKNCXwDBLFKMItshRSGxwapFTRTFvR305CFxEQypcCLEtGdwXYrCwHxEZ+crvc7PjQooUKSkNpmvmLhHgBimESA1QJaMUCAMeY4rabpqedwQ9BrfddpsbyUzSpYyR1CjqP0RkKfXAmVi6dKl9++23rmiGs1CQib2JxpYtW3xyMJPokV8mFSySA1T5aKZHpjecQlWQ/WImhhBCpAv5LgZGwhDVCKIqRA+TvZ5YCLF9MPIxoJjc/u6777pBReMUDdDbo1atWi45TH33jBkzXBaZhumMjAy/buA4ULLEtnBCUuFa8vfff/vgShwiHKXtTXgXiQf3NaS0URHBWcDJ5T0k+xVkwHgMCW0hRNEQq4FpqTqUrSjIl3Qqtcs33nij1zHTt8CNXiSnRJkQ+YVLxc8//+wGE0EDDCYch1Qw8qNxblCaeOmll/ycYHDqvCQvZLwou+XzTr8J5XFkv5i3QFZd/QoiVUgkuyQ4ll+X9bOKMZBOXbN6g+1T5aaEeO2JTsR3eRoWUUahBInBZ0KI9IIypKZNm3qmgcGFZBqYFIlhfMghh6TMZOWCzE5gCjCGJRkYhj+K5IZAGE4fixBCJBO9e/e2Ll26+GyFmDsLlA4Qack9PloIkV7gFDBLoVmzZvbFF1+4oTxnzhxr3769pRt//vmnlx0x7Z3ZCQyQE0IIUXBUhlQ43n//fS+Dpby3a9euXgVQ0MnN+VZD+vTTT+UoCCGyoSyDyCvyqFwfyDakU9kRmvx9+/b1c4DqkRwFIYQQ8YZ78eTJk72/imw3fVdXXnmlP1ZQJBQthCgUtWvXtjPOOMM++uijtDiTGzdu9GzC6NGjXceaib6qYRdCiOigoWyFh+z/448/bosWLbIhQ4bYggUL7KijjvKKgMcee8z7NPKDnAUhRKEh3UnN/oYNG1L6bKJ2RD0ojXikecPJawohhBCJkgVHzhu5cn5H8Y3e4zp16vgcpEiRsyCEKDSU4FSsWNFVklIRLrKTJk3ykisiM7169XLVDiGEENElIys22QX2k6pMmTLFrrnmGqtZs6Zdf/31nmmYOXOmz//5/fffPdh17bXXRrw9aR4KIaLW9ExN5D777JNyMpovvviiNzNfeumldvjhh8f7kIQQQoiwoFrIpPmWLVt6CRKlsvQYhnL++ed7P0OkyFkQQkQFlNK++eablDmbDOGiD2P48OE+sbd///6ePRFCCFGE197/LUVNLPYRD1AmRDqVfsK8qFKlimVmZka8TTkLQohCwQVnxIgR9uGHH/oFKhVg6jSSsJQfoXSUatkSIYQQqceWLVts6NCh1q5du+06C/lFzoIQosCsWLHCBg8e7D9p/N1zzz2T+myuXbvW3njjDc+QnH322Xb66adrErMQQsQQzVkoOEybR7Ev2qjBWQhRIBjEdtttt9luu+3mzVLJ7ChQcoQU6g033OCOz0MPPWStW7eWoyCEECKpuPrqq/0exn0tWiizIIQokKNw77332kEHHWRXXHFF0s4ZoMwI1YjXX3/dG8C4yDZv3jzehyWEEEIUCIRGPv/8cxszZow3O5cvXz7H8++9916+tylnQQiRL1AFwrBu0qSJ/fDDD+4s7Lvvvla/fn2PZGzatMnKli1rVatW9SYqMg6lS5dOmDKjJUuW+DJ79mybMWOGLVu2zOs7jz/++G0UI4QQQsQWlSEVXsr8nHPOsWgiZ0EIEXEUnkbmYcOG2cEHH+zj43ECMLqnT5/uTgR/77TTTm6AT5061RYvXuz1kzgWZCGQHeX5WMGUyu+//94bllmQQa1QoYJVq1bN9thjDzvppJPs0EMPtXLlysXsmIQQQoiiAqnvaCNnQQixQ8gYPP/88z6l+fbbb3c5UVSCOnToYIcddphPMsZBmDVrlkfty5QpY3Xr1rV69epZpUqV3HH45JNP7JVXXnEZ0pNPPtmN9aJgzZo19t133/kQNbSmObb99tvPWrRo4dmP3ClZIYQQiYMyC4lHsSzChSImrF692qe+Eu3EgBIiGaB059FHH7X169fbTTfd5OPikUv94osv7P333/ffS5Ys6c4CDkKNGjU8es/n/JdffvEG6LPOOssj+GQfxo4daxMnTrTrrrsuqv0BHAc1mmQ+kIw74ogj3JFh/0IIIRLbLgmO5fNF91uFSkWfgV67eqOdWOu2hHjt0eadd96xt99+2+bNm2ebN2/O8Rzlw/lFmQUhRJ5QRvTwww9brVq1rGfPntklRDQ0n3DCCXbcccfZtGnT/LHGjRt7r0Io9C9MmDDB06I//vijXXzxxXbZZZd5WRIOCFkKIv+F5a+//vLMByVPjLZn+0IIIZKPjKwszy7EYj+pyOOPP+73Vu63BPQuueQSD9TR+IyIR0FQZiFNPXghdgQ1/gMGDLBjjjnGOnbsWCjFo+XLl7tzQCLz5ptv9s//qFGjfEF2lWxFQSDbQfSELAcj7VkSpZlaCCESnUSyS4JjGbPwPisfg8zCutUbrWXt2xPitUcThogy9+j888+3ihUreqBur732srvuusv+/fdfe+KJJ/K9zeTUOxRCFClff/21Pfjggz42/sILLyy0NGrlypX9QsXP/v37ewaAgWfNmjWzgQMHbpMmjQQuenfffbfNnz/fHnjgAVd/kKMghBDJzdYYLqnIvHnzvDcQyPbTxwedOnXyoaMFQc6CECIbIv9oML/wwgveU4BaUDQnS5ICxaB/7LHHLCMjw7p06WLFihWzZ5991vcdKQsWLPDICQ3LDIarWbOm3kUhhBBpT40aNTyYBgiJIPYBKBcWtE1ZzoIQIruk56mnnvKSnj59+hTJcDIcBaYkk/Z9+umnvTGav1FRevfddyPaBgpHZBSOPfZY69atm2YjCCGEEP+DfsIPPvjAf6dfgT4+FAjPO+88O/vss60gqGchTWsDhQgIlI2o/a9Tp45H/xnqUpTwHcAh2X///e2iiy7yTAEOQOfOne3oo4/O8/+YmTB48GBPp3JBFEIIkRp2SXAsHyzoG7Oehda735EQrz3a9/RApRDefPNN++abb2zvvfe2yy+/vEDlulJDEiKNQdqU2QcbNmywrl27+rA1yoKKGm4IlA/hMNCA1bZtW+vRo4f3LzAgjQFuuRk/frwNHTrUrrrqKjvkkEOK/BiFEEKIZIMew9A+Q+YhsRQGOQtCpCGoE7322muuktCmTRs77bTTvKcgllStWtVuvfVWu+eee3wuQ8uWLX0qNEoNN954Yw75U+RXX375ZZdvZcCaEEKI1ERD2fLPTz/9FPG6CIskVc8C9dEcNOkfFoYojR492p+jOaN79+7WqFEj7+amSePaa6/1dFHuru8zzjjDo5HVqlXzoVFMmw2FEosDDzzQp8qi6U50MjeUNuy5556uI88gJybAhoJ6C+UZqLlg2KC8gga9EMmodITRTYoSZaLWrVvH3FEIoOyJ72yQJmVwGzWWZBjoY4A//vjD5zTQcC1HQQghhMgJJb0HHHBA9s/tLUmXWdh9991dnpE6Kjq0X3rpJY9yTp061f9etGiRGzP77ruvzZ0716644gp/jMl0gJoKjgKd3xgaf//9t9c/Y/jcf//92d3frMP/Ekn9/PPP7dJLL3X1lFNOOcXXeeutt7zJkoZLHAX04HkOnXkcEKBBBE14psNSQnHNNdd46QSGlxDJwieffOKfd0p+uKgkAg0bNvTj4XtXvnx5n+vAMDeGweGgM2ytXbt21rRp03gfqhBCiCJGQ9nyD7ZuADY0AUECcQThYeLEiT43iftqSjQ477bbbtavXz+vn84Nhjqa7+vWrfOoKFmIM8880x2I6tWr+zoY/LfccostXbrUmzj4HSP/559/zt4OtVsrV660jz/+2P/GQaAGOhhUQWMIEU8yG5RJkM2gZOL11193oyVQZGFiLW/A4YcfnnSNRCL9GDFihH8XGIqGg55o4PDjGPCdw4H48MMPXRMa1SOmPseil0IIIdKJRLJLgmMZNu8eKxeDBuf1qzfauXvclRCvPZqQoacfkFlGoXz00Ud255132pQpU5JXOpUsAaUIOAKBJ5Sb4A0NOrwx1Ik2Bo4CkBHgAzdjxozsdXJrxbMOjwPDoDhxoevQGMLfwTo8v2XLlhzrMCGP0qhgnXAQHeVYQhch4pVRCC4UiegoAENkmDhJ5IPyQqYxM7KewIEcBSGESK+ehVgsqcj06dOtXr162zzOY4iaFITiifCi6AGgn4BSoeHDh3vZUW6WLVtm9957r0cYA/75558cjgIEf/Pc9tbBcEcBhu3iqIRbJ3QbZClyy0mGrhMOpsriJQcL2QohYg2OM444aUkc3EQGLWiiIZQn0oRNj0IQHBBCCCHE9qHqBfuTYHgAv/MYzyWls0AD87Rp0+zbb791JRR01nN7Phj29B3gRJBaSRZ69erl2ZBgmT9/frwPSaQZK1assMcff9x7eSjtSQb4npNhDEbUCyGEECIyKMenmoC+YCpiWPidx3iuIMQ9ZEfEHoUiQFt98uTJ9thjj9kzzzzjj2EwnHrqqa7FTtYhVLWFxubcqkWBQhHPBT9zqxbxN+VMqCyVKFHCl3DrhG4Dr4w+h9DsQug64SBbwiJEvEAMAOP7+OOPT4o3Yc6cOfbII4/40DXUyYQQQqQX6FlujdF+UpFDDz3U/vrrLxf1ob8WmN7csWNHFxFJysxCbmguptY/yCigvY5DwehqZE1DobeBMqYlS5ZkP/bpp5+6IxCUMrEOCkihsE7QF8G2cVJC1+EY+DtYh+dxUkLXQSmJuuq8+iuEiDcLFy60r776ys4991xLBmbOnOmlhogW5O4zEkIIIURk4BRQto8MOUu3bt0K7CjEPbNAmQ7DoKijJoOA2hAzEUiVBI7C+vXr7dVXX83RIIwyEdkAnscpIApJUyT9A3fccYfLLQYRffogUDlCAaZLly42duxYe/vtt10VJgDZVMqfmF6LR4aEI2UQ6L0D/QY0WbIeak04Iygl4ShEqoQkRCxZu3atXyD4ftWqVSvhTz4iAnxP+R4ed9xx8T4cIYQQcUJD2QrP77//buPGjfNgOgHwUO66667kchZ4EdRSMx8Bg5wBbTgKNDniNNDHAEGZUqieLCUKOAwjR470XgcMd7wmjA0mwoZ2f+MYMCeB8ibqtpBnDGYsBOkZpFY5gTgc6M8jqxra9ExpBCpJDGMj88H/P/nkkzE5T0LkBxr26VOgRK59+/YJf/KYzszQtauuusoljIUQQghRMJ577jm3i6tUqeJ2QKiaIL8XxFlIuDkLqUwi6RmL1IXhhogEIAZAX04igyP/3nvvedZO05mFECJ97ZLgWJ6b3Ttmcxa61bs7IV57NKlbt64H35gzFi3i3uAshIge9NUw3Iza/0R2FIhRMEmaNCmzFPbaa694H5IQQgiREiqI50a5VzHhGpyFEAWfp0B/z3XXXWfVqlVL2NNI/eSQIUPs66+/tt69e8tREEIIkU2GxWYgG/tJRc4991wbM2ZMVLepzIIQKQC9NvTk0ANU0KErsYBJ6IMHD7YFCxZ4mVTlypXjfUhCCCFEytCgQQO78847bdKkSda0adMcIwfg2muvzfc25SwIkaQwzJDoPHWeyPgeffTRCT1PYePGjS4UgNIYDVapVCMqhBAiOkgNqXA8++yzVqFCBRs/frwvodDgLGdBiDQBBwGpUZwDMgkMLmzevLklKjSQ9e/f32el0KOQyP0UQgghRLIye/bsqG9TmQUhknQyc6NGjeyCCy6wZBgOxxyU+vXru5xb7pSoEEIIIRIXOQtCJBmUHJFafPDBBy0Zmq4pPWJ2Ck1XzCoRQggh8mLr/5aiJhb7iAcMIN4eL7zwQr63KWdBiCQCyVEUjzC+a9asackwbE1TmYUQQojYSafmFhb5+eefbeXKlXbCCScUaJtyFoRIIn766SebM2dOgRqUYunQUCbFNPYbb7zRmjRpEu9DEkIIkSSowblwDB8+PKxkOWXAlAMXBNUECJEkZGRk2GuvvWZnn322Kx0k6jE++eST9uWXX7o0qhwFIYQQIr5QAnzDDTd4WXBBUGZBiCSBsh7SiZQgJWpGYejQoTZ37lyfIL3zzjvH+5CEEEIkGRn/G5oWi/2kE3/++adt3VqwTg05C0IkAcwoGDZsmNf/lyyZmF/bDz/80KZMmSJHQQghhIgTZBByB/L+/vtvGzVqlNsQBSExrQ4hRA4++ugjq1q1qh166KEJeWYmTpxo77//vk+N1FRmIYQQBUU9C4Vj6tSp25QgYT8MGDBgh0pJeSFnQYgkGMBGROCmm27y6YuJ2HTNxEiarvfcc894H44QQgiRtowbNy7q25SzIESCQC0hC1OOQxuG33zzTdtnn318STR+/fVXb5jq2rWrHXDAAfE+HCGEEEKY2dKlS+23337zc8EQV7ILBUXOghBxZtq0aTZy5EhvPtq8ebPVrl3bGjRoYLvvvrtHCJA8Q4I00cCxGTJkiLVr185atGgR78MRQgiRAqgMqXCsW7fOunfvbi+//LLbD1CiRAm76KKLbNCgQVauXLl8b1POghBxZPr06fbYY4+5wX3xxRf7lxin4Y8//rAff/zRB6igfpSITc2ff/65X4hOOeWUeB+KEEIIIey/Bufx48e76MhRRx3l5+Srr77yUmECj0899VS+z1PiWSBCpAkoFKBw1LZtWzvjjDOyH99tt93skEMOsURm7dq19u677/qQl0R0ZIQQQiQniHtujdF+UpF3333XB6Med9xx2Y+dfvrpVrZsWWvfvn2BnAUNZRMijvX+ixYtSti5CTu6GDEJUn0KQggh0oGMjAxX/KtXr54b3twDmSlE4C+ACgGESEKXU089Ncd2/v33X7vgggusUqVKtssuu3jPHwG4aLF+/XqrXr36No9Xq1bNnysICgkKESc++eQTO/HEE3M0NCfLcDhSnFwkhRBCiHToWXjooYc8Kv/SSy/ZfvvtZ99//71dcsklPoCUEp8AnIMXX3wx++8yZcrk2A6OAnMPPv30Ux+0yjYuu+wye/3116PwqsyOOOII6927t/csBPbFhg0b7O677/bnCoKcBSHiwPLly+2HH36w/v37J9X5Z54CF8GePXt6I7YQQgiRDnzzzTfWpk2b7LJhpMLfeOMN++6773Ksh3NQo0aNsNuYOXOmffzxxzZ58mQ7+OCD/TGajikTwh6oVatWoY+TPkh6CRFJad68uT9GDySOA0HKgqAyJCFiCClApFBvueUWO/LIIz0tmCwQRWGeQo8ePTyqIoQQQkSbjKz/zy4U5cJ+8sORRx7pwh6zZs3KNsBpHD7ttNNyrPfFF1/4vR25Uvr6CA6GBtwoPQocBTjppJN8cNq3335r0aBJkyb2+++/2wMPPGD777+/Lw8++KA/VtB7tzILQsRQ87hfv35WoUIFj8xzIUkWuCgOHjzYrrrqKr/wCCGEEKkAg09zZwZylw7Brbfe6usy8wgpUnoY7rvvPi8rCi1BQrSEvgaUDW+77TZ3JnAS+J9//vlnmyAhIiEIm/BctEBZsVu3blHbnpwFIWLA7Nmzvd7xsMMOc61jLhrJwowZM+zRRx+1Sy+9NOFVmoQQQiQ3RP1LxLBnoU6dOjkep96/T58+26z/9ttv22uvvea9BUTomZF03XXXeelQ586dfZ0OHTpkr9+0aVNr1qyZN0KTbaBHMRaQyahcubL/Pn/+fHvuuee8Z6FVq1Z2zDHHFGibchaEKGKIFuAoUJPYunXrpDrf1FcOGDDAG7ACvWYhhBAiVcCgRpkoIFxWAW666SbPLgQOAc7A3LlzvdwncBZys9dee1mVKlV8dhLOAr0MS5Ys2WbAKQpJefU55GduEw4Br2fvvff2kmcyHQxpo8zpkUcecUnVs846K9/bVs+CEEXIihUrvFbw6KOPTjpHgbpMGq46depU4GiEEEIIkcjgKIQueTkL69evd6M7FKoEginJ4ViwYIFH+mvWrOl/o0a0cuVKmzJlSvY6Y8eO9W1QeVAYbr75ZndgUCxkxsKZZ57pzdirVq1yW+Tyyy93e6QgKLMgRBGxceNGzyhQ33j++ecn1Xn+7bffvL+CCMrxxx8f78MRQgiRJsS6DClSWrVq5T0Ke+yxh5chTZ061QYOHGhdunTx55mVgDzpOeec41kCehYw4Bs0aODqRNC4cWOP9tNP8PTTT7t06jXXXOP32sIqIaGwhONB6RMqSAiS0GcYODjdu3e3ww8/vEDblrMgRBFAlAA9ZpqZqfXPHY1IZEhlkq7s2LGjqzQIIYQQ6c6gQYN8KBsGOKVEGPdE6++6667sLMNPP/3kcxjIHvB8y5YtfSZRaLaCvgccBMqSsA1wLh5//PFCH19oKRO2R/ny5W3XXXfNfp7f16xZU6Bty1kQogigLpBaxnvuuceVDpJJHhXVIyZKtmjRIt6HI4QQIs3YiuEdo/3kh4oVK7rYB0s4mOocyRwDlI+iNYAtN0yM3t7fBSV5rBghkgRqEblgkI4MbZpKhoEzqCYQNZHqkRBCCJFcXHzxxdlZDEqhr7jiCs8wwKZNmwq8XTkLQkR5lgLlR5QeMT0xGcjKyvKx80yiRAYumPgohBBCxJqM/w1Ni8V+UonOuRSZLrzwwm3WQbq9IMS1kBqjikaMoAOdLvHRo0dnP09zBh3dPEcqhRqwcDVaDMRgHabiUT5Bk0ko1JChRsOoa/R0H3744W22M2zYMG9EZR26yT/66KNtDCrq0uhoJ9VELTfT8IQIlT9jzDpTHvksJwMMmKFBa8SIET5VWo6CEEIIkXy8+OKLES1J5ywQeUXGibINaqVPOOEEa9OmjQ+BCmSq6BpnAl5e4CiwPpHRkSNHumTUZZddlsMYosGkbt26vh8UXhi2gSMSWn6BWg2OBt3taNCy/Pzzz9nr4GDQgEL3OiO5SevQ3U6aR4igaYnGZqRGkwE+6yg10JQVqDYJIYQQ8YSsQqwWERnFsgiZJxA0fmDQY7gHMPkO+UZ0YskehA6M2nfffV0u6uCDD/bHPv74Yx9+hbYtnehkL26//XYfjFW6dGlfh6EaRFJ//fVX//u8887zoRU4GwHIS+2///7uHHCK2NaNN95oPXv29OfRra1evboNHTo0x8S+7YHjsvPOO/v/JlMtu9gxOJDU+yOrxucikcHBxbHBSSZtSdYtWk1QQgghkodEskuCY+n6c08rXTH8rINosnnNJhvSpH9CvPZEJ2H0HDMyMnzaHEZ7pCUcEydOdOchcBSA8iCkqDDegnUYKBU4CkBGAB15nI9gndwSkazD4zB79mx3NkLX4QPNAI1gHZG+kIEiU0VGK5EdBbIeONZk6hYuXOhZPb4bchSEEEIIkbANzmi64xwQ7UQXdvjw4Z4tiAQM+GrVquV4DJlKshM8F6xTr169HOsEBh3PoTvLz9xGHn+HbiP0/8KtEw46z0O7z/GaRWrxwQcf2Pvvv+9lbIceeqglIhs2bLDx48d71o2+CiY64gwn0+wHIYQQ6QHlQcUTcChbOhN3Z6FRo0Y2bdo0TwOhTU9ZBIZNpA5DIvPAAw+4fKZIPShNe+utt7xEjsZ3emISKUtHtoAR82PGjPGJjjTmt2/f3h2aZJr7IIQQQoj4EnergfIgRmHDQQcd5GUSKMo888wzO/xfJtUxRS8UIqehU+z4uXjx4hzrBH/vaJ3Q54PHMLpC16GvIS969eplN9xwQ47MAmpMIvmh/GzcuHHeLB/6mUiE43r++ec9m0DmgBI9mpgbNmyociMhhBAJjzILiUfcnYVwddWRDo6gfAk5VVSOcDSAKCrboJ8gWIcG5y1btlipUqX8MZSTyGgEY7BZ5/PPP3eN+QDWCXonKGPCYWCdwDnA8Kcv4sorr8zz+BiMETriW6QG9LrQ2M4shURyFOitoXeCoWp77bWXf97VtCWEEEKIpHUWiLyfdtpptscee9iaNWt8/DVlHcG4bPoBWP7444/s/gbGbbM+fQmNGzd2adVu3bq5ahEOwTXXXOPqRKgXQceOHb0UCHUldORpRiVz8cgjj2QfR48ePezYY4+1AQMGeD03jdZIuQbyqpR04Ej07dvX9t57b3ce7rzzTt8HEqsifaC3hs/JgQcemHA9Cm+//badfPLJmr4shBAiadkaI/Ud9iOSwFmghIhpcn///berCzGgDUcBgwdwAEJr/lFuAYZKMNIakIDEQTjxxBO97OKcc87xeQgBbJe67auvvtqzD1WqVPEa89BZDAzRwlG54447XCkGhwBp1SZNmmSvQykHSk38H9mMFi1aeMMoQ9xEekAvwKBBg/w9J6uQSKDuNWvWrO1muoQQQgghkn7OQiqTSHrGIn/wNaEXgCwXziZD+RIFsnLIoDJ9mSZmIYQQItnskuBY2v14vZWKwZyFLWs22TvNH0mI157oSDtRiAgYNmyY/fTTT55hSiRHgeGDlMRVrlzZp58LIYQQQqR0g7MQiZZRQNKXxnnK1DDKE4WpU6faE0884TMT2rVrp7kJQgghhIg6chaE2MEshQkTJnj0vnbt2glzXKNGjbJ3333Xm/vpuRFCCCFSRTq1mIayJRRyFoTIwyCn6f2bb77xjEKgrhVvNm/ebEOGDHFVLxwYJFKFEEIIIYoKOQtChHEUXn31VZ+jgUEeDOWLN6hwDRw40I8PGd9gTogQQgiRKiizkHjIWRAiFyNHjvRJyL1797bq1asnxPmZM2eO9e/f32eLUHrE5HMhhBBCiKJGzoIQIZBNGD58uJceJYqjwDE988wzPgCwVatWPiRQCCGESEWUWUg85CwI8T9+//13HwTIkL9E6AXIzMy09957z0aPHp09VFAIIYQQIpbIWRDCzBYvXmwDBgyw8847LyGM8g0bNtiTTz5p8+fPtz59+lidOnXifUhCCCFEkbOVicEx2o+IDDkLIu1Zu3at9evXz4444gg79dRT434+mCbJROaKFSt6I3OFChXifUhCCCGESFPkLIi0ZuvWrfboo4+64lGnTp3ifTi2dOlSu//++61+/fp2xRVXWMmS+ooKIYRIHzIsNnMW2I+IDFkiIm1BgvS5556z9evXW8+ePeM+AXnBggX2wAMP2CGHHGIXXXRR3I9HCCGEEELOgkhbUD365Zdf7J577rGddtoprsfyxx9/2MMPP2wtW7a0c845R4pHQgghhEgI5CyItOSrr76yUaNG+SyFeA43Q/EItaN33nnHm6sToWdCCCGEiKd0qsWgDMn3IyJCzoJIO2bOnGlDhgyx66+/3vbYY4+4NlYPHjzYFi1aZL169bKGDRvG7ViEEEIIIcIhZ0GkFRjmAwcO9GbmZs2axe045s2b58eBJCp9CuXKlYvbsQghhBCJgjILiYecBZE2rF692vsCTjjhBF/ixcSJE72x+swzz/SpzGpkFkIIIUSiImdBpAWbN2/2oWtMZqY3IB5kZGTYm2++aePGjfMp0QceeGBcjkMIIYRIVJRZSDzkLIi0kEh9+umn/XdmF8Qjkk9WY9CgQbZy5Uq79957rWbNmjE/BiGEEEKI/CJnQaQ8I0aMcGlSjPTSpUvHfP9z5szx/oR69erZDTfcYGXLlo35MQghhBDJQEaK7ScVkLMgUprJkyfbhx9+aH369LGdd945LhKtKC/Rm9C6dWvNTxBCCCFEUiFnQaQsKA5RfkTpUawlUulPeP311238+PHWo0cP23///WO6fyGEEEKIaCBnQaQk9AjQ0HzGGWfYoYceGpf+hFWrVlnfvn2tRo0aMd2/EEIIkcwNzvQaFjUZGsoWMXIWRMqxfPlye+SRR1z56Oyzz47pvtWfIIQQQohUQs6CSClmzJjhUX1kSS+++OKY9gh88803Pj+hTZs2vsRy30IIIUQqoMxC4iFnQaQEW7duddWjUaNG2UUXXWTHH398XOYnXHvttXbAAQfEbN9CCCGEEEWJnAWR9CxcuNCefPJJdxh69+5te+65Z8z2vXbtWs9k/Pvvv5qfIIQQQhQSZRYSDzkLImnJzMy0Tz75xN5++21r2bKltWvXzkqVKhVTtSWaqOvWrWt33323lStXLmb7FkIIIYSIBXIWRFLyzz//2DPPPGMrVqywW265xfbZZ5+Y7n/SpEn27LPP2plnnukzFOIxFVoIIYRINbZmWYzUkIp8FymDnAWRtNmE4447zh2FnXbaKab7f+utt+yzzz6zq6++2g466KCY7VsIIYQQItbIWRBJAUb6Dz/84E3M9AncfPPN1rhx45gew5o1a7w3YsmSJXbPPfdY7dq1Y7p/IYQQItXJMLNYBP0zY7CPVCGutRNPPfWUNWvWzCpVquTLEUccYaNHj85+fuPGjR69rVy5slWoUMHOOeccW7x48TZ14wzeol68WrVqdtNNN3mjayhffPGFS2mWKVPGGjRoYEOHDt3mWAYPHuyNsUSpDzvsMPvuu+9yPB/JsYjoQyryyy+/9AzCCy+8YIcffrg9+OCDMXcU/vzzT7v99tutZMmS3sgsR0EIIYQQ6UBcnYXdd9/dDb8pU6bY999/byeccILr06OVD9dff719+OGHNmzYMBs/frwtWrTI2rZtm0OyEkdh8+bNrnH/0ksvuSNw1113Za8ze/ZsXwcpzWnTptl1111nl156qZeyBFBWcsMNN7iSDtHr5s2b2ymnnOIR5IAdHYsoGvgs8L6efvrp9thjj3mPQCzLjnBWPv30U5/EfPLJJ/vnRI3MQgghhEgXimXFooskH+y2227Wr18/V7apWrWqvf766/47/Prrrx5RnjhxokeYyUJgPGK4V69e3dd5+umnPQq9dOlSK126tP+O9v7PP/+cvY8OHTrYypUr7eOPP/a/ySQccsgh9sQTT2SXvNSpU8e6d+9ut956q61atWqHxxIJq1evtp133tm3RyZF7BiGnPE+du7cOeani2zSkCFD3GHhsxDrbIYQQghRlCSSXRIcS+1vLrPiFUoX+f4y1262hUc+mxCvPdFJGAmXYLDVunXrvByJbMOWLVvspJNOyl4HxZs99tjDDXTgZ9OmTbMdBSAjwAcuyE6wTug2gnWCbZCVYF+h66Bsw9/BOpEci4g+lJNRDsbnIR6zG+68805bvny53XfffXIUhBBCCJGWxL3Befr06W4MEsWlF2D48OG27777eskQEeVddtklx/o4BshmAj9DHYXg+eC57a2DQ7FhwwaX3sRRCbcO2YNgGzs6lnBs2rTJlwD2KfL32aDkiD6TWMuiktHAOWzfvr2VKFEipvsXQggh0nkoW/EYFL1kJlZhTUITd2ehUaNG7hiQBnrnnXe83ISegFTggQce8GFdomAEJV6xmmFAJuO1117zhuorr7zSDj744JjsVwghhBAiUYl7GRIReyLH6NVjXNNcTCNrjRo1vESI3oJQUCDiOeBnbkWi4O8drUN9WtmyZa1KlSoeOQ63Tug2dnQs4ejVq5c7QcEyf/78Apyh9IS+Ecq/6CeJBZQbIYdKNomyIzkKQgghRHwyC7FaRJI4C+GMREp3cB5KlSpln3/+efZzv/32m0ulBjXs/KRUJVS1COUaHAFKmYJ1QrcRrBNsA2eFfYWuwzHwd7BOJMcSDqRaA1nYYBGRQXkYpWl169Yt8lPGZ+i2225zdS4yQblL0oQQQggh0pW4liEReT/ttNO8UZiBV6gNMRMBWVM64rt27epSlSgkYWijSINxHqgPtWzZ0p2CTp062cMPP+z9A3fccYfPQ8BQhyuuuMJVjhji1aVLFxs7dqxP/0UhKYB9UP5ENPnQQw+1Rx991ButL7nkEn8+kmMR0YX3kqwPTlpRQa/Ke++9Zx999JG//0yEFkIIIUT8yMjKikk/QYKJgSY0cXUWyAhcdNFF9vfff7tBzoA2HAX07OGRRx7xenUGoJFtQMWICboBlA+NHDnS68sx3MuXL+9GH+UkAfXq1XPHgDkJlDcRPX7++ed9WwHnnXeeS60ynwEjdf/993dZ1dAI846ORUQXSryKMsJP2RFOJNOgySbgsAohhBBCiASfs5DKJJKecSJD+RHOWc2aNe3iiy+O+vYZAPjMM8/4bA2c1VgOeRNCCCEShUSyS4Jj2eXLrlYsBnMWstZutpVHD0mI157oxF0NSYhQyOzgKFSsWDHqE7JpUqfUDbUjpnjHY36DEEIIIfJmK5HsGJwgRcojR86CSBgYpIejQO/A+eefH9X5BpQ10YtSsmRJu//++9XELIQQQggRAXIWRMJAbwlN6wxCi3bZ0dNPP23HHnusOyE4DEIIIYRIPJA0LaYG54RCVpNIGFDEimajMRK4w4YNszFjxli3bt2kXCWEEEIIkU/kLIioQJ88EXx6DojgF6RZCGeBXoVoNUoNHjzYli1b5upYtWvXjsp2hRBCCFF0KLOQeMhZEIUCGVkmUxPBnzt3rkvTvvPOO9aiRQufocHfOAE4EfQN8BPZ0gMPPNCH3SFHCwsXLvRBbNHILEyePNmGDBli++yzj917771Wrlw5vctCCCGEEAVAzoLIN1u3brWJEyf6TIy//vrLypYta8ccc4xde+21PuuCydbMqbj99tt9qNr69etdDo25CTVq1PDswYsvvugORuvWrf1/PvvsMx+KV5jMAo7L0KFD3VlAcvWoo46yYsVioakghBBCiGigzELioTkLaapnXNDjZwI2PQDMJjj11FN9VsEuu+wS1ijndZItqFat2jbR/S1bttiECRN8ejLUr1/fzj77bJ+tUBAYqjdw4ECf3I3TwqRtIYQQQiSHXRIci31xcczmLNhxQxPitSc6yiyIHUKJ0OjRo+2rr76yvffe22cUMOU6KCHKC770/sUPAxmHE0880ZdoSK4ynZu5CZ06dZLakRBCCCFElJCzIJx169bZDz/8YN999533FTDAjOh/8BND/O6777a6desmVFM1WY4333zTJzEff/zx8T4kIYQQQhSGrFKWlVWq6M9hDORZUwU5C2nOrFmzbMSIETZ9+nSrU6eOHXrooXbSSSdZ6dKlPfrPT0p6KlSoYIlERkaG9z1MmTLFevXqZQ0bNoz3IQkhhBBCpBxyFtKYjRs32uOPP+5Zg86dOyfNVGMarJFFXbBggfXt29cqV64c70MSQgghRDTILGWWWfQ9C5apzEKkyFlIY0aOHOlZg44dOyaNahBlUYMGDfL5CXfeeaeakoQQQgghihA5C2kKxvaoUaNc3jRZHAWUEgYMGODHy3EnWmmUEEIIIQpJVunYZBbUsxAxchbSFJqCkT1t0KCBJQNr1671Scz0VVx55ZXeSyGEEEIIIYoWOQtp2tRMYzBR+mTpUXj00Ud9BkP37t13KNkqhBBCiCSFrIJ6FhIKWV1pBoY3KkKtWrVKisFlHO+zzz5rGzZssKuvvlqOghBCCCFEDFFmIc1AJjUzM9OdhURn/vz59uSTT/rvN998s0+NFkIIIUQKEzM1pMyi30eKIGchjfjrr79cAalPnz4+QyFRwZlhYvQ777xjp5xyirVr105TmYUQQggh4oCchTQBydGnnnrKWrdubXvuuaclKr/++qu98cYbtmrVKrv11lutUaNG8T4kIYQQQoi0Rc5CmvDuu+9amTJl3FlIRObNm2dvvfWWzZw508444wxfVHYkhBBCpBkxa3BWGVKkyFlIE/WjMWPG2L333ptQ5TxZWVn2xx9/2KeffmrffvutnXjiiXbZZZfZzjvvHO9DE0IIIYQQchZSn02bNtnTTz9tbdu2td133z0hHASyCBMnTvRl3bp1dthhh1n//v2tatWq8T48IYQQQsQTZRYSjsQJM4sikR1FTahSpUpe1hMN1q9fbz/99JOVL1/eqlWr5ku4CdD0SCxfvtwnRfNzyZIlNnv2bPvzzz9ty5YtduCBB1qnTp2sefPmCd1sLYQQQgiRzshZSFEwyB977DH7999/7bbbbovKfIKMjAzf5j///OPlTDgA9BVUqFDBSpQo4VOVcRKYtrx69Wp3AipXruxLlSpV3DE455xzrG7dunIQhBBCCBFH6dQMnf0IkbOQgmCwM/EYgx1HAWM+WjMayBI88MADVq5cOXdIFixY4APTyGJQ8kQTNVkHnAMyGuGyDkIIIYQQIjmQs5CCjsKAAQPcgMdRwKiPBr///rvPaOjdu3f2Nskc1KtXLyrbF0IIIYSIXc+CMguRUvjaFJFQID06ffp06969e9QcBRwQeh8oIUrkGQ1CCCGEECK6yFlIMYj0H3TQQXb33XfbjBkzorJNMgqUFp1++ulR2Z4QQgghhEgO5CykGPQJ3HDDDXbWWWe5HCnTkOknKCj0KHz44Yd20UUXRaVJWgghhBBih2VIsVjyKfJy5513elC2bNmyVr9+fZ9fhSR8AL/fddddVrNmTV/npJNO8jLuUBCeueCCC9xe22WXXaxr164uDJPIyPpLQWgq5gPat29flznlg7to0aICbQtn4+CDD7aGDRtG/TiFEEIIIZKBhx56yJ566il74oknvOSbvx9++GEbNGhQ9jr8/fjjj/t8K4bNUpVxyimn2MaNG7PXwVGg8oOBtFRuTJgwwQfSJjJxdRZQ1TnkkEOsYsWKrtdPNPy3337LsQ66/GeffbYP7MILa9++vS1evDjfXhpG89FHH+1Sn3Xq1PE3NDfDhg2zffbZx9dp2rSpffTRRzmej8RjTCRq165t99xzj+233352++2329ixY3N4wDuC92LKlCnWoUOHIj1OIYQQQohs6dSM0kW/sJ988M0331ibNm18bhX9m+3atbOWLVvad999589jX6FEeccdd/h6zZo1s5dfftmDtahJAk7Gxx9/bM8//7wPpG3RooU7G2+++WaBg7op7yyMHz/err76aps0aZJ7WEhxcuKZ6gv85G8i5Ri6X3/9tTfbtmrVyjIzMyP20pAQZTvo+2P89uvXz/r06WPPPvtsjg/B+eef747G1KlT3XFh+fnnn/PlMSYaKBZxfihNeuedd/yDvGbNmh3+H2pKfJj5wDMnQQghhBAiXTnyyCPt888/t1mzZvnfP/74o3311Vd22mmn+d8MnmUOFYHkgJ133tmdgokTJ/rf/CSoTcVGAOtT5o1dmajEVToV7yqUoUOHeoYBg/6YY45x52DOnDluvJM1gJdeesl23XVXdx44wYGXNnny5OyTj5dGMy41+7Vq1bLXXnvNnYwXXnjBB4cRaZ82bZoNHDgw26lg2Nipp55qN910k/9NHRrOB+kmnIPcHiPgMVavXt09xkSPvpMpefDBB+25556zW2+91a644gp/LBy8Vl4zH2gcMyGEEEKImJBV+r+lyPezNTugHArzolhyc+utt/q6VKAwiJYehvvuu88DsoCjANiFofB38Bw/sXNDYcjtbrvtlr1OIpJQPQurVq3yn5w0YMgXWYXQN40SITwwvLlIvTTWwfnAUQggI0CZzYoVK7LXCfUGg3UCbzASjzFZmp/btm3rjtIrr7xi69ev32a9999/318v8qt8IYQQQgghUhFK07HngoUS+XC8/fbbHnx+/fXX7YcffvDgNUFpfqY6CTOUjbKi6667zo466ihr0qSJP3b44Yd7qc8tt9xi999/v0e88ezw5v7++++IvTR+5h4eFnh+PEemgp878gZD/y/cOrnB2WEJyO29xgOcrxNPPNE9YzItOA/nnnuuHXfcce4YkMXBWWD4WpDNEUIIIYRIraFs/2UW5s+fn8PeCZdVACpPsEGDShKqM+bOnevORefOna1GjRr+OH219LYG8Pf+++/vv7POkiVLLBQUK+m9Df4/EUmYzAK9C/QH0OQRQFMzTcdId1aoUME9vpUrV9qBBx6YFDKefIBCvVW810Rqfqakih4N+jyY9kwPyeDBg61bt24aviaEEEKIlAdHIXTJy1lYv379NrYnQdagh5agNAY/fQ2hQWKqXI444gj/m5/YsZTbB1BWzzaoVElUEiKzcM0112Q3Ju++++45nqMxGUWkZcuWecaAkiPejL322itiL42fuRWUgr93tE7o8zvyGHPTq1cvj9yHfmgSyWEgy4Aa1QEHHGCffPKJlyUdf/zx3sQjhBBCCBFzUCmKSWZhS75Wb9Wqlfco7LHHHt77SiUGJd1dunTJtqmokEG2fu+993bngbkM9M4imAONGzf2/liCsvSGIuyDDUy2gvUSlbiG5ykr4iQNHz7cPavcpUKhVKlSxR0F1sM5aN26dcReGuvgiPCmBNC83KhRIy9BCtYJ9QaDdQJvMBKPMTd4p7k91kQEJwwpMPSDO3bsGO/DEUIIIYRIKAYNGuRyqVdddZUb/T179rTLL7/cBXECbr75Zu/3RDyHYCwy/ojw0G8bQN8DpeCUhCPGg3xqqDpnIlIsKz/C+1GGE06jCDXyGO4BlOwwxwBefPFFf1MoSaKRuEePHnbxxRfbgAEDstdHtooIf+ClXXLJJd7wzLaDxmm2T5aC/gfKnfAEH3nkkWw1JKRTjz32WFcMwnCmHIo+CZpYgh4KBnDwPM0sgcfI/IZffvklxwchL3AueG0cT6I6DkIIIYRIDxLJLgmOxd54z6xc+aLf4fp1Zue3TYjXnujEtQyJSDbQXBsKDgIOAaBYRDkPZUUMwWC42PXXX59jfbw0MhR4adSTnXPOOT4PIYAP35gxY7wv4qCDDvIsBcPVQmcxUHqDc0EdP/X7pJCQRA0chcBjZPYD/0c2A28wt8cohBBCCCESvcE5f2VI6UxcMwvpRiJ58EIIIYRIbxIys/DayNhlFi44MyFee6KTEA3OQgghhBBCKLOQeCS+/qgQQgghhBAiLiizIIQQQggh0kw6dXPR7yNFUGZBCCGEEEIIERZlFoQQQgghRJqpIcVgHymCMgtCCCGEEEKIsMhZEEIIIYQQQoRFZUhCCCGEECIxyCj93xKL/YiIUGZBCCGEEEIIERZlFoQQQgghRGKQVcosq3Rs9iMiQpkFIYQQQgghRFiUWRBCCCGEEIkBWYVYyJrGInuRIshZiCFZWVn+c/Xq1bHcrRBCCCHENgT2SGCfCBEOOQsxZM2aNf6zTp06sdytEEIIIcR27ZOdd945Mc6QhrIlHHIWYkitWrVs/vz5VrFiRStWrFgsd52yEREcL85ppUqV4n04SY/Op85noqPPqM5nIpOMn08yCjgK2CdC5IWchRhSvHhx23333WO5y7SAi3KyXJiTAZ1Pnc9ER59Rnc9EJtk+nwmTUQjIKBWjOQtSQ4oUqSEJIYQQQgghwiJnQQghhBBCCBEWlSGJpKVMmTLWu3dv/yl0PhMNfT51ThMdfUZ1PhMSNTgnHMWypJclhBBCCCHi3CDu/ROD/jYrG4Oejw2rzbrXtFWrViVVj0k8UGZBCCGEEEIkBgxLi8XANA1lixj1LAghhBBCCCHCosyCEEIIIYRIDDJK/LfEYj8iIpRZEAnBhAkTrFWrVj4YhoF1I0aM2OH/DB482Bo3bmxly5a1Ro0a2csvv7zNOo8++qg/xzoMy7n++utt48aNluo88MADdsghh/gAwGrVqtlZZ51lv/322w7/b9iwYbbPPvvYTjvtZE2bNrWPPvoox/O0ON11111Ws2ZNP6cnnXSS/f7775bqFMX53LJli91yyy3+ePny5f2zf9FFF9miRYss1Smqz2coV1xxhV9LuAakOkV5PmfOnGmtW7f2WnI+p+xn3rx5luoU1Tldu3atXXPNNT5ziWvovvvua08//XQRvhIhCo+cBZEQrFu3zpo3b+4OQCQ89dRT1qtXL+vTp4/NmDHD7r77brv66qvtww8/zF7n9ddft1tvvdUVk7jhDRkyxN566y277bbbLNUZP368n49JkybZp59+6oZpy5Yt/TznxTfffGPnn3++de3a1aZOneo3R5aff/45e52HH37YHn/8cb+5ffvtt248nHLKKSnvgBXF+Vy/fr398MMPduedd/rP9957z40RDLNUp6g+nwHDhw/3bafLVNqiOp9//vmntWjRwo3fL774wn766Sf/vGIIpzpFdU5vuOEG+/jjj+3VV1/1+9J1113nzsMHH3wQo1eW+BTLzLTiMVjYj4gMqSGJhINoIDd7LrJ5ceSRR9pRRx1l/fr1y37sxhtvdAP2q6++8r+5AHMx/vzzz/NcJ11YunSpR8e4AR5zzDFh1znvvPP8Rjhy5Mjsxw4//HDbf//93Tkgq4DxxTns2bOnP4+KRPXq1W3o0KHWoUMHSxeicT7DMXnyZDv00ENt7ty5tscee1i6EM3zuXDhQjvssMPsk08+sTPOOMONMZZ0Ilrnk+90qVKl7JVXXrF0J1rntEmTJr4eTlfAQQcdZKeddpr17dvX0plADanYgH+tWAzUkLI2rLasG3eTGlIEKLMgkpJNmzZtE90ipfvdd995BChwKKZMmeKPwV9//eUp4dNPP93SDYx62G233fJcZ+LEiV5WFApZAx6H2bNn2z///JNjHS7sGGbBOulCNM5nXtvFWd5ll10snYjW+czMzLROnTrZTTfdZPvtt5+lK9E4n5zLUaNGWcOGDf1xDGW+65GUiKYi0fqMcl8ii4BTSwBm3LhxNmvWLM9aCJGoyFkQSQkX4Oeff96dAS6433//vf+No7Bs2TJfp2PHjnbPPfd4Gp3oWP369e24445LizKkULjpE1klE0NUKy9wBMgShMLfPB48HzyW1zrpQLTOZ24o5aKHgTKGdNL8jub5fOihh6xkyZJ27bXXWroSrfO5ZMkSr69/8MEH7dRTT7UxY8bY2WefbW3btvXoejoRzc/ooEGDvE+BnoXSpUv7uaX8Nq9sRTpSLCMjZouIDKkhiaSEFC4XYFK8OAtckDt37uw19cWL/+cDU2N7//3325NPPukRsT/++MN69Ohh9957b44UcKpD3S01s+lWepVM5xMnt3379v5Zph8nnYjW+SRw8Nhjj3n/B9mZdCVa5xMDGdq0aePCEEA5DXX5lNQce+yxli5E8zuPs0AfBNmFunXrurgH26fEM3dWQohEQZkFkZRQcvTCCy94k+icOXNcnWPPPfd05YqqVav6OjgElCRceumlrkpBVAznAZWL4EaY6tC3Qf0sqW4iWdujRo0atnjx4hyP8TePB88Hj+W1TqoTzfOZ21GgT4FGynTKKkTzfH755ZceDafXg+wCC+eUHhuuDelANM9nlSpV/BwSBQ8FBbp0UEMqinO6YcMGz2wPHDjQ1f+aNWvm26eHoX///kX6OpKJYpkxyixkKrMQKXIWRFJDeREX8BIlStibb75pZ555ZnZmAUci+D2A9YAIbirD6+MmRKP42LFjrV69ejv8nyOOOCJHMzhgvPI4sA1ueqHr0JBGw3iwTqpSFOcz1FFAfvazzz6zypUrWzpQFOeTwABqPdOmTcteiNbSv0CzcypTFOeTEhmkQ3PLhVJfT0Q81SmKc8r3nSXcfSldAlgiOVEZkkgIqI2lTCiAZlpu9jSTESlEJpWGsGCWAjcsGpcpL1qxYoVHakgTv/TSS9nbIHLD4wcccEB2GRLZBh4PnIZUhbQ20rHvv/++Z1uCmlkaksnKAJr+tWvX9kwLUKJFacGAAQNcRQbni16QZ5991p+ntIO6XRQ79t57b795cj4xyLanXJUKFMX5xGho166dl80QuczIyMjeLp97jLVUpSjOJ45WbmeLYAIOLrNWUpmiOJ+Ao0XUm3r6448/3iU/kaemxDPVKYpzStaQ5zmvbAOni/4P7mvcq8R/xErWNCsz05RbiJAsIRKAcePGEerfZuncubM/z89jjz02e/1ffvkla//9988qW7ZsVqVKlbLatGmT9euvv+bY5pYtW7L69OmTVb9+/ayddtopq06dOllXXXVV1ooVK7JSnXDnkuXFF1/MXofzGZzfgLfffjurYcOGWaVLl87ab7/9skaNGpXj+czMzKw777wzq3r16lllypTJOvHEE7N+++23rFSnKM7n7Nmz89wu34dUpqg+n7mpW7du1iOPPJKV6hTl+RwyZEhWgwYN/BravHnzrBEjRmSlA0V1Tv/++++siy++OKtWrVp+Ths1apQ1YMAAv7amO6tWrfJzXOr+RVmlB64t8oX9sD/2K7aP5iwIIYQQQoiEmLNQ+t75VmynGMxZ2LjaNt9ZR3MWIkA9C0IIIYQQQoiwyFkQQgghhBBChEUNzkIIIYQQIiGI2cA0DWWLGGUWhBBCCCGEEGFRZkEIIYQQQiQExTOzYiSdmtrzlqKJMgtCCCGEEEKIsCizIIQQQgghEgL1LCQeyiwIIYQQQgghwiJnQQghkozffvvNatSoYWvWrMl+bMSIEdagQQMrUaKEXXfddWH/b9myZVatWjVbsGBBDI9WCFEYJkyYYK1atbJatWpZsWLF/LueXxhK3b9/f2vYsKGVKVPGateubffdd19CZxZisYjIkLMghBAxJiMjw4488khr27ZtjsdXrVplderUsdtvv327/9+rVy/r3r27VaxYMfuxyy+/3Nq1a2fz58+3e++91y6++GI766yzcvxflSpV7KKLLrLevXtH+RUJIYqKdevWWfPmzW3w4MEF3kaPHj3s+eefd4fh119/tQ8++MAOPfTQqB6nSF2KZeFuCiGEiCmzZs2y/fff35577jm74IIL/DEM+R9//NEmT55spUuXDvt/8+bN8wzC7NmzPToIa9eudcdh7Nixdvzxx/tjOAsrV67cJgo5Y8YMO+igg2zRokW22267FfnrFEJEDzILw4cPzxEI2LRpkwcY3njjDf/ON2nSxB566CE77rjj/PmZM2das2bN7Oeff7ZGjRol7NuxevVq23nnna3iLTOtWJn/D4QUFVmb1tia/2vvfkOkKtcAgL+7mpqFIWZpUFp+uFgp2Q0qKgtNrfxWGCRoYWWJ0qX/BtFfCG8QeeFCfTFLKqIoCv1SbbciUKhEcUuQVLI+WAbZn9vmtd3Zy/PGTLt53N2ymTm7/n5wmDlzzsw7u+B6nvM87/P+c2q+STNmzJi6jzeYySwANEGUA6xatSpnCPbu3ZveeOON9NJLL6V169YdNlAIL7/8cr7LWA0U3nvvvVqGYdasWfliIi4SnnvuufyZsR9bnBfOOuusXM4QFxzA4LdixYq0adOm/Pdj27ZtacGCBemKK65In332WT6+fv36dMYZZ6QNGzak008/PU2ePDnddNNN6dtvv232V2eQECwANEkECnHhv2jRorR06dL0wAMP5P2+fPDBB+m8886r7Uc5U8xhCK+++moOPKLE4Nprr80XDLEfW5xXFeUH8TnA4BaZxrVr16ZXXnklXXLJJWnKlCnprrvuShdffHF+PezevTvt2bMnnxM3I5599tm0efPmXLYIA6F1KkCTxB3/p556Kk2dOjVNmzYtrVy5st/3xH/6PYOFyELEpOUQZUUx8Tkce+yxuTyhut9TZBa2bNnyl/4sQOO1t7fnOVCRqewp/u2PGzcuP69UKnk/AoXqeWvWrMnliHGjoWylSVqnlo9gAaCJnnnmmTR69Og8ByG6FEWJQF9+/vnnNGrUqCMaMwKJjo6OI/oMoPlivlJ0QItMQTz2dPzxx+fHiRMnpuHDh/cKKOIGRTUzUbZggfJRhgTQJBs3bkxPPvlkriWO0qAbb7wxtzjsS3Q02r9//xGNG7XK48ePP6LPAJpvxowZObOwb9++3Pig51bNKl500UWps7Mz7dq1q1eDhTBp0qRUNlqnlo/MAkATxJ396Fi0bNmy3MEoJh5GKdLTTz+dX+vr4mD79u39fn6UJ8VFRJHoilLtlAKUP3uwc+fO2n5kIbdu3ZrLDiNbEN3UopPaE088kf8+fPPNN+mdd97JHZDmz5+fLr/88nTuueemJUuWpNWrV+eypOXLl6c5c+YcUr4ERWQWAJog1kqILEJ0RApRfhQ90O+55570+eefH/Z98+bNy51PDhcIVMXnRWeUqEmOxdh++eWXWpASJQtz5879i38ioB4+/vjjHATEFu644478PBoihJjIHMHCnXfemUuKoq1qtF8+7bTT8vHW1tbcESmykjNnzswBRJQhRfekMmqtVBq2MTDWWQBosPfffz/Nnj07tzONriW/DwaiZKCtrS1PgP69OBalAzHXIc4N0Vt97Nix6d13361lDOLuYtxxjMAi7kxWj0Uv9ocffjgvzARQtnUWxv5jS8PWWdj/rxnWWRgAwQLAIBMruUZ71DfffPMPv/eCCy5It912W1q4cGFdvhvAEQULKzan1pG/Ts6up8r//pv2//vvgoUBMGcBYJC55ZZbcjbhxx9/rC3INhBRjnT11Ven6667rq7fD4ChQ2YBAICmklkoL5kFAACOqkXZGjHGUKEbEgAAUEhmAQCAUmhYW1OtUwdMZgEAACgkswAAQCm0VBo0Z6FizsJAySwAAACFZBYAACgF3ZDKR2YBAAAoJLMAAEAp6IZUPjILAABAIcECAABQSBkSAAClYIJz+cgsAAAAhWQWAAAohZauSmMWZeuq1H2MoUJmAQAAKCSzAABAKWidWj4yCwAAQCGZBQAASqGl0tWYOQuV+o8xVMgsAAAAhQQLAABAIWVIAACUZ1G21ka0TlWGNFAyCwAAQCGZBQAASkHr1PKRWQAAAArJLAAAUArmLJSPzAIAAFBIsAAAQCm0dFV+zS7Ufav8oe81efLk1NLScsi2fPnyfPyyyy475Nitt97a6zO++OKLNH/+/DR69Oh00kknpbvvvjt1dnamslOGBAAAffjoo49SV492q5988kmaM2dOWrBgQe21m2++OT3yyCO1/QgKquK9EShMmDAhbdy4Me3duzctXrw4HXPMMemxxx4r9e9esAAAAH0YP358r/1Vq1alKVOmpEsvvbRXcBDBQJG33norbd++PbW1taWTTz45nXPOOenRRx9N9957b3rooYfSiBEjSvv7V4YEAEAptFQqtfap9dxinD/r4MGD6fnnn09LlizJ5UZVL7zwQjrxxBPT2Wefne67777U0dFRO7Zp06Y0bdq0HChUzZs3L/3www/p008/TWUmswAAwFEpLtZ7GjlyZN768vrrr6fvvvsu3XDDDbXXFi5cmCZNmpROOeWUtG3btpwx2LFjR3rttdfy8a+++qpXoBCq+3GszAQLAAAcla1TTz311F6vP/jgg7ksqC9r1qxJV155ZQ4MqpYuXVp7HhmEiRMnptmzZ6ddu3blcqXBTLAAAMBR6csvv0xjxoyp7feXVdizZ0+ed1DNGBzO+eefnx937tyZg4WYy/Dhhx/2Oufrr7/Oj4eb51AW5iwAAFAKLZVGtE3tyuOECBR6bv0FC2vXrs1tT6OzUV+2bt2aHyPDEC688MLU3t6e9u3bVzvn7bffzmOeeeaZqcxkFgAAoB+VSiUHC9dff30aPvy3S+goNXrxxRfTVVddlcaNG5fnLNx+++1p5syZafr06fmcuXPn5qBg0aJF6fHHH8/zFO6///68TkN/AUqzCRYAACiFareieuv+E2O0tbXlhdWiC1JP0fY0jq1evTr99NNPeR7ENddck4OBqmHDhqUNGzakZcuW5SzDcccdl4OOnusylFVLd3d3d7O/BAAAR3dXohNOOCH9bda6NGz4b4uZ1UtXZ0fa8Z/F6fvvv+81Z4FDySwAAFAKeT5BS+O6IdE/E5wBAIBCggUAAKCQMiQAAEpBGVL5yCwAAACFZBYAACiFMrdOPVrJLAAAAIVkFgAAKIWWrkqDWqfKLAyUzAIAAFBIZgEAgFLQDal8ZBYAAIBCggUAAKCQMiQAAEqhtbtBrVO7TXAeKJkFAACgkMwCAADlmeCcGtE6tf5jDBWCBQAASqGr68CQGmcoECwAANBUI0aMSBMmTEjt7SsbNmaMF+PSt5bu7u7ufs4BAIC6OnDgQDp48GDDfssRKIwaNaph4w1WggUAAKCQbkgAAEAhwQIAAFBIsAAAABQSLAAAAIUECwAAQCHBAgAAUEiwAAAApCL/B5U9FpJoG78AAAAAAElFTkSuQmCC",
+      "text/plain": [
+       "<Figure size 800x600 with 2 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Polygon multipoint terrain modification writer validation\n",
+    "polygon_name = 'API Multipoint Pond'\n",
+    "poly_cx = minx + 0.62 * (maxx - minx)\n",
+    "poly_cy = miny + 0.28 * (maxy - miny)\n",
+    "poly_w = 0.12 * (maxx - minx)\n",
+    "poly_h = 0.12 * (maxy - miny)\n",
+    "polygon_coords = np.array(\n",
+    "    [\n",
+    "        [poly_cx - 0.5 * poly_w, poly_cy - 0.5 * poly_h],\n",
+    "        [poly_cx + 0.5 * poly_w, poly_cy - 0.5 * poly_h],\n",
+    "        [poly_cx + 0.5 * poly_w, poly_cy + 0.5 * poly_h],\n",
+    "        [poly_cx - 0.5 * poly_w, poly_cy + 0.5 * poly_h],\n",
+    "    ],\n",
+    "    dtype=float,\n",
+    ")\n",
+    "polygon_control_points = [\n",
+    "    {\n",
+    "        'x': poly_cx - 0.18 * poly_w,\n",
+    "        'y': poly_cy,\n",
+    "        'elevation': 930.0,\n",
+    "        'name': 'Pond shelf 930',\n",
+    "    },\n",
+    "    {\n",
+    "        'x': poly_cx + 0.18 * poly_w,\n",
+    "        'y': poly_cy,\n",
+    "        'elevation': 925.0,\n",
+    "        'name': 'Pond bottom 925',\n",
+    "    },\n",
+    "]\n",
+    "\n",
+    "RasTerrainModification.add_modification_polygon(\n",
+    "    terrain_hdf_path=polygon_terrain_hdf,\n",
+    "    name=polygon_name,\n",
+    "    polygon_coords=polygon_coords,\n",
+    "    elevation_method='boundary_from_terrain',\n",
+    "    control_points=polygon_control_points,\n",
+    "    rasmap_path=polygon_project / 'BaldEagleDamBrk.rasmap',\n",
+    "    elev_pt_tolerance=15.0,\n",
+    ")\n",
+    "\n",
+    "with h5py.File(polygon_terrain_hdf, 'r') as hdf:\n",
+    "    mod = hdf[f'Modifications/{polygon_name}']\n",
+    "    boundary_xyz = mod['Boundary Points'][:]\n",
+    "    control_xyz = mod['Control Points/Elevation Points'][:]\n",
+    "    profile_values = mod['Profile Values'][:]\n",
+    "    polygon_attrs = mod['Attributes'][0]\n",
+    "\n",
+    "assert np.all(np.isfinite(boundary_xyz)), 'Boundary elevations must be finite'\n",
+    "np.testing.assert_allclose(control_xyz[:, 2], np.array([930.0, 925.0]))\n",
+    "assert int(polygon_attrs['Generate Boundary Elevations']) == 1\n",
+    "assert int(polygon_attrs['Use ShapeFile Z Elevations']) == 0\n",
+    "\n",
+    "root = ET.parse(polygon_project / 'BaldEagleDamBrk.rasmap').getroot()\n",
+    "polygon_layers = [\n",
+    "    layer for layer in root.findall('.//Layer')\n",
+    "    if layer.get('Name') == polygon_name\n",
+    "]\n",
+    "assert len(polygon_layers) == 1\n",
+    "assert polygon_layers[0].get('Type') == 'PolygonElevationModificationLayer'\n",
+    "\n",
+    "polygon_summary = pd.DataFrame({\n",
+    "    'dataset': ['boundary vertices', 'interior controls', 'profile values'],\n",
+    "    'count': [len(boundary_xyz), len(control_xyz), len(profile_values)],\n",
+    "    'min_elevation_ft': [\n",
+    "        float(boundary_xyz[:, 2].min()),\n",
+    "        float(control_xyz[:, 2].min()),\n",
+    "        float(profile_values[:, 1].min()),\n",
+    "    ],\n",
+    "    'max_elevation_ft': [\n",
+    "        float(boundary_xyz[:, 2].max()),\n",
+    "        float(control_xyz[:, 2].max()),\n",
+    "        float(profile_values[:, 1].max()),\n",
+    "    ],\n",
+    "})\n",
+    "display(polygon_summary)\n",
+    "\n",
+    "fig, ax = plt.subplots(figsize=(8, 6))\n",
+    "mesh_areas.boundary.plot(ax=ax, linewidth=0.8, color='0.35')\n",
+    "closed_polygon = np.vstack([polygon_coords, polygon_coords[0]])\n",
+    "ax.plot(closed_polygon[:, 0], closed_polygon[:, 1], color='tab:blue', linewidth=2.0)\n",
+    "sc_boundary = ax.scatter(\n",
+    "    boundary_xyz[:, 0],\n",
+    "    boundary_xyz[:, 1],\n",
+    "    c=boundary_xyz[:, 2],\n",
+    "    cmap='terrain',\n",
+    "    marker='s',\n",
+    "    s=55,\n",
+    "    label='Sampled boundary',\n",
+    ")\n",
+    "sc_control = ax.scatter(\n",
+    "    control_xyz[:, 0],\n",
+    "    control_xyz[:, 1],\n",
+    "    c=control_xyz[:, 2],\n",
+    "    cmap='viridis',\n",
+    "    marker='o',\n",
+    "    edgecolor='black',\n",
+    "    s=90,\n",
+    "    label='Interior controls',\n",
+    ")\n",
+    "for point, label in zip(control_xyz, ['930 ft', '925 ft']):\n",
+    "    ax.annotate(label, xy=(point[0], point[1]), xytext=(6, 6), textcoords='offset points')\n",
+    "ax.set_aspect('equal')\n",
+    "ax.set_title('Polygon multipoint terrain modification inputs')\n",
+    "ax.set_xlabel('X (ft)')\n",
+    "ax.set_ylabel('Y (ft)')\n",
+    "ax.legend(loc='upper right')\n",
+    "fig.colorbar(sc_boundary, ax=ax, label='Boundary elevation (ft)')\n",
+    "polygon_points_png = ARTIFACT_ROOT / 'polygon_multipoint_control_points.png'\n",
+    "fig.tight_layout()\n",
+    "fig.savefig(polygon_points_png, dpi=160)\n",
+    "polygon_points_png"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "7abb17eb",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-05T21:10:59.655758Z",
+     "iopub.status.busy": "2026-05-05T21:10:59.655758Z",
+     "iopub.status.idle": "2026-05-05T21:11:00.158279Z",
+     "shell.execute_reply": "2026-05-05T21:11:00.158279Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>target_x</th>\n",
+       "      <th>target_y</th>\n",
+       "      <th>target_elevation_ft</th>\n",
+       "      <th>readback_station_ft</th>\n",
+       "      <th>readback_elevation_ft</th>\n",
+       "      <th>readback_minus_target_ft</th>\n",
+       "      <th>profile_distance_ft</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>2.051112e+06</td>\n",
+       "      <td>334565.04268</td>\n",
+       "      <td>930.0</td>\n",
+       "      <td>5232.829102</td>\n",
+       "      <td>930.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.000132</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>2.054735e+06</td>\n",
+       "      <td>334565.04268</td>\n",
+       "      <td>925.0</td>\n",
+       "      <td>8855.556641</td>\n",
+       "      <td>925.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.000076</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "       target_x      target_y  target_elevation_ft  readback_station_ft  \\\n",
+       "0  2.051112e+06  334565.04268                930.0          5232.829102   \n",
+       "1  2.054735e+06  334565.04268                925.0          8855.556641   \n",
+       "\n",
+       "   readback_elevation_ft  readback_minus_target_ft  profile_distance_ft  \n",
+       "0                  930.0                       0.0             0.000132  \n",
+       "1                  925.0                       0.0             0.000076  "
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>count</th>\n",
+       "      <th>mean</th>\n",
+       "      <th>std</th>\n",
+       "      <th>min</th>\n",
+       "      <th>25%</th>\n",
+       "      <th>50%</th>\n",
+       "      <th>75%</th>\n",
+       "      <th>max</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>readback_difference</th>\n",
+       "      <td>3.0</td>\n",
+       "      <td>186.990756</td>\n",
+       "      <td>141.90145</td>\n",
+       "      <td>24.46558</td>\n",
+       "      <td>137.342856</td>\n",
+       "      <td>250.220132</td>\n",
+       "      <td>268.253344</td>\n",
+       "      <td>286.286556</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                     count        mean        std       min         25%  \\\n",
+       "readback_difference    3.0  186.990756  141.90145  24.46558  137.342856   \n",
+       "\n",
+       "                            50%         75%         max  \n",
+       "readback_difference  250.220132  268.253344  286.286556  "
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Control-point writer-vs-raster max abs diff: 0.000000 ft\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "WindowsPath('H:/Symphony/ras-commander/CLB-279/316_terrain_modifications/polygon_profile_readback_validation.png')"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA90AAAGGCAYAAABmGOKbAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjksIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvJkbTWQAAAAlwSFlzAAAPYQAAD2EBqD+naQAAtedJREFUeJzs3Qd4FFUXBuBvS3pPCIQSCL0JUkUURAEFQSkC6i9IFQsKClYsVAVRwYYNRQQbogiCjQ4qoCDSBKRD6DW9b/mfc5NZNr2QZEu+93mW7M7OztyZu7vsmXOLzmq1WkFEREREREREpU5f+pskIiIiIiIiIgbdRERERERERGWImW4iIiIiIiKiMsKgm4iIiIiIiKiMMOgmIiIiIiIiKiMMuomIiIiIiIjKCINuIiIiIiIiojLCoJuIiIiIiIiojDDoJiIiIiIiIiojDLqJiApw8803qxsV3bFjx6DT6fDZZ58VaX1Zd9KkSWV6il25HuU8yjmS80pExf+8r1+/Xn2Gvvvuu3I9ffK9Jvu9ePFiue6XiJwPg24icitagKLdvL290aBBAzz22GM4d+6co4tXYf38889lHliXla+++gpvvfUWnMn7779f5Isazmrv3r3qPVFeFxPc4ZwV16ZNm9Q5jo2NdXRRiIgqNAbdROSWpkyZgs8//xyzZ8/GDTfcgA8++ADt27dHcnKyo4tWYYPuyZMn5/lcSkoKXnzxxTLd/8qVK9XNFYPu+++/X52jWrVquV3QLe8JBt1lG3TLOWbQTUTkWEYH75+IqEzcfvvtaNOmjbr/wAMPICwsDLNmzcIPP/yA//3vfzzrTkRaI5Q1T09PuJqkpCT4+fnBYDCoW1kzmUywWCwuea7cQWpqqjr3er3z50Pk4qWvr2+x38tERBWV83+zExGVgs6dO6u/R48etQUYU6dORd26deHl5YWoqCg8//zzSEtLy3cbiYmJ6ofj448/nuu5kydPqsBo+vTptmW7du1Cp06d4OPjgxo1auDll1/GvHnz8uyfK5nLpk2bqrJUq1YNjz76aK7slPRRvOaaa1SG8JZbblE/eqtXr47XXnutSOdA9ivN7L/99ls0adJElUuy/7t371bPf/TRR6hXr54KgmVfOcso52jo0KHF7i8tr3nvvfdsZdBu9uWyb3qu9YP877//cPfddyMwMFBdNJHzLoGJvaLWY359PBctWoRXXnlF1Y8cd5cuXXDo0KFsr/vpp59w/PhxW7llH/m566670KpVq2zL7rzzTvW6ZcuW2Zb99ddfatkvv/ySrVvEhg0bMGrUKFSuXFmVyf45rT5k/3v27FHramWyPzZ53zzxxBOIjIxU50TqdMaMGSqgztnv/o033lBZfO38yXsrP0U91/n10bd//8gxDRgwQN2X97J2HFIv2rp33HGHap3QokULVTfynv3++++zbVN7r+RU3HNmLyMjA6GhoRg2bFiu5+Lj41VZnnrqKduyd999V3125fMYEhKiLvZJ64iCaO+/hQsXqlYe8jmW18v2L1++rLbfrFkz+Pv7q/e/XETcuXNnru0UtG85N08//bS6X7t2bdtx23+uv/jiC7Ru3Vp9F8gx33vvvThx4kSe3zvbtm3DTTfdpPYl9Z4fqWMp9+HDh9GjRw8EBARg4MCB6jl5D8r7Tcos57FKlSp46KGHEBMTk20bcnG0Z8+e6rtQ3mvynpP3ntlszrW/OXPmqOflGK677jr8/vvv+ZZNXi9lj4iIUN/lvXr1ynW88np5b9asWVPtWz5HY8eOVa1NctK+o8LDw9X+GzZsiBdeeAEFke8S+UzKOWWXJ6KKg5luIqoQ5AegkOBNy37Pnz8f/fv3x5NPPqmCIAmY9+3bhyVLluS5Dfkh2bdvX3zzzTcqa26fffz6669htVptPy5PnTplCybGjx+vfuB98skn6kdcTvLjWJqAdu3aFY888gj279+vmsNv3boVGzduhIeHh21d+XHavXt3FdzJjz0ZGOjZZ59VP9Dlh3lh5AelBH8S1As5ZglunnnmGRX4S8An+5BAfvjw4Vi7di2ulvyoPn36NFatWqWa/BeVHJ8ES1LGP//8E++8844q24IFC2zrlKQe7b366qsqsyhBTlxcnDpuqUPZjpAf0LJcLqq8+eabtvdBfjp27KgCBgmeJFiS94TUoexDzr38yBdyX5bdeOON2V4v519+wE+YMEFlB/MiQcvo0aNVObQf+BK8aBlIudAj7z857xI4SBNjeQ+eOXMmVzN5uQgkFzIefPBB9d6UwCs/V3uu7UnwNmbMGFWnEgQ1btxYLdf+ioMHD+Kee+7Bww8/jCFDhqiySjD066+/4tZbby3W/go6ZznJ500+5xLgy4Uo+8z/0qVL1UUGCU7Fxx9/rI5Dzol2UUgutsm5ue+++wotlwSSsn15/8l25b5c+JD9yLFKsCyBmZRD6lWek0C0KPuW74gDBw6o7yZ571aqVEm9Tt5fQi42vfTSS+pzJnV74cIFFcRL3Wzfvh3BwcG2cl66dEl9v8hxDxo0KN9zZ3+Bplu3bujQoYO6sKNlxeU9KRdE5IKGlF0ugkoXINmf/XedrCN1NW7cOPVXvofkMyGfq9dff922n7lz56ptShciudB05MgR9RmT97EEyznJMct3snxnnj9/Xr0v5Ht3x44dKmgWclFSPkfyXSz/X2zZskWdF/kOkOc0cq7l8y5lls+PfFfJ/zPLly9X+8mLPC8XgKV88n2o1QkRVQBWIiI3Mm/ePKt8ta1evdp64cIF64kTJ6wLFy60hoWFWX18fKwnT5607tixQ63zwAMPZHvtU089pZavXbvWtqxTp07qplmxYoVa55dffsn22ubNm2dbb/To0VadTmfdvn27bdmlS5esoaGh6vVHjx5Vy86fP2/19PS03nbbbVaz2Wxbd/bs2Wq9Tz/9NFtZZNmCBQtsy9LS0qwRERHWfv36FXpu5LVeXl62fYuPPvpILZdtxMfH25aPHz8+WzlFrVq1rEOGDMm13ZznSF4jr5W60Dz66KNqWX7lmjhxou2x3JdlvXr1yrbeqFGj1PKdO3eqx1dTj+vWrVPrNG7cWJ1Dzdtvv62W796927asZ8+e6tiLYuvWrer1P//8s3q8a9cu9XjAgAHWdu3a2daTY2vZsmWu922HDh2sJpMp2za15+zromnTptmORzN16lSrn5+f9cCBA9mWP/fcc1aDwWCNjo7OVkeBgYHqPViY4pzrnPWZ3/vn22+/VetKXeS1rjy3ePFi27K4uDhr1apVs5037b2SU3HOWV60z/ny5cuzLe/Ro4e1Tp06tse9e/dW2y0u7f0n20pOTs72XGpqarbvAiHHIZ/dKVOmFGvfr7/+eq7zII4dO6beD6+88kq25fK+NxqN2ZZr3zsffvhhkY5N6ljWl/ecvd9//10t//LLL7Mt//XXX3Mtz3lOxEMPPWT19fVV50ekp6dbK1eubG3RokW2z/CcOXPU9vL6vFevXj3b99yiRYvUcvncF7Tv6dOnq+/z48eP25bddNNN1oCAgGzLhMViyfX+lP+L9u3bZ61WrZq1bdu21suXLxd4DonI/bB5ORG5JcleSEZHsh2SnZFsiWTjpBmnDOolJItiT7J3QpoTF7RdyTR9+eWXtmX//vuvynpIBkgj2Thpui1NYzWS3dAy4ZrVq1cjPT1dZWns+3KOHDlSZUpzlkWOw34/khmTJpWS4SkKaT5t3zy6Xbt26m+/fv1UM9Ccy4u63bKgZeM1kqkUWv1dTT1qJONmn8mUzNXVHHfLli1VHf3222+2jLY0Ex88eDD++ecflUGTuPSPP/6w7cue1PvV9N+WTJxsV5oayzRF2k3et9K0ViuXRupdy3wWpDTOdXHJ50wyzhr5PMh5lKzo2bNnUZYkGylZSGnVopFWFpKdlOy7RrLBkgGVViklIRl8LcOqkRYH2neB1JlkmeU9JU2X5T1UGvuWLL409ZYst/37RJpd169fH+vWrctVprya2xdEMsU535tBQUGqlYL9PqV5uxyf/T7tz0lCQoJaT97X8vmRJt3i77//VtlqaQlh/xmW5u2yn7zI+8f+e05aCVStWtX2/s65b2ltIvuWTLp8buW9J6RVgHyWpDWQtCaxl1d3B/k/QloqyHevfOfL55OIKhY2LycityR9iGWqMKPRqJpCyg9W7Yes9KmT+9Kvzp784JQfsvJ8fuR1EjhL829tMCEJwKV/otZHVduHBN055dynti8pnz35EVmnTp1cZZEALuePOvkBJ0F/UeT8gaj9OM3ZFFNbnrOvZXmSH//2pN+mnH+tT+rV1GN+50P7MVzS45aAWepd61cqfyVYkGa2EkBJM3l5P0q/3byCbmlOfDWkSba8F/ILpCVIKcn+SuNcF5fsK+d7XT7TQt4Dsu+yIt8bckFC+kdLs28JOiVQlf7e9kG3NFOWIEoufEl5b7vtNtW0O2e3gfzkdf4lGH777bdVdw9pfm3fj1nrHnO1+5b3iQSROT9jGvsuLUIuVhZngD05f9qYBPb7lK4aMl5BYe9N6X8vfd2lWbk0Kbcn2xDaey7nMUjZ5bszLznXlfeXnDv7fu7R0dGqKbt0w8n5PaDtW7soJ/2yi0LGdZDP/YoVKwrsnkJE7otBNxG5Jfkhqo1enp+8MhJFIdkS6Vco/S5lJHT5YS79ovPLrpSm/LKgma16S/76omw3v/MlQUF5jK6d3/5LWo+lcT7zIgG29OmUPrYSdEsfYglM5Qe6PNb6w+YVdOfMehaXBGySSZQ++nnRgtaS7u9qznVeg2BdrYLek1dLWshIX2oZ7K5Pnz5q0L1GjRrh2muvta0jfdBlDIYff/xRtW5ZvHixCpYlaMtvirzCzv+0adNUX2vJokqfb2khIxc8pDWM/WB4V7Nv2Y42kF9en4GcgWFx3yf22Xr7fUrAbd9KyJ52oUgGApSssLRskKkf5WKbXNSULL9caLA/B6VN3jfy+ZGLYrIvqW8Zj0PGSJAMekn3LRdwZDwEOXbpg05EFQ+DbiKqcGS+Y/nxJJkX+4GbZMAi+cFnPx9yXiR4kmbE8gNKsjmSGZGBdnLuw34UbE3OZdq+5MezfXZGmpxLlkuaBTsLyQLnNd+vZJzyyyxdTbAm9WOfCZRzJ/WmNY+/2nosquKWXYJpqT8ZwEp+rGvBtQxQpQXdEvwWNhhVScokAYqMsl/a75vinOu83idyPmQgt6Icg319y8UP+/VkYDChvQe0lgmyP/uBv/LKvBe3HqW+pOmxNDGXCymSdc1rZGoJyiT7LTc5ThnATC66yOB1JZkOTwZHlEEYZZAwe3KMOQfeKmzfBb1P5NzK5yvnhZiyIvuUzLxk4gsK4mVkd2lSLy0LpA402swTGu09J+9JbXYKIa0RZF37iyMaWdeenAN5nzVv3lw9lpkc5D0mAbJcXNVItwJ72vedNBsvCrlIK9l/GShRmrcXZZA9InIv7NNNRBWOTGMjco7kLCOSC5mqpjD333+/ms5ItiFNPnOOHC4j927evFmNiquR7EnOLI8ER9JsU0Zxts+uyg9uacpYlLKUF/nRLM2j5ce9RrJsOafcyYs2R29eQXt+tGnGNNqFDe1cl0Y9FoWUXWtWWhTSH16auMo0XZKllOmRhATfcv5k2qq8stzFLVNe51L66Mr7Tpqx5iTry6jSJVGccy3vk5x9x2Vap5zZ58LeEzLivf2o6NLMWEaul3EStKblsi9hvz/phytBU1HPWX4kUyt9fmU0ahl1X86dfdNyIcGhPfksy9Rm8lmW4K8kJPOcs6WF9IeWCzjF3Xd+51iCc9mPZMRz7kse59x2aZD3prwHJHufk5xbrYxa5t2+XPKdI1l8e9KSSbLjH374YbbvJBn5PL96lveP9BG3v8AhF4O075S89i33pbm/PdmvXBD49NNP1UXXwlrJyMUP+QzI+0n68dtPH0hEFQMz3URU4UgGRH74yI8grSmjTAsjP9SlGalkmQojmQppwitBgQwYlLMPpDwnc+BKU0UZAEybMkz6EEvwrWWg5MebZKXkx69MBSbT3UjWW35gtm3bNtugaY4m0wrJj1Qpp/yAlulv5Bi1wKcgMliSkGmC5IKE/LjVpl3Kj2Sr5HzI/iSQlH3JedcyWKVRj0UhZZdspwwiJnUiTW+lj2Z+pJ+/vEYCbG2ObiE/0iUglNvVBt2yfRlXQOZ+lz6p0mxXsn0yL7P8oJfuDtIcVtaT/UkGT+pO+q6WZJqi4pxreZ/I4FbSpFbe/zK/tFwEyLlfCZ7lfSAXJ+SihjRJlmPQ+vxKBnbEiBFqoDBpFSABjmTWZeowjfRjls+UrCfHLtuT9eRzlTMYyu+cFUSCbLnYM3HiRDUtn32WX9u/XACQ7K2UUaZPkymw5CKE/YBdxSF1J82qZeAyGcBL6k4u1uVsTVKUfWufO8nQy+dNvqfkPSmfWTkP8t0j7wmpQ3mNfObkO02mwLKfi7w0yHtGmlbLNHNyMVLKL+WR7LNcVJDAVoJSOWZpwSDvN/m+kM+PXPTIGczKa+UYZJtSj1JXUn55f+TX8kYugkmrBTm38l6Si0jyXpABDIU0J5dzI8cuFzmkibs0289rjAe5UCrbatWqlTpf0mpAzqUMKmh/sdX+Io58h8m5lu9PGbytsPcfEbkRRw+fTkRUmrSpgmTqpoJkZGRYJ0+ebK1du7bVw8PDGhkZqabJ0qajyW+qqZzTB8m+Nm3alOfzMl1Yx44d1VQ/NWrUUNPOvPPOO+o1Z8+ezbauTBHWqFEjVZYqVapYH3nkEWtMTEyusuQ1RZBM0VOUKa1kvzJ1lz1t6iiZWsieNsWOTOtkb+bMmWraHTmmG2+80fr3338XacowmQZLplELDw9XU+/Y//eT35Rhe/futfbv319NyxMSEmJ97LHHrCkpKaVSj/kdX15lT0xMtN53333W4OBg9VxRzvXTTz+t1p0xY0a25fXq1VPLDx8+XOT3bV7TX8n7R6Yyk3OTc3qkhIQEdQ5kXzIdXaVKlaw33HCD9Y033lDTLBVU7wUp6rmW6a6effZZtV+Z4qlbt27WQ4cO5Tnl3Mcff6ymzZLpq+ynD5N15fhk6i6Zjk/eb/L5yFlfYtu2bWo6NjnWmjVrWmfNmlXsc5Yfmf5JjlPWf/nll3M9L1PuydRRMiWhlLFu3bqq7mV6s4Lk9/4Tcj6ffPJJNT2aTHMon7PNmzfneg8Xdd8yjZx8ZvV6fa5zIlOyyTR1Ms2c3OQcy3fE/v37C/3eyY/UsWwrPzKlV+vWrdWxSV00a9bM+swzz1hPnz5tW2fjxo3W66+/Xq0j02zJ89o0bjmnmHv//ffVe1LOQZs2bay//fZbvp/3r7/+Wr1nZaox2ba8H3JO+SXfO127drX6+/ur9/DIkSPVNIU5vxfEv//+a+3bt6/6bvD29rY2bNjQ+tJLL+U5ZZj9lGRSNtn+n3/+WeTzSkSuTSf/ODrwJyJyRTKdkWSh8uq7nR8ZDEkGZ5J+t+Ux+JgrmjRpksr8y7Q8JcnKkuuTPtsydoJ0XyAiInJ17NNNRFQC0g9QmhFK3+78pKSkZHss/SSlmaQ0SWTATURERFQxsE83EVExSJ/BjRs3qv7Z0qewoOlfZL7mm2++WfUDlf6DMjiaDAYl0wERERERUcXAoJuIqBhk5GkZhEcGb5JBpLRRlPMb8VkGr5LBp2QwIBlwRwJv+2lwiIiIiMi9sU83ERERERERURlhn24iIiIiIiKiMsKgm4iIiIiIiKiMsE83AIvFgtOnTyMgIED1uyQiIiIiIiIqiMy+nZCQgGrVqkGvzz+fzaAbUAF3ZGRkgSeUiIiIiIiIKKcTJ06gRo0ayA+DbkBluLWTFRgYCGfNxsfExCAkJKTAqyjkWliv7on1WjiT2YIL8WnQ63Vwla80q8WChPg4BAQGQecqhaZCsV7dE+u14tSrxSI3K8IDvWA08LvZFVlcOM6RqWAleavFk/lh0C1DuGc1KZeA25mDbpPJpMrnam9Gyh/r1T2xXosWdKciDUajDkYX+U6TH3t6WBEUHMyg242wXt0T67Xi1KtJ/Ua2IpBBt8uyuEGcU1gXZdc8KiIiIiIiIiIXwKCbiIiIiIiIqIww6CYiIiIiIiIqI+zTTURERETkZKxWC0wZGWpKItLOiRVmUwbS09NsfWjNapkVqalWDqTmwn26MzIykJqa6nR9uj08PGAwGK56Owy6iYiIiIiciATbF05HqyCz4OGZKhZr1mBqacmJtvOiXZJIvFT4YFbknKxWq20Ec2esw+DgYERERFxV2Rh0ExERERE5UQASe/EcPDyMqBpRlbMl5GAxm6A3GLMH4lbAw6BzyoCNCifveRm93Gg0OlUdSrmSk5Nx/vx59bhq1aol3haDbiIiKldmsxkb1m/A/qMnULVaVXTo0LFUmm4REbkDi9mM9LRUVKtWDT6+vo4ujtMxm00wMOh2K1YnDbqFj4+P+iuBd+XKlUv8e4VBNxERlZvvv/8ejz/+OE6ePGlbVq16dUx7bRbu7N2HNUFEFZ7FYlZNpz09PCr8uSByBr5ZF7+k33lJg27n6qlORERuHXD3798/W8Atzpw+jWGD7sXyH5Y6rGxERM7CNnCak2X8iCoqXSl8Fhl0ExFRuTQplwx3XqPwasteePZJtR4RERGRO2HzciIiKhsX9gMxx4DE8/j99025Mtw5A+9TJ09i55QO6NS4CqD3gFX67Ok9AL0RiT1mAx6Zzbs8934H45l/YJXnstaxv5967WDA01+tazizHYaYI1nb8lTrqHWztmuKuBYweqt1dcmXoEtPyNqeETBo281an2MIkxOTC1abN/6Bc2fPokpEBNrf2IFjJZDL6dK5M65tcS1mzXqzRK9fv349brnlFjUKtow4TeQsGHQTEVExA+njQOI5IOk8kHgh6/4FID0ReHD9lXVXvggcXKnuntmdUbTNH90HD/9DuZ+QoDuLx7F18NqzKN9tpDUZAGtW0O3179fw3jEv33VjR/4NS3Atdd97y2z4bJ2d/7pD1gPGiMx1/3oX3n+/rwL3zCDeLkjXG5HUYzbMlRpllnf/cnjtWXglmM+6QKCtm9r6IVhC66p1DWd3wOPo2qyLDlnbtbsAkVGzI6wBmaOn6hLOwHDpQNbFBk/b+toFCItfFdvFB5gzAHNa1r49AB0burkT6Zrx/DPjcPrUKdsyjpVA5W348GH4fMGCXMtvu+02/PTzL0XaxrfffafmRS5OgD7TLkC/4YYbcObMGQQFBcEVRUVF4YknnlA3ci8MuomIKroLBzIz0iqIPpcZSKv754G0BOChDVfWXfkScHBF/ttKTwY8s0bbDW8IJJwF/KugqjED+H5ZoUUJ6v4cEls1BMwmwJIBncWUGTAavK7som53WAKqqXV0lgy13pX7Jlg9MkcaFebQuipQVdvK2qaso9Y1Z8BqvLJd6PWwSjZdnjen5yqbCmazSEZcn3wx/wORADeLIeYwPA+vzP+UNe5rC7qNp7bA94/p+a6b0O9rZGQF3R5H18B/xdj81+01FxkNe6n7ngd+hP+PD145Fgm6swJwOa7kW2cgvVHfzDJEb4TvmueuBPxZFxS0+2mtHkBGna5qXf2lA/De+n6uCwnadjOiboa5WpvMc5Z0AZ6Hf7W1NLBvySDLLCF1bBdAYErNbKFg19IgW+sDqTeDZ/7nv4IF3DImQs6uG9pYCfO+WMhBCqncdOvWDZ/M/TTbMi8vu+/ZQoSGhl7V/j09PdV8yo5oaSL9fvV657igmZ6ers4FOQ8G3UREFS6Qjgce+u3KuqteAg78mv+20pMAT7/M++ENgIQzKpCGf2XALzzzrzyW+xIgaW572Xa3o9mMGh9F4dSpU3n265YfK5KZa3vP00gvZGTQjIZ3qltRpLV+SN2KIuWml9RNkTJazZkBf1aQbvHwB+IT1NOprUZmBqlaEJ+1XmZwnw5LcO0r5a3TFUm+YdkvJNhdKLAERtrWNYc1RGqzgbYLCNm3a4LFN9y2rtUrEKZKjXKsY3dRIavZvCLP29FZLZkXBsxpmY3mLZYrz6XGwnjxv3zPU0b9nrb7+vhT8N79Zb7rJnn624JuCaL9VozLd93kDs8htf2TmetePoSg+bfku25KuzG2utLHHEXQ/JuvtCKQIF7rEmDwQFrTu5Ha7vHMY0u5DP9lD2S/kKAzwNNshYe3H0w1OyD9mnsyd2JKhc/mmdlaKNi3PjCH1oOp5o2Z61ot8Di8KvuFB7v1rd7BsATWuHKO5YKNuthgvKrWB/JDXzLc+Y2VIJ8rGSuhxx13sqk5lQsJsPMLejesX4/bb++OlStXoUPHjmrZG6+/jlmzZmL7jp2oUqVKrublH3zwAd55+y2cOHFCZa87dOiAr77+WmXVf/ttg7q9+847at0jR47g+PHj2ZqXf/bZZypr/M0336i/sh3Zxrx582xzLstUVePGjcOCBQvU5+SBBx7A2bNnERcXh6VL8x7gU9uuvOa5557DgQMHcOjQIVy4cAHPP/88tm/frka6btGiBd588020atXK9rmcPHkyPv30U5w7dw5hYWFqgNF33nkHN998syr/2LFj1U1bX/zxxx8YP348/v77b1SqVAl9+/bF9OnT4efnZ8uQjxgxAgcPHlRlvuuuu1QZyXkw6CYicodAOjUuM5DWRthcNQE4UEBzvrREwCur6XGlBkD86ezBs/19fd6BdHHID5m3335b/biQQMA+SNBGBX1lxkznCQykTDoJiDL/m7TmCEytfuEwy7kpAnPla9StKExRndStKCSLrWWyC5Pe+C5cbtDzSssBW4Ce1TrA/8qPZFONdoi/+3tb4C/rX7mfDlP162zrWkJqI7nj89laGthv1xze1Lau1TsI6XW75dvqQDWHt2PxrZRj3xnQZdZE9vekOR26jOR8e9xLX33b/YxkeET/nmsdLQ+XavSyBd2yrs+fb+V7TtMa978SdJvTEbBkUL7rptfrgcS+822Pg99vmnnhw44E/xJ8Z0TdgsS+V5roBn52M3SmlNzdGAweWHcuMFuT8vzGSpC+3h1uKtr7ipyP1GN62pXWM+XJ08ur1OZN7nTzzRgz5nEMHToE2/7ZroLkiRMnYOE336iAOycJMMc+8Tg+mz8f7dvfgMuXL6vgU7z55ls4eOAgml7TFBMnTVbXSatFVFZBa07Jycl444038Pnnn6tM9KBBg/DUU0/hyy8zLxjOmDFD3ZdAvHHjxur/KglcJXgviGxXXvvJJ5+o4FnmcJZjGjJkCN59911VbzNnzkSPHj1UMBwQEIDFixerIHzhwoVo2rSpCu537txpm+Hj2muvxYMPPoiRI0fa9nP48GF0794dL7/8sgrWJbB/7LHH1E3KrJFjnDBhAiZOnHgVtURlhUE3EZHTBtKxwEO/Fz2Qlj7VXgFXMtLxp/IPpO2b5t42FeVBrrx/9913ec7TLQE35+kuQ3oDoPfVQlYld240a7lvJZhqZWahCmMJjkLq9fk3cbcnfdwT7/qiaOtWvgaxj+7LY4fmzGDdLissgb/0zb8SwKdnayVgCbhyQcHiHYLEOz66cuFBgnlTOlKT4uHtaYQlopltXavBU7VoyNmKQLtooAbhs61shalqq2wtI660bMiA1cduQCerJVfALXTSssKUdXx2pIWABN15OXc6qkjnUwZXI9clAffIkQ84ZN8ff/wJvLztWs0U4qeffkJwUGC2Zc89Nx7PjR+v7k+ZOhWr16zGIw8/hD179uD+wYNx5515Xzw8cSJaZXJ79rxDBay1atVCy5YtYTabVNZbmk/L/MmSWZeg22DI++KAZJw//PBD1K2b2Y1HgtUpU6bYnpcAWbLIkj0Ws2fPxs8//1zoscp233//fRUoazp37pxtnTlz5qiM+4YNG3DHHXcgOjpalbdr166q73rNmjVx3XXX2ZrWy4VnOVb71gKS0R44cKCtn3f9+vVVZrxTp06qJYB3Vv3Ivp98MrO1EDkfBt1ERKXt4gF4RO8GolOvDDaWXyC9eiKwv4D/3KVPtXfglT7SBQbSdv3mbp0C3Op8VSuBd+/evbF+/QbsP3oCVatVRYcOHZ0nw00ucPEgx3vF4HmlL3hhPP1U1t+e1WJBXGwMEBwCnX1/TE9/JHeZVrTtevggflABYx3Y0+lx+anzWV0M7LobZF0oUE3S7cTfswQ6S3pWa4L0bMF86K4TwMdPF7pLGc2cqDxIE+nZ772fbz9tCZQXLPgcrVq2UEH0zJmz8t1W1663omatWmhQvx5u69ZN9Rfv06cvvLyK11dZAnMt4BbSrPz8+fPqvjQhl2beWuAr5P+j1q1bw2LXuikvcizNmzfPtky29eKLL6pR1GUf0gVEMuISbIsBAwbgrbfeQp06dVT2WrLgd955J4zG/EMyyYTv2rXLlpkXkkWX8h09elRl50WbNpldecg5MegmIiqKiweBy0evBM8yWndiVnY6RyCtWzMZQQUG0vGAd9CVpt1xJ7P6R0sAXTn7fft+ubdOzry5OPlBI80MG7dKg9Gog8FJBp4hKjfyXSGtTQyehbY+MFdrne9mrqtvRrWX3lKDpuU5VoK0JKlaRU0fRq5LmnhLxtlR+y4OyUzXq1evwHU2b96k/kpzcblp/ZJzkozv1q1/q77gq1atwuRJkzB1yhT8sXEjwsIqFblMOUdDz9nFqaR8fHxyNb2XpuWXLl1STdTlooL0cW/fvr0a2ExERkZi//79WL16tTqmUaNG4fXXX1eZ8PxGbU9MTMRDDz2EMWPG5HpOMuWa/M4jOQcG3URUsQPprHmkbcG0dj85BnjYPiM9Cfjvx/y3JX2qtSaklRrAdPk4DIER0KkBx8Kzguis+24YSBORYy5gTXttlhqlPNdYCVl/3+6UAp99i5B+zf9YRS5K6rY4TbydmfRPfurJJ/HhRx/h20WLMHzYMKxYuTLfUb8lA9yla1d1e2nCBFQKC1VZ5H79+sPT00Nlkq+GNFOX/uRbt27FTTfdpJbJNv/55x81CFpxbdy4UTU5lwy2kIHbLl68mCtYl+y23B599FE0atQIu3fvVoOtSfY85zHJ8r179xZ6MYOcG4NuInIvFw8BMUdLKZCOBXxCMu9Xqg9If8+8stFys5umytplImJbjlZN6rI1VyUiKmUyFoJMC5Z7nu5qmHVXJPqF7kNKbGbTVqKylpaWpgYHyxk4y4jbEkwOGTxYzds9dOgwdOvWHS1bXIs3Z83Ck089lWtbP/34I44cPYqOHTsiJCQEv/zys2pS3aBBA/V8ragobPlrC44dOwY/P39UCQ8rUZlHjx6t+k1LUCsBsPTxltHPSzKAnPS3lgHbpKl3fHw8nn76aRVka2REcTkP7dq1U83ev/jiC/W8ZMW1Uch/++033HvvvSpLLuft2WefxfXXX6/6osvI6pLRliBcMuXS/5xcA4NuInLBQFqadp/LO5BeMwnYtzz/baXEAL6hV5p25xdISx9pmbNZ03VS5o2IyAkDb5kWTEYpl0HTpA+3NCk36HVI3LsY6U36ObqIVEGsWLECkTWqZ1vWsGFD/LtnL6ZPm4bo6OP4YdkyW9/qDz78EIMGDkTXW2/NNiCZCAoOxtIlSzB1ymSkpqaiXv36+OLLL9GkSRP1/LhxT6pM+bXNrkFKSooaObwkJKiVCwWDBw9WrUdk9HDpP16SsUbmzp2rXi/ZaWlKPm3aNDVSukYGVXv11VfVFGUSfDdr1gzLly9Xo58LGeBNmpJLH3S5gCGtV6TfuDQ/f+GFF9QFCFkmz99zT9b0huQSdNbS6NTg4uRKlDQvkcEUAgOzj7joLOTKnvR7kcxZfk1wyPVU6HpVgfSxK8FzzkBapr/Szsk39wP7Mv+TztMzR68E0mumAAdW2gXR4dnnlK51A2AsXh+14qrQ9VpEJrMF5+Mz+3QbXeQcaQNuBeUccItcWoWq14wU+P8wDKnXjb4y3ZmbcuV6TU9LxaUzJ1UmVxuZmq6Q0csNhit5QwlkJJrxMOhKZXoz+T9cBie7++67MXVq+czuUdFZZQYIk0m1iiitKepKk1z0kUHrateuneszWdQ4kpluIio9lw5nDjaWZyB9OXOwMe3Hz9opwN4fCm7abZ+RrtIs/0Da027wkC4TMm9ERJSN95bZ8Dy6Bh7H1iOl0wSktnnkSishogpK5vZeuXKlmoJLssvSZFsCrPvuu8/RRSM3wqCbiEovkJYs896lBTft9gsrWiBt37S7y0uZNyIiKrHU6x6FIfYYvPYugu/6iTCc2Yak7m+r6dGIKippkSZ9raUZuGRcr7nmGjW6uDYVF1FpYNBNVJED6ZwDjcnf5EtZTbuz+jKtnQrsWZL/tlIuA36VCgik7eaRts9Id34x80ZEROXDwxdJPWbDVLUVfNe9CK/9y2C8+B8S+syHJZQjI1PFJH2vZdRxorLEoJuoQgbSLwN7vs9/W5LBlqmtRFj9rEA6PI8Bx8KzZ0g6v5B5IyIi56TTIa3VCJirNIP/D8NhuHQAQZ/fioTen8EU1cnRpSMicksMuomcPZBWo3ZrTbrlrwTS5zID6Qc3ANpgIoUG0pcyg2Vt+qtsgXRW027tvlfAldcxkCYicjum6tchbvAa+C9/QAXelpA6ji4SEZHbYtBN5GBe+xZDd25LZkCddDEzI60F0uteAf5dXHAgHVDFLpC+xq5vtBZQV8kdSN/yfOaNiIgqLKt/FSTc/T30MUdgCYq88oQpFTBy1GwiotLCoJvIkdLi4b/mWejUhBdZki8CARF2TbvzCqSzbt52UxMwkCYiouIyeMBSqaHtocfhlfBdMx6JvebCHNGC55OIqBQw6CZyJFP6lYC770dZgXTQledvGZ95IyIiKmtWK3w2vQ5DXDQCv7oDSV1fRXrzQTzvRERXKWueHyJyuOb3AHU7Ax4+ji4JERFVRDodEgZ8h/S63aAzp8F/xVj4rhiX2dyciIhKjEE3ERERESlW7yAk9l2A5A7jYYUO3rs+R+DXd0Iff5JniMrU/PmfoVJYKM+ym5g0aRJatLjSRWXo0KHo06dPue7TmTg06E5ISMATTzyBWrVqwcfHBzfccAO2bt1qe14mqJ8wYQKqVq2qnu/atSsOHjyYbRuXL1/GwIEDERgYiODgYIwYMQKJiYkOOBoiIiIiN6DTI7X9OCT2XwiLdwiMZ3cgcEFX6GTmDKJ8DB8+DB5Gg7r5+nijUcMGeHnqVJhMJp6zIli/fj10Oh1iY2N5vtyQQ4PuBx54AKtWrcLnn3+O3bt347bbblOB9alTp9Tzr732Gt555x18+OGH+Ouvv+Dn54du3bohNfVKMycJuPfs2aO28+OPP+K3337Dgw8+6MCjIioG3zBcfGg3LM8xg0BERM4lo3ZnxA9eDVPlZkhv2EuNdk5UEPmdfuLkKez7bz+eGDsWU6ZMxsw33nD7k5aeng5nIUnLol7oyMjIKPPykIOD7pSUFCxevFgF1jfddBPq1aunmgTI3w8++EC9Yd566y28+OKL6N27N5o3b44FCxbg9OnTWLp0qdrGvn378Ouvv+KTTz5Bu3bt0KFDB7z77rtYuHChWo/I6el0gIcv4OmXeZ+IiMiJWIJqIv6+n5B8y1TbMl3KZSAtwaHlIufk5eWFiIgI1Yr14YcfQZcuXbB8+XL1XExMDIYOHYLwSmEIDPDHHT175GrBqjl27Bg8PYz4+++/sy1/++23Ub9+fVgsFvV4+fJlaNKoIQL9fdG5c2fMnz8/V7ZY4o2mTZuqskVFRWHmzJnZtinLpk2bhuHDhyMgIAA1a9bEnDlzCjzOm2++GY899phqsVupUiV1sUHMmjULzZo1U4nCyMhIjBo1KlsL3OPHj+POO+9ESEiIWkfK9fPPP6vjveWWW9Q68pwcgzTHFnKs06dPR+3atVXL32uvvRbfffddrgz5L7/8gtatW6vj/OOPP/I8p7LeN998g06dOsHb2xtffvmlek5iqcaNG6tljRo1wvvvv5/ttc8++ywaNGgAX19f1KlTBy+99FKugP3VV19FlSpV1DmUlsf2SVJ7kydPRnh4uGql/PDDD2e7YCFxncRz0no5LCwMd9xxBw4fPpzt9SdPnsT//vc/hIaGqnPYpk0blZzNi7xWyit1JbFlhQy65QqM2WxWlWtP3kzyRjl69CjOnj2rMt+aoKAgFVxv3rxZPZa/UilysjWyvl6vz/fkExEREVExyACfRq/M+xYT/Jc9gKAvukF/6QBPY3lKT8r/lnOwu4LWzUgp2rqlQH7Xp2dkBlUjhg/DP9u2YcmSpfj9j40qCOp15x15ZlslEJaAXfp525PH999/v/qtL7HCPXffjV69emPrtu2qpesLL7yQbf1t27bh7rvvxr333qta1UqCTwLGzz7Lvl0JxCWe2L59uwqUH3nkEezfv7/AY5MA39PTExs3blStcoWUS1rpSitceX7t2rV45plnbK959NFHkZaWplrmSnlmzJgBf39/FaDLxQEh+z1z5oy6wCAk4JbEo+xDtjt27FgMGjQIGzZsyFae5557TgW+kpSUZGV+ZL3HH39crScXCyTwlu68r7zyilomFyDkHEn5NRJIyznbu3evKtfHH3+MN9980/b8okWL1LmV18qFEukanDNwF2vWrFH7kAsFX3/9Nb7//nsVhGuSkpIwbtw4tQ1ZV85n3759bRdZ5AKGXDCQVtHLli3Dzp071fnVnre3a9cuFcDfd999mD17trrgUCGnDJPKa9++PaZOnaqurMiVETn5EkhLtlsCbiHL7clj7Tn5W7ly5WzPG41GdeVDWycv8maXmyY+Pl79lQrLq9KcgZRLvpyctXxUMpaUWPivfgbw9ISl93vMdrsJfl6Leo4ssFqyzVLv1KxZ38Pyl9wH67V49HEnoL98CIbEMwj6/DYkdn8b6Q3uhLNx5XpV5c5juXFGjXxfY6l3Kyz/W2R7bJjVALqM5Ly3X+tGmAf/eGXdd6+FLvlSrvVML8UUu+y2fVitWLtmDVauXIlHH31MZbQl473ht9/VGE5iwedfoHZULfzww1L07z8g1zaGjxiBR0eNwhtvzFTZ23/++Qf/7t6Nbxd9q7b/8Zw5aNCwIV6dMUOdr6aNG+Hff/9VgZ86h1aryjxL8C4tZ4VkySVwff311zFkyBDbvnr06KECbSFBnASUEjBLdjc/si0Jmu2PWYJZjWT7Jc6R7b733ntqWXR0NO666y5cc8016rFkrzWS4RaSBZakopBssRyPdKOVuEl7ze+//46PPvpItRbWMrgSvNonK3NmdrXHUkYJZDUTJ07EG2+8YVsmFzzkHMn2Bw8erJbZX8yQ43ryySdVxvzpp59Wy6R1srQUkJuQ4169erUqv305PD09MXfuXJUxb9KkiSqznO8pU6ao5/v165etzLKuxHpSHjlncoHgwoUL2LJli4r3RN26dW3Hp+1LLoRIi4Lnn39elfVqs9zatvOKFYsamzl0nm7pyy2VU716dRgMBrRq1Uo1F5CrUmVJrhjZX1XRSLMXZx3sQSpUBp6TCperPuQerEkXEP5f5pXNix2nMuh2E/y8Fs5stiAhOQMGgw4GF+laId+/SYmZTWodfcWcSg/rtbgCEd/rW1ReNw4+Z7YgYPkDiG02ApfbjAX0Dv1Z6Tb1ajZlqIsFFrO0Cr3yu9RYyPHar2sozrr5xCP26xSFbPenn35CcFCgyl7L/4X33HsvXnjxBaxbu1Ylxtq0aW3bbnBwkApqJXsqy7TgRXtemhaPGT0a33+/WGWr5382T2U5I2vWVK1l9+//TzWnlvtyCDqrRT0W8ntebrJtCb7sf99ff/31KlsrCTiJP4Q087ZfR0vy5RcXyLG2bNky1/OSnZWus5KtlqSePC+Bp9yXQFMy3dLUWS5GSHN4CXS1rLQch33ZxX///Yfk5GQ17pU9aZIto3RrLYeF9jg/2nP25ZbMsjTBlnG27MfEkuelhbG2nmSy5cLBkSNHVLZZlkvzcO15yV7LNuz3L62TJaOtLbNYLOpYJfDWlrVt21ZtT1ot1KhRQ12ckRhNBta+ePGi7T0hz0uzd2mJIMdpv297sr5c2JDzJYH8mDFjSiW2k23ItuPi4lR92JP4rCgc+u0oVyakaYRUuLwZpSnCPffco9reS38Qce7cObVcI4+1oeBlnfPnz+c6KTKiufb6vIwfP141XdDIvqVZh1xhkkp0RlLR8p+GlJFBt/uweFz5IlBX7FzshwHljZ/XwpnMFpg80mA06GB0kQuJWsYsKCgYOhcpMxWO9VoCwSFIvncJ8Psr8Pn7fQTvngu/2P+QcMdHsPqGO8XbzpXrNT09DWnJidAbjDAYrvxUNz1bwKCrekO2dc3jCmj6r9NnX3fMzjxXs1+nKOR3qvR1nv3e+yqwqlatmgq0M4tnsG1TC3SzXgR9Vnm037fafn18jBg06H58vmAB+vXrrzKrM2e9qdaTbcj+5Cb3Jeg2ZC0Xsl+5yfOyvlaOzO1fWUe7L5l0+3W0stgvy3ms0izc/nnpMy1TYkk/ZWmqLb/rpMusBKPyu0DWlcD29ttvVxcnJHstAbpkmUePHp2r7ELrFy2DRUuS0p5WZu11EiTnV177Y5FYJ+f2pQ+7BMn2ZLuynrRCllYB0nxcmqPLfmT8LGlFkPO82j/W6sf2HtDrsz22L5N2HNIKQDLpUh55/8h5kz7ycmFB1pELFzm3YU/2IS0F5LVyoUDOfWnEdrI/2bYce86u0QWd82zrwQlIJ3i5SaZ5xYoV6g0oTSckcJYrRlqQLcGx9NXWmn9IMwsZKEEy49qVLWkKIhWU842T800qt5zkZDpzQKt9cThzGamY7OpS1SuDbrfBz2vB9FY5R3ro9DqX+kGsfkTIDwcXKjMVjvVaAnpPpNwyGaZqreD/yxh4nNiIgJ8eRsI9S5zmLeeq9arKndcTMuhqUZXVuoWQ3/PSTTSnRo0aq8SY/I7XmpdfunQJB/bvR+MmjfPdnjQxb3FtczXIsrxegjL5qSTnqEGDhvjl118yfzup/1NgG3hNC/ikC+umTZuytXaQx5JhzytAtJfXsoKel+bvEoNIMKr9Vv/2229zrSsDtUksIzdJBMogZpKR1WIT7cK90AaAO3HihLqgkV85ilrenOtJrCUBqmSSpZ94XiTolkBYa6IvJJtsv005z9Lk277Jvja+ln2Zdu7cqQJ96euvraP1aZdm49JCQPqLd+zYUT2vDQinlVkGkZMm5xIzas3Lcx6jbFsuUkiXge7du6tWBdKt+Wpo+88rDitqXObQbyEJsGWUOqloudojo/ZJ04Fhw4apA5MRAV9++WXVUV4GG5B+BfLG0CZWlwqWkzly5EhV0dJ+X5psyGAJsh4RERERlZ2Mhr0RN2glTFWaI7nzNJ5qyrf/c69evfDIww+pQEqCryGD71fZWxkILT/yW79du+vx/PjnVFN1LVgTIx98EPv/+w/jn3sOBw4cUJlNbYA0LdCT/rySwJM+xrKODA4mg2o99dRTpV5TcrFBmtXLTErSDFu60WoDrGkktpH4R2IfCdLXrVunjlFIYCvlloBRAlBpdi3BopRVBk+TsktTcHmd7MN+oLOrIc25peutDAAn50hirnnz5qmLB1rdSZAt2W3Zv6y3ZEn2i2vST/zTTz9Vr5NtSD9x6YedU3p6uhrZXJr9y6jtsp7EbhK4SmteGbFcstyHDh1SiVT7lslCuiHLhQKJBSXuk/MsA9Bpg2zbX/yR1gRyYUVaFtiPIO8oDg26pV289G2QQFsCahlhTt6IHh4e6nnpWC/NLaQphtbmX4J0+7S+dKiX18sgCXJFQ7ZR2DD/RERERFQ6LJUaIv7+1TCHX8lYGo//lnuUbKrQPpn7KVq2aoU+vXuhY4cbVb/oZct/tP3uz8+w4cNUsDZ06LBsy6VV7DeLFuGHpUvQplULFeBqA35pWWMZL0qCcQkYZSAuGaVb+vpq03GVJsnCSqAqg6tpg35JMGtPmklL7KMlDiXjro3yLRcgJACW0cWlT7kEo0IuGMho4rIt7XUSUNoPwnY1pAm2ZNslYJam3NJvXi5eaNuXiyUS9Et5pPWxtBSQ8tiT7sGyTGI3aX0sU6NpLZPtdenSRQXxMgCcvEa2Lc3WhQTeMqi2tGCW8yf7lAHv7Em3Bclcy+BqEvdJeWXE9mxdFrJIBl2mUZP3Wc+ePVV3ZkfSWR09aZkTkGbr0kZfLgI4c59u6asuTSnYvNx9WBLOQz+zfuaDibFsXu4m+HktWp/u8/FpMBpdq093XGwMgoJDXK65KuWP9Vr6jCf/QsA3fWAOb4LE3vPUXN/lzZXrNT0tFZfOnEStqKhc/UcroldefhnfLf4O27fvsA20Zt/fXAIZiWY8DDo10rcE39Icm1yH1WpV3Qe0fvjORprES+sEuRCR8zNZ1DjStb6FiIiIiMi5WTJg9QqE8dwuBC7oCuPRdY4uEbkgaeEqU4C9//57KjucF+nr/ffWrbbm3DmnAiNyFgy6iRzJNxSXhv8Fy5MFjDJKRETkQkw1OyB+8BqYIlpAnxqDgO/ugfefb2WmI4mKaMyY0Wh3XVvV3HnYsMz5n3M6dPAg+t3VFy2aX6PGgZI+3FpzZSJnwublbF5ODsRmyO6J9Vo4Ni8nZ+HKzZCdnikVvmvGw3vXF+pher0eSOwxG/C6upGE3b1e2by8YAU1L3fGpslUODYvJyIiIiIqCaM3kru9iaRus2A1eMLz0M/w2vc9zyURVThOMU83UYWVlgC/DROhk1E2e87kQGpEROR20prfD1P4NfDa+y3Srh3s6OIQEZU712pvQ+RuTGnw2f0FdH/PdXRJiIiIyoy5akskd5l25eJyeiK8/3oHMGfwrBOR22PQTURERETlyu/XJ+D721QEfNsfuqTzPPtE5NYYdBMRERFRuUpv1AdWDz94nNiEoAVdYDj9N2uAiNwWg24iIiIiKlcZDe5A3P2rYA5rAH3iWQR+3Qte2+dxWjEicksMuomIiIio3FnC6iNu0AqkN7gTOksG/FY/A79fRgMZKayNCq5e3Tp4++23HV0MlybTpy1durTEr1+/fr3aRmxsLBxt0qRJaNGiBVwZg24iIiIicgxPfyT2movkTpNg1enhcWwddGlxrA0X89FHHyIkOAgmk8m2LDExET7eXujSuXO2dTesXw8PowGHDx/Od3ub//wLI0eOtD2W9X/4IXsAOWXyZLRu3Qruwh0Cy7K6WPDUU09hzZo1cGWcMoyIiIiIHEenQ+p1j8IUcS2g94DVP4K1UQrMZjP++P13nDl7BlUjqqJDx44wGAxlcm5vvvkWFWT//fffuP7669Uy2XdERAS2bPkLqamp8Pb2tmVQa9asibp16+baTnp6Ojw9PREeHl4m5XQHGRkZ8PDwQEXi7++vbq6MmW4iR/IJweXB62EZvYP1QEREFZqpZgeYarSzPfb8bym8N88ErBaHlssVLVnyvWqi3bVrF9w/aJD6K49leVlo2LAhqlatit82bLAt27BhA+7s1Qu1a9fGX3/+mW15p5tvVveHDx+Gfnf1xfRp01AzsgaaNmmcq3m53Bf9+/VTGe8GDRpg/vzPMHXqFOzauROeRgO8PAz47LPP1HrSHPqBBx5QgXtgYCA6d+6MnTt35soof/7554iKikJQUBDuvfdeJCQkFHiMGzduxM033wxfX1+EhISgW7duiImJUc+lpaVhzJgxqFy5srq40KFDB2zdujVXU23J1rZp00Zt44YbbsD+/fvV81L2yZMnq3LKenLTjkfuf/DBB+jVqxf8/PzwyiuvqOWyTC5cyEUKOf9yPMVhsVgwffp0VT8+Pj649tpr8d133xX4mj/++AMdO3ZU60dGRqpjTkpKUs89//zzaNfuyudXI9udMmWKui/n5NZbb0WlSpXUee/UqRP++ecf27pSFtG3b1913FI/ebUCkLLLNmvUqAEvLy/13K+//mp7/tixY+r133//PW655RZ1vqUcmzdvtq1z/Phx3Hnnnaou5bw2bdoUP//8M8oKg24iR9IbYAmMBEJqXZm7lIiIqILTJZ6F36+Pw/ePV+G/ZDB0qWxyXlQSWN9z9904efJktuWnTp1Sy8sq8JZAev36ddkCTQmqOt50k7ovUlJSVOZbglfN2rVrsf/Afvzy6wos/WFZnk3NxSdz5+LEyVMq+L377nswduw4FShFnzyF4ydO4Z577lHrDRgwAOfPn8cvv/yCbdu2oVWrVujSpQsuX75s26Y0bZcmzD/++KO6yYWAV199Nd9j27Fjh9pGkyZNVOAmwacEbNKaQDzzzDNYvHgx5s+fr4LIevXqqaDcfp/ihRdewMyZM1WLAKPRiOHDh6vlUvYnn3xSHc+ZM2fUTTseLeiUQHT37t3qNUuWLMHjjz+uXvPvv//ioYcewrBhw7Bu3ZXzXxgJuBcsWIAPP/wQe/bswdixYzFo0CB1LvIi56x79+7o168fdu3ahW+++Uadh8cee0w9P3DgQGzZsiVbtwHZrqx73333qcdyYWPIkCHqdX/++Sfq16+PHj162C54yOvFvHnz1Dmwv3BhTy7IyHl844031PblXMtFiYMHD+Y639I0XepPLtb873//s3WBePTRR9XFkt9++02d1xkzZpRpNp3Ny4mIiIjIqUgT86Qu0+G36hl4Hl4Bw+e3IrHPZzCHN3F00ZyaBIHjxo6F1WrN9Zwsk+zfuLHj0KtX71Jvai6B9JPjxqmgRoLrHTu246abOqnm0HM+mqPW+XPzZhXoSHN0jWQZ58z5WGVs86I1NQ8ODlbN1c1mEwwGowqQDEajWiaH62HQqWBOAjcJuiUDKiQwkwBbsrgPPvigLVMqmeSAgAD1+P7771dZaC2LnNNrr72mMtTvv/++bZkEyEIyvZJ1lu3dfvvtatnHH3+MVatWYe7cuXj66adtr5Hty4UI8dxzz6Fnz56q6b1kjuV4jFnHk5MErRJUayR4HDp0KEaNGqUejxs3TgWxcqyS2S2M1MG0adOwevVqtG/fXi2rU6eOOn8fffSRrYw5g3QJrJ944gn1WALmd955R60rxy/nQ7LJX331FV566SW1zpdffqmy3/Xq1VOPpdWBvTlz5qh6lUBfAvqcdZ0fOc5nn31WtVAQEjDLBYe33noL7733nm09CbjlHAtpSSBlPHToEBo1aoTo6Gh1AaFZs2a24y9LzHQTOVJ6Inw3vgrdqgmcJoWIiMj+v8hm9yH+vp9gDoyEIfYoAr+8HZ77yiZL6y6kH3XODHfOwPvkyRNqvdLWqdPNKgCV7KRsXzKLEkRJ4K3165bgSoIb6dOtueaaa/INuItLmmdL3/KwsDBbP2C5HT16NFsGVpotawG3kKbxEqgXlunOi2xXLizceOONtmXS5/q6667Dvn37sq3bvHnzbPsUBe1XIwG/Pdmu/f6EPM65v/xI4JmcnKyaetufJ8l85zfAnZxbubBgv75kmOUChpxfIUG5BN3ae+3rr79WyzTnzp1TA+RJwC7Ny6X5v9SXBMBFFR8fj9OnTxfp+As639I0/uWXX1avmzhxosqYlyVmuokcKSMVvts/zrx/21TWBRERkR1zxLWIH7wa/ssfgsfx9fD/8SGknvkHybdMZbesPMigaaW5XnFINlP62Mro5NLXWZqVi2rVqqn+v5s3bVLNzG/OkYmVTHdpkQBOgiutObs9yZ5qcg5EJi0AJHjMj2SiS4P9fmWfoqD9lsU50s6T+Omnn1C9evVsz2ktBPJ6jTRjl2A1J+0iimTgJQMtTeyltcOJEyeyNZMfMmQILl26pJqH16pVS+1LMu0ygF5ZKOh8S79/uWgg52DlypUqky9N1kePHl0mZWGmm4iIiIicltUnFAn9FyLl+sxmrVa9BwPufMgo5aW5Xkn6dW/YsB4bftuQrYmyjJwuA11t3bolW3/u4gRPWv9pjWTHcy6T/ttnz55VzbTlIoD9TQbvKinJmOY3ZZU2mJn0NddI5lsy/tIHvKjyOp78NG7cONv+hDwu6v5kPQl4JcOc8zzJBZK8yLndu3dvrvXlprVUkIsuUu/SrFxukkmXweXsyyhBu/TjlqbeUoaLFy+isLq2J9lxuZBzNcevkWN9+OGH1YBr0j9eugWUFWa6iYiIiMi56Q1I6fgCMqJuhqm63QjJMrK5jjkk++BWAh8ZNC2vft2S7atevYZaryxIQD1m9GgVdEqzcs1NN92Ex8eMURlN+/7cRSXNwWXAtRtuuBFGowGVKoWjVlQtHDt6VDX9lmMKDQ5E165dVea0T58+qh+2NHGXpsiSzZSByHI20y6q8ePHq76/0odagjQJMqUPsQzaJsH8I488ovpuh4aGqqyv7Fuab48YMaJYx3g063ikDqX5e35ZZ9nX3XffjZYtW6pjXr58uQocpY92Uci2pb+zDJ4mmV8ZbT0uLk4FrhLUSkY6J8lgy3RwMnCaZIkl+y5BuPRdnz17tm09aU4uzbWlrt98881s26hfv74aZV3qQZqJy3HkbEUg50EucEizbzl+GV08r+OXfcgFDxm5XAZek/MmgX5RSd906YMv7xFpmSH1KRczygq/pYiIiIjIJZgibwT0WTkjczoCvukLr38+5rgoWWRwtFlZgY7WnFajPZ715qwyna9bmhVL9rNKlSq25RKAywjV2tRixfXaa69jzerVqB1VyzYt1V139VPNg2/r2gXVq1ZR/YflGGXaJwnyZeAxCahksC2ZHsq+PMUl25EmyNKvWfpqS2D/ww8/qIy6kJHPZVAuGZBNMsLSZ3rFihV5Boz5kdfLYGIyEJr0hZfjyY9cVJAm2jKgmGSMZfAzCTyL04pg6tSpasAzaVYtwabsWy5OaNN25ZXtlz75Bw4cUNOGScA/YcIElXW2179/f9WEXC46SDntzZ07VwW4co7kXGnTrNmTJt4SyEsWWvaRF3mdDB4n2Wm5GCKtKJYtW6aC+qKSbLqMYK4du9Sx/UB5pU1nzesyWAUjV1qkM79c4ZGrO85IrkLJtANyBU2v57USd2FJOA/9zKwviImxbC7nJvh5LZzJbMH5+DQYjToYXeQ7zWqxIC42BkHBIdC5SJmpcKxX1+W5+0v4/5rZ5DytyQAk3fYG4OHr8vWanpaKS2dOolZUlJrzuSRkWjAZxdx+ULUaNSJVwN23711wZdro5RoJZLTRy3NeaCDXYLVa1aj3chHDGetQBgGUVghyQSLnZ7KocSSblxMRERGRy0m/5j4kpSXAd/0keO39FoYLe5HYex4sIXln6ioSCaxlWjAZRVwGTZM+3NKkvKwy3ERUMAbdREREROR6dDqktXkY5irN4L9sJIwX9iDw81uR1PN9pNfuiopOAmwZ2IyIHM+12tsQuRufYMT87xdYHt7k6JIQERG5bD/vuMFrYKraBvq0OAR8PxBeOxc4ulhERDYMuokcSW+EOawBULkx+3MTERGVkDWgKuL/9wNSWwyDxTMAGTU78FwSkdNg0E1ERERErs/gieRbX0Pc8D9gCaljW6xLuezQYhERMegmcqT0JPhseQfYMIPTnRAREZUCa8CVKYw8jm9A8Eet4LnnW55bInIYBt1EjpSRAr8tb0O/4VU2LyciIiplXnsWQZeRBP+fR8F39XNqbm8iovLGoJuIiIiI3FJi93eQ0v5Jdd97+1wELOwDXeJZRxeLiCoYBt1ERERE5J70BqR0eA4Jfb+AxSsQHqe3Imh+ZxhPcNYQIio/DLqJiIiIyK1l1OuG+PtXwVSpMfTJFxDwzV0wnN8DV2KxWGEyW8rtJvsrT/Pnf4ZKYaFwBVarFQ8++CBCQ0Oh0+mwY8cOOKOhQ4eiT58+ji4GOTroNpvNeOmll1C7dm34+Pigbt26mDp1qnoj279Z5M1sf+vevXu27Vy+fBkDBw5EYGAggoODMWLECCQmJjrgiIiIiIjIGcmI5vEDf0Fa47uQ3qQ/zOFN4CokAL6YlIbzCeV3k/0VJ/AePnwYPIwGdfP18Uajhg3w8tSpMJlMcDe//vorPvvsM/z44484c+YMrrnmmlLZ7s0334wnnngCpeXtt99W5SwOibWWLl1aamWgTEY40IwZM/DBBx9g/vz5aNq0Kf7++28MGzYMQUFBGDNmjG09CbLnzZtne+zl5ZVtOxJwyxt+1apVyMjIUNuQq09fffVVuR4PERERETkxTz8k9fwQsJhsA5jqUmOhS7kES0hdOCuLVbLcVuh1OujLIWVmsUDtT/arR+Z5Kopu3brhk7mfIi0tDb/88jPGjB4NDw8PPPvcc3Anhw8fRtWqVXHDDTfAGUliU4JnianIOTg0071p0yb07t0bPXv2RFRUFPr374/bbrsNW7ZsybaeBNkRERG2W0hIiO25ffv2qatNn3zyCdq1a4cOHTrg3XffxcKFC3H69GkHHBUREREROS0Jtg0emfetFvj9NAqBC26Fx6EVcHYScBv1+jK/lTSw136z16pVCw8//Ai6dOmC5cuXq+diYmIwdOgQhFcKQ2CAP+7o2QMHDx7MczvHjh2Dp4dRJeRyZm7r168Pi1wVALB8+TI0adQQgf6+6Ny5s0rkSbAZGxtre83ixYtVck/KJvHGzJkzs21Tlk2bNg3Dhw9HQEAAatasiTlz5uR7jNIKd/To0YiOjlb7ktcLudAgScPKlSvD29tbxSRbt27N9toNGzbguuuuU2WRoP25556ztQSQ7crzcoxa6145D+vXr1f3f/rpJzRv3lxt+/rrr8e///5r265ks6W177Jly9CkSRO1fSlfzublkkmXMj7zzDOqabzU1aRJk7KdC9G3b99sx0YuHnTL1aE1a9bgwIED6vHOnTvxxx9/4Pbbb8+2nrzZ5A3csGFDPPLII7h06ZLtuc2bN6s3WZs2bWzLunbtCr1ej7/++qscj4aoBLyDEDvge1hGrObpIyIiKme69ETo0uKgT09AwJJB8PljOmAxsx5KiXQfTc/InKZtxPBh+GfbNixZshS//7FRdSftdecdqpVqThLsScAu/bztyeP7779f/c4/evQo7rn7bvTq1Rtbt21XrVxfeOGFbOtv27YNd999N+69917s3r1bBZjStTVnk2sJxCWW2L59O0aNGqXijf379+d5TBIUT5kyBTVq1FAtbbXAWgJZCfAl8P/nn39Qr149lfmXbrDi1KlT6NGjB9q2batiHmntO3fuXLz88su27bZv3x4jR45U25VbZGSkbb9PP/20KqfsLzw8HHfeeWe2c5ecnKxaEUsics+ePSp2youUz8/PT8VJr732mjoWaS0stGORFsb2x0Yu3rxcru7Ex8ejUaNGMBgMqinEK6+8opqL2zctv+uuu1S/b2nK8fzzz6ugXIJtec3Zs2dzvamMRqO6eiPP5UWuRMlNI2UQctVMu3LmbKRc8uXkrOWjkrHoDMio3BwWab3BunUb/LwW9RxZYLXoUL5D9ZScNet7WP6S+2C9Vux6tXr4I37AYvhumASf7XPhs3kWDGe2I7HHB7D6XGlZWZ5UueHa5BjWrlmDlStX4tFHH1MZbcl4b/jtd1uT7AWff4HaUbXwww9L0b//gFzbGD5iBB4dNQpvvDFTZW4lkP139258u+hbtf2P58xBg4YN8eqMGep8NW3cSGV/JWutzqHVilmzZqng/cUXX1TblCy5BKSvv/46hgwZYtuXBMMSaGvB85tvvom1a9eiQYMGucolY0j5+/urOKRKlSpqmYwlJUG0BKva2FOSLZdgVoJgCZjfe+89FURLi1zJIksyUQJxiYfkQoBs19PTU12o0LarnUsxYcIElVgUctFAtvX999+riwqyjgTgso9rr702z/rQSLZctiXkwsDs2bOxevVqte1KlSqp5dIsXSuD/WvLg7Wc91cU2vspr1ixqLGZQ4PuRYsW4csvv1R9r6XZh4z8J4MHVKtWzfZBkCtTmmbNmqk3igy4Jtlv+RCVxPTp0zF58uRcy6XZi7MO9iAVmpCQoCpcru6Re2C9uifWa+HMZgsSkjNgMOhgyOpX6ezk+zcpMUHdlx9M5B5Yr+6puPUa1+pp+Ac2RKU/JsDz2DoELOiCc13eQXqlpihvZlOGulhgMZtgNpts35lyXyc9rK1lf+HPbLFm7dOg9lnUcy5NoIODAlUAKP8X3nPvvXjhxRewbu1alRRr06a17ZiCg4NUULt37161TAtetOfvuOMO1Sf8++8Xq8By/mfz0KlTJ0TWrKkSdfv3/4fWrWV7ZhV0y3mRx0J+z8tNti0ZYfvf99I0W7LKkoCTwFlIHGK/jgSckrzLLy7Qyqo9L1lxOWbp6qotk/edZM+lDFpZ5Hkpr0YeS8AuzcilWbsW3NnvV1tfMuTacgnQ5dzJBQRZJuWRgF2altu/VgsStWWybRn0Leexnjt3Ltc+yzsmMtudF2ejneO4uDjVosCexGdOH3TLVR+5uqMF1hJUHz9+XAXF9lef7NWpU0ddhTl06JAKuqUvwvnz53OdGGnKIc/lZfz48Rg3bly2TLdcLZK+4vImdkZS0fLhlTIy6HYflrRE+G7/BD6+PtDd+Liji0OlhJ/XwqkpaTzSYDToVP9BV6BlzIKCgqFzkTJT4Viv7qlE9dpmCOJrtkHAsmHwiDuOiN+fQ9yQDWqu7/KUnp6GtORE6A1GGAyZP9WtsMBgMGdeqCyH7x+rzgIZQk32bzAUbX/yO1X6DM9+730VAEoSTQJtoc8KbjO3Z3c+ZWA4XeZ+tN+32jH7+BgxaND9+HzBAvTr1x/ffPMNZs56U60n29D6Pct9CbrlvGjblv3KTZ6X9bVyZG7/yjrafcmk26+jlcV+mb2cz9v/zbkdKYMsk/s5y5Lzddox5Vde++X2xyZ/JUMug9blLKf9PuU1Ujf5bd9+WX7HXpaMDthnUWjnWFoASJ/6nM8VaRtwILlSkDOAlEouKE1/8uRJ1adbBh8Q0vdBBkuQPhva1S1pDiLbkKtHeZEPVs4R0O3fmM5K+3A5cxmpmEyp8N88I/N+x7E8fW6En9eC6a1yjvTQ6XUuFcCqH0TyI8qFykyFY726p5LUqyWiGeIHr4bfirFIafcEdMbsQUy5lRuuSfoKS5PlnBo1aqySYtKPWGteLr/nD+zfj8ZNGue7PWli3uLa5qrptrxeupxKwwU5Rw0aNMQvv/6SOTCe+j8FtoHXtOC1cePGauBm+9YO8liyxDkD2JwtIvJaZv+c/V85ZglmZdva4GOS+ZY+0dKKVyuL9Pm2f52sL4O3SfJPC4i1C/c59yXnTgao01rnyphYktm2L2dh5S3ouLRlErjnLEN5NinXOWFLMu2c5RWHFTUuc+ivBmnuIX24pSmKNKtYsmSJ6nshI+YJaW4h2fA///xTPS+Drslo59rABELewNJ3QgYdkFHPN27ciMcee0xlz+UKGxERERFRUVm9g5HYex7MEVf6xsrI5roEzopTUtKXulevXnjk4YfUoMkykNiQwfejevXqaiC0/Mjv/Hbtrsfz459TTdUlm6sZ+eCD2P/ffxj/3HMqAJVuq9oAaVrg9uSTT6r4YerUqWodGURM+jA/9dRTKO2LDdInXOIWmVVJmpJLbCIJxhEjRqh1ZIC2EydOqJHP//vvP/zwww+YOHGian2rBW4SsEtwLXHPxYsXsyUiZcAzORbpty6jkkvLX/uRyUuLlEH2I83rJbin0uHQoFsGEpBpwuRNKB8q+QA89NBD6oOhZb137dqlPqRyRUretJLN/v3337NlqqVfuAzGJs3NZSAEGaK/oKH+iYiIiIiKwnB2B/yXjUDQgi4wRv/h0JOm5s+WPrplfCuL8SJl/u6WrVqhT+9e6NjhRpXdXLb8x1xNonMaNnwY0tPTMXTosGzLZZDlbxYtwg9Ll6BNqxb48MMPbaOXa3FCq1atVDAuUwlLX2YZQEyCVwlaS9urr76Kfv36qdHVZb/SFXbFihW2qY7lAsPPP/+skoQy2NnDDz+sYhttkDchsZDEP5LBlhHKZdov++0//vjjKhaSgFgGppPMeGmTEdJlADjJvrds2bLUt19R6azOOERcOZM+3dJGXzrHO3OfbumnLqOys3m5+7AknId+Zv3MB5PiHF0cKiX8vBatT/f5+DQYja7VpzsuNgZBwSFsXu5GWK/uqTTrVR97DP5Lh8J4YQ+sOgNSbnoJqW1HZbZnLgPpaam4dOYkakVF2fqPWixWXExKg8lcfj/bZcyNSn5e0Osd29z3lZdfxneLv8P27TtsA61p/b6FnBGJZjwMOjVyuQTfklF2FzJ49C233KKyzjJNsjuyZg0ep/Vrdzapqalqijq50JOzT3dR40jn7K1OREREROQELMFRiB/4M/xWPgWvvd+q6cUMZ/9BUve3AU//cimDBL4SAFvKMVemV31YHRcAaaN6v//+e5g8ZUqe60hfbxkhPCQ0DFv+3KSmApNupkTOhkE3EREREVFBPHyR1OM9mKq2hu+6F+G1fxmMF/9DQp/5sITmHjisLEgArHfZIdaKb8yY0fhm4UI1ntOwYcPzXOfQwYOYPu0V1RpUptySPtwySxGRs2HQTURERERUGJ0Oaa1GwFylGfx/GA7DpQPw3L8Mqe2vTENLpefTT+epW0FmzpqFN2bNsjUvd8amyVdLpmFjb2DXx6CbyJG8AxHX5wsEBAQ6dlRDIiIiKhJT9esQN3gNvHd8itTrn+BZI6JC8Xc+kSMZPJFRoz1QuyPrgYiIyEVY/asgpcN4QJf1UzojBb5rxkOXfOmqt23L1nKsYyKnUBotDRh0ExERERFdBd91L8H7n08Q+HlXNcXY1dDrDWpE7vSMDNYJkROQ+dZFYdPbFYTNy4kcKSMF3ru/AHx9gXYPsi6IiIhcUFrLEfCI/h2GmCMI/OoOJHV9FenNB5VoW3qDAZ5e3rh48QI8ZAolF5lWsbxYzCbo85gyzOymfborAquTThkm5ZKA+/z582q6NplDvaQYdBM5UnoS/DdMzLzPoJuIiMglmcMbI/7+VfD7+VF4HvoV/ivGIvXMP0juMh0wehVrWxJ0BFeqgguno3E8OroCjVdeOBVgWyzqQoR2XrSGvzK7mTMFbFS84NZisUAv9eqEdSgBd0RExFVtg0E3EREREdFVsnoFIrHPfHj/+RZ8/ngV3rs+h/H8v0jsPQ+WwOrF+4Hu4YGImrVhysjgyNX259hqRWJ8HPwDg2zBmdlqhdlkRai/J4wGtgpwRRaLBXFxcQgKClKBtzORJuVXk+HWMOgmIiIiIioNOr2aQswc0QJ+Pz4MfdxxSc2WbFM6PTw8i5cld3eS5TYYPeDp6WVrdm9SmW8rvL29GHS7cNCdnJwMb29vpwu6SwuDbiIiIiKiUpRRu7Nqbq5PPAtLUCTPLVEF556XEoiIiIiIHMgSXAumGu1sjz2kr/cPw4C0BNYLUQXDTDcRERERUVnKSIbfirHQJ19E0MX9SOjzGSxhDXjOiSoIZrqJiIiIiMqShy8S+n4Bi39VGC4fRNDnt8Fj/3Kec6IKgkE3kSN5BSDujk9guXch64GIiMiNmau1RtzgNciIvBG6jCQELBsOn/WTAYvJ0UUjojLGoJvIkYxeyIi6BWjQjfVARETk5qx+4Ui4+zuktH1UPfbZOhsB394NmNIcXTQiKkMMuomIiIiIyoveiJSbJyGh1yewevjCHFZfXYQnIvfFgdSIHMmUCq99iwF/f6DlQNYFERFRBZHRsDfiwq/JPqVYRgpg9JZJuh1ZNCIqZQy6iRwpLREBa57JvM+gm4iIqEKxhNa1e2BCwPf3wRJUE0ldZ2QG30TkFti8nIiIiIjIwYwn/4TxxCZ47f4KgV/dAX3cCUcXiYhKCYNuIiIiIiIHM9XsgIT+i2DxCYXx3E4Eft4VxmPrHV0sIioFDLqJiIiIiJyAKaoT4gevgSmiBfQplxHw3T3w/vMtwGpxdNGIqDyD7n379mHixIno3Lkz6tati6pVq6J58+YYMmQIvvrqK6SlccoDIiIiIqKSsATWQPz/liO1+SDorBb4/v4KfNdN4MkkqghB9z///IOuXbuiZcuW+OOPP9CuXTs88cQTmDp1KgYNGgSr1YoXXngB1apVw4wZMxh8ExERERGVhNEbyd3eRFK3Waq5eVrzQTyPRBVh9PJ+/frh6aefxnfffYfg4OB819u8eTPefvttzJw5E88//3xplZOIiIiIqEJJa34/0hr1BTz9bcv0MUdhCant0HIRURkF3QcOHICHh0eh67Vv317dMjIyilkUogrIyx/x3d6Bv78/B1ggIiKi3OwCbhnhPOCbvkhtNRIpnSYAes7+S+RWzcvtA+4FCxbk2Xw8PT1dPZdzfSLKh9Eb6fV7Ak378hQRERFRgYyntkBnMcHn7w8QsKgfdEnnecaI3HX08mHDhiEuLi7X8oSEBPUcERERERGVrtR2Y5DQex6sHn7wOLEJQQu6wHD6b55mIncMumXQNJ1Ol2v5yZMnERQUVBrlIqoYTGnwPPQzsHepo0tCRERELiCjwR2Iu38VzKH1oU88i8Cve8Fr+zz5ge7oohFRPorVEURGLpdgW25dunSB0Xjl5WazGUePHkX37t15somKKi0Bgb+Ozrx/zV08b0RERFQoS1h9xN2/Ev6/jIbngR/ht/oZWIJqIKPOrTx7RK4edPfp00f93bFjB7p166YGf9J4enoiKipKjXJORERERERlyNMfib0+hffW92A4vxsZtbvydBO5etB911134bPPPkNgYKAKru+99154eXmVbemIiIiIiChvOh1Sr3sss2m51vUzPRHGM9thqtWRZ43I1fp0//jjj0hKSlL3hw8fnudAasUlTdJfeukl1K5dGz4+Pqhbty6mTp2q+oxr5P6ECRNQtWpVtU7Xrl1x8ODBbNu5fPkyBg4cqC4IyBziI0aMQGJi4lWXj4iIiIjI6WkBt9WqmpzLyObem2YCVoujS0ZExcl0N2rUCOPHj8ctt9yiAuFFixapIDcvgwcPLtI2Z8yYgQ8++ADz589H06ZN8ffff6vRz2UwtjFjxqh1XnvtNbzzzjtqHQnOJUiXpu179+6Ft7e3WkcC7jNnzmDVqlVqfnDZxoMPPoivvvqKlUxEREREFYPFBItPJehghe/GV2E8ux1JPd6D1ZsDHRM5ks5qn1YuwKZNmzBu3DgcPnxYZZYDAgLyHMFclsnzRXHHHXegSpUqmDt3rm2Z9AmXjPYXX3yhgvtq1arhySefxFNPPaWelwy7vEaauksT93379qFJkybYunUr2rRpo9b59ddf0aNHDzWaury+MPHx8SrQl23ndyHB0SwWizqvoaGh0OtLNOg8OSFLwnnoZ9bPfDDp6luPkHPg57VwJrMF5+PTYDTqYHSR7zSrxYK42BgEBYdA5yJlpsKxXt1TRa9Xz91fwW/VM9CZ02AOro3EPp/BHN4E7livJosFJpMVlQO9YDRUvLp2BxYXjnOKGkcWOdN9ww034M8//1T35WQcOHAAlStXvqpCyjbnzJmjttWgQQPs3LkTf/zxB2bNmqWel9HQz549q5qUa+Sg2rVrh82bN6ugW/5Kk3It4BayvpTxr7/+Qt++fXPtNy0tTd3sT5ZW4XJzRlIuuQjhrOWjkpH61L5aWLfug5/Xop4jC6wWyce4zo89+R6Wv+Q+WK/uqaLXa1rTe2Gq1BgBy0bAEHsUgV90R+Jts5De+C63q1dtmfodnzsfSC7A4sJxTlHLXKzRyzUSDIeHh+NqPffccyrglabrBoNB9fF+5ZVXVHNxIQG3kMy2PXmsPSd/cwb/MpWZXCnR1slp+vTpmDx5cq7lMTExMJlMcNYKTUhIUG9IV7sCRPmzpGcA7SeqrhLpRWwhQs6Pn9fCmc0WJCRnwGDQwZBHqylnJN+/SYkJ6n5eLb3INbFe3RPrFYBXTcTeuQiV1z0J39Ob4LN+Ai6GtYXV88rsQ+5Qr2arFWazFcYMDxiY6XZJFheOc6TcpRp0R0dHo2bNmup+rVq1Cl3/1KlTqF69eoHrSL/wL7/8UvW9lj7dMhXZE088oZqEDxkyBGVF+qZLU3mNBP6RkZEICQlx6ubl8uUiZXS1NyMVXK8xre6Hb0gI/FmvboOf16I1Lzd5pMFocK3m5SIoKLhCNld1V6xX98R61YQg5Z7vgE2vIaN2FwRWjoS71atqXm62IiSAzctdlcWF4xxJ9hZpvaJusG3btmqe7gceeEDdz4u0ZZdA+u2331YDmWmDoeXn6aefVtluaSYumjVrhuPHj6tMtATdERERavm5c+fU6OUaedyiRQt1X9Y5f/58tu1Ktlr6BWivz0mmOstrujOpZGeuaHkzOnsZqfhYr+6J9VowvZrdRg+dXudSAazUq5TXlcpMhWO9uifWaxa9Hqk3vZB5TrIWeRz4EVbfcJhqtIOr16sck86SmSHlb2TXpXPROKeo5S1y0C2jhUvT71tvvVU1hW3durXKSMt9aZYtz+/ZswetWrVSI47LQGaFSU5OzlVQaWautY2X0colcF6zZo0tyJastPTVfuSRR9Tj9u3bIzY2Ftu2bVNlEmvXrlXbkL7fRE7NlAaPY+uASwFAw+6OLg0RERG5OcPF/+D/86OAOR3Jt0xBWssHrkw5RkRlosiXEsLCwtQAZzI11+zZs1G/fn1cvHjRNme29MOWwFcGNitKwC3uvPNOFcj/9NNPOHbsGJYsWaL2oQ1+Jlc8pLn5yy+/jGXLlmH37t1qOjIJ9iXrLho3bozu3btj5MiR2LJlCzZu3IjHHntMZc+LMnI5kUOlJSDoxweg//oeVgQRERGVOXNgDaTXvQ06iwl+a56HnwTgGck880RlqNgDqcl0Xv3791e3q/Xuu++qebdHjRqlmohLkPzQQw9hwoQJtnWeeeYZJCUlqebqktHu0KGDmhJMm6NbSL9wCbS7dOmiMucy7ZjM7U1ERERERHY8/ZF0xxyYqraG7/pJ8Nr7LQwX9iKx9zxYQmrzVBE5cp5ud8Z5uslROE+3e3Ll+SbLC+fpJmdR0edzdles16IxntgI/2UjoU++AItXEJJ6vo+MurfBWXGebvdkceHfTUWNI13rqIiIiIiIqFSYIm9E3OA1MFVtA31aHIwn/+SZJSoDJZqnm4iIiIiIXJ81oCri//cDvHZ8hrSWwx1dHCK3xEw3EREREVFFZvBEWusHAX1WPs6UBr8fH4Lh/L+OLhmRW2DQTURERERENj5/vgmvfd8j8Mse8NzzLc8MkaOal8tUYevWrVOjjmvzamvsRx8nogJ4+iHxpknw9fPlFTAiIiJyCqmtH4Lh7HZ4Hl0L/59HIfXM30i+ZarKiBNROQXdH3/8MR555BFUqlQJERERaj5tjdxn0E1URB4+SG1+P3xDQ3nKiIiIyClYfUKQeNdX8Nn0Onw2z4T39k9hOLcbib0/hdU/wtHFI6oYQffLL7+MV155Bc8++2zpl4iIiIiIiBxLb0BKh+dgimgJv59HweP0VgTN74yEvgtgrtaGtUNU1n26Y2JiMGDAgJK8lIjsmdNhPPUXcGwjzwsRERE5nYx63RB//yqYKjUGzGmw+rB1HlG5BN0ScK9cubIkLyUie6nxCF5yH/QL7uB5ISIiIqdkCamD+IG/IGHAd+r+lSfMjiwWkXs3L69Xrx5eeukl/Pnnn2jWrBk8PDyyPT9mzJjSKh8RERERETmapx/MVVvaHhqPrYfv+klI7D0XlpC6Di0akVsG3XPmzIG/vz82bNigbvZkIDUG3UREREREbspqge+6CTBe3IfABbciqecHqhk6EZVi0H306NGSvIyIiIiIiFydTo+EAYvgv2wEPE5tQcCSQUhpPw4pNzyjBmAjolLo023ParWqGxERERERVQwydVjCPUuQ2uoB9dhn8yz4L/4fdCkxji4akfsE3QsWLFD9uX18fNStefPm+Pzzz0u3dERERERE5JwMnkjuMh2JPd6H1egDz2PrEPh5V+iSLzm6ZESu37x81qxZaiC1xx57DDfeeKNa9scff+Dhhx/GxYsXMXbs2NIuJxEREREROaH0pgNgDm8C/x+GwlTjek4rRlQaQfe7776LDz74AIMHD7Yt69WrF5o2bYpJkyYx6CYqKk9fJN3wDHx8fK++rwcRERGRg5grN1XzeVsNXjKyslqmS4vPfGz0Yr1QhVaioPvMmTO44YYbci2XZfIcERWRhy9SWj0En9BQnjIiIiJyaVbvYLsHFvgtfxD61Fgk9P4U1oBqjiwakUPpSzpP96JFi3It/+abb1C/fv3SKBcREREREbkofcwRGE//DeOZbQha0BXG6I2OLhKRa2W6J0+ejHvuuQe//fabrU/3xo0bsWbNmjyDcSLKhzkDxnO7gJRAILINTxMRERG5BUtoPdXc3P+HYTBe2IOARf2Q0mkCUts8Ymt+TlRRlCjT3a9fP/z111+oVKkSli5dqm5yf8uWLejbt2/pl5LIXaXGIfjbvtDP7eLokhARERGVKktIbcQP/BlpTe6GzmqG7/qJ8Fs+EkhP5JmmCqVEmW7RunVrfPHFF6VbGiIiIiIich8evkjqMRumqq3gu+5FeO3/AbqMJCT2+9rRJSNyvqA7Pj4egYGBtvsF0dYjIiIiIqIKTqdDWqsRMFdpBr+fHkVKh+ccXSIi5wy6Q0JC1MjklStXRnBwMHR59MWwWq1qudlsLu1yEhERERGRCzNVvw5xD2wG9FdCEMOZf2Cuci2gNzi0bEROEXSvXbsWoVnTGq1bt64sy0RERERERO4oW8C9HYFf3wlTjfZIvOMjWH3DHFo0IocH3Z06dbLdr127NiIjI3NluyXTfeLEidItIRERERERuR194lkVhHsc34DAz7sisfc8mCNaOLpYRM4xerkE3RcuXMi1/PLly+o5IiIiIiKigmTUvx3xA3+FOaQODPEnEfjVHfDcxYGayf2UKOjW+m7nlJiYCG9v79IoF1HF4OGD5LajYb3pGUeXhIiIiKjcmcMbq/m80+t1h86cBv8VY+G74knAlMbaoIo5Zdi4cePUXwm4X3rpJfj6+tqek8HTZO7uFi3YJISoyDz9kNzuCXiHhiL3ZSwiIiIi92f1CkRin/nw/vMt+PzxKrx3LVDNzNOuvd/RRSMq/6B7+/bttkz37t274enpaXtO7l977bV46qmnSqdkRERERERUMej0SG0/DqaIlvDatxhpzQc6ukREjgm6tVHLhw0bhrfffpvzcRNdLYsJhssHAXMQUKUJzycRERFVaKbat6ibTUYyPPd9j/RmDMKpggTdmnnz5pV+SYgqopRYhHzVPfP+pDhHl4aIiIjIeVit8Fv5NLz2LkL6kdVI7Pa2o0tEVH4DqYm///4bzzzzDO69917cdddd2W5FFRUVpfqH57w9+uij6vmbb74513MPP/xwtm1ER0ejZ8+eqn955cqV8fTTT8NkMpX0sIiIiIiIyEmYqreFVe8Bz4M/IfCr2+ERe9jRRSIqn6B74cKFuOGGG7Bv3z4sWbIEGRkZ2LNnD9auXYugoKAib2fr1q04c+aM7bZq1Sq1fMCAAbZ1Ro4cmW2d1157LdvgbRJwp6enY9OmTZg/fz4+++wzTJgwoSSHRUREREREzkKnQ1qLoYj/33JY/KvCePkgqi8bAM8DPzq6ZERlH3RPmzYNb775JpYvX64GUJP+3f/99x/uvvtu1KxZs8jbCQ8PR0REhO32448/om7duujUqZNtHclg268TGBhoe27lypXYu3cvvvjiCzVq+u23346pU6fivffeU4E4ERERERG5NnO11ogbvAYZkTdAn5GMgOUj4LN+shobh8ht+3QfPnxYZZiFBN1JSUmq6ffYsWPRuXNnTJ48udjblCBZgmeZlsx+DvAvv/xSLZeA+84778w2VdnmzZvRrFkzVKlSxbZ+t27d8Mgjj6jMe8uWLfPcV1pamrpp4uPj1V+LxaJuzkjKJaPGO2v5qGSkPrUrX6xb98HPa1HPkQVWiw5WuAZr1vew/CX3wXp1T6xX92P1CUPcXd/AuGYigv/9FF7/fo2UViNh9a1s+41s4fyrLsniwnFOUctcoqA7JCQECQkJ6n716tXx77//quA3NjYWycnJJdkkli5dql4/dOhQ27L77rsPtWrVQrVq1bBr1y48++yz2L9/P77//nv1/NmzZ7MF3EJ7LM/lZ/r06XleGIiJiXHa/uBSoXLO5Q2p15e4Kz45GWtSDMKz7l++fNnBpaHSws9r4cxmCxKSM2Aw6GCwu9DqzOT7Nykx8/8++4vD5NpYr+6J9erG9drkYaSGN4fFOxipJi+Y42JhNlthzPCAwcDfyK7I4sJxjhYTl0nQfdNNN6n+1xJoS//rxx9/XPXnlmVdunQpySYxd+5c1TxcAmzNgw8+aLsv+6pataravmTapRl6SY0fP15l1O0z3ZGRkepign3zdWd7M8qPPCmjq70ZKX8WjysXeUJDQ3mq3AQ/r4UzmS0weaTBaNDB6CLfaVqGOygoGDoXKTMVjvXqnliv7l2vxur3qO9hL/n/xGKByWxFSIAXjAy6XZLFheMco9FYdkH37NmzkZqaqu6/8MIL8PDwUAOZ9evXDy+++GKxt3f8+HGsXr3alsHOT7t27dTfQ4cOqaBbmpxv2bIl2zrnzp1Tf+W5/Hh5ealbTlLJzlzR8mZ09jJSMXn5IrnlA/Dx9ma9uhl+Xgumt8o50kOn17lUAKtm0tDrXarMVDjWq3tivbp/vRpPbIT/X7ORXqkp9N0n8beUC9O5aJxT1PKWKOi2z8jJjp577jlcDZn3W6b70vqJ52fHjh3qr2S8Rfv27fHKK6/g/Pnz6vVCsu2SrW7SpMlVlYmoXHj6I/nG8fAODQUbqxIREREVnT7xHLyOrgZMV8ZqInJGJbqU0LVrVzU1lzYA2dU2J5Cge8iQIdnS89KEXEYi37ZtG44dO4Zly5Zh8ODBqml78+bN1Tq33XabCq7vv/9+7Ny5EytWrFCZdpnnO69MNhERERERuRmrqwzJSRVViYLupk2bqn7R0oRb+nT/8MMPaq7ukpBm5dHR0Rg+fHi25TIqujwngXWjRo3w5JNPqubrMk2ZxmAwqGnG5K9kvQcNGqQC8ylTppSoLETlzmKGPv4UEBvNk09ERERULGwnSK6hRM3LZV5umadbguKvvvpKBboS+Pbv3x8DBw7MNs92YSSolpHqcpKBzTZs2FDo62V0859//rnYx0DkFFJiELrgpsz7k+IcXRoiIiIiF2R1q8HikmPOwmJKh9UrCFZdZo40ICDA5fo701UG3UIqXQJmuX344YcqAy39q2UUcrPZXNLNEhERERERVahE97H1X8D0+1uonB6NQENmH/XRRzrjkslH3e9a+RI6VE6Ed6cnUPPGAXBW5ow0JF04geRLJxGLIGRkhZseKRfglXgCMuOm1a7iZFBVudBwXl8Z0YGVVRzpkXwWfnEHkBxQB+EN22Wb3arCBd0amQ974cKF+OKLL9Rc2tddd13plIyIiIiIiMjNM93n/v0NVdeOgZfeDBiuLNdJeKrTqVbBTQ3H0CD9LNJWPISLlaNQqX5bOJPEiycRvfAZRJ1fgUC9CTIJ84fR7XEgNXMA7luDjmFYlT35vn7RybbYmZw5MHanwBN4KGIXFpxvgsDbnkWfPn3K7TicKuiWAdQWL16smpavX78ederUUc3Kv/nmm6uaP5uIiIiIiKhodC4/kFp6cjwsi4aqgPuYrib0XSeicrNb4OkXhLfV1Jp6mEwmnPxrKaJXvoia+jM489VwhL64HXrDVedPr4pkqI//9hVStyxAzcRtaKI3qRHDLFYg2eqJKmFBSNFHqnW9DKk4YzmjLiTkJMsCwyqjdpXaamBtf50HjuMifCpHZZs1y5WVqKaqVKmiJi+/5557MH36dLRp06b0S0ZERERERJSP9Ia9cb5BL5hMVmTmSF2LBNNbP3wMN+ovId7shZCHFyOoeoNc60kgGnVjf1wMr4W0L7ohSh+N/75+Ho0GvQZHkez7n7NHov3l7zIX6IEzljAkth2Nurc/Bn+jBx4pxmxWAy5fVgG2fb/1WnAfJQq6ZfquLl26sDM/ERERERE5huog7HpZbgky9+7di/nz5yP2TDKuifLExY5TUDePgNtepQZtsS9qIBpHL0DtA58gemNbh/XvXrlyJT7/MwkJlWuhVtVK8LxuKGrddB+qOjj77qxKdFZuvfVWdWVm7dq1aj7t++67T42od/r0aQQGBsLf37/0S0pEREREROTkEhMTcWz1JzAcWQPvhGMwWE3q4oBZ7wmzwQveKecx/egNakCxwMBKONT1M7S+uWeRtt1w8CwcmfY76uAoKq14GNH+VVDz2qyZcMrJjh07sGDBAlihR1qXV9DwzjvLdf8VJug+fvw4unfvrubXTktLU0G4BN0zZsxQj2U0cyIqyifQCynXDIS3t5c7DcBJREREVOYMp7fBd+v7yAiuB3R7yeFnPCEhAT/++CNWrVqF/wVuxa3B0VeelB96kpQ3yVDeQOOgFFRtc6fqrluchKXe6IHq49bh+BsdsC/OiO/f+xxvvNFCJT7Lw4ElM5C6cT501uboeNPNuOOOO8plvxUy6H788cdVP+6dO3ciLCzMtrxv374YOXJkaZaPyL15BSDp5inwCg1l0E1ERERUDPqE0/A+sAy6atc7/LyZMjIwZcoUnDp1Sj2OrtwU+4LqQletBQw+AYDOAEtqPCwpcfCq1hTPdbwXRi/fEu3Lyz8ElZ/8A7OnvILEC6exefNmdOvWDWXtv6+eR4P970HvDyRe2wqdRoxQo6tTGQXdv//+OzZt2gRPT89sy6OiomxvNCIiIiIiorLn+H7dBxY8jgGW1VgW0hZ9h49Dq1atyjQg9QkIQZcuXVUz740bN5Z50J1w9ihq//chZJyzff4d0PmJeSrrTkVzZXi4Ynb+l4nLczp58qRqZk5ERWS1QJdyCUi6yFNGREREVBxOkmWVgDTq+De4LuAcBnWojdatW5dLBvj666/HzUEncG/q57h4YGuZ7uvE4glqWrOT1spoNG45A+7yCLpvu+02vPXWW7bH8qaSAQMmTpyIHj16lGSTRBVT8mWEzb0O+pn1HV0SIiIiItfk4BHMT37+CHz1JpyyVEKDuyeV236Dg4Nxa0Q8mvhexvm175fZftISY1Dz7K/qfnKLB9Tc4VQ8JTpjM2fOVM0YmjRpgtTUVDV6uda0XAZTIyIiIiIiKluOzXRbzCbsfeduNE7arB5ndJkKfTlPmZXWsLf6G3Z6LawWS5ns48j3U+FvSMdFsz/q3vFEmezD3ZXoXVGjRg01iNrChQuxa9culeUeMWIEBg4cCB8fn9IvJRERERERUR50DujTnRxzFqfe64Mmpn3q8d4qfdCk033lXo6a3UYhfe+7qKKPxYktyxB5fZ9SH5E9ad9awAu4UO8eVPLwKtXtVxQlvhRjNBoxaNCg0i0NERERERFRUZRyv2nJFB//fSFSTuyEzugFndETeg8fGP1CYPQPhWdIdXhVqa/GsYr/chhu8DqADKseR64ZiyYDJjikznxDIrDfpzkapu2A/uenYGrZDUav0kmCxsfHY/r06TgT3RCjIoFr+zl+Wja3D7qXLVtW5I326tWrpOUhIiIiIiLKV1JSIo4fO4pjh5Nw1vsZNK99HbqU8HxZrVbVRfbff//F7vVL8LT3wnzX3ZVUCa+eaqfuBxpqomqtGBh7voaG7e9yaG1VGfQRkj7uiOr6C9g7bxSaPDzvqrd5fv9WvPnpNzh+4jSCg8NQffRPaqoyKuOgu0+fojVVkEHV8hrZnIiIiIiIqDgkrjhz6iSOHjmMo4cP4cihg7h48UK2dfYeOIzrrrsOIcFBxdr20dWf4vKatzHzeFPbsm01qiI4wE8Nzqa3mmCwZsDDkgovaxri4a9iHbk1b98FVYYsgK+fn8MrNDiyEfY3G4OGe95AvdNLceK/0Yhs1KrE2f79Xz+PqP1zcF1ybcQFt8OLL76IatWqlXq5KxJjcaYJIyIiIiIiKivx8XE4lhVgS6Adfewo0tPTc61XuUoEourUVetePHca2+c9g1se/6BII2unJ8Xh8JwhaBy3DpGeOgR4NUPNeo3V3NqNOs6Bn79/nq/rAODGrJHSy2NKsOJo0O8FbDv4O5Yd0iN9/reYOrW56g5cHPFnDuP83HvRyHRADbfdolI6bho1CWHhlcus3BVF+Q6vR0Q5PoGeSG3YF15eXg4ef5OIiIiofJlMJpw8EW0LsuXvpUsXc63n7eODqNp11K1y5Spock1z+AcGquf+3b0TukVD0DHuFPa+eQqNnlha4AjiJ/5cAq+fHkdjQ5x6fND/erzz7mx4+QcXqczOFmxr5GJDvUe/xZmnn0bi8eNYunQp+vfvX+j5P/73CqTt+A6GmCOolrwP9Qxpqp/6wZr/Q6Oh75T7aOzuqlhnUebg/vrrrxEUlNl049VXX8XDDz+s5ogTly5dQseOHbF3796yKS2Ru/EKROKtb8AzNJRBNxEREbm1mMuXVPZaBdlHDuPE8WMq8MsZ1EZUq47adSTIrovadeuhSkRV6PV61fQ5LjYmWya6UdNmOHlNT1iOz0GThN/x38weaPDkz3kGi/vmj0PDI3OhNwCxZh9c6jAJjbs9DHchMdrw4cPxzjvv4K+fvkALn9Oo032U7VwknI/G6fXzsD/WA3su6XD48GG0MhzAqKo7MzdgAM5YQoG75qBJi1sdezAVOehesWIF0tLSbI+nTZuGu+++2xZ0y4dm//79pV9KIiIiIiJyGdIkXIJqLciWW2xsTK71JIBWwXWduqq5eK3adYo9BXFE3ynYv9IXDfe+hUbJf2H/611R78kVMNhNb7Xvs7FofOxTNbX3Aa/mqPbAV6gbHgl3c/311+PcH5/j9vhf4Ll1HS7++RoSjcHwMiehiu4yGuqAfy40xO6Yemr9Q4FROOBpgalSY3hWb45anYfBwyfv5vVUTkG3jO5X0GMiKib5DGWkABnJgBe/4IiIiMj1SExw6eIFWz/sY0eO4OTJaFhyDK4s2epqNSJVgK0F2eGVq5RKk+36/Sfi0A8+qLvzVTRM3Y6TL1+Ds/7NsT24Oy5evIgq0VvQuAqwN7Q7Gj/2dZH6fruqW0e8hMOfHEFUwhZUMiSgkjVB9dEWpy1hiGx2Ix5s1BuRkZGoXbu2qhcqW2ykT+RIyZdQ6aNrMu9PyuxbREREROTMUlNTEH3sWGaQfTQzi52YkJBrvYDAQNSuU081EZcgO7JWlBrHpqw0uOs5HPTwRu2/J6GG7jwun9+Bddsz97cbtVCjbQ/cOnS8Wwfc2tzdjZ/+Banxl3Bw/WewZKTBIyAcwfXboVrt5uA45E4edGtD5OdcRkRERERE7kdmMDp/7qytH7b8PX3qZK4WrwaDAZE1a6nstdzq1K2HkNCwco8V6t/5BM7VbYuYHT8hOcOIftdfi9DQUJXVrVu3boWKXbwDw1C/15OOLgaVpHn50KFDbVeoUlNT1UBqflnz09n39yYiIiIiIteSnJSEY0ePZAXZh9T9lOTkXOtJQK01EZdbZM2a8PDwhDOo0uRGdSNyyaB7yJAh2R4PGjQo1zqDBw+++lIREREREVGZZ7HPnD51ZUTxw4dw7uyZXOt5eHqiZq2obEF2cHAIa4eoLILuefPmFWd1IiIiIiJyEgkJ8dmaiR8/ehRpaam51qsUXhm162YG19Inu3r1GjAYORQUUUnx00NERERE5GbMJhNOnTqpstdaoH3xwvlc63l5eaNW7doquM7MYtdBQECgQ8pM5K4YdBMRERERuTiZA1trIi5TdkUfP4qMjIxc60VUrZaVwc7MZFetVp1TRhGVMQbdRI5k8EBa3dvh6emJijOWJhEREV2NjIx0nIiOvhJkHz2MmMuXc63n4+ubGVzXrqum7ZKMtq9v5gDIRFR+GHQTOZJ3EBJun62msmDQTURERHnNHnT50sUrg50dOYyT0cdhNpuzrSdTYVWrXsOWxZYgO7xyFWaxiZwAg24iIiIiIichU/BGHzt6ZcCzo4cRHxeXaz3/gABbP2wJsmtF1YaXt7dDykxEThx0R0VF4fjx47mWjxo1Cu+9956aB/zJJ5/EwoUL1RdQt27d8P7776NKlSq2daOjo/HII49g3bp18Pf3V9OaTZ8+HUaOsEhERERETp7FPn/unAqwJbiWIPv0yRNqKi97eoMBkZE1bdN1SZAdVilcZbeJyPk5NOjeunVrtqYx//77L2699VYMGDBAPR47dix++uknfPvttwgKCsJjjz2Gu+66Cxs3blTPy2t79uyJiIgIbNq0CWfOnFHzhHt4eGDatGkOOy6iIku6iEqz62fen5T7KjYRERG5j5TkZBw7diQzyM7KZCcnJeVaT+bA1qbsiqpTD5E1a6nxX4jINTk06A4PD8/2+NVXX0XdunXRqVMnxMXFYe7cufjqq6/QuXNn2zzhjRs3xp9//onrr78eK1euxN69e7F69WqV/W7RogWmTp2KZ599FpMmTeKXExERERE5hGSrz505g6NHDtn6Y589c1plt+1J68yataIQVbeebdCzkNBQ1hqRG3GaPt3p6en44osvMG7cONVUZtu2bWqag65du9rWadSoEWrWrInNmzeroFv+NmvWLFtzc2mCLs3N9+zZg5YtWzroaIiIiIioIklMTMTxrCbiRw8fxvFjR5CakpJrPWkWbhvsrE5dVI+syW6RRG7OaYLupUuXIjY2FkOHDlWPz549qzLVwcHB2daTAFue09axD7i157Xn8iP9w+WmiY+Pt12RzNmHxllIueTKqLOWj0pG6lNvd5/cAz+vRT1HFlgtOmTP+Tgva9b3sPwl98F6dU9lXa/SxfH0qZM4djSzqbgE2hfOn8u1nvyWrRVVB1F16qgMtvwNDAzKs7xUsnrVlqnf8ezi7pIsLhznFLXMThN0S1Py22+/HdWqVSvzfclAa5MnT861PCYmBiaTCc5aoQkJCeoNqddrYRq5OmtSDLROFpfzmF+TXBM/r4Uzmy1ISM6AwaCDwUUGApLv36TEBHWfgxe5D9areyrtek1IiMeJ6ONZt2icOnFCzZWdU6XwcNX/WrtVrhIBg8FwpVwWC+JiY666PBVVXvVqtlphNlthzPCAwcDfyK7I4sJxjpTbZYJuGcFc+mV///33tmUyOJo0OZfst322+9y5c+o5bZ0tW7Zk25Y8rz2Xn/Hjx6tm7PaZ7sjISISEhCAwMBDO+maULxcpo6u9GSl/Fo8rF3lkrm5yD/y8Fs5ktsDkkQajQQeji3ynaZmVoKBg6FykzFQ41qt7upp6lQTMyRPHcezIERw9Kn2xj6h5snPy8fFBrdpXMthRUXXg5+9fasdARatXk8UCk9mKkAAvGBl0uySLC8c5RZ0xyymCbhkgrXLlymokck3r1q3VKORr1qxBv3791LL9+/erKcLat2+vHsvfV155BefPn1evF6tWrVKBc5MmTfLdn5eXl7rlJJXszBUtb0ZnLyMVk11dsl7dCz+vBdNb5RzpodPrXCqAlXqV8rpSmalwrNeKW6+SWYuNuaz6YGtzYp84fixXy0fZVkS16rZ+2NInu0pEVf7f7QT1KvlunSUzQ8rfUq5L56JxTlHLa3SGKxsSdMv82vZXCmSKsBEjRqiMtGQAJZAePXq0CrRlEDVx2223qeD6/vvvx2uvvab6cb/44ot49NFH8wyqiZyOwQPptTqpC0yu0cCWiIjIdUkrSgmq7UcUj4uNzbWeZKwlgy3TdtWuUw81o2qrzDYRUUk4POiWZuWSvR4+fHiu595880119UAy3TLwmYxM/v7779uelz4yP/74oxqtXIJxPz8/FbxPmTKlnI+CqIS8gxB/56fqwhKDbiIiotIjWewLF87j+NEjmSOKHzmMUydPwGI2Z1tPfmtWrxGZOaJ41rRdlcIrc+wGInKfoFuy1TnnK9R4e3vjvffeU7f81KpVCz///HMZlpCIiIiInF1qagqOHz2aOZr44UM4cuQQkpOScq0XGBSkstfatF0yR7YnW0gSkTsH3URERERExe2eeP7cWVsTcQmyz5w+lSuRI10Xa9SsZeuHLX9DQsOYxSaicsWgm8iRki4i7MPmMnoE8MIZ1gUREVEeJGMtg5xpQbbMj52SnJxrPQmopR+2jCQeHl4ZDZs0ZRabiByOQTeRg+lMKY4uAhERkVNlsU+fOpmZwc4Kss+dzX1h2sPTUzUNl6biksGuVacOgoNDss2HLQOVEhE5GoNuIiIiInKYhPj4KxlsuR07gvS0tFzrhVeuoubD1oLsatVrwFDEOXKJiByJ31REREREVC5k/msZQVz6YGc2Ez+Mixcu5DmYbq3adWzTdslf/4AA1hIRuSQG3URERERUJmJjYrLNiS1zZGdkZORaL6JqtSuDndWtpx7LVF5ERO6AQTcRERERXbWMjHScOH78yojiRw4jNuZyrvV8ff1sI4nL31q1a6tlRETuikE3ERERERWLTM11+dJFHD2c2URcAuyT0cdhNpuzrafT6VTfa8lea4F25SoRnLKLiCoUBt1EjmTwQEa169Q8ojrWBBEROam0tDREHzuqmoprWWwZAC2ngIDArCbiWVnsWrXh5e3tkDITETkLBt1EjuQdhLi7vkZoaCiDbiIicgqSxT5/7lxWcJ0ZZMsUXjKVlz29wYDIyJpZGezMTHZYpUrMYhMR5cCgm4iIiKgCS0lOVtN0qSA7q7l4clJSrvWCQ0JRu04dW5Bdo2YteHp6OqTMRESuhEE3ERERUQUh2eqzZ07bmojL1F3nzp5R2W170u2pZlTtKwOe1a6LkNBQh5WbiMiVMegmcqTkSwidex10Oj3wzGHWBRERlarEhASVuc4Mso/g+NHDSE1NzbVepfBwFVhrQXb1yJoq8CYioqvHb1MiR7JaoU/JPZ0KERFRccnI4adPnsg2ZdeF8+dyrefp5YWoqMxm4pm3OggMDOIJJyIqIwy6iYiIiFykaXhsTIyaqivzdgmXsv7K45jLl2AymXK9rkpEBKLq1LPNi121WnUYDAaHHAMRUUXEoJuIiIjICUjAHBtzGZcuXsTly5mB9GXt/sWLiImNgSXHPNg5+fj4oFbtzCm7JMiuVbsO/Pz8y+0YiIgoNwbdREREROUgIyMdly9dtmWqJUsdY5etjouNyTWgWU6SoZYBzULDKqlbWFglhISFqb+hYWEICQ2DXq9nfRIROREG3URERESlIC0tLXvTb5WlvpKtjo+LK/yHmdFoC6hD7YLp0ErhCA0NQ1BwMINqIiIXw6CbiIiIqIjzWdv3oday1drjpMTEQrchg5jZAmm7bHVmYF0JAQGB0Ol0rA8iIjfCoJvIkfRGZFRupjIb/IlFROQ40qxbgmZbMC19qC9nZauzlqWkpBS6HelTbQumK1VSzb3lr7bMz8+PQTURUQXDoJvIkXyCEXf3UoSGhjLoJiIq46A6IT4u14jfElRfPH8OsXGxSE9LK3Q7/v4B2fpQ2wfY0vzbx9eX9UhERNkw6CYiIiK3mE4rLjY2a6TvC3lOp5WRkVHodgKDglTwLE29Q0OzgmktuA4Ng5e3d7kcDxERuQ8G3UREROT0zGZz5nRaWiBtN5WWDFYWc/myWqcg0lc6KDgkW5ZaRgL39vJCZK0oFWh7eHiW2zEREVHFwKCbyJGSLyNkfifoDHrgid2sCyKqsCQLbZuj2n4E8Ky/8lxh02nJVFkhIaFZWeqsbLXdQGXBIaFqDA17VpUhj1HBuI5TbRERURlg0E3kSFYLDAknWQdE5Pakv7TKTGf1o76Spc5cJtNpFRZUS8AsA5Nl9qEOU82/bQF2WCU1nZbMY01ERORMGHQTERHRVZORvbXs9JVM9ZVsdWJCQqHb8PD0zDFAWfZptQICAzlHNRERuRwG3URERFQgyUAnJyfZ9aXOylbL46yMtTxfGG9v78wgOis7bZtKK6spuIwMzjmqiYjI3TDoJiIiquAkqJZMtGr6nSNbfenSJcRcuojU1NRCt+Pr55etD7WWrc58XElNp8WgmoiIKhoG3URERBVgOq14maPalp3OzFTLNFpa/+qM9PRCtxMQEGjXhzr3tFre3j7lcjxERESuhEE3ERGRi5OpstQc1bbstH22+pIKrk0mU4HbkAy0zFEtWemQPLLVEmh7enmV2zERERG5CwbdRI6kN8AUUk+NtqtjTRBRPiRglnmoVRCtjfqdFVzHSFAdc1llswsLqmVOavs+1Jn9qsNt02l5eHiwDoiIiEoZg24iR/IJQezAFQgNDWXQTVSBpaenq2z0lXmpL16ZTuviRcTFxRY6nZZcvMucTutKH2pbn+pKMp1WCKfTIiIiqohB96lTp/Dss8/il19+QXJyMurVq4d58+ahTZs26vmhQ4di/vz52V7TrVs3/Prrr7bHly9fxujRo7F8+XI1lUi/fv3w9ttvw9/fv9yPh4iIKKe01NSsgPpCVrNv+4HKLiIhPr7QkyZZaAmgQ7Q+1Fq2OqspuDQNl/8DiYiIyLk4NOiOiYnBjTfeiFtuuUUF3eHh4Th48CBCQkKyrde9e3cViGu8cvQpGzhwIM6cOYNVq1YhIyMDw4YNw4MPPoivvvqq3I6FiIgqLtt0Wtq81FnTamnZ6qTExEK34eXlnX3E76xByjID6zA1iBlH/iYiInI9Dg26Z8yYgcjIyGwBde3atXOtJ0F2REREntvYt2+fynpv3brVlh1/99130aNHD7zxxhuoVq1aGR4B0VVKiUHwV92hMxiAR//i6SRyQtKsW4LmSxcv4GT0cTV1lmr2bZetTklJKXQ7Ml1Wtrmp7abTkoHL/Pz8GFQTERG5IYcG3cuWLVNNxQcMGIANGzagevXqGDVqFEaOHJltvfXr16Ny5coqA965c2e8/PLLCAsLU89t3rwZwcHBtoBbdO3aVTWx++uvv9C3b99c+01LS1M3TXxWsz4ZhKawgWgcRcolP/yctXxUMhZTBoyXD2beZ926DX5ei3qOLLBadCi4p3LZk+9Wad6dbcRvFVRr02tdQrrd/xn5kS5NtpG+tcHKbI/D4OPjW1hBCu23TaXPmvX/q/wl98F6rTj1qi1Tv+M5Kq1LsrhwnFPUMjs06D5y5Ag++OADjBs3Ds8//7zKVo8ZMwaenp4YMmSIrWn5XXfdpTLghw8fVuvdfvvtKtiWQWPOnj2rAnJ7RqNRDUwlz+Vl+vTpmDx5cp7N3QubUsWRFZqQkKDekK7WZ8+ckQ690YMZnDxYk2IQbjc2AbkHV/68lhez2YKE5AwYDDoYdLqyr4/4eDXCd2xsDGJjMm/yOE7uxxbtu98/IACBgUEqkA4JDUFwcKi6GBycdfP0zH86LQnaixK4k6NaMiSo+2y+7z5YrxWnXs1WK8xmK4wZHjAY+H+uK7K48O8mKbfTB91ygiVDPW3aNPW4ZcuW+Pfff/Hhhx/agu57773Xtn6zZs3QvHlz1K1bV2W/u3TpUqL9jh8/XgX69pluaeYuP54CAwPhjORcqeleQkKc/s1oSkvB0V/eBQ78ipCkI9if6I85F1qpQfJuuOEGXN+6OfxDsl8oqagsHld+6MuFInIPrvR5dRST2QKTRxqMBh2MV3mOzGaTumgqU2flzFbLMrmgZbGYC9yG1FdwcAhCtJG/7abUyhy8LAxGg0GNIh4UFAwd69VtaBkz1qt7Yb1WnHo1WSwwma0ICfCCkUG3S7K48O8mSfYWaT04UNWqVdGkSZNsyxo3bozFixfn+5o6deqgUqVKOHTokAq6pa/3+fPns60jGQv5kZVfP3DpI55zMDYhlezMFS1vRmcuo8Vswn/zn0DVo4vR0JCcudAA7LAGqw/TgQMHcO7wLlz3+ybEjViFkKhmji6y49nVpbPWK7nn59XR9FY5R3ro9LpCA1gZIFObTst+xG/tsWStC2uWrZfptEJCsw9UZjetlvxHbyjkP075sSf1KuVl0O1eWK/uifVaMepV8t06S2aGlP/nui6di/5uKmp5HRp0y8jl+/fvz7ZMArNatWrl+5qTJ0/i0qVLKmAX7du3R2xsLLZt24bWrVurZWvXrlVBXrt27cr4CMjefwvGokn05yrQjjd74WT4LfBqeAuua94N1+p98ffff8P82ywEG1Jw+POhCH5hK3+4EpFqdi1ZaTXitzZHdVZfalkWHxdbpCvNIbZByrTAOjNTrc1R7Wr/kRMREZF7cGjQPXbsWNXcWJqX33333diyZQvmzJmjbiIxMVH1vZZ5tyVrLX26n3nmGdVMWQZg0zLj0u9bBl+TZumSEXnsscdUs3SOXF5+zu5ah3pHvwD0wN4qfVB/6Hto4pN9nvSePXviXK0AZHzbG3XNh7B/8StoOOClciwlEZU3aXkkTb/lYqm0QNJu8vjMuQuIjbmExCL0h5KxPnKP+H0lWx0QGMigmoiIiJySQ4Putm3bYsmSJaqP9ZQpU9RgaW+99Zaad1vIQGm7du3C/PnzVTZbgujbbrsNU6dOzdY8/Msvv1SBtjQ3l0yGBOnvvPOOA4+s4v2o/nrhQvSz+iHDpzIaPzQv3wx2lWtuwt4/+qLJ2cWI2DUbyV0fhG9IFVRYOj3MAdXU+5YDbpKrSU9PzxZIa8G0/eO4uLgibcvbxydHIG2XrQ4Lg79/AAe5IiIiIpeks3J+EjWQWlBQkPpx6MwDqckPWBlsy5maSErA/dFHH2Hjxo0I9vfB9CkvISgiqsDXZKQkImZaY1Q2xGOfX3s0fvpXVFTOWq90ddyhXmXe6ZwBdc7gWlojFYWHh4c6F3KTvtMy5aM09zb6BKBS5XBUDg+Hr68fnJ306Y6LjVFlZ59u98F6dU+sV/eUV72qgdRMVlQO5EBqrsriwr+bihpHOjTTTa7NnJGGpbPGYuPOWPUBGfHQqEIDbuHh44+km6cCvz+OxkmbcXD5W6h/5xPlUmaiik5Nt5KUlG8grd2XoLsopNWRFlBLMK3dt78FBOTOUsvo5efj02A0Xv3o5URERETOjEE3ldiBt/qgf8ompIddg8bDZ6sp34qqdpeh2Pvvj2gSswq6zbORdMsD8PPP3geciIofUMt8kXk187a/pRVxvmhfX99cAXTOwFrW4dzGRERERPlj0E0lcnrbL2ictAkWK3Bd93tQrxgBt6b+g59h+eS++O5EKG7+9lsMGzas4tVGSiyCFvWFTqYqenCdo0tDTt70SpouFZSdlgHLZDDJovD39883M63dfHx8yvy4iIiIiNwdg24qkeRfJqq/B71boGHPMSXahjQzrz3oTWRMm4bffvsNgwYNUn0/KxSLCR7ndzm6FORgZrNZDRZZUHZaAmpZryikb1FB2Wm5yWjgRERERFT2GHRTsR3/7WvUM+1XWe7gXi9f1Rls2rSpGlgpJuYy9u3egeat2rJGyK1I5lkC5vxG95abBNxFGdNSmnHL5yW/zLQE1/K8zFlNRERERM6Bv8yoWExpyfBaPV7Nx73frx0aN+14VWdQgoi7GurR9Ox6xKyLB1r9xBohlyF9o/MbkOz8+fNqREu5FYVMkWgfUOeVnQ4ODlbrEREREZHrYNBNRSaZuANv90ETfQwSzF6IHDa3VM5erXqNEHE5GZ6x29VUEJyKh5xtyqz8mn2XZMqs/AYmk2kmXG2aDCIiIiIqHINuKrKVK1di2wEralb1wPkbJqFueGSpnL2anQYh7c+XEGpIwsltP6NG2ztYK1QuU2ZpwbTW/LukU2blzEpLxlr6TNesWVM9l9eUWURERERUMTDopiKRoGTRokVISQnH5us+wq239yu1M+fpF4QDXo3QIGMP4jcvABh001WM8K1NmVVQljo9Pb1I25PpsPIb4VtbLiN85wyopRyyH3me2WsiIiKiio1BNxXJooVfqcxf3bp10aVn39I/a037ADv2oPKFjRWriblOB4t3KHR6HZgHLdqUWfk19ZblcnHIZDIV6dRL9rmwEb69vb1LpZqJiIiIqOJi0E2FOrt7PQacnAKPoLq4afDkMsnc1ew8Amn/vIpKhkQc//1r1Oo0sGLUjG8YLj+wVQV4FTnolkBZRvAuKDstAbUE3oWRrHPOKbNyBtZa828iIiIiorLGoJsKZDGbkLxkLCI8UtGxugX16tcvkzPmHRiGfYHt0DhxE6zrpsF6033sA+tGU2blN/e0FlxLBrskU2bllZ3mlFlERERE5EwYdFOB/vvgfjSxHEGGVY+A3q+W6dmKGPAG/nx3ABZfrINBu3bh2muvZe04udTU1DwHIbO/FWfKrIKy03KTDDanzCIiIiIiV8Kgm/K19+OH0OTiz+r+kSZj0LDZzWV6tkJqNcWhFs/j1M8/Y+HChWjWrJn7D0KVGofAJfdBZ/QAhjnXHOXJycn5Zqa1m4wCXpwpswoalEz6WLt9fRMRERFRhcOgm/L039cvosmpher+3ip90eSeyeVypnr37o3169fj+PHj2LRhNTrccpt715A5A56n/nL4lFl53Yo6ZZYMNlZQdlpu/v7+7C5ARERERBUSg27K5dDGH1Dvv9mQkb32hnVHk0c+K7ezJNnO/j27wvO3l9F47TCkX7dXTSlGxZsyq6BgujhTZvn5+RU6wrdMq0VERERERHlj0E3ZnDlzBjPmLUNPnzpoXNUPjR/9utzPUOfbbkfiP2MRakjG3q+eQZORHzllLSWcPYqTq96HNSZaPd5fvT/q1m+IBg0alMlUUxJQFzbCt9zMZnORthcYGFjoCN+cMouIiIiI6Oow6KZszY4//fRTJCWnYHv1O9HjyfEOmS9bMtvnr3kIofveRNSJxUi6NBF+YdWcoqZiju3GmVWz4X1mC2qZj6Kx7sqI26/+BZisBjXQV++m/mjdpi2iOg8t8jm8cOFCgX2oJeAu7pRZ+fWh5pRZRERERETlg0E32exetwT/7dkNo9ETjz32GDy9Sj9bW1QN+r2As1M+Q4Q+Bnu/m4AmD33isLJI5vjQoUO4vGwC2iauQIgWaOuAU5ZwxAU3gU6nR/sbOmDf/oO4ePECro9bhhp/fIXzGybiYuUbETXoLfiGRGTb7qm9W5D400tomPX48ccfL7QsMtCY/ZRZeTX7Dg4OhtHIjzYRERERkTPgL3NS0hJjUGPdY5heS4ddTZ5FeHi4Q8+M3uiBuGbDEbFnJmqcXIb0pLhy79t9evtKLN+wHVv/PahG8m7ldxHtq1txTBeJ5Bo3Iaz9QFRvciOqZ63fWHvd8UOIWzwWqbGbUNkQj8qXfsHlWb/hXOdXEdVpkBrE7MeffsLqn3/AtBo7AU8gOi1ABcoSUBc0wrdksDnCNxERERGR62DQTbBaLDg8dySaGGT6Jz906Xu/U5yVur2exqVdHyLMkIR9i6ei8eA3ynyfFrMJp//+GUlrZ6J+6g5UjamL5ORGakAxn2v74OT1TyGqze0FbqNarXqoNm45UmIvYP+ajxG24z1UMiQidMNoWNaPxvToG3E0LVilylcG/Q/N60QgstMgfFapKgNqIiIiIiI3w6C7gktPjsext25Hk/R/1eNLbZ9EqH8InIHRywfn696DsGOfImHfWiTExyMgMLDU92POSMPxdQuQtnMxqsbvQA1D1lRZOqBe1SBMGT0ZderWLXZA7BMcjob9nkdKl5HY9/EgNE76E3od4KM3ISIiAvfddx9atWql+msHhYYy4CYiIiIickMMuiswCTZPvHEzGlgOw2TV4UC1/mh8x1g4kzr9J2DHKyvxQXQ9hE6ejIceekiNDl4aoqOj8duGDej030uo4xGTudAApFqMiPZqCN/bnkeTtndc9X4k+G789Ao12rmc8ydDqsHbL0ANeFaUgdGIiIiIiMh1MeiuwA7MvgeNLYeRZjHgTOd30OTmQXA2Xv4hqPToCvjPmKGmM5s0aSIev6s92vUfU6Ltndj8PeJ/+wjvH4tCTFyCWhYaHozgwGScDGwFr2vvQmTH+9DAx7+UjwQIiKhd6tskIiIiIiLnxqC7ApLs6tJvvkC781sALyC69Quo74QBt6ZGjRp45ZVX8OUXX6D2/o/Q7t+fsS/xKBoPfbNIr0+6dBonVs+B139LUNt6TC2rnmFBgrGqat5d7fqH4NOyLRp7+ZbxkRARERERUUXDoLuC2bnjH3y9cJFqWv2T/kY83KUO2vZ+Es4uMDAQDz/8MPa9swaIPYbGxz7FkSnrkRraGPrgGrCkJSLGGIELQc1V32hPZKDmiaXwubgTkZZoNMqa5sts1eGgbyvc/cBYRLbsAi8vL0cfGhERERERuTEG3RVEcsw5HP94EC6fOY3oc9fCx8cHQ4c+grYdO8JV6PR6NB7zLfZ+NBxNzi1BHcsR4KLcMp//NSYKiy78p+6HGFPxXp01WS8EzlpCcLlKR1S+bQwa1W/rwKMgIiIiIqKKhEG3GzOlJSN6w5dI27UE1eK2obEhFQ0DgfhrhqLLPY/A37/0+y2XR+Dd5JHPcHrbPYjbvRK683tgTI+F2eADjzrX4Oam16rm8x6mBPyXFAdr1RYIbd0HEU07IsLRhSciIiIiogqHQbebsVqtOLltJZLWvo5aidtRR2/KfMIAXDT7I6nra+jdaSBcXbXWt6ubvYYAumRb8nQ5l4qIiIiIiCg7Bt1uwJSWguP7d+HQmVhs2LABVS9twuiq2wE9EGf2xunAFvC8pjdq3jwYlcpgVG4iIiIiIiLKG4NuFw2yz+5YhYQ9q2A88zeqpR3EobhqmH/hGvX8OY8a2OPtAf8bhiPyxgFobGA1ExEREREROYIeDnbq1CkMGjQIYWFhanCvZs2a4e+//87WXHrChAmoWrWqer5r1644ePBgtm1cvnwZAwcOVCNcBwcHY8SIEUhMTIQ7SU5OxplNC3Hg9duQ/kokavxyPxpHL0D9jL3w02egincGmjdvrs7DW7M/QNPnVqHWTf+DngE3ERERERGRwzg0BRoTE4Mbb7wRt9xyC3755ReEh4ergDokJMS2zmuvvYZ33nkH8+fPR+3atfHSSy+hW7du2Lt3L7y9vdU6EmieOXMGq1atQkZGBoYNG4YHH3wQX331FdzF008/jQkhP6CqZ5K6VJJk8cRZj5pIq9IK/k27oXm73mhh9HB0MYmIiIiIiMhZgu4ZM2YgMjIS8+bNsy2TwNo+y/3WW2/hxRdfRO/evdWyBQsWoEqVKli6dCnuvfde7Nu3D7/++iu2bt2KNm3aqHXeffdd9OjRA2+88QaqVasGdyDHcSghArHB4fBtNxiRHe5BXWaxiYiIiIiInJpDg+5ly5aprPWAAQPUAGDVq1fHqFGjMHLkSPX80aNHcfbsWdWkXBMUFIR27dph8+bNKuiWv9KkXAu4hayv1+vx119/oW/fvrn2m5aWpm6a+Ph49VemmpKbs2a6ExIeVq0A5NiEs5aVik7qUC4usS7dC+u1qOfIAqtFBytcgzXr8yp/yX2wXt0T67Xi1Ku2TP2O1zm0eFQBfzdZilhmhwbdR44cwQcffIBx48bh+eefV9nqMWPGwNPTE0OGDFEBt5DMtj15rD0nfytXrpzteaPRiNDQUNs6OU2fPh2TJ0/Os7m7yZQ1xZYTVmhCQoJ6Q2pBN7k+1qt7Yr0Wzmy2ICE5AwaDDgada/xKku/fpMQEdV/nImWmwrFe3RPrteLUq9lqhdlshTHDAwYDfyO7IosLxzlSbqcPuuUES4Z62rRp6nHLli3x77//4sMPP1RBd1kZP368CvTtM93SzF2yyDIYmzOScyVfLvaZbnJ9rFf3xHotnMlsgckjDUaDDkYX+U7TMitBQcHQuUiZqXCsV/fEeq049WqyWGAyWxES4AUjg26XZHHhOEeSvUVaDw4kI5I3adIk27LGjRtj8eLF6n5ERIT6e+7cObWuRh63aNHCts758+ezbUOy1TKiufb6nLy8vNQtJ6lkZ65oeTM6exmp+Fiv7on1WjC9Vc6RHjq9zqUCWKlXKa8rlZkKx3p1T6zXilGvku/WWTIzpPyN7Lp0LhrnFLW8Dj0qGbl8//792ZYdOHAAtWrVsg2qJoHzmjVrsmWlpa92+/bt1WP5Gxsbi23bttnWWbt2rbpiIn2/iYiIiIiIiBzFoZnusWPH4oYbblDNy++++25s2bIFc+bMUTftiscTTzyBl19+GfXr17dNGSYjeffp08eWGe/evbsafE2apcuUYY899pgaZM1dRi4nIiIiIiIi1+TQoLtt27ZYsmSJ6mM9ZcoUFVTLFGEy77bmmWeeQVJSkpp3WzLaHTp0UFOEaXN0iy+//FIF2l26dFEp/n79+qm5vYmIiIiIiIgcSWeVYeIqOGmyLlORxcXFOfVAatJPXUZld7W+DpQ/1qt7Yr0WbSC18/FpMBpdayC1uNgYBAWHsE+3G2G9uifWa8WpVzWQmsmKyoEcSM1VWVw4zilqHOlaR0VERERERETkQhh0ExEREREREZURBt1EREREREREZYRBNxEREREREZE7jl7uLLSx5KQjvDMPMJCQkACj0ehyAwxQ/liv7on1WrSB1BLi06DX6+AqX2kygE9CfDws0HEgNTfCenVPrNeKU68Wi9ys8AYHUnNVFheOc7T4sbCxyRl0A6qSRWRkZHnUDREREREREblRPCmjmOeHU4ZlXV05ffo0AgICoNPp4KxXUeSiwIkTJ5x2WjMqPtare2K9uifWq3tivbon1qt7Yr26p3gXjnMkwy0Bd7Vq1QrM0jPTLR3b9XrUqFEDrkDeiK72ZqTCsV7dE+vVPbFe3RPr1T2xXt0T69U9BbponFNQhlvjWo3miYiIiIiIiFwIg24iIiIiIiKiMsKg20V4eXlh4sSJ6i+5D9are2K9uifWq3tivbon1qt7Yr26J68KEOdwIDUiIiIiIiKiMsJMNxEREREREVEZYdBNREREREREVEYYdBMRERERERGVEQbdLuK9995DVFQUvL290a5dO2zZssXRRaIs06dPR9u2bREQEIDKlSujT58+2L9/f7bzk5qaikcffRRhYWHw9/dHv379cO7cuWzrREdHo2fPnvD19VXbefrpp2Ey/b+9ewGKqnz/AP4gF0VNwTAIuXgBUUEJMa9pF03ExmuFEXmrMcVKVDKzIqecTNFUMiOrSZy0DCZBI4tBBEUjbwmImlIiKYqEiEIwQvD+53n/c86cJaD84Vl23e9nZl3P7ruHszycy3Pe298GZTIyMmjgwIFyoAkvLy+Ki4tDHIxg1apVZGVlRQsXLkRM7wJFRUX03HPPyf3R3t6e+vfvT8eOHVPfF0LQ22+/Tffff798f8yYMZSfn2+wjrKyMgoLC5PziTo4ONALL7xAlZWVBmVyc3Np5MiR8rjt7u5O0dHRRvuOlqauro6ioqKoR48eMma9evWiFStWyFgqEFfTd+DAAZowYQK5urrKY25SUpLB+8aMYUJCAvXp00eW4WPEnj17dPrWlh3X2tpaWrp0qfwdd+jQQZaZMWMGXb582WAdiKv57a9a8+bNk2U2bNhguXEVYPJ27Ngh7OzsxBdffCFOnTol5syZIxwcHMTVq1dbe9NACBEUFCS2bNki8vLyRHZ2thg/frzw8PAQlZWV6u9n3rx5wt3dXaSlpYljx46JoUOHiuHDh6vv//3338LPz0+MGTNGnDhxQuzZs0c4OTmJZcuWqWXOnz8v2rdvLxYvXixOnz4tNm7cKKytrcWPP/6IOOjoyJEjonv37mLAgAEiIiICMTVzZWVlwtPTU8yaNUscPnxY7lcpKSnit99+U8usWrVKdO7cWSQlJYmcnBwxceJE0aNHD1FdXa2WGTdunPD39xc///yzyMzMFF5eXiI0NFR9/8aNG8LZ2VmEhYXJY8PXX38t7O3txebNm43+nS3Be++9J+69916RnJwsCgoKREJCgujYsaOIiYlRyyCupo/PfW+++abYuXMn3y0RiYmJBu8bK4aHDh2S59fo6Gh5vn3rrbeEra2tOHnypJF+E5YT1/Lycnnt880334hff/1VZGVlicGDB4vAwECDdSCu5re/Kvh9f39/4erqKtavX2+xcUXSbQb44PPSSy+py3V1dfIP9/3332/V7YLGlZSUyIPP/v371RMK7/x8Eag4c+aMLMMnF+XA1aZNG1FcXKyWiY2NFZ06dRK3bt2Sy6+99prw9fU1+FnTpk2TST/oo6KiQnh7e4vU1FTx8MMPq0k3Ymq+li5dKh566KEm36+vrxcuLi5izZo16msc77Zt28qTPeOTOu+/R48eVcv88MMPwsrKShQVFcnljz/+WDg6Oqr7r/KzfXx8dPpmlu2JJ54Qzz//vMFrU6dOlRdqDHE1Pw0v4o0Zw5CQEPk3pTVkyBAxd+5cnb6t5WguOdPe7OZyhYWFchlxNd+4Xrp0SXTr1k0mzHzDW5t0W1pc0bzcxNXU1NDx48dlEypFmzZt5HJWVlarbhs07saNG/K5S5cu8pnjx82ntDHkJjAeHh5qDPmZm8M4OzurZYKCgujmzZt06tQptYx2HUoZ/B3oh7sEcJP/hr93xNR87d69mwYNGkRPP/207MYREBBAn332mfp+QUEBFRcXG8S8c+fOsluPdn/lZnC8HgWX52Pz4cOH1TKjRo0iOzs7g/2Vu55cv37dSN/WcgwfPpzS0tLo3LlzcjknJ4cOHjxIwcHBchlxNX/GjCHOt61/HcVNkTmWSjwQV/NTX19P06dPl90lfX19//G+pcUVSbeJKy0tlX3VtMkY42U++YDpHWC43++IESPIz89PvsZx4oOFcvJoLIb83FiMlfeaK8OJeXV1ta7fyxLt2LGDfvnlF9lnvyHE1HydP3+eYmNjydvbm1JSUig8PJwWLFhAW7duNdjfmjvm8jMn7Fo2NjbyRtvt7NNw57z++uv0zDPPyBuatra28mYKH4u5ryDiencw5r7ZVBnsu/rjMXC4j3doaKjs56vEA3E1P6tXr5b7H59jG2NpcbVp7Q0AuNtqRvPy8mQNC5ivixcvUkREBKWmpspBOeDuujHGd9VXrlwplzk54332k08+oZkzZ7b25sH/KD4+nrZv305fffWVrFHJzs6WSTcP8IO4ApgHbhUYEhIiB8zjm6NgvrhFYExMjKy84FYLgJpuk+fk5ETW1tb/GOmal11cXFptu+CfXn75ZUpOTqb09HRyc3NTX+c4cTeB8vLyJmPIz43FWHmvuTJ8J5hHcYU7e7IoKSmRI8XzXVd+7N+/nz788EP5f76DipiaJx71uF+/fgav9e3bV84eoN3fmjvm8jP/fWjxTAM8Cuvt7NNw53DzRaW2m7vqcJPGRYsWqS1VEFfzZ8wYNlUG+67+CXdhYaG84a3UcivxQFzNS2ZmpowZd6VUrqMKCwspMjJSzsZkiXFF83ITx82SAwMDZV81bU0NLw8bNqxVtw3+H9+R5YQ7MTGR9u3bJ6es0eL4cXNHbQy5Lwpf5Csx5OeTJ08aHHyUk46SIHAZ7TqUMvg7uPNGjx4t48G1ZcqDa0e5qaryf8TUPHHXj4ZT+nE/YE9PT/l/3n/5RK3d17gLB/cv0+6vfBONb84oeN/nYzP3L1XK8HQqfCGp3V99fHzI0dFR9+9paaqqqmQ/QC2+Yc0xYYir+TNmDHG+bZ2Em6d/27t3r5zOUQtxNT9845On+tJeR7m6usobpNy1yyLj2tojucF/mzKMR+eMi4uTI/29+OKLcsow7UjX0HrCw8PlFCYZGRniypUr6qOqqspgyjCeRmzfvn1yyrBhw4bJR8Mpw8aOHSunHeNpwLp27drolGFLliyRo59v2rQJU4YZkXb0csTUfPGouDY2NnKKqfz8fLF9+3a5X23bts1gWiI+xu7atUvk5uaKSZMmNTotUUBAgJx27ODBg3KUe+00JzyqMk9zMn36dDlqKx/H+edgyjB9zJw5U46Qq0wZxlPU8LSLPOsD4mpeM0bwtJn84EvUdevWyf8ro1gba9/kKYj4OLF27Vp5vl2+fLlJTkF0N8S1pqZGTv3m5uYmr3+011HaEasRV/PbXxvybDB6uaXFFUm3meA5mTlp4/m6eQoxns8OTAMfaBp78NzdCr4gmD9/vpz2gA8WU6ZMkScUrQsXLojg4GA5/yBfLEZGRora2lqDMunp6eKBBx6Qfwc9e/Y0+Blg3KQbMTVf3333nbzJxTcz+/TpIz799FOD93lqoqioKHmi5zKjR48WZ8+eNShz7do1eWHAc0Hz1H6zZ8+WFyBaPI8wT0/G6+CEkBMG0MfNmzfl/snnyXbt2snjI88fq71oR1xNH5/jGjuf8k0VY8cwPj5e9O7dW55vebrO77//Xudvb5lx5ZtkTV1H8ecUiKv57a//Jem+ZkH7qxX/09q17QAAAAAAAAB3I/TpBgAAAAAAANAJkm4AAAAAAAAAnSDpBgAAAAAAANAJkm4AAAAAAAAAnSDpBgAAAAAAANAJkm4AAAAAAAAAnSDpBgAAAAAAANAJkm4AAAAAAAAAnSDpBgAAsGBxcXHk4OBglJ919uxZcnFxoYqKCvW1pKQk8vLyImtra1q4cGGjnystLaX77ruPLl26ZJTtBAAAuJOQdAMAAJiQP//8k8LDw8nDw4Patm0rk9SgoCA6dOiQWsbKykomq7ere/futGHDBoPXpk2bRufOnSNjWLZsGb3yyit0zz33qK/NnTuXnnrqKbp48SKtWLGCZs2aRZMnTzb4nJOTE82YMYOWL19ulO0EAAC4k2zu6NoAAACgRZ588kmqqamhrVu3Us+ePenq1auUlpZG165d0+U3a29vLx96++OPPyg5OZk2btyovlZZWUklJSXypoKrq2uzn589ezYFBgbSmjVrqEuXLrpvLwAAwJ2Cmm4AAAATUV5eTpmZmbR69Wp69NFHydPTkwYPHixriCdOnKjWVrMpU6bIGm9l+ffff6dJkyaRs7MzdezYkR588EHau3evuu5HHnmECgsLadGiRfJz/GiqeXlsbCz16tWL7OzsyMfHh7788kuD9/mzn3/+udyG9u3bk7e3N+3evbvZ7xYfH0/+/v7UrVs3uZyRkaHWeD/22GNynbyNfLNh165d6jZyOebr6ysT88TExBb/ngEAAIwJSTcAAICJ4GSZH9x0/NatW42WOXr0qHzesmULXblyRV3mWuPx48fLWvETJ07QuHHjaMKECbKGme3cuZPc3Nzo3XfflZ/jR2M4qY2IiKDIyEjKy8uTzb+5ljk9Pd2g3DvvvEMhISGUm5srf25YWBiVlZU1+d34ZsKgQYPU5eHDh8s+3uzbb7+V28OJO6+Tt13ZRi6n4BsQvB4AAABzgqQbAADARNjY2MiaZ67t5drnESNG0BtvvCETW0XXrl3lM7/P/b2VZa5F5gTZz89P1jxz/2iurVZqoLlJNg9WxrXL/Dl+NGbt2rWyX/X8+fOpd+/etHjxYpo6dap8XYvLhIaGykHQVq5cKZP+I0eONPnduJZd24Sca9F5cDRl23h7OnXqJJu6K33Z+cHlFPx5Xg8AAIA5QdINAABgYn26L1++LJNlrvHl5tUDBw6UyXhzOOl99dVXqW/fvjIh5xrzM2fOqDXd/xV/hpN9LV7m17UGDBig/r9Dhw4yYeb+2U2prq6mdu3aUUtwQl5VVdWidQAAABgbkm4AAAATw8np448/TlFRUfTTTz/JWuV/G7mbE25uGs61ztwEOzs7m/r37y8HZdODra2twTL3v66vr2+yPI9Afv369Rb9TG6+rtTsAwAAmAsk3QAAACauX79+9NdffxkkvHV1dQZleEoxTs55cDNOtrlp9oULFwzKcFPthp9riGvKtdOTKevmbWiJgIAAOn369L+Wa24buY85rwcAAMCcIOkGAAAwETwtGI/kvW3bNtmPu6CggBISEig6OlqOTK7gEct5wLTi4mK19pj7cfNgaVzDnZOTQ88+++w/ap75cwcOHKCioiIqLS1tdBuWLFkim7LzCOb5+fm0bt06uV6uSW8JnhYsKyvrX5N+3kb+7jzIGm9jbW2tfJ2blR8/fpzGjh3bou0AAAAwNiTdAAAAJoL7YQ8ZMoTWr19Po0aNkoOicRPzOXPm0EcffaSW++CDDyg1NZXc3d3Vml9Ojh0dHeVo3zxqOSe53Bdci0cu59pvHmCtqWbakydPppiYGDlwGk/TtXnzZjlSOk/n1RLBwcFyoDjtNGaN4e/K05TxSOe8jUqtO08j5uHhQSNHjmzRdgAAABiblRBCGP2nAgAAgMXZtGmTHCAuJSXltj87dOhQWrBggazBBwAAMCc2rb0BAAAAYBl4SrPy8nKqqKiQU5f9V9zMnKct4ynKAAAAzA1qugEAAAAAAAB0gj7dAAAAAAAAADpB0g0AAAAAAACgEyTdAAAAAAAAADpB0g0AAAAAAACgEyTdAAAAAAAAADpB0g0AAAAAAACgEyTdAAAAAAAAADpB0g0AAAAAAACgEyTdAAAAAAAAADpB0g0AAAAAAABA+vg/jr8/cjdVMiIAAAAASUVORK5CYII=",
+      "text/plain": [
+       "<Figure size 1000x400 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Read the polygon modification back through RasMapperLib and compare profile response\n",
+    "polygon_profile_x = [poly_cx - 0.70 * poly_w, poly_cx + 0.70 * poly_w]\n",
+    "polygon_profile_y = [poly_cy, poly_cy]\n",
+    "polygon_existing_profile = RasTerrainMod.get_terrain_profile(\n",
+    "    base_project / 'BaldEagleDamBrk.rasmap',\n",
+    "    base_geom_hdf,\n",
+    "    polygon_profile_x,\n",
+    "    polygon_profile_y,\n",
+    "    filter_tolerance=0.01,\n",
+    ")\n",
+    "polygon_readback_profile = RasTerrainMod.get_terrain_profile(\n",
+    "    polygon_project / 'BaldEagleDamBrk.rasmap',\n",
+    "    polygon_geom_hdf,\n",
+    "    polygon_profile_x,\n",
+    "    polygon_profile_y,\n",
+    "    filter_tolerance=0.01,\n",
+    ")\n",
+    "assert not polygon_existing_profile.empty, 'Base polygon profile is empty'\n",
+    "assert not polygon_readback_profile.empty, 'Polygon readback profile is empty'\n",
+    "\n",
+    "polygon_stations = polygon_readback_profile['station'].to_numpy(dtype=float)\n",
+    "polygon_existing_interp = np.interp(\n",
+    "    polygon_stations,\n",
+    "    polygon_existing_profile['station'].to_numpy(dtype=float),\n",
+    "    polygon_existing_profile['elevation'].to_numpy(dtype=float),\n",
+    ")\n",
+    "profile_length = float(np.hypot(\n",
+    "    polygon_profile_x[1] - polygon_profile_x[0],\n",
+    "    polygon_profile_y[1] - polygon_profile_y[0],\n",
+    "))\n",
+    "polygon_sample_x = (\n",
+    "    polygon_profile_x[0]\n",
+    "    + (polygon_stations / profile_length)\n",
+    "    * (polygon_profile_x[1] - polygon_profile_x[0])\n",
+    ")\n",
+    "polygon_sample_y = (\n",
+    "    polygon_profile_y[0]\n",
+    "    + (polygon_stations / profile_length)\n",
+    "    * (polygon_profile_y[1] - polygon_profile_y[0])\n",
+    ")\n",
+    "inside_polygon = MplPath(boundary_xyz[:-1, :2]).contains_points(\n",
+    "    np.column_stack([polygon_sample_x, polygon_sample_y]),\n",
+    "    radius=1e-6,\n",
+    ")\n",
+    "polygon_validation = polygon_readback_profile[['station', 'elevation']].copy()\n",
+    "polygon_validation = polygon_validation.rename(columns={'elevation': 'raster_read_elevation'})\n",
+    "polygon_validation['x'] = polygon_sample_x\n",
+    "polygon_validation['y'] = polygon_sample_y\n",
+    "polygon_validation['existing_elevation'] = polygon_existing_interp\n",
+    "polygon_validation['inside_polygon'] = inside_polygon\n",
+    "polygon_validation['readback_difference'] = (\n",
+    "    polygon_validation['raster_read_elevation']\n",
+    "    - polygon_validation['existing_elevation']\n",
+    ")\n",
+    "\n",
+    "control_checks = []\n",
+    "for control_point in control_xyz:\n",
+    "    distance = np.hypot(\n",
+    "        polygon_validation['x'].to_numpy(dtype=float) - control_point[0],\n",
+    "        polygon_validation['y'].to_numpy(dtype=float) - control_point[1],\n",
+    "    )\n",
+    "    nearest_idx = int(np.argmin(distance))\n",
+    "    row = polygon_validation.iloc[nearest_idx]\n",
+    "    control_checks.append({\n",
+    "        'target_x': float(control_point[0]),\n",
+    "        'target_y': float(control_point[1]),\n",
+    "        'target_elevation_ft': float(control_point[2]),\n",
+    "        'readback_station_ft': float(row['station']),\n",
+    "        'readback_elevation_ft': float(row['raster_read_elevation']),\n",
+    "        'readback_minus_target_ft': float(row['raster_read_elevation'] - control_point[2]),\n",
+    "        'profile_distance_ft': float(distance[nearest_idx]),\n",
+    "    })\n",
+    "control_check_df = pd.DataFrame(control_checks)\n",
+    "control_max_abs_diff = float(control_check_df['readback_minus_target_ft'].abs().max())\n",
+    "assert control_max_abs_diff <= 0.01, (\n",
+    "    f'Control-point readback differs from written elevations by '\n",
+    "    f'{control_max_abs_diff:.6f} ft'\n",
+    ")\n",
+    "assert polygon_validation.loc[inside_polygon, 'readback_difference'].max() > 200.0\n",
+    "\n",
+    "polygon_profile_stats = polygon_validation.loc[\n",
+    "    inside_polygon, ['readback_difference']\n",
+    "].describe().T\n",
+    "display(control_check_df)\n",
+    "display(polygon_profile_stats)\n",
+    "print(f'Control-point writer-vs-raster max abs diff: {control_max_abs_diff:.6f} ft')\n",
+    "\n",
+    "fig, ax = plt.subplots(figsize=(10, 4))\n",
+    "ax.plot(\n",
+    "    polygon_validation['station'],\n",
+    "    polygon_validation['existing_elevation'],\n",
+    "    label='Existing raster',\n",
+    "    color='0.35',\n",
+    ")\n",
+    "ax.plot(\n",
+    "    polygon_validation['station'],\n",
+    "    polygon_validation['raster_read_elevation'],\n",
+    "    label='Polygon raster readback',\n",
+    "    color='tab:orange',\n",
+    "    linestyle='--',\n",
+    ")\n",
+    "control_station = [\n",
+    "    float(np.hypot(point[0] - polygon_profile_x[0], point[1] - polygon_profile_y[0]))\n",
+    "    for point in control_xyz\n",
+    "]\n",
+    "ax.scatter(\n",
+    "    control_station,\n",
+    "    control_xyz[:, 2],\n",
+    "    color='black',\n",
+    "    zorder=5,\n",
+    "    label='Written control elevations',\n",
+    ")\n",
+    "inside_rows = polygon_validation[polygon_validation['inside_polygon']]\n",
+    "if not inside_rows.empty:\n",
+    "    ax.axvspan(\n",
+    "        inside_rows['station'].min(),\n",
+    "        inside_rows['station'].max(),\n",
+    "        color='tab:blue',\n",
+    "        alpha=0.08,\n",
+    "        label='Polygon footprint',\n",
+    "    )\n",
+    "ax.set_xlabel('Station (ft)')\n",
+    "ax.set_ylabel('Elevation (ft)')\n",
+    "ax.set_title('Polygon multipoint writer output vs raster readback')\n",
+    "ax.legend()\n",
+    "ax.grid(True, alpha=0.25)\n",
+    "polygon_profile_png = ARTIFACT_ROOT / 'polygon_profile_readback_validation.png'\n",
+    "fig.tight_layout()\n",
+    "fig.savefig(polygon_profile_png, dpi=160)\n",
+    "polygon_profile_png"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
    "id": "63407540",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-02T00:33:05.904929Z",
-     "iopub.status.busy": "2026-05-02T00:33:05.904929Z",
-     "iopub.status.idle": "2026-05-02T00:33:06.251557Z",
-     "shell.execute_reply": "2026-05-02T00:33:06.251557Z"
+     "iopub.execute_input": "2026-05-05T21:11:00.160318Z",
+     "iopub.status.busy": "2026-05-05T21:11:00.160318Z",
+     "iopub.status.idle": "2026-05-05T21:11:00.502537Z",
+     "shell.execute_reply": "2026-05-05T21:11:00.502537Z"
     }
    },
    "outputs": [
@@ -761,10 +1307,10 @@
     {
      "data": {
       "text/plain": [
-       "WindowsPath('H:/Symphony/ras-commander/CLB-324/316_terrain_modifications/terrain_difference_map.png')"
+       "WindowsPath('H:/Symphony/ras-commander/CLB-279/316_terrain_modifications/terrain_difference_map.png')"
       ]
      },
-     "execution_count": 6,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     },
@@ -829,14 +1375,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 9,
    "id": "01af5c99",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-02T00:33:06.253599Z",
-     "iopub.status.busy": "2026-05-02T00:33:06.253599Z",
-     "iopub.status.idle": "2026-05-02T00:34:19.871206Z",
-     "shell.execute_reply": "2026-05-02T00:34:19.871206Z"
+     "iopub.execute_input": "2026-05-05T21:11:00.502537Z",
+     "iopub.status.busy": "2026-05-05T21:11:00.502537Z",
+     "iopub.status.idle": "2026-05-05T21:12:06.530134Z",
+     "shell.execute_reply": "2026-05-05T21:12:06.530134Z"
     }
    },
    "outputs": [
@@ -871,13 +1417,13 @@
        "      <th>0</th>\n",
        "      <td>base</td>\n",
        "      <td>True</td>\n",
-       "      <td>H:\\Symphony\\ras-commander\\CLB-324\\316_terrain_...</td>\n",
+       "      <td>H:\\Symphony\\ras-commander\\CLB-279\\316_terrain_...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
        "      <td>proposed</td>\n",
        "      <td>True</td>\n",
-       "      <td>H:\\Symphony\\ras-commander\\CLB-324\\316_terrain_...</td>\n",
+       "      <td>H:\\Symphony\\ras-commander\\CLB-279\\316_terrain_...</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -885,11 +1431,11 @@
       ],
       "text/plain": [
        "  condition  success                                           plan_hdf\n",
-       "0      base     True  H:\\Symphony\\ras-commander\\CLB-324\\316_terrain_...\n",
-       "1  proposed     True  H:\\Symphony\\ras-commander\\CLB-324\\316_terrain_..."
+       "0      base     True  H:\\Symphony\\ras-commander\\CLB-279\\316_terrain_...\n",
+       "1  proposed     True  H:\\Symphony\\ras-commander\\CLB-279\\316_terrain_..."
       ]
      },
-     "execution_count": 7,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -927,14 +1473,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 10,
    "id": "ec9696f0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-02T00:34:19.871206Z",
-     "iopub.status.busy": "2026-05-02T00:34:19.871206Z",
-     "iopub.status.idle": "2026-05-02T00:34:20.834858Z",
-     "shell.execute_reply": "2026-05-02T00:34:20.834858Z"
+     "iopub.execute_input": "2026-05-05T21:12:06.530134Z",
+     "iopub.status.busy": "2026-05-05T21:12:06.530134Z",
+     "iopub.status.idle": "2026-05-05T21:12:07.353732Z",
+     "shell.execute_reply": "2026-05-05T21:12:07.353732Z"
     }
    },
    "outputs": [
@@ -1024,10 +1570,10 @@
     {
      "data": {
       "text/plain": [
-       "WindowsPath('H:/Symphony/ras-commander/CLB-324/316_terrain_modifications/wse_difference_map.png')"
+       "WindowsPath('H:/Symphony/ras-commander/CLB-279/316_terrain_modifications/wse_difference_map.png')"
       ]
      },
-     "execution_count": 8,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     },
@@ -1084,14 +1630,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 11,
    "id": "c0375de4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-02T00:34:20.834858Z",
-     "iopub.status.busy": "2026-05-02T00:34:20.834858Z",
-     "iopub.status.idle": "2026-05-02T00:34:20.843104Z",
-     "shell.execute_reply": "2026-05-02T00:34:20.843104Z"
+     "iopub.execute_input": "2026-05-05T21:12:07.355791Z",
+     "iopub.status.busy": "2026-05-05T21:12:07.355791Z",
+     "iopub.status.idle": "2026-05-05T21:12:07.361966Z",
+     "shell.execute_reply": "2026-05-05T21:12:07.361966Z"
     }
    },
    "outputs": [
@@ -1124,32 +1670,42 @@
        "    <tr>\n",
        "      <th>0</th>\n",
        "      <td>terrain_profile_difference.png</td>\n",
-       "      <td>H:\\Symphony\\ras-commander\\CLB-324\\316_terrain_...</td>\n",
+       "      <td>H:\\Symphony\\ras-commander\\CLB-279\\316_terrain_...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
        "      <td>terrain_profile_readback_validation.png</td>\n",
-       "      <td>H:\\Symphony\\ras-commander\\CLB-324\\316_terrain_...</td>\n",
+       "      <td>H:\\Symphony\\ras-commander\\CLB-279\\316_terrain_...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
-       "      <td>terrain_difference_map.png</td>\n",
-       "      <td>H:\\Symphony\\ras-commander\\CLB-324\\316_terrain_...</td>\n",
+       "      <td>polygon_multipoint_control_points.png</td>\n",
+       "      <td>H:\\Symphony\\ras-commander\\CLB-279\\316_terrain_...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3</th>\n",
-       "      <td>wse_difference_map.png</td>\n",
-       "      <td>H:\\Symphony\\ras-commander\\CLB-324\\316_terrain_...</td>\n",
+       "      <td>polygon_profile_readback_validation.png</td>\n",
+       "      <td>H:\\Symphony\\ras-commander\\CLB-279\\316_terrain_...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>4</th>\n",
-       "      <td>base plan HDF</td>\n",
-       "      <td>H:\\Symphony\\ras-commander\\CLB-324\\316_terrain_...</td>\n",
+       "      <td>terrain_difference_map.png</td>\n",
+       "      <td>H:\\Symphony\\ras-commander\\CLB-279\\316_terrain_...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>5</th>\n",
+       "      <td>wse_difference_map.png</td>\n",
+       "      <td>H:\\Symphony\\ras-commander\\CLB-279\\316_terrain_...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>6</th>\n",
+       "      <td>base plan HDF</td>\n",
+       "      <td>H:\\Symphony\\ras-commander\\CLB-279\\316_terrain_...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>7</th>\n",
        "      <td>proposed plan HDF</td>\n",
-       "      <td>H:\\Symphony\\ras-commander\\CLB-324\\316_terrain_...</td>\n",
+       "      <td>H:\\Symphony\\ras-commander\\CLB-279\\316_terrain_...</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -1159,21 +1715,25 @@
        "                                  artifact  \\\n",
        "0           terrain_profile_difference.png   \n",
        "1  terrain_profile_readback_validation.png   \n",
-       "2               terrain_difference_map.png   \n",
-       "3                   wse_difference_map.png   \n",
-       "4                            base plan HDF   \n",
-       "5                        proposed plan HDF   \n",
+       "2    polygon_multipoint_control_points.png   \n",
+       "3  polygon_profile_readback_validation.png   \n",
+       "4               terrain_difference_map.png   \n",
+       "5                   wse_difference_map.png   \n",
+       "6                            base plan HDF   \n",
+       "7                        proposed plan HDF   \n",
        "\n",
        "                                                path  \n",
-       "0  H:\\Symphony\\ras-commander\\CLB-324\\316_terrain_...  \n",
-       "1  H:\\Symphony\\ras-commander\\CLB-324\\316_terrain_...  \n",
-       "2  H:\\Symphony\\ras-commander\\CLB-324\\316_terrain_...  \n",
-       "3  H:\\Symphony\\ras-commander\\CLB-324\\316_terrain_...  \n",
-       "4  H:\\Symphony\\ras-commander\\CLB-324\\316_terrain_...  \n",
-       "5  H:\\Symphony\\ras-commander\\CLB-324\\316_terrain_...  "
+       "0  H:\\Symphony\\ras-commander\\CLB-279\\316_terrain_...  \n",
+       "1  H:\\Symphony\\ras-commander\\CLB-279\\316_terrain_...  \n",
+       "2  H:\\Symphony\\ras-commander\\CLB-279\\316_terrain_...  \n",
+       "3  H:\\Symphony\\ras-commander\\CLB-279\\316_terrain_...  \n",
+       "4  H:\\Symphony\\ras-commander\\CLB-279\\316_terrain_...  \n",
+       "5  H:\\Symphony\\ras-commander\\CLB-279\\316_terrain_...  \n",
+       "6  H:\\Symphony\\ras-commander\\CLB-279\\316_terrain_...  \n",
+       "7  H:\\Symphony\\ras-commander\\CLB-279\\316_terrain_...  "
       ]
      },
-     "execution_count": 9,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1184,6 +1744,8 @@
     "    'artifact': [\n",
     "        'terrain_profile_difference.png',\n",
     "        'terrain_profile_readback_validation.png',\n",
+    "        'polygon_multipoint_control_points.png',\n",
+    "        'polygon_profile_readback_validation.png',\n",
     "        'terrain_difference_map.png',\n",
     "        'wse_difference_map.png',\n",
     "        'base plan HDF',\n",
@@ -1192,6 +1754,8 @@
     "    'path': [\n",
     "        str(profile_png),\n",
     "        str(readback_profile_png),\n",
+    "        str(polygon_points_png),\n",
+    "        str(polygon_profile_png),\n",
     "        str(terrain_png),\n",
     "        str(wse_png),\n",
     "        str(base_plan_hdf),\n",

--- a/ras_commander/__init__.py
+++ b/ras_commander/__init__.py
@@ -126,7 +126,7 @@ _FIXIT_EXPORTS = {
 }
 
 # Terrain module - HEC-RAS terrain creation and manipulation
-_TERRAIN_EXPORTS = {'RasTerrain'}
+_TERRAIN_EXPORTS = {'RasTerrain', 'RasTerrainModification', 'RasTerrainModWriter'}
 
 # Results module - Compute message parsing and execution summary
 _RESULTS_EXPORTS = {'ResultsParser', 'ResultsSummary'}
@@ -209,8 +209,8 @@ __all__ = [
     # Fixit module - Automated geometry repair (lazy loaded)
     'RasFixit', 'FixResults', 'FixMessage', 'FixAction', 'BlockedObstruction',
 
-    # Terrain module - HEC-RAS terrain creation (lazy loaded)
-    'RasTerrain',
+    # Terrain module - HEC-RAS terrain creation and modification (lazy loaded)
+    'RasTerrain', 'RasTerrainModification', 'RasTerrainModWriter',
 
     # Results module - Compute message parsing and execution summary (lazy loaded)
     'ResultsParser', 'ResultsSummary',

--- a/ras_commander/terrain/RasTerrainModWriter.py
+++ b/ras_commander/terrain/RasTerrainModWriter.py
@@ -9,6 +9,7 @@ Supports:
     - Channel modifications (TakeLower) along polylines
     - High-ground levee/road modifications (TakeHigher) along polylines
     - Fill-surface encroachment modifications (SetValue) along polylines
+    - Polygon multipoint modifications with boundary and interior elevations
     - Modification groups for organizing multiple modifications
     - Writing to both terrain HDF and .rasmap XML
 
@@ -21,7 +22,7 @@ Requirements:
 """
 
 from pathlib import Path
-from typing import Dict, List, Optional, Sequence, Union
+from typing import Any, Dict, List, Optional, Sequence, Union
 import xml.etree.ElementTree as ET
 
 import numpy as np
@@ -75,6 +76,17 @@ _MODIFICATION_TYPE_BY_DISK_NAME = {
     "add": MODIFICATION_ADD_VALUE,
     "addvalue": MODIFICATION_ADD_VALUE,
     "add_value": MODIFICATION_ADD_VALUE,
+}
+
+_RASTER_SOURCE_SUFFIXES = {
+    ".adf",
+    ".asc",
+    ".bil",
+    ".flt",
+    ".img",
+    ".tif",
+    ".tiff",
+    ".vrt",
 }
 
 
@@ -257,6 +269,127 @@ class RasTerrainModWriter:
             transition_fraction=transition_fraction,
             group_name=group_name,
         )
+
+    @staticmethod
+    @log_call
+    def add_modification_polygon(
+        terrain_hdf_path: Union[str, Path],
+        name: str,
+        polygon_coords: Any,
+        elevation_method: str = "boundary_from_terrain",
+        control_points: Optional[Sequence[Any]] = None,
+        rasmap_path: Optional[Union[str, Path]] = None,
+        boundary_elevations: Optional[Union[np.ndarray, Sequence[float]]] = None,
+        mode: Union[str, int] = "set_value",
+        elev_pt_tolerance: float = 50.0,
+        group_name: str = "Modifications",
+    ) -> Path:
+        """
+        Add a polygon multipoint terrain modification.
+
+        This writes the RAS Mapper ``Polygons | Multipoint`` style sidecar
+        data. Boundary elevations can be sampled from the terrain source raster
+        references stored in the terrain HDF, supplied from polygon Z values, or
+        passed explicitly. Interior control points are persisted as point
+        features with their elevations for detention pond and wetland grading
+        workflows.
+
+        Parameters
+        ----------
+        terrain_hdf_path : Path
+            Path to the copied terrain HDF file to modify.
+        name : str
+            Name for this terrain modification layer.
+        polygon_coords : array-like or GeoJSON-like
+            Polygon boundary as an Nx2/Nx3 ring or a sequence of rings. Rings
+            are closed automatically when needed.
+        elevation_method : {"boundary_from_terrain", "shape_z", "provided"}
+            Source for polygon boundary elevations. ``boundary_from_terrain``
+            samples the terrain source raster(s); ``shape_z`` uses the third
+            coordinate from ``polygon_coords``; ``provided`` uses
+            ``boundary_elevations``.
+        control_points : sequence, optional
+            Interior elevation points as ``(x, y, elevation)`` tuples or dicts
+            with ``x``, ``y``, and ``elevation``/``z`` keys.
+        rasmap_path : Path, optional
+            Path to the .rasmap XML file. When omitted, the writer searches the
+            terrain folder and project folder for a .rasmap referencing this
+            terrain HDF.
+        boundary_elevations : array-like, optional
+            Explicit boundary elevations matching the closed polygon point
+            count. Used with ``elevation_method="provided"``.
+        mode : str or int
+            Terrain merge mode. Multipoint polygon pond workflows typically use
+            ``set_value``.
+        elev_pt_tolerance : float
+            Elevation point tolerance written to HDF and .rasmap metadata.
+        group_name : str
+            Name of the modification group in .rasmap.
+
+        Returns
+        -------
+        Path
+            Path to the modified terrain HDF file.
+        """
+        terrain_hdf_path = Path(terrain_hdf_path)
+        if rasmap_path is None:
+            rasmap_path = RasTerrainModWriter._infer_rasmap_path(terrain_hdf_path)
+        else:
+            rasmap_path = Path(rasmap_path)
+
+        modification_type = RasTerrainModWriter._resolve_modification_type(mode)
+        RasTerrainModWriter._validate_non_negative(
+            "elev_pt_tolerance", elev_pt_tolerance
+        )
+
+        rings_xy, rings_z = RasTerrainModWriter._validate_polygon_rings(polygon_coords)
+        control_xy, control_elevations, control_names = (
+            RasTerrainModWriter._validate_control_points(control_points)
+        )
+        RasTerrainModWriter._validate_control_points_inside_polygon(
+            control_xy, rings_xy[0]
+        )
+
+        boundary_xy = np.vstack(rings_xy)
+        boundary_values = RasTerrainModWriter._boundary_elevations_for_polygon(
+            terrain_hdf_path=terrain_hdf_path,
+            boundary_xy=boundary_xy,
+            rings_z=rings_z,
+            elevation_method=elevation_method,
+            boundary_elevations=boundary_elevations,
+        )
+
+        logger.info(
+            "Adding polygon multipoint terrain modification '%s' to %s",
+            name,
+            terrain_hdf_path.name,
+        )
+
+        RasTerrainModWriter._write_polygon_to_hdf(
+            terrain_hdf_path=terrain_hdf_path,
+            name=name,
+            rings_xy=rings_xy,
+            boundary_elevations=boundary_values,
+            control_xy=control_xy,
+            control_elevations=control_elevations,
+            control_names=control_names,
+            modification_type=modification_type,
+            elevation_method=elevation_method,
+            elev_pt_tolerance=elev_pt_tolerance,
+        )
+
+        RasTerrainModWriter._update_rasmap_xml(
+            rasmap_path,
+            terrain_hdf_path,
+            name,
+            mod_type="PolygonElevationModificationLayer",
+            default_mod_type=modification_type,
+            elev_pt_tolerance=elev_pt_tolerance,
+            group_name=group_name,
+        )
+
+        logger.info("Polygon terrain modification '%s' added successfully", name)
+        return terrain_hdf_path
 
     @staticmethod
     @log_call
@@ -814,6 +947,637 @@ class RasTerrainModWriter:
                        f"width={width}, mode={modification_type}")
 
     @staticmethod
+    def _write_polygon_to_hdf(
+        terrain_hdf_path: Path,
+        name: str,
+        rings_xy: Sequence[np.ndarray],
+        boundary_elevations: np.ndarray,
+        control_xy: np.ndarray,
+        control_elevations: np.ndarray,
+        control_names: Sequence[str],
+        modification_type: int,
+        elevation_method: str,
+        elev_pt_tolerance: float,
+    ) -> None:
+        """Write a polygon multipoint modification to a terrain HDF file."""
+        import h5py
+
+        polygon_parts: List[List[int]] = []
+        all_points: List[np.ndarray] = []
+        point_start = 0
+        for ring in rings_xy:
+            ring_count = int(len(ring))
+            polygon_parts.append([point_start, ring_count])
+            all_points.append(ring)
+            point_start += ring_count
+
+        polygon_points = np.vstack(all_points).astype(np.float64)
+        polygon_info = np.array(
+            [[0, len(polygon_points), 0, len(polygon_parts)]],
+            dtype=np.int32,
+        )
+        polygon_parts_array = np.asarray(polygon_parts, dtype=np.int32)
+        profile_values = RasTerrainModWriter._polygon_profile_values(
+            rings_xy, boundary_elevations
+        )
+        profile_info = np.array([[0, len(profile_values)]], dtype=np.int32)
+        boundary_points = np.column_stack(
+            [polygon_points, boundary_elevations.astype(np.float64)]
+        )
+
+        if len(control_xy):
+            control_points_xyz = np.column_stack(
+                [control_xy, control_elevations.astype(np.float64)]
+            )
+            elevation_points = np.vstack([boundary_points, control_points_xyz])
+        else:
+            control_points_xyz = np.empty((0, 3), dtype=np.float64)
+            elevation_points = boundary_points.copy()
+
+        with h5py.File(terrain_hdf_path, "a") as f:
+            mods = f.require_group("Modifications")
+
+            if name in mods:
+                logger.warning("Modification '%s' already exists, overwriting", name)
+                del mods[name]
+
+            mod_grp = mods.create_group(name)
+            mod_grp.attrs["Type"] = np.bytes_("Polygon")
+            mod_grp.attrs["Subtype"] = np.bytes_("Multipoint")
+            mod_grp.attrs["Priority"] = np.int32(0)
+            mod_grp.attrs["Boundary Elevation Method"] = np.bytes_(
+                str(elevation_method)[:64]
+            )
+
+            polygon_info_ds = RasTerrainModWriter._create_hdf_dataset(
+                mod_grp, "Polygon Info", polygon_info
+            )
+            polygon_parts_ds = RasTerrainModWriter._create_hdf_dataset(
+                mod_grp, "Polygon Parts", polygon_parts_array
+            )
+            polygon_points_ds = RasTerrainModWriter._create_hdf_dataset(
+                mod_grp, "Polygon Points", polygon_points
+            )
+            polygon_info_ds.attrs["Column"] = np.asarray(
+                [
+                    "Point Starting Index",
+                    "Point Count",
+                    "Part Starting Index",
+                    "Part Count",
+                ],
+                dtype="S32",
+            )
+            polygon_info_ds.attrs["Feature Type"] = np.bytes_("Polygon")
+            polygon_info_ds.attrs["Row"] = np.bytes_("Feature")
+            polygon_parts_ds.attrs["Column"] = np.asarray(
+                ["Point Starting Index", "Point Count"], dtype="S32"
+            )
+            polygon_parts_ds.attrs["Row"] = np.bytes_("Part")
+            polygon_points_ds.attrs["Column"] = np.asarray(["X", "Y"], dtype="S8")
+            polygon_points_ds.attrs["Row"] = np.bytes_("Points")
+
+            profile_info_ds = RasTerrainModWriter._create_hdf_dataset(
+                mod_grp, "Profile Info", profile_info
+            )
+            profile_values_ds = RasTerrainModWriter._create_hdf_dataset(
+                mod_grp, "Profile Values", profile_values.astype(np.float32)
+            )
+            profile_info_ds.attrs["Column"] = np.asarray(
+                ["Starting Index", "Count"], dtype="S16"
+            )
+            profile_info_ds.attrs["Row"] = np.bytes_("Feature")
+            profile_values_ds.attrs["Column"] = np.asarray(["X", "Y"], dtype="S8")
+            profile_values_ds.attrs["Row"] = np.bytes_("Values")
+
+            RasTerrainModWriter._create_hdf_dataset(
+                mod_grp, "Boundary Points", boundary_points
+            )
+            RasTerrainModWriter._create_hdf_dataset(
+                mod_grp, "Boundary Elevations", boundary_elevations.astype(np.float32)
+            )
+            RasTerrainModWriter._create_hdf_dataset(
+                mod_grp, "Elevation Points", elevation_points
+            )
+
+            method_key = (
+                str(elevation_method)
+                .strip()
+                .lower()
+                .replace("-", "_")
+                .replace(" ", "_")
+            )
+            generate_boundary = method_key in {
+                "boundary_from_terrain",
+                "terrain",
+                "from_terrain",
+            }
+            attr_dtype = np.dtype(
+                [
+                    ("Name", "S128"),
+                    ("Elevation Value", "<f4"),
+                    ("Elevation Type", "S11"),
+                    ("Elev Pt Tolerance", "<f4"),
+                    ("Generate Boundary Elevations", "u1"),
+                    ("Use ShapeFile Z Elevations", "u1"),
+                ]
+            )
+            attrs_data = np.array(
+                [
+                    (
+                        name.encode("utf-8")[:128],
+                        np.float32(0.0),
+                        RasTerrainModWriter._modification_type_disk_name(
+                            modification_type
+                        ).encode("utf-8")[:11],
+                        np.float32(elev_pt_tolerance),
+                        np.uint8(1 if generate_boundary else 0),
+                        np.uint8(1 if method_key in {"shape_z", "polygon_z", "z"} else 0),
+                    )
+                ],
+                dtype=attr_dtype,
+            )
+            RasTerrainModWriter._create_hdf_dataset(
+                mod_grp, "Attributes", attrs_data
+            )
+
+            cp_grp = mod_grp.create_group("Control Points")
+            cp_grp.attrs["Type"] = np.bytes_("ElevationControlPointLayer")
+            cp_points_ds = RasTerrainModWriter._create_hdf_dataset(
+                cp_grp, "Points", control_xy.astype(np.float64)
+            )
+            cp_points_ds.attrs["Column"] = np.asarray(["X", "Y"], dtype="S8")
+            cp_points_ds.attrs["Feature Type"] = np.bytes_("Point")
+            cp_points_ds.attrs["Row"] = np.bytes_("Points")
+            RasTerrainModWriter._create_hdf_dataset(
+                cp_grp, "Elevations", control_elevations.astype(np.float32)
+            )
+            RasTerrainModWriter._create_hdf_dataset(
+                cp_grp, "Elevation Points", control_points_xyz
+            )
+
+            cp_attr_dtype = np.dtype([("Name", "S128"), ("Elevation", "<f4")])
+            cp_attrs = np.zeros(len(control_xy), dtype=cp_attr_dtype)
+            for idx, (point_name, elevation) in enumerate(
+                zip(control_names, control_elevations)
+            ):
+                cp_attrs[idx]["Name"] = str(point_name).encode("utf-8")[:128]
+                cp_attrs[idx]["Elevation"] = np.float32(elevation)
+            RasTerrainModWriter._create_hdf_dataset(cp_grp, "Attributes", cp_attrs)
+
+            logger.info(
+                "Wrote polygon multipoint modification '%s' to HDF: "
+                "%d boundary pts, %d control pts, mode=%d",
+                name,
+                len(boundary_points),
+                len(control_xy),
+                modification_type,
+            )
+
+    @staticmethod
+    def _polygon_profile_values(
+        rings_xy: Sequence[np.ndarray],
+        boundary_elevations: np.ndarray,
+    ) -> np.ndarray:
+        """Build RasMapper polygon perimeter profile values from boundary elevations."""
+        rows: List[np.ndarray] = []
+        elev_start = 0
+        station_offset = 0.0
+        for ring in rings_xy:
+            elev_end = elev_start + len(ring)
+            ring_elevations = boundary_elevations[elev_start:elev_end]
+            stations = RasTerrainModWriter._station_values(ring)
+            if rows:
+                stations = stations + station_offset
+            rows.append(np.column_stack([stations, ring_elevations]))
+            station_offset = float(stations[-1])
+            elev_start = elev_end
+
+        if not rows:
+            return np.empty((0, 2), dtype=np.float64)
+        return np.vstack(rows).astype(np.float64)
+
+    @staticmethod
+    def _validate_polygon_rings(polygon_coords: Any) -> tuple[List[np.ndarray], List[np.ndarray]]:
+        """Normalize polygon input to closed XY rings and optional Z arrays."""
+        coords = RasTerrainModWriter._geojson_polygon_coordinates(polygon_coords)
+        if RasTerrainModWriter._is_ring_like(coords):
+            raw_rings = [coords]
+        else:
+            if not isinstance(coords, Sequence) or isinstance(coords, (str, bytes)):
+                raise ValueError(
+                    "polygon_coords must be a coordinate ring or sequence of rings"
+                )
+            raw_rings = list(coords)
+
+        if len(raw_rings) == 0:
+            raise ValueError("polygon_coords must contain at least one ring")
+
+        rings_xy: List[np.ndarray] = []
+        rings_z: List[np.ndarray] = []
+        for ring_index, raw_ring in enumerate(raw_rings):
+            if not RasTerrainModWriter._is_ring_like(raw_ring):
+                raise ValueError("Each polygon ring must be a sequence of XY points")
+
+            xy_rows: List[List[float]] = []
+            z_rows: List[float] = []
+            for point in raw_ring:
+                x, y, z = RasTerrainModWriter._coordinate_to_xy_z(point)
+                xy_rows.append([x, y])
+                z_rows.append(z)
+
+            if len(xy_rows) < 3:
+                raise ValueError("Each polygon ring must contain at least three points")
+
+            if xy_rows[0] != xy_rows[-1]:
+                xy_rows.append(xy_rows[0].copy())
+                z_rows.append(z_rows[0])
+
+            if len(xy_rows) < 4:
+                raise ValueError(
+                    "Each polygon ring must contain at least four closed points"
+                )
+
+            xy = np.asarray(xy_rows, dtype=np.float64)
+            z = np.asarray(z_rows, dtype=np.float64)
+            if not np.all(np.isfinite(xy)):
+                raise ValueError("polygon_coords XY values must be finite")
+
+            area = RasTerrainModWriter._ring_signed_area(xy)
+            if abs(area) <= 0.0:
+                raise ValueError("Each polygon ring must enclose a non-zero area")
+
+            if ring_index > 0:
+                logger.debug("Writing polygon interior ring %d", ring_index)
+            rings_xy.append(xy)
+            rings_z.append(z)
+
+        return rings_xy, rings_z
+
+    @staticmethod
+    def _geojson_polygon_coordinates(polygon_coords: Any) -> Any:
+        if hasattr(polygon_coords, "__geo_interface__"):
+            polygon_coords = polygon_coords.__geo_interface__
+
+        if not isinstance(polygon_coords, dict):
+            return polygon_coords
+
+        geometry = polygon_coords
+        if str(geometry.get("type", "")).lower() == "feature":
+            geometry = geometry.get("geometry") or {}
+
+        geometry_type = str(geometry.get("type", "")).lower()
+        coordinates = geometry.get("coordinates")
+        if geometry_type == "polygon":
+            return coordinates
+        if geometry_type == "multipolygon":
+            return [ring for polygon in coordinates for ring in polygon]
+
+        raise ValueError(
+            "polygon_coords GeoJSON input must be Polygon or MultiPolygon geometry"
+        )
+
+    @staticmethod
+    def _is_ring_like(value: Any) -> bool:
+        if isinstance(value, np.ndarray):
+            return value.ndim == 2 and value.shape[0] > 0 and value.shape[1] >= 2
+        if not isinstance(value, Sequence) or isinstance(value, (str, bytes)):
+            return False
+        return len(value) > 0 and RasTerrainModWriter._is_coordinate_like(value[0])
+
+    @staticmethod
+    def _is_coordinate_like(value: Any) -> bool:
+        if isinstance(value, np.ndarray):
+            if value.ndim != 1 or value.shape[0] < 2:
+                return False
+        elif not isinstance(value, Sequence) or isinstance(value, (str, bytes)):
+            return False
+        elif len(value) < 2:
+            return False
+
+        try:
+            float(value[0])
+            float(value[1])
+        except (TypeError, ValueError):
+            return False
+        return True
+
+    @staticmethod
+    def _coordinate_to_xy_z(value: Any) -> tuple[float, float, float]:
+        if not RasTerrainModWriter._is_coordinate_like(value):
+            raise ValueError(f"Invalid polygon coordinate: {value!r}")
+        x = float(value[0])
+        y = float(value[1])
+        z = np.nan
+        if len(value) >= 3 and value[2] is not None:
+            z = float(value[2])
+        return x, y, z
+
+    @staticmethod
+    def _ring_signed_area(ring_xy: np.ndarray) -> float:
+        x = ring_xy[:, 0]
+        y = ring_xy[:, 1]
+        return float(0.5 * np.sum(x[:-1] * y[1:] - x[1:] * y[:-1]))
+
+    @staticmethod
+    def _validate_control_points(
+        control_points: Optional[Sequence[Any]],
+    ) -> tuple[np.ndarray, np.ndarray, List[str]]:
+        if control_points is None:
+            return (
+                np.empty((0, 2), dtype=np.float64),
+                np.empty((0,), dtype=np.float64),
+                [],
+            )
+
+        xy_rows: List[List[float]] = []
+        elevations: List[float] = []
+        names: List[str] = []
+        for idx, point in enumerate(control_points):
+            if isinstance(point, dict):
+                x = RasTerrainModWriter._mapping_value(point, "x", "X")
+                y = RasTerrainModWriter._mapping_value(point, "y", "Y")
+                elevation = RasTerrainModWriter._mapping_value(
+                    point, "elevation", "Elevation", "z", "Z"
+                )
+                point_name = point.get("name", point.get("Name", f"Control Point {idx + 1}"))
+            else:
+                if not isinstance(point, Sequence) or isinstance(point, (str, bytes)):
+                    raise ValueError("control_points entries must be sequences or dicts")
+                if len(point) < 3:
+                    raise ValueError(
+                        "control_points entries must include x, y, and elevation"
+                    )
+                x, y, elevation = point[:3]
+                point_name = point[3] if len(point) >= 4 else f"Control Point {idx + 1}"
+
+            x = float(x)
+            y = float(y)
+            elevation = float(elevation)
+            if not np.isfinite([x, y, elevation]).all():
+                raise ValueError("control_points must contain finite x/y/elevation values")
+
+            xy_rows.append([x, y])
+            elevations.append(elevation)
+            names.append(str(point_name))
+
+        if not xy_rows:
+            return (
+                np.empty((0, 2), dtype=np.float64),
+                np.empty((0,), dtype=np.float64),
+                [],
+            )
+
+        return (
+            np.asarray(xy_rows, dtype=np.float64),
+            np.asarray(elevations, dtype=np.float64),
+            names,
+        )
+
+    @staticmethod
+    def _mapping_value(mapping: Dict[str, Any], *keys: str) -> Any:
+        for key in keys:
+            if key in mapping:
+                return mapping[key]
+        raise ValueError(f"control point is missing one of: {', '.join(keys)}")
+
+    @staticmethod
+    def _validate_control_points_inside_polygon(
+        control_xy: np.ndarray,
+        exterior_ring: np.ndarray,
+    ) -> None:
+        if len(control_xy) == 0:
+            return
+
+        outside = [
+            idx
+            for idx, point in enumerate(control_xy)
+            if not RasTerrainModWriter._point_in_or_on_ring(point, exterior_ring)
+        ]
+        if outside:
+            raise ValueError(
+                "control_points must fall inside the polygon exterior; "
+                f"outside point indices: {outside}"
+            )
+
+    @staticmethod
+    def _point_in_or_on_ring(point: np.ndarray, ring: np.ndarray) -> bool:
+        x = float(point[0])
+        y = float(point[1])
+        tolerance = 1e-9
+
+        for start, end in zip(ring[:-1], ring[1:]):
+            vector = end - start
+            rel = point - start
+            length2 = float(vector @ vector)
+            if length2 <= 0:
+                continue
+            t = float((rel @ vector) / length2)
+            if -tolerance <= t <= 1.0 + tolerance:
+                closest = start + np.clip(t, 0.0, 1.0) * vector
+                if np.linalg.norm(point - closest) <= tolerance:
+                    return True
+
+        inside = False
+        for start, end in zip(ring[:-1], ring[1:]):
+            xi, yi = start
+            xj, yj = end
+            intersects = (yi > y) != (yj > y)
+            if intersects:
+                x_intersect = (xj - xi) * (y - yi) / (yj - yi) + xi
+                if x < x_intersect:
+                    inside = not inside
+        return inside
+
+    @staticmethod
+    def _boundary_elevations_for_polygon(
+        terrain_hdf_path: Path,
+        boundary_xy: np.ndarray,
+        rings_z: Sequence[np.ndarray],
+        elevation_method: str,
+        boundary_elevations: Optional[Union[np.ndarray, Sequence[float]]],
+    ) -> np.ndarray:
+        method = str(elevation_method).strip().lower().replace("-", "_").replace(" ", "_")
+        if boundary_elevations is not None:
+            method = "provided"
+
+        if method in {"provided", "explicit", "boundary_elevations"}:
+            if boundary_elevations is None:
+                raise ValueError(
+                    "boundary_elevations is required when elevation_method='provided'"
+                )
+            elevations = np.asarray(boundary_elevations, dtype=np.float64)
+            if elevations.ndim != 1 or len(elevations) != len(boundary_xy):
+                raise ValueError(
+                    "boundary_elevations must be a 1D array matching the closed "
+                    "polygon boundary point count"
+                )
+            if not np.all(np.isfinite(elevations)):
+                raise ValueError("boundary_elevations must contain finite values")
+            return elevations
+
+        if method in {"shape_z", "polygon_z", "z"}:
+            elevations = np.concatenate(rings_z).astype(np.float64)
+            if elevations.ndim != 1 or len(elevations) != len(boundary_xy):
+                raise ValueError("polygon Z values do not match boundary point count")
+            if not np.all(np.isfinite(elevations)):
+                raise ValueError(
+                    "polygon_coords must include finite Z values when "
+                    "elevation_method='shape_z'"
+                )
+            return elevations
+
+        if method in {"boundary_from_terrain", "terrain", "from_terrain"}:
+            return RasTerrainModWriter._sample_terrain_elevations(
+                terrain_hdf_path, boundary_xy
+            )
+
+        raise ValueError(
+            "Unsupported elevation_method. Use 'boundary_from_terrain', "
+            "'shape_z', or 'provided'."
+        )
+
+    @staticmethod
+    def _sample_terrain_elevations(
+        terrain_hdf_path: Path,
+        xy: np.ndarray,
+    ) -> np.ndarray:
+        try:
+            import rasterio
+        except ImportError as exc:
+            raise ImportError(
+                "rasterio is required for elevation_method='boundary_from_terrain'."
+            ) from exc
+
+        raster_paths = RasTerrainModWriter._terrain_source_raster_paths(terrain_hdf_path)
+        if not raster_paths:
+            raise FileNotFoundError(
+                "No source raster paths were found in or beside terrain HDF "
+                f"{terrain_hdf_path}"
+            )
+
+        elevations = np.full(len(xy), np.nan, dtype=np.float64)
+        for raster_path in raster_paths:
+            pending = np.where(~np.isfinite(elevations))[0]
+            if len(pending) == 0:
+                break
+
+            with rasterio.open(raster_path) as src:
+                nodata = getattr(src, "nodata", None)
+                sampled_values: List[float] = []
+                for sample in src.sample(
+                    [(float(x), float(y)) for x, y in xy[pending]]
+                ):
+                    if np.ma.is_masked(sample):
+                        mask = np.ma.getmaskarray(sample)
+                        value = np.nan if mask.size and mask.flat[0] else sample.data[0]
+                    else:
+                        sample_array = np.asarray(sample)
+                        value = sample_array.flat[0] if sample_array.size else np.nan
+                    sampled_values.append(float(value))
+
+                sampled = np.asarray(sampled_values, dtype=np.float64)
+                valid = np.isfinite(sampled)
+                if nodata is not None and np.isfinite(float(nodata)):
+                    valid &= sampled != float(nodata)
+                elevations[pending[valid]] = sampled[valid]
+
+        if not np.all(np.isfinite(elevations)):
+            missing = np.where(~np.isfinite(elevations))[0].tolist()
+            raise ValueError(
+                "Could not sample finite terrain elevations for polygon boundary "
+                f"point indices {missing} from source rasters: "
+                f"{[str(path) for path in raster_paths]}"
+            )
+
+        return elevations
+
+    @staticmethod
+    def _terrain_source_raster_paths(terrain_hdf_path: Path) -> List[Path]:
+        import h5py
+
+        terrain_hdf_path = Path(terrain_hdf_path)
+        candidates: List[Path] = []
+
+        def add_candidate(text: str) -> None:
+            cleaned = text.strip().strip("\"'").rstrip("\x00")
+            if not cleaned:
+                return
+            normalized = cleaned.replace("\\", "/")
+            if Path(normalized).suffix.lower() not in _RASTER_SOURCE_SUFFIXES:
+                return
+
+            raw_path = Path(normalized)
+            search_bases = [terrain_hdf_path.parent, terrain_hdf_path.parent.parent]
+            possible = [raw_path] if raw_path.is_absolute() else [
+                base / raw_path for base in search_bases
+            ]
+            for candidate in possible:
+                if candidate.exists():
+                    candidates.append(candidate)
+                    return
+
+        with h5py.File(terrain_hdf_path, "r") as f:
+            for value in f.attrs.values():
+                for text in RasTerrainModWriter._iter_hdf_strings(value):
+                    add_candidate(text)
+
+            def visitor(_name, obj):
+                for value in obj.attrs.values():
+                    for text in RasTerrainModWriter._iter_hdf_strings(value):
+                        add_candidate(text)
+                if isinstance(obj, h5py.Dataset):
+                    if obj.size <= 10000 and (
+                        obj.dtype.names is not None or obj.dtype.kind in {"S", "U", "O"}
+                    ):
+                        for text in RasTerrainModWriter._iter_hdf_strings(obj[()]):
+                            add_candidate(text)
+
+            f.visititems(visitor)
+
+        for suffix in (".tif", ".tiff", ".vrt"):
+            fallback = terrain_hdf_path.with_suffix(suffix)
+            if fallback.exists():
+                candidates.append(fallback)
+
+        unique: List[Path] = []
+        seen = set()
+        for candidate in candidates:
+            key = str(candidate.resolve()).lower()
+            if key in seen:
+                continue
+            seen.add(key)
+            unique.append(candidate)
+        return unique
+
+    @staticmethod
+    def _iter_hdf_strings(value: Any):
+        if isinstance(value, str):
+            yield value
+            return
+        if isinstance(value, (bytes, np.bytes_)):
+            yield bytes(value).decode("utf-8", errors="ignore")
+            return
+        if isinstance(value, np.void) and value.dtype.names:
+            for field_name in value.dtype.names:
+                yield from RasTerrainModWriter._iter_hdf_strings(value[field_name])
+            return
+        if isinstance(value, np.ndarray):
+            if value.dtype.names:
+                for field_name in value.dtype.names:
+                    yield from RasTerrainModWriter._iter_hdf_strings(value[field_name])
+                return
+            if value.dtype.kind in {"S", "U", "O"}:
+                for item in value.reshape(-1):
+                    yield from RasTerrainModWriter._iter_hdf_strings(item)
+            return
+        if isinstance(value, np.generic):
+            yield from RasTerrainModWriter._iter_hdf_strings(value.item())
+            return
+        if isinstance(value, Sequence) and not isinstance(value, (str, bytes)):
+            for item in value:
+                yield from RasTerrainModWriter._iter_hdf_strings(item)
+
+    @staticmethod
     def _validate_polyline_points(
         polyline_points: Union[np.ndarray, Sequence[Sequence[float]]],
     ) -> np.ndarray:
@@ -1280,6 +2044,61 @@ class RasTerrainModWriter:
         return value
 
     @staticmethod
+    def _infer_rasmap_path(terrain_hdf_path: Path) -> Path:
+        """Find a project .rasmap file that references a terrain HDF."""
+        terrain_hdf_path = Path(terrain_hdf_path)
+        search_roots: List[Path] = []
+        for root in (terrain_hdf_path.parent, terrain_hdf_path.parent.parent):
+            if root not in search_roots and root.exists():
+                search_roots.append(root)
+
+        candidates: List[Path] = []
+        for root in search_roots:
+            candidates.extend(sorted(root.glob("*.rasmap")))
+
+        unique_candidates: List[Path] = []
+        seen = set()
+        for candidate in candidates:
+            key = str(candidate.resolve()).lower()
+            if key not in seen:
+                seen.add(key)
+                unique_candidates.append(candidate)
+
+        referencing: List[Path] = []
+        for candidate in unique_candidates:
+            try:
+                root = ET.parse(candidate).getroot()
+            except ET.ParseError:
+                continue
+            for layer in root.findall(".//Terrains/Layer"):
+                if RasTerrainModWriter._layer_references_path(
+                    layer.get("Filename", ""), candidate, terrain_hdf_path
+                ):
+                    referencing.append(candidate)
+                    break
+
+        if len(referencing) == 1:
+            return referencing[0]
+        if len(referencing) > 1:
+            raise ValueError(
+                "Multiple .rasmap files reference this terrain HDF; pass "
+                f"rasmap_path explicitly: {[str(path) for path in referencing]}"
+            )
+        if len(unique_candidates) == 1:
+            return unique_candidates[0]
+
+        if unique_candidates:
+            raise ValueError(
+                "Could not infer rasmap_path because multiple .rasmap files were "
+                f"found and none referenced {terrain_hdf_path.name}: "
+                f"{[str(path) for path in unique_candidates]}"
+            )
+        raise FileNotFoundError(
+            f"Could not infer rasmap_path for terrain HDF {terrain_hdf_path}; "
+            "pass rasmap_path explicitly."
+        )
+
+    @staticmethod
     def _find_terrain_layer(
         root: ET.Element,
         rasmap_path: Path,
@@ -1345,6 +2164,8 @@ class RasTerrainModWriter:
             mod_group.set('Name', group_name)
             mod_group.set('Type', 'ElevationModificationGroup')
             logger.info(f"Created modification group '{group_name}' in .rasmap")
+        mod_group.set('Checked', 'True')
+        mod_group.set('Expanded', 'True')
 
         tree.write(rasmap_path, xml_declaration=False, encoding='unicode')
         return mod_group
@@ -1390,6 +2211,8 @@ class RasTerrainModWriter:
         mod_layer = ET.SubElement(mod_group, 'Layer')
         mod_layer.set('Name', name)
         mod_layer.set('Type', mod_type)
+        mod_layer.set('Checked', 'True')
+        mod_layer.set('Expanded', 'True')
 
         default_type_el = ET.SubElement(mod_layer, 'DefaultModificationType')
         default_type_el.set('Value', str(default_mod_type))
@@ -1401,6 +2224,11 @@ class RasTerrainModWriter:
         cp_layer = ET.SubElement(mod_layer, 'Layer')
         cp_layer.set('Name', 'Control Points')
         cp_layer.set('Type', 'ElevationControlPointLayer')
+        cp_layer.set('Checked', 'True')
 
         tree.write(rasmap_path, xml_declaration=False, encoding='unicode')
         logger.info(f"Added modification layer '{name}' to .rasmap")
+
+
+class RasTerrainModification(RasTerrainModWriter):
+    """User-facing alias for terrain modification writer APIs."""

--- a/ras_commander/terrain/__init__.py
+++ b/ras_commander/terrain/__init__.py
@@ -6,6 +6,7 @@ This subpackage provides terrain capabilities for HEC-RAS projects:
 - VRT mosaic to single TIFF conversion via HEC-RAS GDAL tools
 - USGS 3DEP elevation data download from AWS
 - Terrain modification writing for channel, high-ground, and fill-surface layers
+- Polygon multipoint terrain modification writing for pond/wetland grading
 - Terrain modification analysis (cut/fill, no-net-fill) via RasMapperLib.dll
 
 Main Classes:
@@ -29,6 +30,7 @@ Main Classes:
         - add_channel_modification(): add TakeLower channel cuts
         - add_high_ground_modification(): add TakeHigher levee/road lines
         - add_fill_surface_modification(): add SetValue fill surfaces
+        - add_modification_polygon(): add polygon multipoint modifications
         - list_modifications(): inspect terrain modification sidecar groups
 
 Requirements:
@@ -60,11 +62,22 @@ See Also:
 
 from .RasTerrain import RasTerrain
 from .Usgs3depAws import Usgs3depAws
-from .RasTerrainModWriter import RasTerrainModWriter
+from .RasTerrainModWriter import RasTerrainModification, RasTerrainModWriter
 
 # Conditional import - RasTerrainMod requires pythonnet (Windows only)
 try:
     from .RasTerrainMod import RasTerrainMod
-    __all__ = ['RasTerrain', 'Usgs3depAws', 'RasTerrainMod', 'RasTerrainModWriter']
+    __all__ = [
+        'RasTerrain',
+        'Usgs3depAws',
+        'RasTerrainMod',
+        'RasTerrainModification',
+        'RasTerrainModWriter',
+    ]
 except ImportError:
-    __all__ = ['RasTerrain', 'Usgs3depAws', 'RasTerrainModWriter']
+    __all__ = [
+        'RasTerrain',
+        'Usgs3depAws',
+        'RasTerrainModification',
+        'RasTerrainModWriter',
+    ]

--- a/tests/test_ras_terrain_mod_writer.py
+++ b/tests/test_ras_terrain_mod_writer.py
@@ -1,4 +1,6 @@
 import xml.etree.ElementTree as ET
+import sys
+from types import SimpleNamespace
 
 import h5py
 import numpy as np
@@ -9,6 +11,7 @@ from ras_commander.terrain.RasTerrainModWriter import (
     MODIFICATION_SET_VALUE,
     MODIFICATION_TAKE_HIGHER,
     MODIFICATION_TAKE_LOWER,
+    RasTerrainModification,
     RasTerrainModWriter,
 )
 
@@ -44,12 +47,221 @@ def _decode(value):
     return value
 
 
+def _decode_array(values):
+    return [_decode(value) for value in values]
+
+
 def _mod_layer(rasmap, name):
     root = ET.parse(rasmap).getroot()
     for layer in root.findall(".//Layer"):
         if layer.get("Name") == name:
             return layer
     raise AssertionError(f"Layer not found: {name}")
+
+
+class _FakeRaster:
+    nodata = -9999.0
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def sample(self, coords):
+        for x, y in coords:
+            yield np.array([900.0 + float(x) + float(y)], dtype=np.float64)
+
+
+def test_top_level_exports_polygon_modification_alias():
+    import ras_commander as ras
+    from ras_commander.terrain import RasTerrainModification as terrain_alias
+
+    assert ras.RasTerrainModification is terrain_alias
+    assert terrain_alias.add_modification_polygon is not None
+
+
+def test_add_polygon_modification_samples_boundary_and_writes_control_points(
+    tmp_path, monkeypatch
+):
+    terrain_hdf, rasmap = _write_minimal_terrain(tmp_path)
+    terrain_hdf.with_suffix(".tif").write_text("fake raster", encoding="utf-8")
+
+    opened_paths = []
+
+    def fake_open(path):
+        opened_paths.append(path)
+        return _FakeRaster()
+
+    monkeypatch.setitem(sys.modules, "rasterio", SimpleNamespace(open=fake_open))
+
+    result = RasTerrainModification.add_modification_polygon(
+        terrain_hdf,
+        name="Wetland Pond",
+        polygon_coords=[
+            [0.0, 0.0],
+            [10.0, 0.0],
+            [10.0, 10.0],
+            [0.0, 10.0],
+        ],
+        control_points=[
+            {"x": 3.0, "y": 4.0, "elevation": 930.0, "name": "Rim"},
+            (7.0, 6.0, 925.0, "Pool Bottom"),
+        ],
+        elev_pt_tolerance=15.0,
+    )
+
+    assert result == terrain_hdf
+    assert opened_paths == [terrain_hdf.with_suffix(".tif")]
+
+    expected_boundary = np.array(
+        [
+            [0.0, 0.0, 900.0],
+            [10.0, 0.0, 910.0],
+            [10.0, 10.0, 920.0],
+            [0.0, 10.0, 910.0],
+            [0.0, 0.0, 900.0],
+        ]
+    )
+
+    with h5py.File(terrain_hdf, "r") as hdf:
+        mod = hdf["Modifications/Wetland Pond"]
+        assert _decode(mod.attrs["Type"]) == "Polygon"
+        assert _decode(mod.attrs["Subtype"]) == "Multipoint"
+        assert _decode(mod.attrs["Boundary Elevation Method"]) == "boundary_from_terrain"
+        assert mod["Polygon Info"].attrs["Feature Type"] == b"Polygon"
+        assert _decode_array(mod["Polygon Info"].attrs["Column"]) == [
+            "Point Starting Index",
+            "Point Count",
+            "Part Starting Index",
+            "Part Count",
+        ]
+        np.testing.assert_array_equal(mod["Polygon Info"][:], np.array([[0, 5, 0, 1]]))
+        assert _decode_array(mod["Polygon Parts"].attrs["Column"]) == [
+            "Point Starting Index",
+            "Point Count",
+        ]
+        np.testing.assert_array_equal(mod["Polygon Parts"][:], np.array([[0, 5]]))
+        assert _decode_array(mod["Polygon Points"].attrs["Column"]) == ["X", "Y"]
+        np.testing.assert_allclose(mod["Polygon Points"][:], expected_boundary[:, :2])
+        np.testing.assert_array_equal(mod["Profile Info"][:], np.array([[0, 5]]))
+        np.testing.assert_allclose(
+            mod["Profile Values"][:],
+            np.column_stack(
+                [
+                    [0.0, 10.0, 20.0, 30.0, 40.0],
+                    expected_boundary[:, 2],
+                ]
+            ),
+        )
+        np.testing.assert_allclose(mod["Boundary Points"][:], expected_boundary)
+        np.testing.assert_allclose(mod["Boundary Elevations"][:], expected_boundary[:, 2])
+        np.testing.assert_allclose(
+            mod["Control Points/Points"][:],
+            np.array([[3.0, 4.0], [7.0, 6.0]]),
+        )
+        np.testing.assert_allclose(
+            mod["Control Points/Elevations"][:],
+            np.array([930.0, 925.0]),
+        )
+        np.testing.assert_allclose(
+            mod["Control Points/Elevation Points"][:],
+            np.array([[3.0, 4.0, 930.0], [7.0, 6.0, 925.0]]),
+        )
+        np.testing.assert_allclose(
+            mod["Elevation Points"][-2:],
+            np.array([[3.0, 4.0, 930.0], [7.0, 6.0, 925.0]]),
+        )
+
+        attrs = mod["Attributes"][0]
+        assert set(mod["Attributes"].dtype.names) == {
+            "Name",
+            "Elevation Value",
+            "Elevation Type",
+            "Elev Pt Tolerance",
+            "Generate Boundary Elevations",
+            "Use ShapeFile Z Elevations",
+        }
+        assert _decode(attrs["Name"]) == "Wetland Pond"
+        assert attrs["Elevation Value"] == pytest.approx(0.0)
+        assert _decode(attrs["Elevation Type"]) == "SetValue"
+        assert attrs["Elev Pt Tolerance"] == pytest.approx(15.0)
+        assert attrs["Generate Boundary Elevations"] == 1
+        assert attrs["Use ShapeFile Z Elevations"] == 0
+
+        assert mod["Control Points/Points"].attrs["Feature Type"] == b"Point"
+        assert _decode_array(mod["Control Points/Points"].attrs["Column"]) == ["X", "Y"]
+
+        cp_attrs = mod["Control Points/Attributes"][:]
+        assert [_decode(value) for value in cp_attrs["Name"]] == ["Rim", "Pool Bottom"]
+        np.testing.assert_allclose(cp_attrs["Elevation"], np.array([930.0, 925.0]))
+
+    layer = _mod_layer(rasmap, "Wetland Pond")
+    assert layer.get("Type") == "PolygonElevationModificationLayer"
+    assert layer.get("Checked") == "True"
+    assert layer.get("Expanded") == "True"
+    assert layer.find("DefaultModificationType").get("Value") == str(
+        MODIFICATION_SET_VALUE
+    )
+    assert layer.find("DefaultElevPtTol").get("Value") == "15"
+    cp_layer = layer.find("Layer")
+    assert cp_layer.get("Name") == "Control Points"
+    assert cp_layer.get("Type") == "ElevationControlPointLayer"
+    assert cp_layer.get("Checked") == "True"
+
+
+def test_add_polygon_modification_uses_shape_z_boundary_elevations(tmp_path):
+    terrain_hdf, _rasmap = _write_minimal_terrain(tmp_path)
+
+    RasTerrainModWriter.add_modification_polygon(
+        terrain_hdf,
+        name="Shape Z Pond",
+        polygon_coords=[
+            [0.0, 0.0, 942.0],
+            [20.0, 0.0, 943.0],
+            [20.0, 20.0, 944.0],
+            [0.0, 20.0, 945.0],
+        ],
+        elevation_method="shape_z",
+        control_points=[(10.0, 10.0, 925.0)],
+    )
+
+    with h5py.File(terrain_hdf, "r") as hdf:
+        mod = hdf["Modifications/Shape Z Pond"]
+        np.testing.assert_allclose(
+            mod["Boundary Elevations"][:],
+            np.array([942.0, 943.0, 944.0, 945.0, 942.0]),
+        )
+        np.testing.assert_allclose(
+            mod["Profile Values"][:, 1],
+            np.array([942.0, 943.0, 944.0, 945.0, 942.0]),
+        )
+        assert mod["Attributes"][0]["Use ShapeFile Z Elevations"] == 1
+        np.testing.assert_allclose(
+            mod["Control Points/Elevations"][:],
+            np.array([925.0]),
+        )
+
+    layer = _mod_layer(tmp_path / "Project.rasmap", "Shape Z Pond")
+    assert layer.get("Type") == "PolygonElevationModificationLayer"
+
+
+def test_polygon_modification_validates_control_points_inside_polygon(tmp_path):
+    terrain_hdf, _rasmap = _write_minimal_terrain(tmp_path)
+
+    with pytest.raises(ValueError, match="inside the polygon"):
+        RasTerrainModWriter.add_modification_polygon(
+            terrain_hdf,
+            name="Bad Pond",
+            polygon_coords=[
+                [0.0, 0.0, 1.0],
+                [10.0, 0.0, 1.0],
+                [10.0, 10.0, 1.0],
+                [0.0, 10.0, 1.0],
+            ],
+            elevation_method="shape_z",
+            control_points=[(30.0, 30.0, 925.0)],
+        )
 
 
 def test_add_high_ground_modification_writes_hdf_and_rasmap(tmp_path):


### PR DESCRIPTION
## Summary

- Adds `RasTerrainModWriter.add_modification_polygon()` for detention pond and wetland grading workflows
- Supports boundary elevations from terrain source rasters, polygon Z values, or explicit arrays
- Persists polygon geometry, boundary profile, and interior control points to terrain HDF
- Registers `PolygonElevationModificationLayer` in `.rasmap` XML
- Includes notebook 316 with end-to-end validation: writes terrain mod, runs HEC-RAS base/proposed plans, compares water surface elevations

## Test plan

- [x] 11 pytest functions pass (13 total including terrain create tests)
- [x] Notebook 316 executes successfully (84s) — runs HEC-RAS compute and validates WSE results
- [ ] Manual review of terrain difference map artifacts on H: drive

🤖 Generated with [Claude Code](https://claude.com/claude-code)