### PR TITLE
CLB-639: levee read/write API for GeomCrossSection

### DIFF
--- a/examples/217_levee_read_write.ipynb
+++ b/examples/217_levee_read_write.ipynb
@@ -1,0 +1,1687 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Cross-Section Levee Read/Write with GeomCrossSection\n",
+    "\n",
+    "This notebook demonstrates using `GeomCrossSection.get_levees()` and `set_levees()` to read and write cross-section levee station-elevation data in HEC-RAS geometry files.\n",
+    "\n",
+    "**Example Project:** Bald Eagle Creek (1D Unsteady Flow Hydraulics)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Overview\n",
+    "\n",
+    "HEC-RAS 1D cross sections can have left and/or right levee points defined as station-elevation pairs. These control when water overtops the levee and enters the floodplain.\n",
+    "\n",
+    "**Storage format:** Each cross section's levee data is stored on a single `Levee=` line in the `.g##` text file:\n",
+    "```\n",
+    "Levee=left_flag,left_station,left_elevation,right_flag,right_station,right_elevation,0,0\n",
+    "```\n",
+    "- Active sides use flag `-1` with station and elevation values\n",
+    "- Inactive sides use flag `0` with blank station/elevation fields\n",
+    "\n",
+    "**API methods:**\n",
+    "- `get_levees()` — Read all levee data as a DataFrame\n",
+    "- `set_levees()` — Write levee data for a single cross section (update or insert)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Setup and Imports"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-08T17:00:05.294429Z",
+     "iopub.status.busy": "2026-05-08T17:00:05.294429Z",
+     "iopub.status.idle": "2026-05-08T17:00:07.591436Z",
+     "shell.execute_reply": "2026-05-08T17:00:07.591436Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "📁 LOCAL SOURCE MODE: Loading from G:\\GH\\ras-commander/ras_commander\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-08 13:00:05 - numexpr.utils - INFO - NumExpr defaulting to 8 threads.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✓ Loaded: G:\\GH\\ras-commander\\ras_commander\\__init__.py\n"
+     ]
+    }
+   ],
+   "source": [
+    "# =============================================================================\n",
+    "# DEVELOPMENT MODE TOGGLE\n",
+    "# =============================================================================\n",
+    "USE_LOCAL_SOURCE = True  # <-- TOGGLE THIS\n",
+    "\n",
+    "from pathlib import Path\n",
+    "\n",
+    "if USE_LOCAL_SOURCE:\n",
+    "    import sys\n",
+    "    local_path = str(Path.cwd().parent)\n",
+    "    if local_path not in sys.path:\n",
+    "        sys.path.insert(0, local_path)\n",
+    "    print(f\"\\U0001f4c1 LOCAL SOURCE MODE: Loading from {local_path}/ras_commander\")\n",
+    "else:\n",
+    "    print(\"\\U0001f4e6 PIP PACKAGE MODE: Loading installed ras-commander\")\n",
+    "\n",
+    "from ras_commander import RasExamples\n",
+    "from ras_commander.geom.GeomCrossSection import GeomCrossSection\n",
+    "\n",
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "import shutil\n",
+    "\n",
+    "import ras_commander\n",
+    "print(f\"\\u2713 Loaded: {ras_commander.__file__}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Extract Example Project"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-08T17:00:07.593185Z",
+     "iopub.status.busy": "2026-05-08T17:00:07.593185Z",
+     "iopub.status.idle": "2026-05-08T17:00:07.792255Z",
+     "shell.execute_reply": "2026-05-08T17:00:07.792255Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-08 13:00:07 - ras_commander.RasExamples - INFO - Found zip file: C:\\Users\\bill\\AppData\\Local\\ras-commander\\examples\\Example_Projects_7_0.zip\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-08 13:00:07 - ras_commander.RasExamples - INFO - Loading project data from CSV...\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-08 13:00:07 - ras_commander.RasExamples - INFO - Loaded 67 projects from CSV.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-08 13:00:07 - ras_commander.RasExamples - INFO - ----- RasExamples Extracting Project -----\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-08 13:00:07 - ras_commander.RasExamples - INFO - Extracting project 'Balde Eagle Creek'\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-08 13:00:07 - ras_commander.RasExamples - INFO - Folder 'Balde Eagle Creek' already exists. Deleting existing folder...\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-08 13:00:07 - ras_commander.RasExamples - INFO - Existing folder 'Balde Eagle Creek' has been deleted.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-08 13:00:07 - ras_commander.RasExamples - INFO - Successfully extracted project 'Balde Eagle Creek' to G:\\GH\\ras-commander\\examples\\example_projects\\Balde Eagle Creek\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Project: G:\\GH\\ras-commander\\examples\\example_projects\\Balde Eagle Creek\n",
+      "Geometry file exists: True\n"
+     ]
+    }
+   ],
+   "source": [
+    "project_path = RasExamples.extract_project(\"Balde Eagle Creek\")\n",
+    "geom_file = project_path / \"BaldEagle.g01\"\n",
+    "\n",
+    "print(f\"Project: {project_path}\")\n",
+    "print(f\"Geometry file exists: {geom_file.exists()}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. Read All Levees\n",
+    "\n",
+    "`get_levees()` returns a DataFrame with columns: `xs_id`, `River`, `Reach`, `RS`, `left_station`, `left_elevation`, `right_station`, `right_elevation`. Cross sections without levees have NaN values."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-08T17:00:07.794667Z",
+     "iopub.status.busy": "2026-05-08T17:00:07.794667Z",
+     "iopub.status.idle": "2026-05-08T17:00:07.833129Z",
+     "shell.execute_reply": "2026-05-08T17:00:07.832122Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-08 13:00:07 - ras_commander.geom.GeomCrossSection - INFO - Read levee data for 189 cross sections from G:\\GH\\ras-commander\\examples\\example_projects\\Balde Eagle Creek\\BaldEagle.g01\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Total cross sections: 189\n",
+      "  With left levee:  28\n",
+      "  With right levee: 18\n",
+      "  With both sides:  5\n",
+      "  With no levees:   148\n",
+      "\n",
+      "Columns: ['xs_id', 'River', 'Reach', 'RS', 'left_station', 'left_elevation', 'right_station', 'right_elevation']\n",
+      "\n",
+      "First 15 rows:\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>xs_id</th>\n",
+       "      <th>River</th>\n",
+       "      <th>Reach</th>\n",
+       "      <th>RS</th>\n",
+       "      <th>left_station</th>\n",
+       "      <th>left_elevation</th>\n",
+       "      <th>right_station</th>\n",
+       "      <th>right_elevation</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>Bald Eagle|Loc Hav|138154.4</td>\n",
+       "      <td>Bald Eagle</td>\n",
+       "      <td>Loc Hav</td>\n",
+       "      <td>138154.4</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>Bald Eagle|Loc Hav|137690.8</td>\n",
+       "      <td>Bald Eagle</td>\n",
+       "      <td>Loc Hav</td>\n",
+       "      <td>137690.8</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>Bald Eagle|Loc Hav|137327.0</td>\n",
+       "      <td>Bald Eagle</td>\n",
+       "      <td>Loc Hav</td>\n",
+       "      <td>137327.0</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>Bald Eagle|Loc Hav|136564.9</td>\n",
+       "      <td>Bald Eagle</td>\n",
+       "      <td>Loc Hav</td>\n",
+       "      <td>136564.9</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>Bald Eagle|Loc Hav|136202.3</td>\n",
+       "      <td>Bald Eagle</td>\n",
+       "      <td>Loc Hav</td>\n",
+       "      <td>136202.3</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5</th>\n",
+       "      <td>Bald Eagle|Loc Hav|135591.4</td>\n",
+       "      <td>Bald Eagle</td>\n",
+       "      <td>Loc Hav</td>\n",
+       "      <td>135591.4</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>574.99</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>6</th>\n",
+       "      <td>Bald Eagle|Loc Hav|135068.7</td>\n",
+       "      <td>Bald Eagle</td>\n",
+       "      <td>Loc Hav</td>\n",
+       "      <td>135068.7</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>7</th>\n",
+       "      <td>Bald Eagle|Loc Hav|134487.2</td>\n",
+       "      <td>Bald Eagle</td>\n",
+       "      <td>Loc Hav</td>\n",
+       "      <td>134487.2</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>8</th>\n",
+       "      <td>Bald Eagle|Loc Hav|133881.0</td>\n",
+       "      <td>Bald Eagle</td>\n",
+       "      <td>Loc Hav</td>\n",
+       "      <td>133881.0</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>9</th>\n",
+       "      <td>Bald Eagle|Loc Hav|133446.1</td>\n",
+       "      <td>Bald Eagle</td>\n",
+       "      <td>Loc Hav</td>\n",
+       "      <td>133446.1</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>10</th>\n",
+       "      <td>Bald Eagle|Loc Hav|132973.6</td>\n",
+       "      <td>Bald Eagle</td>\n",
+       "      <td>Loc Hav</td>\n",
+       "      <td>132973.6</td>\n",
+       "      <td>80.0</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>11</th>\n",
+       "      <td>Bald Eagle|Loc Hav|132363.8</td>\n",
+       "      <td>Bald Eagle</td>\n",
+       "      <td>Loc Hav</td>\n",
+       "      <td>132363.8</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>12</th>\n",
+       "      <td>Bald Eagle|Loc Hav|131699.7</td>\n",
+       "      <td>Bald Eagle</td>\n",
+       "      <td>Loc Hav</td>\n",
+       "      <td>131699.7</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>13</th>\n",
+       "      <td>Bald Eagle|Loc Hav|130997.6</td>\n",
+       "      <td>Bald Eagle</td>\n",
+       "      <td>Loc Hav</td>\n",
+       "      <td>130997.6</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>14</th>\n",
+       "      <td>Bald Eagle|Loc Hav|130339.2</td>\n",
+       "      <td>Bald Eagle</td>\n",
+       "      <td>Loc Hav</td>\n",
+       "      <td>130339.2</td>\n",
+       "      <td>100.0</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                          xs_id       River    Reach        RS  left_station  \\\n",
+       "0   Bald Eagle|Loc Hav|138154.4  Bald Eagle  Loc Hav  138154.4           NaN   \n",
+       "1   Bald Eagle|Loc Hav|137690.8  Bald Eagle  Loc Hav  137690.8           NaN   \n",
+       "2   Bald Eagle|Loc Hav|137327.0  Bald Eagle  Loc Hav  137327.0           NaN   \n",
+       "3   Bald Eagle|Loc Hav|136564.9  Bald Eagle  Loc Hav  136564.9           NaN   \n",
+       "4   Bald Eagle|Loc Hav|136202.3  Bald Eagle  Loc Hav  136202.3           NaN   \n",
+       "5   Bald Eagle|Loc Hav|135591.4  Bald Eagle  Loc Hav  135591.4           NaN   \n",
+       "6   Bald Eagle|Loc Hav|135068.7  Bald Eagle  Loc Hav  135068.7           NaN   \n",
+       "7   Bald Eagle|Loc Hav|134487.2  Bald Eagle  Loc Hav  134487.2           NaN   \n",
+       "8   Bald Eagle|Loc Hav|133881.0  Bald Eagle  Loc Hav  133881.0           NaN   \n",
+       "9   Bald Eagle|Loc Hav|133446.1  Bald Eagle  Loc Hav  133446.1           NaN   \n",
+       "10  Bald Eagle|Loc Hav|132973.6  Bald Eagle  Loc Hav  132973.6          80.0   \n",
+       "11  Bald Eagle|Loc Hav|132363.8  Bald Eagle  Loc Hav  132363.8           NaN   \n",
+       "12  Bald Eagle|Loc Hav|131699.7  Bald Eagle  Loc Hav  131699.7           NaN   \n",
+       "13  Bald Eagle|Loc Hav|130997.6  Bald Eagle  Loc Hav  130997.6           NaN   \n",
+       "14  Bald Eagle|Loc Hav|130339.2  Bald Eagle  Loc Hav  130339.2         100.0   \n",
+       "\n",
+       "    left_elevation  right_station  right_elevation  \n",
+       "0              NaN            NaN              NaN  \n",
+       "1              NaN            NaN              NaN  \n",
+       "2              NaN            NaN              NaN  \n",
+       "3              NaN            NaN              NaN  \n",
+       "4              NaN            NaN              NaN  \n",
+       "5              NaN         574.99              NaN  \n",
+       "6              NaN            NaN              NaN  \n",
+       "7              NaN            NaN              NaN  \n",
+       "8              NaN            NaN              NaN  \n",
+       "9              NaN            NaN              NaN  \n",
+       "10             NaN            NaN              NaN  \n",
+       "11             NaN            NaN              NaN  \n",
+       "12             NaN            NaN              NaN  \n",
+       "13             NaN            NaN              NaN  \n",
+       "14             NaN            NaN              NaN  "
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "all_levees = GeomCrossSection.get_levees(geom_file)\n",
+    "\n",
+    "total_xs = len(all_levees)\n",
+    "has_left = all_levees[\"left_station\"].notna().sum()\n",
+    "has_right = all_levees[\"right_station\"].notna().sum()\n",
+    "has_both = (all_levees[\"left_station\"].notna() & all_levees[\"right_station\"].notna()).sum()\n",
+    "has_none = (all_levees[\"left_station\"].isna() & all_levees[\"right_station\"].isna()).sum()\n",
+    "\n",
+    "print(f\"Total cross sections: {total_xs}\")\n",
+    "print(f\"  With left levee:  {has_left}\")\n",
+    "print(f\"  With right levee: {has_right}\")\n",
+    "print(f\"  With both sides:  {has_both}\")\n",
+    "print(f\"  With no levees:   {has_none}\")\n",
+    "print(f\"\\nColumns: {list(all_levees.columns)}\")\n",
+    "print(f\"\\nFirst 15 rows:\")\n",
+    "all_levees.head(15)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. Filter by River/Reach/RS\n",
+    "\n",
+    "Use optional `river`, `reach`, and `rs` parameters to narrow the query."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-08T17:00:07.835130Z",
+     "iopub.status.busy": "2026-05-08T17:00:07.835130Z",
+     "iopub.status.idle": "2026-05-08T17:00:07.852630Z",
+     "shell.execute_reply": "2026-05-08T17:00:07.852630Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "River: Bald Eagle, Reach: Loc Hav\n",
+      "\n",
+      "Active levee cross sections (41 of 189):\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>xs_id</th>\n",
+       "      <th>left_station</th>\n",
+       "      <th>left_elevation</th>\n",
+       "      <th>right_station</th>\n",
+       "      <th>right_elevation</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>5</th>\n",
+       "      <td>Bald Eagle|Loc Hav|135591.4</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>574.99</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>10</th>\n",
+       "      <td>Bald Eagle|Loc Hav|132973.6</td>\n",
+       "      <td>80.0</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>14</th>\n",
+       "      <td>Bald Eagle|Loc Hav|130339.2</td>\n",
+       "      <td>100.0</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>18</th>\n",
+       "      <td>Bald Eagle|Loc Hav|127410.9</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>2349.99</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>19</th>\n",
+       "      <td>Bald Eagle|Loc Hav|126741.0</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>1935.00</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>52</th>\n",
+       "      <td>Bald Eagle|Loc Hav|104647.2</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>3488.00</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>53</th>\n",
+       "      <td>Bald Eagle|Loc Hav|104195.0</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>3068.00</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>54</th>\n",
+       "      <td>Bald Eagle|Loc Hav|103854.0</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>3285.00</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>55</th>\n",
+       "      <td>Bald Eagle|Loc Hav|103369.7</td>\n",
+       "      <td>205.0</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>3615.00</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>57</th>\n",
+       "      <td>Bald Eagle|Loc Hav|103122.3</td>\n",
+       "      <td>135.0</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>3630.00</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>58</th>\n",
+       "      <td>Bald Eagle|Loc Hav|101440.3</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>3795.00</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>59</th>\n",
+       "      <td>Bald Eagle|Loc Hav|100657.3</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>3800.00</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>60</th>\n",
+       "      <td>Bald Eagle|Loc Hav|99452.75</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>3945.00</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>61</th>\n",
+       "      <td>Bald Eagle|Loc Hav|98206.87</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>3850.00</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>62</th>\n",
+       "      <td>Bald Eagle|Loc Hav|97607.35</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>2865.00</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>78</th>\n",
+       "      <td>Bald Eagle|Loc Hav|81084.18</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>2025.00</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>79</th>\n",
+       "      <td>Bald Eagle|Loc Hav|80500.50</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>1595.00</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>153</th>\n",
+       "      <td>Bald Eagle|Loc Hav|22982.97</td>\n",
+       "      <td>10.0</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>154</th>\n",
+       "      <td>Bald Eagle|Loc Hav|22386.15</td>\n",
+       "      <td>185.0</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>155</th>\n",
+       "      <td>Bald Eagle|Loc Hav|21283.34</td>\n",
+       "      <td>310.0</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>157</th>\n",
+       "      <td>Bald Eagle|Loc Hav|21199.93</td>\n",
+       "      <td>295.0</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>158</th>\n",
+       "      <td>Bald Eagle|Loc Hav|20127.30</td>\n",
+       "      <td>670.0</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>159</th>\n",
+       "      <td>Bald Eagle|Loc Hav|19036.24</td>\n",
+       "      <td>895.0</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>160</th>\n",
+       "      <td>Bald Eagle|Loc Hav|18200.10</td>\n",
+       "      <td>395.0</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>161</th>\n",
+       "      <td>Bald Eagle|Loc Hav|17549.23</td>\n",
+       "      <td>225.0</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>162</th>\n",
+       "      <td>Bald Eagle|Loc Hav|16787.45</td>\n",
+       "      <td>185.0</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>163</th>\n",
+       "      <td>Bald Eagle|Loc Hav|15407.88</td>\n",
+       "      <td>430.0</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>820.00</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>165</th>\n",
+       "      <td>Bald Eagle|Loc Hav|14814.34</td>\n",
+       "      <td>340.0</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>720.00</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>166</th>\n",
+       "      <td>Bald Eagle|Loc Hav|13326.74</td>\n",
+       "      <td>210.0</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>167</th>\n",
+       "      <td>Bald Eagle|Loc Hav|12035.22</td>\n",
+       "      <td>965.0</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>169</th>\n",
+       "      <td>Bald Eagle|Loc Hav|11865.80</td>\n",
+       "      <td>225.0</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>170</th>\n",
+       "      <td>Bald Eagle|Loc Hav|11116.44</td>\n",
+       "      <td>465.0</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>171</th>\n",
+       "      <td>Bald Eagle|Loc Hav|10995.73</td>\n",
+       "      <td>440.0</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>172</th>\n",
+       "      <td>Bald Eagle|Loc Hav|10221.14</td>\n",
+       "      <td>85.0</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>173</th>\n",
+       "      <td>Bald Eagle|Loc Hav|9258.941</td>\n",
+       "      <td>135.0</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>174</th>\n",
+       "      <td>Bald Eagle|Loc Hav|8541.462</td>\n",
+       "      <td>110.0</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>175</th>\n",
+       "      <td>Bald Eagle|Loc Hav|7936.130</td>\n",
+       "      <td>145.0</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>1240.02</td>\n",
+       "      <td>544.39</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>176</th>\n",
+       "      <td>Bald Eagle|Loc Hav|6940.066</td>\n",
+       "      <td>165.0</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>177</th>\n",
+       "      <td>Bald Eagle|Loc Hav|6267.489</td>\n",
+       "      <td>200.0</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>178</th>\n",
+       "      <td>Bald Eagle|Loc Hav|5523.234</td>\n",
+       "      <td>210.0</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>179</th>\n",
+       "      <td>Bald Eagle|Loc Hav|4293.710</td>\n",
+       "      <td>5.0</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                           xs_id  left_station  left_elevation  right_station  \\\n",
+       "5    Bald Eagle|Loc Hav|135591.4           NaN             NaN         574.99   \n",
+       "10   Bald Eagle|Loc Hav|132973.6          80.0             NaN            NaN   \n",
+       "14   Bald Eagle|Loc Hav|130339.2         100.0             NaN            NaN   \n",
+       "18   Bald Eagle|Loc Hav|127410.9           NaN             NaN        2349.99   \n",
+       "19   Bald Eagle|Loc Hav|126741.0           NaN             NaN        1935.00   \n",
+       "52   Bald Eagle|Loc Hav|104647.2           NaN             NaN        3488.00   \n",
+       "53   Bald Eagle|Loc Hav|104195.0           NaN             NaN        3068.00   \n",
+       "54   Bald Eagle|Loc Hav|103854.0           NaN             NaN        3285.00   \n",
+       "55   Bald Eagle|Loc Hav|103369.7         205.0             NaN        3615.00   \n",
+       "57   Bald Eagle|Loc Hav|103122.3         135.0             NaN        3630.00   \n",
+       "58   Bald Eagle|Loc Hav|101440.3           NaN             NaN        3795.00   \n",
+       "59   Bald Eagle|Loc Hav|100657.3           NaN             NaN        3800.00   \n",
+       "60   Bald Eagle|Loc Hav|99452.75           NaN             NaN        3945.00   \n",
+       "61   Bald Eagle|Loc Hav|98206.87           NaN             NaN        3850.00   \n",
+       "62   Bald Eagle|Loc Hav|97607.35           NaN             NaN        2865.00   \n",
+       "78   Bald Eagle|Loc Hav|81084.18           NaN             NaN        2025.00   \n",
+       "79   Bald Eagle|Loc Hav|80500.50           NaN             NaN        1595.00   \n",
+       "153  Bald Eagle|Loc Hav|22982.97          10.0             NaN            NaN   \n",
+       "154  Bald Eagle|Loc Hav|22386.15         185.0             NaN            NaN   \n",
+       "155  Bald Eagle|Loc Hav|21283.34         310.0             NaN            NaN   \n",
+       "157  Bald Eagle|Loc Hav|21199.93         295.0             NaN            NaN   \n",
+       "158  Bald Eagle|Loc Hav|20127.30         670.0             NaN            NaN   \n",
+       "159  Bald Eagle|Loc Hav|19036.24         895.0             NaN            NaN   \n",
+       "160  Bald Eagle|Loc Hav|18200.10         395.0             NaN            NaN   \n",
+       "161  Bald Eagle|Loc Hav|17549.23         225.0             NaN            NaN   \n",
+       "162  Bald Eagle|Loc Hav|16787.45         185.0             NaN            NaN   \n",
+       "163  Bald Eagle|Loc Hav|15407.88         430.0             NaN         820.00   \n",
+       "165  Bald Eagle|Loc Hav|14814.34         340.0             NaN         720.00   \n",
+       "166  Bald Eagle|Loc Hav|13326.74         210.0             NaN            NaN   \n",
+       "167  Bald Eagle|Loc Hav|12035.22         965.0             NaN            NaN   \n",
+       "169  Bald Eagle|Loc Hav|11865.80         225.0             NaN            NaN   \n",
+       "170  Bald Eagle|Loc Hav|11116.44         465.0             NaN            NaN   \n",
+       "171  Bald Eagle|Loc Hav|10995.73         440.0             NaN            NaN   \n",
+       "172  Bald Eagle|Loc Hav|10221.14          85.0             NaN            NaN   \n",
+       "173  Bald Eagle|Loc Hav|9258.941         135.0             NaN            NaN   \n",
+       "174  Bald Eagle|Loc Hav|8541.462         110.0             NaN            NaN   \n",
+       "175  Bald Eagle|Loc Hav|7936.130         145.0             NaN        1240.02   \n",
+       "176  Bald Eagle|Loc Hav|6940.066         165.0             NaN            NaN   \n",
+       "177  Bald Eagle|Loc Hav|6267.489         200.0             NaN            NaN   \n",
+       "178  Bald Eagle|Loc Hav|5523.234         210.0             NaN            NaN   \n",
+       "179  Bald Eagle|Loc Hav|4293.710           5.0             NaN            NaN   \n",
+       "\n",
+       "     right_elevation  \n",
+       "5                NaN  \n",
+       "10               NaN  \n",
+       "14               NaN  \n",
+       "18               NaN  \n",
+       "19               NaN  \n",
+       "52               NaN  \n",
+       "53               NaN  \n",
+       "54               NaN  \n",
+       "55               NaN  \n",
+       "57               NaN  \n",
+       "58               NaN  \n",
+       "59               NaN  \n",
+       "60               NaN  \n",
+       "61               NaN  \n",
+       "62               NaN  \n",
+       "78               NaN  \n",
+       "79               NaN  \n",
+       "153              NaN  \n",
+       "154              NaN  \n",
+       "155              NaN  \n",
+       "157              NaN  \n",
+       "158              NaN  \n",
+       "159              NaN  \n",
+       "160              NaN  \n",
+       "161              NaN  \n",
+       "162              NaN  \n",
+       "163              NaN  \n",
+       "165              NaN  \n",
+       "166              NaN  \n",
+       "167              NaN  \n",
+       "169              NaN  \n",
+       "170              NaN  \n",
+       "171              NaN  \n",
+       "172              NaN  \n",
+       "173              NaN  \n",
+       "174              NaN  \n",
+       "175           544.39  \n",
+       "176              NaN  \n",
+       "177              NaN  \n",
+       "178              NaN  \n",
+       "179              NaN  "
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "river_name = all_levees[\"River\"].iloc[0]\n",
+    "reach_name = all_levees[\"Reach\"].iloc[0]\n",
+    "\n",
+    "print(f\"River: {river_name}, Reach: {reach_name}\")\n",
+    "\n",
+    "# Filter to just cross sections with active levees\n",
+    "active_levees = all_levees[\n",
+    "    all_levees[\"left_station\"].notna() | all_levees[\"right_station\"].notna()\n",
+    "].copy()\n",
+    "\n",
+    "print(f\"\\nActive levee cross sections ({len(active_levees)} of {total_xs}):\")\n",
+    "active_levees[[\"xs_id\", \"left_station\", \"left_elevation\", \"right_station\", \"right_elevation\"]]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-08T17:00:07.854824Z",
+     "iopub.status.busy": "2026-05-08T17:00:07.854824Z",
+     "iopub.status.idle": "2026-05-08T17:00:07.871386Z",
+     "shell.execute_reply": "2026-05-08T17:00:07.871386Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-08 13:00:07 - ras_commander.geom.GeomCrossSection - INFO - Read levee data for 1 cross sections from G:\\GH\\ras-commander\\examples\\example_projects\\Balde Eagle Creek\\BaldEagle.g01\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Single cross section: Bald Eagle|Loc Hav|135591.4\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>xs_id</th>\n",
+       "      <th>River</th>\n",
+       "      <th>Reach</th>\n",
+       "      <th>RS</th>\n",
+       "      <th>left_station</th>\n",
+       "      <th>left_elevation</th>\n",
+       "      <th>right_station</th>\n",
+       "      <th>right_elevation</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>Bald Eagle|Loc Hav|135591.4</td>\n",
+       "      <td>Bald Eagle</td>\n",
+       "      <td>Loc Hav</td>\n",
+       "      <td>135591.4</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>574.99</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                         xs_id       River    Reach        RS  left_station  \\\n",
+       "0  Bald Eagle|Loc Hav|135591.4  Bald Eagle  Loc Hav  135591.4           NaN   \n",
+       "\n",
+       "   left_elevation  right_station  right_elevation  \n",
+       "0             NaN         574.99              NaN  "
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Read a single cross section by xs_id\n",
+    "target_xs = active_levees[\"xs_id\"].iloc[0]\n",
+    "single = GeomCrossSection.get_levees(geom_file, xs_id=target_xs)\n",
+    "\n",
+    "print(f\"Single cross section: {target_xs}\")\n",
+    "single"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 5. Update Existing Levees (Round-Trip)\n",
+    "\n",
+    "`set_levees()` updates the `Levee=` line for a specific cross section. We demonstrate a read-modify-write round trip: raise the left levee elevation by 2 feet, write it back, and verify."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-08T17:00:07.874396Z",
+     "iopub.status.busy": "2026-05-08T17:00:07.874396Z",
+     "iopub.status.idle": "2026-05-08T17:00:08.053584Z",
+     "shell.execute_reply": "2026-05-08T17:00:08.053584Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Working copy: BaldEagle_levee_test.g01\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-08 13:00:08 - ras_commander.geom.GeomCrossSection - INFO - Read levee data for 1 cross sections from G:\\GH\\ras-commander\\examples\\example_projects\\Balde Eagle Creek\\BaldEagle_levee_test.g01\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Original levees for Bald Eagle|Loc Hav|103369.7:\n",
+      "  Left:  station=205.0\n",
+      "  Right: station=3615.0\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-08 13:00:08 - ras_commander.geom.GeomParser - INFO - Created backup: G:\\GH\\ras-commander\\examples\\example_projects\\Balde Eagle Creek\\BaldEagle_levee_test.g01.bak\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-08 13:00:08 - ras_commander.geom.GeomParser - INFO - Successfully wrote geometry file: G:\\GH\\ras-commander\\examples\\example_projects\\Balde Eagle Creek\\BaldEagle_levee_test.g01\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-08 13:00:08 - ras_commander.geom.GeomCrossSection - INFO - Updated levees for Bald Eagle/Loc Hav/RS 103369.7\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-08 13:00:08 - ras_commander.geom.GeomCrossSection - INFO - Read levee data for 1 cross sections from G:\\GH\\ras-commander\\examples\\example_projects\\Balde Eagle Creek\\BaldEagle_levee_test.g01\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Backup: BaldEagle_levee_test.g01.bak\n",
+      "\n",
+      "Updated levees:\n",
+      "  Left:  station=215.0\n",
+      "  Right: station=3615.0\n",
+      "\n",
+      "✓ Round trip verified\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Create a working copy\n",
+    "work_copy = project_path / \"BaldEagle_levee_test.g01\"\n",
+    "shutil.copy(geom_file, work_copy)\n",
+    "print(f\"Working copy: {work_copy.name}\")\n",
+    "\n",
+    "# Pick a cross section with both-side levees\n",
+    "both_sides = active_levees[\n",
+    "    active_levees[\"left_station\"].notna() & active_levees[\"right_station\"].notna()\n",
+    "]\n",
+    "target_xs = both_sides[\"xs_id\"].iloc[0]\n",
+    "original = GeomCrossSection.get_levees(work_copy, xs_id=target_xs)\n",
+    "\n",
+    "print(f\"\\nOriginal levees for {target_xs}:\")\n",
+    "print(f\"  Left:  station={original['left_station'].iloc[0]}\")\n",
+    "print(f\"  Right: station={original['right_station'].iloc[0]}\")\n",
+    "\n",
+    "# Move the left levee station outward by 10 units\n",
+    "new_left_sta = original[\"left_station\"].iloc[0] + 10.0\n",
+    "\n",
+    "backup = GeomCrossSection.set_levees(\n",
+    "    work_copy,\n",
+    "    xs_id=target_xs,\n",
+    "    left_station=new_left_sta,\n",
+    "    right_station=original[\"right_station\"].iloc[0],\n",
+    ")\n",
+    "print(f\"\\nBackup: {backup.name}\")\n",
+    "\n",
+    "# Verify round trip\n",
+    "updated = GeomCrossSection.get_levees(work_copy, xs_id=target_xs)\n",
+    "print(f\"\\nUpdated levees:\")\n",
+    "print(f\"  Left:  station={updated['left_station'].iloc[0]}\")\n",
+    "print(f\"  Right: station={updated['right_station'].iloc[0]}\")\n",
+    "\n",
+    "assert np.isclose(updated[\"left_station\"].iloc[0], new_left_sta), \"Left station mismatch!\"\n",
+    "assert np.isclose(updated[\"right_station\"].iloc[0], original[\"right_station\"].iloc[0]), \"Right station changed!\"\n",
+    "print(f\"\\n✓ Round trip verified\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 6. Insert Levees into a Cross Section Without Them\n",
+    "\n",
+    "When a cross section has no `Levee=` line, `set_levees()` inserts one after the Manning's n data block."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-08T17:00:08.056590Z",
+     "iopub.status.busy": "2026-05-08T17:00:08.056590Z",
+     "iopub.status.idle": "2026-05-08T17:00:08.102272Z",
+     "shell.execute_reply": "2026-05-08T17:00:08.102272Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-08 13:00:08 - ras_commander.geom.GeomCrossSection - INFO - Read levee data for 189 cross sections from G:\\GH\\ras-commander\\examples\\example_projects\\Balde Eagle Creek\\BaldEagle_levee_test.g01\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-08 13:00:08 - ras_commander.geom.GeomParser - INFO - Successfully wrote geometry file: G:\\GH\\ras-commander\\examples\\example_projects\\Balde Eagle Creek\\BaldEagle_levee_test.g01\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-08 13:00:08 - ras_commander.geom.GeomCrossSection - INFO - Updated levees for Bald Eagle/Loc Hav/RS 138154.4\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-08 13:00:08 - ras_commander.geom.GeomCrossSection - INFO - Read levee data for 1 cross sections from G:\\GH\\ras-commander\\examples\\example_projects\\Balde Eagle Creek\\BaldEagle_levee_test.g01\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Cross section with no levees: Bald Eagle|Loc Hav|138154.4\n",
+      "\n",
+      "After insertion:\n",
+      "  Left:  station=nan (inactive)\n",
+      "  Right: station=500.0, elevation=650.0\n",
+      "✓ Right-only levee inserted successfully\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Find a cross section with no levees\n",
+    "all_work = GeomCrossSection.get_levees(work_copy)\n",
+    "no_levees = all_work[\n",
+    "    all_work[\"left_station\"].isna() & all_work[\"right_station\"].isna()\n",
+    "]\n",
+    "\n",
+    "insert_target = no_levees[\"xs_id\"].iloc[0]\n",
+    "print(f\"Cross section with no levees: {insert_target}\")\n",
+    "\n",
+    "# Insert a right-side-only levee (station + elevation)\n",
+    "GeomCrossSection.set_levees(\n",
+    "    work_copy,\n",
+    "    xs_id=insert_target,\n",
+    "    right_station=500.0,\n",
+    "    right_elevation=650.0,\n",
+    "    create_backup=False,\n",
+    ")\n",
+    "\n",
+    "# Verify insertion\n",
+    "inserted = GeomCrossSection.get_levees(work_copy, xs_id=insert_target)\n",
+    "print(f\"\\nAfter insertion:\")\n",
+    "print(f\"  Left:  station={inserted['left_station'].iloc[0]} (inactive)\")\n",
+    "print(f\"  Right: station={inserted['right_station'].iloc[0]}, elevation={inserted['right_elevation'].iloc[0]}\")\n",
+    "\n",
+    "assert np.isnan(inserted[\"left_station\"].iloc[0]), \"Left should be inactive\"\n",
+    "assert np.isclose(inserted[\"right_station\"].iloc[0], 500.0), \"Right station mismatch\"\n",
+    "assert np.isclose(inserted[\"right_elevation\"].iloc[0], 650.0), \"Right elevation mismatch\"\n",
+    "print(f\"✓ Right-only levee inserted successfully\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 7. Remove a Levee Side\n",
+    "\n",
+    "Omit station/elevation for a side to deactivate it. Here we take a cross section with both sides and deactivate the left."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-08T17:00:08.104278Z",
+     "iopub.status.busy": "2026-05-08T17:00:08.104278Z",
+     "iopub.status.idle": "2026-05-08T17:00:08.245378Z",
+     "shell.execute_reply": "2026-05-08T17:00:08.245378Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-08 13:00:08 - ras_commander.geom.GeomCrossSection - INFO - Read levee data for 189 cross sections from G:\\GH\\ras-commander\\examples\\example_projects\\Balde Eagle Creek\\BaldEagle_levee_test.g01\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-08 13:00:08 - ras_commander.geom.GeomCrossSection - INFO - Read levee data for 1 cross sections from G:\\GH\\ras-commander\\examples\\example_projects\\Balde Eagle Creek\\BaldEagle_levee_test.g01\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Before (both sides active):\n",
+      "  Left:  station=215.0\n",
+      "  Right: station=3615.0\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-08 13:00:08 - ras_commander.geom.GeomParser - INFO - Successfully wrote geometry file: G:\\GH\\ras-commander\\examples\\example_projects\\Balde Eagle Creek\\BaldEagle_levee_test.g01\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-08 13:00:08 - ras_commander.geom.GeomCrossSection - INFO - Updated levees for Bald Eagle/Loc Hav/RS 103369.7\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-08 13:00:08 - ras_commander.geom.GeomCrossSection - INFO - Read levee data for 1 cross sections from G:\\GH\\ras-commander\\examples\\example_projects\\Balde Eagle Creek\\BaldEagle_levee_test.g01\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "After (left deactivated):\n",
+      "  Left:  station=nan\n",
+      "  Right: station=3615.0\n",
+      "✓ Left levee deactivated, right preserved\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Pick a cross section that currently has both sides\n",
+    "current = GeomCrossSection.get_levees(work_copy)\n",
+    "both_now = current[\n",
+    "    current[\"left_station\"].notna() & current[\"right_station\"].notna()\n",
+    "]\n",
+    "deactivate_target = both_now[\"xs_id\"].iloc[0]\n",
+    "\n",
+    "before = GeomCrossSection.get_levees(work_copy, xs_id=deactivate_target)\n",
+    "print(f\"Before (both sides active):\")\n",
+    "print(f\"  Left:  station={before['left_station'].iloc[0]}\")\n",
+    "print(f\"  Right: station={before['right_station'].iloc[0]}\")\n",
+    "\n",
+    "# Keep only the right side\n",
+    "GeomCrossSection.set_levees(\n",
+    "    work_copy,\n",
+    "    xs_id=deactivate_target,\n",
+    "    right_station=before[\"right_station\"].iloc[0],\n",
+    "    create_backup=False,\n",
+    ")\n",
+    "\n",
+    "after = GeomCrossSection.get_levees(work_copy, xs_id=deactivate_target)\n",
+    "print(f\"\\nAfter (left deactivated):\")\n",
+    "print(f\"  Left:  station={after['left_station'].iloc[0]}\")\n",
+    "print(f\"  Right: station={after['right_station'].iloc[0]}\")\n",
+    "\n",
+    "assert np.isnan(after[\"left_station\"].iloc[0]), \"Left should now be inactive\"\n",
+    "assert np.isclose(after[\"right_station\"].iloc[0], before[\"right_station\"].iloc[0]), \"Right station changed\"\n",
+    "print(f\"✓ Left levee deactivated, right preserved\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 8. Identify by River/Reach/RS Instead of xs_id\n",
+    "\n",
+    "Both `get_levees()` and `set_levees()` accept `river`, `reach`, and `rs` parameters as an alternative to `xs_id`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-08T17:00:08.247635Z",
+     "iopub.status.busy": "2026-05-08T17:00:08.247635Z",
+     "iopub.status.idle": "2026-05-08T17:00:08.268825Z",
+     "shell.execute_reply": "2026-05-08T17:00:08.267819Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Querying by river=Bald Eagle, reach=Loc Hav, rs=132973.6\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-08 13:00:08 - ras_commander.geom.GeomCrossSection - INFO - Read levee data for 1 cross sections from G:\\GH\\ras-commander\\examples\\example_projects\\Balde Eagle Creek\\BaldEagle.g01\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Result:\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>xs_id</th>\n",
+       "      <th>River</th>\n",
+       "      <th>Reach</th>\n",
+       "      <th>RS</th>\n",
+       "      <th>left_station</th>\n",
+       "      <th>left_elevation</th>\n",
+       "      <th>right_station</th>\n",
+       "      <th>right_elevation</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>Bald Eagle|Loc Hav|132973.6</td>\n",
+       "      <td>Bald Eagle</td>\n",
+       "      <td>Loc Hav</td>\n",
+       "      <td>132973.6</td>\n",
+       "      <td>80.0</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                         xs_id       River    Reach        RS  left_station  \\\n",
+       "0  Bald Eagle|Loc Hav|132973.6  Bald Eagle  Loc Hav  132973.6          80.0   \n",
+       "\n",
+       "   left_elevation  right_station  right_elevation  \n",
+       "0             NaN            NaN              NaN  "
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Pick a cross section and use river/reach/rs addressing\n",
+    "sample = active_levees.iloc[1]\n",
+    "river_val = sample[\"River\"]\n",
+    "reach_val = sample[\"Reach\"]\n",
+    "rs_val = sample[\"RS\"]\n",
+    "\n",
+    "print(f\"Querying by river={river_val}, reach={reach_val}, rs={rs_val}\")\n",
+    "\n",
+    "by_rrs = GeomCrossSection.get_levees(\n",
+    "    geom_file,\n",
+    "    river=river_val,\n",
+    "    reach=reach_val,\n",
+    "    rs=rs_val,\n",
+    ")\n",
+    "print(f\"\\nResult:\")\n",
+    "by_rrs"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 9. Batch Analysis: Levee Elevation Summary\n",
+    "\n",
+    "Use the DataFrame output for bulk analysis across the entire geometry."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-08T17:00:08.270826Z",
+     "iopub.status.busy": "2026-05-08T17:00:08.269826Z",
+     "iopub.status.idle": "2026-05-08T17:00:08.278191Z",
+     "shell.execute_reply": "2026-05-08T17:00:08.278191Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Levee elevation statistics (active cross sections only):\n",
+      "\n",
+      "Left levees (28 active):\n",
+      "\n",
+      "Right levees (18 active):\n",
+      "  Min elevation: 544.39\n",
+      "  Max elevation: 544.39\n",
+      "  Mean elevation: 544.39\n",
+      "  Station range: 574.99 to 3945.00\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Compute summary statistics for active levees\n",
+    "active = all_levees[\n",
+    "    all_levees[\"left_station\"].notna() | all_levees[\"right_station\"].notna()\n",
+    "].copy()\n",
+    "\n",
+    "print(f\"Levee elevation statistics (active cross sections only):\")\n",
+    "print(f\"\\nLeft levees ({active['left_station'].notna().sum()} active):\")\n",
+    "if active[\"left_elevation\"].notna().any():\n",
+    "    print(f\"  Min elevation: {active['left_elevation'].min():.2f}\")\n",
+    "    print(f\"  Max elevation: {active['left_elevation'].max():.2f}\")\n",
+    "    print(f\"  Mean elevation: {active['left_elevation'].mean():.2f}\")\n",
+    "    print(f\"  Station range: {active['left_station'].min():.2f} to {active['left_station'].max():.2f}\")\n",
+    "\n",
+    "print(f\"\\nRight levees ({active['right_station'].notna().sum()} active):\")\n",
+    "if active[\"right_elevation\"].notna().any():\n",
+    "    print(f\"  Min elevation: {active['right_elevation'].min():.2f}\")\n",
+    "    print(f\"  Max elevation: {active['right_elevation'].max():.2f}\")\n",
+    "    print(f\"  Mean elevation: {active['right_elevation'].mean():.2f}\")\n",
+    "    print(f\"  Station range: {active['right_station'].min():.2f} to {active['right_station'].max():.2f}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 10. Cleanup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-08T17:00:08.280198Z",
+     "iopub.status.busy": "2026-05-08T17:00:08.280198Z",
+     "iopub.status.idle": "2026-05-08T17:00:08.286039Z",
+     "shell.execute_reply": "2026-05-08T17:00:08.285034Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Removed: BaldEagle_levee_test.g01\n",
+      "Removed backup: BaldEagle_levee_test.g01.bak\n",
+      "Cleanup complete!\n"
+     ]
+    }
+   ],
+   "source": [
+    "cleanup = True\n",
+    "\n",
+    "if cleanup:\n",
+    "    if work_copy.exists():\n",
+    "        work_copy.unlink()\n",
+    "        print(f\"Removed: {work_copy.name}\")\n",
+    "    for bak in project_path.glob(\"BaldEagle_levee_test.g01.bak*\"):\n",
+    "        bak.unlink()\n",
+    "        print(f\"Removed backup: {bak.name}\")\n",
+    "    print(\"Cleanup complete!\")\n",
+    "else:\n",
+    "    print(\"Cleanup skipped.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Summary\n",
+    "\n",
+    "This notebook demonstrated:\n",
+    "\n",
+    "- **`get_levees()`** — Read levee data as a DataFrame with `xs_id`, `River`, `Reach`, `RS`, and station/elevation columns\n",
+    "- **`set_levees()`** — Update, insert, or deactivate levee sides for individual cross sections\n",
+    "- **Filtering** — Query by `xs_id` or `river`/`reach`/`rs` parameters\n",
+    "- **Round-trip verification** — Read-modify-write with assertion checks\n",
+    "- **Batch analysis** — Use DataFrame output for bulk statistics across geometry files\n",
+    "\n",
+    "### Example Project\n",
+    "\n",
+    "Bald Eagle Creek (1D Unsteady Flow Hydraulics) — 41 cross sections with active levees, including left-only, right-only, and both-side configurations."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/ras_commander/geom/GeomCrossSection.py
+++ b/ras_commander/geom/GeomCrossSection.py
@@ -20,6 +20,8 @@ List of Functions:
 - interpolate_station_elevation() - Interpolate between two station/elevation profiles
 - interpolate_cross_section() - Read two cross sections and interpolate a reviewable profile
 - get_mannings_n() - Read Manning's roughness values with LOB/Channel/ROB classification
+- get_levees() - Read left/right levee station-elevation points
+- set_levees() - Write left/right levee station-elevation points
 - get_ineffective_flow() - Read ineffective flow area triplets (left_sta, right_sta, elevation)
 - set_ineffective_flow() - Write corrected ineffective flow area data
 - set_mannings_n() - Write Manning's n breakpoints (station, n_value triplets)
@@ -665,6 +667,103 @@ class GeomCrossSection:
             f"Exp/Cntr={GeomCrossSection._format_numeric(expansion)},"
             f"{GeomCrossSection._format_numeric(contraction)}\n"
         )
