### PR TITLE
CLB-642 Complete MRMS precipitation support

### DIFF
--- a/ras_commander/LoggingConfig.py
+++ b/ras_commander/LoggingConfig.py
@@ -14,11 +14,52 @@ CRITICAL = logging.CRITICAL
 
 
 _logging_setup_done = False
+_RAS_CONSOLE_HANDLER_ATTR = "_ras_commander_console_handler"
+
+
+def _dedupe_root_handlers(root_logger: logging.Logger) -> None:
+    """Remove duplicate stream/file handlers registered on the root logger."""
+    seen = set()
+    for handler in list(root_logger.handlers):
+        if isinstance(handler, logging.FileHandler):
+            identity = ("file", getattr(handler, "baseFilename", None))
+        elif isinstance(handler, logging.StreamHandler):
+            identity = ("stream", id(getattr(handler, "stream", None)))
+        else:
+            identity = (type(handler), id(handler))
+
+        if identity in seen:
+            root_logger.removeHandler(handler)
+            try:
+                handler.close()
+            except Exception:
+                pass
+            continue
+        seen.add(identity)
+
+    stream_handlers = [
+        handler for handler in root_logger.handlers
+        if isinstance(handler, logging.StreamHandler)
+        and not isinstance(handler, logging.FileHandler)
+    ]
+    external_stream_handlers = [
+        handler for handler in stream_handlers
+        if not getattr(handler, _RAS_CONSOLE_HANDLER_ATTR, False)
+    ]
+    if external_stream_handlers:
+        for handler in stream_handlers:
+            if getattr(handler, _RAS_CONSOLE_HANDLER_ATTR, False):
+                root_logger.removeHandler(handler)
+                try:
+                    handler.close()
+                except Exception:
+                    pass
 
 def setup_logging(log_file=None, log_level=logging.INFO):
     """Set up logging configuration for the ras-commander library."""
     global _logging_setup_done
     if _logging_setup_done:
+        _dedupe_root_handlers(logging.getLogger())
         return
     
     # Define log format
@@ -39,6 +80,7 @@ def setup_logging(log_file=None, log_level=logging.INFO):
     )
     if not has_stream_handler:
         console_handler = logging.StreamHandler()
+        setattr(console_handler, _RAS_CONSOLE_HANDLER_ATTR, True)
         console_handler.setFormatter(log_format)
         root_logger.addHandler(console_handler)
 
@@ -53,6 +95,8 @@ def setup_logging(log_file=None, log_level=logging.INFO):
         )
         file_handler.setFormatter(log_format)
         root_logger.addHandler(file_handler)
+
+    _dedupe_root_handlers(root_logger)
     
     _logging_setup_done = True
 

--- a/ras_commander/RasPrj.py
+++ b/ras_commander/RasPrj.py
@@ -1316,11 +1316,17 @@ class RasPrj:
         geom_entries = []
 
         try:
-            with open(self.prj_file, 'r') as f:
-                for line in f:
-                    match = geom_pattern.search(line)
-                    if match:
-                        geom_entries.append(match.group(1))
+            content, encoding = read_file_with_fallback_encoding(self.prj_file)
+            if content is None:
+                raise IOError(
+                    f"Could not read project file {self.prj_file} with any supported encoding"
+                )
+            logger.debug("Parsed geometry entries from %s using %s encoding", self.prj_file, encoding)
+
+            for line in content.splitlines():
+                match = geom_pattern.search(line)
+                if match:
+                    geom_entries.append(match.group(1))
         
             geom_df = pd.DataFrame({'geom_file': geom_entries})
             if geom_df.empty:

--- a/ras_commander/RasProcess.py
+++ b/ras_commander/RasProcess.py
@@ -1043,9 +1043,20 @@ Step 5: Configure (optional — auto-detection usually works)
                 )
                 return False
 
-            with rasterio.open(tif_path, 'r+') as dst:
-                dst.transform = transform
-                dst.crs = crs
+            tif_path = Path(tif_path)
+            tmp_path = tif_path.with_name(f"{tif_path.stem}.georef_tmp{tif_path.suffix}")
+            with rasterio.open(tif_path) as src:
+                data = src.read()
+                profile = src.profile.copy()
+                tags = src.tags()
+
+            profile.update(crs=crs, transform=transform)
+            with rasterio.open(tmp_path, "w", **profile) as dst:
+                dst.write(data)
+                if tags:
+                    dst.update_tags(**tags)
+
+            tmp_path.replace(tif_path)
 
             logger.info(f"Fixed georeferencing: {tif_path}")
             return True
@@ -1053,6 +1064,44 @@ Step 5: Configure (optional — auto-detection usually works)
         except Exception as e:
             logger.error(f"Failed to fix georeferencing for {tif_path}: {e}")
             return False
+
+    @staticmethod
+    def _drop_unreadable_tifs(
+        generated_files: Dict[str, List[Path]],
+    ) -> Dict[str, List[Path]]:
+        """
+        Remove invalid GeoTIFFs from StoreAllMaps results.
+
+        HEC-RAS can occasionally emit a partial or corrupt TIFF for a single
+        stored-map timestep. Downstream animation code treats a missing timestep
+        as dry/no-data, but it cannot recover from a path that exists and then
+        fails during raster read.
+        """
+        if not HAS_RASTERIO:
+            return generated_files
+
+        for map_key, tif_list in list(generated_files.items()):
+            readable_tifs: List[Path] = []
+            for tif_path in tif_list:
+                try:
+                    with rasterio.open(tif_path) as src:
+                        if src.count < 1 or src.width < 1 or src.height < 1:
+                            raise ValueError("GeoTIFF has no readable raster band")
+                        src.read(1)
+                    readable_tifs.append(tif_path)
+                except Exception as exc:
+                    logger.warning(
+                        "Dropping unreadable stored-map TIFF %s: %s",
+                        tif_path,
+                        exc,
+                    )
+                    try:
+                        Path(tif_path).unlink(missing_ok=True)
+                    except OSError:
+                        logger.debug("Could not delete unreadable TIFF: %s", tif_path)
+            generated_files[map_key] = readable_tifs
+
+        return generated_files
 
     @staticmethod
     def _get_plan_short_id(hdf_path: Path) -> Optional[str]:
@@ -1629,6 +1678,7 @@ Step 5: Configure (optional — auto-detection usually works)
                             )
                 else:
                     logger.warning("Could not find terrain for georef fix")
+                RasProcess._drop_unreadable_tifs(generated_files)
 
             return generated_files
 
@@ -1637,6 +1687,132 @@ Step 5: Configure (optional — auto-detection usually works)
             if rasmap_backup.exists():
                 shutil.copy2(rasmap_backup, rasmap_path)
                 rasmap_backup.unlink()
+
+    @staticmethod
+    @log_call
+    def store_maps_at_timesteps(
+        plan_number: str,
+        output_path: Union[str, Path] = None,
+        timesteps: Optional[Union[int, str, datetime, List[Union[int, str, datetime]]]] = None,
+        max_timesteps: Optional[int] = None,
+        wse: bool = False,
+        depth: bool = True,
+        velocity: bool = False,
+        froude: bool = False,
+        shear_stress: bool = False,
+        depth_x_velocity: bool = False,
+        depth_x_velocity_sq: bool = False,
+        render_mode: str = None,
+        clear_existing: bool = True,
+        fix_georef: bool = True,
+        ras_object=None,
+        ras_version: str = None,
+        timeout: int = 600,
+    ) -> Dict[str, Dict[str, List[Path]]]:
+        """
+        Generate stored maps for one or more output timesteps.
+
+        This convenience wrapper routes each selected timestep through
+        ``store_maps(profile=<timestamp>)`` so callers can export a sequence of
+        rasters suitable for animation.
+
+        Args:
+            plan_number: Plan number (e.g., "02").
+            output_path: Optional directory for generated rasters.
+            timesteps: Optional timestep selector. Items may be zero-based
+                integer indices, exact RASMapper timestamp strings, or datetimes.
+                If omitted, all available output timesteps are used.
+            max_timesteps: Optional cap applied after timestep selection.
+            wse, depth, velocity, froude, shear_stress, depth_x_velocity,
+                depth_x_velocity_sq: Map types to export. Defaults to Depth only.
+            render_mode, clear_existing, fix_georef, ras_object, ras_version,
+                timeout: Passed through to ``store_maps``.
+
+        Returns:
+            Dict keyed by RASMapper timestamp string. Each value is the
+            ``store_maps`` result for that timestep.
+        """
+        ras_obj = ras_object or ras
+        ras_obj.check_initialized()
+
+        available = RasProcess.get_plan_timestamps(plan_number, ras_obj)
+        if not available:
+            raise ValueError(f"No output timesteps found for plan {plan_number}")
+
+        selected = RasProcess._select_store_map_timesteps(available, timesteps)
+        if max_timesteps is not None:
+            selected = selected[: int(max_timesteps)]
+        if not selected:
+            raise ValueError("No timesteps selected for stored map export")
+
+        results: Dict[str, Dict[str, List[Path]]] = {}
+        for timestamp in selected:
+            results[timestamp] = RasProcess.store_maps(
+                plan_number=plan_number,
+                output_path=output_path,
+                profile=timestamp,
+                render_mode=render_mode,
+                wse=wse,
+                depth=depth,
+                velocity=velocity,
+                froude=froude,
+                shear_stress=shear_stress,
+                depth_x_velocity=depth_x_velocity,
+                depth_x_velocity_sq=depth_x_velocity_sq,
+                clear_existing=clear_existing,
+                fix_georef=fix_georef,
+                ras_object=ras_obj,
+                ras_version=ras_version,
+                timeout=timeout,
+            )
+        return results
+
+    @staticmethod
+    def _select_store_map_timesteps(
+        available: List[str],
+        timesteps: Optional[Union[int, str, datetime, List[Union[int, str, datetime]]]],
+    ) -> List[str]:
+        if timesteps is None:
+            return list(available)
+        if isinstance(timesteps, (int, str, datetime, pd.Timestamp)):
+            requested = [timesteps]
+        else:
+            requested = list(timesteps)
+
+        selected: List[str] = []
+        for item in requested:
+            if isinstance(item, int):
+                try:
+                    selected.append(available[item])
+                except IndexError as exc:
+                    raise ValueError(
+                        f"Timestep index {item} out of range for {len(available)} timesteps"
+                    ) from exc
+                continue
+
+            if isinstance(item, (datetime, pd.Timestamp)):
+                item_text = pd.Timestamp(item).strftime("%d%b%Y %H:%M:%S").upper()
+            else:
+                item_text = str(item).strip()
+
+            if item_text in available:
+                selected.append(item_text)
+                continue
+
+            parsed_text = None
+            try:
+                parsed_text = pd.Timestamp(item_text).strftime("%d%b%Y %H:%M:%S").upper()
+            except Exception:
+                pass
+            if parsed_text in available:
+                selected.append(parsed_text)
+                continue
+
+            raise ValueError(
+                f"Timestep {item!r} not found. First available timesteps: {available[:5]}"
+            )
+
+        return selected
 
     @staticmethod
     @log_call

--- a/ras_commander/hdf/HdfPump.py
+++ b/ras_commander/hdf/HdfPump.py
@@ -201,17 +201,23 @@ class HdfPump:
                     logger.warning(f"Timestamp count ({len(time)}) doesn't match data time dimension ({data.shape[0]}). Using numeric index.")
                     time = list(range(data.shape[0]))
 
+                variable_units = hdf[data_path].attrs.get('Variable_Unit', None)
+                variable_names, unit_by_variable = HdfPump._pump_variable_columns(
+                    variable_units,
+                    data.shape[1],
+                )
+
                 # Create DataArray
                 da = xr.DataArray(
                     data=data,
                     dims=['time', 'variable'],
-                    coords={'time': time, 'variable': ['Flow', 'Stage HW', 'Stage TW', 'Pump Station', 'Pumps on']},
+                    coords={'time': time, 'variable': variable_names},
                     name=pump_station
                 )
 
                 # Add attributes and decode byte strings
-                units = hdf[data_path].attrs.get('Variable_Unit', b'')
-                da.attrs['units'] = units.decode('utf-8') if isinstance(units, bytes) else units
+                da.attrs['units'] = variable_units
+                da.attrs['unit_by_variable'] = unit_by_variable
                 da.attrs['pump_station'] = pump_station
 
                 return da
@@ -309,13 +315,20 @@ class HdfPump:
                 # Extract time information - Updated to use new method name
                 time = HdfBase.get_unsteady_timestamps(hdf)
 
+                variable_units = hdf[data_path].attrs.get('Variable_Unit', None)
+                variable_names, unit_by_variable = HdfPump._pump_variable_columns(
+                    variable_units,
+                    data.shape[1],
+                )
+
                 # Create DataFrame and decode byte strings
-                df = pd.DataFrame(data, columns=['Flow', 'Stage HW', 'Stage TW', 'Pump Station', 'Pumps on'])
+                df = pd.DataFrame(data, columns=variable_names)
                 string_columns = df.select_dtypes([object]).columns
                 for col in string_columns:
                     df[col] = df[col].apply(lambda x: x.decode('utf-8') if isinstance(x, bytes) else x)
                     
                 df['Time'] = time
+                df.attrs['unit_by_variable'] = unit_by_variable
 
                 return df
 
@@ -328,3 +341,78 @@ class HdfPump:
         except Exception as e:
             logger.error(f"Error extracting pump operation data: {e}")
             raise
+
+    @staticmethod
+    def _pump_variable_columns(variable_units: Any, column_count: int) -> tuple[List[str], Dict[str, str]]:
+        """
+        Build unique pump result column names from the HEC-RAS Variable_Unit attr.
+
+        HEC-RAS writes five columns for simple pump stations and additional
+        flow/on columns for each pump group. Older ras-commander releases
+        assumed exactly five columns, which fails for multi-group stations.
+        """
+        fallback_names = ['Flow', 'Stage HW', 'Stage TW', 'Pump Station', 'Pumps on']
+        if variable_units is None:
+            names = fallback_names[:column_count]
+            names.extend([f"Variable {idx + 1}" for idx in range(len(names), column_count)])
+            return names, {name: "" for name in names}
+
+        rows = np.asarray(variable_units)
+        if rows.ndim != 2 or rows.shape[1] < 2:
+            names = fallback_names[:column_count]
+            names.extend([f"Variable {idx + 1}" for idx in range(len(names), column_count)])
+            return names, {name: "" for name in names}
+
+        decoded_rows = [
+            (
+                HdfPump._decode_hdf_text(row[0]),
+                HdfPump._decode_hdf_text(row[1]),
+            )
+            for row in rows[:column_count]
+        ]
+
+        if column_count == 5 and len(decoded_rows) >= 5:
+            names = fallback_names.copy()
+        else:
+            names = []
+            for label, unit in decoded_rows:
+                unit_lower = unit.lower()
+                if label in {'Flow', 'Stage HW', 'Stage TW'}:
+                    column_name = label
+                elif unit_lower == 'pumps on':
+                    column_name = f"{label} Pumps on"
+                elif unit_lower == 'cfs':
+                    column_name = f"{label} Flow"
+                elif unit:
+                    column_name = f"{label} ({unit})"
+                else:
+                    column_name = label
+                names.append(column_name)
+
+        if len(names) < column_count:
+            names.extend([f"Variable {idx + 1}" for idx in range(len(names), column_count)])
+
+        names = HdfPump._dedupe_names(names[:column_count])
+        unit_by_variable = {
+            name: decoded_rows[idx][1] if idx < len(decoded_rows) else ""
+            for idx, name in enumerate(names)
+        }
+        return names, unit_by_variable
+
+    @staticmethod
+    def _decode_hdf_text(value: Any) -> str:
+        if isinstance(value, (bytes, np.bytes_)):
+            return value.decode('utf-8').strip()
+        return str(value).strip()
+
+    @staticmethod
+    def _dedupe_names(names: List[str]) -> List[str]:
+        counts: Dict[str, int] = {}
+        result: List[str] = []
+        for name in names:
+            counts[name] = counts.get(name, 0) + 1
+            if counts[name] == 1:
+                result.append(name)
+            else:
+                result.append(f"{name} {counts[name]}")
+        return result

--- a/ras_commander/hdf/HdfResultsMesh.py
+++ b/ras_commander/hdf/HdfResultsMesh.py
@@ -1190,6 +1190,292 @@ class HdfResultsMesh:
 
     @staticmethod
     @log_call
