### PR TITLE
feat(unsteady): add gridded DSS .u## configuration helper

### DIFF
--- a/ras_commander/RasUnsteady.py
+++ b/ras_commander/RasUnsteady.py
@@ -41,9 +41,13 @@ List of Functions in RasUnsteady:
 - write_table_to_file()
 - set_precipitation_hyetograph()
 - set_gridded_precipitation()
+- configure_gridded_dss_precipitation()
 
-Precipitation Hyetograph Functions:
+Precipitation Functions:
 - set_precipitation_hyetograph() - Write hyetograph DataFrame to unsteady file
+- set_gridded_precipitation() - Configure GDAL raster precipitation
+- configure_gridded_dss_precipitation() - Configure gridded DSS precipitation
+- get_met_precipitation_config() - Read meteorologic precipitation configuration
 
 DSS Boundary Condition Functions:
 - get_dss_boundaries() - Extract all DSS-linked BCs with full path info
@@ -1395,6 +1399,382 @@ class RasUnsteady:
         except Exception as e:
             logger.error(f"Error updating HDF file: {e}")
             raise
+
+    @staticmethod
+    def _format_met_dss_filename(dss_filename: Union[str, Path], unsteady_path: Path) -> str:
+        """
+        Normalize a DSS filename for RAS meteorology text/HDF attributes.
+
+        Relative paths are written with RAS' conventional ``.\\`` prefix. Absolute
+        paths under the unsteady file folder are converted to project-relative
+        paths; absolute paths elsewhere are preserved.
+        """
+        raw_filename = str(dss_filename).strip()
+        if not raw_filename:
+            raise ValueError("dss_filename must not be empty")
+
+        dss_path = Path(raw_filename)
+        if dss_path.is_absolute():
+            try:
+                relative_path = dss_path.relative_to(unsteady_path.parent)
+                return f".\\{relative_path}".replace("/", "\\")
+            except ValueError:
+                return str(dss_path)
+
+        normalized = raw_filename.replace("/", "\\")
+        if normalized.startswith((".\\", "..\\", "\\")):
+            return normalized
+        return f".\\{normalized}"
+
+    @staticmethod
+    def _normalize_gridded_interpolation(interpolation: str) -> str:
+        """Normalize optional gridded interpolation names used by HEC-RAS."""
+        interpolation_value = str(interpolation or "").strip()
+        if not interpolation_value:
+            return ""
+
+        valid_values = {
+            "nearest": "Nearest",
+            "bilinear": "Bilinear",
+        }
+        normalized = valid_values.get(interpolation_value.lower())
+        if normalized is None:
+            raise ValueError(
+                "interpolation must be '', 'Nearest', or 'Bilinear'"
+            )
+        return normalized
+
+    @staticmethod
+    def _get_default_met_insert_index(lines: List[str]) -> int:
+        """Choose a stable insertion point for meteorologic BC metadata."""
+        for i, line in enumerate(lines):
+            if line.startswith("Boundary Location="):
+                return i
+        for i, line in enumerate(lines):
+            if line.startswith("Program Version="):
+                return i + 1
+        for i, line in enumerate(lines):
+            if line.startswith("Flow Title="):
+                return i + 1
+        return len(lines)
+
+    @staticmethod
+    def _ensure_meteorology_attributes_dataset(hdf_file: Any, met_path: str) -> None:
+        """Ensure HEC-RAS' Meteorology/Attributes dataset indexes precipitation."""
+        attrs_path = f"{met_path}/Attributes"
+        attr_dtype = np.dtype([("Variable", "S32"), ("Group", "S42")])
+        precip_row = np.array(
+            [(b"Precipitation", b"Event Conditions/Meteorology/Precipitation")],
+            dtype=attr_dtype,
+        )
+
+        if attrs_path not in hdf_file:
+            hdf_file.create_dataset(
+                attrs_path,
+                data=precip_row,
+                chunks=(1,),
+                maxshape=(None,),
+                compression="gzip",
+            )
+            return
+
+        attrs_ds = hdf_file[attrs_path]
+        if attrs_ds.dtype.names is None or "Variable" not in attrs_ds.dtype.names:
+            logger.debug(
+                "Meteorology/Attributes dataset has unexpected dtype; "
+                "leaving existing dataset unchanged"
+            )
+            return
+
+        existing = attrs_ds[...]
+        for row in existing:
+            variable = bytes(row["Variable"]).decode("utf-8", errors="ignore").rstrip("\x00")
+            if variable == "Precipitation":
+                return
+
+        new_data = np.empty(len(existing) + 1, dtype=attr_dtype)
+        for i, row in enumerate(existing):
+            group_value = row["Group"] if "Group" in existing.dtype.names else b""
+            new_data[i] = (bytes(row["Variable"]), bytes(group_value))
+        new_data[-1] = precip_row[0]
+
+        del hdf_file[attrs_path]
+        hdf_file.create_dataset(
+            attrs_path,
+            data=new_data,
+            chunks=(len(new_data),),
+            maxshape=(None,),
+            compression="gzip",
+        )
+
+    @staticmethod
+    def _update_gridded_dss_precipitation_hdf(
+        unsteady_path: Path,
+        dss_filename: str,
+        dss_pathname: str,
+        interpolation: str = "",
+    ) -> Path:
+        """
+        Write gridded DSS precipitation metadata to the unsteady sidecar HDF.
+
+        This writes only configuration attributes. It does not write DSS grid
+        records or import raster precipitation values.
+        """
+        import h5py
+
+        hdf_path = Path(str(unsteady_path) + ".hdf")
+        met_path = "Event Conditions/Meteorology"
+        precip_grp_path = f"{met_path}/Precipitation"
+
+        with h5py.File(hdf_path, "a") as hdf_file:
+            if "Event Conditions" not in hdf_file:
+                hdf_file.create_group("Event Conditions")
+            if met_path not in hdf_file:
+                hdf_file.create_group(met_path)
+            if precip_grp_path not in hdf_file:
+                hdf_file.create_group(precip_grp_path)
+
+            precip_grp = hdf_file[precip_grp_path]
+            precip_grp.attrs["Enabled"] = np.uint8(1)
+            precip_grp.attrs["Mode"] = np.bytes_("Gridded")
+            precip_grp.attrs["Source"] = np.bytes_("DSS")
+            precip_grp.attrs["DSS Filename"] = np.bytes_(dss_filename)
+            precip_grp.attrs["DSS Pathname"] = np.bytes_(dss_pathname)
+            if interpolation:
+                precip_grp.attrs["Interpolation Method"] = np.bytes_(interpolation)
+            elif "Interpolation Method" in precip_grp.attrs:
+                del precip_grp.attrs["Interpolation Method"]
+
+            for stale_attr in (
+                "GDAL Filename",
+                "GDAL Datasetname",
+                "GDAL Filter",
+                "GDAL Folder",
+            ):
+                if stale_attr in precip_grp.attrs:
+                    del precip_grp.attrs[stale_attr]
+
+            RasUnsteady._ensure_meteorology_attributes_dataset(hdf_file, met_path)
+
+        return hdf_path
+
+    @staticmethod
+    @log_call
+    def configure_gridded_dss_precipitation(
+        unsteady_file: Path,
+        dss_filename: str,
+        dss_pathname: str,
+        interpolation: str = "",
+    ) -> None:
+        """
+        Configure a .u## file to reference gridded DSS precipitation.
+
+        This helper wires an existing DSS grid file into the HEC-RAS unsteady
+        flow configuration. It does not write DSS data.
+
+        Parameters
+        ----------
+        unsteady_file : Path
+            Path to the unsteady flow file (.u##).
+        dss_filename : str
+            DSS filename for the gridded precipitation source. Relative values
+            are written using RAS-style backslashes (for example,
+            ``.\\Precipitation\\precip.dss``). Absolute paths inside the
+            unsteady file folder are converted to that relative form; absolute
+            paths elsewhere are preserved.
+        dss_pathname : str
+            DSS pathname for the precipitation grid record.
+        interpolation : str, optional
+            Spatial interpolation method. Use ``"Nearest"`` or ``"Bilinear"``.
+            The default empty string leaves the RAS default unset in the .u##.
+
+        Returns
+        -------
+        None
+            The .u## file and its .u##.hdf sidecar metadata are updated in place.
+        """
+        unsteady_path = Path(unsteady_file)
+        if not unsteady_path.exists():
+            raise FileNotFoundError(f"Unsteady flow file not found: {unsteady_path}")
+        unsteady_path = unsteady_path.resolve()
+
+        dss_pathname = str(dss_pathname).strip()
+        if not dss_pathname:
+            raise ValueError("dss_pathname must not be empty")
+
+        dss_filename_str = RasUnsteady._format_met_dss_filename(
+            dss_filename,
+            unsteady_path,
+        )
+        interpolation_value = RasUnsteady._normalize_gridded_interpolation(interpolation)
+
+        desired_lines = [
+            "Precipitation Mode=Enable\n",
+            "Met BC=Precipitation|Mode=Gridded\n",
+            "Met BC=Precipitation|Gridded Source=DSS\n",
+        ]
+        if interpolation_value:
+            desired_lines.append(
+                f"Met BC=Precipitation|Gridded Interpolation={interpolation_value}\n"
+            )
+        desired_lines.extend([
+            f"Met BC=Precipitation|Gridded DSS Filename={dss_filename_str}\n",
+            f"Met BC=Precipitation|Gridded DSS Pathname={dss_pathname}\n",
+        ])
+
+        remove_prefixes = (
+            "Precipitation Mode=",
+            "Met BC=Precipitation|Mode=",
+            "Met BC=Precipitation|Gridded Source=",
+            "Met BC=Precipitation|Gridded Interpolation=",
+            "Met BC=Precipitation|Gridded DSS Filename=",
+            "Met BC=Precipitation|Gridded DSS Pathname=",
+            "Met BC=Precipitation|Gridded GDAL Filename=",
+            "Met BC=Precipitation|Gridded GDAL Datasetname=",
+            "Met BC=Precipitation|Gridded GDAL Filter=",
+            "Met BC=Precipitation|Gridded GDAL Folder=",
+        )
+        anchor_prefixes = remove_prefixes + ("Met BC=Precipitation|",)
+
+        with open(unsteady_path, "r", encoding="utf-8", errors="ignore") as f:
+            lines = f.readlines()
+
+        insert_index = None
+        for i, line in enumerate(lines):
+            if line.startswith(anchor_prefixes):
+                insert_index = i
+                break
+        if insert_index is None:
+            insert_index = RasUnsteady._get_default_met_insert_index(lines)
+
+        filtered_lines = []
+        removed_before_insert = 0
+        for i, line in enumerate(lines):
+            if line.startswith(remove_prefixes):
+                if i < insert_index:
+                    removed_before_insert += 1
+                continue
+            filtered_lines.append(line)
+
+        insert_index = max(0, insert_index - removed_before_insert)
+        if insert_index == len(filtered_lines) and filtered_lines:
+            if not filtered_lines[-1].endswith(("\n", "\r")):
+                filtered_lines[-1] = f"{filtered_lines[-1]}\n"
+
+        updated_lines = (
+            filtered_lines[:insert_index]
+            + desired_lines
+            + filtered_lines[insert_index:]
+        )
+
+        with open(unsteady_path, "w", encoding="utf-8") as f:
+            f.writelines(updated_lines)
+
+        hdf_path = RasUnsteady._update_gridded_dss_precipitation_hdf(
+            unsteady_path=unsteady_path,
+            dss_filename=dss_filename_str,
+            dss_pathname=dss_pathname,
+            interpolation=interpolation_value,
+        )
+
+        logger.info(
+            f"Configured gridded DSS precipitation in {unsteady_path.name}: "
+            f"{dss_filename_str}, {dss_pathname}; HDF metadata={hdf_path.name}"
+        )
+
+    @staticmethod
+    def _decode_hdf_attr_value(value: Any) -> Any:
+        """Decode scalar HDF attribute values to plain Python objects."""
+        if isinstance(value, np.bytes_):
+            return value.decode("utf-8", errors="ignore")
+        if isinstance(value, bytes):
+            return value.decode("utf-8", errors="ignore")
+        if isinstance(value, np.generic):
+            return value.item()
+        if isinstance(value, np.ndarray):
+            return [RasUnsteady._decode_hdf_attr_value(item) for item in value]
+        return value
+
+    @staticmethod
+    @log_call
+    def get_met_precipitation_config(
+        unsteady_file: Union[str, Path],
+    ) -> Dict[str, Any]:
+        """
+        Read the meteorologic precipitation configuration from a .u## file.
+
+        Returns a flat dictionary with normalized convenience keys plus the raw
+        ``Met BC=Precipitation|...`` values and any sidecar HDF precipitation
+        attributes when ``<unsteady_file>.hdf`` exists.
+        """
+        unsteady_path = Path(unsteady_file)
+        if not unsteady_path.exists():
+            raise FileNotFoundError(f"Unsteady flow file not found: {unsteady_path}")
+
+        config: Dict[str, Any] = {
+            "unsteady_file": str(unsteady_path),
+            "precipitation_mode": "",
+            "mode": "",
+            "source": "",
+            "interpolation": "",
+            "dss_filename": "",
+            "dss_pathname": "",
+            "gdal_filename": "",
+            "raw": {},
+            "hdf_path": str(Path(str(unsteady_path) + ".hdf")),
+            "hdf_attributes": {},
+        }
+
+        with open(unsteady_path, "r", encoding="utf-8", errors="ignore") as f:
+            for line in f:
+                stripped = line.rstrip("\r\n")
+                if stripped.startswith("Precipitation Mode="):
+                    config["precipitation_mode"] = stripped.split("=", 1)[1].strip()
+                    continue
+
+                met_prefix = "Met BC=Precipitation|"
+                if not stripped.startswith(met_prefix):
+                    continue
+
+                met_payload = stripped[len(met_prefix):]
+                if "=" not in met_payload:
+                    continue
+
+                met_key, value = met_payload.split("=", 1)
+                value = value.strip()
+                config["raw"][met_key] = value
+                if met_key == "Mode":
+                    config["mode"] = value
+                elif met_key == "Gridded Source":
+                    config["source"] = value
+                elif met_key == "Gridded Interpolation":
+                    config["interpolation"] = value
+                elif met_key == "Gridded DSS Filename":
+                    config["dss_filename"] = value
+                elif met_key == "Gridded DSS Pathname":
+                    config["dss_pathname"] = value
+                elif met_key == "Gridded GDAL Filename":
+                    config["gdal_filename"] = value
+
+        config["gridded_source"] = config["source"]
+        config["gridded_interpolation"] = config["interpolation"]
+        config["gridded_dss_filename"] = config["dss_filename"]
+        config["gridded_dss_pathname"] = config["dss_pathname"]
+        config["gridded_gdal_filename"] = config["gdal_filename"]
+
+        hdf_path = Path(config["hdf_path"])
+        if hdf_path.exists():
+            import h5py
+
+            precip_path = "Event Conditions/Meteorology/Precipitation"
+            with h5py.File(hdf_path, "r") as hdf_file:
+                if precip_path in hdf_file:
+                    config["hdf_attributes"] = {
+                        key: RasUnsteady._decode_hdf_attr_value(value)
+                        for key, value in hdf_file[precip_path].attrs.items()
+                    }
+
+        return config
 
     @staticmethod
     @log_call