+
+
+    @staticmethod
+    def _is_missing_number(value) -> bool:
+        """Return True for scalar missing numeric inputs."""
+        if value is None:
+            return True
+        try:
+            return bool(pd.isna(value))
+        except TypeError:
+            return False
+
+    @staticmethod
+    def _parse_levee_line(line: str) -> Tuple[float, float, float, float]:
+        """
+        Parse a HEC-RAS cross-section Levee= line.
+
+        The observed XS format is:
+        ``Levee=<left_flag>,<left_sta>,<left_elev>,<right_flag>,<right_sta>,<right_elev>,,``.
+        A flag of ``-1`` means active; ``0`` or blank means the side is absent.
+        """
+        value_str = GeomParser.extract_keyword_value(line, "Levee")
+        values = [v.strip() for v in value_str.split(',')]
+        values.extend([''] * (8 - len(values)))
+
+        def parse_side(flag_idx: int, sta_idx: int, elev_idx: int) -> Tuple[float, float]:
+            flag = values[flag_idx]
+            if not flag or flag == '0':
+                return (math.nan, math.nan)
+
+            station = values[sta_idx]
+            elevation = values[elev_idx]
+            if not station:
+                return (math.nan, math.nan)
+
+            return (float(station), float(elevation) if elevation else math.nan)
+
+        left_station, left_elevation = parse_side(0, 1, 2)
+        right_station, right_elevation = parse_side(3, 4, 5)
+        return left_station, left_elevation, right_station, right_elevation
+
+    @staticmethod
+    def _levee_line(left_station: Optional[float] = None,
+                    left_elevation: Optional[float] = None,
+                    right_station: Optional[float] = None,
+                    right_elevation: Optional[float] = None,
+                    existing_line: Optional[str] = None) -> str:
+        """Build a Levee= line, preserving existing numeric precision when possible."""
+        existing_vals = []
+        if existing_line:
+            existing = GeomParser.extract_keyword_value(existing_line, "Levee")
+            existing_vals = [v.strip() for v in existing.split(',')]
+        existing_vals.extend([''] * (8 - len(existing_vals)))
+
+        def format_value(value: float, original: str) -> str:
+            min_decimals = GeomCrossSection._decimal_places_for_value(float(value))
+            if original:
+                return GeomCrossSection._format_numeric_like(
+                    value,
+                    original,
+                    min_decimals=min_decimals
+                )
+            return GeomCrossSection._format_numeric(value)
+
+        def side_tokens(station, elevation, sta_idx: int, elev_idx: int) -> List[str]:
+            station_missing = GeomCrossSection._is_missing_number(station)
+            elevation_missing = GeomCrossSection._is_missing_number(elevation)
+            if station_missing and elevation_missing:
+                return ['0', '', '']
+            if station_missing:
+                raise ValueError("Levee elevation requires a station")
+            sta_str = format_value(float(station), existing_vals[sta_idx])
+            elev_str = format_value(float(elevation), existing_vals[elev_idx]) if not elevation_missing else ''
+            return ['-1', sta_str, elev_str]
+
+        values = (
+            side_tokens(left_station, left_elevation, 1, 2)
+            + side_tokens(right_station, right_elevation, 4, 5)
+            + ['', '']
+        )
+        return f"Levee={','.join(values)}\n"
+
+    @staticmethod
+    def _find_mann_block_end(lines: List[str], xs_idx: int) -> Optional[int]:
+        """Return the insertion index immediately after the #Mann= data block."""
+        section_end = GeomCrossSection._find_xs_section_end(lines, xs_idx)
+
+        for idx in range(xs_idx, section_end):
+            if lines[idx].startswith("#Mann="):
+                value_str = GeomParser.extract_keyword_value(lines[idx], "#Mann")
+                parts = [p.strip() for p in value_str.split(',')]
+                count = int(parts[0]) if parts and parts[0] else 0
+                total_values = count * 3
+                data_lines = math.ceil(total_values / GeomCrossSection.VALUES_PER_LINE)
+                return min(idx + 1 + data_lines, section_end)
+
+        return None
 
     @staticmethod
     def _prepare_station_elevation_df(sta_elev_df: pd.DataFrame,
@@ -1828,6 +1927,248 @@ class GeomCrossSection:
         except Exception as e:
             logger.error(f"Error writing expansion/contraction: {str(e)}")
             raise IOError(f"Failed to write expansion/contraction: {str(e)}")
+
+    @staticmethod
+    @log_call
+    def get_levees(geom_number: Union[str, Path],
+                   river: Optional[str] = None,
+                   reach: Optional[str] = None,
+                   rs: Optional[str] = None,
+                   xs_id: Optional[str] = None,
+                   ras_object=None) -> pd.DataFrame:
+        """
+        Read left and right levee station-elevation points from cross sections.
+
+        Cross-section levees are stored in plain-text geometry files as a
+        single ``Levee=`` line with left and right triplets:
+        ``flag, station, elevation``. Active sides use flag ``-1``; inactive
+        sides use flag ``0`` and blank station/elevation fields.
+
+        Parameters:
+            geom_number: Geometry number or direct path to a .g## text file
+            river: Optional river filter
+            reach: Optional reach filter. If supplied, ``river`` is required.
+            rs: Optional river-station filter. If supplied, ``river`` and
+                ``reach`` are required.
+            xs_id: Optional exact ID from the returned ``xs_id`` column.
+            ras_object: Optional RasPrj instance for API consistency (unused)
+
+        Returns:
+            pd.DataFrame: Columns ``xs_id``, ``left_station``,
+            ``left_elevation``, ``right_station``, ``right_elevation``.
+            Matching cross sections without levees are included with NaN values.
+        """
+        geom_file = GeomCrossSection._resolve_geom_text_path(geom_number, ras_object=ras_object)
+
+        if not geom_file.exists():
+            raise FileNotFoundError(f"Geometry file not found: {geom_file}")
+        if reach is not None and river is None:
+            raise ValueError("If reach is specified, river must also be specified")
+        if rs is not None and (river is None or reach is None):
+            raise ValueError("If rs is specified, river and reach must also be specified")
+
+        columns = [
+            'xs_id',
+            'River',
+            'Reach',
+            'RS',
+            'left_station',
+            'left_elevation',
+            'right_station',
+            'right_elevation'
+        ]
+
+        try:
+            with open(geom_file, 'r', encoding='utf-8', errors='replace') as f:
+                lines = f.readlines()
+
+            rows = []
+            current_river = None
+            current_reach = None
+
+            i = 0
+            while i < len(lines):
+                line = lines[i]
+                if line.startswith("River Reach="):
+                    values = GeomParser.extract_comma_list(line, "River Reach")
+                    if len(values) >= 2:
+                        current_river = values[0]
+                        current_reach = values[1]
+
+                elif line.startswith("Type RM Length L Ch R ="):
+                    value_str = GeomParser.extract_keyword_value(line, "Type RM Length L Ch R")
+                    values = [v.strip() for v in value_str.split(',')]
+                    if len(values) < 2 or current_river is None or current_reach is None:
+                        i += 1
+                        continue
+
+                    current_rs = values[1]
+                    current_xs_id = GeomCrossSection._make_xs_id(
+                        current_river,
+                        current_reach,
+                        current_rs
+                    )
+
+                    if river is not None and current_river != river:
+                        i += 1
+                        continue
+                    if reach is not None and current_reach != reach:
+                        i += 1
+                        continue
+                    if rs is not None and current_rs != rs:
+                        i += 1
+                        continue
+                    if xs_id is not None and current_xs_id != xs_id:
+                        i += 1
+                        continue
+
+                    levee_values = (math.nan, math.nan, math.nan, math.nan)
+                    section_end = GeomCrossSection._find_xs_section_end(lines, i)
+                    for j in range(i, section_end):
+                        if lines[j].startswith("Levee="):
+                            levee_values = GeomCrossSection._parse_levee_line(lines[j])
+                            break
+
+                    rows.append({
+                        'xs_id': current_xs_id,
+                        'River': current_river,
+                        'Reach': current_reach,
+                        'RS': current_rs,
+                        'left_station': levee_values[0],
+                        'left_elevation': levee_values[1],
+                        'right_station': levee_values[2],
+                        'right_elevation': levee_values[3],
+                    })
+
+                    i = section_end
+                    continue
+
+                i += 1
+
+            df = pd.DataFrame(rows, columns=columns)
+            logger.info(f"Read levee data for {len(df)} cross sections from {geom_file}")
+            return df
+
+        except FileNotFoundError:
+            raise
+        except ValueError:
+            raise
+        except Exception as e:
+            logger.error(f"Error reading levees: {str(e)}")
+            raise IOError(f"Failed to read levees: {str(e)}")
+
+    @staticmethod
+    @log_call
+    def set_levees(geom_number: Union[str, Path],
+                   xs_id: Optional[str] = None,
+                   left_station: Optional[float] = None,
+                   left_elevation: Optional[float] = None,
+                   right_station: Optional[float] = None,
+                   right_elevation: Optional[float] = None,
+                   *,
+                   river: Optional[str] = None,
+                   reach: Optional[str] = None,
+                   rs: Optional[str] = None,
+                   create_backup: bool = True,
+                   ras_object=None) -> Optional[Path]:
+        """
+        Write left and right levee station-elevation points for a cross section.
+
+        Updates an existing ``Levee=`` line or inserts one immediately after the
+        target cross section's ``#Mann=`` data block. Pass station/elevation
+        together for each side; omit both values for a side to write it as
+        inactive.
+
+        Parameters:
+            geom_number: Geometry number or direct path to a .g## text file
+            xs_id: Cross-section ID emitted by ``get_levees()``. Optional if
+                ``river``, ``reach``, and ``rs`` are provided.
+            left_station: Optional left levee station
+            left_elevation: Optional left levee elevation
+            right_station: Optional right levee station
+            right_elevation: Optional right levee elevation
+            river: Optional target river, used with ``reach`` and ``rs``
+            reach: Optional target reach
+            rs: Optional target river station
+            create_backup: Whether to create a .bak backup before modification
+            ras_object: Optional RasPrj instance for API consistency (unused)
+
+        Returns:
+            Optional[Path]: Backup path if ``create_backup=True``, otherwise None.
+        """
+        geom_file = GeomCrossSection._resolve_geom_text_path(geom_number, ras_object=ras_object)
+
+        if not geom_file.exists():
+            raise FileNotFoundError(f"Geometry file not found: {geom_file}")
+        if xs_id is None and (river is None or reach is None or rs is None):
+            raise ValueError("Provide xs_id or all of river, reach, and rs")
+        if xs_id is not None and any(v is not None for v in (river, reach, rs)):
+            raise ValueError("Provide either xs_id or river/reach/rs, not both")
+
+        try:
+            with open(geom_file, 'r', encoding='utf-8', errors='replace') as f:
+                lines = f.readlines()
+
+            xs_df = GeomCrossSection.get_cross_sections(geom_file)
+            if xs_id is not None:
+                target_river, target_reach, target_rs = GeomCrossSection._resolve_xs_identifier(xs_id, xs_df)
+            else:
+                target_river, target_reach, target_rs = river, reach, rs
+
+            xs_idx = GeomCrossSection._find_cross_section(lines, target_river, target_reach, target_rs)
+            if xs_idx is None:
+                raise ValueError(f"Cross section not found: {target_river}/{target_reach}/RS {target_rs}")
+
+            modified_lines = lines.copy()
+            levee_idx = GeomCrossSection._find_keyword_index(modified_lines, xs_idx, "Levee=")
+            new_line = GeomCrossSection._levee_line(
+                left_station=left_station,
+                left_elevation=left_elevation,
+                right_station=right_station,
+                right_elevation=right_elevation,
+                existing_line=modified_lines[levee_idx] if levee_idx is not None else None
+            )
+
+            if levee_idx is not None:
+                modified_lines[levee_idx] = new_line
+            else:
+                insert_idx = GeomCrossSection._find_mann_block_end(modified_lines, xs_idx)
+                if insert_idx is not None:
+                    modified_lines.insert(insert_idx, new_line)
+                else:
+                    GeomCrossSection._insert_xs_keyword_line(
+                        modified_lines,
+                        xs_idx,
+                        new_line,
+                        prefer_before=[
+                            "#XS Ineff=",
+                            "#Block Obstruct=",
+                            "Bank Sta=",
+                            "XS Rating Curve=",
+                            "XS HTab Starting El and Incr=",
+                            "XS HTab Horizontal Distribution=",
+                            "Exp/Cntr="
+                        ]
+                    )
+
+            backup_path = GeomParser.safe_write_geometry(
+                geom_file,
+                modified_lines,
+                create_backup=create_backup
+            )
+
+            logger.info(
+                f"Updated levees for {target_river}/{target_reach}/RS {target_rs}"
+            )
+            return backup_path
+
+        except FileNotFoundError:
+            raise
+        except ValueError:
+            raise
+        except Exception as e:
+            logger.error(f"Error writing levees: {str(e)}")
+            raise IOError(f"Failed to write levees: {str(e)}")
 
     @staticmethod
     @log_call

--- a/tests/test_geom_cross_section_setters.py
+++ b/tests/test_geom_cross_section_setters.py
@@ -33,6 +33,7 @@ def _xs_block(
     bank_line=None,
     exp_cntr_line=None,
     blocked_obstructions=None,
+    levee_line=None,
 ):
     lines = [
         f"Type RM Length L Ch R = 1 ,{rs},     0.0,     0.0,     0.0\n",
@@ -50,6 +51,8 @@ def _xs_block(
         "#Mann= 2 , 0 , 0\n",
         _sta_elev_line([0.0, 0.04, 0.0, 500.0, 0.04, 0.0]) + "\n",
     ])
+    if levee_line:
+        lines.append(levee_line)
     return "".join(lines)
 
 
@@ -365,3 +368,115 @@ def test_interpolate_cross_section_reads_banks_from_geometry(tmp_path):
     assert {225.0, 825.0}.issubset(
         set(interpolated.loc[interpolated["IsBankPoint"], "Station"])
     )
+
+
+def _write_geom_with_levees(tmp_path: Path):
+    text = (
+        "Geom Title=CLB-639 Test\n"
+        "Program Version=6.50\n"
+        f"River Reach={RIVER}    ,{REACH}\n"
+        "Reach XY= 2\n"
+        "         0.00         0.00\n"
+        "      3000.00         0.00\n"
+        + _xs_block(
+            "1000",
+            [0.0, 100.0, 500.0, 90.0, 1000.0, 100.0],
+            bank_line="Bank Sta=200,800\n",
+            levee_line="Levee=-1,125.5,105.25,-1,875.25,106.5,,\n",
+        )
+        + _xs_block(
+            "2000",
+            [0.0, 102.0, 250.0, 95.0, 750.0, 95.0, 1000.0, 102.0],
+            bank_line="Bank Sta=250,850\n",
+            levee_line="Levee=0,,,-1,900,103.75,,\n",
+        )
+        + _xs_block(
+            "3000",
+            [0.0, 103.0, 300.0, 96.0, 900.0, 97.0, 1000.0, 104.0],
+            bank_line="Bank Sta=300,900\n",
+        )
+    )
+
+    geom_file = tmp_path / "clb639.g01"
+    geom_file.write_text(text, encoding="utf-8")
+    return geom_file
+
+
+def test_get_levees_reads_multiple_xs_and_missing_values(tmp_path):
+    geom_file = _write_geom_with_levees(tmp_path)
+
+    levees = GeomCrossSection.get_levees(geom_file, river=RIVER, reach=REACH)
+
+    assert {
+        "xs_id", "River", "Reach", "RS",
+        "left_station", "left_elevation",
+        "right_station", "right_elevation",
+    }.issubset(levees.columns)
+    assert list(levees["xs_id"]) == [
+        f"{RIVER}|{REACH}|1000",
+        f"{RIVER}|{REACH}|2000",
+        f"{RIVER}|{REACH}|3000",
+    ]
+
+    xs_1000 = levees.loc[levees["xs_id"].eq(f"{RIVER}|{REACH}|1000")].iloc[0]
+    assert np.isclose(xs_1000["left_station"], 125.5)
+    assert np.isclose(xs_1000["left_elevation"], 105.25)
+    assert np.isclose(xs_1000["right_station"], 875.25)
+    assert np.isclose(xs_1000["right_elevation"], 106.5)
+
+    xs_2000 = levees.loc[levees["xs_id"].eq(f"{RIVER}|{REACH}|2000")].iloc[0]
+    assert np.isnan(xs_2000["left_station"])
+    assert np.isnan(xs_2000["left_elevation"])
+    assert np.isclose(xs_2000["right_station"], 900.0)
+    assert np.isclose(xs_2000["right_elevation"], 103.75)
+
+    xs_3000 = levees.loc[levees["xs_id"].eq(f"{RIVER}|{REACH}|3000")].iloc[0]
+    assert np.isnan(xs_3000["left_station"])
+    assert np.isnan(xs_3000["right_station"])
+
+
+def test_set_levees_updates_and_inserts_round_trip(tmp_path):
+    geom_file = _write_geom_with_levees(tmp_path)
+
+    backup_path = GeomCrossSection.set_levees(
+        geom_file,
+        f"{RIVER}|{REACH}|1000",
+        left_station=150.0,
+        left_elevation=108.5,
+        right_station=None,
+        right_elevation=None,
+    )
+    assert backup_path is not None
+    assert backup_path.exists()
+
+    GeomCrossSection.set_levees(
+        geom_file,
+        left_station=None,
+        left_elevation=None,
+        right_station=920.25,
+        right_elevation=109.75,
+        river=RIVER,
+        reach=REACH,
+        rs="3000",
+        create_backup=False,
+    )
+
+    levees = GeomCrossSection.get_levees(geom_file, river=RIVER, reach=REACH)
+    xs_1000 = levees.loc[levees["xs_id"].eq(f"{RIVER}|{REACH}|1000")].iloc[0]
+    assert np.isclose(xs_1000["left_station"], 150.0)
+    assert np.isclose(xs_1000["left_elevation"], 108.5)
+    assert np.isnan(xs_1000["right_station"])
+    assert np.isnan(xs_1000["right_elevation"])
+
+    xs_3000 = levees.loc[levees["xs_id"].eq(f"{RIVER}|{REACH}|3000")].iloc[0]
+    assert np.isnan(xs_3000["left_station"])
+    assert np.isclose(xs_3000["right_station"], 920.25)
+    assert np.isclose(xs_3000["right_elevation"], 109.75)
+
+    text = geom_file.read_text(encoding="utf-8")
+    assert "Levee=-1,150.0,108.50,0,,,,\n" in text
+
+    target_block = text.split("Type RM Length L Ch R = 1 ,3000", 1)[1]
+    mann_idx = target_block.index("#Mann= 2 , 0 , 0\n")
+    levee_idx = target_block.index("Levee=0,,,-1,920.25,109.75,,\n")
+    assert mann_idx < levee_idx


### PR DESCRIPTION
## Summary
- Add `get_levees()` and `set_levees()` static methods to `GeomCrossSection` for reading/writing cross-section levee station-elevation data in `.g##` text files
- Fix station-only levee parsing (no explicit elevation) — HEC-RAS resolves elevation from ground profile
- Add helper methods: `_parse_levee_line()`, `_levee_line()`, `_is_missing_number()`, `_find_mann_block_end()`
- API consistency with CLB-640: uses `_make_xs_id()`, `_resolve_geom_text_path()`, `_resolve_xs_identifier()`, `geom_number` parameter
- Add example notebook `217_levee_read_write.ipynb` using Bald Eagle Creek (41 levees)
- Add 2 unit tests for levee get/set round-trip

## Test plan
- [x] 13/13 setter tests pass (`test_geom_cross_section_setters.py`)
- [x] Notebook 217 executes cleanly with all 11 code cells producing output
- [x] Verified with real HEC-RAS data: Bald Eagle Creek (station-only levees, left/right/both configs)
- [x] Round-trip verification: read → modify → write → re-read matches

🤖 Generated with [Claude Code](https://claude.com/claude-code)