+    @standardize_input(file_type='plan_hdf')
+    def export_depth_rasters_at_times(
+        hdf_path: Path,
+        timestamps: Union[str, pd.Timestamp, List[Union[str, pd.Timestamp]]],
+        output_dir: Union[str, Path],
+        mesh_name: Optional[str] = None,
+        geom_hdf_path: Optional[Union[str, Path]] = None,
+        resolution: Optional[float] = None,
+        max_dimension: int = 600,
+        method: str = "nearest",
+        nodata: float = -9999.0,
+    ) -> Dict[str, Path]:
+        """
+        Export per-timestep 2D depth rasters from a computed plan HDF.
+
+        The method reads cell-centered HEC-RAS results through the plan HDF.
+        If the Depth dataset is not present, it computes depth as Water
+        Surface minus Cells Minimum Elevation and clips negative values to
+        zero. This is useful when RAS Mapper stored-map export cannot create
+        GeoTIFFs for every requested timestep but the plan HDF contains the
+        needed hydraulic results.
+
+        Args:
+            hdf_path: Plan HDF path.
+            timestamps: One or more simulation timestamps. Strings may use
+                RAS format such as ``10Apr2024 12:00:00``.
+            output_dir: Folder where GeoTIFFs will be written.
+            mesh_name: 2D flow area name. Required when the plan has multiple
+                2D flow areas.
+            geom_hdf_path: Optional geometry HDF path. Defaults to ``hdf_path``
+                because plan HDFs normally contain embedded geometry.
+            resolution: Optional output cell size in the model CRS units. If
+                omitted, a resolution is chosen so the longest raster dimension
+                is approximately ``max_dimension`` pixels.
+            max_dimension: Target maximum raster width/height when
+                ``resolution`` is omitted.
+            method: Rasterization method. ``nearest`` uses a precomputed cell
+                center nearest-neighbor lookup. ``linear`` and ``cubic`` use
+                scipy grid interpolation.
+            nodata: GeoTIFF nodata value.
+
+        Returns:
+            Dict[str, Path]: Mapping from the original timestamp label to the
+            exported GeoTIFF path.
+        """
+        from datetime import datetime
+
+        import rasterio
+        from rasterio.features import geometry_mask
+        from rasterio.transform import from_bounds
+
+        if isinstance(timestamps, (str, pd.Timestamp, datetime)):
+            timestamp_values = [timestamps]
+        else:
+            timestamp_values = list(timestamps)
+        if not timestamp_values:
+            raise ValueError("timestamps must contain at least one value")
+
+        method = method.lower()
+        if method not in {"nearest", "linear", "cubic"}:
+            raise ValueError("method must be one of: nearest, linear, cubic")
+
+        if max_dimension <= 1:
+            raise ValueError("max_dimension must be greater than 1")
+
+        hdf_path = Path(hdf_path)
+        geom_source = Path(geom_hdf_path) if geom_hdf_path is not None else hdf_path
+        output_dir = Path(output_dir)
+        output_dir.mkdir(parents=True, exist_ok=True)
+
+        def _parse_timestamp(value: Union[str, pd.Timestamp, datetime]) -> pd.Timestamp:
+            if isinstance(value, pd.Timestamp):
+                return value.round("s")
+            if isinstance(value, datetime):
+                return pd.Timestamp(value).round("s")
+
+            text = str(value).strip()
+            formats = [
+                "%d%b%Y %H:%M:%S",
+                "%d%b%Y %H:%M:%S:%f",
+                "%d%b%Y %H:%M:%S.%f",
+                "%Y-%m-%d %H:%M:%S",
+                "%Y-%m-%dT%H:%M:%S",
+            ]
+            for fmt in formats:
+                try:
+                    return pd.Timestamp(datetime.strptime(text.upper(), fmt)).round("s")
+                except ValueError:
+                    continue
+            return pd.Timestamp(text).round("s")
+
+        def _safe_timestamp_label(value: object, parsed: pd.Timestamp) -> str:
+            if isinstance(value, str):
+                label = value
+            else:
+                label = parsed.strftime("%d%b%Y %H:%M:%S")
+            return (
+                label.replace(":", " ")
+                .replace("/", "_")
+                .replace("\\", "_")
+                .replace(".", "_")
+            )
+
+        mesh_names = HdfMesh.get_mesh_area_names(geom_source)
+        if mesh_name is None:
+            if len(mesh_names) != 1:
+                raise ValueError(
+                    "mesh_name is required when the HDF contains "
+                    f"{len(mesh_names)} 2D flow areas: {mesh_names}"
+                )
+            mesh_name = mesh_names[0]
+        elif mesh_name not in mesh_names:
+            raise ValueError(f"Mesh '{mesh_name}' not found. Available meshes: {mesh_names}")
+
+        cell_points = HdfMesh.get_mesh_cell_points(geom_source)
+        if cell_points.empty:
+            raise ValueError(f"No 2D mesh cell centers found in {geom_source}")
+        cell_points = cell_points[cell_points["mesh_name"] == mesh_name].copy()
+        if cell_points.empty:
+            raise ValueError(f"No 2D mesh cell centers found for mesh '{mesh_name}'")
+
+        x = cell_points.geometry.x.to_numpy(dtype=float)
+        y = cell_points.geometry.y.to_numpy(dtype=float)
+        x_min, y_min, x_max, y_max = cell_points.total_bounds
+        if resolution is None:
+            longest_side = max(float(x_max - x_min), float(y_max - y_min))
+            resolution = longest_side / float(max_dimension)
+        if resolution <= 0:
+            raise ValueError("resolution must be positive")
+
+        cols = max(2, int(np.ceil((x_max - x_min) / resolution)))
+        rows = max(2, int(np.ceil((y_max - y_min) / resolution)))
+        transform = from_bounds(x_min, y_min, x_max, y_max, cols, rows)
+
+        x_res = (x_max - x_min) / cols
+        y_res = (y_max - y_min) / rows
+        grid_x = np.linspace(x_min + x_res / 2.0, x_max - x_res / 2.0, cols)
+        grid_y = np.linspace(y_max - y_res / 2.0, y_min + y_res / 2.0, rows)
+        gx, gy = np.meshgrid(grid_x, grid_y)
+        grid_points = np.column_stack([gx.ravel(), gy.ravel()])
+
+        if method == "nearest":
+            from scipy.spatial import cKDTree
+
+            tree = cKDTree(np.column_stack([x, y]))
+            _, nearest_indices = tree.query(grid_points)
+        else:
+            from scipy.interpolate import griddata as scipy_griddata
+
+            nearest_indices = None
+
+        mesh_areas = HdfMesh.get_mesh_areas(geom_source)
+        mesh_areas = mesh_areas[mesh_areas["mesh_name"] == mesh_name] if not mesh_areas.empty else mesh_areas
+        if mesh_areas.empty:
+            mesh_mask = np.ones((rows, cols), dtype=bool)
+        else:
+            mesh_mask = geometry_mask(
+                list(mesh_areas.geometry),
+                out_shape=(rows, cols),
+                transform=transform,
+                invert=True,
+            )
+
+        target_times = [_parse_timestamp(value) for value in timestamp_values]
+        output_paths: Dict[str, Path] = {}
+
+        time_stamp_path = (
+            "Results/Unsteady/Output/Output Blocks/Base Output/"
+            "Unsteady Time Series/Time Date Stamp (ms)"
+        )
+        time_path = (
+            "Results/Unsteady/Output/Output Blocks/Base Output/"
+            "Unsteady Time Series/Time"
+        )
+        depth_path = HdfResultsMesh._get_mesh_timeseries_output_path(mesh_name, "Depth")
+        wse_path = HdfResultsMesh._get_mesh_timeseries_output_path(mesh_name, "Water Surface")
+        min_elev_path = f"Geometry/2D Flow Areas/{mesh_name}/Cells Minimum Elevation"
+
+        with h5py.File(hdf_path, "r") as result_hdf, h5py.File(geom_source, "r") as geom_hdf:
+            if time_stamp_path in result_hdf:
+                raw_times = result_hdf[time_stamp_path][()]
+                hdf_times = pd.DatetimeIndex(
+                    [_parse_timestamp(value.decode("utf-8")) for value in raw_times]
+                ).round("s")
+            elif time_path in result_hdf:
+                start_time = HdfBase.get_simulation_start_time(result_hdf)
+                hdf_times = HdfUtils.convert_timesteps_to_datetimes(
+                    np.asarray(result_hdf[time_path][()]),
+                    start_time,
+                    round_to="s",
+                )
+            else:
+                raise ValueError(f"No unsteady timestep dataset found in {hdf_path}")
+
+            if depth_path not in result_hdf and wse_path not in result_hdf:
+                raise ValueError(
+                    f"Neither Depth nor Water Surface time series exists for mesh '{mesh_name}'"
+                )
+            if depth_path not in result_hdf and min_elev_path not in geom_hdf:
+                raise ValueError(
+                    f"Depth is absent and Cells Minimum Elevation is missing from {geom_source}"
+                )
+
+            min_elev = (
+                np.asarray(geom_hdf[min_elev_path][()], dtype=np.float32)
+                if depth_path not in result_hdf
+                else None
+            )
+
+            for original_value, target_time in zip(timestamp_values, target_times):
+                exact_matches = np.flatnonzero(hdf_times == target_time)
+                if len(exact_matches):
+                    time_index = int(exact_matches[0])
+                else:
+                    deltas = np.abs(hdf_times - target_time)
+                    nearest_position = int(np.argmin(deltas))
+                    if deltas[nearest_position] > pd.Timedelta(seconds=30):
+                        raise ValueError(
+                            f"Timestamp {target_time} not found in {hdf_path}; "
+                            f"nearest is {hdf_times[nearest_position]}"
+                        )
+                    time_index = nearest_position
+
+                if depth_path in result_hdf:
+                    values = np.asarray(result_hdf[depth_path][time_index], dtype=np.float32)
+                else:
+                    wse = np.asarray(result_hdf[wse_path][time_index], dtype=np.float32)
+                    values = np.maximum(wse - min_elev, 0.0).astype(np.float32)
+                values = np.where(np.isfinite(values), values, 0.0).astype(np.float32)
+
+                if len(values) != len(cell_points):
+                    raise ValueError(
+                        f"Depth value count ({len(values)}) does not match cell count "
+                        f"({len(cell_points)}) for mesh '{mesh_name}'"
+                    )
+
+                if method == "nearest":
+                    grid_values = values[nearest_indices].reshape(rows, cols)
+                else:
+                    grid_values = scipy_griddata(
+                        points=np.column_stack([x, y]),
+                        values=values.astype(np.float64),
+                        xi=(gx, gy),
+                        method=method,
+                        fill_value=nodata,
+                    ).astype(np.float32)
+                    grid_values = np.where(np.isnan(grid_values), nodata, grid_values)
+
+                grid_values = np.where(mesh_mask, grid_values, nodata).astype(np.float32)
+                safe_label = _safe_timestamp_label(original_value, target_time)
+                raster_path = output_dir / f"Depth ({safe_label}).hdf.tif"
+
+                with rasterio.open(
+                    raster_path,
+                    "w",
+                    driver="GTiff",
+                    height=rows,
+                    width=cols,
+                    count=1,
+                    dtype=np.float32,
+                    crs=cell_points.crs,
+                    transform=transform,
+                    nodata=nodata,
+                    compress="lzw",
+                    BIGTIFF="IF_SAFER",
+                ) as dst:
+                    dst.write(grid_values, 1)
+                    dst.update_tags(
+                        mesh_name=mesh_name,
+                        timestamp=target_time.strftime("%d%b%Y %H:%M:%S"),
+                        source="HEC-RAS plan HDF",
+                        units="ft",
+                    )
+
+                output_paths[str(original_value)] = raster_path
+
+        logger.info(
+            "Wrote %s depth raster(s) for mesh '%s' to %s",
+            len(output_paths),
+            mesh_name,
+            output_dir,
+        )
+        return output_paths
+
+    @staticmethod
+    @log_call
     def get_flood_extent_polygon(
         plan_number: str,
         profile: str = "Max",

--- a/ras_commander/precip/PrecipMrms.py
+++ b/ras_commander/precip/PrecipMrms.py
@@ -1,0 +1,2398 @@
+"""
+MRMS precipitation download and visualization helpers.
+
+This module downloads NOAA Multi-Radar Multi-Sensor (MRMS) QPE GRIB2 files
+from public archives and prepares them for HEC-RAS rain-on-grid workflows.
+It follows the static-class pattern used by the other precipitation helpers in
+ras-commander.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+import gzip
+from pathlib import Path
+import re
+import shutil
+from typing import Any, Dict, Iterable, List, Optional, Tuple, Union
+from urllib.parse import quote
+import xml.etree.ElementTree as ET
+
+from ..LoggingConfig import get_logger, log_call
+
+logger = get_logger(__name__)
+
+Bounds = Tuple[float, float, float, float]
+
+_TIMESTAMP_RE = re.compile(r"(\d{8})-(\d{6})")
+_DATE_ONLY_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$|^\d{8}$")
+_OSM_TILE_CACHE: Dict[Tuple[int, int, int], Any] = {}
+
+
+def _check_http_dependencies() -> None:
+    missing = []
+    try:
+        import requests  # noqa: F401
+    except ImportError:
+        missing.append("requests")
+
+    if missing:
+        raise ImportError(
+            "Missing required packages for MRMS downloads: "
+            f"{', '.join(missing)}. Install with: pip install {' '.join(missing)}"
+        )
+
+
+def _check_grib_dependencies() -> None:
+    missing = []
+    try:
+        import xarray  # noqa: F401
+    except ImportError:
+        missing.append("xarray")
+    try:
+        import cfgrib  # noqa: F401
+    except ImportError:
+        missing.append("cfgrib")
+
+    if missing:
+        raise ImportError(
+            "Missing packages for reading MRMS GRIB2 files: "
+            f"{', '.join(missing)}. Install with: pip install {' '.join(missing)}"
+        )
+
+
+def _check_animation_dependencies() -> None:
+    missing = []
+    try:
+        import matplotlib  # noqa: F401
+    except ImportError:
+        missing.append("matplotlib")
+    try:
+        import numpy  # noqa: F401
+    except ImportError:
+        missing.append("numpy")
+
+    if missing:
+        raise ImportError(
+            "Missing packages for MRMS animation: "
+            f"{', '.join(missing)}. Install with: pip install {' '.join(missing)}"
+        )
+
+
+class PrecipMrms:
+    """
+    MRMS QPE download, direct processing, and animation utilities.
+
+    The default public product name is ``GaugeCorr_QPE_01H`` because that is
+    the historical IEM/MTArchive name. For NOAA Open Data S3, ras-commander
+    maps that name to the current
+    ``MultiSensor_QPE_01H_Pass2_00.00`` archive prefix.
+    """
+
+    NOAA_S3_BASE_URL = "https://noaa-mrms-pds.s3.amazonaws.com"
+    IOWA_CATALOG_BASE_URL = "https://mtarchive.geol.iastate.edu/thredds/catalog"
+    IOWA_FILESERVER_BASE_URL = "https://mtarchive.geol.iastate.edu/thredds/fileServer"
+
+    # MRMS CONUS grid bounds are approximate and used for validation only.
+    CONUS_BOUNDS: Bounds = (-130.0, 20.0, -60.0, 55.0)
+
+    PRODUCT_HOURS = (1, 3, 6, 12, 24, 48, 72)
+    DEFAULT_PRODUCT = "GaugeCorr_QPE_01H"
+    DEFAULT_S3_PASS = "Pass2"
+
+    @staticmethod
+    @log_call
+    def catalog(
+        bounds: Bounds,
+        start_date: Union[str, datetime],
+        end_date: Union[str, datetime],
+        product: str = DEFAULT_PRODUCT,
+        source: str = "auto",
+        timeout: int = 60,
+    ) -> "pd.DataFrame":
+        """
+        List MRMS QPE files available for a date range.
+
+        Parameters
+        ----------
+        bounds
+            Bounding box in WGS84 as ``(west, south, east, north)``. MRMS
+            archives store full-domain CONUS grids, so bounds are validated and
+            carried in metadata but do not spatially subset the catalog.
+        start_date, end_date
+            Start and end of the time window. Date-only strings include the
+            whole UTC day.
+        product
+            MRMS product name. ``GaugeCorr_QPE_01H`` is the default and maps to
+            NOAA S3 ``MultiSensor_QPE_01H_Pass2_00.00``.
+        source
+            ``"auto"``, ``"noaa_s3"``, or ``"iowa"``. Auto prefers NOAA S3 for
+            supported dates and falls back to Iowa MTArchive.
+        timeout
+            HTTP timeout in seconds.
+
+        Returns
+        -------
+        pandas.DataFrame
+            Columns include ``valid_time``, ``source``, ``product``,
+            ``archive_product``, ``url``, ``filename``, ``size_bytes``, and
+            ``compressed``.
+        """
+        _check_http_dependencies()
+        PrecipMrms._validate_bounds(bounds)
+
+        start_ts = PrecipMrms._parse_timestamp(start_date, end_of_day=False)
+        end_ts = PrecipMrms._parse_timestamp(end_date, end_of_day=True)
+        if end_ts < start_ts:
+            raise ValueError("end_date must be greater than or equal to start_date")
+
+        source = source.lower().strip()
+        if source not in {"auto", "noaa_s3", "s3", "iowa", "mtarchive"}:
+            raise ValueError("source must be one of: auto, noaa_s3, iowa")
+
+        frames = []
+        if source in {"auto", "noaa_s3", "s3"}:
+            try:
+                s3_df = PrecipMrms._catalog_noaa_s3(
+                    start_ts, end_ts, product, timeout=timeout
+                )
+                if not s3_df.empty:
+                    frames.append(s3_df)
+                    if source != "auto":
+                        return PrecipMrms._filter_catalog(s3_df, start_ts, end_ts)
+            except Exception as exc:
+                if source != "auto":
+                    raise
+                logger.warning("NOAA MRMS S3 catalog lookup failed: %s", exc)
+
+        if source in {"auto", "iowa", "mtarchive"}:
+            try:
+                iowa_df = PrecipMrms._catalog_iowa_mtarchive(
+                    start_ts, end_ts, product, timeout=timeout
+                )
+                if not iowa_df.empty:
+                    frames.append(iowa_df)
+                    if source != "auto":
+                        return PrecipMrms._filter_catalog(iowa_df, start_ts, end_ts)
+            except Exception as exc:
+                if source != "auto":
+                    raise
+                logger.warning("Iowa MTArchive MRMS catalog lookup failed: %s", exc)
+
+        if not frames:
+            return PrecipMrms._empty_catalog()
+
+        import pandas as pd
+
+        catalog_df = pd.concat(frames, ignore_index=True)
+        catalog_df = PrecipMrms._filter_catalog(catalog_df, start_ts, end_ts)
+        if source == "auto" and not catalog_df.empty:
+            catalog_df = PrecipMrms._prefer_catalog_source(catalog_df)
+        return catalog_df
+
+    @staticmethod
+    @log_call
+    def download(
+        bounds: Bounds,
+        start_time: Union[str, datetime],
+        end_time: Union[str, datetime],
+        output_dir: Union[str, Path],
+        product: str = DEFAULT_PRODUCT,
+        source: str = "auto",
+        overwrite: bool = False,
+        decompress: bool = True,
+        timeout: int = 120,
+    ) -> List[Path]:
+        """
+        Download MRMS QPE GRIB2 files for a time range.
+
+        Files are downloaded as full-domain MRMS grids. If the archive object is
+        gzip-compressed, the default behavior is to decompress it to ``.grib2``
+        because cfgrib consumes the uncompressed GRIB2 file directly.
+        """
+        catalog_df = PrecipMrms.catalog(
+            bounds=bounds,
+            start_date=start_time,
+            end_date=end_time,
+            product=product,
+            source=source,
+            timeout=timeout,
+        )
+        if catalog_df.empty:
+            raise FileNotFoundError(
+                "No MRMS files found for "
+                f"{start_time} to {end_time}, product={product}, source={source}"
+            )
+
+        output_path = Path(output_dir)
+        output_path.mkdir(parents=True, exist_ok=True)
+
+        downloaded: List[Path] = []
+        for row in catalog_df.itertuples(index=False):
+            archive_name = str(row.filename)
+            local_name = (
+                archive_name[:-3]
+                if decompress and archive_name.endswith(".gz")
+                else archive_name
+            )
+            local_path = output_path / local_name
+
+            if local_path.exists() and not overwrite:
+                downloaded.append(local_path)
+                continue
+
+            logger.info("Downloading MRMS: %s", archive_name)
+            PrecipMrms._download_one(
+                url=str(row.url),
+                local_path=local_path,
+                decompress=decompress and archive_name.endswith(".gz"),
+                timeout=timeout,
+            )
+            downloaded.append(local_path)
+
+        return sorted(downloaded)
+
+    @staticmethod
+    @log_call
+    def to_dss(
+        grib2_files: Union[str, Path, Iterable[Union[str, Path]]],
+        output_dss: Union[str, Path],
+        clip_shp: Optional[Union[str, Path]] = None,
+        product: str = DEFAULT_PRODUCT,
+        variables: Optional[List[str]] = None,
+        target_wkt: str = "SHG",
+        target_cell_size: int = 2000,
+        resampling_method: str = "Bilinear",
+        dss_parts: Optional[Dict[str, str]] = None,
+        vortex_path: Optional[Union[str, Path]] = None,
+        jython_jar: Optional[Union[str, Path]] = None,
+        timeout: int = 1800,
+    ) -> Path:
+        """
+        Convert MRMS GRIB2 files to HEC-DSS using HEC-Vortex.
+
+        This is the MRMS-specific wrapper around :meth:`VortexCli.import_gridded`.
+        It supplies the Vortex variable name for the requested MRMS QPE product
+        and preserves the standard SHG output defaults expected by HEC-RAS/HMS
+        gridded precipitation workflows.
+        """
+        from .VortexCli import VortexCli
+
+        grib_paths = PrecipMrms._normalize_paths(grib2_files)
+        if not grib_paths:
+            raise ValueError("grib2_files must contain at least one file")
+
+        output_path = Path(output_dss)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+
+        product_info = PrecipMrms._product_info(product)
+        import_variables = variables or PrecipMrms._vortex_variables_for_files(
+            product, grib_paths
+        )
+        write_parts = {
+            "A": "SHG",
+            "B": "MRMS_QPE",
+            "F": product_info["canonical"].upper(),
+        }
+        if dss_parts:
+            write_parts.update(dss_parts)
+
+        logger.info(
+            "Converting %d MRMS GRIB2 file(s) to DSS via HEC-Vortex: %s",
+            len(grib_paths),
+            output_path,
+        )
+        return VortexCli.import_gridded(
+            input_files=grib_paths,
+            output_dss=output_path,
+            variables=import_variables,
+            clip_shp=clip_shp,
+            target_wkt=target_wkt,
+            target_cell_size=target_cell_size,
+            resampling_method=resampling_method,
+            dss_parts=write_parts,
+            vortex_path=vortex_path,
+            jython_jar=jython_jar,
+            timeout=timeout,
+        )
+
+    @staticmethod
+    @log_call
+    def load_grib2_stack(
+        grib2_files: Union[str, Path, Iterable[Union[str, Path]]],
+        bounds: Optional[Bounds] = None,
+        variable: Optional[str] = None,
+    ) -> "xr.DataArray":
+        """
+        Load MRMS GRIB2 files into a time-indexed xarray DataArray.
+
+        Requires ``xarray`` and ``cfgrib``. The returned values are MRMS
+        precipitation depths, normally in millimeters for QPE products.
+        """
+        _check_grib_dependencies()
+        import pandas as pd
+        import xarray as xr
+
+        grib_paths = PrecipMrms._normalize_paths(grib2_files)
+        if not grib_paths:
+            raise ValueError("grib2_files must contain at least one file")
+
+        frames = []
+        times = []
+        for grib_path in grib_paths:
+            if not grib_path.exists():
+                raise FileNotFoundError(f"GRIB2 file not found: {grib_path}")
+
+            ds = xr.open_dataset(
+                grib_path,
+                engine="cfgrib",
+                backend_kwargs={"indexpath": ""},
+            )
+            try:
+                data_var = PrecipMrms._select_data_var(ds, variable)
+                da = ds[data_var].squeeze(drop=True)
+                da = PrecipMrms._drop_scalar_coords(da)
+                if bounds is not None:
+                    da = PrecipMrms._clip_dataarray(da, bounds)
+                da = da.load()
+            finally:
+                ds.close()
+
+            frame_time = PrecipMrms._frame_time_from_dataarray(da, grib_path)
+            frames.append(da)
+            times.append(frame_time)
+
+        time_index = pd.DatetimeIndex(times, name="time")
+        stack = xr.concat(frames, dim=time_index)
+        stack.name = "mrms_precipitation"
+        if str(stack.attrs.get("units", "")).lower() in {"", "unknown"}:
+            stack.attrs["units"] = "mm"
+        if str(stack.attrs.get("long_name", "")).lower() in {"", "unknown"}:
+            stack.attrs["long_name"] = "MRMS QPE"
+        return stack.sortby("time")
+
+    @staticmethod
+    @log_call
+    def to_hyetograph(
+        grib2_files: Any,
+        bounds: Optional[Bounds] = None,
+        variable: Optional[str] = None,
+        depth_units: str = "in",
+    ) -> "pd.DataFrame":
+        """
+        Convert MRMS QPE grids to a spatial-mean HEC-RAS hyetograph.
+
+        ``grib2_files`` may be GRIB2 paths or an already loaded xarray/numpy
+        grid stack. The output DataFrame matches
+        ``RasUnsteady.set_precipitation_hyetograph()`` with ``hour``,
+        ``incremental_depth``, and ``cumulative_depth`` columns.
+        """
+        import numpy as np
+        import pandas as pd
+
+        precip = PrecipMrms._prepare_precipitation_data(
+            grib2_files,
+            bounds=bounds,
+            variable=variable,
+        )
+        precip_depth = PrecipMrms._convert_precip_units(precip, depth_units)
+        values = np.asarray(precip_depth.values, dtype=float)
+        if values.ndim != 3:
+            raise ValueError(f"MRMS hyetograph expects 3-D time/y/x data, got {values.shape}")
+
+        times = pd.to_datetime(precip_depth.coords["time"].values)
+        incremental_depth = np.nanmean(values, axis=(1, 2))
+        incremental_depth = np.nan_to_num(incremental_depth, nan=0.0)
+
+        if len(times) > 1:
+            interval_hours = float((times[1] - times[0]) / pd.Timedelta(hours=1))
+        else:
+            interval_hours = 1.0
+
+        hours = (np.arange(len(incremental_depth), dtype=float) + 1.0) * interval_hours
+        return pd.DataFrame(
+            {
+                "time": times,
+                "hour": hours,
+                "incremental_depth": incremental_depth,
+                "cumulative_depth": np.cumsum(incremental_depth),
+            }
+        )
+
+    @staticmethod
+    @log_call
+    def to_ras_netcdf(
+        grib2_files: Any,
+        output_netcdf: Union[str, Path],
+        bounds: Optional[Bounds] = None,
+        variable: Optional[str] = None,
+        target_crs: Optional[str] = "EPSG:5070",
+        resolution: Optional[float] = 2000.0,
+        output_variable: str = "APCP_surface",
+    ) -> Path:
+        """
+        Export MRMS QPE grids to a HEC-RAS GDAL-raster NetCDF input.
+
+        The export path is intended for ``RasUnsteady.set_gridded_precipitation``.
+        MRMS depths are written in millimeters. When ``target_crs`` is provided,
+        rioxarray reprojects the WGS84 MRMS grid to that CRS before writing.
+        """
+        precip = PrecipMrms._prepare_precipitation_data(
+            grib2_files,
+            bounds=bounds,
+            variable=variable,
+        )
+        precip_mm = PrecipMrms._convert_precip_units(precip, "mm")
+        precip_mm = precip_mm.rename(output_variable)
+        precip_mm.attrs.update(
+            {
+                "units": "mm",
+                "long_name": "MRMS QPE precipitation depth",
+                "source": "NOAA Multi-Radar Multi-Sensor QPE",
+            }
+        )
+
+        if target_crs is not None:
+            try:
+                import rioxarray  # noqa: F401
+            except ImportError as exc:
+                raise ImportError(
+                    "rioxarray is required to reproject MRMS grids for HEC-RAS. "
+                    "Install with: pip install rioxarray"
+                ) from exc
+
+            lat_name = PrecipMrms._find_coord_name(precip_mm, ("latitude", "lat", "y"))
+            lon_name = PrecipMrms._find_coord_name(precip_mm, ("longitude", "lon", "x"))
+            if lat_name is None or lon_name is None:
+                raise ValueError("MRMS data must have latitude/longitude coordinates for reprojection")
+
+            precip_mm = precip_mm.rio.write_crs("EPSG:4326")
+            precip_mm = precip_mm.rio.set_spatial_dims(x_dim=lon_name, y_dim=lat_name)
+            precip_mm = precip_mm.rio.reproject(target_crs, resolution=resolution)
+
+        output_path = Path(output_netcdf)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        precip_mm.to_dataset(name=output_variable).to_netcdf(output_path)
+        return output_path
+
+    @staticmethod
+    @log_call
+    def animate_precipitation(
+        grib2_files: Any,
+        output_mp4: Union[str, Path],
+        bounds: Optional[Bounds] = None,
+        boundary: Optional[Any] = None,
+        mesh_boundary: Optional[Any] = None,
+        pump_stations: Optional[Any] = None,
+        variable: Optional[str] = None,
+        units: str = "in/hr",
+        terrain: Optional[Any] = None,
+        add_basemap: bool = False,
+        crs: Optional[Any] = None,
+        raster_alpha: float = 0.85,
+        fps: int = 2,
+        dpi: int = 150,
+        cmap: str = "turbo",
+        title: str = "MRMS QPE",
+    ) -> Path:
+        """
+        Generate an MP4 animation of MRMS precipitation over time.
+
+        The animation includes a timestamp, colorbar, optional study area
+        boundary overlay, and spatial-mean cumulative precipitation counter.
+        ``grib2_files`` may be GRIB2 paths or an already loaded xarray/numpy
+        grid stack, which keeps notebook smoke tests independent of cfgrib.
+        """
+        precip = PrecipMrms._prepare_precipitation_data(
+            grib2_files,
+            bounds=bounds,
+            variable=variable,
+        )
+        return PrecipMrms._animate_grid_stack(
+            data=precip,
+            output_path=output_mp4,
+            title=title,
+            value_label=f"Precipitation ({units})",
+            units=units,
+            terrain=PrecipMrms._prepare_terrain_data(terrain) if terrain is not None else None,
+            boundary=boundary,
+            mesh_boundary=mesh_boundary,
+            pump_stations=pump_stations,
+            add_basemap=add_basemap,
+            crs=crs,
+            raster_alpha=raster_alpha,
+            cmap=cmap,
+            fps=fps,
+            dpi=dpi,
+            cumulative=True,
+        )
+
+    @staticmethod
+    @log_call
+    def animate_flood_inundation(
+        flood_data: Any,
+        output_mp4: Union[str, Path],
+        times: Optional[Iterable[Any]] = None,
+        extent: Optional[Tuple[float, float, float, float]] = None,
+        terrain: Optional[Any] = None,
+        boundary: Optional[Any] = None,
+        mesh_boundary: Optional[Any] = None,
+        pump_stations: Optional[Any] = None,
+        add_basemap: bool = False,
+        crs: Optional[Any] = None,
+        raster_alpha: float = 0.85,
+        mesh_name: Optional[str] = None,
+        variable: str = "Depth",
+        max_frames: Optional[int] = 24,
+        units: str = "ft",
+        fps: int = 2,
+        dpi: int = 150,
+        cmap: str = "Blues",
+        title: str = "Flood Inundation",
+    ) -> Path:
+        """
+        Generate an MP4 animation from a gridded flood-depth or WSE stack.
+
+        ``flood_data`` may be a 3-D numpy array with shape ``(time, y, x)``, an
+        xarray DataArray with a time dimension, or a HEC-RAS plan HDF path. HDF
+        inputs are rendered from 2D mesh cell centers via ras-commander HDF APIs.
+        """
+        if isinstance(flood_data, (str, Path)):
+            flood_path = Path(flood_data)
+            if flood_path.suffix.lower() in {".tif", ".tiff"}:
+                return PrecipMrms.animate_flood_inundation_from_rasters(
+                    [flood_path],
+                    output_mp4=output_mp4,
+                    terrain=terrain,
+                    boundary=boundary,
+                    mesh_boundary=mesh_boundary,
+                    pump_stations=pump_stations,
+                    add_basemap=add_basemap,
+                    crs=crs,
+                    raster_alpha=raster_alpha,
+                    units=units,
+                    fps=fps,
+                    dpi=dpi,
+                    cmap=cmap,
+                    title=title,
+                )
+            return PrecipMrms.animate_flood_inundation_from_hdf(
+                plan_hdf=flood_data,
+                output_mp4=output_mp4,
+                variable=variable,
+                mesh_name=mesh_name,
+                max_frames=max_frames,
+                boundary=boundary,
+                mesh_boundary=mesh_boundary,
+                pump_stations=pump_stations,
+                add_basemap=add_basemap,
+                crs=crs,
+                raster_alpha=raster_alpha,
+                units=units,
+                fps=fps,
+                dpi=dpi,
+                cmap=cmap,
+                title=title,
+            )
+        if PrecipMrms._looks_like_raster_paths(flood_data):
+            return PrecipMrms.animate_flood_inundation_from_rasters(
+                flood_data,
+                output_mp4=output_mp4,
+                times=times,
+                terrain=terrain,
+                boundary=boundary,
+                mesh_boundary=mesh_boundary,
+                pump_stations=pump_stations,
+                add_basemap=add_basemap,
+                crs=crs,
+                raster_alpha=raster_alpha,
+                max_frames=max_frames,
+                units=units,
+                fps=fps,
+                dpi=dpi,
+                cmap=cmap,
+                title=title,
+            )
+
+        data_array = PrecipMrms._coerce_grid_data(
+            flood_data,
+            times=times,
+            extent=extent,
+            name="flood_inundation",
+            units=units,
+        )
+        return PrecipMrms._animate_grid_stack(
+            data=data_array,
+            output_path=output_mp4,
+            title=title,
+            value_label=f"Depth ({units})",
+            units=units,
+            terrain=PrecipMrms._prepare_terrain_data(terrain) if terrain is not None else None,
+            boundary=boundary,
+            mesh_boundary=mesh_boundary,
+            pump_stations=pump_stations,
+            add_basemap=add_basemap,
+            crs=crs,
+            raster_alpha=raster_alpha,
+            cmap=cmap,
+            fps=fps,
+            dpi=dpi,
+            cumulative=False,
+        )
+
+    @staticmethod
+    @log_call
+    def animate_flood_inundation_from_hdf(
+        plan_hdf: Union[str, Path],
+        output_mp4: Union[str, Path],
+        variable: str = "Depth",
+        mesh_name: Optional[str] = None,
+        max_frames: Optional[int] = 24,
+        boundary: Optional[Any] = None,
+        mesh_boundary: Optional[Any] = None,
+        pump_stations: Optional[Any] = None,
+        add_basemap: bool = False,
+        crs: Optional[Any] = None,
+        raster_alpha: float = 0.85,
+        units: str = "ft",
+        fps: int = 2,
+        dpi: int = 150,
+        cmap: str = "Blues",
+        title: str = "HEC-RAS Flood Inundation",
+    ) -> Path:
+        """
+        Generate an MP4 flood animation from HEC-RAS 2D plan HDF results.
+
+        This method uses ras-commander HDF APIs and plots mesh cell centers as
+        a point cloud, which is lightweight and works without RAS Mapper GUI
+        automation.
+        """
+        _check_animation_dependencies()
+        import matplotlib.pyplot as plt
+        import pandas as pd
+
+        flood = PrecipMrms._load_hdf_flood_points(
+            plan_hdf=plan_hdf,
+            variable=variable,
+            mesh_name=mesh_name,
+            max_frames=max_frames,
+        )
+        value_array = flood["values"]
+        x = flood["x"]
+        y = flood["y"]
+        times = flood["times"]
+        value_units = units or flood["units"]
+        vmax = PrecipMrms._robust_vmax(value_array, 0.1)
+
+        output_path = Path(output_mp4)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+
+        fig, ax = plt.subplots(figsize=(8, 6), constrained_layout=True)
+        data_crs = crs or flood.get("crs")
+        scat = ax.scatter(
+            x,
+            y,
+            c=value_array[0],
+            s=3,
+            cmap=cmap,
+            vmin=0,
+            vmax=vmax,
+            linewidths=0,
+            alpha=raster_alpha,
+            zorder=2,
+        )
+        cbar = fig.colorbar(scat, ax=ax, shrink=0.8)
+        cbar.set_label(f"{variable} ({value_units})")
+        label = ax.text(
+            0.02,
+            0.98,
+            "",
+            transform=ax.transAxes,
+            va="top",
+            ha="left",
+            color="black",
+            bbox={"facecolor": "white", "alpha": 0.75, "edgecolor": "none"},
+        )
+        ax.set_title(title)
+        ax.set_aspect("equal", adjustable="box")
+        PrecipMrms._plot_spatial_overlays(
+            ax,
+            data_crs=data_crs,
+            boundary=boundary,
+            mesh_boundary=mesh_boundary,
+            pump_stations=pump_stations,
+            add_basemap=add_basemap,
+        )
+
+        def update(frame_idx: int) -> list:
+            scat.set_array(value_array[frame_idx])
+            label.set_text(pd.Timestamp(times[frame_idx]).strftime("%Y-%m-%d %H:%M"))
+            return [scat, label]
+
+        PrecipMrms._save_animation(fig, update, value_array.shape[0], output_path, fps, dpi)
+        return output_path
+
+    @staticmethod
+    @log_call
+    def animate_flood_inundation_from_rasters(
+        raster_files: Union[str, Path, Iterable[Union[str, Path]]],
+        output_mp4: Union[str, Path],
+        times: Optional[Iterable[Any]] = None,
+        terrain: Optional[Any] = None,
+        boundary: Optional[Any] = None,
+        mesh_boundary: Optional[Any] = None,
+        pump_stations: Optional[Any] = None,
+        add_basemap: bool = False,
+        crs: Optional[Any] = None,
+        raster_alpha: float = 0.85,
+        max_frames: Optional[int] = None,
+        units: str = "ft",
+        fps: int = 2,
+        dpi: int = 150,
+        cmap: str = "Blues",
+        title: str = "HEC-RAS Flood Inundation",
+    ) -> Path:
+        """
+        Generate a flood animation from stored-map depth rasters.
+
+        This is the raster-video companion for
+        ``RasProcess.store_maps_at_timesteps()`` outputs.
+        """
+        flood = PrecipMrms._load_raster_stack(
+            raster_files,
+            times=times,
+            max_frames=max_frames,
+            name="flood_inundation",
+            units=units,
+        )
+        return PrecipMrms._animate_grid_stack(
+            data=flood,
+            output_path=output_mp4,
+            title=title,
+            value_label=f"Depth ({units})",
+            units=units,
+            terrain=PrecipMrms._prepare_terrain_data(terrain) if terrain is not None else None,
+            boundary=boundary,
+            mesh_boundary=mesh_boundary,
+            pump_stations=pump_stations,
+            add_basemap=add_basemap,
+            crs=crs,
+            raster_alpha=raster_alpha,
+            cmap=cmap,
+            fps=fps,
+            dpi=dpi,
+            cumulative=False,
+        )
+
+    @staticmethod
+    @log_call
+    def animate_combined(
+        precip_data: Any,
+        flood_data: Any,
+        output_mp4: Union[str, Path],
+        precip_bounds: Optional[Bounds] = None,
+        flood_times: Optional[Iterable[Any]] = None,
+        flood_extent: Optional[Tuple[float, float, float, float]] = None,
+        boundary: Optional[Any] = None,
+        mesh_boundary: Optional[Any] = None,
+        pump_stations: Optional[Any] = None,
+        add_basemap: bool = False,
+        precip_crs: Optional[Any] = None,
+        flood_crs: Optional[Any] = None,
+        raster_alpha: float = 0.85,
+        fps: int = 2,
+        dpi: int = 150,
+        title: str = "MRMS Precipitation and Flood Response",
+        bounds: Optional[Bounds] = None,
+        mesh_name: Optional[str] = None,
+        flood_variable: str = "Depth",
+        max_frames: Optional[int] = 24,
+    ) -> Path:
+        """
+        Generate a synchronized split-screen precipitation and flood animation.
+
+        ``precip_data`` can be GRIB2 file paths or an already loaded xarray
+        DataArray. ``flood_data`` can be a gridded array, xarray DataArray, or a
+        HEC-RAS plan HDF path. ``bounds`` is accepted as an alias for
+        ``precip_bounds`` for notebook readability.
+        """
+        _check_animation_dependencies()
+        import matplotlib.pyplot as plt
+        import numpy as np
+        import pandas as pd
+
+        if bounds is not None and precip_bounds is None:
+            precip_bounds = bounds
+
+        precip = PrecipMrms._prepare_precipitation_data(
+            precip_data,
+            bounds=precip_bounds,
+        )
+        precip_in = PrecipMrms._convert_precip_units(precip, "in/hr")
+
+        if isinstance(flood_data, (str, Path)):
+            flood_points = PrecipMrms._load_hdf_flood_points(
+                plan_hdf=flood_data,
+                variable=flood_variable,
+                mesh_name=mesh_name,
+                max_frames=max_frames,
+            )
+            return PrecipMrms._animate_combined_hdf_points(
+                precip=precip_in,
+                flood_points=flood_points,
+                output_mp4=output_mp4,
+                boundary=boundary,
+                mesh_boundary=mesh_boundary,
+                pump_stations=pump_stations,
+                add_basemap=add_basemap,
+                precip_crs=precip_crs,
+                flood_crs=flood_crs,
+                raster_alpha=raster_alpha,
+                fps=fps,
+                dpi=dpi,
+                title=title,
+            )
+
+        if PrecipMrms._looks_like_raster_paths(flood_data):
+            flood = PrecipMrms._load_raster_stack(
+                flood_data,
+                times=flood_times,
+                max_frames=max_frames,
+                name="flood_inundation",
+                units="ft",
+            )
+        else:
+            flood = PrecipMrms._coerce_grid_data(
+                flood_data,
+                times=flood_times,
+                extent=flood_extent,
+                name="flood_inundation",
+                units="ft",
+            )
+        precip_extent, precip_origin = PrecipMrms._data_extent(precip_in)
+        flood_extent_resolved, flood_origin = PrecipMrms._data_extent(flood)
+        precip_data_crs = precip_crs or PrecipMrms._data_crs(precip_in, "EPSG:4326")
+        flood_data_crs = flood_crs or PrecipMrms._data_crs(flood)
+        precip_times = pd.to_datetime(precip_in.coords["time"].values)
+        flood_times_index = pd.to_datetime(flood.coords["time"].values)
+        n_frames = int(flood.sizes["time"])
+        if n_frames < 1 or len(precip_times) < 1:
+            raise ValueError("Combined animation requires at least one frame")
+        precip_frame_indices = PrecipMrms._nearest_previous_time_indices(
+            source_times=precip_times,
+            target_times=flood_times_index,
+        )
+        flood_values = np.asarray(flood.values, dtype=float)
+        precip_vmax = PrecipMrms._robust_vmax(np.asarray(precip_in.values), 0.1)
+        flood_vmax = PrecipMrms._robust_vmax(flood_values, 0.1)
+
+        output_path = Path(output_mp4)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+
+        fig, (ax_p, ax_f) = plt.subplots(1, 2, figsize=(12, 5), constrained_layout=True)
+        im_p = ax_p.imshow(
+            np.asarray(precip_in.isel(time=int(precip_frame_indices[0])).values, dtype=float),
+            extent=precip_extent,
+            origin=precip_origin,
+            cmap="turbo",
+            vmin=0,
+            vmax=precip_vmax,
+            alpha=raster_alpha,
+            zorder=2,
+        )
+        im_f = ax_f.imshow(
+            np.asarray(flood.isel(time=0).values, dtype=float),
+            extent=flood_extent_resolved,
+            origin=flood_origin,
+            cmap="Blues",
+            vmin=0,
+            vmax=flood_vmax,
+            alpha=raster_alpha,
+            zorder=2,
+        )
+        fig.colorbar(im_p, ax=ax_p, shrink=0.8).set_label("Precipitation (in/hr)")
+        fig.colorbar(im_f, ax=ax_f, shrink=0.8).set_label("Depth (ft)")
+        ax_p.set_title("MRMS QPE")
+        ax_f.set_title("Flood Inundation")
+        timestamp = fig.suptitle(title)
+        PrecipMrms._plot_spatial_overlays(
+            ax_p,
+            data_crs=precip_data_crs,
+            boundary=boundary,
+            mesh_boundary=mesh_boundary,
+            pump_stations=pump_stations,
+            add_basemap=add_basemap,
+        )
+        PrecipMrms._plot_spatial_overlays(
+            ax_f,
+            data_crs=flood_data_crs,
+            boundary=boundary,
+            mesh_boundary=mesh_boundary,
+            pump_stations=pump_stations,
+            add_basemap=add_basemap,
+        )
+
+        def update(frame_idx: int) -> list:
+            precip_idx = int(precip_frame_indices[frame_idx])
+            im_p.set_data(np.asarray(precip_in.isel(time=precip_idx).values, dtype=float))
+            im_f.set_data(np.asarray(flood.isel(time=frame_idx).values, dtype=float))
+            timestamp.set_text(
+                f"{title}\n"
+                f"Precip: {precip_times[precip_idx].strftime('%Y-%m-%d %H:%M')} | "
+                f"Flood: {flood_times_index[frame_idx].strftime('%Y-%m-%d %H:%M')}"
+            )
+            return [im_p, im_f, timestamp]
+
+        PrecipMrms._save_animation(fig, update, n_frames, output_path, fps, dpi)
+        return output_path
+
+    @staticmethod
+    def _prepare_precipitation_data(
+        precip_data: Any,
+        bounds: Optional[Bounds] = None,
+        variable: Optional[str] = None,
+    ) -> Any:
+        if PrecipMrms._looks_like_paths(precip_data):
+            return PrecipMrms.load_grib2_stack(
+                grib2_files=precip_data,
+                bounds=bounds,
+                variable=variable,
+            )
+
+        precip = PrecipMrms._coerce_grid_data(
+            precip_data,
+            name="mrms_precipitation",
+            units="mm",
+        )
+        if bounds is not None:
+            precip = PrecipMrms._clip_dataarray(precip, bounds)
+        return precip
+
+    @staticmethod
+    def _load_hdf_flood_points(
+        plan_hdf: Union[str, Path],
+        variable: str = "Depth",
+        mesh_name: Optional[str] = None,
+        max_frames: Optional[int] = 24,
+    ) -> Dict[str, Any]:
+        import numpy as np
+        import pandas as pd
+
+        from ..hdf.HdfBase import HdfBase
+        from ..hdf.HdfMesh import HdfMesh
+        from ..hdf.HdfResultsMesh import HdfResultsMesh
+
+        plan_hdf = Path(plan_hdf)
+        cell_points = HdfMesh.get_mesh_cell_points(plan_hdf)
+        if cell_points.empty:
+            raise ValueError(f"No 2D mesh cell centers found in {plan_hdf}")
+
+        mesh_names = list(cell_points["mesh_name"].astype(str).unique())
+        if mesh_name is None:
+            mesh_name = mesh_names[0]
+        if mesh_name not in mesh_names:
+            raise ValueError(f"mesh_name {mesh_name!r} not found; choices: {mesh_names}")
+
+        mesh_points = (
+            cell_points[cell_points["mesh_name"].astype(str) == mesh_name]
+            .sort_values("cell_id")
+            .reset_index(drop=True)
+        )
+        values = HdfResultsMesh.get_mesh_timeseries(plan_hdf, mesh_name, variable)
+        value_array = np.asarray(values.values, dtype=float)
+        if value_array.ndim == 1:
+            value_array = value_array.reshape((1, -1))
+        if value_array.ndim != 2:
+            raise ValueError(
+                f"HDF flood animation expects 2-D time/cell data, got {value_array.shape}"
+            )
+        if value_array.shape[1] != len(mesh_points) and value_array.shape[0] == len(mesh_points):
+            value_array = value_array.T
+        if value_array.shape[1] != len(mesh_points):
+            raise ValueError(
+                f"HDF {variable!r} cell count {value_array.shape[1]} does not match "
+                f"mesh cell centers {len(mesh_points)}"
+            )
+
+        if "time" in values.coords:
+            time_values = pd.to_datetime(values.coords["time"].values)
+        else:
+            time_values = pd.date_range("2000-01-01", periods=value_array.shape[0], freq="h")
+
+        if max_frames is not None and value_array.shape[0] > max_frames:
+            frame_indices = np.linspace(
+                0, value_array.shape[0] - 1, int(max_frames), dtype=int
+            )
+            value_array = value_array[frame_indices]
+            time_values = time_values[frame_indices]
+
+        return {
+            "x": mesh_points.geometry.x.to_numpy(dtype=float),
+            "y": mesh_points.geometry.y.to_numpy(dtype=float),
+            "values": value_array,
+            "times": time_values,
+            "mesh_name": mesh_name,
+            "variable": variable,
+            "units": values.attrs.get("units", ""),
+            "crs": HdfBase.get_projection(plan_hdf),
+        }
+
+    @staticmethod
+    def _animate_combined_hdf_points(
+        precip: Any,
+        flood_points: Dict[str, Any],
+        output_mp4: Union[str, Path],
+        boundary: Optional[Any],
+        mesh_boundary: Optional[Any],
+        pump_stations: Optional[Any],
+        add_basemap: bool,
+        precip_crs: Optional[Any],
+        flood_crs: Optional[Any],
+        raster_alpha: float,
+        fps: int,
+        dpi: int,
+        title: str,
+    ) -> Path:
+        import matplotlib.pyplot as plt
+        import numpy as np
+        import pandas as pd
+
+        flood_values = flood_points["values"]
+        precip_times = pd.to_datetime(precip.coords["time"].values)
+        flood_times = pd.to_datetime(flood_points["times"])
+        n_frames = int(flood_values.shape[0])
+        if n_frames < 1 or len(precip_times) < 1:
+            raise ValueError("Combined animation requires at least one frame")
+        precip_frame_indices = PrecipMrms._nearest_previous_time_indices(
+            source_times=precip_times,
+            target_times=flood_times,
+        )
+
+        precip_extent, precip_origin = PrecipMrms._data_extent(precip)
+        precip_data_crs = precip_crs or PrecipMrms._data_crs(precip, "EPSG:4326")
+        flood_data_crs = flood_crs or flood_points.get("crs")
+        precip_values = np.asarray(precip.values, dtype=float)
+        precip_vmax = PrecipMrms._robust_vmax(precip_values, 0.1)
+        flood_vmax = PrecipMrms._robust_vmax(flood_values, 0.1)
+
+        output_path = Path(output_mp4)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+
+        fig, (ax_p, ax_f) = plt.subplots(1, 2, figsize=(12, 5), constrained_layout=True)
+        im_p = ax_p.imshow(
+            np.asarray(precip.isel(time=int(precip_frame_indices[0])).values, dtype=float),
+            extent=precip_extent,
+            origin=precip_origin,
+            cmap="turbo",
+            vmin=0,
+            vmax=precip_vmax,
+            alpha=raster_alpha,
+            zorder=2,
+        )
+        scat = ax_f.scatter(
+            flood_points["x"],
+            flood_points["y"],
+            c=flood_values[0],
+            s=3,
+            cmap="Blues",
+            vmin=0,
+            vmax=flood_vmax,
+            linewidths=0,
+            alpha=raster_alpha,
+            zorder=2,
+        )
+        fig.colorbar(im_p, ax=ax_p, shrink=0.8).set_label("Precipitation (in/hr)")
+        flood_label = flood_points["variable"]
+        flood_units = flood_points["units"]
+        fig.colorbar(scat, ax=ax_f, shrink=0.8).set_label(
+            f"{flood_label} ({flood_units})" if flood_units else flood_label
+        )
+        ax_p.set_title("MRMS QPE")
+        ax_f.set_title("Flood Inundation")
+        ax_f.set_aspect("equal", adjustable="box")
+        timestamp = fig.suptitle(title)
+        PrecipMrms._plot_spatial_overlays(
+            ax_p,
+            data_crs=precip_data_crs,
+            boundary=boundary,
+            mesh_boundary=mesh_boundary,
+            pump_stations=pump_stations,
+            add_basemap=add_basemap,
+        )
+        PrecipMrms._plot_spatial_overlays(
+            ax_f,
+            data_crs=flood_data_crs,
+            boundary=boundary,
+            mesh_boundary=mesh_boundary,
+            pump_stations=pump_stations,
+            add_basemap=add_basemap,
+        )
+
+        def update(frame_idx: int) -> list:
+            precip_idx = int(precip_frame_indices[frame_idx])
+            im_p.set_data(np.asarray(precip.isel(time=precip_idx).values, dtype=float))
+            scat.set_array(flood_values[frame_idx])
+            timestamp.set_text(
+                f"{title}\n"
+                f"Precip: {precip_times[precip_idx].strftime('%Y-%m-%d %H:%M')} | "
+                f"Flood: {flood_times[frame_idx].strftime('%Y-%m-%d %H:%M')}"
+            )
+            return [im_p, scat, timestamp]
+
+        PrecipMrms._save_animation(fig, update, n_frames, output_path, fps, dpi)
+        return output_path
+
+    @staticmethod
+    def _catalog_noaa_s3(
+        start_ts: "pd.Timestamp",
+        end_ts: "pd.Timestamp",
+        product: str,
+        timeout: int,
+    ) -> "pd.DataFrame":
+        import pandas as pd
+        import requests
+
+        product_info = PrecipMrms._product_info(product)
+        s3_product = product_info["s3_product"]
+        records = []
+
+        for day in PrecipMrms._iter_days(start_ts, end_ts):
+            prefix = f"CONUS/{s3_product}/{day:%Y%m%d}/"
+            continuation = None
+            while True:
+                params = {
+                    "list-type": "2",
+                    "prefix": prefix,
+                    "max-keys": "1000",
+                }
+                if continuation:
+                    params["continuation-token"] = continuation
+                response = requests.get(
+                    PrecipMrms.NOAA_S3_BASE_URL,
+                    params=params,
+                    timeout=timeout,
+                )
+                if response.status_code == 404:
+                    break
+                response.raise_for_status()
+                root = ET.fromstring(response.content)
+                namespace = PrecipMrms._xml_namespace(root)
+
+                for item in root.findall(f"{namespace}Contents"):
+                    key = PrecipMrms._xml_text(item, "Key", namespace)
+                    if not key or not key.endswith((".grib2", ".grib2.gz")):
+                        continue
+                    valid_time = PrecipMrms._timestamp_from_name(Path(key).name)
+                    if valid_time is None:
+                        continue
+                    size_text = PrecipMrms._xml_text(item, "Size", namespace)
+                    last_modified = PrecipMrms._xml_text(item, "LastModified", namespace)
+                    records.append(
+                        {
+                            "valid_time": valid_time,
+                            "source": "noaa_s3",
+                            "product": product_info["canonical"],
+                            "archive_product": s3_product,
+                            "url": f"{PrecipMrms.NOAA_S3_BASE_URL}/{quote(key)}",
+                            "filename": Path(key).name,
+                            "size_bytes": int(size_text or 0),
+                            "last_modified": pd.to_datetime(last_modified)
+                            if last_modified
+                            else pd.NaT,
+                            "compressed": key.endswith(".gz"),
+                        }
+                    )
+
+                next_token = PrecipMrms._xml_text(
+                    root, "NextContinuationToken", namespace
+                )
+                truncated = PrecipMrms._xml_text(root, "IsTruncated", namespace)
+                if truncated != "true" or not next_token:
+                    break
+                continuation = next_token
+
+        return PrecipMrms._records_to_catalog(records)
+
+    @staticmethod
+    def _catalog_iowa_mtarchive(
+        start_ts: "pd.Timestamp",
+        end_ts: "pd.Timestamp",
+        product: str,
+        timeout: int,
+    ) -> "pd.DataFrame":
+        import pandas as pd
+        import requests
+
+        product_info = PrecipMrms._product_info(product)
+        iowa_product = product_info["iowa_product"]
+        if not iowa_product:
+            return PrecipMrms._empty_catalog()
+
+        records = []
+        for day in PrecipMrms._iter_days(start_ts, end_ts):
+            catalog_url = (
+                f"{PrecipMrms.IOWA_CATALOG_BASE_URL}/mtarchive/"
+                f"{day:%Y/%m/%d}/mrms/ncep/{iowa_product}/catalog.xml"
+            )
+            response = requests.get(catalog_url, timeout=timeout)
+            if response.status_code == 404:
+                continue
+            response.raise_for_status()
+            root = ET.fromstring(response.content)
+            namespace = PrecipMrms._xml_namespace(root)
+
+            for dataset in root.findall(f".//{namespace}dataset"):
+                filename = dataset.attrib.get("name", "")
+                url_path = dataset.attrib.get("urlPath", "")
+                if not filename.endswith((".grib2", ".grib2.gz")) or not url_path:
+                    continue
+                valid_time = PrecipMrms._timestamp_from_name(filename)
+                if valid_time is None:
+                    continue
+                size_bytes = PrecipMrms._parse_thredds_size(dataset, namespace)
+                modified_text = PrecipMrms._xml_text(dataset, "date", namespace)
+                records.append(
+                    {
+                        "valid_time": valid_time,
+                        "source": "iowa",
+                        "product": product_info["canonical"],
+                        "archive_product": iowa_product,
+                        "url": f"{PrecipMrms.IOWA_FILESERVER_BASE_URL}/{quote(url_path)}",
+                        "filename": filename,
+                        "size_bytes": size_bytes,
+                        "last_modified": pd.to_datetime(modified_text)
+                        if modified_text
+                        else pd.NaT,
+                        "compressed": filename.endswith(".gz"),
+                    }
+                )
+
+        return PrecipMrms._records_to_catalog(records)
+
+    @staticmethod
+    def _records_to_catalog(records: List[Dict[str, Any]]) -> "pd.DataFrame":
+        import pandas as pd
+
+        if not records:
+            return PrecipMrms._empty_catalog()
+
+        df = pd.DataFrame.from_records(records)
+        df["valid_time"] = pd.to_datetime(df["valid_time"])
+        df = PrecipMrms._dedupe_catalog(df)
+        return df.sort_values(["valid_time", "source", "filename"]).reset_index(drop=True)
+
+    @staticmethod
+    def _empty_catalog() -> "pd.DataFrame":
+        import pandas as pd
+
+        return pd.DataFrame(
+            columns=[
+                "valid_time",
+                "source",
+                "product",
+                "archive_product",
+                "url",
+                "filename",
+                "size_bytes",
+                "last_modified",
+                "compressed",
+            ]
+        )
+
+    @staticmethod
+    def _filter_catalog(
+        catalog_df: "pd.DataFrame",
+        start_ts: "pd.Timestamp",
+        end_ts: "pd.Timestamp",
+    ) -> "pd.DataFrame":
+        if catalog_df.empty:
+            return catalog_df
+        mask = (catalog_df["valid_time"] >= start_ts) & (
+            catalog_df["valid_time"] <= end_ts
+        )
+        return catalog_df.loc[mask].sort_values("valid_time").reset_index(drop=True)
+
+    @staticmethod
+    def _dedupe_catalog(catalog_df: "pd.DataFrame") -> "pd.DataFrame":
+        if catalog_df.empty:
+            return catalog_df
+        df = catalog_df.copy()
+        df["_prefer_uncompressed"] = df["compressed"].map(lambda value: 1 if not value else 0)
+        df = df.sort_values(
+            ["valid_time", "source", "_prefer_uncompressed", "filename"],
+            ascending=[True, True, False, True],
+        )
+        df = df.drop_duplicates(
+            subset=["valid_time", "source", "archive_product"],
+            keep="first",
+        )
+        return df.drop(columns=["_prefer_uncompressed"]).reset_index(drop=True)
+
+    @staticmethod
+    def _prefer_catalog_source(catalog_df: "pd.DataFrame") -> "pd.DataFrame":
+        if catalog_df.empty:
+            return catalog_df
+        source_rank = {"noaa_s3": 0, "iowa": 1}
+        df = catalog_df.copy()
+        df["_source_rank"] = df["source"].map(source_rank).fillna(99)
+        df = df.sort_values(["valid_time", "_source_rank", "filename"])
+        df = df.drop_duplicates(subset=["valid_time", "product"], keep="first")
+        return df.drop(columns=["_source_rank"]).reset_index(drop=True)
+
+    @staticmethod
+    def _download_one(
+        url: str,
+        local_path: Path,
+        decompress: bool,
+        timeout: int,
+    ) -> None:
+        import requests
+
+        tmp_path = local_path.with_name(local_path.name + ".tmp")
+        gz_tmp_path = local_path.with_name(local_path.name + ".gz.tmp")
+
+        for stale in (tmp_path, gz_tmp_path):
+            if stale.exists():
+                stale.unlink()
+
+        response = requests.get(url, stream=True, timeout=timeout)
+        response.raise_for_status()
+
+        if decompress:
+            with open(gz_tmp_path, "wb") as gz_file:
+                for chunk in response.iter_content(chunk_size=1024 * 1024):
+                    if chunk:
+                        gz_file.write(chunk)
+            with gzip.open(gz_tmp_path, "rb") as src, open(tmp_path, "wb") as dst:
+                shutil.copyfileobj(src, dst)
+            gz_tmp_path.unlink(missing_ok=True)
+        else:
+            with open(tmp_path, "wb") as dst:
+                for chunk in response.iter_content(chunk_size=1024 * 1024):
+                    if chunk:
+                        dst.write(chunk)
+
+        tmp_path.replace(local_path)
+
+    @staticmethod
+    def _product_info(product: str) -> Dict[str, Any]:
+        canonical = PrecipMrms._canonical_product(product)
+        hours = PrecipMrms._product_hours(canonical)
+        if hours not in PrecipMrms.PRODUCT_HOURS:
+            raise ValueError(
+                f"Unsupported MRMS QPE duration {hours}H. "
+                f"Supported durations: {PrecipMrms.PRODUCT_HOURS}"
+            )
+
+        hours_text = f"{hours:02d}H"
+        is_radar_only = canonical.lower().startswith("radaronly_")
+        s3_stem = "RadarOnly_QPE" if is_radar_only else "MultiSensor_QPE"
+        return {
+            "canonical": canonical,
+            "hours": hours,
+            "family": "RadarOnly" if is_radar_only else "GaugeCorr",
+            "iowa_product": (
+                f"GaugeCorr_QPE_{hours_text}"
+                if not is_radar_only and hours == 1
+                else None
+            ),
+            "s3_product": (
+                f"{s3_stem}_{hours_text}"
+                if is_radar_only
+                else f"{s3_stem}_{hours_text}_{PrecipMrms.DEFAULT_S3_PASS}_00.00"
+            ),
+        }
+
+    @staticmethod
+    def _canonical_product(product: str) -> str:
+        cleaned = str(product).strip()
+        compact = cleaned.replace("-", "_")
+
+        if compact.lower().startswith("multisensor_qpe_"):
+            hours = PrecipMrms._product_hours(compact)
+            return f"GaugeCorr_QPE_{hours:02d}H"
+
+        if compact.lower().startswith("radaronly_qpe"):
+            hours = PrecipMrms._product_hours(compact)
+            return f"RadarOnly_QPE_{hours:02d}H"
+
+        if compact.lower().startswith("gaugecorr"):
+            hours = PrecipMrms._product_hours(compact)
+            return f"GaugeCorr_QPE_{hours:02d}H"
+
+        hours_match = re.search(r"(?:QPE_?|QPE)(\d{1,2})H", compact, re.IGNORECASE)
+        if hours_match:
+            return f"GaugeCorr_QPE_{int(hours_match.group(1)):02d}H"
+
+        match = re.search(r"(\d{1,2})H", compact, re.IGNORECASE)
+        if match:
+            return f"GaugeCorr_QPE_{int(match.group(1)):02d}H"
+
+        raise ValueError(
+            f"Unsupported MRMS product {product!r}. "
+            "Use names like 'GaugeCorr_QPE_01H', 'RadarOnly_QPE_01H', "
+            "or 'MultiSensor_QPE_01H_Pass2_00.00'."
+        )
+
+    @staticmethod
+    def _vortex_variables(product: str) -> List[str]:
+        compact = str(product).strip().replace("-", "_")
+        multisensor_match = re.search(
+            r"MultiSensor_QPE_(\d{1,2})H_(Pass\d)",
+            compact,
+            flags=re.IGNORECASE,
+        )
+        if multisensor_match:
+            hours = int(multisensor_match.group(1))
+            pass_name = multisensor_match.group(2)
+            return [f"MultiSensor_QPE_{hours:02d}H_{pass_name}_altitude_above_msl"]
+
+        product_info = PrecipMrms._product_info(product)
+        hours_text = f"{product_info['hours']:02d}H"
+        if product_info["family"] == "RadarOnly":
+            stem = "RadarOnlyQPE"
+        else:
+            stem = "GaugeCorrQPE"
+        return [f"{stem}{hours_text}_altitude_above_msl"]
+
+    @staticmethod
+    def _vortex_variables_for_files(product: str, grib_paths: Iterable[Path]) -> List[str]:
+        for grib_path in grib_paths:
+            filename = grib_path.name
+            multisensor_match = re.search(
+                r"MRMS_(MultiSensor_QPE_(\d{1,2})H_(Pass\d))_",
+                filename,
+                flags=re.IGNORECASE,
+            )
+            if multisensor_match:
+                hours = int(multisensor_match.group(2))
+                pass_name = multisensor_match.group(3)
+                return [
+                    f"MultiSensor_QPE_{hours:02d}H_{pass_name}_altitude_above_msl"
+                ]
+
+            radaronly_match = re.search(
+                r"MRMS_(RadarOnly_QPE_(\d{1,2})H)_",
+                filename,
+                flags=re.IGNORECASE,
+            )
+            if radaronly_match:
+                hours = int(radaronly_match.group(2))
+                return [f"RadarOnlyQPE{hours:02d}H_altitude_above_msl"]
+
+        return PrecipMrms._vortex_variables(product)
+
+    @staticmethod
+    def _product_hours(product: str) -> int:
+        match = re.search(r"(\d{1,2})H", str(product), flags=re.IGNORECASE)
+        if not match:
+            raise ValueError(f"Could not determine MRMS QPE duration from {product!r}")
+        return int(match.group(1))
+
+    @staticmethod
+    def _validate_bounds(bounds: Bounds) -> None:
+        if len(bounds) != 4:
+            raise ValueError("bounds must be (west, south, east, north)")
+        west, south, east, north = [float(value) for value in bounds]
+        if west >= east or south >= north:
+            raise ValueError(f"Invalid bounds: {bounds}")
+        conus_west, conus_south, conus_east, conus_north = PrecipMrms.CONUS_BOUNDS
+        if (
+            east < conus_west
+            or west > conus_east
+            or north < conus_south
+            or south > conus_north
+        ):
+            logger.warning(
+                "Bounds %s do not intersect approximate MRMS CONUS bounds %s",
+                bounds,
+                PrecipMrms.CONUS_BOUNDS,
+            )
+
+    @staticmethod
+    def _parse_timestamp(value: Union[str, datetime], end_of_day: bool):
+        import pandas as pd
+
+        is_date_only = isinstance(value, str) and bool(_DATE_ONLY_RE.match(value.strip()))
+        ts = pd.Timestamp(value)
+        if ts.tzinfo is not None:
+            ts = ts.tz_convert("UTC").tz_localize(None)
+        if is_date_only and end_of_day:
+            ts = ts + pd.Timedelta(days=1) - pd.Timedelta(nanoseconds=1)
+        return ts
+
+    @staticmethod
+    def _iter_days(start_ts: "pd.Timestamp", end_ts: "pd.Timestamp"):
+        current = start_ts.normalize()
+        last = end_ts.normalize()
+        while current <= last:
+            yield current.to_pydatetime()
+            current += timedelta(days=1)
+
+    @staticmethod
+    def _timestamp_from_name(filename: str) -> Optional[datetime]:
+        match = _TIMESTAMP_RE.search(filename)
+        if not match:
+            return None
+        return datetime.strptime("".join(match.groups()), "%Y%m%d%H%M%S")
+
+    @staticmethod
+    def _xml_namespace(root: ET.Element) -> str:
+        if root.tag.startswith("{"):
+            return root.tag.split("}", 1)[0] + "}"
+        return ""
+
+    @staticmethod
+    def _xml_text(element: ET.Element, tag: str, namespace: str) -> Optional[str]:
+        child = element.find(f"{namespace}{tag}")
+        if child is None or child.text is None:
+            return None
+        return child.text.strip()
+
+    @staticmethod
+    def _parse_thredds_size(dataset: ET.Element, namespace: str) -> int:
+        size_node = dataset.find(f"{namespace}dataSize")
+        if size_node is None or not size_node.text:
+            return 0
+
+        try:
+            size_value = float(size_node.text.strip())
+        except ValueError:
+            return 0
+
+        units = size_node.attrib.get("units", "").lower()
+        if units.startswith("k"):
+            return int(size_value * 1024)
+        if units.startswith("m"):
+            return int(size_value * 1024 * 1024)
+        if units.startswith("g"):
+            return int(size_value * 1024 * 1024 * 1024)
+        return int(size_value)
+
+    @staticmethod
+    def _normalize_paths(
+        paths: Union[str, Path, Iterable[Union[str, Path]]]
+    ) -> List[Path]:
+        if isinstance(paths, (str, Path)):
+            return [Path(paths)]
+        return [Path(path) for path in paths]
+
+    @staticmethod
+    def _select_data_var(ds: Any, variable: Optional[str]) -> str:
+        if variable is not None:
+            if variable not in ds.data_vars:
+                raise ValueError(
+                    f"Variable {variable!r} not found in GRIB2. "
+                    f"Available variables: {list(ds.data_vars)}"
+                )
+            return variable
+
+        data_vars = list(ds.data_vars)
+        if not data_vars:
+            raise ValueError("No data variables found in MRMS GRIB2 file")
+        if len(data_vars) == 1:
+            return data_vars[0]
+
+        priority = ["qpe", "precip", "unknown", "tp"]
+        for token in priority:
+            for var_name in data_vars:
+                if token in var_name.lower():
+                    return var_name
+        return data_vars[0]
+
+    @staticmethod
+    def _drop_scalar_coords(da: Any) -> Any:
+        scalar_coords = [
+            name for name in da.coords if name not in da.dims and da.coords[name].ndim == 0
+        ]
+        if scalar_coords:
+            try:
+                da = da.drop_vars(scalar_coords)
+            except ValueError:
+                pass
+        return da
+
+    @staticmethod
+    def _frame_time_from_dataarray(da: Any, grib_path: Path) -> datetime:
+        for coord_name in ("valid_time", "time"):
+            if coord_name in da.coords:
+                timestamp = PrecipMrms._timestamp_from_xarray(da.coords[coord_name])
+                if timestamp is not None:
+                    return timestamp
+        timestamp = PrecipMrms._timestamp_from_name(grib_path.name)
+        if timestamp is not None:
+            return timestamp
+        return datetime.fromtimestamp(grib_path.stat().st_mtime)
+
+    @staticmethod
+    def _timestamp_from_xarray(coord: Any) -> Optional[datetime]:
+        """Extract a scalar datetime from an xarray coordinate-like object."""
+        import numpy as np
+        import pandas as pd
+
+        values = getattr(coord, "values", coord)
+        array = np.asarray(values)
+        if array.size == 0:
+            return None
+
+        value = array.reshape(-1)[0]
+        try:
+            timestamp = pd.Timestamp(value)
+        except Exception:
+            return None
+
+        if pd.isna(timestamp):
+            return None
+        if timestamp.tzinfo is not None:
+            timestamp = timestamp.tz_convert("UTC").tz_localize(None)
+        return timestamp.to_pydatetime()
+
+    @staticmethod
+    def _clip_dataarray(da: Any, bounds: Bounds) -> Any:
+        import xarray as xr
+
+        west, south, east, north = bounds
+        lat_name = PrecipMrms._find_coord_name(da, ("latitude", "lat", "y"))
+        lon_name = PrecipMrms._find_coord_name(da, ("longitude", "lon", "x"))
+        if lat_name is None or lon_name is None:
+            logger.warning("MRMS grid has no latitude/longitude coordinates; skipping clip")
+            return da
+
+        lon = da[lon_name]
+        lat = da[lat_name]
+        lon_values = xr.where(lon > 180, lon - 360, lon)
+
+        if lat.ndim == 1 and lon.ndim == 1 and lat_name in da.dims and lon_name in da.dims:
+            da = da.assign_coords({lon_name: lon_values})
+            lat_values = da[lat_name].values
+            lon_values_np = da[lon_name].values
+            lat_slice = slice(north, south) if lat_values[0] > lat_values[-1] else slice(south, north)
+            lon_slice = slice(west, east) if lon_values_np[0] <= lon_values_np[-1] else slice(east, west)
+            return da.sel({lat_name: lat_slice, lon_name: lon_slice})
+
+        mask = (
+            (lat >= south)
+            & (lat <= north)
+            & (lon_values >= west)
+            & (lon_values <= east)
+        )
+        if not bool(mask.any()):
+            raise ValueError(f"Bounds do not intersect MRMS grid: {bounds}")
+        return da.where(mask, drop=True)
+
+    @staticmethod
+    def _find_coord_name(da: Any, candidates: Tuple[str, ...]) -> Optional[str]:
+        lower_lookup = {name.lower(): name for name in list(da.coords) + list(da.dims)}
+        for candidate in candidates:
+            if candidate.lower() in lower_lookup:
+                return lower_lookup[candidate.lower()]
+        return None
+
+    @staticmethod
+    def _looks_like_paths(value: Any) -> bool:
+        if isinstance(value, (str, Path)):
+            return True
+        if isinstance(value, (list, tuple, set)) and not hasattr(value, "dims"):
+            values = list(value)
+            return bool(values) and all(isinstance(item, (str, Path)) for item in values)
+        return False
+
+    @staticmethod
+    def _looks_like_raster_paths(value: Any) -> bool:
+        if isinstance(value, (str, Path)):
+            return Path(value).suffix.lower() in {".tif", ".tiff"}
+        if isinstance(value, (list, tuple, set)) and not hasattr(value, "dims"):
+            values = list(value)
+            return bool(values) and all(
+                isinstance(item, (str, Path))
+                and Path(item).suffix.lower() in {".tif", ".tiff"}
+                for item in values
+            )
+        return False
+
+    @staticmethod
+    def _coerce_grid_data(
+        data: Any,
+        times: Optional[Iterable[Any]] = None,
+        extent: Optional[Tuple[float, float, float, float]] = None,
+        name: str = "value",
+        units: str = "",
+    ) -> Any:
+        import numpy as np
+        import pandas as pd
+        import xarray as xr
+
+        if hasattr(data, "dims") and hasattr(data, "values"):
+            da = data
+            if "time" not in da.dims:
+                da = da.expand_dims(time=[pd.Timestamp("2000-01-01")])
+            return da
+
+        array = np.asarray(data, dtype=float)
+        if array.ndim == 2:
+            array = array.reshape((1, array.shape[0], array.shape[1]))
+        if array.ndim != 3:
+            raise ValueError("Grid animation data must be 2-D or 3-D")
+
+        if times is None:
+            time_index = pd.date_range("2000-01-01", periods=array.shape[0], freq="h")
+        else:
+            time_index = pd.DatetimeIndex(pd.to_datetime(list(times)), name="time")
+            if len(time_index) != array.shape[0]:
+                raise ValueError("times length must match flood_data time dimension")
+
+        y_size, x_size = array.shape[1], array.shape[2]
+        if extent is None:
+            x_coords = np.arange(x_size)
+            y_coords = np.arange(y_size)
+        else:
+            west, east, south, north = extent
+            x_coords = np.linspace(west, east, x_size)
+            y_coords = np.linspace(south, north, y_size)
+
+        da = xr.DataArray(
+            array,
+            dims=("time", "y", "x"),
+            coords={"time": time_index, "y": y_coords, "x": x_coords},
+            name=name,
+            attrs={"units": units},
+        )
+        return da
+
+    @staticmethod
+    def _load_raster_stack(
+        raster_files: Union[str, Path, Iterable[Union[str, Path]]],
+        times: Optional[Iterable[Any]] = None,
+        max_frames: Optional[int] = None,
+        name: str = "raster",
+        units: str = "",
+    ) -> Any:
+        try:
+            import rasterio
+        except ImportError as exc:
+            raise ImportError(
+                "rasterio is required to animate stored-map rasters. "
+                "Install with: pip install rasterio"
+            ) from exc
+
+        import numpy as np
+        import pandas as pd
+        import xarray as xr
+
+        raster_paths = PrecipMrms._normalize_paths(raster_files)
+        if not raster_paths:
+            raise ValueError("raster_files must contain at least one raster")
+
+        frames = []
+        x_coords = None
+        y_coords = None
+        crs = None
+        for raster_path in raster_paths:
+            if not raster_path.exists():
+                raise FileNotFoundError(f"Raster file not found: {raster_path}")
+            with rasterio.open(raster_path) as src:
+                data = src.read(1).astype(float)
+                if crs is None and src.crs is not None:
+                    crs = src.crs.to_string()
+                if src.nodata is not None:
+                    data[data == src.nodata] = np.nan
+                if x_coords is None or y_coords is None:
+                    rows, cols = data.shape
+                    xs = np.arange(cols) + 0.5
+                    ys = np.arange(rows) + 0.5
+                    x_coords = src.transform.c + xs * src.transform.a
+                    y_coords = src.transform.f + ys * src.transform.e
+                frames.append(data)
+
+        values = np.stack(frames, axis=0)
+
+        if times is None:
+            time_index = pd.date_range("2000-01-01", periods=values.shape[0], freq="h")
+        else:
+            time_index = pd.DatetimeIndex(pd.to_datetime(list(times)), name="time")
+            if len(time_index) != values.shape[0]:
+                raise ValueError("times length must match raster_files length")
+
+        if max_frames is not None and values.shape[0] > max_frames:
+            frame_indices = np.linspace(0, values.shape[0] - 1, int(max_frames), dtype=int)
+            values = values[frame_indices]
+            time_index = time_index[frame_indices]
+
+        return xr.DataArray(
+            values,
+            dims=("time", "y", "x"),
+            coords={"time": time_index, "y": y_coords, "x": x_coords},
+            name=name,
+            attrs={"units": units, "crs": crs} if crs else {"units": units},
+        )
+
+    @staticmethod
+    def _prepare_terrain_data(terrain: Any) -> Any:
+        if terrain is None:
+            return None
+        if isinstance(terrain, (str, Path)):
+            try:
+                import rasterio
+            except ImportError as exc:
+                raise ImportError(
+                    "rasterio is required to use a terrain raster overlay. "
+                    "Install with: pip install rasterio"
+                ) from exc
+            with rasterio.open(terrain) as src:
+                terrain_data = src.read(1).astype(float)
+                if src.nodata is not None:
+                    terrain_data[terrain_data == src.nodata] = float("nan")
+            return PrecipMrms._hillshade(terrain_data)
+        return terrain
+
+    @staticmethod
+    def _hillshade(values: Any, azimuth: float = 315.0, altitude: float = 45.0) -> Any:
+        import numpy as np
+
+        data = np.asarray(values, dtype=float)
+        if data.ndim != 2:
+            return data
+        filled = np.where(np.isfinite(data), data, np.nanmean(data))
+        dy, dx = np.gradient(filled)
+        slope = np.pi / 2.0 - np.arctan(np.hypot(dx, dy))
+        aspect = np.arctan2(-dx, dy)
+        azimuth_rad = np.deg2rad(azimuth)
+        altitude_rad = np.deg2rad(altitude)
+        shaded = (
+            np.sin(altitude_rad) * np.sin(slope)
+            + np.cos(altitude_rad) * np.cos(slope) * np.cos(azimuth_rad - aspect)
+        )
+        return np.clip((shaded + 1.0) / 2.0, 0.0, 1.0)
+
+    @staticmethod
+    def _convert_precip_units(data: Any, units: str) -> Any:
+        units_clean = units.lower().strip()
+        if units_clean.startswith("in"):
+            converted = data / 25.4
+            converted.attrs.update(data.attrs)
+            converted.attrs["units"] = units
+            return converted
+        converted = data.copy()
+        converted.attrs["units"] = units
+        return converted
+
+    @staticmethod
+    def _animate_grid_stack(
+        data: Any,
+        output_path: Union[str, Path],
+        title: str,
+        value_label: str,
+        units: str,
+        boundary: Optional[Any] = None,
+        mesh_boundary: Optional[Any] = None,
+        pump_stations: Optional[Any] = None,
+        terrain: Optional[Any] = None,
+        add_basemap: bool = False,
+        crs: Optional[Any] = None,
+        raster_alpha: float = 0.85,
+        cmap: str = "viridis",
+        fps: int = 2,
+        dpi: int = 150,
+        cumulative: bool = False,
+    ) -> Path:
+        _check_animation_dependencies()
+        import matplotlib.pyplot as plt
+        import numpy as np
+        import pandas as pd
+
+        if "time" not in data.dims:
+            raise ValueError("Animation data must have a time dimension")
+
+        plot_data = PrecipMrms._convert_precip_units(data, units) if cumulative else data
+        values = np.asarray(plot_data.values, dtype=float)
+        if values.ndim != 3:
+            raise ValueError(f"Animation data must be 3-D, got shape {values.shape}")
+
+        extent, origin = PrecipMrms._data_extent(plot_data)
+        data_crs = crs or PrecipMrms._data_crs(plot_data)
+        vmax = PrecipMrms._robust_vmax(values, 0.1)
+        output = Path(output_path)
+        output.parent.mkdir(parents=True, exist_ok=True)
+
+        fig, ax = plt.subplots(figsize=(8, 6), constrained_layout=True)
+        if terrain is not None:
+            ax.imshow(
+                terrain,
+                extent=extent,
+                origin=origin,
+                cmap="gray",
+                alpha=0.35,
+                zorder=1,
+            )
+        image = ax.imshow(
+            values[0],
+            extent=extent,
+            origin=origin,
+            cmap=cmap,
+            vmin=0,
+            vmax=vmax,
+            alpha=raster_alpha,
+            zorder=2,
+        )
+        cbar = fig.colorbar(image, ax=ax, shrink=0.8)
+        cbar.set_label(value_label)
+        annotation = ax.text(
+            0.02,
+            0.98,
+            "",
+            transform=ax.transAxes,
+            va="top",
+            ha="left",
+            color="black",
+            bbox={"facecolor": "white", "alpha": 0.75, "edgecolor": "none"},
+        )
+        ax.set_title(title)
+        ax.set_xlabel("Longitude" if "longitude" in plot_data.coords else "X")
+        ax.set_ylabel("Latitude" if "latitude" in plot_data.coords else "Y")
+        PrecipMrms._plot_spatial_overlays(
+            ax,
+            data_crs=data_crs,
+            boundary=boundary,
+            mesh_boundary=mesh_boundary,
+            pump_stations=pump_stations,
+            add_basemap=add_basemap,
+        )
+
+        times = pd.to_datetime(plot_data.coords["time"].values)
+        cumulative_values = (
+            np.nanmean(values, axis=(1, 2)).cumsum() if cumulative else None
+        )
+
+        def update(frame_idx: int) -> list:
+            image.set_data(values[frame_idx])
+            timestamp = times[frame_idx].strftime("%Y-%m-%d %H:%M")
+            if cumulative:
+                annotation.set_text(
+                    f"{timestamp}\nMean cumulative: {cumulative_values[frame_idx]:.2f} {units}"
+                )
+            else:
+                annotation.set_text(timestamp)
+            return [image, annotation]
+
+        PrecipMrms._save_animation(fig, update, values.shape[0], output, fps, dpi)
+        return output
+
+    @staticmethod
+    def _save_animation(
+        fig: Any,
+        update_func: Any,
+        frame_count: int,
+        output_path: Path,
+        fps: int,
+        dpi: int,
+    ) -> None:
+        import matplotlib.pyplot as plt
+        from matplotlib import animation
+
+        anim = animation.FuncAnimation(
+            fig,
+            update_func,
+            frames=frame_count,
+            blit=False,
+            repeat=False,
+        )
+        suffix = output_path.suffix.lower()
+        try:
+            if suffix == ".gif":
+                writer = animation.PillowWriter(fps=fps)
+            else:
+                if not animation.writers.is_available("ffmpeg"):
+                    raise RuntimeError(
+                        "Matplotlib ffmpeg writer is not available. Install ffmpeg "
+                        "or save as .gif with PillowWriter."
+                    )
+                writer = animation.FFMpegWriter(fps=fps, bitrate=1800)
+            anim.save(output_path, writer=writer, dpi=dpi)
+        finally:
+            plt.close(fig)
+
+    @staticmethod
+    def _data_extent(data: Any) -> Tuple[Tuple[float, float, float, float], str]:
+        import numpy as np
+
+        lat_name = PrecipMrms._find_coord_name(data, ("latitude", "lat"))
+        lon_name = PrecipMrms._find_coord_name(data, ("longitude", "lon"))
+        if lat_name is not None and lon_name is not None:
+            lat = np.asarray(data[lat_name].values, dtype=float)
+            lon = np.asarray(data[lon_name].values, dtype=float)
+            lon = np.where(lon > 180, lon - 360, lon)
+            origin = "upper" if lat.ndim == 1 and lat[0] > lat[-1] else "lower"
+            return (
+                float(np.nanmin(lon)),
+                float(np.nanmax(lon)),
+                float(np.nanmin(lat)),
+                float(np.nanmax(lat)),
+            ), origin
+
+        if "x" in data.coords and "y" in data.coords:
+            x = np.asarray(data.coords["x"].values, dtype=float)
+            y = np.asarray(data.coords["y"].values, dtype=float)
+            origin = "upper" if y.ndim == 1 and y[0] > y[-1] else "lower"
+            return (
+                float(np.nanmin(x)),
+                float(np.nanmax(x)),
+                float(np.nanmin(y)),
+                float(np.nanmax(y)),
+            ), origin
+
+        shape = data.isel(time=0).shape
+        return (0.0, float(shape[1]), 0.0, float(shape[0])), "lower"
+
+    @staticmethod
+    def _data_crs(data: Any, fallback: Optional[Any] = None) -> Optional[Any]:
+        attrs = getattr(data, "attrs", {}) or {}
+        crs = attrs.get("crs") or attrs.get("spatial_ref")
+        if crs:
+            return crs
+        rio = getattr(data, "rio", None)
+        if rio is not None:
+            try:
+                if rio.crs is not None:
+                    return rio.crs
+            except Exception:
+                pass
+        if "latitude" in getattr(data, "coords", {}) and "longitude" in getattr(data, "coords", {}):
+            return "EPSG:4326"
+        if "lat" in getattr(data, "coords", {}) and "lon" in getattr(data, "coords", {}):
+            return "EPSG:4326"
+        return fallback
+
+    @staticmethod
+    def _nearest_previous_time_indices(source_times: Any, target_times: Any) -> Any:
+        import numpy as np
+        import pandas as pd
+
+        source = pd.DatetimeIndex(pd.to_datetime(source_times))
+        target = pd.DatetimeIndex(pd.to_datetime(target_times))
+        if len(source) == 0:
+            raise ValueError("source_times must contain at least one timestamp")
+        positions = np.searchsorted(source.values, target.values, side="right") - 1
+        return np.clip(positions, 0, len(source) - 1).astype(int)
+
+    @staticmethod
+    def _robust_vmax(values: Any, minimum: float) -> float:
+        import numpy as np
+
+        finite = np.asarray(values, dtype=float)
+        finite = finite[np.isfinite(finite)]
+        finite = finite[finite > 0]
+        if finite.size == 0:
+            return minimum
+        return max(float(np.percentile(finite, 98)), minimum)
+
+    @staticmethod
+    def _plot_spatial_overlays(
+        ax: Any,
+        data_crs: Optional[Any],
+        boundary: Optional[Any] = None,
+        mesh_boundary: Optional[Any] = None,
+        pump_stations: Optional[Any] = None,
+        add_basemap: bool = False,
+    ) -> None:
+        xlim = ax.get_xlim()
+        ylim = ax.get_ylim()
+
+        if add_basemap:
+            PrecipMrms._add_osm_basemap(ax, data_crs)
+            ax.set_xlim(xlim)
+            ax.set_ylim(ylim)
+
+        PrecipMrms._plot_boundary(
+            ax,
+            boundary,
+            target_crs=data_crs,
+            color="black",
+            linewidth=1.0,
+            zorder=4,
+        )
+        PrecipMrms._plot_boundary(
+            ax,
+            mesh_boundary,
+            target_crs=data_crs,
+            color="#111111",
+            linewidth=0.8,
+            zorder=5,
+        )
+        PrecipMrms._plot_pump_stations(ax, pump_stations, target_crs=data_crs)
+
+    @staticmethod
+    def _add_osm_basemap(ax: Any, data_crs: Optional[Any]) -> None:
+        if data_crs is None:
+            logger.warning("Cannot add OSM basemap without a data CRS")
+            return
+
+        try:
+            import contextily as ctx  # type: ignore
+
+            ctx.add_basemap(
+                ax,
+                source=ctx.providers.OpenStreetMap.Mapnik,
+                crs=data_crs,
+                attribution=False,
+                reset_extent=False,
+                zorder=0,
+            )
+            return
+        except ImportError:
+            pass
+        except Exception as exc:
+            logger.warning("contextily basemap rendering failed; trying fallback: %s", exc)
+
+        try:
+            PrecipMrms._add_osm_basemap_fallback(ax, data_crs)
+        except Exception as exc:
+            logger.warning("OSM basemap fallback failed: %s", exc)
+
+    @staticmethod
+    def _add_osm_basemap_fallback(ax: Any, data_crs: Any) -> None:
+        import numpy as np
+        from PIL import Image
+        from pyproj import CRS, Transformer
+        import rasterio
+        from rasterio.transform import from_bounds
+        from rasterio.warp import calculate_default_transform, reproject, Resampling
+
+        crs_obj = CRS.from_user_input(data_crs)
+        xlim = ax.get_xlim()
+        ylim = ax.get_ylim()
+        west, east = min(xlim), max(xlim)
+        south, north = min(ylim), max(ylim)
+
+        to_3857 = Transformer.from_crs(crs_obj, "EPSG:3857", always_xy=True)
+        xs, ys = to_3857.transform(
+            [west, west, east, east],
+            [south, north, south, north],
+        )
+        minx, maxx = min(xs), max(xs)
+        miny, maxy = min(ys), max(ys)
+
+        from_3857 = Transformer.from_crs("EPSG:3857", "EPSG:4326", always_xy=True)
+        lon_min, lat_min = from_3857.transform(minx, miny)
+        lon_max, lat_max = from_3857.transform(maxx, maxy)
+        zoom = PrecipMrms._choose_osm_zoom(lon_min, lat_min, lon_max, lat_max)
+        x0, y0 = PrecipMrms._lonlat_to_tile(lon_min, lat_max, zoom)
+        x1, y1 = PrecipMrms._lonlat_to_tile(lon_max, lat_min, zoom)
+        max_index = (2 ** zoom) - 1
+        x0, x1 = max(0, min(x0, max_index)), max(0, min(x1, max_index))
+        y0, y1 = max(0, min(y0, max_index)), max(0, min(y1, max_index))
+        if x1 < x0 or y1 < y0:
+            return
+
+        tile_size = 256
+        mosaic = Image.new(
+            "RGB",
+            ((x1 - x0 + 1) * tile_size, (y1 - y0 + 1) * tile_size),
+        )
+        for tile_x in range(x0, x1 + 1):
+            for tile_y in range(y0, y1 + 1):
+                tile = PrecipMrms._fetch_osm_tile(zoom, tile_x, tile_y)
+                mosaic.paste(tile, ((tile_x - x0) * tile_size, (tile_y - y0) * tile_size))
+
+        left, bottom, _, _ = PrecipMrms._tile_bounds_mercator(x0, y1, zoom)
+        _, _, right, top = PrecipMrms._tile_bounds_mercator(x1, y0, zoom)
+        source = np.asarray(mosaic).transpose((2, 0, 1))
+        src_transform = from_bounds(left, bottom, right, top, source.shape[2], source.shape[1])
+
+        if crs_obj.to_epsg() == 3857:
+            extent = (left, right, bottom, top)
+            ax.imshow(source.transpose((1, 2, 0)), extent=extent, origin="upper", zorder=0)
+            return
+
+        dst_transform, width, height = calculate_default_transform(
+            "EPSG:3857",
+            crs_obj,
+            source.shape[2],
+            source.shape[1],
+            left,
+            bottom,
+            right,
+            top,
+        )
+        dest = np.zeros((3, height, width), dtype=np.uint8)
+        for band_idx in range(3):
+            reproject(
+                source[band_idx],
+                dest[band_idx],
+                src_transform=src_transform,
+                src_crs="EPSG:3857",
+                dst_transform=dst_transform,
+                dst_crs=crs_obj,
+                resampling=Resampling.bilinear,
+            )
+
+        bounds = rasterio.transform.array_bounds(height, width, dst_transform)
+        ax.imshow(
+            dest.transpose((1, 2, 0)),
+            extent=(bounds[0], bounds[2], bounds[1], bounds[3]),
+            origin="upper",
+            zorder=0,
+        )
+
+    @staticmethod
+    def _choose_osm_zoom(
+        lon_min: float,
+        lat_min: float,
+        lon_max: float,
+        lat_max: float,
+        max_tiles: int = 24,
+    ) -> int:
+        for zoom in range(14, 5, -1):
+            x0, y0 = PrecipMrms._lonlat_to_tile(lon_min, lat_max, zoom)
+            x1, y1 = PrecipMrms._lonlat_to_tile(lon_max, lat_min, zoom)
+            tile_count = (abs(x1 - x0) + 1) * (abs(y1 - y0) + 1)
+            if tile_count <= max_tiles:
+                return zoom
+        return 6
+
+    @staticmethod
+    def _lonlat_to_tile(lon: float, lat: float, zoom: int) -> Tuple[int, int]:
+        import math
+
+        lat = max(min(float(lat), 85.05112878), -85.05112878)
+        lon = max(min(float(lon), 180.0), -180.0)
+        n = 2 ** zoom
+        x_tile = int((lon + 180.0) / 360.0 * n)
+        lat_rad = math.radians(lat)
+        y_tile = int(
+            (1.0 - math.log(math.tan(lat_rad) + (1.0 / math.cos(lat_rad))) / math.pi)
+            / 2.0
+            * n
+        )
+        return x_tile, y_tile
+
+    @staticmethod
+    def _tile_bounds_mercator(x_tile: int, y_tile: int, zoom: int) -> Tuple[float, float, float, float]:
+        origin_shift = 20037508.342789244
+        n = 2 ** zoom
+        tile_span = 2 * origin_shift / n
+        left = -origin_shift + x_tile * tile_span
+        right = -origin_shift + (x_tile + 1) * tile_span
+        top = origin_shift - y_tile * tile_span
+        bottom = origin_shift - (y_tile + 1) * tile_span
+        return left, bottom, right, top
+
+    @staticmethod
+    def _fetch_osm_tile(zoom: int, x_tile: int, y_tile: int) -> Any:
+        from io import BytesIO
+
+        from PIL import Image
+        import requests
+
+        key = (zoom, x_tile, y_tile)
+        if key in _OSM_TILE_CACHE:
+            return _OSM_TILE_CACHE[key].copy()
+
+        url = f"https://tile.openstreetmap.org/{zoom}/{x_tile}/{y_tile}.png"
+        response = requests.get(
+            url,
+            headers={"User-Agent": "ras-commander MRMS notebook/0.96"},
+            timeout=20,
+        )
+        response.raise_for_status()
+        tile = Image.open(BytesIO(response.content)).convert("RGB")
+        _OSM_TILE_CACHE[key] = tile
+        return tile.copy()
+
+    @staticmethod
+    def _plot_boundary(
+        ax: Any,
+        boundary: Optional[Any],
+        target_crs: Optional[Any] = None,
+        color: str = "black",
+        linewidth: float = 1.0,
+        zorder: int = 4,
+    ) -> None:
+        if boundary is None:
+            return
+
+        if isinstance(boundary, (str, Path)):
+            try:
+                import geopandas as gpd
+
+                gdf = gpd.read_file(boundary)
+                if target_crs is not None and gdf.crs is not None:
+                    gdf = gdf.to_crs(target_crs)
+                gdf.boundary.plot(ax=ax, color=color, linewidth=linewidth, zorder=zorder)
+                return
+            except Exception as exc:
+                logger.warning("Could not plot boundary file %s: %s", boundary, exc)
+                return
+
+        if isinstance(boundary, tuple) and len(boundary) == 4:
+            west, south, east, north = boundary
+            ax.plot(
+                [west, east, east, west, west],
+                [south, south, north, north, south],
+                color=color,
+                linewidth=linewidth,
+                zorder=zorder,
+            )
+            return
+
+        if hasattr(boundary, "boundary") and hasattr(boundary.boundary, "plot"):
+            plot_boundary = boundary
+            if target_crs is not None and getattr(plot_boundary, "crs", None) is not None:
+                plot_boundary = plot_boundary.to_crs(target_crs)
+            plot_boundary.boundary.plot(ax=ax, color=color, linewidth=linewidth, zorder=zorder)
+            return
+
+        geom = getattr(boundary, "geometry", boundary)
+        if hasattr(geom, "exterior"):
+            x, y = geom.exterior.xy
+            ax.plot(x, y, color=color, linewidth=linewidth, zorder=zorder)
+
+    @staticmethod
+    def _plot_pump_stations(
+        ax: Any,
+        pump_stations: Optional[Any],
+        target_crs: Optional[Any] = None,
+    ) -> None:
+        if pump_stations is None:
+            return
+
+        try:
+            import geopandas as gpd
+
+            if isinstance(pump_stations, (str, Path)):
+                pumps = gpd.read_file(pump_stations)
+            else:
+                pumps = pump_stations
+
+            if getattr(pumps, "empty", False):
+                return
+            if target_crs is not None and getattr(pumps, "crs", None) is not None:
+                pumps = pumps.to_crs(target_crs)
+
+            label_column = next(
+                (column for column in ("Name", "name", "station_id") if column in pumps.columns),
+                None,
+            )
+            pumps.plot(
+                ax=ax,
+                marker="^",
+                color="#d7191c",
+                edgecolor="white",
+                linewidth=0.7,
+                markersize=45,
+                zorder=6,
+            )
+            for idx, row in pumps.iterrows():
+                label = str(row[label_column]) if label_column else f"Pump {idx + 1}"
+                point = row.geometry
+                ax.annotate(
+                    label,
+                    xy=(point.x, point.y),
+                    xytext=(4, 4),
+                    textcoords="offset points",
+                    fontsize=7,
+                    color="black",
+                    bbox={"facecolor": "white", "alpha": 0.75, "edgecolor": "none", "pad": 1.5},
+                    zorder=7,
+                )
+        except Exception as exc:
+            logger.warning("Could not plot pump stations: %s", exc)

--- a/ras_commander/precip/PrecipMrms.py
+++ b/ras_commander/precip/PrecipMrms.py
@@ -2114,9 +2114,17 @@ class PrecipMrms:
             ax,
             mesh_boundary,
             target_crs=data_crs,
-            color="#111111",
-            linewidth=0.8,
+            color="white",
+            linewidth=2.4,
             zorder=5,
+        )
+        PrecipMrms._plot_boundary(
+            ax,
+            mesh_boundary,
+            target_crs=data_crs,
+            color="#111111",
+            linewidth=1.1,
+            zorder=6,
         )
         PrecipMrms._plot_pump_stations(ax, pump_stations, target_crs=data_crs)
 

--- a/ras_commander/precip/VortexCli.py
+++ b/ras_commander/precip/VortexCli.py
@@ -5,8 +5,10 @@ Converts GRIB2, NetCDF, and other gridded meteorological formats to HEC-DSS
 using HEC-Vortex's BatchImporter via Jython scripts.
 
 This module wraps HEC-Vortex's command-line interface, generating temporary
-Jython scripts that use Vortex's Java API (mil.army.usace.hec.vortex.io.BatchImporter)
-and executing them via `vortex.bat -s script.py`.
+Jython scripts that use Vortex's Java API
+(mil.army.usace.hec.vortex.io.BatchImporter) and executing them through a
+local Jython runtime. This supports both older `vortex.bat` distributions and
+current HEC-Vortex 0.13.x installations that ship `importer.bat`.
 
 HEC-Vortex is a free tool from USACE that handles:
 - GRIB2 (HRRR, GFS, MRMS, QPF)
@@ -25,7 +27,7 @@ Platform:
     Windows only (HEC-Vortex is a Windows application)
 
 Requirements:
-    - HEC-Vortex 3.x installed (free from https://www.hec.usace.army.mil/software/hec-vortex/)
+    - HEC-Vortex installed (free from https://www.hec.usace.army.mil/software/hec-vortex/)
     - Windows OS
 
 Example:
@@ -52,6 +54,7 @@ See Also:
     - https://www.hec.usace.army.mil/software/hec-vortex/ for HEC-Vortex documentation
 """
 
+import os
 import subprocess
 import tempfile
 import textwrap
@@ -69,6 +72,11 @@ _VORTEX_BASE_PATHS = [
     Path("C:/Program Files/HEC/HEC-Vortex"),
     Path("C:/Program Files (x86)/HEC/HEC-Vortex"),
     Path("C:/HEC/HEC-Vortex"),
+]
+
+_JYTHON_JAR_CANDIDATES = [
+    Path("C:/Program Files/HEC/HEC-DSSVue/jar/jython-standalone-2.7.3.jar"),
+    Path("C:/Program Files/HEC/HEC-DSSVue/jar/jython-standalone-2.7.2.jar"),
 ]
 
 # Common GRIB2 variable names for meteorological data
@@ -139,18 +147,12 @@ class VortexCli:
         # If explicit path provided, validate it
         if vortex_path is not None:
             vortex_path = Path(vortex_path)
-            vortex_bat = vortex_path / "bin" / "vortex.bat"
-            if vortex_bat.exists():
-                logger.info(f"Found HEC-Vortex at: {vortex_path}")
-                return vortex_path
-            # Also check if vortex.bat is directly in the path
-            vortex_bat = vortex_path / "vortex.bat"
-            if vortex_bat.exists():
+            if VortexCli._has_vortex_runtime(vortex_path):
                 logger.info(f"Found HEC-Vortex at: {vortex_path}")
                 return vortex_path
             raise FileNotFoundError(
                 f"HEC-Vortex not found at specified path: {vortex_path}. "
-                f"Expected vortex.bat at {vortex_path / 'bin' / 'vortex.bat'}"
+                f"Expected Vortex libraries or launcher under {vortex_path}"
             )
 
         # Search standard installation paths
@@ -164,16 +166,14 @@ class VortexCli:
                     reverse=True  # Latest version first
                 )
                 for subdir in subdirs:
-                    vortex_bat = subdir / "bin" / "vortex.bat"
-                    if vortex_bat.exists():
+                    if VortexCli._has_vortex_runtime(subdir):
                         logger.info(f"Found HEC-Vortex {subdir.name} at: {subdir}")
                         return subdir
             except PermissionError:
                 continue
 
-            # Check if vortex.bat is directly in base path
-            vortex_bat = base_path / "bin" / "vortex.bat"
-            if vortex_bat.exists():
+            # Check if the base path itself is a Vortex distribution
+            if VortexCli._has_vortex_runtime(base_path):
                 logger.info(f"Found HEC-Vortex at: {base_path}")
                 return base_path
 
@@ -193,15 +193,104 @@ class VortexCli:
         )
 
     @staticmethod
+    def _has_vortex_runtime(vortex_path: Path) -> bool:
+        """Return True when a path looks like a HEC-Vortex distribution."""
+        return any(
+            candidate.exists()
+            for candidate in (
+                vortex_path / "bin" / "vortex.bat",
+                vortex_path / "vortex.bat",
+                vortex_path / "bin" / "importer.bat",
+                vortex_path / "importer.bat",
+            )
+        ) or bool(list((vortex_path / "lib").glob("vortex-*.jar")))
+
+    @staticmethod
     def _get_vortex_bat(vortex_path: Path) -> Path:
-        """Get path to vortex.bat executable."""
-        vortex_bat = vortex_path / "bin" / "vortex.bat"
-        if vortex_bat.exists():
-            return vortex_bat
-        vortex_bat = vortex_path / "vortex.bat"
-        if vortex_bat.exists():
-            return vortex_bat
-        raise FileNotFoundError(f"vortex.bat not found in {vortex_path}")
+        """Get a Vortex launcher path for legacy callers."""
+        for launcher in (
+            vortex_path / "bin" / "vortex.bat",
+            vortex_path / "vortex.bat",
+            vortex_path / "bin" / "importer.bat",
+            vortex_path / "importer.bat",
+        ):
+            if launcher.exists():
+                return launcher
+        raise FileNotFoundError(f"Vortex launcher not found in {vortex_path}")
+
+    @staticmethod
+    def _find_jython_jar(jython_jar: Optional[Union[str, Path]] = None) -> Path:
+        """Find a Jython standalone jar for calling the Vortex Java API."""
+        if jython_jar is not None:
+            jar_path = Path(jython_jar)
+            if jar_path.exists():
+                return jar_path
+            raise FileNotFoundError(f"Jython standalone jar not found: {jar_path}")
+
+        for env_name in ("JYTHON_STANDALONE_JAR", "JYTHON_JAR"):
+            env_path = os.environ.get(env_name)
+            if env_path and Path(env_path).exists():
+                return Path(env_path)
+
+        candidates = list(_JYTHON_JAR_CANDIDATES)
+        hms_root = Path("C:/Program Files/HEC/HEC-HMS")
+        if hms_root.exists():
+            candidates.extend(sorted(hms_root.glob("*/lib/jython-standalone*.jar"), reverse=True))
+
+        for candidate in candidates:
+            if candidate.exists():
+                return candidate
+
+        raise FileNotFoundError(
+            "Jython standalone jar not found. Install HEC-DSSVue/HEC-HMS or pass "
+            "jython_jar= with a path to jython-standalone-2.7.x.jar."
+        )
+
+    @staticmethod
+    def _build_jython_command(
+        vortex_path: Path,
+        script_file: Path,
+        jython_jar: Optional[Union[str, Path]] = None,
+        max_heap: str = "4g",
+        include_add_opens: bool = True,
+    ) -> List[str]:
+        """Build the Java/Jython command used to call Vortex BatchImporter."""
+        jython_path = VortexCli._find_jython_jar(jython_jar)
+        java_exe = vortex_path / "jre" / "bin" / "java.exe"
+        if not java_exe.exists():
+            java_exe = Path("java")
+
+        bin_dir = vortex_path / "bin"
+        classpath = f"{jython_path};{vortex_path / 'lib' / '*'}"
+        library_path = f"{bin_dir};{bin_dir / 'gdal'}"
+
+        command = [
+            str(java_exe),
+            f"-Xmx{max_heap}",
+            f"-Djava.library.path={library_path}",
+        ]
+        if include_add_opens:
+            command.append("--add-opens=java.desktop/sun.awt.shell=ALL-UNNAMED")
+        command.extend(
+            [
+                "-cp",
+                classpath,
+                "org.python.util.jython",
+                str(script_file),
+            ]
+        )
+        return command
+
+    @staticmethod
+    def _vortex_environment(vortex_path: Path) -> Dict[str, str]:
+        """Return environment variables required by Vortex GDAL/NetCDF libraries."""
+        env = os.environ.copy()
+        bin_dir = vortex_path / "bin"
+        path_entries = [bin_dir, bin_dir / "gdal", bin_dir / "netcdf"]
+        env["PATH"] = os.pathsep.join(str(path) for path in path_entries) + os.pathsep + env.get("PATH", "")
+        env["GDAL_DATA"] = str(bin_dir / "gdal" / "gdal-data")
+        env["PROJ_LIB"] = str(bin_dir / "gdal" / "projlib")
+        return env
 
     @staticmethod
     def _generate_import_script(
@@ -231,9 +320,8 @@ class VortexCli:
             str: Jython script content.
         """
         # Escape backslashes for Java string literals
-        input_paths_java = ", ".join(
-            f'r"{str(f)}"' for f in input_files
-        )
+        input_paths = [str(f).replace("\\", "/") for f in input_files]
+        input_paths_java = ", ".join(f'r"{path}"' for path in input_paths)
         output_dss_java = str(output_dss).replace("\\", "/")
 
         # Build variables list
@@ -265,54 +353,53 @@ class VortexCli:
                     )
         write_options_block = "\n".join(write_options_lines)
 
-        script = textwrap.dedent(f"""\
-            # Auto-generated HEC-Vortex import script
-            # Generated by ras-commander VortexCli at {datetime.now().isoformat()}
+        script = f"""# Auto-generated HEC-Vortex import script
+# Generated by ras-commander VortexCli at {datetime.now().isoformat()}
 
-            from mil.army.usace.hec.vortex.io import BatchImporter
-            from mil.army.usace.hec.vortex.geo import WktFactory
-            import java.util.ArrayList as ArrayList
-            import java.util.HashMap as HashMap
+from mil.army.usace.hec.vortex.io import BatchImporter
+from mil.army.usace.hec.vortex.geo import WktFactory
+import java.util.ArrayList as ArrayList
+import java.util.HashMap as HashMap
 
-            # Input files
-            inFiles = [{input_paths_java}]
+# Input files
+inFiles = [{input_paths_java}]
 
-            # Variables to extract
-            variables = ArrayList()
-            {variables_block}
+# Variables to extract
+variables = ArrayList()
+{variables_block}
 
-            # Geo-processing options
-            geoOptions = HashMap()
-            geoOptionsDict = {{
-            {geo_options_block}
-            }}
-            for key, val in geoOptionsDict.items():
-                geoOptions.put(key, str(val) if not isinstance(val, str) else val)
+# Geo-processing options
+geoOptions = HashMap()
+geoOptionsDict = {{
+{geo_options_block}
+}}
+for key, val in geoOptionsDict.items():
+    geoOptions.put(key, str(val) if not isinstance(val, str) else val)
 
-            # Write options (DSS pathname parts)
-            writeOptions = HashMap()
-            writeOptionsDict = {{
-            {write_options_block}
-            }}
-            for key, val in writeOptionsDict.items():
-                writeOptions.put(key, val)
+# Write options (DSS pathname parts)
+writeOptions = HashMap()
+writeOptionsDict = {{
+{write_options_block}
+}}
+for key, val in writeOptionsDict.items():
+    writeOptions.put(key, val)
 
-            # Destination
-            destination = r"{output_dss_java}"
+# Destination
+destination = r"{output_dss_java}"
 
-            # Build and execute importer
-            importer = BatchImporter.builder() \\
-                .inFiles(inFiles) \\
-                .variables(variables) \\
-                .geoOptions(geoOptions) \\
-                .writeOptions(writeOptions) \\
-                .destination(destination) \\
-                .build()
+# Build and execute importer
+importer = BatchImporter.builder() \\
+    .inFiles(inFiles) \\
+    .variables(variables) \\
+    .geoOptions(geoOptions) \\
+    .writeOptions(writeOptions) \\
+    .destination(destination) \\
+    .build()
 
-            importer.process()
+importer.process()
 
-            print("VORTEX_IMPORT_COMPLETE")
-        """)
+print("VORTEX_IMPORT_COMPLETE")
+"""
         return script
 
     @staticmethod
@@ -327,6 +414,8 @@ class VortexCli:
         resampling_method: str = "Bilinear",
         dss_parts: Optional[Dict[str, str]] = None,
         vortex_path: Optional[Union[str, Path]] = None,
+        jython_jar: Optional[Union[str, Path]] = None,
+        max_heap: str = "4g",
         timeout: int = 600,
     ) -> Path:
         """