--- a/tests/test_rasunsteady_gridded_dss_precipitation.py
+++ b/tests/test_rasunsteady_gridded_dss_precipitation.py
@@ -1,0 +1,152 @@
+"""Tests for gridded DSS precipitation .u## configuration."""
+
+from pathlib import Path
+
+import pytest
+
+h5py = pytest.importorskip("h5py")
+
+
+BALD_EAGLE_DSS_PATHNAME = (
+    "/SHG/MARFC/PRECIP/01SEP2018:0200/01SEP2018:0300/NEXRAD/"
+)
+
+
+def _write_unsteady_file(path: Path, content: str) -> Path:
+    path.write_text(content, encoding="utf-8")
+    return path
+
+
+def test_configures_official_baldeagle_gridded_dss_structure_and_round_trips(tmp_path):
+    from ras_commander import RasUnsteady
+
+    unsteady_file = _write_unsteady_file(
+        tmp_path / "BaldEagleDamBrk.u03",
+        """Flow Title=Gridded Precipitation
+Program Version=6.60
+Use Restart= 0
+Precipitation Mode=Disable
+Met BC=Precipitation|Mode=Constant
+Met BC=Precipitation|Gridded Source=GDAL Raster File(s)
+Met BC=Precipitation|Gridded Interpolation=Bilinear
+Met BC=Precipitation|Gridded GDAL Filename=.\\Precipitation\\old.nc
+Boundary Location=                ,                ,        ,        ,                ,BaldEagleCr     ,                ,                                ,
+""",
+    )
+
+    RasUnsteady.configure_gridded_dss_precipitation(
+        unsteady_file=unsteady_file,
+        dss_filename=".\\Precipitation\\precip.2018.09.dss",
+        dss_pathname=BALD_EAGLE_DSS_PATHNAME,
+    )
+
+    lines = unsteady_file.read_text(encoding="utf-8").splitlines()
+    expected_block = [
+        "Precipitation Mode=Enable",
+        "Met BC=Precipitation|Mode=Gridded",
+        "Met BC=Precipitation|Gridded Source=DSS",
+        "Met BC=Precipitation|Gridded DSS Filename=.\\Precipitation\\precip.2018.09.dss",
+        f"Met BC=Precipitation|Gridded DSS Pathname={BALD_EAGLE_DSS_PATHNAME}",
+    ]
+    start_idx = lines.index("Precipitation Mode=Enable")
+    assert lines[start_idx:start_idx + len(expected_block)] == expected_block
+    assert not any("Gridded GDAL" in line for line in lines)
+    assert not any("Gridded Interpolation=" in line for line in lines)
+
+    config = RasUnsteady.get_met_precipitation_config(unsteady_file)
+    assert config["precipitation_mode"] == "Enable"
+    assert config["mode"] == "Gridded"
+    assert config["source"] == "DSS"
+    assert config["dss_filename"] == ".\\Precipitation\\precip.2018.09.dss"
+    assert config["dss_pathname"] == BALD_EAGLE_DSS_PATHNAME
+
+    hdf_attrs = config["hdf_attributes"]
+    assert hdf_attrs["Mode"] == "Gridded"
+    assert hdf_attrs["Source"] == "DSS"
+    assert hdf_attrs["DSS Filename"] == ".\\Precipitation\\precip.2018.09.dss"
+    assert hdf_attrs["DSS Pathname"] == BALD_EAGLE_DSS_PATHNAME
+    assert "Interpolation Method" not in hdf_attrs
+
+
+def test_configure_gridded_dss_creates_met_bc_section_for_minimal_file(tmp_path):
+    from ras_commander import RasUnsteady
+
+    unsteady_file = _write_unsteady_file(
+        tmp_path / "minimal.u01",
+        """Flow Title=Minimal
+Program Version=6.60
+""",
+    )
+
+    RasUnsteady.configure_gridded_dss_precipitation(
+        unsteady_file=unsteady_file,
+        dss_filename="Precipitation/precip.dss",
+        dss_pathname="/SHG/TEST/PRECIP/01JAN2020:0000/01JAN2020:0100/VORTEX/",
+        interpolation="Nearest",
+    )
+
+    config = RasUnsteady.get_met_precipitation_config(unsteady_file)
+    assert config["mode"] == "Gridded"
+    assert config["source"] == "DSS"
+    assert config["interpolation"] == "Nearest"
+    assert config["dss_filename"] == ".\\Precipitation\\precip.dss"
+    assert config["hdf_attributes"]["Interpolation Method"] == "Nearest"
+
+
+def test_absolute_dss_path_inside_unsteady_folder_is_written_relative(tmp_path):
+    from ras_commander import RasUnsteady
+
+    unsteady_file = _write_unsteady_file(
+        tmp_path / "absolute_inside.u01",
+        "Flow Title=Absolute Inside\nProgram Version=6.60\n",
+    )
+    absolute_dss = tmp_path / "Precipitation" / "precip.dss"
+
+    RasUnsteady.configure_gridded_dss_precipitation(
+        unsteady_file=unsteady_file,
+        dss_filename=str(absolute_dss),
+        dss_pathname=BALD_EAGLE_DSS_PATHNAME,
+    )
+
+    config = RasUnsteady.get_met_precipitation_config(unsteady_file)
+    assert config["dss_filename"] == ".\\Precipitation\\precip.dss"
+    assert config["hdf_attributes"]["DSS Filename"] == ".\\Precipitation\\precip.dss"
+
+
+def test_absolute_dss_path_outside_unsteady_folder_is_preserved(tmp_path):
+    from ras_commander import RasUnsteady
+
+    project_dir = tmp_path / "project"
+    project_dir.mkdir()
+    unsteady_file = _write_unsteady_file(
+        project_dir / "absolute_outside.u01",
+        "Flow Title=Absolute Outside\nProgram Version=6.60\n",
+    )
+    absolute_dss = tmp_path / "external_precip.dss"
+
+    RasUnsteady.configure_gridded_dss_precipitation(
+        unsteady_file=unsteady_file,
+        dss_filename=str(absolute_dss),
+        dss_pathname=BALD_EAGLE_DSS_PATHNAME,
+    )
+
+    config = RasUnsteady.get_met_precipitation_config(unsteady_file)
+    assert config["dss_filename"] == str(absolute_dss)
+    assert config["hdf_attributes"]["DSS Filename"] == str(absolute_dss)
+
+
+def test_invalid_gridded_dss_interpolation_raises(tmp_path):
+    from ras_commander import RasUnsteady
+
+    unsteady_file = _write_unsteady_file(
+        tmp_path / "invalid_interpolation.u01",
+        "Flow Title=Invalid\nProgram Version=6.60\n",
+    )
+
+    with pytest.raises(ValueError, match="interpolation"):
+        RasUnsteady.configure_gridded_dss_precipitation(
+            unsteady_file=unsteady_file,
+            dss_filename="Precipitation/precip.dss",
+            dss_pathname=BALD_EAGLE_DSS_PATHNAME,
+            interpolation="Kriging",
+        )