@@ -356,6 +445,10 @@ class VortexCli:
                 single letters A-F. Example: {"A": "SHG", "B": "BASIN", "F": "HRRR"}.
             vortex_path: Optional explicit path to HEC-Vortex installation.
                 If None, searches standard locations.
+            jython_jar: Optional path to jython-standalone-2.7.x.jar. If None,
+                searches HEC-DSSVue, HEC-HMS, and JYTHON_STANDALONE_JAR.
+            max_heap: Maximum Java heap for the Vortex import process.
+                Default: "4g".
             timeout: Maximum execution time in seconds. Default: 600 (10 min).
 
         Returns:
@@ -380,24 +473,23 @@ class VortexCli:
         # Normalize input_files to list of Paths
         if isinstance(input_files, (str, Path)):
             input_files = [input_files]
-        input_files = [Path(f) for f in input_files]
+        input_files = [Path(f).resolve() for f in input_files]
 
         # Validate input files exist
         for f in input_files:
             if not f.exists():
                 raise FileNotFoundError(f"Input file not found: {f}")
 
-        output_dss = Path(output_dss)
+        output_dss = Path(output_dss).resolve()
 
         # Validate clip shapefile if provided
         if clip_shp is not None:
-            clip_shp = Path(clip_shp)
+            clip_shp = Path(clip_shp).resolve()
             if not clip_shp.exists():
                 raise FileNotFoundError(f"Clip shapefile not found: {clip_shp}")
 
         # Find Vortex installation
         vortex_dir = VortexCli.find_vortex(vortex_path)
-        vortex_bat = VortexCli._get_vortex_bat(vortex_dir)
 
         # Create output directory if needed
         output_dss.parent.mkdir(parents=True, exist_ok=True)
@@ -434,18 +526,46 @@ class VortexCli:
             logger.debug(f"Vortex script: {script_file}")
             logger.debug(f"Variables: {variables}")
 
-            # Execute: vortex.bat -s script.py
-            cmd_str = f'"{vortex_bat}" -s "{script_file}"'
-            logger.debug(f"Executing: {cmd_str}")
+            # Execute the Vortex Java API through Jython. HEC-Vortex 0.13.x
+            # ships importer.bat for the GUI, not the older vortex.bat -s
+            # script runner, so the API invocation is assembled directly.
+            cmd = VortexCli._build_jython_command(
+                vortex_path=vortex_dir,
+                script_file=script_file,
+                jython_jar=jython_jar,
+                max_heap=max_heap,
+                include_add_opens=True,
+            )
+            logger.debug("Executing Vortex Jython command: %s", " ".join(cmd))
 
             result = subprocess.run(
-                cmd_str,
-                shell=True,
+                cmd,
                 capture_output=True,
                 text=True,
                 timeout=timeout,
-                cwd=str(output_dss.parent),
+                cwd=str(vortex_dir / "bin"),
+                env=VortexCli._vortex_environment(vortex_dir),
             )