### PR DESCRIPTION
## Summary
- Adds `configure_gridded_dss_precipitation()` to `RasUnsteady` for writing gridded DSS meteorology boundary conditions to HEC-RAS `.u##` files and their `.u##.hdf` sidecar metadata
- Adds `get_met_precipitation_config()` for round-trip readback of the meteorologic precipitation configuration from both the text file and HDF attributes
- Includes comprehensive test suite (`tests/test_rasunsteady_gridded_dss_precipitation.py`) covering the Bald Eagle Dam Break reference structure, minimal files, relative/absolute DSS path normalization, and input validation

## Dependencies
This PR depends on **CLB-701** (Met BC Reader, branch `feature/CLB-701-met-bc-reader`). CLB-701 was not yet pushed when this branch was created, so this is currently based on `main`. Once CLB-701 is merged or its branch is available, this PR should be rebased onto it to resolve any overlap in the `get_met_precipitation_config` implementation.

## Test plan
- [ ] Run `pytest tests/test_rasunsteady_gridded_dss_precipitation.py` to verify all 5 test cases pass
- [ ] Verify round-trip: configure gridded DSS precip then read it back via `get_met_precipitation_config()`
- [ ] Confirm HDF sidecar metadata is correctly written (Mode, Source, DSS Filename, DSS Pathname attributes)
- [ ] Validate that stale GDAL attributes are cleaned up when switching from raster to DSS source
- [ ] Test path normalization: absolute paths inside project folder become `.\relative`, outside paths preserved

Closes CLB-702

🤖 Generated with [Claude Code](https://claude.com/claude-code)