+            if (
+                result.returncode != 0
+                and "Unrecognized option: --add-opens" in (result.stderr or "")
+            ):
+                cmd = VortexCli._build_jython_command(
+                    vortex_path=vortex_dir,
+                    script_file=script_file,
+                    jython_jar=jython_jar,
+                    max_heap=max_heap,
+                    include_add_opens=False,
+                )
+                logger.debug("Retrying Vortex Jython command without --add-opens")
+                result = subprocess.run(
+                    cmd,
+                    capture_output=True,
+                    text=True,
+                    timeout=timeout,
+                    cwd=str(vortex_dir / "bin"),
+                    env=VortexCli._vortex_environment(vortex_dir),
+                )
 
             # Check execution result
             if result.returncode != 0:
@@ -470,8 +590,12 @@ class VortexCli:
 
             # Validate output DSS file exists
             if not output_dss.exists():
+                stdout_tail = (result.stdout or "").strip()[-2000:]
+                stderr_tail = (result.stderr or "").strip()[-2000:]
                 raise RuntimeError(
-                    f"Vortex execution completed but DSS file not created: {output_dss}"
+                    f"Vortex execution completed but DSS file not created: {output_dss}\n"
+                    f"stdout: {stdout_tail or '<empty>'}\n"
+                    f"stderr: {stderr_tail or '<empty>'}"
                 )
 
             file_size = output_dss.stat().st_size
@@ -657,16 +781,20 @@ class VortexCli:
             raise FileNotFoundError(f"GRIB2 file not found: {grib_file}")
 
         vortex_dir = VortexCli.find_vortex(vortex_path)
-        vortex_bat = VortexCli._get_vortex_bat(vortex_dir)
 
         grib_path_java = str(grib_file).replace("\\", "/")
 
         script_content = textwrap.dedent(f"""\
             # Auto-generated HEC-Vortex variable listing script
-            from mil.army.usace.hec.vortex.io import DataReader
+            try:
+                from mil.army.usace.hec.vortex.io import NetcdfDataReader
+                reader_class = NetcdfDataReader
+            except ImportError:
+                from mil.army.usace.hec.vortex.io import DataReader
+                reader_class = DataReader
 
             source = r"{grib_path_java}"
-            variables = DataReader.getVariables(source)
+            variables = reader_class.getVariables(source)
 
             print("VORTEX_VARIABLES_START")
             for v in variables:
@@ -685,14 +813,36 @@ class VortexCli:
                 f.write(script_content)
                 script_file = Path(f.name)
 
-            cmd_str = f'"{vortex_bat}" -s "{script_file}"'
+            cmd = VortexCli._build_jython_command(
+                vortex_path=vortex_dir,
+                script_file=script_file,
+                include_add_opens=True,
+            )
             result = subprocess.run(
-                cmd_str,
-                shell=True,
+                cmd,
                 capture_output=True,
                 text=True,
                 timeout=timeout,
+                cwd=str(vortex_dir / "bin"),
+                env=VortexCli._vortex_environment(vortex_dir),
             )
+            if (
+                result.returncode != 0
+                and "Unrecognized option: --add-opens" in (result.stderr or "")
+            ):
+                cmd = VortexCli._build_jython_command(
+                    vortex_path=vortex_dir,
+                    script_file=script_file,
+                    include_add_opens=False,
+                )
+                result = subprocess.run(
+                    cmd,
+                    capture_output=True,
+                    text=True,
+                    timeout=timeout,
+                    cwd=str(vortex_dir / "bin"),
+                    env=VortexCli._vortex_environment(vortex_dir),
+                )
 
             if result.returncode != 0:
                 raise RuntimeError(

--- a/ras_commander/precip/__init__.py
+++ b/ras_commander/precip/__init__.py
@@ -10,13 +10,13 @@ from various sources for use in HEC-RAS rain-on-grid 2D models:
 - Atlas14Variance - Spatial variance analysis for uniform vs. distributed rainfall decisions
 - AbmHyetographGrid - Per-pixel Alternating Block Method hyetograph grids (NetCDF for HEC-RAS rain-on-grid)
 - VortexCli - HEC-Vortex CLI wrapper for converting GRIB2/NetCDF to HEC-DSS
-- MRMS (Multi-Radar Multi-Sensor) - Real-time and historical radar (future)
+- PrecipMrms - MRMS QPE catalog, download, HEC-Vortex DSS conversion, direct hyetograph/NetCDF, and MP4 animation helpers
 - QPF (Quantitative Precipitation Forecast) - NWS forecasts (future)
 
 The primary workflow is:
 1. Extract project extent from HEC-RAS HDF file using HdfProject
 2. Download precipitation data for the extent and time period
-3. Export as NetCDF for direct import into HEC-RAS
+3. Export as HEC-DSS through HEC-Vortex or NetCDF/direct hyetograph inputs for HEC-RAS
 
 Design Storm Generation:
 Four HMS-validated methods are available for design storm hyetograph generation:
@@ -170,6 +170,23 @@ Example (AORC - Historical Data):
     ...     output_path="Precipitation/aorc_precip.nc"
     ... )
 
+Example (MRMS - Historical QPE):
+    >>> from ras_commander.precip import PrecipMrms
+    >>>
+    >>> files = PrecipMrms.download(
+    ...     bounds=(-121.79, 38.52, -121.71, 38.59),
+    ...     start_time="2022-12-31 00:00",
+    ...     end_time="2023-01-01 12:00",
+    ...     output_dir="Precipitation/mrms",
+    ... )
+    >>> mrms_dss = PrecipMrms.to_dss(
+    ...     files,
+    ...     "Precipitation/mrms_qpe.dss",
+    ...     clip_shp="Precipitation/study_area.shp",
+    ... )
+    >>> hyetograph = PrecipMrms.to_hyetograph(files, bounds=(-121.79, 38.52, -121.71, 38.59))
+    >>> PrecipMrms.to_ras_netcdf(files, "Precipitation/mrms_qpe.nc")
+
 Dependencies:
     Install with: pip install ras-commander[precip]
 
@@ -184,8 +201,10 @@ Dependencies:
     - pygeohydro (optional, for HUC12 watershed boundaries in Atlas14Variance)
 """
 
+from ..LoggingConfig import setup_logging as _setup_logging
 from .PrecipAorc import PrecipAorc
 from .PrecipHrrr import PrecipHrrr
+from .PrecipMrms import PrecipMrms
 from .StormGenerator import StormGenerator
 from .Atlas14Grid import Atlas14Grid
 from .Atlas14Variance import Atlas14Variance
@@ -208,9 +227,14 @@ except ImportError:
     FrequencyStorm = None
     ScsTypeStorm = None
 
+# hms-commander has its own logging bootstrap. Re-run ras-commander setup so
+# notebook imports do not retain duplicate root stream handlers.
+_setup_logging()
+
 __all__ = [
     'PrecipAorc',
     'PrecipHrrr',                  # HRRR real-time forecast download
+    'PrecipMrms',                  # MRMS QPE catalog, download, DSS/direct processing, and animation
     'StormGenerator',
     'VortexCli',                   # HEC-Vortex CLI wrapper for GRIB2/NetCDF → DSS conversion
     'Atlas14Grid',                 # Remote access to NOAA Atlas 14 CONUS grids

--- a/tests/ras_process_store_maps_output_path_test.py
+++ b/tests/ras_process_store_maps_output_path_test.py
@@ -195,3 +195,117 @@ def test_store_maps_leaves_unchanged_files_in_default_folder(monkeypatch, tmp_pa
     assert benchmark_path.exists()
     assert benchmark_path.read_text(encoding="utf-8") == "keep-me"
     assert not (custom_output_dir / "manual_benchmark.tif").exists()
+
+
+def test_store_maps_at_timesteps_routes_each_timestamp(monkeypatch, tmp_path):
+    ras_obj = _DummyRas(project_folder=tmp_path)
+    available = [
+        "04FEB2024 00:00:00",
+        "04FEB2024 01:00:00",
+        "04FEB2024 02:00:00",
+    ]
+    calls = []
+
+    monkeypatch.setattr(
+        RasProcess,
+        "get_plan_timestamps",
+        staticmethod(lambda plan_number, ras_object=None: available),
+    )
+
+    def fake_store_maps(**kwargs):
+        calls.append(kwargs)
+        return {"depth": [tmp_path / f"{kwargs['profile']}.tif"]}
+
+    monkeypatch.setattr(RasProcess, "store_maps", staticmethod(fake_store_maps))
+
+    results = RasProcess.store_maps_at_timesteps(
+        plan_number="02",
+        output_path=tmp_path / "depth_frames",
+        timesteps=[0, "2024-02-04 02:00"],
+        depth=True,
+        velocity=False,
+        fix_georef=False,
+        ras_object=ras_obj,
+    )
+
+    assert list(results) == ["04FEB2024 00:00:00", "04FEB2024 02:00:00"]
+    assert [call["profile"] for call in calls] == list(results)
+    assert all(call["plan_number"] == "02" for call in calls)
+    assert all(call["depth"] is True and call["velocity"] is False for call in calls)
+
+
+def test_fix_georeferencing_rewrites_compressed_tiff(tmp_path):
+    rasterio = __import__("pytest").importorskip("rasterio")
+    np = __import__("pytest").importorskip("numpy")
+    from rasterio.crs import CRS
+    from rasterio.transform import from_origin
+
+    terrain_path = tmp_path / "terrain.tif"
+    depth_path = tmp_path / "depth.tif"
+    terrain_transform = from_origin(1000, 2000, 10, 10)
+    raw_transform = from_origin(0, 0, 1, 1)
+    data = np.arange(9, dtype="float32").reshape(3, 3)
+
+    terrain_profile = {
+        "driver": "GTiff",
+        "height": 3,
+        "width": 3,
+        "count": 1,
+        "dtype": "float32",
+        "crs": CRS.from_epsg(2871),
+        "transform": terrain_transform,
+    }
+    with rasterio.open(terrain_path, "w", **terrain_profile) as dst:
+        dst.write(data, 1)
+
+    depth_profile = dict(terrain_profile)
+    depth_profile.update(
+        crs=None,
+        transform=raw_transform,
+        compress="deflate",
+        tiled=True,
+        blockxsize=16,
+        blockysize=16,
+        nodata=-9999.0,
+    )
+    with rasterio.open(depth_path, "w", **depth_profile) as dst:
+        dst.write(data, 1)
+
+    assert RasProcess._fix_georeferencing(depth_path, None, terrain_path)
+
+    with rasterio.open(depth_path) as src:
+        assert src.crs == CRS.from_epsg(2871)
+        assert src.transform == terrain_transform
+        assert np.array_equal(src.read(1), data)
+
+
+def test_drop_unreadable_tifs_removes_corrupt_stored_map(tmp_path):
+    pytest = __import__("pytest")
+    rasterio = pytest.importorskip("rasterio")
+    np = pytest.importorskip("numpy")
+    from rasterio.transform import from_origin
+
+    valid_path = tmp_path / "Depth (04FEB2024 00 00 00).tif"
+    corrupt_path = tmp_path / "Depth (04FEB2024 01 00 00).tif"
+
+    with rasterio.open(
+        valid_path,
+        "w",
+        driver="GTiff",
+        height=2,
+        width=2,
+        count=1,
+        dtype="float32",
+        transform=from_origin(1000, 2000, 10, 10),
+    ) as dst:
+        dst.write(np.ones((2, 2), dtype="float32"), 1)
+
+    corrupt_path.write_bytes(b"not a readable tiff")
+
+    results = RasProcess._drop_unreadable_tifs(
+        {"depth": [valid_path, corrupt_path]}
+    )
+
+    assert results["depth"] == [valid_path]
+    assert valid_path.exists()
+    assert not corrupt_path.exists()

--- a/tests/test_hdf_pump.py
+++ b/tests/test_hdf_pump.py
@@ -1,0 +1,97 @@
+from pathlib import Path
+
+import h5py
+import numpy as np
+
+from ras_commander.hdf import HdfPump
+
+
+def _write_pump_hdf(path: Path) -> None:
+    data = np.array(
+        [
+            [0.0, -21.0, 1.0, 10.0, 1.0, 20.0, 2.0],
+            [5.0, -20.5, 1.2, 12.0, 1.0, 25.0, 3.0],
+        ],
+        dtype=np.float32,
+    )
+    variable_units = np.array(
+        [
+            [b"Flow", b"cfs"],
+            [b"Stage HW", b"ft"],
+            [b"Stage TW", b"ft"],
+            [b"V Pumps", b"cfs"],
+            [b"V Pumps", b"Pumps on"],
+            [b"G Pumps", b"cfs"],
+            [b"G Pumps", b"Pumps on"],
+        ],
+        dtype="S32",
+    )
+    timestamps = np.array(
+        [b"10APR2024 00:00:00:000", b"10APR2024 00:05:00:000"],
+        dtype="S24",
+    )
+
+    with h5py.File(path, "w") as hdf:
+        for output_block in ("DSS Hydrograph Output", "DSS Profile Output"):
+            base = (
+                "Results/Unsteady/Output/Output Blocks/"
+                f"{output_block}/Unsteady Time Series"
+            )
+            base_group = hdf.require_group(base)
+            base_group.create_dataset("Time Date Stamp (ms)", data=timestamps)
+            station_group = base_group.require_group("Pumping Stations/17th St Pumps")
+            dataset = station_group.create_dataset("Structure Variables", data=data)
+            dataset.attrs["Variable_Unit"] = variable_units
+
+        base_output = hdf.require_group(
+            "Results/Unsteady/Output/Output Blocks/Base Output/Unsteady Time Series"
+        )
+        base_output.create_dataset("Time Date Stamp (ms)", data=timestamps)
+
+
+def test_pump_station_timeseries_supports_multi_group_columns(tmp_path):
+    hdf_path = tmp_path / "multi_group_pump.p01.hdf"
+    _write_pump_hdf(hdf_path)
+
+    pump_timeseries = HdfPump.get_pump_station_timeseries(
+        hdf_path,
+        pump_station="17th St Pumps",
+    )
+
+    assert list(pump_timeseries.coords["variable"].values) == [
+        "Flow",
+        "Stage HW",
+        "Stage TW",
+        "V Pumps Flow",
+        "V Pumps Pumps on",
+        "G Pumps Flow",
+        "G Pumps Pumps on",
+    ]
+    assert pump_timeseries.sel(variable="V Pumps Flow").values.tolist() == [
+        10.0,
+        12.0,
+    ]
+    assert pump_timeseries.attrs["unit_by_variable"]["G Pumps Pumps on"] == "Pumps on"
+
+
+def test_pump_operation_timeseries_supports_multi_group_columns(tmp_path):
+    hdf_path = tmp_path / "multi_group_pump.p01.hdf"
+    _write_pump_hdf(hdf_path)
+
+    pump_operation = HdfPump.get_pump_operation_timeseries(
+        hdf_path,
+        pump_station="17th St Pumps",
+    )
+
+    assert list(pump_operation.columns) == [
+        "Flow",
+        "Stage HW",
+        "Stage TW",
+        "V Pumps Flow",
+        "V Pumps Pumps on",
+        "G Pumps Flow",
+        "G Pumps Pumps on",
+        "Time",
+    ]
+    assert pump_operation["G Pumps Flow"].tolist() == [20.0, 25.0]
+    assert pump_operation.attrs["unit_by_variable"]["V Pumps Flow"] == "cfs"

--- a/tests/test_hdf_results_mesh.py
+++ b/tests/test_hdf_results_mesh.py
@@ -51,6 +51,72 @@ def _create_synthetic_face_results_hdf(path):
         )
 
 
+def _create_synthetic_depth_results_hdf(path):
+    with h5py.File(path, "w") as hdf:
+        plan_info = hdf.require_group("Plan Data/Plan Information")
+        plan_info.attrs["Simulation Start Time"] = np.bytes_("01Jan2024 00:00:00")
+
+        hdf.create_dataset(
+            f"{BASE_TS_PATH}/Time",
+            data=np.array([0.0, 1.0 / 24.0]),
+        )
+        hdf.create_dataset(
+            f"{BASE_TS_PATH}/Time Date Stamp (ms)",
+            data=np.array(
+                [
+                    b"01Jan2024 00:00:00.000",
+                    b"01Jan2024 01:00:00.000",
+                ]
+            ),
+        )
+
+        attrs_dtype = np.dtype([("Name", "S64")])
+        hdf.create_dataset(
+            "Geometry/2D Flow Areas/Attributes",
+            data=np.array([(MESH_NAME.encode("utf-8"),)], dtype=attrs_dtype),
+        )
+        geom_group = hdf.require_group(f"Geometry/2D Flow Areas/{MESH_NAME}")
+        geom_group.create_dataset(
+            "Perimeter",
+            data=np.array(
+                [
+                    [0.0, 0.0],
+                    [2.0, 0.0],
+                    [2.0, 2.0],
+                    [0.0, 2.0],
+                ],
+                dtype=float,
+            ),
+        )
+        geom_group.create_dataset(
+            "Cells Center Coordinate",
+            data=np.array(
+                [
+                    [0.5, 0.5],
+                    [1.5, 0.5],
+                    [0.5, 1.5],
+                    [1.5, 1.5],
+                ],
+                dtype=float,
+            ),
+        )
+        geom_group.create_dataset(
+            "Cells Minimum Elevation",
+            data=np.array([0.0, 1.0, 2.0, 3.0], dtype=np.float32),
+        )
+
+        mesh_group = hdf.require_group(f"{BASE_TS_PATH}/2D Flow Areas/{MESH_NAME}")
+        _write_face_variable(
+            mesh_group,
+            "Water Surface",
+            [
+                [1.0, 1.0, 1.0, 1.0],
+                [2.0, 2.0, 5.0, 7.0],
+            ],
+            "ft",
+        )
+
+
 def test_get_mesh_faces_timeseries_returns_optional_face_outputs(tmp_path):
     hdf_path = tmp_path / "synthetic.p01.hdf"
     _create_synthetic_face_results_hdf(hdf_path)
@@ -68,6 +134,39 @@ def test_get_mesh_faces_timeseries_returns_optional_face_outputs(tmp_path):
     np.testing.assert_allclose(
         result["face_mannings_n"].values,
         np.array([[0.030, 0.040], [0.031, 0.041], [0.032, 0.042]]),
+    )
+
+
+def test_export_depth_rasters_at_times_computes_depth_from_wse(tmp_path):
+    import rasterio
+
+    hdf_path = tmp_path / "synthetic.p01.hdf"
+    _create_synthetic_depth_results_hdf(hdf_path)
+
+    result = HdfResultsMesh.export_depth_rasters_at_times(
+        hdf_path,
+        ["01Jan2024 01:00:00"],
+        tmp_path / "rasters",
+        mesh_name=MESH_NAME,
+        resolution=1.0,
+    )
+
+    raster_path = result["01Jan2024 01:00:00"]
+    assert raster_path.exists()
+    with rasterio.open(raster_path) as src:
+        data = src.read(1)
+        assert src.nodata == -9999.0
+        assert src.tags()["mesh_name"] == MESH_NAME
+
+    np.testing.assert_allclose(
+        data,
+        np.array(
+            [
+                [3.0, 4.0],
+                [2.0, 1.0],
+            ],
+            dtype=np.float32,
+        ),
     )
 
 

--- a/tests/test_precip_mrms.py
+++ b/tests/test_precip_mrms.py
@@ -1,0 +1,427 @@
+from __future__ import annotations
+
+import gzip
+from io import BytesIO
+from pathlib import Path
+import types
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from ras_commander.precip import PrecipMrms
+from ras_commander.precip.VortexCli import VortexCli
+
+
+class FakeResponse:
+    def __init__(self, content: bytes, status_code: int = 200):
+        self.content = content
+        self.status_code = status_code
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise RuntimeError(f"HTTP {self.status_code}")
+
+    def iter_content(self, chunk_size=8192):
+        for idx in range(0, len(self.content), chunk_size):
+            yield self.content[idx : idx + chunk_size]
+
+
+def test_catalog_parses_noaa_s3_listing(monkeypatch):
+    xml = b"""<?xml version="1.0" encoding="UTF-8"?>
+    <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+      <IsTruncated>false</IsTruncated>
+      <Contents>
+        <Key>CONUS/MultiSensor_QPE_01H_Pass2_00.00/20240708/MRMS_MultiSensor_QPE_01H_Pass2_00.00_20240708-120000.grib2.gz</Key>
+        <LastModified>2024-07-08T12:58:00.000Z</LastModified>
+        <Size>12345</Size>
+      </Contents>
+      <Contents>
+        <Key>CONUS/MultiSensor_QPE_01H_Pass2_00.00/20240708/readme.txt</Key>
+        <LastModified>2024-07-08T12:58:00.000Z</LastModified>
+        <Size>1</Size>
+      </Contents>
+    </ListBucketResult>
+    """
+
+    def fake_get(url, params=None, timeout=None):
+        assert url == PrecipMrms.NOAA_S3_BASE_URL
+        assert params["prefix"] == "CONUS/MultiSensor_QPE_01H_Pass2_00.00/20240708/"
+        return FakeResponse(xml)
+
+    monkeypatch.setitem(__import__("sys").modules, "requests", types.SimpleNamespace(get=fake_get))
+
+    catalog = PrecipMrms.catalog(
+        bounds=(-96.0, 29.0, -95.0, 30.0),
+        start_date="2024-07-08 12:00",
+        end_date="2024-07-08 12:00",
+        source="noaa_s3",
+    )
+
+    assert len(catalog) == 1
+    row = catalog.iloc[0]
+    assert row["source"] == "noaa_s3"
+    assert row["product"] == "GaugeCorr_QPE_01H"
+    assert row["archive_product"] == "MultiSensor_QPE_01H_Pass2_00.00"
+    assert row["filename"].endswith("20240708-120000.grib2.gz")
+    assert row["size_bytes"] == 12345
+    assert bool(row["compressed"]) is True
+    assert row["valid_time"] == pd.Timestamp("2024-07-08 12:00:00")
+
+
+def test_catalog_parses_iowa_mtarchive_listing(monkeypatch):
+    xml = b"""<?xml version="1.0" encoding="UTF-8"?>
+    <catalog xmlns="http://www.unidata.ucar.edu/namespaces/thredds/InvCatalog/v1.0">
+      <dataset name="GaugeCorr_QPE_01H">
+        <dataset name="GaugeCorr_QPE_01H_00.00_20171220-120000.grib2.gz"
+                 urlPath="mtarchive/2017/12/20/mrms/ncep/GaugeCorr_QPE_01H/GaugeCorr_QPE_01H_00.00_20171220-120000.grib2.gz">
+          <dataSize units="Kbytes">698.6</dataSize>
+          <date type="modified">2017-12-20T13:34:01.420Z</date>
+        </dataset>
+      </dataset>
+    </catalog>
+    """
+
+    def fake_get(url, timeout=None):
+        assert url.endswith("/mtarchive/2017/12/20/mrms/ncep/GaugeCorr_QPE_01H/catalog.xml")
+        return FakeResponse(xml)
+
+    monkeypatch.setitem(__import__("sys").modules, "requests", types.SimpleNamespace(get=fake_get))
+
+    catalog = PrecipMrms.catalog(
+        bounds=(-96.0, 29.0, -95.0, 30.0),
+        start_date="2017-12-20 12:00",
+        end_date="2017-12-20 12:00",
+        source="iowa",
+    )
+
+    assert len(catalog) == 1
+    row = catalog.iloc[0]
+    assert row["source"] == "iowa"
+    assert row["archive_product"] == "GaugeCorr_QPE_01H"
+    assert row["url"].startswith(PrecipMrms.IOWA_FILESERVER_BASE_URL)
+    assert row["size_bytes"] == int(698.6 * 1024)
+
+
+def test_download_decompresses_gzip_to_grib2(monkeypatch, tmp_path):
+    payload = b"GRIB-test-payload"
+    compressed = BytesIO()
+    with gzip.GzipFile(fileobj=compressed, mode="wb") as gz_file:
+        gz_file.write(payload)
+
+    catalog = pd.DataFrame(
+        [
+            {
+                "valid_time": pd.Timestamp("2024-07-08 12:00"),
+                "source": "noaa_s3",
+                "product": "GaugeCorr_QPE_01H",
+                "archive_product": "MultiSensor_QPE_01H_Pass2_00.00",
+                "url": "https://example.test/mrms.grib2.gz",
+                "filename": "MRMS_MultiSensor_QPE_01H_Pass2_00.00_20240708-120000.grib2.gz",
+                "size_bytes": len(compressed.getvalue()),
+                "last_modified": pd.Timestamp("2024-07-08 12:58"),
+                "compressed": True,
+            }
+        ]
+    )
+
+    monkeypatch.setattr(PrecipMrms, "catalog", staticmethod(lambda *args, **kwargs: catalog))
+
+    def fake_get(url, stream=False, timeout=None):
+        assert stream is True
+        assert url == "https://example.test/mrms.grib2.gz"
+        return FakeResponse(compressed.getvalue())
+
+    monkeypatch.setitem(__import__("sys").modules, "requests", types.SimpleNamespace(get=fake_get))
+
+    files = PrecipMrms.download(
+        bounds=(-96.0, 29.0, -95.0, 30.0),
+        start_time="2024-07-08 12:00",
+        end_time="2024-07-08 12:00",
+        output_dir=tmp_path,
+    )
+
+    assert len(files) == 1
+    assert files[0].suffix == ".grib2"
+    assert files[0].read_bytes() == payload
+
+
+def test_to_dss_wraps_vortex_with_mrms_defaults(monkeypatch, tmp_path):
+    grib_path = tmp_path / "MRMS_RadarOnly_QPE_01H_00.00_20240708-120000.grib2"
+    grib_path.write_bytes(b"GRIB")
+    output_dss = tmp_path / "mrms.dss"
+    clip_shp = tmp_path / "clip.shp"
+    clip_shp.write_text("placeholder")
+    calls = []
+
+    def fake_import_gridded(**kwargs):
+        calls.append(kwargs)
+        output = Path(kwargs["output_dss"])
+        output.write_bytes(b"DSS")
+        return output
+
+    monkeypatch.setattr(VortexCli, "import_gridded", staticmethod(fake_import_gridded))
+
+    result = PrecipMrms.to_dss(
+        [grib_path],
+        output_dss,
+        clip_shp=clip_shp,
+        product="RadarOnly_QPE_01H",
+        timeout=123,
+    )
+
+    assert result == output_dss
+    assert output_dss.exists()
+    assert len(calls) == 1
+    assert calls[0]["input_files"] == [grib_path]
+    assert calls[0]["variables"] == ["RadarOnlyQPE01H_altitude_above_msl"]
+    assert calls[0]["clip_shp"] == clip_shp
+    assert calls[0]["target_wkt"] == "SHG"
+    assert calls[0]["dss_parts"]["A"] == "SHG"
+    assert calls[0]["dss_parts"]["B"] == "MRMS_QPE"
+    assert calls[0]["dss_parts"]["F"] == "RADARONLY_QPE_01H"
+    assert calls[0]["timeout"] == 123
+
+
+def test_vortex_variables_respect_mrms_product_family():
+    assert PrecipMrms._vortex_variables("GaugeCorr_QPE_01H") == [
+        "GaugeCorrQPE01H_altitude_above_msl"
+    ]
+    assert PrecipMrms._vortex_variables("GaugeCorrQPE03H") == [
+        "GaugeCorrQPE03H_altitude_above_msl"
+    ]
+    assert PrecipMrms._vortex_variables("RadarOnly_QPE_06H") == [
+        "RadarOnlyQPE06H_altitude_above_msl"
+    ]
+    assert PrecipMrms._vortex_variables("MultiSensor_QPE_01H_Pass2_00.00") == [
+        "MultiSensor_QPE_01H_Pass2_altitude_above_msl"
+    ]
+    assert PrecipMrms._vortex_variables_for_files(
+        "GaugeCorr_QPE_01H",
+        [Path("MRMS_MultiSensor_QPE_01H_Pass2_00.00_20240708-120000.grib2")],
+    ) == ["MultiSensor_QPE_01H_Pass2_altitude_above_msl"]
+
+
+def test_timestamp_from_xarray_returns_scalar_for_vector_coord():
+    xr = pytest.importorskip("xarray")
+
+    coord = xr.DataArray(
+        pd.date_range("2024-07-08 12:00", periods=2, freq="h"),
+        dims=("time",),
+    )
+
+    timestamp = PrecipMrms._timestamp_from_xarray(coord)
+
+    assert timestamp == pd.Timestamp("2024-07-08 12:00").to_pydatetime()
+
+
+def test_vortex_finder_accepts_vortex_013_importer_layout(tmp_path):
+    vortex_dir = tmp_path / "HEC-Vortex" / "0.13.3"
+    (vortex_dir / "bin").mkdir(parents=True)
+    (vortex_dir / "lib").mkdir()
+    (vortex_dir / "bin" / "importer.bat").write_text("@echo off\n")
+    (vortex_dir / "lib" / "vortex-0.13.3.jar").write_text("placeholder")
+
+    assert VortexCli.find_vortex(vortex_dir) == vortex_dir
+    assert VortexCli._get_vortex_bat(vortex_dir).name == "importer.bat"
+
+
+def test_direct_mrms_hyetograph_and_netcdf_exports(tmp_path):
+    xr = pytest.importorskip("xarray")
+
+    times = pd.date_range("2024-02-04 00:00", periods=3, freq="h")
+    lat = np.array([38.7, 38.6])
+    lon = np.array([-121.8, -121.7])
+    precip = xr.DataArray(
+        np.array(
+            [
+                [[25.4, 0.0], [0.0, 25.4]],
+                [[12.7, 12.7], [12.7, 12.7]],
+                [[0.0, 0.0], [25.4, 25.4]],
+            ],
+            dtype=float,
+        ),
+        dims=("time", "latitude", "longitude"),
+        coords={"time": times, "latitude": lat, "longitude": lon},
+        attrs={"units": "mm"},
+    )
+
+    hyetograph = PrecipMrms.to_hyetograph(precip)
+
+    assert list(hyetograph.columns) == [
+        "time",
+        "hour",
+        "incremental_depth",
+        "cumulative_depth",
+    ]
+    assert hyetograph["hour"].tolist() == [1.0, 2.0, 3.0]
+    assert np.allclose(hyetograph["incremental_depth"], [0.5, 0.5, 0.5])
+    assert np.allclose(hyetograph["cumulative_depth"], [0.5, 1.0, 1.5])
+
+    nc_path = PrecipMrms.to_ras_netcdf(
+        precip,
+        tmp_path / "mrms_qpe.nc",
+        target_crs=None,
+    )
+
+    assert nc_path.exists()
+    with xr.open_dataset(nc_path) as ds:
+        assert "APCP_surface" in ds.data_vars
+        assert ds["APCP_surface"].attrs["units"] == "mm"
+        assert ds["APCP_surface"].shape == precip.shape
+
+
+def test_animation_helpers_accept_dataarray_and_hdf(monkeypatch, tmp_path):
+    gpd = pytest.importorskip("geopandas")
+    h5py = pytest.importorskip("h5py")
+    pytest.importorskip("matplotlib")
+    xr = pytest.importorskip("xarray")
+    from shapely.geometry import Point, box
+
+    monkeypatch.setattr(
+        PrecipMrms,
+        "_add_osm_basemap",
+        staticmethod(lambda ax, data_crs: None),
+    )
+
+    times = pd.date_range("2024-07-08 12:00", periods=2, freq="h")
+    lon = np.linspace(-95.5, -95.0, 5)
+    lat = np.linspace(29.5, 30.0, 4)
+    precip = xr.DataArray(
+        np.arange(2 * 4 * 5, dtype=float).reshape(2, 4, 5),
+        dims=("time", "latitude", "longitude"),
+        coords={"time": times, "latitude": lat, "longitude": lon},
+        attrs={"units": "mm"},
+    )
+    mesh_boundary = gpd.GeoDataFrame(
+        {"mesh_name": ["Demo 2D Area"]},
+        geometry=[box(-95.5, 29.5, -95.0, 30.0)],
+        crs="EPSG:4326",
+    )
+    pump_stations = gpd.GeoDataFrame(
+        {"Name": ["Demo Pump"]},
+        geometry=[Point(-95.25, 29.75)],
+        crs="EPSG:4326",
+    )
+
+    mesh_name = "Demo 2D Area"
+    hdf_path = tmp_path / "synthetic_plan.p01.hdf"
+    centers = np.array(
+        [
+            [-95.5, 29.5],
+            [-95.0, 29.5],
+            [-95.5, 30.0],
+            [-95.0, 30.0],
+        ],
+        dtype=float,
+    )
+    depth = np.array(
+        [
+            [0.1, 0.2, 0.0, 0.3],
+            [0.4, 0.1, 0.5, 0.2],
+        ],
+        dtype="float32",
+    )
+    with h5py.File(hdf_path, "w") as hdf:
+        hdf.attrs["Projection"] = (
+            'GEOGCS["WGS 84",DATUM["WGS_1984",'
+            'SPHEROID["WGS 84",6378137,298.257223563]],'
+            'PRIMEM["Greenwich",0],UNIT["degree",0.0174532925199433]]'
+        )
+        plan_info = hdf.require_group("Plan Data").require_group("Plan Information")
+        plan_info.attrs["Simulation Start Time"] = np.bytes_("08Jul2024 12:00:00")
+        geom_root = hdf.require_group("Geometry").require_group("2D Flow Areas")
+        dtype = np.dtype([("Name", "S64")])
+        geom_root.create_dataset(
+            "Attributes",
+            data=np.array([(mesh_name.encode("utf-8"),)], dtype=dtype),
+        )
+        mesh_group = geom_root.require_group(mesh_name)
+        mesh_group.create_dataset("Cells Center Coordinate", data=centers)
+        ts_root = (
+            hdf.require_group("Results")
+            .require_group("Unsteady")
+            .require_group("Output")
+            .require_group("Output Blocks")
+            .require_group("Base Output")
+            .require_group("Unsteady Time Series")
+        )
+        ts_root.create_dataset("Time", data=np.array([0.0, 1.0 / 24.0]))
+        flow_root = ts_root.require_group("2D Flow Areas").require_group(mesh_name)
+        depth_dataset = flow_root.create_dataset("Depth", data=depth)
+        depth_dataset.attrs["Units"] = b"ft"
+
+    precip_gif = PrecipMrms.animate_precipitation(
+        precip,
+        tmp_path / "precip.gif",
+        bounds=(-95.5, 29.5, -95.0, 30.0),
+        mesh_boundary=mesh_boundary,
+        pump_stations=pump_stations,
+        add_basemap=True,
+        units="mm",
+        fps=1,
+    )
+    flood_gif = PrecipMrms.animate_flood_inundation(
+        hdf_path,
+        tmp_path / "flood.gif",
+        mesh_name=mesh_name,
+        mesh_boundary=mesh_boundary,
+        pump_stations=pump_stations,
+        add_basemap=True,
+        crs="EPSG:4326",
+        fps=1,
+    )
+    combined_gif = PrecipMrms.animate_combined(
+        precip,
+        hdf_path,
+        tmp_path / "combined.gif",
+        bounds=(-95.5, 29.5, -95.0, 30.0),
+        mesh_name=mesh_name,
+        mesh_boundary=mesh_boundary,
+        pump_stations=pump_stations,
+        add_basemap=True,
+        precip_crs="EPSG:4326",
+        flood_crs="EPSG:4326",
+        fps=1,
+    )
+
+    for animation_path in (precip_gif, flood_gif, combined_gif):
+        assert animation_path.exists()
+        assert animation_path.stat().st_size > 0
+
+
+def test_flood_animation_accepts_stored_map_rasters(tmp_path):
+    rasterio = pytest.importorskip("rasterio")
+    pytest.importorskip("matplotlib")
+
+    from rasterio.transform import from_origin
+
+    raster_paths = []
+    for idx in range(2):
+        raster_path = tmp_path / f"Depth (04FEB2024 0{idx} 00 00).Terrain.tif"
+        with rasterio.open(
+            raster_path,
+            "w",
+            driver="GTiff",
+            height=3,
+            width=4,
+            count=1,
+            dtype="float32",
+            crs="EPSG:2871",
+            transform=from_origin(1000, 2000, 10, 10),
+            nodata=-9999,
+        ) as dst:
+            dst.write(np.full((3, 4), idx + 1, dtype="float32"), 1)
+        raster_paths.append(raster_path)
+
+    output = PrecipMrms.animate_flood_inundation_from_rasters(
+        raster_paths,
+        tmp_path / "flood_rasters.gif",
+        times=pd.date_range("2024-02-04", periods=2, freq="h"),
+        fps=1,
+    )
+    raster_stack = PrecipMrms._load_raster_stack(raster_paths)
+
+    assert output.exists()
+    assert output.stat().st_size > 0
+    assert raster_stack.attrs["crs"] == "EPSG:2871"

--- a/tests/test_rasprj_encoding.py
+++ b/tests/test_rasprj_encoding.py
@@ -21,3 +21,26 @@ def test_project_entries_use_fallback_encoding_for_cp1252_project_file(tmp_path)
 
     assert geom_df.loc[0, "geom_number"] == "02"
     assert geom_df.loc[0, "full_path"].endswith("NewOrleansLike.g02")
+
+
+def test_get_geom_entries_uses_fallback_encoding_for_cp1252_project_file(tmp_path):
+    project_file = tmp_path / "NewOrleansLike.prj"
+    project_file.write_bytes(
+        b"Proj Title=New Orleans Like\r\n"
+        b"Current Plan=p01\r\n"
+        b"Geom File=g02\r\n"
+        b"Plot Driver Conduit Layer List Feature=Base\x95Fairmont 2\r\n"
+    )
+
+    ras_project = RasPrj()
+    ras_project.initialized = True
+    ras_project.suppress_logging = True
+    ras_project.project_folder = tmp_path
+    ras_project.project_name = "NewOrleansLike"
+    ras_project.prj_file = project_file
+
+    geom_df = ras_project.get_geom_entries()
+
+    assert geom_df.loc[0, "geom_file"] == "g02"
+    assert geom_df.loc[0, "geom_number"] == "02"
+    assert geom_df.loc[0, "full_path"].endswith("NewOrleansLike.g02")


### PR DESCRIPTION
## Summary
- Adds `PrecipMrms` download/catalog/DSS conversion and animation helpers for MRMS QPE workflows.
- Adds the executed `examples/917_mrms_precipitation_qpe.ipynb` workflow covering Davis and NewOrleans with full-event 5-minute depth animations.
- Adds HDF-derived depth raster export support and targeted tests.

## Review Feedback Addressed
- Davis animation now spans 2022-12-31 00:00 through 2023-01-01 18:00, producing 505 five-minute depth frames.
- NewOrleans animation now spans 2024-04-10 00:00 through 2024-04-11 06:00, producing 361 five-minute depth frames with mesh/pump/OSM overlays.

## Validation
- `pytest tests/test_precip_mrms.py tests/ras_process_store_maps_output_path_test.py tests/test_rasprj_encoding.py tests/test_hdf_results_mesh.py -q` -> 22 passed, 1 warning.
- `run_notebook_visible.py --notebook examples/917_mrms_precipitation_qpe.ipynb --repo ras-commander --issue CLB-642 --env symphony-dev --workspace ... --timeout 10800 --interval 60` -> passed in 2886s.
- `git diff --check` -> no whitespace errors; LF-to-CRLF warnings only.

Artifacts: `H:/Symphony/ras-commander/CLB-642/`