### PR TITLE
CLB-757: polygon mask API + depth-varying Manning's n notebook

### DIFF
--- a/examples/414_depth_varying_mannings_n.ipynb
+++ b/examples/414_depth_varying_mannings_n.ipynb
@@ -2,48 +2,224 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "a515a871",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002913,
+     "end_time": "2026-05-12T12:22:40.882396+00:00",
+     "exception": false,
+     "start_time": "2026-05-12T12:22:40.879483+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
-    "# 414 — 2D Manning's n Modification (Edit-Run-Read Loop)\n",
+    "# 414 — Depth-Varying Manning's n for HEC-RAS 2D Models\n",
     "\n",
-    "This notebook demonstrates a self-proving **edit-run-read** loop for 2D Manning's n:\n",
+    "Manning's roughness coefficient varies with flow depth — this is well-established\n",
+    "in hydraulic literature (Chow 1959, HEC-15, Limerinos 1970, Jarrett 1984) but\n",
+    "often ignored in practice because HEC-RAS 2D models default to uniform roughness.\n",
     "\n",
-    "1. **Read** the current Manning's n settings from the plain-text geometry file\n",
-    "2. **Modify** the uniform Manning's n via `GeomStorage.set_2d_flow_area_settings()`\n",
-    "3. **Run** both baseline and modified models with `force_geompre=True`\n",
-    "4. **Verify** that face property tables in the geometry HDF reflect the new n values\n",
-    "5. **Compare** simulation results to confirm the modifications impacted hydraulics\n",
+    "This notebook demonstrates a complete workflow for implementing **depth-varying\n",
+    "Manning's n** in HEC-RAS 2D face property tables using `ras-commander`:\n",
     "\n",
-    "**Bonus**: Demonstrates the `HdfMesh` face property table read/write API for direct\n",
-    "HDF manipulation (useful for post-processing and analysis).\n",
+    "1. **Literature grounding** — formulas that relate n to hydraulic radius\n",
+    "2. **Edit-run-read loop** — modify geometry, execute, verify face tables\n",
+    "3. **Face property table extension** — extend tables to higher elevations with\n",
+    "   depth-varying n using the HEC-15 vegetal retardance concept\n",
+    "4. **Polygon mask API** — apply modifications selectively to channel faces using\n",
+    "   calibration regions or computed channel polygons\n",
+    "5. **Channel polygon strategies** — multiple approaches to identify channel cells\n",
     "\n",
-    "**Key insight**: HEC-RAS 2D models can use either a **uniform** Manning's n\n",
-    "(`Storage Area Mannings=` in the `.g##` file) or **spatially varied** values from a\n",
-    "land cover table. The Muncie model uses uniform n. To change Manning's n values that\n",
-    "persist through HEC-RAS compute, modify the **plain-text geometry file** (`.g##`)\n",
-    "and run with `force_geompre=True`. HEC-RAS regenerates the geometry HDF face property\n",
-    "tables during preprocessing — direct HDF edits are overwritten.\n",
+    "**Key insight**: HEC-RAS 2D face property tables store Manning's n as a function\n",
+    "of elevation for each cell face. By **extending** these tables to higher elevations\n",
+    "with a depth-varying formula, we can model the physical reality that roughness\n",
+    "decreases with increasing flow depth.\n",
     "\n",
     "**API methods demonstrated**:\n",
-    "- `GeomStorage.get_2d_flow_area_settings()` — read 2D flow area configuration\n",
-    "- `GeomStorage.set_2d_flow_area_settings()` — modify uniform Manning's n\n",
-    "- `GeomLandCover.get_base_mannings_n()` — read land cover Manning's n table\n",
-    "- `HdfMesh.get_mesh_face_property_tables()` — read face-level n from geometry HDF\n",
-    "- `HdfMesh.set_face_mannings_n_values()` — direct HDF n replacement\n",
-    "- `HdfMesh.extend_face_property_tables()` — extend tables to higher elevations\n",
-    "- `HdfMesh.pin_property_tables()` — set Pinned attribute on mesh group"
+    "\n",
+    "| Method | Purpose |\n",
+    "|--------|---------|\n",
+    "| `GeomStorage.get/set_2d_flow_area_settings()` | Uniform Manning's n in `.g##` |\n",
+    "| `HdfMesh.get_mesh_face_property_tables()` | Read face-level n from geometry HDF |\n",
+    "| `HdfMesh.set_face_mannings_n_values()` | Replace n column with custom function |\n",
+    "| `HdfMesh.extend_face_property_tables()` | Extend tables to higher elevations |\n",
+    "| `HdfMesh.get_face_ids_in_polygon()` | Spatial filter: faces within a polygon |\n",
+    "| `HdfMesh.get_face_ids_in_calibration_region()` | Filter by named calibration region |\n",
+    "| `HdfMesh.pin_property_tables()` | Set Pinned attribute on mesh group |\n",
+    "| `HdfFluvialPluvial.generate_fluvial_pluvial_polygons()` | Channel delineation |\n",
+    "| `HdfXsec.get_river_bank_lines()` | Bank line extraction for channel polygon |"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "87885ad1",
+   "metadata": {
+    "papermill": {
+     "duration": 0.001904,
+     "end_time": "2026-05-12T12:22:40.886518+00:00",
+     "exception": false,
+     "start_time": "2026-05-12T12:22:40.884614+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Workflow Overview\n",
+    "\n",
+    "```mermaid\n",
+    "flowchart LR\n",
+    "    A[Read Geometry<br/>Settings] --> B[Identify Channel<br/>Region]\n",
+    "    B --> C[Read Face<br/>Property Tables]\n",
+    "    C --> D[Extend Tables<br/>Depth-Varying n]\n",
+    "    D --> E[Pin Tables]\n",
+    "    E --> F[Run Model]\n",
+    "    F --> G[Compare Results<br/>Baseline vs Modified]\n",
+    "\n",
+    "    style A fill:#e1f5fe\n",
+    "    style D fill:#fff3e0\n",
+    "    style G fill:#e8f5e9\n",
+    "```\n",
+    "\n",
+    "The critical step is **D: Extend Tables** — we append rows above the current\n",
+    "maximum elevation using a depth-varying Manning's n function. This gives\n",
+    "HEC-RAS the information it needs to use lower roughness values at higher\n",
+    "water depths, matching the physics described by HEC-15 and other formulas."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3c1336fb",
+   "metadata": {
+    "papermill": {
+     "duration": 0.001891,
+     "end_time": "2026-05-12T12:22:40.890750+00:00",
+     "exception": false,
+     "start_time": "2026-05-12T12:22:40.888859+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Literature: Why Manning's n Varies with Depth\n",
+    "\n",
+    "Manning's n is **not a constant** — it varies with the ratio of flow depth to\n",
+    "roughness element size (relative roughness R/k_s). At shallow depths, roughness\n",
+    "elements dominate the water column and form drag is high. At greater depths,\n",
+    "skin friction dominates and effective roughness decreases.\n",
+    "\n",
+    "> *\"If the depth of flow is shallow in relation to the size of the roughness\n",
+    "> elements, the n value can be large, and the n value decreases with\n",
+    "> increasing depth.\"* — Chow, V.T., 1959. *Open-Channel Hydraulics*\n",
+    "\n",
+    "### Key Formulas\n",
+    "\n",
+    "**HEC-15 Vegetal Retardance** (FHWA, [HEC-15 3rd Ed. 2005](https://www.fhwa.dot.gov/engineering/hydraulics/pubs/05114/05114.pdf)):\n",
+    "\n",
+    "$$n = \\frac{R^{1/6}}{X + 19.97 \\cdot \\log(R^{1.4} \\cdot S^{0.4})}$$\n",
+    "\n",
+    "where X is a retardance class coefficient (A=15.8 through E=37.7).\n",
+    "\n",
+    "**Limerinos (1970)** ([USGS WSP 1898-B](https://pubs.usgs.gov/wsp/1898b/report.pdf)) — gravel-bed rivers:\n",
+    "\n",
+    "$$n = \\frac{0.0926 \\cdot R^{1/6}}{1.16 + 2.0 \\cdot \\log_{10}(R/d_{84})}$$\n",
+    "\n",
+    "**Jarrett (1984)** — high-gradient streams (S > 0.002):\n",
+    "\n",
+    "$$n = 0.39 \\cdot S^{0.38} \\cdot R^{-0.16}$$\n",
+    "\n",
+    "All three formulas show that **n decreases as hydraulic radius R (a proxy for\n",
+    "depth) increases** relative to roughness element size."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 1,
+   "id": "6bcada36",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T00:21:12.602378Z",
-     "iopub.status.busy": "2026-05-12T00:21:12.602378Z",
-     "iopub.status.idle": "2026-05-12T00:21:14.093473Z",
-     "shell.execute_reply": "2026-05-12T00:21:14.093473Z"
+     "iopub.execute_input": "2026-05-12T12:22:40.896170Z",
+     "iopub.status.busy": "2026-05-12T12:22:40.895765Z",
+     "iopub.status.idle": "2026-05-12T12:22:41.373062Z",
+     "shell.execute_reply": "2026-05-12T12:22:41.372242Z"
+    },
+    "papermill": {
+     "duration": 0.481427,
+     "end_time": "2026-05-12T12:22:41.374066+00:00",
+     "exception": false,
+     "start_time": "2026-05-12T12:22:40.892639+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAxYAAAHqCAYAAACZcdjsAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjgsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvwVt1zgAAAAlwSFlzAAAPYQAAD2EBqD+naQAAt0FJREFUeJzsnQd4U9Ubxr/ulr132XvvjaBMUQQBGaJMwcEUHKBMUUGUpaCICqiA8EdREWSDiLKn7L1nmWV25v+8J9z0Jk3atEnJen/Pc0juvjm5Kec93/IzGAwGIYQQQgghhBAH8HfkYEIIIYQQQgihsCCEEEIIIYQ4BVosCCGEEEIIIQ5DYUEIIYQQQghxGAoLQgghhBBCiMNQWBBCCCGEEEIchsKCEEIIIYQQ4jAUFoQQQgghhBCHobAghBBCCCGEOAyFBSHEbfDz85NGjRq5+jYIcSmFCxdWLa2PcQb8zaYNo0ePVn37119/pdEVCEkbKCwI8UBOnz6t/tNBy5Mnj8TGxlrd79ChQ6b9XDHo8BTQN+4saLp37276HtECAwMla9asUrZsWenSpYv8/PPPEh0d7erbJF4w0MT59c+aZcuSJYt4CtY+S4YMGSQ8PFyefvppGT9+vFy8eNGlf8Px2ybEmwh09Q0QQlIPBphXrlyRP//8U5577rlE27/77jvx9/ec+QMIoXTp0rn6NtyWXr16SYECBcRgMEhkZKQcO3ZM/vjjD5k/f76UKVNGFixYIBUrVnT1bRIHWbt2rcv7sFq1avLss88mWh8aGiqehv6z3L9/Xy5fviybNm2SFStWyJgxY2TChAnSv39/V98mIV4BhQUhHkzdunVl7969MmvWrETCAlaMuXPnSpMmTWTDhg3iCZQuXdrVt+DWvPLKK1K7dm2zdXfu3JFRo0bJ5MmTpVmzZrJr1y7Jly+fy+6ROE6xYsVc3o3Vq1dXVhJvwNZn+f3335VYHzBggKRPn1569uzpkvsjxJvwnKlMQkgiwsLCpFOnTrJs2TK5evWq2balS5cqa4at/yzhAoABKQaquXLlkpCQEOUS9MYbbyQ6l94d59SpU/L5558rEYBjChUqpGb94uPjzfafM2eO2h+vq1atUiII1ojs2bNLt27d5Pr163b5a6f0utqs5DvvvKNcHjDDWr58efnmm29MrhH2DJhu374tI0eOVO5GcJ/IlCmTFC9eXN37mTNnkj1ef60dO3ZI06ZNJWPGjJI5c2Z5/vnnlSuEM8A5J02apPoJ3/eHH36YaB98n2+++aa6f/Rdjhw5pF27drJ//36r58T+Q4YMkVKlSqlnLFu2bFKrVi357LPPrLpywNKEz4TvFuv0nw2Dt8aNGyvXLe27wHni4uIS9fcnn3wiDRs2VMIoODhYvXbt2lVOnDiR6B4fPnwoEydOlEqVKqk+xcAQz2+HDh2U2LbE3vvA8/Ttt99KzZo11efG54eVqFWrVna5IVWpUkXdj/68OCfOhb7Bua25OOnFv2W8BH4TeNbBk08+maR74927d2XgwIGq7/Bdw4IFV7nHzbVr12TQoEFSpEgRdR/4G4PvxvKZmzp1qvoslveIY7G+fv36Zuu1565Hjx4O32Pr1q1N13333Xfl3r17ZtthGcSkTb169dTvH3+/IFKwLilXNViKK1SooJ6z/Pnzq98eJgA08DcR/QK+//57M1cta88YLJKVK1dWz2LevHnV9/vgwQOHPz8haYKBEOJxnDp1yoCfb/PmzQ1bt25V7z/77DOzfVq1amXIli2b4eHDh4aQkBBDoUKFzLb/9NNPhvTp0xuee+45w4ABAwxDhgwxPPXUU+pcRYsWNdy6dcts/27duqlt7dq1M+TIkcPQvXt3dVzBggXV+vfee89s/9mzZ6v1zz//vCE4OFgdh2vUqFFDra9Xr16iz4X1DRs2dOi6sbGxhieffFJtq1ChguGdd94xvPLKK4aMGTOqPsH6UaNGmR2DvtFfNz4+3lCrVi3Tfb755pvq3tu3b2/IkiWLYfXq1cl+R+vXr1fHt2zZ0hAWFqZe9X1crFgxw4MHD5I9j74PNm/ebHOfEydOqH2yZ8+u7l/j+PHjhgIFCqhtzZo1U/fw8ssvG9KlS6e+/y1btpid5/Dhw4a8efOq/evXr6/6r2/fvoZGjRoZsmbNmugZRP9kypRJvQ4ePFjd64ULF9Q+Q4cOVfvkz5/f0LNnT9WP1atXV+vQl3rw2fCc4Jl+4403DG+//bb6vgICAtRzfPr0abP9O3TooM5TsWJFw8CBA9V9du7c2ZAnTx7DN998Y7ZvSu4D59G+H3xuHIv+KlKkiOH9999P9rvCuXH8tm3bTOt27dql1qG9+OKLZvs/8cQThtDQUPU71T+P+t8rfkt4PnE8+hfPL9rkyZPNjsmXL5+hTp06htKlSxv69eunPiu+Zz8/P8PKlSsN9qA9t6+++qpd+1v7zV69elX1H7bhuUEfduzYUX2XuJ+NGzea9t27d6/aD9+5HnyvWB8UFGS4e/euaf2sWbPU+u+//95pn6VBgwZqvyVLlpjW4TeE5wnrS5Qooc7Rv39/1bdYh9+RHnwfWI9nFp+xR48ehnfffddQrVo1tb527dqG6Ohote/u3bvVM4v1lSpVMn2faPhd6c+Hv3v4neK5wbNVpkwZq88RIe4ChQUhHi4sQPny5Q3lypUzbb906ZIhMDBQ/UcIrAmLK1euGO7cuZPo3PgPG+f+8MMPrQ5uMcC6ePGiaX1ERIQabGPgHhUVlUhY4D7++ecfs4E/BhvWBspJCQt7r/vtt9+q/Z9++ml1LY0DBw6oAZw1YWHJf//9p/Zr06ZNom0YAFrrN1uDGrQFCxaYbcNAFesh7pwlLEB4eLjaDyJDo27dumpAt2LFCrN9jxw5ovoO4kuPNuCeOXNmovOfO3cu0TOINnLkyET7rlq1yvSM6geGGLC99tpratvPP/9sWg8he/369UTnWbduncHf31+JQ/2+GCxj0Kb/jgGWb968mer7gIjBAP3evXuJ7sXa/VmCwSnO+cknn5jWTZw4Ua1r3LixEm0a9+/fV2IKYlOPpbDQDzTxXFkD+2N769atzX4Pa9asMftbYe9zi77VD3i1dujQoWR/sxhUY/2wYcPM1i9btkytL168uCEuLs70PUAMY8Csce3aNfX9or+wv14Uab+ds2fPOk1YjBgxQu2HVw08/1iHz6IJAoC+1SYoduzYkej7wfcJsaSBzwcRYDn5o/1+8Nu2hna+zJkzK7Gvf2ZKliypfhOagCfEnaCwIMQLhMWkSZPUsjb7PH78eLWMmTFbwsIW+I8QM9AY/Fsb3GLG0BJtGwbklsKia9euifbXtn3++ed2Cwt7r6uJFswSW9KnT58UCQvMWKYWbVCDGWlb2zDD70xhoVlZYMXSz5Rj5toauD6279u3Ty1r1i9r92zrGYSFQD+Q1YAlDNvPnDmTaJsmDDAbaw8QP4ULFzYt375922Qt0VtnrJHS+4CwwLX0FoSUgHNCyOkH8s8++6yhVKlSptl2bXCuDfo/+OADpwmLkydPWt2Gz2UPekFsrf36669J/mbxLEDAQyxYE2dNmzZVx/z999+mdeh/rMOECIDQ0z4r/nZh5l8D1jdYVFPyWZITFl999ZXa7/XXXzezmMBSgIG8rb8PequF9v3oBbAGrG14JjABlFJhYU20a9v0FhZC3AUGbxPiBbz00kvKRxi+v/CFnz17tvL1hl9uUixevFi+/vprFfB78+ZNM79wW2kYkWHFEvigg1u3bjm8vy3sPQ/86+Fvj89vCXylZ86cmey1kGEJvuk//fSTnD9/Xtq0aaP83NGfKc2y5azPnxq2bNmiXhF7YS2u5PDhw6ZXxBxs27ZNLSMI3F4Q44B4CGvXxvdgzR8dwF9cu74G/MunTJkiW7duVT76+jTK+mvA371ly5YqG1rVqlXlhRdeUN9PjRo1JCgoyKH7QMzSl19+qfoD7xHTUKdOHbWfPSC+As/eP//8IzExMep5+fvvv1VaYJwLrF+/XsUK4RVo6x0FqWA1333L523z5s0pOterr74qM2bMSPE9oC8R/4LPZC3DG9avXr1a9uzZIw0aNDCt++WXX1R/dO7cWb0idgjxFYgB0/rp+PHj6veIgOu0BDFa+/btU3EqiPuxBN+r9lkt0T6THsSDId7rwIEDKi20td+LO/79ICQ1UFgQ4gXkzJlTBZci3SgGWUeOHJEvvvgiyWMQ+PrWW2+pYzGQxH9W2uAJg7uoqCirx2FQZy3tLbAMhE3N/raw9zxIw4r/xK2RO3duu66F865bt04NxjHgQSAzQF/169dP3n//fQkICHDqfTsDTQziPsGNGzfUK4L70WyhBa0igBog4NRebPUprg1hoAUdJ3VdsGjRIunYsaMKlG/evLkKTMbAVEsAYBkwj/0//vhjFdiK70PrawT1Yr02qE3pfSCYGINziHMEwqMhCBeBx/jNIPA9OTBQRsD+9u3bldDBM/nUU0+ZgrIxUH799dfVK+4TgeLOAKLGGnjerCU5SAvwWZN6LhB8rN8P6AWXJiyeeOIJdd/YNnbsWLW/s4WYrd8NJllgjLlw4YLdz42Grc+N9Qg8RxA3khzYy+P8+0GIM6CwIMRLwCweLBDI0oOBEGZIbYGBFv6zxn/ymDlExhYN/IeKvO6eCv4jjoiIsLoNM/f2gv/8Ic6QiQozkxAaWEYmLQwWhw0bJu7EyZMn5dy5c2pwpGUL0gYluG8IouTQip9hQGUvGPhbA9fGNlge7AEiDs/tzp07pUSJEmbbIJgtwYBcG/gjYxgGnZhhhzBAxhxY4lJzHxi0QXCjYcCJbE0QGT/88IOqf7By5cpkz4GB76effqruCbPT+mxn2IaMbcjeBOGB9SmZwXZ3tGfO1m8NfajfDyDzGgbe6C9kJDt48KApmx36C8/Gxo0bTRmTnC0stPPC4qW/N1gLIBBTgq3PjfV4DmCJIcSbYbpZQrwEzPJiphmDQrjuIK2mLTDIwuw0XDz0ogLgP1JPTmUI1xzMJEIwWYKiWCkFgwG4RvXt21e5cIAlS5aIuwGhCDDrrw324RYH7HWD0WbOkR7YUXBtpBRGET97QEpZ9LOlqLh06ZISTUkBCwMGohABsHjov5+U3oceuMJgBh2F1JCqd82aNXb9NuAOo1m9MFhG6lHN0gHLBYQvhA9cauyt+K5ZyNx9lhouXhCIEE1wKbI1iLd000Q/wNXpxx9/NPUTgCsULKlaX+L5cGadFjwzEC34O6hdE4N/PItIo5xSdyOcyxJY2yD6y5UrZxKRnvJ9EpJSKCwI8RLwH9Vvv/0mv/76q4wbNy7JffGfKP6zRmyF/j9/uAB4egVazVIzfPhwM/cPWB2QM94e4LJgrc6ENhvpTtWHMfMNVy24C8EC9d5775kJBQysESuycOHCRMeif/T1EzBji4aYANT9sCQllgwUHQMY8FurWYKZawzc9H7oGFjqZ3zhqw+XIc2nXQMDc2s1OPD8woVP//2k5D5wrDXxCaGKfoalyp4YG4gb1DvAuTDQ1Aas+tl2zXff3tl31MEAGKC6Mxg4Q4xh8sLy7xAEGiw+EGmId9Kj7xd8VkwQaOfDvhAcEJnOtFagaj3quWjX1ceE4LnB38bevXtbdXmClcza3whYtv777z8zCzB+kxAQsCZrYOIHEwDu/n0SklLoCkWIF4HBDFpyYHCEQnhagTHEZ8CHefny5WqA58mVm+Fjj0EIYgoQRPv0008rP3u406BIHQYTyQ0OYe1o27atGpjDTSNPnjxqUA3hhmNR8MoVoLgaBmcYrMBXG7PwEAZ4j9lQfEbNh10DogKDMQQiI3YGwc4QlWfPnlWWDAzSMYDXmDdvnpo97tOnj+pHWLWwHYGnu3fvtjo4t0aLFi1kxIgRypKCgSSW8WzheAgIDLjhxoSZYQBBi4bvrH379spdDxYifFY8o/qid/gusB/WI8geljqcF0XwIELgxpSa+4A1AoPYkiVLKjeYggULKkEB1yUIEJwXxd7sAX2uBc/rB8O4V8y647uDANHcb+w5HwaiGKTiu0A8BVzX7HFxe9xgkI7nEv0KcQVxi0E44mIweIdrmeVvUOsjPI8otqjfjm2wFun3SwmwwmrJC/AsQ6DgvvD947cwffp0s0G/FryO7w+TEf/++680adJE/V2E8MUkBRIMIL7HskghLMf4zeD3BrfEtWvXquvD8qKftNG+e4j4l19+WT0T+Mx4j+eTEI/F1WmpCCGOp5tNDmvpZpGb/aOPPlLFn7AdBeeQPhE1Gqylu9RSnmoFnJJLhamllMWrrTSQlmlfk0o3a+91AeoV4LOgHgE+W9myZVVeei2Npb6wmDVQrwFFvVDUKleuXCo3Pfqnbdu2yaZ8Te4z2pNq0hKtD7SG1JWo4YHP1aVLF8OiRYvMcu1bcuPGDcPw4cNVuksU68uQIYP63pFff/HixYn2v3z5sirghbSe+OxIVYpUtkhrnNLPgGKCyPufM2dOVewM6WlRxG3s2LFmtQiQNnbGjBmqHgvSlWK/Xr16qWJrWnE4DdSpGD16tEqLi7oQuEd81y1atDAsX7481feBPkT9CRQSRFpTnDd37tzqOvPnz082ta0erX4GvivLYpNa2mNbv19rvz8wZ84clXoXzzSO1+9j6xhg2X9pXSBPqzODQpa4J/Q3iluiGKGW2tgaKGCI833xxRdm6zdt2mR69rWUtCn5LPqG4nX4btH3SMutr41jjYULFxqaNGmiikPic+AekdIatUnwGa39LUKBRjzH+J7wfOK3FBkZmejcqCWDwpn4LSPtsf5vWVLphZP620qIq/HDP64WN4QQ8jiAe9RHH32k0pTCkkEIIc4AFhFkkEIciL1xM4R4I4yxIIR4HXB1sASZZpDhCe4j/I+fEEIIcT6MsSCEeB0I+IVPN2IkECSJjEOIrYD//XfffWd3sTNCCCGE2A+FBSHE60CRQNQ0QF0PpNVFoGTDhg1V9iQEVxJCCCHER1yhkKEBmRaQMhDZJLZt22ZzX6RERM5wzEqiIXOD5f4IIxk5cqTKloKZSuxjmdMcWWOQphKFceAqgWJjyAZCCPE88FtGth+kvISVAmlIUZuBooIQklYxFhhr0M2S+DpuJyyQa33w4MGqui1y7COdIAYDqMZpDRTbQc5sBEwhdWJ4eLg0a9bMLN86qgjDtxozmEgRlz59enVOfYpFDESQwg/pDZFaECngkG6REEIIIYQQkjxulxUKFgrkdp42bZqpgBPEAvI/Dx06NNnjUYQGlgsc37VrVzWDgNzTcIHQcpvDNSJ37tyqoBRyTaM4EnLVo1KoVgMAueJbtmwp58+f9+ic/oQQQgghhPhcjEV0dLTs3LlThg0bZlqHgjFwXYI1wh5QKROuD1qVUlTHRGEjnEMDhYUgYHBOCAu8wv1JX1gM++PasHCgWI8lqNCKpgEBBHeq7NmzqyJGhBBCCCGEeDpaUVZMtCdXYNathAX8oWFxgDVBD5ZR6dIe3n33XfXBNSEBUaGdw/Kc2ja85sqVy2x7YGCgEifaPpaMGzdO5awmhBBCCCHE2zl37pwUKFDAc4SFo4wfP14WLFig4i4Q+J2WwKqCWBANuFcVLFhQzpw5owLAXcnJkyLVqhkVZYcOBvn6a/fxdoNlBwIyR44cyapewv50BXxG2Z/uDp9R9qe7w2fUu/ozMjJSChUqJBkzZkx2X7cSFuiwgIAAuXLlitl6LOfJkyfJYz/77DMlLNasWSMVK1Y0rdeOwzmQFUp/zsqVK5v2sQwOj42NVa5Ntq4bEhKimiVwqXK1sNDfcmws7knc6scBlzf0E4UF+9Md4TPK/nR3+IyyP90dPqPe1Z/aNe1x9XerKePg4GCpVq2arF271qwzsVynTh2bxyHr09ixY1XAtT5OAhQpUkSJA/05obwQO6GdE6+3bt1S8R0a69atU9dGLIankS5dwvv79115J4QQQgghxFdwK4sFgHtRt27dlEBA1dwpU6bIvXv3pEePHmo7Mj3lz59fxTiATz75RNWomD9/vqp9ocVEoCAWGtTVoEGD5MMPP5QSJUoooTFixAgVh9GmTRu1b5kyZaRFixbSu3dvlZIWwd/9+vVTgd2emBGKwoIQQgghhIivC4uOHTtKRESEEgsQCXBXgiVCC74+e/asmRnoq6++Uuah9u3bm50HdTBQsAa88847SpygLgUsE/Xr11fn1MdhzJs3T4mJxo0bq/O3a9dO1b7wRIKCYLaCtYcWC0IIIYQQ4qN1LDwVuFchjS2CuF0dYwEQX4PC4WXLihw4IG4D3MsQz4IsXIyxYH+6I3xG2Z/ujrs+o8jqCIu/J/bn9evXVbp4d+pPT4Z96ln9GRQUpGKcnTHGdTuLBXGeOxSExYMH7FFCCCFpB+Yn4WEAjwBPvX8M3JCnn3Wo2Ke++oxmyZJFxSQ7en4KCy9Fi7Ng8DYhhJC0RBMVsKCkS5fO4wbnGLQhEyTqV3navbsr7FPP6U+cG8Wlteyo+gyqqYHCwkuhsCCEEPI43J80UQE3DU+Eg2D2qa8/o2FhYepVc7FMyi0qOehM6KU8ekaUxYJRNIQQQtICLaYClgpCiOei/YYdjZOisPBStL/xcXF4SFx9N4QQQrwZuhAR4tk46zdMYeGlsJYFIYQQQgh5nFBY+ICwYGYoQgghhFjy119/qZlqT8zotXbtWlXgGHE+JOnvFbXbUBcOmaXSGgoLL4UWC0IIIcQ23bt3lzZt2iQ7KNOWrTVkxNLn+n///feldOnSqgAvUnc2adJEFi9erIJvbTFz5kxp1KiRqg9ga5BfuHDhRNceP358sl/v7t275YUXXlBFhnFPJUqUkN69e8vRo0fd5tFYv369tGzZUgX/w8+/bNmyMmTIELlw4UKSx6H48fDhwx0KNE4L5syZo1K3upPIa9GihapVgWLQaQ2FhZdCYUEIIYQ4jyNHjsilS5fMGjLoAAwG69atKz/88IMMGzZMdu3aJX///bd07NhRDYBRWMwWSPWJgd97772X5PU/+OADs2v3798/yf2XLl0qtWvXlqioKDWgPHTokMydO1cVOhsxYoS4A19//bUSXxBhv/zyixw8eFBmzJih+mvixIk2j/vnn3/kxIkT0q5du8d6v54upD///PO0vxAqbxPHuX37NqYj1Ks7MGAApkeMbcsWg9sQFxdnuHTpknol7E93hM8o+9Pdcadn9MGDB4aDBw+qV0+jW7duhtatWxvi4+MN0dHR6hWsX79e/X9+8+ZNq8vWeP311w3p06c3XLhwIdG2O3fuGGJiYpK9n6SuU6hQIcPkyZPt/mz37t0z5MiRw9CmTRur2219tmvXrhk6depkyJcvnyEsLMxQvnx5w/z5882OXbRokVofGhpqyJYtm6Fx48aGu3fvms5Xo0YNQ7p06QyZM2c21K1b13D69Gmr93Du3DlDcHCwYdCgQUneozX69u1raN++vWn5yJEj6nMcOnTIbL9JkyYZihYtalret2+foUWLFuq7ypUrl+Gll14yREREmLZHRkYaXnzxRXX/efLkUcc3bNjQMHDgQNM+Dx8+NAwZMkT1EfarWbOm+tz6/hRdGzVqlNr2ww8/GKpVq2bIkCGDIXfu3IbOnTsbrly5oradOnUq0XF4PgF+5x999JGhcOHCqs8rVqyovgM9y5YtM5QoUUJtb9SokWH27NmJnqUzZ86odcePH0/xbzklY1xaLLwUWiwIIYSQtAd+6wsWLJAuXbpIvnz5Em3PkCGDqj/gKHB9grtQlSpV5NNPP1V1DWyxcuVKuXbtmrKWWMOWq87Dhw+lWrVqsmzZMtm/f7/06dNHXn75Zdm2bZvaDktJ586dpWfPnsoCAvedtm3bmuoswLWsYcOGsnfvXmWxgduVrWxDixYtkujo6BTfI9i4caNUr17dtFyyZEm1bOnqg+UXX3zRZFV66qmnVP/t2LFDxR1cuXJFOnToYNp/8ODB8u+//8qSJUtk9erV6jqwPunp16+fbN68WX3n//33n3I1g8Xp2LFjymo1ZcoU5damWZbeeustUxrXsWPHqr757bff5PTp08qKAMLDw5XFRm8Zmzp1qloeN26c/PjjjzJt2jT1nbz55pvy0ksvyYYNG9T2c+fOqe+gVatWsmfPHnnllVdk6NChifqsYMGCyiUOnyktYYE8L4XCghBCiKvAmE8XfvDYyJNHZMcO+/eHu1DGjBnN1tkKBi5QoIDZcqFCheTAgQNqAH/z5k0VW5FWDBgwQKpWrSrZsmWTTZs2KXcrDD4nTZpkdX8MckFK7yl//vymgTCAuxVEyv/+9z+pWbOmuiYEBAay+PygQoUK6vXGjRvKhenZZ5+VYsWKqf2wzZawwD1iAJ6aSs9nzpxJJOIg7DD4xuAdII5k586dyv0LYBtExccff2w6ZtasWWpQj31xH99//73Mnz9fGjdurLbPnj3b7Dpnz55V6/CqrUd/QaRg/ccff6xczfCZ4d6lB2JMo2jRosotqUaNGnL37l0lPvHdArjXaaIKbmw4J0QO9oVARd/CFQxuZBBxX331lVqnuY6VKlVK9u3bJ5988kmifsM9o+/SEgoLL4VZoQghhLgKiIpkYm/dgieffFK+/PJLs6rGW7duVTPClmCmVy9CEAwLkgrM1oMBon5Qi3gCzCLbA2bSNSpWrCjBwcHy6quvqtnskJCQRPvbe0+WQFThHiEkEDwNiwIGt1rxtEqVKqlBNwRD8+bNpVmzZtK+fXvJmjWrGhhjBh7rmzZtqvq2U6dOVq042j2mtnbCgwcPVDC6HlwLg/wtW7ao2BJYKyDGNHEFSwECxTGItwTxGjgnrAoQUBoQCRioa2DAjj6ChUQP+ii5yvM7d+6U0aNHq/uAENUyNEGkIGDdGsePH1cxOOhnPfheIJIALEe1atUy216nTh2bFbZxvrSEwsJLocWCEEKIq7CYrHXb66ZPn16KFy9uJizOnz9vdd8iRYpYdc/JmTOnWn/48OEkr/Xaa6+Zud3YGnDbAwaSuGe40+gHvhrawBf3ZGuQaQ24WMEFB+48EA/on0GDBqmBLEAGJsyew2qyatUq+eKLL1QmLIgx9A9m7WFdWb58uXJ1GjVqlNofA31r9wgLB6wgKbVa5MiRQw3O9cBCAFcnWBxwPby+/vrrpu2wDMBdyNpMPq6PQXxy4BzoA4gEy2xU1gSLxr1795TgQoPgwTMDQYFlrW9tXU+zrMGNSXtGgTVBmRywKuHaaQmFhZcSFpbwPo3FKSGEEGJGStyRPB1/f381Ww4/eAykLQUDBoeYXceMvubu4ijwpcd1taxUlmCGG4PvCRMmyK+//ppoO+INrIkkxBe0bt3aZLHBrDrchPQz6hjY1qtXT7WRI0cqlyhcQ7OqYCYdNRPefvtteeKJJ0wDfUtg6UAsAO5x8uTJdt+jdg1YfCyBOxRiNhAHcvLkSfW9aMB6gTgGpO61FvMC9yRYobZv326yJEH44PPjc2jXhcXi6tWr0qBBA6v3FhwcnMidDgLv+vXrKk4GrlcAcR6WxwH9seh3CAiIEPS3XlhooJYHYkL0wGpjLX4GlhnN0pFWMHjbS6HFghBCCHEeGEyiboW+wXUGfPTRR2rACEsCUs5i0IsYAvjwYyCnzTxbA+eBUNBmzOFug2XMLgMECsOCABcaDJYx460F8MIFyRqwNHz77bcqCPu5556TNWvWKOsGBrMYeMN6Yg3UudAsEnCxgbsVApw1YJmAqxTOg8EuanRERESowe2pU6dU7AfuF378OA/6ANusgf6CoICFpFevXioYGcdB3OC6WqyENTDTjzgDSxD7cefOHWWpgCuWXuT17dtX9SlEB8QDBtmIH+nRo4cazMPNrVu3bkoQwWUK8TO4Lwg4bTAPKwvES9euXdVnx2dGYDtc0tDXAMIF3zcK+CH+Bq5HECoQDrDw4DuEELD8fBBouA6sE+hTnAP3BPcuiDY8V7hnBJPjPIgHAfgu0c+4bwR+Q8ihloYlEBsQKSmxYKWKZPNGEY9MN/vHHwnpZseONbgN7pQm0Rtgf7JP3R0+o97dp76UbtZa27x5s+l8t27dMgwdOlSl/UQaVaQUbdKkieHXX381ndsaSEdq7dxIGQp27txpqFWrlkrfinSiZcqUMXz88ccq7WlybN++3dC2bVtDzpw5DSEhIYbixYsb+vTpYzh27JjVz3r9+nXVJ0iJinSsw4cPN3Tt2lWtA/iumzdvbjpfyZIlDV988YXadvnyZZXeNm/evOrzI0XuiBEjkn1OV69erc6ZNWtW9flKly5teOuttwwXL160eQzuE/sePnw40bYOHTqozzRr1qxE244ePWp4/vnnDVmyZFHpdHEtpLvVvh9r6WaRThbfqwaelZEjR6r0r0FBQerz4pz//fefaZ/XXnvNkD17drN0s0jbi2PQb3Xq1DEsWbJEbd+9e7fpuA8++EBd18/Pz5RuFveGVMPoa1wPfY/+2rBhg+m4P/74Q323OHeDBg3UZ7dMN4vv/dVXX7XZp85KN+uHf9JWuvgGqLiJIB+YzZDlwNWsWyfyKKmBDBuGoDFxC2BWxawPzLeYBSDsT3eDzyj7091xp2cU7hWYtYV/vWUwraegpUq15mZC3LdPMUOPsReyI6UViI1ApixkXIL1wlP789q1ayoWB5Ym/FZT+ltOyRiXIzsvhVmhCCGEEOKtIGgc7kNadiVnsHv3bvnpp59MLkdwewKIO/FkTp8+rbKf2RIVzoTB214KYywIIYQQ4q0gsPu9995z+nk/++wzFauAmAgUC0SaYQTCezLVq1c3KyiYllBYeCnMCkUIIYQQYj8ItEcqWZJ66ArlpdBiQQghhBBCHicUFl4KhQUhhBBCCHmcUFh4KRQWhBBCCCHkcUJh4aWggKOWhfDBA1ffDSGEEEII8XYoLLwUpDnWArjv33f13RBCCCGEEG+HwsIH3KEoLAghhBBCSFpDYeHFUFgQQgghqQMVjn/77TeXdN+cOXNUnQZXc/36dVXhHQXWbPHXX3+pvrp165b4Avfv35d27dqpCtRJfe6hQ4dK//79xdegsPBiKCwIIYQQ63Tv3l3atGljs3suXbokTz/9tEu6r2PHjnL06FFxNR999JGqOl24cOEUHbdy5UqpX7++GnznzJlTDcRtiZN///1XAgMDpXLlyg7d640bN1SlbFwToqxXr15y9+7dJI9p1KiREgf69tprryV5zPfff6+K5m3atEk9Izdv3lTH7dmzx2y/t956S+178uRJ8SUoLLwYCgtCCCEkdeTJk0dCQkIee/fFxMRIWFiYshS4emb+u+++UwP0lHDq1Ckl2DBo3717txIZ165dk7Zt2ybaF7P9Xbt2lcaNGzt8vxAVBw4ckNWrV8vSpUvl77//lj59+iR7XO/evZVA0NqECROS3P/EiRNSpkwZKV++vHpGICqskSNHDmnevLl89dVX4ktQWPiAsIiLwx8qV98NIYQQ4pmuUJhtx/L//vc/adCggRr416hRQ1kVtm/fLtWrV5cMGTIoC0dERITZeb799ls1EA0NDZXSpUvLl19+adqmnXfhwoXSsGFDtc+8efMSuUKNHj1azej/+OOPynqQOXNm6dSpk9y5c8e0T1RUlAwYMEAJEpwHFgPcmwZm1jH4hgUB91+iRAmZPXu2zc//559/KmFVu3btROtLliypzvHkk08mskSgcnVcXJx88MEHUqxYMalataqavceMPkSTHlgHXnzxRalTp444wqFDh2TFihWqr2vVqqU++xdffCELFiyQixcvJnlsunTplEDQGiwetoBYmjhxohIt+N6wXKRIEVPVbr9H6zRatWql7sGXoLDwYrSsUIAB3IQQQohjjBo1SoYPHy67du1S7jsYFL/zzjsydepU5R5z/PhxGTlypGl/iAQsw6UIg9+PP/5YRowYoVxkLP3xBw4cqPbBLLetmXIIHczGo23YsEHGjx9v2o77+OWXX9S5cX/FixdX54KLEMB1Dx48KMuXL1fXwUw6ZtVtgc9TrVo1s3Xnzp1TlgcMmCEUXnnlFXXvenCMv7+/ug8IjNu3bytB1KRJEwkKCjLtB1EDNyH0qTXQVxBrSbWzZ8+qfTdv3qyEGASeBq6H+9i6daskBb4j9AMsEMOGDVOWGlssXrxYWTgghGDdwPK2bdvUtjVr1pjWadSsWVPOnz+fZIyKtxHo6hsgj69IXubM7G1CCCGPiUmTjC05qlYVWbLEfN1zz4ns2pX8sYMHG9tjAjPv2sAfQqBz586ydu1aqVevnloHtyFYGzQwaMYMt+YGhNltDO6//vpr6datm2m/QYMGWXUV0hMfH6/OnTFjRrX88ssvq2tDtNy7d08JBWzX4kK++eYb5RYEd6a3335bDcIxq64NvpOLmzhz5ozky5fPbB2uASsEPhMoVaqU7Nu3Tz755BPTPviMcH9CnMgbb7yhxAUG4rB0aBw7dkwJEogXCDRrwJrRoUOHJO9Ru7/Lly8nch3DebNly6a22QLCsFChQuo8//33n7z77rty5MgRM3GgB+eDhSM4OFhZN0BkZKR6zZ49u2md5f2hL1Map+KpUFh4May+TQghxGVgwHXhQvL7hYcnXgd3InuOfTSoe1xUrFjR9D537tzqtUKFCmbrrl69qt5jsA8rA8QGZrk1YmNjlSuTHv1Muy0wMNVEBcibN6/pWrgO3Iw0gQNgHcCMOawT4PXXX1dB1LBmNGvWTMVB1K1b1+b1Hjx4oFyq9OBccDXSY+nGhIE8Yhteeukl5XqFAGpYbdq3b6+EDgQSBvRjxoxRLlW2wCAeLS3Rx2Dge0SfIt4D/QkB5Shhj1xHkrKCeBsUFl4MhQUhhBCXAV/1/PmT3y9nTuvr7Dk2CX/4tEDvyqMF7Vquw8AZaBmJYDmwHIwHBASYLadPnz5F17a8lj3AkoGZc1gOMMDHALpv377y2WefWd0f7kGIy0gp06dPV8IJblqwGuA+586dK+Hh4cotCXEmO3bsUIHd/fr1U8fgcxgMBrX/qlWr5KmnnlKuUGhJAetPwYIFlaVAE1l6AQc3MEsrQlJo3xNc2pwhLG48ckNDXIuvQGHhxVBYEEIIcRmOuClZukZ5ILBewBUGcQSYuU9LMAiGew5St8K1B8CCgeBtuFlpYIALFyw0BKHDRcqWsIDbFASBHgShL7H4brZs2WK2jNl5xDZYE1IQEAiOhvuUHgS0r1u3Tn7++WdTMHRKXKFgNUGGKQSOa3EhOB+uZynqkkJLGQvLhb2g3wFcvizZv3+/EoTlypUTX4HCwkeExb17rrwTQgghxP1AYDEGk5jd1mbX4SuP2XVnAHcfZGrCDH6LFi1U5ibM1sMSMNiJsSGweMDVCUIB7kOYxUfaVAzytXSxcEfCoBuDXNwHAsAhFGyBWBIEM+Nes2bNahrsI74C10HgNgby+pgS8Mwzz8jkyZPlww8/NLlCvffee0rwQKxAdCBQWo+WyUq/PiWuUPgc6F+4nM2YMUOJKlhDkDlLEx8XLlxQVpoffvhBuYjB3Wn+/PnSsmVL9Z0jxuLNN9+UJ554wszlLTlw73B5QlaqAgUKqM+hubohhkTLIuYrMCuUF6P/PV6/7so7IYQQQtwPVI1GOlQMNPGKgS/EgLPA4BspUJEBCT78SCmLgbg2K+9M4HqEGAoEdeOzwJ0HQdSaKMDMOoQCBs0YPMOKkFQqVNwvzoMUuxoQLMg8hexUlSpVUoN4S3cluDEh0xIsGzgeA36krcXAOy0H2Lgm3KwgHiAWkHJ25syZpu0QGwjM1uId0B/I5IR4Exw3ZMgQ1X9//PFHiq4LQfr555+rgPx8+fKpgoIa6F99fI0v4GeAUxtxGGQFgELF7EdSOZAfJ8hm17278f20aSJ9+7r6joxmUPhBQuFbmkoJ+9Md4DPK/nR33OkZffjwoSqIhoGyZaCvp4BhkN5iQRJYtmyZsk7ApSclzxr7VFRaX4gVWEJsZb5yp/5M6reckjGu243sEPSDzAf4UPCL0/IDWwMVFqEusT86esqUKYn20bZZNgQsOVLS3RPQxwpZ1OshhBBCCEkSuDUhcxLciEjKuHfvnrJUOSoqPA23+rSoPAmfQ5jWICogFODjB9OVtdL2MGcVLVpUXnjhBeUXZw0ELukDaqC6mzZtqo7RA1MVqkRqIE+xp6PvMotkCYQQQgghyaIP/ib20759e5/sLreyWEyaNEkN8Hv06CFly5ZVAgMD/FmzZlndv0aNGvLpp5+q4Bz471kDGRD0pdoRrITsCfBzTG1Jd0+BwoIQQgghhPicxSI6OlplF0BgkQb8+VCSHaXanXUNpE6DVcTSRw1BP9gGUYFS9SNGjEjSaoGMCmgaWuVF+L6mJK90WpI9e4J2vHrVIPHxrg+n0XJVu0sfeTrsT/apu8Nn1Lv7VLsXrXkq2r178mdwN9inntWf2m/Y2jg2JX9r3EZYXLt2TbksaZUsNbB8+PBhp1wDWQyQ57i7FtGcypLuYNy4cVYzR0RERKgAGHchQ4Zccveuv1y8GCdXr15z9e2ohxPBP3h4XR106A2wP9mn7g6fUe/uU2Tawf0gsBTNE0E/ai7TDN5mn/rqMxobG6t+y9evX09UjPHOnTueJyweB999952qPKnlNHakpDssK/oc1LBYIO81XK/cyY0qd24/QfHPGzcCrMapPG7w0OJHgX5y9X+I3gD7k33q7vAZ9e4+xUQaBh0IUPX0IFXLwRRhn/rSMxoYGKj+nqCmh2VWqJRkfHObvwIoHY+cyleuXDFbj+WUlGO3BcrYI19xUlaIlJR0R0yHtbgOfCmu/kOvB1rixAmRmzf9JC7OT9zh7yb+Q3S3fvJk2J/sU3eHz6j39imur8+o6Kmzwdq9e+pncDfYp57Xn9pv2NrflZT8nXGbkR0KlaAi5Nq1a81mZbCMUu2OgpRfmLFH6rS0KOnuCSlnr7neE4oQQgghhHgpbmOxAHAt6tatm1SvXl1VwUS6WeQBRpYo0LVrV8mfP7+Kb9CCsQ8ePGh6jzzLEAUZMmSQ4sWLmwkUCAuc29JU66yS7p6SGcoLtBIhhBBCCHFD3EpYdOzYUQU/jxw5Ui5fviyVK1dWJeC1gO6zZ8+amWMuXrwoVapUMS1/9tlnqiGV7F9//WVaDxcoHNuzZ89E19RKumsiBnESKLo3fPhw8QaYcpYQQgjxPpC9Eu7iM2fOFF8Dk8klS5aUn3/+WU1GE/fBbVyhNPr166fiIZDKdevWraZ4BwCxMGfOHLOq2vo0d1rTiwrQrFkztR4PoSUQEhs2bFBR8AhCO3bsmEyYMMGtArAdgcKCEEIISQwyRLZp08Ztrn369Gnl4665YycFJl+nTp0q77//vmkdJmZff/11KViwoIoBRXwqigz/+++/qb5PeHE0aNBABe9ivITxUXJgIvfZZ5+VzJkzq4nht99+O1HGMIzTqlatqu4THib6sR0YPXq0WewOWunSpc0mhd966y2VxZO4F25lsSDOh8KCEEIISZtUu5ZZejCTjkFvWvPtt99K3bp1Vap8DXhb4Prff/+9FC1aVFkzEKeKidPUgGyXmJhFPTEULN63b5/y/MiSJYtZNk09SImKWFaIGkzaQuzADR399PHHH6t9Tp06pfZ57bXXVA0x3OMrr7yi4lohhDTKlSunPEo0LF3Zu3TpIkOGDJEDBw6ofYl74HYWC+JcKCwIIYSQpFm5cqWamcegGfGWmHFHDKalNWHhwoXK3Roz+BgUa5aHjz76SKWyL1WqlNr/3Llz0qFDB3W+bNmySevWrdU5tNl4DP5///1302w8ZvCLFCmitsPFG+saNWpk834XLFigivlqoEbXxo0b5ZNPPpEnn3xSCQ7EqiI1/nPPPZeqrx+fD0Jl1qxZauDeqVMnGTBggEyaNMnmMatWrVKxrz/++KNyZ0eK/7Fjx8r06dPVuQBECj7rxIkTpUyZMspTpX379jJ58mSzc0FIQKBoDdlD9WTNmlXq1aun+oK4DxQWXg6FBSGEEJI0iLFE4pYdO3aoGXTEcz7//POJKg4PHTpUBg4cKIcOHTLNrmN/FNVdvXq1LF26VFkysC1jxoxqsA9XJCSVadGihRpcw4UHogPLly5dUg3Wh23btqnzYZYe62ylx79x44YavOtjC3B+NBQChiu5LTDQ1/a11vQz/5s3b1aJbPQWGHwufNabN29aPT+OQT0wfbFjHAPrBywL2j6wgujBPlivB67pEGuwvsA6ARcrSyCe0MfEfaArlJejTzcbEeHKOyGEEOJLTNo8STVHmdt2rjQqnDB7/9fpv+SlxS+p94PrDFbNUdq2batmyLUaAZilRwFCDODLly9v2m/QoEFqXz3p06dXrknaAHzu3LlKkGCddj5kpoT1ApYJuBeFhYUpAaCv04XrAVhMkqrfhQE24kb1xX5x74hT6N27t7IIIH4BlhVYGfQZLnFPDx48sHluvWsX4jg0K4qGJhiwDRYDS7BeLyosj0lqH4gP3Bv6BvG1+DywAEFkjRkzRlmU9u/frwSbBvoAcbnEfaCw8HL0lkOkmyWEEEIeB5FRkXLhzgWHzxMVG5VoWTsvruEMMDsOlx0kjbl27ZrJUoFBvF5YWMtAhBl6/az+3r17VYFd/QAYIEGM3r0qtWjCwLIaMmIsELuAGfwtW7bI8uXLVbA1xARctgBS9nsCsKxoQBhBaMC963//+5/06tXLtA0i5P79+y66S2INCgsvB7FO2bOLIHaLwoIQQsjjIlNIJsmf0fGBbEhgSKJl7by4hjOA2xMyTX7zzTdqFhzCAoJCiwvQWycssVx39+5dVfAXMQqWaFYJR9BiDeCOZHk+iI2mTZuqhnS0CIoeNWqUSVhgwJ6U6xAG75rLEqwmCADXoy3bsqhgvebSZesYW+dFNk4IBWvA2oPMnhBslm5hzuhT4jwoLHwkzoLCghBCyOPEWW5KlsAt6vzg8047H7ImHT16VIkKxBSAf/75J9XngxsSgrxz5cplM3U9LBzIoGS5Dliut6RYsWLqvHDTspZGX0/ZsmVV3EVqXKHq1Kmj0tnqs18hjgTuSdbcoLRjEMh+9epVFbSuHYP7xb1o+/z5559mx2EfrLcFxBqsPS+//LLZerhG6euZEdfD4G0fCuC+d8/YCCGEEGIEg2TENUBYYEZ83bp1Mnhw6gURAo1hVUAmKFgHkF4VsRXIqHT+vFEQwTqCGhEIhIbrFQbvECKYsUdhYMzg37592+r5EViO4Ge9+IE4euqpp1R8B86Lay5atEi5QuE+NOAKhboRtpo+fe2LL76oxA5cj2DFgFhC7Qx93/z6669m9SUQPwIB0bVrV+UShmxbKDjct29fVbMCIM3syZMn5Z133pHDhw/Ll19+qVycEDyvgQB3pKtFJq1NmzYpi1JAQIB07tzZrC/Qv7gmcR8oLHwsMxQDuAkhhBBR7k4IesZAHQPynTt3KvcnDHA//fTTVHdRunTp5O+//1aF6hDojZSqGJwjxkKzYCDIGjP/iNmAKw8yR+FePv/8c/n666+VO5ZeEFgCFyekWdViQZDRCXEISNkKqws+B1yhcJ1p06al6nOgwB3Sx0KkwLULNSNGjhxpVsMC4gfiSAODf2TGwivuAxYGiIwPPvjAtA8CwpctW6asFJUqVVJpZ2FJ0dewgACDiEAfIYMWhB/iRvRuT8gihesjVS1xH/wMSC1AHAbZDPAjxEPublW7+/UTmT7d+H7rVqRnc9294I8gTKSYmcEfc8L+dDf4jLI/3R13ekYxWMbAE4NFy2BidwfpXjFL/8UXX6jK0PqsUO4Ohm4QEhBBlrP47nJ/ad2nHTt2VMLkvffeE2/H8Bj6M6nfckrGuBzZ+QBMOUsIIYSIKegZs+pwT7Ksp+ApYHA5c+ZMNdj0RRBUj2xcevcp4h4weNsHYJE8QgghxEjPnj1l+/btyrUnKXcjdweVrdF8EcR+IHaDuB8UFj4AhQUhhBCSEHCshx7hhDgPukL5ABQWhBBCCCEkraGw8AEoLAghhBBCSFpDYeEDUFgQQgghhJC0hsLCB8iSRSTwUTQN61gQQgghhJC0gMLCB0DKYy3l7NWrrr4bQgghhBDijVBY+Jg7FIQFSyISQgghhBBnQ2HhY8IiJkbk9m1X3w0hhBDivaD4HorY3bp1yynnO336tDrfnj17JC2ZM2eOZIH/tA4U4gsPD1dV3qdMmZKm1yeeD4WFj8AAbkIIIcQIBulaw4AZBdfwqq0bPXq0Q11Vt25duXTpkmTOnNmjurxjx45y9OhR03JkZKT069dP3n33Xblw4YL06dNHvJGzZ8/KM888I+nSpZNcuXLJ22+/nWxV8xs3bkiXLl0kU6ZMSoz16tVL7t69m6hGymeffSYlS5aUkJAQyZ8/v3z00UfizbBAno8Ki5IlXXk3hBBCiOvAoF9jwYIFMmrUKDl8+LASFSBDhgwOnR9CJU+ePOJphIWFqaYfcMfExKhBd968eVN9XpwjKChI3JG4uDj1+fB9bdq0ST0bXbt2Vff78ccf2zwOogL7rl69Wn2+Hj16KOE1f/580z4DBw6UVatWKXFRoUIFJUbQvBlaLHwEWiwIIYQQIxhEag1WBQgKvM+YMaOaXV6xYoVZV/3222+SPn16uXPnjsktCYIElonQ0FApX768bNiwIUlXqH///VcaNWqkZsWzZs0qzZs3l5s3b6ptuF79+vXVzHf27Nnl2WeflRMnTqTo68L1cJ96cD64NwHtvhcvXixPPvmkuo9KlSrJ5s2brbpC4T0Gw6Bo0aLqWJwDfPXVV1KsWDEloEqVKiU//vij2XVh/fn666+ldevWqt8wSw8rUOXKlWXWrFlSsGBBJd7eeOMNNbCfMGGC6n9YC5Kb0e/evbu0adNGDdYhdtBfffv2VYP71ICB/8GDB2Xu3Lnq/p5++mkZO3asTJ8+XaKjo60ec+jQIfWdffvtt1KrVi313X3xxRfqmbh48aJpH/TT77//Ls8995wUKVJEqlWrJk2bNhVvhsLCR9CyQgGmnCWEEJLWwJUEDe4gGvHx8WodBpPO3tcZYBDcqVMnmT17ttl6LLdv314JDw24ywwZMkR2794tderUkVatWsn169etnhexEY0bN5ayZcuqgfw///yj9tc+271792Tw4MGyY8cOWbt2rRqYP//88077XHref/99eeutt9Q9QUR17tzZqtsP3KLWrFmj3m/btk3NziPW4tdff1Uz8fjs+/fvl1dffVXN1q9fv97seAzOIQD27dsnPXv2VOsglpYvX64G5T/99JN89913ylpw/vx5Jcw++eQTGT58uGzdujXJz4Br4Vx4/f7775UI0gQUeO2115RwSapp4PuAgMqdO7dpHUQf3MAOHDhg9fo4BgKsevXqpnVNmjRR35t273/88YcSZEuXLlWionDhwvLKK694vcWCrlA+Ai0WhBBCHieLFi1SrxggY1Zfm8X977//1IALM70amEXHIBszuxjcA/j6Y9BeqFAhZRnQWLJkiURFRUnLli1NMQwnT56U4sWLO+W+MfjTYiQwI3716lX5888/TYNsDcQetGvXTr3HzDQGyxgov/POO4nOiRl5DEK//PJL07py5cqZ3mvn0cCsfs6cOdVMOqwhzgSiAoN5MGbMGHUfx48fl9KlS5vtB5coWAMA7kVz7YKlAFYDWBsABNGWLVvUelhCNCDQIDg09zIAoYTPBoEGkYX9jxw5ovoXg3JYPyAuIBj0z4clsPhMmzZNAgIC1H3j80CQ9e7dW23/4IMP1Oe0h8uXL5uJCqAtY5utY2Bd0RMYGCjZsmUzHYNn8syZM+p38MMPP6jn+80331QCdd26deKt0GLhI1BYEEIIIclTs2ZNNdjGTDiAiwzEzRNPPGG2H6wU+kElhAOEU1IWC1scO3ZMWQ4guBAMjNltLcbB2VSsWNH0XoubgHiyF3zGevXqma3DsuVnr1q1aqJj8bn0Vh8M4CEwICr065K7H3w/EBX6z6E/BoN+CM2kWloTHx+vBDBERYMGDZQbHIQnRBPElLdCi4WPQGFBCCHkcfLCCy+oV/0AsEyZMmpWWj+LDdq2bZtoX7jpYABouS+sGpb7YkDuTGC1gI/90KFDlRuU5cx7StEHRFsDblEQL998843ky5dPDUphqbDl428N3J/ePQxYizvQB1FrnyktXK40y5Ota2vXt7YuuftJ7hi4QkEQJoWWwQmWGLh66bly5YppmzWw3lL8wJ3sxo0bpmMgdiA48Rzrn39NMOJ34I3QYuEjUFgQQgh5nGBQhaYfkGNmGuv0osBZ+zqTl156SbmxfP7558odqVu3bon2gfuPflC5c+dO08DRmpUArjrWQFwGZrARWwCrBs6hBXWnBLgr6bNdwQpy//59cTa4PwSi68EyLA/uAlyhYCVKquktT4gD0QsFZHqC5cjWZ8IxCMzHd64B96b4+HiTCxesOHgu9EH4WipfiEhvhRYLHwETB+nSieBvTAosnoQQQojPAR9+WFEQoN2sWTMpUKBAon1g0ShRooQaaE+ePFmJAS1I2ZJhw4apAGHEJWA2HdmU4BIDqw788hHLgEJ0mOXGbDYsJSnlqaeeUnEHGPTCnx+1J9IixSv6pEOHDlKlShUVsIwgZcTIWMaguBK4QlnGQNgC3y8ExMsvv6xiYRAjAZGHTFOoPQFg0UAKWohD1KLAd96iRQsV0zFjxgxlGULMTadOnZTFCaBv4A6GZwKFBSE6cE5khdJbMbwNWix8CO03RmFBCCGEJA0KnsEVyZZYGD9+vGpI2YosTwgqz5Ejh9V9MZBEWtO9e/eqGA4M/pGGFJYXWFuQphSz33B/QoDvp59+muKvZ+LEiSprE/z5X3zxRRW8jJSyzgaZnqZOnaqCtRHrgLSycBdDDIEnAosYMjfhFd8LrFUQEbB6aMDyA6uS3rVs3rx5KnAcViYkEkDK2ZkzZ5q243uF6MIzgfgcBJhDkOC79mb8DJYOeSRVIC0ZslPcvn1bmc/ckZo1RbZvhy8i/C7xY3r89wDFDnMjZhKcbbr2Rdif7FN3h8+od/fpw4cP5dSpUyqdppb5ydPAMAguK5buVajNgEE+6hLAwqCBWg74vMhYhboHxP4+Je7bn0n9llMyxuXIzgctFpCSNlJtE0IIIT4NZqfhFw9rBGo06EUFISRpKCx8CAZwE0IIIUkDP3u4uCC7D2IjCCH2w+BtH4LCghBCCEma0aNHq2YL1GKgFzkh1qHFwoegsCCEEEIIIWkFhYUPQWFBCCEkLeAMPiGejbN+wxQWPgSFBSGEEGei1UlIi0JshJDHh/YbdrT2CWMsfIicORPeR0S48k4IIYR4A8j9nyVLFlPVYtRN8LT0okyNyj715WfUYDAoUYHfMH7LlpXuUwqFhQ9BiwUhhBBng+xJQBMXngYGVqgNgpogniaK3BX2qef1J0SF9lv2KmExffp0VXESJdVRzfKLL75QVSqtceDAARk5cqSqVnnmzBmZPHmyDBo0yGwfZHYYM2aM2bpSpUrJ4cOHzYqCDBkyRFVDjIqKkubNm8uXX34puXPnFm+1WHjo339CCCFuBgY6efPmVQX79JWJPQUM2K5fvy7Zs2d3ecFBb4F96ln9CfcnRy0VbiksFi5cKIMHD5YZM2ZIrVq1ZMqUKWqQjzLq+INlCUw3RYsWlRdeeEFVx7QFSs6vWbPGtAxTkh4cu2zZMlm0aJGqLNivXz9p27at/Pvvv+JNoMZPliwit25RWBBCCHEuGJg4a3DyuAdtGFih2jCFBfvUHYn3oGfUre5u0qRJ0rt3b+nRo4eULVtWCQz4a86aNcvq/jVq1FDWjU6dOklISIjN80JIwLyjtRw5cpi2oTz5d999p6791FNPSbVq1WT27NmyadMm2bJli3gbmj6jxYIQQgghhDgTt7FYREdHK5cmfZVLqLImTZrI5s2bHTr3sWPHJF++fErp1alTR8aNGycFCxZU23BNmG5xHQ1U3MR2XLd27dpWzwmXKTSNyMhIk6pEc1dy5fKTo0f9BLd7/368hIY+3uujbzRfQcL+dEf4jLI/3R0+o+xPd4fPqHf1Z0qu6zbC4tq1axIXF5corgHL+niIlAKXqjlz5qi4ikuXLql4iwYNGsj+/fslY8aMKpYjODhYBa1YXhfbbAFxYhm7ASIiIlTMhruSMSM+p1FNHDp0TfLnj3/sDyesRPiBuLs5zxNgf7JP3R0+o+xTd4fPKPvU3Yl38djpzp07nics0oqnn37a9L5ixYpKaBQqVEj+97//Sa9evVJ9XlhWEA+it1iEh4dLzpw5JVOmTOKuhIcnZBMwGHKYZYp6XD8OBPqhnygs2J/uCJ9R9qe7w2eU/enu8Bn1rv6Ex4/HCQvEPSDo68qVK2brseyM9FcasEyULFlSjh8/rpZxbrhh3bp1y8xqkdx1EdNhLa4DX7g7D5j1BqFr13Cvj/8e8ONw937yJNif7FN3h88o+9Td4TPKPnV3/Fw4dkrJNd1mZAd3JAROr1271kyhYRlxEc7i7t27cuLECZUaD+CaiLTXXxdZqM6ePevU67oLrGVBCCGEEELSArexWAC4FnXr1k2qV6+ualcg3ey9e/dUlijQtWtXyZ8/v4pvALA0HDx40PT+woULsmfPHsmQIYMUL15crX/rrbekVatWyv3p4sWLMmrUKGUZ6dy5s9qO9LJwicK1s2XLptyY+vfvr0SFrcBtT4bCghBCCCGEeL2w6Nixowp+RtE7BE5XrlxZVqxYYQrohhVBb46BUKhSpYpp+bPPPlOtYcOG8tdff6l158+fVyIChUXgm1a/fn2VRhbvNVBYD+dt166dWYE8b4TCghBCCCGEeL2wAChOh2YNTSxoFC5cWEXIJwWqadsTlIKK32jeDoUFIYQQQghJC9wmxoI8HnSGGhbJI4QQQgghToPCwsfIlg3R/cb3ERGuvhtCCCGEEOItUFj4GAEBSO1rfH/1qqvvhhBCCCGEeAsUFj6IFmcBYZFMiAohhBBCCCF2QWHhw8Li4UPU9XD13RBCCCGEEG+AwsIHYWYoQgghhBDibCgsfBAKC0IIIYQQ4mwoLHwQppwlhBBCCCHOhsLCxy0WTDlLCCGEEEKcAYWFD0JXKEIIIYQQ4mwoLHwQCgtCCCGEEOJsKCx8XFhcvuzKOyGEEEIIId4ChYUPEh4u4udnfH/ihKvvhhBCCCGEeAMUFj5ISIhI4cLG90ePsvo2IYQQQghxHAoLH6VkSeNrZKTI1auuvhtCCCGEEOLpUFj4uLAAR4648k4IIYQQQog3QGHho+iFBdyhCCGEEEIIcQQKCx+lVKmE9xQWhBBCCCHEUSgsfBRaLAghhBBCiDOhsPDhlLPIDgUYY0EIIYQQQhyFwsJH8fcXKVEioZZFbKyr74gQQgghhHgyFBY+jBZnERMjcuaMq++GEEIIIYR4MhQWPgzjLAghhBBCiLOgsPBhWMuCEEIIIYQ4CwoLH4YWC0IIIYQQ4iwoLHwY1rIghBBCCCHOgsLCh8meXSRbNuN7FskjhBBCCCGOQGHh42juUOfOidy/7+q7IYQQQgghngqFhY+jj7M4dsyVd0IIIYQQQjwZCgsfh3EWhBBCCCHEGVBY+DjMDEUIIYQQQpwBhYWPQ2FBCCGEEEKcAYWFj1O8eML7I0dceSeEEEIIIcSTobDwcdKlEylYMEFYGAyuviNCCCGEEOKJUFgQkzvUrVsi16+zQwghhBBCSMqhsCCMsyCEEEIIIQ5DYUHMhAXjLAghhBBCSGqgsCCsZUEIIYQQQhyGwoLQFYoQQgghhHifsJg+fboULlxYQkNDpVatWrJt2zab+x44cEDatWun9vfz85MpU6Yk2mfcuHFSo0YNyZgxo+TKlUvatGkjRyz8fRo1aqSO17fXXntNfIVChUSCgozvjx519d0QQgghhBBPxK2ExcKFC2Xw4MEyatQo2bVrl1SqVEmaN28uV69etbr//fv3pWjRojJ+/HjJkyeP1X02bNggffv2lS1btsjq1aslJiZGmjVrJvfu3TPbr3fv3nLp0iVTmzBhgvgKAQEJ9SyOHROJj3f1HRFCCCGEEE8jUNyISZMmqQF+jx491PKMGTNk2bJlMmvWLBk6dGii/WGJQAPWtoMVK1aYLc+ZM0dZLnbu3ClPPPGEaX26dOlsihNfoFQpkUOHRKKiRM6eFSlc2NV3RAghhBBCPAm3ERbR0dFqsD9s2DDTOn9/f2nSpIls3rzZade5ffu2es2WLZvZ+nnz5sncuXOVuGjVqpWMGDFCiQ1bREVFqaYRGRmpXuPj41XzNEqU8BMRNJHDh+NNRfOcDfrGYDB4ZB+5I+xP9qm7w2eUferu8Blln7o78S4eO6Xkum4jLK5duyZxcXGSO3dus/VYPnz4sNM6ZtCgQVKvXj0pX768af2LL74ohQoVknz58sl///0n7777rorDWLx4sc1zIXZjzJgxidZHRETIw4cPxdPIkydMRDKr97t23ZXKle+nyXXwHUDc4QcC4UjYn+4Gn1H2p7vDZ5T96e7wGfWu/rxz547nCYvHAWIt9u/fL//884/Z+j59+pjeV6hQQfLmzSuNGzeWEydOSLFixayeC5YVxIPoLRbh4eGSM2dOyZQpk3ga1aolvL90CYHuGdLsx4HgePQThQX70x3hM8r+dHf4jLI/3R0+o97Vn0iolObCYuXKlfLdd9/JyZMn5ebNm0pF6UEHYGBuLzly5JCAgAC5cuWK2XosOyP2oV+/frJ06VL5+++/pUCBAknui2xU4Pjx4zaFRUhIiGqW4Av3xAFz6dIJ748e9RN/f6NbVFqAZ8NT+8kdYX+yT90dPqPsU3eHzyj71N3xc+HYKSXXTJWw+PTTT1WwNNyUatasqWb5HSU4OFiqVasma9euVSlhNYWGZYiC1ALB079/f/n111/lr7/+kiJFiiR7zJ49e9QrLBe+Qq5cIpkzIwaFKWcJIYQQQkjKSZWwmDp1qjz11FPy559/SpBWAMEJwLWoW7duUr16dSVYUJcCaWG1LFFdu3aV/Pnzq/gGLeD74MGDpvcXLlxQoiBDhgxS/FH+VLg/zZ8/X37//XdVy+Ly5ctqfebMmSUsLExZVbC9ZcuWkj17dhVj8eabb6qMURUrVhRfwc/PWChv+3aRM2dEECaSAssXIYQQQgjxcVIlLOD61L59e6eKCtCxY0cV/Dxy5EglACpXrqzSxWoB3WfPnjUzx1y8eFGqVKliWv7ss89Ua9iwobJOgK+++spUBE/P7NmzpXv37spSsmbNGpOIQZwEiu4NHz5cfA1NWMCrDV5s5cq5+o4IIYQQQohXCwtYEyyrVzsLuD3Zcn3SxIIGKm5bxnZYktx2CAkU0SNGYaGBr5fCghBCCCGE2EuqIkC+/PJLlYoVLkTEu4rkaRw96so7IYQQQgghPmGxgMtSbGysvPzyy/L666+rLEvI6GQZvb53715n3Sd5zBYLCgtCCCGEEJLmwgJVqxHoXKJEidQcTtwU/ddJYUEIIYQQQtJcWFjGOhDvIEMGkXz5EBRvjLEghBBCCCHEXlihjFiNs7h2TeTqVXYOIYQQQgixDwoLYka1agnvN29m5xBCCCGEEPugsCBm1KuX8P7ff9k5hBBCCCHEPigsiBl16iS8p7AghBBCCCH2QmFBzECR8+LFje937BB5+JAdRAghhBBCkofCgth0h4qOFtm5kx1ECCGEEELSSFjcuXNHzp07Z7bu4sWLMnLkSHn33Xdl27ZtqTktccM4i02bXHknhBBCCCHEq+tY9OnTR06dOiVbtmxRy5GRkVK7dm05f/68+Pv7y9SpU2XFihXSqFEjZ98vcUEA99tvs9sJIYQQQkgaWCz++ecfefbZZ03Lc+fOVRaLTZs2yc2bN6VixYry4YcfpubUxA0oXVoka9YEi4XB4Oo7IoQQQgghXiksrl27Jvnz5zctL1myROrXr6+sFhkzZpSuXbvK3r17nXmf5DHi7y9St67xfUSEyLFj7H5CCCGEEJIGwiJLlixy+fJl9f7BgweyceNGadasmWl7YGCg3L9/PzWnJm6CJiwA084SQgghhJA0ibGoW7eufPnll1K6dGkVS/Hw4UNp3bq1afvRo0fNLBrE8+MsevRw5d0QQgghhBCvFBaffPKJslC0a9dOLQ8ZMkTKlSun3sfFxcmiRYukRYsWzr1T8lipUQOWJ5HYWGaGIoQQQgghaSQsihcvLkeOHJGDBw9K5syZpXDhwqZtcIGaNm2aVKpUKTWnJm5CunQiVauKIHPwoUMiN26IZMvm6rsihBBCCCFeVyAvKChIiQe9qAAI3oZblOV64nmwngUhhBBCCHG6sDh79myiRnwrzoIQQgghhBCHXaFggfDz81PvDQaDeo94CuK9MDMUIYQQQghxurBYv3693Scl3kHevCJFioicOiWyfbtIdLRIcLCr74oQQgghhHi0sGjYsGHa3glxW3coCIuHD0V27RKpXdvVd0QIIYQQQrwqeJv4BgzgJoQQQgghaZZutmfPnkluR/xFaGioFChQQBo1aiR16tRJzWWIGwZwDx7syrshhBBCCCFeJSzWrVsnDx48kIiICLWcNWtW9Xrz5k31mjNnTomPj5fr168rkdG8eXP5+eefJR2KIxCPAnUPM2cWuX3bKCwMBghHV98VIYQQQgjxCleo5cuXS0hIiIwePVqJB61du3ZNRo0aJWFhYfLvv/8qoTFixAhZsWKFeiWeh7+/iGZwunJF5ORJV98RIYQQQgjxGmHRr18/admypYwcOdJkrQDZsmVTwqJFixZqH1Tlhvjo1KmTslgQz4T1LAghhBBCSJoIiy1btqiq27bAtk2bNpmWGzRoIFcw3U08EtazIIQQQgghaSIssmTJIqtWrbK5Ha5PsFZo3L17VzJlypSaSxE3oFYtkYAA43udXiSEEEIIIcQxYdG7d2/5/fffpX379rJ27Vo5c+aManiPdUuXLlX7aPz5559SuXLl1FyKuAHp04toX9+BAyK3brn6jgghhBBCiFdkhUIcBbJCTZ48WX799VezbQEBATJ48GC1D3j48KF0795dKlas6Jw7Ji6Ls9i505gVavNmkaef5hdBCCGEEEIcFBZIIfvJJ5/IkCFDTBYLUKhQIWncuLHkypXLtC/qWXTr1i01lyFuRP36Ip9/bnwPLzgKC0IIIYQQ4rCw0ICA6Ny5syOnIB5CkyYigYEisbEiixeLTJrEehaEEEIIIcRJwuLOnTvKWoF6FQb4yFjwxBNPOHJ64kYgqzDExYoVImfPiuzYIVKjhqvvihBCCCGEeLSwQDE81Kn45ZdfJC4uTq2DsICLlP69to14B+3aGYUFQFkSCgtCCCGEEOKQsEDGpz/++EMGDBigalToi+QR76VNG5HXXhOBXoSwGD+e7lCEEEIIIcQBYYEaFm+++aZMmDAhNYcTDyVHDpFGjUTWrhU5eVJk796ENLSEEEIIIcS3SVUdi3Tp0knhwoWdfzfEI9yhNGC1IIQQQgghJNXC4qWXXkpUv8JZTJ8+XYkWpKmtVauWbNu2zea+Bw4ckHbt2qn9EdMxZcqUVJ0TtTb69u0r2bNnlwwZMqhzXrlyxemfzRt4/vkE9ycICysx+4QQQgghxAdJlbBAde0bN25IixYtZPHixbJ9+3bZtWtXopZSFi5caCquh+MrVaokzZs3l6tXr1rd//79+1K0aFEZP3685MmTJ9XnhFsXYkYWLVokGzZskIsXL0rbtm1TfP++ALoZNS3AkSMiBw+6+o4IIYQQQog74Gewlic2Gfz9E/SIlglKT2qzQsGaUKNGDZk2bZpajo+Pl/DwcOnfv78MHTo0yWNhkRg0aJBqKTnn7du3JWfOnDJ//nwlmMDhw4elTJkysnnzZqldu7Zd9x4ZGSmZM2dW58uUKZN4MyiUN3Cg8f3o0ajEbv+x6H+IOtRA0T9HJHWwP50P+5T96e7wGWV/ujt8Rr2rP1Myxk1V8Pbs2bPF2URHR8vOnTtl2LBhpnXovCZNmqgBflqdE9tjYmLUOo3SpUtLwYIFkxQWUVFRquk7Xfvy0bw9O9TAgcYH+5dfDDJihP3aFH0D4entffS4YH+yT90dPqPsU3eHzyj71N2Jd/HYKSXXTZWw6Natmziba9euKQtH7ty5zdZjGRaEtDrn5cuXJTg4WLJkyZJoH2yzxbhx42TMmDGJ1kdERKiYDW8mOFikWrVssnNnsOzb5yebN1+TYsXi7H44oXjxA6HFwnHYn86Hfcr+dHf4jLI/3R0+o97VnyiI/Vgqb/sysIIgdkNvsYCLFdyqvN0VCnTqBGuP8f2GDdmlTh37fxxwk0M/UVg4DvvT+bBP2Z/uDp9R9qe7w2fUu/oTyY+cKix69uypPtDMmTMlICBALScH9v/uu+/svpEcOXKoc1tmY8KyrcBsZ5wTr3CZunXrlpnVIrnrhoSEqGYJvnBfGDAj7ezbbxvf//KLv7z3nv3H4tnwlX56HLA/2afuDp9R9qm7w2eUferu+Llw7JSSa9olLNatW6dOCsWEgTqWrQVt60luuyVwR6pWrZqsXbtW2sCJ/5FCw3K/fv1SdK6UnBPbg4KC1DqkmQVHjhyRs2fPSh17p+F9kCJF0HdGqwUSgKFgXtGirr4rQgghhBDiKuwSFqdPn05y2VnAtQjxG9WrV5eaNWuquhT37t2THj16qO1du3aV/Pnzq/gGAEvDwUf5TvH+woULsmfPHlWLonjx4nadE1HuvXr1Uvtly5ZNuTEhYxREhb0ZoXwV6DDNHWrxYpG33nL1HRFCCCGEEFfhVjEWHTt2VMHPI0eOVIHTlStXlhUrVpiCr2FF0JtjUG+iSpUqpuXPPvtMtYYNG8pff/1l1znB5MmT1XlhsUCmJ9S5+PLLLx/rZ/dUYaG5QKFYHoUFIYQQQojvkqo6Fnru3r0rN2/eVJHqliBlq6/gS3Us9FSqJPLff8b3Z8+KhIe7dy5mb4P9yT51d/iMsk/dHT6j7FN3J97b61ggnSpSrSI4+/r16zb3S2mBPOKZVgtNWMAdSiucRwghhBBCfItUCYs33nhDvv/+exUQ3aBBA8maNavz74x4BChWrlXeXriQwoIQQgghxFdJlbBYvHixvPLKK/L11187/46IR1G2rEi5ciIHDoigmDkyRFWt6uq7IoQQQgghj5tUOWohlWxVjh7JI/TZgKdOZbcQQgghhPgiqRIWrVu3ljVr1jj/bohH0rWriOYN99NPIpcvu/qOCCGEEEKIRwiLESNGyMmTJ6VPnz6yc+dOlc71xo0biRrxDdKlE3n1VeP7mBgRZuolhBBCCPE9UhVjUaJECfW6e/dulRnKFswK5Tv07Ys6IiKxsSJffWWsbxEa6uq7IoQQQgghbi0sUGwOcRaEaBQoIPLCC0ZXqGvXRObPF+nZk/1DCCGEEOIrpEpYjB492vl3QjyeQYOMwgJMmSLSowcC/V19V4QQQggh5HHA0sfEadSsKVKnjvH9vn0i69axcwkhhBBCfIVUWSzAzZs35aefflJB3HhvMBjMtsNVKqn4C+K9VgvUs9CsFo0bu/qOCCGEEEKI2wqLlStXSvv27eXevXuSKVMmq5W3GYPhm7RtKxIeLnLunMjSpSLHjiHY39V3RQghhBBC3NIVasiQIZInTx7Zu3ev3Lp1S06dOpWowZJBfI/AQJH+/ROWWTCPEEIIIcQ3SJWwOH78uAwYMEAqVKjg/DsiHs8rrxhrW4DZs+E25+o7IoQQQgghbiksUMfizp07zr8b4hXAMw4ZocD9+yIMtSGEEEII8X5SJSw+/PBD+fLLL+X06dPOvyPiFQwYkPD+iy+MhfMIIYQQQoj3kqrg7bVr10rOnDmlTJky0rRpUwkPD5eAgIBEwdtT6WDvs5QsKfLMMyLLlomcPSsyZ47RRYoQQgghhHgnqRIW06ZNM71fitQ/VqCwIEOHGoUFGD5cpGNHkfTp2S+EEEIIId5Iqlyh4uPjk21xcXHOv1viUdSvL9KunfH9lSsi48a5+o4IIYQQQkhawcrbJE2ZMEEkONj4ftIkEYblEEIIIYR4JxQWJE0pWlRk4EDj+6gokffe82OPE0IIIYR4IakWFsuXL1eB29mzZ5fAwEAVvG3ZCAHvvy+SI4exLxYu9JMdO4LYMYQQQgghXkaqhMUvv/wizz77rFy5ckU6deqkYio6d+6s3oeFhUnFihVl5MiRzr9b4pFkzizywQcJy6NGZZT4eFfeESGEEEIIcQthMW7cOKlZs6bs3r1bxowZo9b17NlT5s2bJ/v375dLly5JkSJFnH2vxIPp3VukXDnj+127gmXBAlffESGEEEIIcbmwOHjwoLJOwN0JblAgJiZGvRYuXFjeeOMN+eSTT5x6o8SzwWMycWLCMmItUJWbEEIIIYT4sLBIly6dBD9K9ZMlSxYJCQlRVgqN3Llzy6lTp5x3l8QraN5cpEULg3p/7pyfTJ7s6jsihBBCCCEuFRalSpVSVguNypUry48//iixsbHy8OFDmT9/vhQsWNBpN0m8h08/NUhAgFFcoK6FTo8SQgghhBBfExbPP/+8/P777xKF/KEq68/78tdffynrRc6cOWXjxo0yFGWXCbGgbFmRl182+kDduyfy5psiBqPOIIQQQgghviYs3nrrLTl79qxygQLIEAVh0bt3b3n11Vdl7dq10r17d2ffK/ES3nrrrmTNalQTCxeKzJvn6jsihBBCCCGOYoy8dgINGjRQjZDkyJ7dINOnG+TFF43F8vr2FalfH4H/7DtCCCGEEE+FlbeJS+jYES5RxveRkcb3cXH8MgghhBBCvN5i8dxzz6XoxH5+fioOgxBbTJsmsnGjyOnTIv/8IzJ+vLFKNyGEEEII8WJhsXTpUgkNDZU8efKIwY5oWwgLQpIiUyaRuXNFnnhCVCXu0aNFmjUTqVGD/UYIIYQQ4rXCIn/+/HLhwgXJkSOHvPjii6pAHkQGIY5Qrx6K5Yl8+KFIbKxIly6ozC2SIQP7lRBCCCHEK2Mszp07J+vXr5cqVarI2LFjJTw8XJo0aSKzZ8+WO3fupO1dEq9m5EiRmjWN748dExk82NV3RAghhBBC0jR4u2HDhvL111/L5cuX5eeff5bs2bNLv379JFeuXNK2bVu1TqttQYi9BAUZXaLSpzcuf/ONyG+/sf8IIYQQQrw+K1RQUJC0bt1aFi5cKFeuXDGJjY4dO8qECROcf5fE6ylRQmTq1ITlnj1Fjh515R0RQgghhJDHlm4W1omVK1eq7E+7d+9Wwd2FWYyApBKIibZtje9v3hR55hmRa9fYnYQQQgghXiks4uPjlZhAZe3cuXNL586d5cGDB/LNN9/I1atX5WWtOIEDTJ8+XQkUCJVatWrJtm3bktx/0aJFUrp0abV/hQoV5M8//0yUocpa+/TTT0374HqW28cj/yl5bCCR2KxZIuXLG5ePHxdp3Vrk4UN+CYQQQgghXiMsNm3apOIp8ubNK88884wcP35cPv74Y7l48aIayL/00kuSXnOSdwC4Vw0ePFhGjRolu3btkkqVKknz5s2VaLF1XxA3vXr1UlaTNm3aqLZ//37TPpcuXTJrs2bNUsKhXbt2Zuf64IMPzPbr37+/w5+HpIzMmUWWLRPREo5t2iTSvbsxHS0hhBBCCHFf/Az2FKWAAvH3l7CwMGnZsqUayNvj8lS1atUU3xAsFDVq1JBpqJ72yEKCDFQY5A8dOjTR/ojruHfvnqqzoVG7dm2pXLmyzJgxw+o1IDyQyWrt2rWmdfg8gwYNUi01REZGSubMmeX27duSCQUaiFXwfUIkIuAfz5Qtdu401re4f9+4PGyYyMcfs1NT25/EftinzoX96XzYp+xPd4fPqHf1Z0rGuHbXsQBwefrll19k8eLFSe4HrQKLQFxcXEpOL9HR0bJz504ZhlHkI9CBSGu7efNmq8dgPSwcemDh+M1GWiEEmy9btky+//77RNvg+oRUugULFlS1Ot58800JDExRFxEnUa2ayIIFEIFGa8W4cSJFi4q88gq7mBBCCCHEHbF71Ix6FWnNtWvXlBhB7IYeLB8+fNjqMchGZW1/rLcGBEXGjBlVelw9AwYMUBaWbNmyKfcqiBu4Q02aNMlm4Lo+tS7UnKYq0Yh10DcQnvb0EYK3J08WGTjQqM5fe80g4eEGadqUvZua/iT2wT51LuxP58M+ZX+6O3xGvas/U3Jdu4VFt27dxBtAfEWXLl1UoLcevdWjYsWKEhwcLK+++qqMGzdOQkJCEp0H68eMGZNofUREhDxktHGSDydMafiB2GPO69BBZN++jPLtt+klLs5PXnjBID//fEMqVoxN/sv2AVLan4R9+rjhM8o+dXf4jLJP3Z14F/9fn5JC2G7l55MjRw4JCAhQ7kp6sJxHi+a1AOvt3X/jxo1y5MgRFSBuT6xHbGysnD59WkqVKpVoOywaejECiwViQXLmzMkYi2R+HHCTQz/Z++P48kuRq1cNsmSJn9y54y8dO2aXP/80SK1adh3u1aSmPwn79HHCZ5R96u7wGWWfujvxLv6/3nIy3mOEBawE1apVU0HVCLDWOhPLyEhljTp16qjt+qDr1atXq/WWfPfdd+r8yDSVHHv27FFfHgJlrAErhjVLBo7hAC9p8ONIST9ht/nzRVq0EPnnH5Fbt/ykeXM/QVbh+vXtOoVXk9L+JOzTxw2fUfapu8NnlH3q7vi58P/6lFzT7UYisAKgJgZiIQ4dOiSvv/66yvrUo0cPtb1r165mwd0DBw6UFStWyMSJE1UcxujRo2XHjh2JhAgsCqh38YqV6F8EgE+ZMkX27t0rJ0+elHnz5qnAbaTQzZo162P41CQ5kMl4+XKRJ580LsMq17y5yLp17DtCCCGEEHfArSwWWvpYxCmMHDlSBWAjbSyEgxagffbsWTPlVLduXZk/f74MHz5c3nvvPSlRooTKCFVeq7L2iAULFijfNKTKtQSWB2yHKEFAdpEiRZSwsMw2RVxLhgzGGheIu1+xwpiKFgHev/5qtGYQQgghhBAPqGNBkoZ1LB5fLmYk40JQ95IlxuXgYJH//c9YpdvXcHVua2+Efcr+dHf4jLI/3R0+o97VnykZ43Ik4k34iEZEaMvPP4u88IJxOTpapH17kZ9+cvWdEUIIIYT4LhQW3iIoULSwZk1ENrv6bh4LQUHGgO6XXjIux8aKvPiiyIgRxoJ6hBBCCCHk8UJh4Q188olIu3YiO3aIDB8uvgKKos+ZI9KnT8K6Dz80Wi/u3nXlnRFCCCGE+B4UFt5Aly7GtEla0YedO8VXCAgQmTFDZOJEY1pagGDuunVFTp929d0RQgghhPgOFBbeQHi4yOjRCW5Rr78uEhcnvoKfH9IUGzNGZc5sXLdvn0iNGiIbNrj67gghhBBCfAMKC29h4ECRcuWM77dvF/nmG/E1kHJ261aRkiWNy9euiTRpYrRo+EhcOyGEEEKIy6Cw8KZoZrhBaaCI4NWr4muUKiWyZYuxeJ4W1A0DDtLT3rjh6rsjhBBCCPFeKCy8iSeeQGly43tkh3rnHfFFUCx96VKje5QG0tNWrMhK3YQQQgghaQWFhbcxYYJIlizG999/L7Jxo/giyBiFgG4ICggNcOGCSOPGIm+9ZSyyRwghhBBCnAeFhbeRO7fIxx8nLPuo1UIDWXj/+88oKDQgOGrVEjlwwJV3RgghhBDiXVBYeCMo7FC9urGgw6JF4usUKCCyapXIZ5+JBAcb1+3da+wiGHhiYlx9h4QQQgghng+FhbcWd1i/3igqMKomqsbFkCEi27aJlC1r7JCHD0XefVekalWRf/5hJxFCCCGEOAKFhbeSIYOr78AtqVTJWKAc2XlR/wLs3y/SoIHIK6+IXL/u6jskhBBCCPFMKCx8BUQu9+8vEh0tvk5YmMiUKUbrRbVqCeu/+86YrnbOHNa9IIQQQghJKRQWvgCm6FGGeto0kX79OGp+BGIsUFDviy9EMmY0roPFokcPkfr1RTZtcuF3RgghhBDiYVBY+AKITtaqw6EiN6briSkcBVrr8GGRjh0TOgWiol49keefN24jhBBCCCFJQ2HhC9SpY/Tz0UAhh2XLXHlHbke+fCILFoisXClSunTC+t9+EylfXuTVV0UuXnTlHRJCCCGEuDcUFr5Cly4iw4cb38fHi3TubIxaJmY0ayayb5/IzJkiefMa18XFGZeLFxd5//0E4w8hhBBCCEmAwsKXGDPGWNsC3Lkj8uyzIlevuvqu3LJqd+/eIseOiXz4YUL8xYMHxtqDhQoZ6w5evuzqOyWEEEIIcR8oLHytmMP33yekQjpzRqRhQ5GzZ119Z25J+vRGC8XJk8b0tEFBxvV374p8+qlIkSLG+Ax2HyGEEEIIhYXvkS6dyJIlCYXzEJmMKOXISFffmduSI4cx3h0WjDfeEAkJSSiwN326SLFiIj17ihw65Oo7JYQQQghxHbRY+Gqk8saNIiVKGJdR3yJTJlffldsDFygIiVOnjFW8YdEAsbEis2cbK3o3b26Mi0cYCyGEEEKIL0Fh4WRiY2PFYDCYluPj49W6OEQAW+zn0n0LF5bYv/+W2KlTxYAsUcmcF8tYj+0auEZK90XztH0t+zJnzliZMCFeeZKNGCGSJYtBAgNjVVu1yqBCV0qWhJUjXq5fd8PvPoX7av2Tkn3d+ftMq3095ftM6+eEfyPife454d+I5H8Drv6O3GFf/o0w7x9Pe07sJdDuPYld/Prrr9KlSxcJDQ1Vy4cOHZL//vtPihYtKrVq1TLtt3jxYvWFPvfcc5L+0dT30aNHZffu3VKoUCGpW7euad8lS5ZIVFSUtGzZUjJnzqzWnTx5UrZv3y758+eXJ554wrTvsmXL5P79+9KsWTPJnj27Wnf27FnZvHmz5M6dW5566inTvit37pTInDnlqYgItQ1cvHhRNq5cKTkKFpSmTZua9l2zZo3cuHFDXQvXBFeuXJH169dLlixZ5Omnnzbti3URERFSr149KViwoFp37do1dQ581po1a5r23bhxo1y6dEn1DfoI3Lp1S1asWCFhYWHSpk0b0774DOfOnZNq1apJSYzcVbzDXVm6dKkEBQVJey0wXUT1zalTp6Ry5cpSpkwZte7Bgwfy+++/i5+fn3Tq1Mm0765du+T48eNSvnx5qVChgloXExMjv/zyi3rfsWNHdQzYu3evHD58WEqXLi1VqlSRDz4QGTzYINOnL1KWjB9+aCcxMcFy4oTIrFkHZNeu/ZIrV3Hp0qWGVKlivN7PP/+sfrStW7eWdHBNE5EjR47Inj17pEiRIlK7dm3Tvf3222/qXp599lnJ+CiKHPe6c+dOCQ8PN3tO0A/4jC1atJCsWbOqdadPn5atW7dK3rx5pVGjRqZ9ly9frvquSZMmkjNnTrXu/Pnz8u+//6plrNdYtWqV+k6efPJJyZMnj1qH7+zvv/+WbNmySXOYaR6xbt069V03aNBACjxyt7t69apanylTJnnmmWdM+27YsEE9Q3Xq1JHChQurdXjGcD30C/pHA/d14cIFqVGjhhRHei6B916k/PnnnxISEiJt27Y17YvPe+bMGfX94HsC+E3gdxQQECAdOnQw7btjxw71W6pYsaKUK1dOrcNvbfXq1eq8L774omlffD/4jZYtW1YqVaqk1uE3vGjRIvX+hRdekEBE/gsyi+2TgwcPqucUz6uGtu/zzz/vGX8jVq5U/Yx1Zn8jNm6UHDly2PU3At89+hKf2Z6/ERkyZJBWrVp5zd8IgN+79t23a9dOgoOD1fsDBw7I/v371TONZ1sjub8R+r+hyf2NqI9qn4/g3wjbfyMePnyo+h2/YXv+RuD/etAZGRYfwb8RCX8j8P8Dnl38/XL2OMIX/0YUK1bM1A/OHkfY8zcC34e90GJBzNm8Gb9okS1b6M9jJ/Aiw98yjMf+9z8R3ZhcuUlt2CBStaqxwZUK9QoJIYQQQrwNP4Pe3kFSDWb1MFN4/fp1pfI0ZQoTEhqWMVuqoZmVsM5t9j11SuIrVJD4qCg8GBLQuLExi1SePGrmFI+Kv7+/agDLWG953qT2xX1gxiJXrlxqW1L7Am0GOLnzpuW+1voyuX0PHhT54ot4mTcvXu7d85P4+IT+SZ8+VjCB0qNHgDz5pJ9K1pXa7xMNFgH0p2ZWdfZzovVPSvZ15+8zuX2xDrNf6FNt1ii1z4lH/O6d/JxY9g9myjDzCKuZvo/d8bt/nH8jHOn3x/G796W/EbhPzJzDgoflx/mcuONv2Rn7Yn1Kfvee8Jw4+7v3T8G+2I7xpTZ2etzfJyxA+H3cvn1beR8kBYWFk4WFPZ2eFpy6eUqmbp0qr1Z7VcrkNJrsUgw05rhxxhyrGnCTQWSyzoXFEfCAav8haj8ob+b2bWNFbxQ+37498XZ4C8GaCms6LKKPfsd242v9+Thgn7I/3R0+o+xPd4fPqHf1Z0rGuByJeAnf7PpGCYuyX5aVRnMayYL9CyQqNiplJ8Go9r33RFavTig7HRFhLKQ3YIAxvypJEXB3f/VVkW3bRP77z1gPI1u2hO3nz4t89pmxtAhcOFHD8OhRdjIhhBBCPA8KCy8AJrL5++abljec2SCdf+ks4ZPD5d3V78qx68dSdkIECezdK6ILjpIvvhBBwOCBA068c98C8Vyoh3HxosjChUa9prOkypEjIqNHi5QqZYzHGDvW2N10ViSEEEKIJ0Bh4QXAD27Xq7tkcvPJUip7KdP6iPsRMmHTBCk5raTU/KamTNo8SS5EXrDvpHCB+v13Y7Txo+w1sm+fSPXqxkINJNWgwB6Sjvzxh8jlyyJff20sgK53g9q9W2TkSJHy5UWQtGTYMKPVgyKDEEIIIe4KhYWXkC0smwyqPUgO9T0k67utl07lO0mQf5Bp+/aL22XIqiHKigFXqa93fC3X719P+qQY6aLUNIIDMMIFYWEiujRmxDGQ7bNPH5G//kLKzwS3KD1wjRo/XgSZSMPDjftD8929y94nhBBCiPvA4G0vCd62xtV7V+X7Pd/L/P3zZc/lPYm2B/oHSoOCDeS5Us9Jq5KtpFi2YrZP9uCBcQodNQQQNKAnMtLuyt2uDkDyFFB877ffUBfFWCTdWiVvJCxq2NAgDRrckY4dM0jJkuxPZ8Bn1LmwP50P+5T96e7wGfWu/kzJGJfCwgWd7goOXzssP+37SX7a/5Mcu2E95mJK8ykysPbAlJ346lWRsmWNaY0QIPCo4Ja7/jg8EcTPL1mCgmkia9eiOJP1/VBLA/XKECKDmhr6IHFiP3xGnQv70/mwT9mf7g6fUe/qT2aFIokonaO0jHlyjBzpd0R29N4hQ+oMkaJZjRUqNRoUamC2fPT6UZm5c6ZKZWsTpKa9fl1k2jQRVE9+912U0uQ34EQQ7tKrlzG05cYNY2zG66+L6IpwKk6eNMZrvPCCSI4cIijkiyRfECP37/MrIYQQQkjawiljHwz0rpavmnzW7DM53v+4HHjjgIxrPE65Q1XJYywtr/HLwV/k1aWvStHPi8oPe39IfDJEEhcrJvKonLxy+p8wQaRIEZFBg0Qu2BkoTuwGXY1sUl9+KXL6NJJ3xcv7799RLlFBQeZfzY4dxrIksGBkySJSr55RB65axfgMQgghhDgfCgsfFxllc5aVofWHyu+dfjdVWdRYfXK16X298Hpm2/4+87f0WfqqzG1ZQM7uXGcM8taqFCMeY+pUo28OptYxAiZp8P0ZY+r79bsn69YZ5OZNkeXLRQYPFqlY0XzfmBiRTZtEPv5YpHlzkaxZjTH4Q4YYXayQnYoQQgghxBF0WfQJMWdC0wmy8vhK2R+xP1Fg97Kjy1RRPjRQsERBqfvd01J7/y2pvWiLVD4TJSHR0SIzZojMnCmyYYNI/frs4jQkfXqRFi2MDcAjDW5Q6HpkndIX3ouNFdm61dgmTTKugw6sW9do2YDogGjR19kghBBCCEkKDhuITarnq66aNf4996/Z8tnbZ1VbECYiXUWCDQFS5ZJBap+Nl5r3Mkm14lmkhEGX2ogFGdKc3LlFXnzR2MClS0aRobVDhxLHaKDNnZuQWRipb1EXEalu8VqokHm9DUIIIYQQDQoLkipWvbxKtpzfIhvPbJS/z/4tm89tlgexD0zbo/3iZGs+UU3klsjXFSRDcAYVx1E6c2lpsHyvVI/PI6U69xP/J58SCQjgN5HG5M0r0qmTsYFr14zuUWj//mssV6LPOAWPtn/+MTZ9IDnEBiqDa68UG4QQQghx2xiL6dOnS+HChSU0NFRq1aol21ByOAkWLVokpUuXVvtXqFBB/vzzT7Pt3bt3V/ED+tZC8xd5xI0bN6RLly4qVWyWLFmkV69ecpcVyGySLiidPFXkKRnVaJSs7bpWbg+9Lbv67JIvW34pXSt1NasArnE3+q5sPLtRvtn3jXQtsE2q5l0i8c2bGdMbwdl/5045c/O03HxwM6WPDEkFyBz13HPG4nuolYFyJJs3i0ycKNKxozHJl7XUtytWGGM12rUzxulDbDRrJvLOOyLz5ons32+M6SCEEEKIb+F2FouFCxfK4MGDZcaMGUpUTJkyRZo3by5HjhxR+Xst2bRpk3Tu3FnGjRsnzz77rMyfP1/atGkju3btkvJatWiB33kLmT17tmk5JCTE7DwQFZcuXZLVq1dLTEyM9OjRQ/r06aPOR5InKCBIquStotrrNV5X6248uCHbLmyTHRd3yM5LO2XnxZ1yLvKc6ZjyV0UC4R118aLR0X/SJBnwSgZZUuCu5A/LLbv77pOc6XOa9jcYDIkCzInzQOw9Yiv0hdVRpgSWDGh7xGMg0xSyC+vB8urVxqaBn1e5ciKVKhkbfopocM8ihBBCiHfidgXyICZq1Kgh01AX4VFRkPDwcOnfv78MHTo00f4dO3aUe/fuydKlS03rateuLZUrV1biRLNY3Lp1S35DKWMrHDp0SMqWLSvbt2+X6tWNMQUrVqyQli1byvnz5yVfPuXP49EF8tyFK3euyLrD6+Rk5BHJfvyCvLY8QgQWpkdT3IUHiZzJIpIhSiRySVnx271HtDyq76x+RxYeWKhqcpTOXtr4+qjlyZDHJ0XH4y6ag78W584p45Jqu3YZXyFA7AHWDU1koKG2YpkyydZV9KlCRN4G+5N96u7wGWWfujvxHlQgz60sFtHR0bJz504ZNmyYaR06sEmTJrIZPhpWwHpYOPTAwmEpIv766y/1hWTNmlWeeuop+fDDDyX7o9EMzgH3J01UAFwT1966das8//zzTv6kvgssEE+GPykdc3UU/8b+Iq8qPzSRX36R+Hlz5dmjf8ve3CIZokX8cuU2iQqw/+p+U5D4qhOrzM6bKSSTlMxeUkpkK6Gaep/d+D5rWFYXfFLvBNoNnmto2s8CYgNGp717E9qePcYsVJbTFnClWr/e2PTAGKmJDLTSpY0tf378DXh8n48QQgghqcethMW1a9ckLi5Oclv4S2D58OHDVo+5fPmy1f2xXu8G1bZtWylSpIicOHFC3nvvPXn66aeVoAgICFD7WrpZBQYGSrZs2czOoycqKko1vZrTVCUasQ76BkYysz5C9TaUlu7VSz7HdPjPP4vfkiUS3/55HGDaLTQgRDJH+cntkMRGtsioSOVyhWZJtrBsUixrMVVpHK/DGwyXkEBzVziv6k8XBYaj6UOXUO0b8Rb79okcOOCn3h84gN9sYssSLB5oSIurJ106g5QsKaqVKoVXg5QoIVK8uLEWhzf3qbfA/mSfujt8Rtmn7k68i/9fSsl13UpYpBWdtDQ4Iiq4u2LFilKsWDFlxWjcuHGqzomYjjFjxiRaHxERIQ8fPnTofr0ZPJwwpeEHYtWcB+f8Ll2MDeh8bL7J0EuyjftNrqYXOZwjoR3KEyCH8wbL2dCHYpDEogOxHmjbL26X0MBQ6Ve2n5nb1Be7v5BNFzdJwUwFZVDVQZI3fV7xmv50MQgAR2vVKmHdtWt+cvRokBw+HCjHjgXIsWOBcvRooEREJM4Mdv++n7J+oBlJ+N6yZo2XokVjpUiROClSJFYKF45TrVChWMmWDfE43tmnngb7k33q7vAZZZ+6O/Eu/n/pzp07nikscuTIoSwIV1DZSweW8+TJY/UYrE/J/qBo0aLqWsePH1fCAvvCd01PbGysyhRl6zxw19K7YMFigViQnDlzMsYimR8HBvXopxT/ODBC7dtXcq1ZI7mPHJGGZ7QNcUiOKlEBIiezihwJD5NjH78lx2Iuy/Ebx1U7H3leiQ5YLCwtXPtu7ZO/zhunysc2HSu5MiVYr77d/a1M3DRRCmYpqIRHocyFJDxzuIRnetQyhyux4pH96SI0tydLbtyIV7U1Dh6EG5WfHDlidKdCbY24uMQq4eZNf9m5M1jFeFiSKZNBFfzTWuHCBpXBCg3pcUNDvatP3Rn2J/vU3eEzyj51d+Jd/P8Ssq56pLAIDg6WatWqydq1a1VmJ60zsdyvXz+rx9SpU0dtHzRokGkdMjthvS0QkH39+nXJC9+NR+dAcDfiO3B9sG7dOnVtBJNbA1mlLDNLAXzhHIwkDX4cqeonRPs+CuqXs2cTUhGtWaNSE4XEiZS5JlImKItI8zFmldwefj5JTp/aLXfDS4n/qVPG0eaj7VfuGYVpkH+Q5M+U3+y+IEqO3jiqmi1ypstpEhv5M+aXApkKqIZzqdeM+SV9cHpxu/50w/S3DRoYmx4UcIe40ITGsWMJ7cIF6+eKjLRt6QDIxwCRAa0KoaFv4eHe06fuAvuTferu8Blln7o7fi78fykl13QrYQFgBejWrZsKpK5Zs6ZKN4usT0j/Crp27Sr58+dXrkhg4MCB0rBhQ5k4caI888wzsmDBAtmxY4fMnDlTbUctCrgstWvXTlkfEGPxzjvvSPHixVWQNyhTpoyKw+jdu7fKJIV0sxAycKGyJyMUcQGIHn4Ul6HiMBAxjGIMf/9tzGlq4QcTuuBnKW1KADDCOIqtUUNVedtS5V2JqFdQLmYJkAB/c3ecuPg4SR+UXu7F3LN5KxH3I1TbdWmXzX3+7fmv1A2va1o+FHFIVp9cLfky5pOa+WtKwcwFU90VvpAGVwvmtgRxHMePG9uJE8YGEYLXM2dg6bB+TgSbo6EwYGL8JXv2nFKokJ8pUB0NggOvBQrAUoo4LGd/UkIIIcSzcbv/GpE+FnEKI0eOVIHTSBuL1K+a+8rZs2fNlFPdunVVrYnhw4eroOwSJUqojFBaDQu4Vv3333/y/fffK6sEhEKzZs1k7NixZhaHefPmKTEB1yicH0Lk888/d0EPkBSD56FKFWMbMCDxdqSy3b3bfB3KTi9frhokCJyfciEaGPU0unc37Tax+UT5rNlnKkbjzO0zKiPVudvnjK+R54zt9jm5eOeixBnibAc3ZzCP2/j7zN8ycMVA9f7bVt9Kr6q9TNtO3TwlPZf0VCl0cRxetZY7fW7JnSG35EiXQwL93e7n+9hJl06kYkVjs/a1w7AFA5W1llSK3OvXA1R9DqTTtfXIweAJkQHBgVfMQSCLlb6FhTnvsxJCCCHujluOTDDAt+X6hIBrS1544QXVrBEWFiYrV65M9prIAMVieF4KUtbCZwaV3lDlTWuWld5u3sSDYL7uv//Er1MnyV6hgmpVIVjLNBOpVsxsyjo2Plau3L0iF+5cUPEc+oZ1eTOaCwus07DcBtHy1+nEz7keP/GT7OmyK6GRNSirFMhaQAmOXOlzmVq5nOWkWLZi4stfe7FixmYNWDsgPGDZOH3a+GpsBjl1Kl6uXPG3GtsBYCTDI4WGR8kW0KoQGFrWLIgP/avWKEAIIYR4A24pLAhxOhAMcH175P6mCixgNAlLBhqmpvEKq4ceuFghohjtf/8zH7Ui7+mjoguB5cpJ/s6dVVwFXJuSo2O5jlI8W3G5dOeSVMhVwWybFvORFAhEv3b/mmqKi4n3QVrdsU+NNS0/iHkg9WbVU7VEGhRsIMOfGG62P1y5EIgOawhS9Hq7RQTWDmsuVvHxBrl6NUKyZcslV674KfGBLMgQHefPJzSss8gbkQhoVTSk2k0K1BuCwICLFV5hoMV7vGoNywh815V2IYQQQtwK7x45EGILxGBoaYLatrXdT6joBid/RBBb+tkgfREagD9M587m+3z7rdHfBkUXECyOqfNHxRfK5SqnmjU6lOsgLUu0lMt3L5s1iBCIjqv3rqpXWEjw+jDWenpjWC3MPsr9CNl92egSliE4Q6L92/2vnZy+ddq0nCU0i2QPy64sIxAb6v2jZbxCfGjv8YplxKN4SwV0GKTwtaLZAo8FYjUgMvCqWTH07dIlkeQyUKMMDhoC1JMDjxCEBkSG9qo1VDbXXtGwL+PPCSGEPC4oLAhJCqQU7t/fGB1srPSWYMFAiiJNcKCCmyWzZqGsu/k6FAOEwEjIg2pMg1TOXGRg4A+LBlpSoKDkqQunJD5dvFx7cE2Jjoh7Eeq1XsF6ZvvefHBTWSHgtoVMVpaYrB+PuPXwlmonbp6w+xlBOt/jA46brZu2bZrKrgXhMaTOELMMWbinqLgoyRqa1SOLFkJzarU6bAHj2K1bRoGhBY1r71F/E++117t3k7+mZgWxUTPUjIAAY54CNE1s6N9nz56wHQ3LsOQQQgghqYHCgpDkgO8JXJ7Q9CDlEKKAITKspB5WwsMSjDBReEFffOHTT82FxY0bIn36mKci0l4xHa2bgoZ1ACIkV7ZcUtLfirjRUSlPJYkeHq3EQrzBvIomll+r9poSJxAm1x9cl+v3ryuxcfPhTbufkUwhmRKtW3xosaw/vV69h7DQM2XLFPng7w/U+7DAMMkallWJDFhL8B6vWUKymC1nDslsXI/3ocb3OMYyo5e7AAMOLAdo1up36IGwgMiAixWa/r22rFUpt0eE4BHVjrUXxHtAYOgbPAktl7V1eMVno4sWIYQQCgtCUgumg+HmhGZtmhr1NVBsQZ8DFa9w2kf0r4bldDdiP375xfo1MXrTpx+aPt18O/xpIDwyJHZ10oQIBuiW+Pv5y6fNPrV6DFLuQlxAZEBsQHQgS5bZ+0evJbKVSHS8JkxQJyRdkPl0uF60PIh9IA/uPFAZtlLKX93+koaFG5qWN57ZKB9u/FCJkO6VuyvXMtN1Yh7IyhMrlQjCdrxqzZXFDgG+NluPlLXgc01kQDjAaw/v8aq9R0MCNCwn546l8eBBQhxJSsiY0SgwNKGhvWbJ4idBQelV5iwIEU1kGbcZG1P3EkKId0BhQUhaTVNXrmxslsB9CuICIgMRwZZFGOGwbwvEdmjpi8Ds2SJ37iRsnzhR5IMPjKM8feohLRIYr2gQM6VK2fVRYAlAjAVaavj5hZ+Va9ad6DuJ4i/K5yovrUq2UgIDblHaK0RGSoDVQs+pW6dk1YlV6v0ThZ4w23bp7iV5fuHzVs8D8QOBkT4wvWRNl9UkODKGZJRMwZnMlivmrihPFXnK7HhkAYPlBduDA4IlLYHLUnJuWHqdCyGiiQ5NbCAxGt5rr1rDMhoeN3vBY4iGR9scfOcZkxVUEBh6sYGWOXPi93i1fJ+CorCEEELSEAoLQlzhmJ/UtHTLlgmWDYgMNLxHwzQyIoIx6sOUMPxW9MICjvoA6xAJbCsauFkzEcs0zCg2CP8aCBDNCd+y4ZopjAZGyltbaW/7VOujmiXRcdFy++FtU5wHBIf2Xr/+dpTxvWWgOvbRgFVCT2RUpM17jYmPMbqByXU5eyfRCNmMHpV7JBIWFb6qoO6nZPaScqSfed+/s/od+e/Kf0p0wH0tY3BG1dR73Tr9sr5BsKQ2MB6HpU9vbPYIEU2M3LuXIDK0Bk89fdPWa7EfWJcSQQLw2KGl1Eqi/0lpIgMNWbYs3+PVWoMG197jPIQQQlIPhQUh7gbcnbSMVbaAXwumli1BCtyGDROig2054sNqYcmyZck742OEiqB0XRFB5fiPwoKWDvl6R/wUTiljth9pcdFSwxs13pCXK72sBvkIGtcDETKu8TglPiAyIqMjE95HRSqxcvvBbbkbc1cFltsCIkCPwWAwiRbLbWDL+S2y8exGSS1wV0PWrctvXTZzKftx74+y5OgSte3deu9KmZwJsUAo3ohijBAmCJrHPnhVy4/e41w4t7WvGpYEtEKF7L9PTZBoIuP69Xg5ffq2xMdnltu3/U0CBO32bWPYEd7jFQ2uWCkFRkDNGuMICJXShIb+1fI9GvpFv6xfp/UbM3IRQnwNCgtCPBEM1OG0ro/VAG+/bWwasFxoUb9aw3KlSubH4Tz2jMowasQISw8C2BGAntz9QmSgoMOjlLuKtWtF/v3X3Ole7w+DqWZMs6dwph7uW1qAtyX5MuaTofWH2jw2Pj5erl69Krly5VIWDLhwaaID7U6UcdkyYxeybbUv215tt5bN6260HdHWSYAAe5zDMg4EKYR/Pvizem9p/dl6Yau89OtLyZ4b1hBNZGiCQ//arVI3eabkM6b970Xfkzl75qjt+Kz1C9Y3bcNXdTPunARlDZKiudJL2YBQKVs2yjLvgE2iohIEh9b0y3ivNctlhBjhFUHrqQHXRrOm2VPrrqYXGlrT1uHR1q/Xlq29au/p9kUIcWcoLAjxZrSp1OSigTHiw4hMHwmsOeLrG9ZB0OixrGBuy8ICCwruRQ/csZITJQiSR2FDWFT0jBljnBK39IGx9H1BHtVUlrZGClw0e+JLggKCZGH7hTa3b31lqxIGECoQH3jFstawTtuOgbvldrQ4Q1wi64JesEAE6MF57EEFzicR14KCinoQM9NveT/1vlP5TmbCAtT6tpaKZdEI9g+WdMHplHCx1SBu9O/zZMgjfWv2NTvv7ku7lUUJ+1TJU0X1uV54oSI9YjoQT6IXG9YatkF34732qjVt2bJ8TUrBfaClJCuXfW5tfhIWllMyZvQziQ59g6Cxtmzt1bLhp+IlpWgIIS6AwoIQYkSbNkV9jZRQt67I+vUJDvj6V835XnO8t0z/g23Jgelna1Pd8+YZs24lB9y03nwzYRlWm2efTezHovNnCYNlBkHvrVqZiyH46eBzYFQGwZMCMAhW6XStZOVyhInNJqoq6hARRbKau8/VyF9DpraYqrbdi7mnXiFE1PtHy5av2H4/5r6q7q6hrz0CsF0jXWDiwhc4l57o+GiJfmhMdWwvyDBmKSxGrB8hy44ZBWbE2xFmgm/8P+Nl+LrhEhYUpoSJ1dfgMAnLGyZh4QnrClrs81yp56RwFmMgCqwX56/dkj0XDkncwzAJi80nQdG5TIHqkZEG9Xr3rp8pTsS4nBDMDrcwbR3O5yh4NI3XC3DY9csW1gSHJjpsLeO9tmztvbVlxLRQxBDiXVBYEEIcAy5OjRql7tghQ0Rat05wsrd0vtderRUgxDZ7sHTdgsjR1xGxABLGFO6NIHq9sEA19QEDjO8xMtL7suj9VSDOJk82P/Effxinrq1NL1tOJacg/yoCvdGsUTZnWdVSCuJFUNFdExuWYihvxrzyfZvvlcBAoLolrUu1Vu5iOB7pfRGzEmOIUftrLbnMX5apiS0FDYSAHlwHYkg7v6QiVgOUyl7KJCwQc3H8wVZpv7yFWh75xEgZ02KMad87UXclyydZJDRzqIRmD1X3BFc1CBS8ZgsMk3yBoeo9WrB/qARKmATEh4pfXKj4xYeKxIZKDr+SUjm4nUmcQIwcuveP3HsYIzH300n6m7XUOm3bnYf3JDIyXqLuh8n9u4Gpikuxx9KS1kBU6IWGvsHly9Yy3mvL+tek3usbBQ0haQeFBSHEdZQubWypYcOGBBGi+bVY+r5gGQHtejAygwXEMj7FGpauW/pgeIzm0Kw55FeokHjd1KnGmBJ7qr0jbbAG7hMxMdamii1fX3rJPO0TXNv27k16xGZllIXsU2oWPyjMqhsYAuK7Vupq8yP88PwPVmNW/HWWJ7guQbyYiY2YByYxYq0Se5cKXaRGvhpKlFjGmkDsaNtwPF61cyYVhG8JPrMevQCyvCa24XOYxEwqeabEMzKuYzuzdSW/6CnHbhyTrLmyyo2vbpht6/brG/LDf8Y+DvQPlAyBoRISAOESIkH+oRLsFyoBEiKBEioBhlDxjw8Rf4iYuBAlaAwxIWKICZWKt98TuZdLiQj8LCLkgESEbpHYhyHid76exEYUMYmMGLkvkv2IOofEhjx6DU14Hwe3tJT5UGlpkB+HiNGDx10vNEJC/CQwMIdkyOBnsT7x+9S8as1yGfMHtNgQb4PCghDimaRWkNSoIRIbaxzNaP4quhZ/+7bcuXRJMvr7i7+ltQPpkZo2NY7CtOllrelHR9YKFOIYe4BA0APxgqB3e3jiCXNhsWmTyPPWa3aYwMgGMSmWbmkTJogsWZL8FHD58iIdOpgfu2KFsY8xegoOliD0DVzLtONDQsQ/NFTSpU8v6VJQH6VX1V5JZgJDs4YmYjTBkdRr6Rzmz1WRLEVkUK1B6vhq+aolsuxUz1fdJF7wiv3UtR6JDnuwVpgR50hum5Y0QMXgSAqSA0DfhYj88uFAKaIzRn2xdZ0MWGG0yM0dN1e6VExwrdt69pDUnl09ydMG+UHMhChRE2AIEX+txRvFh19ciOS+0U7ynetv0uVoZ8v3l7iYAIm/UUQMmweaF3Ms+YdIums6QRP8SMgE60RNsI1twSLxgYkEDwSNdm0jfi4ZDuGnpxcayTXMAdizTXtv7dWebUhMSMFDUguFBSHE99AXdrBMvRsfLw+uXpWM1tIYvfiisVkDlgVt6teaNWTECGMNEmzX9tO/au8tCxdilAWxYc+0rmWQuj0+MhhloVmCGijI2JUc7dsnFha9e5uKUqAHs9s6duZM474aiJmBW509I6lp04ypjDVwr6tXWx1d+YeESLpgBJAHG7OO1atnfh/4XhA7kzlY5IG/SFykaaRVKU8lmdzCwq3tEbkz5Jbtvbdb3QbRgaxiUbFRJqGhiQ5N5OAVgsSyDgsYUGuAqm5vzSUM7m318tWTeP94k6DBq3Yt7bwQHUlhaRXSW3Yst8VK8qXbYwxREiM665Axlt74EDwabbz4ZBWZ3MK8n/w/mKbe18xfU7auG6geR8Sj4PFtunCc7LyyWVKNwU/8DcHyzJ57EvUwQP2c0M6Gfyo3CswViQ2W9Ou+kdjzFSU62k+iovxE8m8VqT1VJ1a0ZrlspemPuV5SJDI84V78Y0UyXjBui0kvhqhMpvtxNyAu9ILDUoAk14KC/CQuLqNkzuxnY7t9y/r1luu0V4S7UQi5DxQWhBDiDCBCtHgLW4UPUwMGzxAc+mlWiAxrr5axKGXLigwfnnCcZcOIBq8QWJbYG2lsLf+pvSMljFT04HMie5g9WMawQFggU1hywE3tv//M13XrZttNDaMWbWQzaJDI6NHmiQVgAbMy2vELDpbgoCAJDg6WjFiHeKIyZcxF1P/+92j/kyJBO43vH7W3gsJFgopardo3omgP6RvfQLLlzq1Ek/44UwsMlNgAP4mCuIkzCg5NeGjLOdOZ14lpXqy5KiiJ7ci6pQfi57VqryWc65GQsfWq7YNil1iGyLImWLT1altASCJXJYO/gxHvfgbx84+VJb+bJ1sYsPycfLHN+BxsWPlQCgcZ3fWghObuOSXd/vjJsesim9q9yVLm9iBTGuOb8RdlZVmjRTH75Q5SZMdC0zaVKKBtCYkPjRBDrCZUghILl3gr67T9sO1ubpH1Y81vpPRvIllPGPfZ00MkWvc3KttxkRyHE50rJj5IYrTzPgwSuWdxHby3Yg3SdTzSPsjjQvvpWRMfSb1Pal1S61PTAgOTXuctrnEUFoQQ4gngfxwtxkI/U58UiM2wrFliL3PnisyZkyBANBGCEZC2jKYGY1asM4hxefhQDA8fyv1btySdn5/4IX8rjtHOER6e+DMinTH204+4rFlULAfc9goha+W1k8orC/GgCTHLkuJY3r3bvusi/kUvLA4eNIq+5MCIw+L+/MaPlxxffZXsoYHPPiuBf/wh6fUDvNq1Rc6dMx/VPHqt8Kip5TfDRVoXMx1WIjaTfPVT5KP904kEZTbupz+H9r5fP/N6NQcOSPymfyU60E/8LgWKLFxo2j8wwF92VvhCov0Mki5j4oxpI8u8LpfzX5AoiZMoQ4xEq9dYiZZYiYqPVesgnqKxDu9jH4kZnaixVrE+wC9ABdtjHxTk1M8POCxmHtHphWB5o0bC8vEb0VLiC+P7Fk2DZK7FV5jz01ty7f5t5aaWWnIGFpFPXh6rfg7az2j2gzlyyPC72t6nfgcJfJjBtH1vxl/kv1y26/okixIbQSI/LxA52iphfb4dIm26GUXI7p4iWx8lvQB+cSId2yYIFDOxYvGa1LY7+URONlWnxGdRP5O8O0UCHxqPO6XrfBB607gt0fmSEkiPl4AAW0LET/z8ckiTJn7K0OvOUFgQQgix8T9EYEIa3pSgZc6CJ0p8vNy5elXCcuUSv+Qq5EEEYdCrB6IC8Rp6oYGGAop6unQxWg+07dqoShtxaMu5cye+bpMmIvnzJ+wDwaA/TmuWx2Id/te3FBzWwH567DkmNUIoqWtq6ZbtsQp17my+jOxs8+fbd92XX05UCNN/4ECxYttSXlJVtQUkWjhqXtCx9Se/Ja5hYw2ImS8ejdo1IMDx/OA5HpnPOGp7JGgmBwTI5MCial1cg9sSUSaf6bB20cWkwfa6Eh3kL1GBfhId5KdEUVSASEwA3ot6H43W/WUlbGB5gUiJPvCfRJ8+IdEBBqm2bJfIyg+N1w0IkDC/u9IxqIpE+8VJ9RuJe6OEf07JFhwkMYY4iZE4iTbEmQSTWmdI2rUNZA0T6dHolOmaaOuX35VDZ43bx43xl2w6g8XYDdHy31+SegJiVPvhBz9pmNf4aOLR3nDupry++aDapUufK/LymIRtdx9GS7djS8RRstxqKOV3NDWdF6/Hm/SSqKx7lUtazq8fmrap1vh9kRo2BHl8gHXxAtFhuW7xXJHrOpfVwutFan1u3L6zt0nsKBAf1OBj83PhVTuf6b1xW1x8oMTFBclDy33v5BeJKCsXL1qZZHEzKCwIIYS4L5ht1qbtbLmZAaT4TWkNFo2RI1N3HIL7MXLRxI9+hINXTaSgFTGvMaLiPBAcbzby0R2rNSv1UgwNGsiDBw8kLDBQ/HBd7Ke9ag3L5colvmcE0cMKoz9Gf6yGZcpje4WQtWNx/tQc58ix+E6QWtoO/CzilzLcui8Zlm2y77pT1prHYv08RGTS948WzGOU8ovIAm2hSS6RV8xPtWm2v8iBhMKSlmBIGQMx8/FYie7/hsTEGcVM1IUzEtOwgdoWEH9KZIj57+D9cJEeGY1CKEObcyKVElzgGh16IGPXG4VTTKD26q/EU4y/UUQpMZU+VKKfqKcEFK6rXk+dkOjImxLjL1Jk+BApePsD4/Pq7y8XckRKhor+alvJyzukec+E+7n9MFrkE3GY6pnPyeqmCdfEa7moy3IwXiRDoMjVc1Fm7pavzL4s3z0SWInwR72kOPhxJnvdL/ttlwLxkRIT56/aWv+N8k3Ib2pb2+K1pIx/U9PP6WrcVZmXzXqMVkoIPdxNwlbOUjEr7g6FBSGEEOIs8WMvWgHG1PDyyxLZvLmE2mMFsmRzEoHQGIxDdGAwbyloEL+DuBC9KNELEm0ZDdXu9TRrZqwBY3mcdi2tWXPxQxY2JFjQH2N5HNYXL25+HBIoIHMctmv761/157L83uwVM/jeLfsf57MHawU2kzkWQ8rgOJHgoPQiYdkSNtw2iFjJeq1RT28EDDK3lDQILCoNNkCyJDMTnj+7yIyliRM3/PLLo4WjZpuaoM6LZpToZe7yiLo7l75KL7EP7inhAcEDUYT3+le1fti7ElOvdoKYOXJIYsZ9qPbJf+ekyJFRZufuWUfkYkaRoPhHlkudsKh6JkquH7Z+rVh/3bp0IRKTL49JRCEJQszd2xIj8WqfRl++LGV0/X27msg3j37KzwT/LT1HDzFt238yUub9KA7zYtRc+Wzyk5IZ1kA3cduyBYUFIYQQQowDZS1WwppLluXg3V6QkhgtNSDoPTVg4H7okH37QoSg5oteCCFGyFKQaO/16625ZKHop6WQsTzOMhsdGDrUWBdHv7/lcWjVzNMeq7irHj2sH2fZLK1+EIHVq1vfF/2ivYcQtvZMIBOdfl9r8VAW4svfz1/y3EERE3v8nWqIlG6TsHz7H5FdH9rcfchm29d9I66qvLHwz+SvWbda4ox4tWqJbNtmdfeX94q0OmIUJVnfNH/Oi2YsKP9+ZxQtsRYixnI5Ztg7ElOwgBIySszs2SmxixaqbdUuxYm0Fo+AwoIQQgghxDK2KDVAfKVWgCE7WWqAOJg1K3XHtmljbKnBWswNhEV8vMTHxMjVy5clV7Zs4m/Nknf0aGIBY/mKZuneCIG6Zo1xH/1+1s5hmbHuueeMsVT6fay9xz7Wki80aJCwn+64sLg4CXv0uaVKLbPD0oVlkrq12id9Ta2V726e4OHuSpG7x9U2Q0i83EjtM/mYobAghBBCCCHOsXpphSUwsIeFxJq7nrXBuz0gaUPjxqk7Fskd0FJD//6pOy5DBpFFi1J3bPPmxvYoCUaM3qrmxqTQOZMQQgghhBBCEkNhQQghhBBCCHEYCgtCCCGEEEKIw1BYEEIIIYQQQhyGwoIQQgghhBDiMBQWhBBCCCGEEIehsCCEEEIIIYQ4DIUFIYQQQgghxGEoLAghhBBCCCEOQ2FBCCGEEEIIcRgKC0IIIYQQQojDUFgQQgghhBBCHIbCghBCCCGEEOIwFBaEEEIIIYQQh6GwIIQQQgghhDgMhQUhhBBCCCHEO4XF9OnTpXDhwhIaGiq1atWSbdu2Jbn/okWLpHTp0mr/ChUqyJ9//mnaFhMTI++++65anz59esmXL5907dpVLl68aHYOXM/Pz8+sjR8/Ps0+IyGEEEIIId6E2wmLhQsXyuDBg2XUqFGya9cuqVSpkjRv3lyuXr1qdf9NmzZJ586dpVevXrJ7925p06aNavv371fb79+/r84zYsQI9bp48WI5cuSIPPfcc4nO9cEHH8ilS5dMrX///mn+eQkhhBBCCPEG3E5YTJo0SXr37i09evSQsmXLyowZMyRdunQya9Ysq/tPnTpVWrRoIW+//baUKVNGxo4dK1WrVpVp06ap7ZkzZ5bVq1dLhw4dpFSpUlK7dm21befOnXL27Fmzc2XMmFHy5MljarBwEEIIIYQQQjxMWERHR6sBf5MmTUzr/P391fLmzZutHoP1+v0BLBy29ge3b99Wrk5ZsmQxWw/Xp+zZs0uVKlXk008/ldjYWIc/EyGEEEIIIb5AoLgR165dk7i4OMmdO7fZeiwfPnzY6jGXL1+2uj/WW+Phw4cq5gLuU5kyZTKtHzBggLJ0ZMuWTblXDRs2TLlDwYJijaioKNU0IiMj1Wt8fLxqxDroG4PBwD5yEuxP58M+ZX+6O3xG2Z/uDp9R7+rPlFzXrYRFWoNAbrhE4cv56quvzLYhrkOjYsWKEhwcLK+++qqMGzdOQkJCEp0L68eMGZNofUREhBIvxPbDCYsRvgNYo4hjsD+dD/uU/enu8Bllf7o7fEa9qz/v3LnjmcIiR44cEhAQIFeuXDFbj2XEPFgD6+3ZXxMVZ86ckXXr1plZK6yBbFRwhTp9+rSKzbAEFg29GIHFIjw8XHLmzJnsuX39xwE3NPQThQX70x3hM8r+dHf4jLI/3R0+o97Vn8i66pHCAlaCatWqydq1a1VmJ60zsdyvXz+rx9SpU0dtHzRokGkdgrWx3lJUHDt2TNavX6/iKJJjz5496svLlSuX1e2wYlizZOAYDpiTBj8O9pPzYH86H/Yp+9Pd4TPK/nR3+Ix6T3+m5JpuJSwArADdunWT6tWrS82aNWXKlCly7949lSUKoAZF/vz5lSsSGDhwoDRs2FAmTpwozzzzjCxYsEB27NghM2fONImK9u3bq1SzS5cuVTEcWvwF4ikgZhDovXXrVnnyySdVZigsv/nmm/LSSy9J1qxZXdgbhBBCCCGEeAZuJyw6duyo4hRGjhypBEDlypVlxYoVpgBtpIjVK6e6devK/PnzZfjw4fLee+9JiRIl5LfffpPy5cur7RcuXJAlS5ao9ziXHlgvGjVqpCwPECSjR49WAdlFihRRwkLv6kQIIYQQQgixjZ8BkSDEYRBjgZoZCK5hjIVt4NqGYodwMaPLmOOwP50P+5T96e7wGWV/ujt8Rr2rP1MyxmVaHkIIIYQQQojDUFgQQgghhBBCHIbCghBCCCGEEOIwFBaEEEIIIYQQh6GwIIQQQgghhDgMhQUhhBBCCCHEYSgsCCGEEEIIIQ5DYUEIIYQQQghxGAoLQgghhBBCiMNQWBBCCCGEEEIchsKCEEIIIYQQ4jAUFoQQQgghhBCHobAghBBCCCGEOAyFBSGEEEIIIcRhKCwIIYQQQgghDkNhQQghhBBCCHEYCgtCCCGEEEKIw1BYEEIIIYQQQhyGwoIQQgghhBDiMBQWhBBCCCGEEIehsCCEEEIIIYQ4DIUFIYQQQgghxGEoLAghhBBCCCEOQ2FBCCGEEEIIcRgKC0IIIYQQQojDUFgQQgghhBBCHIbCghBCCCGEEOIwFBaEEEIIIYQQh6GwIIQQQgghhDgMhQUhhBBCCCHEYSgsCCGEEEIIIQ5DYUEIIYQQQghxGAoLQgghhBBCiMNQWBBCCCGEEEIchsKCEEIIIYQQ4jAUFoQQQgghhBAKC0IIIYQQQojrocWCEEIIIYQQ4jAUFoQQQgghhBDvFBbTp0+XwoULS2hoqNSqVUu2bduW5P6LFi2S0qVLq/0rVKggf/75p9l2g8EgI0eOlLx580pYWJg0adJEjh07ZrbPjRs3pEuXLpIpUybJkiWL9OrVS+7evZsmn48QQgghhBBvw+2ExcKFC2Xw4MEyatQo2bVrl1SqVEmaN28uV69etbr/pk2bpHPnzkoI7N69W9q0aaPa/v37TftMmDBBPv/8c5kxY4Zs3bpV0qdPr8758OFD0z4QFQcOHJDVq1fL0qVL5e+//5Y+ffo8ls9MCCGEEEKIp+NnwHS+GwELRY0aNWTatGlqOT4+XsLDw6V///4ydOjQRPt37NhR7t27p8SARu3ataVy5cpKSODj5cuXT4YMGSJvvfWW2n779m3JnTu3zJkzRzp16iSHDh2SsmXLyvbt26V69epqnxUrVkjLli3l/Pnz6vjkiIyMlMyZM6tzw+pBrIPvEyIxV65c4u/vdrrW42B/sk/dHT6j7FN3h88o+9TdiXfx2CklY1y3GtlFR0fLzp07lauSBjoQy5s3b7Z6DNbr9wewRmj7nzp1Si5fvmy2DzoHAkbbB69wf9JEBcD+uDYsHIQQQgghhJCkCRQ34tq1axIXF6esCXqwfPjwYavHQDRY2x/rte3auqT2gQrUExgYKNmyZTPtY0lUVJRqGlBx4NatW0pZEuugb6B8g4ODabFwAuxP58M+ZX+6O3xG2Z/uDp9R7+pPXBvY4+TkVsLCkxg3bpyMGTMm0fpChQq55H4IIYQQQghJK+7cuaO8fjxGWOTIkUMCAgLkypUrZuuxnCdPHqvHYH1S+2uvWIesUPp9EIeh7WMZHB4bG6syRdm67rBhw1SQuV5NYv/s2bOLn59fCj+57wDVi5iZc+fOMRaF/emW8Bllf7o7fEbZn+4On1Hv6k9YKiAq7Ik5dithARNPtWrVZO3atSqzkzZgx3K/fv2sHlOnTh21fdCgQaZ1yOyE9aBIkSJKHGAfTUjgC0LsxOuvv246B1yYEN+B64N169apayMWwxohISGq6UGcBrEP/DAY5O482J/Oh33K/nR3+IyyP90dPqPe05/JWSrcUlgAWAG6deumAqlr1qwpU6ZMUVmfevToobZ37dpV8ufPr1yRwMCBA6Vhw4YyceJEeeaZZ2TBggWyY8cOmTlzptoO6wFEx4cffiglSpRQQmPEiBFKdWnipUyZMtKiRQvp3bu3yiQVExOjhAwyRtmjzgghhBBCCPF13E5YIH1sRESEKmiHwGlYGZD6VQu+Pnv2rFngSt26dWX+/PkyfPhwee+995R4+O2336R8+fKmfd555x0lTlCXApaJ+vXrq3OioJ7GvHnzlJho3LixOn+7du1U7QtCCCGEEEKIBwoLgAG+Ldenv/76K9G6F154QTVbwGrxwQcfqGYLZICCQCFpC9zHUPzQ0o2MsD/dBT6j7E93h88o+9Pd4TPqu/3pdgXyCCGEEEIIIZ6HWxXII4QQQgghhHgmFBaEEEIIIYQQh6GwIIQQQgghhDgMhQV5LPz999/SqlUrlb4XwfTI3EVSD9It16hRQzJmzCi5cuVSqZOPHDnCLk0lX331lVSsWNGUIxy1bZYvX87+dCLjx483pf8mKWf06NGq//StdOnS7EoHuXDhgrz00kuquG1YWJhUqFBBpawnqaNw4cKJnlO0vn37sktTQVxcnCqRgFIJeD6LFSsmY8eOVQXr3BW3zApFvA+k+61UqZL07NlT2rZt6+rb8Xg2bNig/lBDXKBKPFItN2vWTA4ePCjp06d39e15HAUKFFADX6Srxh/s77//Xlq3bi27d++WcuXKufr2PJ7t27fL119/rcQbST14FtesWWNaDgzkf+GOcPPmTalXr548+eSTaiIhZ86ccuzYMcmaNSsfUwd+6xgMa+zfv1+aNm2aZOZOYptPPvlETXzh/yT8/iF6UdcNxeoGDBgg7gj/KpHHwtNPP60acQ6ow6Jnzpw5ynKB6vFPPPEEuzmFwJqm56OPPlJ/zLds2UJh4SB3796VLl26yDfffKMKlZLUAyGRJ08edqETB23h4eEye/Zs0zrMDJPUA3GmBxM2mGVHIWOScjZt2qQmuVAAWrMI/fTTT7Jt2zZxV+gKRYgXcPv2bVM9FuIYmG1bsGCBsrLBJYo4Bixr+E+xSZMm7EoHwWw63EmLFi2qxBoKxpLUs2TJEqlevbqaTcfETJUqVZQAJs4hOjpa5s6dqzwV4A5FUg6KQK9du1aOHj2qlvfu3Sv//POPW0/U0mJBiIcTHx+v/NZh0tdXnCcpY9++fUpIPHz4UDJkyCC//vqrlC1blt3oABBou3btUu4RxDFq1aqlLJOlSpWSS5cuyZgxY6RBgwbK1QSxViTlnDx5UlkmBw8erNxJ8ZzCvSQ4OFi6devGLnUQxFLeunVLunfvzr5MJUOHDpXIyEgVTxUQEKAmvmBRx8SCu0JhQYgXzAhjcIFZDJJ6MGDbs2ePsv78/PPPamCBWBaKi9Rx7tw5GThwoKxevVpCQ0P5aDqIfoYSsSoQGoUKFZL//e9/0qtXL/ZvKidlYLH4+OOP1TIsFvhbOmPGDAoLJ/Ddd9+p5xZWNpI68PueN2+ezJ8/X7nl4v8oTCSiT91V/FJYEOLB9OvXT5YuXaqybiEAmaQezFIWL15cva9WrZqavZw6daoKOiYpB/E+V69elapVq5rWYbYNz+q0adMkKipKzcCR1JElSxYpWbKkHD9+nF2YSvLmzZto4qBMmTLyyy+/sE8d5MyZMyrRwOLFi9mXDvD2228rq0WnTp3UMrKWoW+RGZLCghDiNJC5qH///spd56+//mLAYRrNZmLwS1JH48aNlXuZHmQzgUn/3XffpahwQlD8iRMn5OWXX+YjmkrgPmqZphu+7LAEEcdAQDziVrSgY5I67t+/L/7+5uHQmJDB/0/uCi0W5LH9J6ifWTt16pQy6SHYuGDBgvwWUuH+BNPo77//rvyrL1++rNYjBR1yXZOUMWzYMGWyx7N4584d1bcQbCtXrmRXphI8l5YxP0iFjHoBjAVKOW+99ZbKXoZB78WLF2XUqFFqgNG5c2c+o6nkzTffVMGxcIXq0KGDyrQzc+ZM1UjqwaAXwgIz6kyJ7Bj4zSOmAv83wRUKKdAnTZqkAuLdFgMhj4H169ejmkui1q1bN/Z/KrDWl2izZ89mf6aCnj17GgoVKmQIDg425MyZ09C4cWPDqlWr2JdOpmHDhoaBAweyX1NBx44dDXnz5lXPaP78+dXy8ePH2ZcO8scffxjKly9vCAkJMZQuXdowc+ZM9qmDrFy5Uv1/dOTIEfalg0RGRqq/mQULFjSEhoYaihYtanj//fcNUVFRBnfFD/+4WtwQQgghhBBCPBvWsSCEEEIIIYQ4DIUFIYQQQgghxGEoLAghhBBCCCEOQ2FBCCGEEEIIcRgKC0IIIYQQQojDUFgQQgghhBBCHIbCghBCCCGEEOIwFBaEEEIIIYQQh6GwIIQQJ3P69Gnx8/OTOXPmuKxvcf3Ro0eblnEvWId78/S+xOfCOpI6tP67du2aQ13YsmVL6d27t9m6Y8eOSbNmzSRz5szqGr/99pvN4w8ePCiBgYGyf/9+h+6DEOI+UFgQQrwebVC9Y8cOq9sbNWok5cuXf+z35en9qTUMDvPnzy/du3eXCxcuiDcTHx8vOXPmlAkTJiQ7cNdaunTppGDBgtKqVSuZPXu2REVFPZZ7/fjjj5Mc2DvCv//+K6tWrZJ3333XbH23bt1k37598tFHH8mPP/4o1atXl/nz58uUKVMSnaNs2bLyzDPPyMiRI9PkHgkhjx8KC0II8QFefvllefDggRQqVMhp5/zggw/U4HHGjBny9NNPy9y5c6Vhw4by8OFDSUuGDx+uPosr2LZtm5rpx4A4Ob766ivVP1988YW88sorcuPGDenZs6fUrFlTzp0759HC4tNPP5XGjRtL8eLFTevwnWzevFl69eol/fr1k5deekkKFChgU1iA1157TX799Vc5ceJEmtwnIeTxEviYr0cIIeQR9+7dk/Tp0z+W/ggICFDNmUBMYEYaYOCcI0cO+eSTT2TJkiXSoUMHSStgIUFzBX/++acSZ+XKlUt23/bt26s+0cDM/Lx586Rr167ywgsvyJYtW8QTuXr1qixbtkwJSj0RERHqNUuWLHafq0mTJpI1a1b5/vvvlVAlhHg2tFgQQogFmHWvVKmS1X4pVaqUNG/e3LR869Yt5QIEn3IMqOAKgnWWYJ8MGTKomVn4pmfMmFG6dOmitm3cuFENNOEuExISIuHh4fLmm28mmpWHyxaatXMXLlw4ye/RVozF8uXL1efF/WTKlElq1KihZphTQ4MGDdSrfvY5OjpaDairVaum+ghCCvutX78+0fH29qVljEVSMS2WsSZ37tyRQYMGqf5CX+fKlUuaNm0qu3btsuszYkBtj7XCFvjOIcK2bt0qq1evNtuGdS1atFCfH+5T+F7gcmTtsx8+fFiJN3xn2bNnl4EDB5pZirAPhCsG7JpLFvrWWn+jr3HNHj16yP379+3qg9jYWCUK9PelWcPefvttdT30MZ5X7H/mzBnTfeif1aCgILXP77//noreJIS4G7RYEEJ8htu3b1sNWI2JiUnkNoSgVASV6mMvtm/fLkePHlWuOMBgMEjr1q3ln3/+US4dZcqUUW4dGBBbA4MxiJL69evLZ599pgaPYNGiRWpA9/rrr6tBItxt4D5z/vx5tS2twEAcrjmYfR82bJgaYO7evVtWrFghL774YorPp4kWzEBrREZGyrfffiudO3dWfYqB/Xfffaf6AZ+zcuXKqerL1IJz//zzz8pVBz7+169fV9c8dOiQVK1aNcljL1++rPrH0Zl1PF8zZ85UMQoQNWDdunXKAgQBNmrUKPH391fxGE899ZQSnnCf0gNRgQH6uHHjlOXj888/l5s3b8oPP/ygtsMFCwIGx/Xp00etK1asWKJzFClSRJ0DwgrfE4QWrE5JsWnTJvWc6t3q2rZtq54fCGJ81xDPENIQkvjd4VmePHmy2hfr9eAzQ1jgWYFQIoR4MAZCCPFyZs+ebcCfu6RauXLlTPvfunXLEBoaanj33XfNzjNgwABD+vTpDXfv3lXLv/32mzp2woQJpn1iY2MNDRo0UOtxXY1u3bqpdUOHDk10f/fv30+0bty4cQY/Pz/DmTNnTOsaNmyomiU4d6FChczW4VqjRo1K1AenTp0yfcaMGTMaatWqZXjw4IHZsfHx8Tb7Un+uNWvWGCIiIgznzp0z/Pzzz4acOXMaQkJC1LK+P6KiosyOv3nzpiF37tyGnj17mtalpC/xufT/feEzWe5jqx8yZ85s6Nu3ryE1fPfdd4awsDCr35ce7f7QN9bA58f2559/3tTfJUqUMDRv3tys73GdIkWKGJo2bZro3M8995zZOd944w21fu/evaZ1eFbxbNi6P33/A9xP9uzZk+2H+vXrG6pVq5ZovfY9fPrpp2brn3nmmUTPp5758+er47Zu3ZrstQkh7g1doQghPsP06dOV+4llq1ixotl+cAvB7PlPP/2kZtJBXFycLFy4UNq0aWOKi4C/PXz9YWnQQBxD//79bd6Dfl+NsLAw03u4r8CqUrduXXVtzJCnBfjcsB4MHTpUQkNDzbbZm8oVrjDIkATXLcQToF8QX4GAXX1/BAcHmzIqIYAZlhvEZujdj1LTl6kBs+pwObp48WKKj8U9Pvnkk2bfV2rQZuzR/2DPnj0qTSusRLCg4PtHw7OAAOm///5b9Z2evn37mi1r/YR7TIn1Rg9c1HB9WA6SAvvorVKOop3L0fS3hBDXQ1coQojPALcQLdjYcmBjOahBgC2EBNxQnnjiCVmzZo1cuXJFubFowG88b968iVw7EIdhDQyc9YNujbNnz6o4BAzK4c6iB24kaYEWB+FIml0ItZIlS6p7nDVrlhoAI27BEvj5T5w4UcUF6N3O4IaT2r5MLUgTC/cqiCG44MBlB9910aJFkzwO9w0xBrchR7l79656RVwLgKgASbl9oY/1g/kSJUqYbYebE9ynUlKnBDE9erTz4xlMziVJE9zOQDsXa5MQ4vlQWBBCiBUQA5A7d26VQhXCAq958uQxC1hNKRh0Y/CnB5YQ+NljJh81AUqXLq1m/lEPAoG1+plqDLysDehwDlcLNVhyEDuCWfcjR46YBAL6DZ8D2xHUCx9+WCIwQHdWilFbA1Jr/YK4AszMI34DMQ5Im4qYgsWLF6sYB1sgDgMz+RAijqIVhNNStWrfMe5FizmxxFJwWZKaQbmtLGHJiQbEV1gKYEfQzqXPoEUI8UzoCkUIITYGXRgkI9AXAx/UA0BQqn4whuDVS5cumWagNTCwthcUE0NAOGb0ISzgggXxki9fvkT7YkbZWpYkzPanFC2Q11lVjzWxABejadOmmdaj/2ANwMAd1h4INnw+y1oXjvSlNtNu2Te2+gWWkTfeeEN9p6dOnVIDZRR0SwpkNkKwd3LZt+wBgdVAyy6mfRewEqBvrDVkT9KjWTk0jh8/rgSK/v7SygIA8Yt+s5fk7gPnguCG9YsQ4tlQWBBCiA0wEIaoePXVV9WAFwW/9GD2GvECKISmnyVHRid70YSKfpYY76dOnZpoXwxA4U6k1QsAe/fuTZSS1B6aNWumXHEgBiwH+al1c0HaUFgxUAxNO6e1z4cYBxRSc1ZfYkCO2W64Yun58ssvzZZxPkvXMlhQIOKSq4aN2AVH0sxqIJUvsi/VqVNHxU8AuGThu0WmMEthBfTft94NTY/WT3qrCyxf1oSoo+De8bs4efKkXftrmaFssXPnTpWZDLFNhBDPhq5QhBBigypVqqgYBKR8RfpTy3SkrVq1knr16qkAaPi2Y0YbM/MpiYvA7C8GlW+99ZZyf8Ig+ZdffrHqaoLUsJMmTVIz3ahujEJlKFKGQVlyAbeW4DpI/4mUpKhdAesMZv4hVJD6FnERqQHuTqjJgVS2CA5+9tlnVZ88//zzamCO2WncM/pKP4h2tC/xOcaPH69e4Z4FkQFLkB4ESyPGBYHmqFMC96L/t3fHrIkEYRjHc00qEQN2WukHMDYKFlqYUlJIsBCsxC6VEIt0Nn4CsRGsBCGdRhALC2sLOwn4DYT0gsgcz8Bynlk9L8thzvx/YJDo6uzMFr4684zWzihGWL8YHaI2K452t+g5hX6t0XtoLw+N7Xg8tkWg3ns3Rljf1qvYUFGgsdR+EqFQyB6j/T40Vq+vrx/adH9/b/e9UJGmKWcaw939V1Sw6Px0zah40pqWZDJ55ZXGUeuF9NpOlO0xaofWK1WrVXutqU803s7alel0an9BAnABzh1LBQD/mhOPOpvNXB9XhOtu3OwuxZ/q2Eaj4fr4+/u7KZVKxu/32yhT3Z/P565xs4r/dLNYLMzd3Z3x+XwmGAyaSqViY0PdIlS73a6JRCLm+vra3N7emvF4/Km4WcdgMDCpVMrGqOocEomE6fV6ru08pT+3262JRqP2prhYxaeq79Q+RdHG43EzHA5d23xqX+7HzTrRrOVy2R6nGN1CoWBWq9Vv/aDY26enJxOLxexzNB6632q1jp5vs9m0r7vZbI4+b799zk3RxeFw2ORyOdPpdMx6vXY9Tueaz+dt5Kv6Sv2j85hMJh9eW9fMw8ODPY+bmxvz+Pj4ITb47e3NpNNpO7Y6xomePRSHe+gacaO422w2e1LcrOKZi8WiCQQC9vHdcR+NRvZ/y+Xyj+8J4Ov7oT/nLm4A4KvSlCRt+qVv0fdTdPA9OJu9vby8nLspdofrer1up0edc7Gz0tI09U1T8/YTqv6GFvVrDYYW0wP4/zEVCgAO0Pcu2iU6k8lQVHxj+gCtJCn8ov7QOh3F97bb7U91jaaXDYdDu48HgMtAYQEAe7QxmfaU0Px2pTb1+3366Bur1WrnbsKXNBqNPB2vdUtasA/gclBYAMAeTTPRQljt0vz8/GwXyQIAgONYYwEAAADAM/axAAAAAOAZhQUAAAAAzygsAAAAAHhGYQEAAADAMwoLAAAAAJ5RWAAAAADwjMICAAAAgGcUFgAAAAA8o7AAAAAAcOXVT27melFMrg+NAAAAAElFTkSuQmCC",
+      "text/plain": [
+       "<Figure size 800x500 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
     }
+   ],
+   "source": [
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "# --- Plot Manning's n vs depth for three formulas ---\n",
+    "depths = np.linspace(0.5, 8.0, 100)  # ft\n",
+    "S = 0.005   # slope\n",
+    "d84 = 0.5   # ft (gravel bed)\n",
+    "\n",
+    "# HEC-15 Class C (moderate retardance)\n",
+    "X_C = 30.2\n",
+    "n_hec15 = depths**(1/6) / (X_C + 19.97 * np.log10(depths**1.4 * S**0.4))\n",
+    "n_hec15 = np.clip(n_hec15, 0.01, 0.3)\n",
+    "\n",
+    "# Limerinos (1970)\n",
+    "n_lim = (0.0926 * depths**(1/6)) / (1.16 + 2.0 * np.log10(depths / d84))\n",
+    "n_lim = np.clip(n_lim, 0.01, 0.3)\n",
+    "\n",
+    "# Jarrett (1984)\n",
+    "n_jar = 0.39 * S**0.38 * depths**(-0.16)\n",
+    "n_jar = np.clip(n_jar, 0.01, 0.3)\n",
+    "\n",
+    "fig, ax = plt.subplots(figsize=(8, 5))\n",
+    "ax.plot(depths, n_hec15, 'b-', linewidth=2, label='HEC-15 Class C (vegetated)')\n",
+    "ax.plot(depths, n_lim, 'r--', linewidth=2, label=f'Limerinos (d84={d84} ft)')\n",
+    "ax.plot(depths, n_jar, 'g-.', linewidth=2, label=f'Jarrett (S={S})')\n",
+    "ax.axhline(y=0.06, color='gray', linestyle=':', alpha=0.7, label='Typical uniform n=0.06')\n",
+    "ax.set_xlabel('Hydraulic Radius / Depth (ft)', fontsize=12)\n",
+    "ax.set_ylabel(\"Manning's n\", fontsize=12)\n",
+    "ax.set_title(\"Manning's n Decreases with Flow Depth\", fontsize=14)\n",
+    "ax.legend(fontsize=10)\n",
+    "ax.set_ylim(0, 0.20)\n",
+    "ax.grid(True, alpha=0.3)\n",
+    "fig.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "664021c1",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-12T12:22:41.380263Z",
+     "iopub.status.busy": "2026-05-12T12:22:41.379917Z",
+     "iopub.status.idle": "2026-05-12T12:22:42.369950Z",
+     "shell.execute_reply": "2026-05-12T12:22:42.369048Z"
+    },
+    "papermill": {
+     "duration": 0.994348,
+     "end_time": "2026-05-12T12:22:42.370896+00:00",
+     "exception": false,
+     "start_time": "2026-05-12T12:22:41.376548+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [],
    "source": [
@@ -51,6 +227,7 @@
     "import sys\n",
     "import numpy as np\n",
     "import pandas as pd\n",
+    "import matplotlib.pyplot as plt\n",
     "\n",
     "try:\n",
     "    from ras_commander import (\n",
@@ -58,7 +235,10 @@
     "        get_logger\n",
     "    )\n",
     "    from ras_commander.geom import GeomLandCover, GeomStorage\n",
-    "    from ras_commander.hdf import HdfMesh, HdfResultsMesh, HdfResultsPlan\n",
+    "    from ras_commander.hdf import (\n",
+    "        HdfMesh, HdfResultsMesh, HdfResultsPlan,\n",
+    "        HdfFluvialPluvial, HdfXsec,\n",
+    "    )\n",
     "except ImportError:\n",
     "    current_file = Path(\".\").resolve()\n",
     "    sys.path.append(str(current_file.parent))\n",
@@ -67,338 +247,379 @@
     "        get_logger\n",
     "    )\n",
     "    from ras_commander.geom import GeomLandCover, GeomStorage\n",
-    "    from ras_commander.hdf import HdfMesh, HdfResultsMesh, HdfResultsPlan\n",
+    "    from ras_commander.hdf import (\n",
+    "        HdfMesh, HdfResultsMesh, HdfResultsPlan,\n",
+    "        HdfFluvialPluvial, HdfXsec,\n",
+    "    )\n",
     "\n",
     "logger = get_logger(__name__)"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "c04b914a",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002313,
+     "end_time": "2026-05-12T12:22:42.375791+00:00",
+     "exception": false,
+     "start_time": "2026-05-12T12:22:42.373478+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## Configuration"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 3,
+   "id": "c40f05f0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T00:21:14.095476Z",
-     "iopub.status.busy": "2026-05-12T00:21:14.095476Z",
-     "iopub.status.idle": "2026-05-12T00:21:14.098504Z",
-     "shell.execute_reply": "2026-05-12T00:21:14.098504Z"
-    }
+     "iopub.execute_input": "2026-05-12T12:22:42.383099Z",
+     "iopub.status.busy": "2026-05-12T12:22:42.382523Z",
+     "iopub.status.idle": "2026-05-12T12:22:42.386768Z",
+     "shell.execute_reply": "2026-05-12T12:22:42.386018Z"
+    },
+    "papermill": {
+     "duration": 0.009694,
+     "end_time": "2026-05-12T12:22:42.387755+00:00",
+     "exception": false,
+     "start_time": "2026-05-12T12:22:42.378061+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [],
    "source": [
     "PROJECT_NAME = \"Muncie\"\n",
     "RAS_VERSION = \"6.6\"\n",
-    "PLAN_NUMBER = \"03\"  # Unsteady Run with 2D 50ft Grid (uses g02 geometry)\n",
+    "PLAN_NUMBER = \"03\"          # Unsteady Run with 2D 50ft Grid (uses g02)\n",
     "MESH_NAME = \"2D Interior Area\"\n",
+    "GEOM_NUMBER = \"02\"\n",
     "\n",
-    "# Manning's n modification factor\n",
-    "# Doubling roughness produces a large, easily measurable WSE increase\n",
-    "N_MULTIPLIER = 2.0"
+    "# Manning's n modification factor for the uniform-n edit-run-read loop\n",
+    "N_MULTIPLIER = 2.0\n",
+    "\n",
+    "# Depth-varying n parameters (exponential decay toward asymptote)\n",
+    "N_ASYMPTOTE = 0.045   # Deep-flow Manning's n\n",
+    "DEPTH_HALF = 1.0      # Depth at which n decays to ~37% of excess above asymptote"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "2a51d35e",
+   "metadata": {
+    "papermill": {
+     "duration": 0.00222,
+     "end_time": "2026-05-12T12:22:42.392532+00:00",
+     "exception": false,
+     "start_time": "2026-05-12T12:22:42.390312+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
-    "## Step 1: Extract Baseline and Modified Projects"
+    "## Step 1: Extract Baseline and Modified Projects\n",
+    "\n",
+    "We extract two independent copies of Muncie so the baseline stays pristine."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 4,
+   "id": "e68cf3b7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T00:21:14.100511Z",
-     "iopub.status.busy": "2026-05-12T00:21:14.100511Z",
-     "iopub.status.idle": "2026-05-12T00:21:14.895380Z",
-     "shell.execute_reply": "2026-05-12T00:21:14.895380Z"
-    }
+     "iopub.execute_input": "2026-05-12T12:22:42.398997Z",
+     "iopub.status.busy": "2026-05-12T12:22:42.398786Z",
+     "iopub.status.idle": "2026-05-12T12:22:43.020051Z",
+     "shell.execute_reply": "2026-05-12T12:22:43.019189Z"
+    },
+    "papermill": {
+     "duration": 0.626049,
+     "end_time": "2026-05-12T12:22:43.020772+00:00",
+     "exception": false,
+     "start_time": "2026-05-12T12:22:42.394723+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:21:14 - ras_commander.RasExamples - INFO - Found zip file: C:\\Users\\bill\\AppData\\Local\\ras-commander\\examples\\Example_Projects_7_0.zip\n"
+      "2026-05-12 08:22:42 - ras_commander.RasExamples - INFO - Found zip file: C:\\Users\\bill\\AppData\\Local\\ras-commander\\examples\\Example_Projects_7_0.zip\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:21:14 - ras_commander.RasExamples - INFO - Loading project data from CSV...\n"
+      "2026-05-12 08:22:42 - ras_commander.RasExamples - INFO - Loading project data from CSV...\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:21:14 - ras_commander.RasExamples - INFO - Loaded 67 projects from CSV.\n"
+      "2026-05-12 08:22:42 - ras_commander.RasExamples - INFO - Loaded 67 projects from CSV.\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:21:14 - ras_commander.RasExamples - INFO - ----- RasExamples Extracting Project -----\n"
+      "2026-05-12 08:22:42 - ras_commander.RasExamples - INFO - ----- RasExamples Extracting Project -----\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:21:14 - ras_commander.RasExamples - INFO - Extracting project 'Muncie' as 'Muncie_414_baseline'\n"
+      "2026-05-12 08:22:42 - ras_commander.RasExamples - INFO - Extracting project 'Muncie' as 'Muncie_414_baseline'\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:21:14 - ras_commander.RasExamples - INFO - Folder 'Muncie_414_baseline' already exists. Deleting existing folder...\n"
+      "2026-05-12 08:22:42 - ras_commander.RasExamples - INFO - Folder 'Muncie_414_baseline' already exists. Deleting existing folder...\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:21:14 - ras_commander.RasExamples - INFO - Existing folder 'Muncie_414_baseline' has been deleted.\n"
+      "2026-05-12 08:22:42 - ras_commander.RasExamples - INFO - Existing folder 'Muncie_414_baseline' has been deleted.\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:21:14 - ras_commander.RasExamples - INFO - Successfully extracted project 'Muncie' to G:\\GH\\ras-commander\\examples\\example_projects\\Muncie_414_baseline\n"
+      "2026-05-12 08:22:42 - ras_commander.RasExamples - INFO - Successfully extracted project 'Muncie' to G:\\GH\\ras-commander\\example_projects\\Muncie_414_baseline\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:21:14 - ras_commander.RasExamples - INFO - ----- RasExamples Extracting Project -----\n"
+      "2026-05-12 08:22:42 - ras_commander.RasExamples - INFO - ----- RasExamples Extracting Project -----\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:21:14 - ras_commander.RasExamples - INFO - Extracting project 'Muncie' as 'Muncie_414_modified'\n"
+      "2026-05-12 08:22:42 - ras_commander.RasExamples - INFO - Extracting project 'Muncie' as 'Muncie_414_modified'\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:21:14 - ras_commander.RasExamples - INFO - Folder 'Muncie_414_modified' already exists. Deleting existing folder...\n"
+      "2026-05-12 08:22:42 - ras_commander.RasExamples - INFO - Folder 'Muncie_414_modified' already exists. Deleting existing folder...\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:21:14 - ras_commander.RasExamples - INFO - Existing folder 'Muncie_414_modified' has been deleted.\n"
+      "2026-05-12 08:22:42 - ras_commander.RasExamples - INFO - Existing folder 'Muncie_414_modified' has been deleted.\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:21:14 - ras_commander.RasExamples - INFO - Successfully extracted project 'Muncie' to G:\\GH\\ras-commander\\examples\\example_projects\\Muncie_414_modified\n"
+      "2026-05-12 08:22:42 - ras_commander.RasExamples - INFO - Successfully extracted project 'Muncie' to G:\\GH\\ras-commander\\example_projects\\Muncie_414_modified\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:21:14 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 7.0 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\7.0\\Ras.exe via filesystem (x86)\n"
+      "2026-05-12 08:22:42 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 7.0 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\7.0\\Ras.exe via filesystem (x86)\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:21:14 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 6.7 Beta 5 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.7 Beta 5\\Ras.exe via filesystem (x86)\n"
+      "2026-05-12 08:22:42 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 6.7 Beta 5 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.7 Beta 5\\Ras.exe via filesystem (x86)\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:21:14 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 6.5 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.5\\Ras.exe via filesystem (x86)\n"
+      "2026-05-12 08:22:42 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 6.5 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.5\\Ras.exe via filesystem (x86)\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:21:14 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 6.3.1 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.3.1\\Ras.exe via filesystem (x86)\n"
+      "2026-05-12 08:22:42 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 6.3.1 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.3.1\\Ras.exe via filesystem (x86)\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:21:14 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 6.2 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.2\\Ras.exe via filesystem (x86)\n"
+      "2026-05-12 08:22:42 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 6.2 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.2\\Ras.exe via filesystem (x86)\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:21:14 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 6.1 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.1\\Ras.exe via filesystem (x86)\n"
+      "2026-05-12 08:22:42 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 6.1 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.1\\Ras.exe via filesystem (x86)\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:21:14 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 6.0 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.0\\Ras.exe via filesystem (x86)\n"
+      "2026-05-12 08:22:42 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 6.0 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.0\\Ras.exe via filesystem (x86)\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:21:14 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 5.0.7 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\5.0.7\\Ras.exe via filesystem (x86)\n"
+      "2026-05-12 08:22:42 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 5.0.7 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\5.0.7\\Ras.exe via filesystem (x86)\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:21:14 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 5.0.6 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\5.0.6\\Ras.exe via filesystem (x86)\n"
+      "2026-05-12 08:22:42 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 5.0.6 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\5.0.6\\Ras.exe via filesystem (x86)\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:21:14 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 5.0.5 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\5.0.5\\Ras.exe via filesystem (x86)\n"
+      "2026-05-12 08:22:42 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 5.0.5 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\5.0.5\\Ras.exe via filesystem (x86)\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:21:14 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 5.0.4 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\5.0.4\\Ras.exe via filesystem (x86)\n"
+      "2026-05-12 08:22:42 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 5.0.4 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\5.0.4\\Ras.exe via filesystem (x86)\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:21:14 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 5.0.3 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\5.0.3\\Ras.exe via filesystem (x86)\n"
+      "2026-05-12 08:22:42 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 5.0.3 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\5.0.3\\Ras.exe via filesystem (x86)\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:21:14 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 5.0.1 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\5.0.1\\Ras.exe via filesystem (x86)\n"
+      "2026-05-12 08:22:42 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 5.0.1 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\5.0.1\\Ras.exe via filesystem (x86)\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:21:14 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 5.0 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\5.0\\Ras.exe via filesystem (x86)\n"
+      "2026-05-12 08:22:42 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 5.0 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\5.0\\Ras.exe via filesystem (x86)\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:21:14 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 4.1.0 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\4.1.0\\Ras.exe via filesystem (x86)\n"
+      "2026-05-12 08:22:42 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 4.1.0 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\4.1.0\\Ras.exe via filesystem (x86)\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:21:14 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 4.0 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\4.0\\Ras.exe via filesystem (x86)\n"
+      "2026-05-12 08:22:42 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 4.0 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\4.0\\Ras.exe via filesystem (x86)\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:21:14 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 6.6 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.6\\Ras.exe via filesystem (x86)\n"
+      "2026-05-12 08:22:42 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 6.6 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.6\\Ras.exe via filesystem (x86)\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:21:14 - ras_commander.RasUtils - INFO - Discovered 17 installed HEC-RAS version(s)\n"
+      "2026-05-12 08:22:42 - ras_commander.RasUtils - INFO - Discovered 17 installed HEC-RAS version(s)\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:21:14 - ras_commander.RasPrj - INFO - HEC-RAS 6.6 found via version discovery: C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.6\\Ras.exe\n"
+      "2026-05-12 08:22:42 - ras_commander.RasPrj - INFO - HEC-RAS 6.6 found via version discovery: C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.6\\Ras.exe\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:21:14 - ras_commander.RasMap - INFO - Successfully parsed RASMapper file: G:\\GH\\ras-commander\\examples\\example_projects\\Muncie_414_baseline\\Muncie.rasmap\n"
+      "2026-05-12 08:22:42 - ras_commander.RasMap - INFO - Successfully parsed RASMapper file: G:\\GH\\ras-commander\\example_projects\\Muncie_414_baseline\\Muncie.rasmap\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:21:14 - ras_commander.hdf.HdfBase - INFO - Found projection in projection file: G:\\GH\\ras-commander\\examples\\example_projects\\Muncie_414_baseline\\GIS_Data\\Muncie_IA_Clip.prj\n"
+      "2026-05-12 08:22:42 - ras_commander.hdf.HdfBase - INFO - Found projection in projection file: G:\\GH\\ras-commander\\example_projects\\Muncie_414_baseline\\GIS_Data\\Muncie_IA_Clip.prj\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:21:14 - ras_commander.RasPrj - INFO - Updated results_df with 3 plan(s)\n"
+      "2026-05-12 08:22:43 - ras_commander.RasPrj - INFO - Updated results_df with 3 plan(s)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:22:43 - ras_commander.RasPrj - INFO - ras-commander v0.96.2 | An open-source project of CLB Engineering Corporation (https://clbengineering.com/) | Docs: https://ras-commander.readthedocs.io | GitHub: https://github.com/gpt-cmdr/ras-commander\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:22:43 - ras_commander.RasPrj - INFO - Project initialized: Muncie | Folder: G:\\GH\\ras-commander\\example_projects\\Muncie_414_baseline\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:22:43 - ras_commander.RasPrj - INFO - Using HEC-RAS executable: C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.6\\Ras.exe\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Baseline: G:\\GH\\ras-commander\\examples\\example_projects\\Muncie_414_baseline\n",
-      "Modified: G:\\GH\\ras-commander\\examples\\example_projects\\Muncie_414_modified\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-11 20:21:14 - ras_commander.RasPrj - INFO - ras-commander v0.93.0 | An open-source project of CLB Engineering Corporation (https://clbengineering.com/) | Docs: https://ras-commander.readthedocs.io | GitHub: https://github.com/gpt-cmdr/ras-commander\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-11 20:21:14 - ras_commander.RasPrj - INFO - Project initialized: Muncie | Folder: G:\\GH\\ras-commander\\examples\\example_projects\\Muncie_414_baseline\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-11 20:21:14 - ras_commander.RasPrj - INFO - Using HEC-RAS executable: C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.6\\Ras.exe\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "Baseline: G:\\GH\\ras-commander\\example_projects\\Muncie_414_baseline\n",
+      "Modified: G:\\GH\\ras-commander\\example_projects\\Muncie_414_modified\n",
       "\n",
       "Plan 03: Unsteady Run with 2D 50ft Grid\n",
       "Geometry: g02\n"
@@ -412,8 +633,6 @@
     "print(f\"Baseline: {baseline_path}\")\n",
     "print(f\"Modified: {modified_path}\")\n",
     "\n",
-    "# Use ras_object=\"new\" to create independent RasPrj instances\n",
-    "# (without this, both would share the global ras singleton)\n",
     "baseline_ras = init_ras_project(baseline_path, RAS_VERSION, ras_object=\"new\")\n",
     "plan_row = baseline_ras.plan_df[baseline_ras.plan_df['plan_number'] == PLAN_NUMBER].iloc[0]\n",
     "print(f\"\\nPlan {PLAN_NUMBER}: {plan_row['Plan Title']}\")\n",
@@ -422,25 +641,44 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "96048b69",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003075,
+     "end_time": "2026-05-12T12:22:43.027130+00:00",
+     "exception": false,
+     "start_time": "2026-05-12T12:22:43.024055+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## Step 2: Read Current Manning's n Settings\n",
     "\n",
-    "HEC-RAS 2D flow areas can use either a **uniform** Manning's n (single value for all\n",
-    "faces) or **spatially varied** values from a land cover table. The Muncie model uses\n",
-    "uniform n. We read both the 2D flow area settings and the land cover table."
+    "Muncie uses a **uniform** Manning's n (0.06) for the entire 2D flow area.\n",
+    "The land cover table exists but is inactive because *Spatially Varied Manning's\n",
+    "on Faces* is disabled."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
+   "id": "1d46ed8e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T00:21:14.895380Z",
-     "iopub.status.busy": "2026-05-12T00:21:14.895380Z",
-     "iopub.status.idle": "2026-05-12T00:21:14.919421Z",
-     "shell.execute_reply": "2026-05-12T00:21:14.919421Z"
-    }
+     "iopub.execute_input": "2026-05-12T12:22:43.035591Z",
+     "iopub.status.busy": "2026-05-12T12:22:43.035404Z",
+     "iopub.status.idle": "2026-05-12T12:22:43.050955Z",
+     "shell.execute_reply": "2026-05-12T12:22:43.049989Z"
+    },
+    "papermill": {
+     "duration": 0.021514,
+     "end_time": "2026-05-12T12:22:43.051653+00:00",
+     "exception": false,
+     "start_time": "2026-05-12T12:22:43.030139+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -449,7 +687,7 @@
      "text": [
       "2D Flow Area: '2D Interior Area'\n",
       "  Uniform Manning's n: 0.06\n",
-      "  Spatially varied Manning's on faces: False\n",
+      "  Spatially varied: False\n",
       "\n",
       "Land cover table (7 classes):\n",
       "Table Number            Land Cover Name  Base Mannings n Value\n",
@@ -459,19 +697,14 @@
       "           7                 Open Space                   0.04\n",
       "           7                       Park                   0.06\n",
       "           7                      Trees                   0.12\n",
-      "           7                      Urban                   0.10\n",
-      "\n",
-      "Note: Land cover table is only used when 'Spatially Varied Manning's on Faces' is enabled.\n"
+      "           7                      Urban                   0.10\n"
      ]
     }
    ],
    "source": [
-    "# Resolve geometry file path from plan metadata\n",
-    "geom_num = plan_row['geometry_number']\n",
-    "baseline_geom = baseline_path / f\"{baseline_ras.project_name}.g{str(geom_num).zfill(2)}\"\n",
-    "modified_geom = modified_path / f\"{baseline_ras.project_name}.g{str(geom_num).zfill(2)}\"\n",
+    "baseline_geom = baseline_path / f\"{baseline_ras.project_name}.g{GEOM_NUMBER}\"\n",
+    "modified_geom = modified_path / f\"{baseline_ras.project_name}.g{GEOM_NUMBER}\"\n",
     "\n",
-    "# Read the 2D flow area settings (uniform Manning's n)\n",
     "settings = GeomStorage.get_2d_flow_area_settings(baseline_geom)\n",
     "area_row = settings[settings['name'] == MESH_NAME].iloc[0]\n",
     "original_n = area_row['mannings_n']\n",
@@ -479,300 +712,370 @@
     "\n",
     "print(f\"2D Flow Area: '{MESH_NAME}'\")\n",
     "print(f\"  Uniform Manning's n: {original_n}\")\n",
-    "print(f\"  Spatially varied Manning's on faces: {spatially_varied}\")\n",
+    "print(f\"  Spatially varied: {spatially_varied}\")\n",
     "\n",
-    "# Also show the land cover table (exists but not active for uniform n models)\n",
     "original_mannings = GeomLandCover.get_base_mannings_n(baseline_geom)\n",
     "print(f\"\\nLand cover table ({len(original_mannings)} classes):\")\n",
-    "print(original_mannings.to_string(index=False))\n",
-    "print(f\"\\nNote: Land cover table is only used when 'Spatially Varied Manning's on Faces' is enabled.\")"
+    "print(original_mannings.to_string(index=False))"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "f7ffc75a",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003108,
+     "end_time": "2026-05-12T12:22:43.058102+00:00",
+     "exception": false,
+     "start_time": "2026-05-12T12:22:43.054994+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## Step 3: Modify Uniform Manning's n\n",
     "\n",
-    "We double the uniform Manning's n value (0.06 → 0.12) in the modified project's\n",
-    "plain-text geometry file. This is the value that controls all face property tables\n",
-    "when spatially varied Manning's is disabled."
+    "We double the roughness (0.06 → 0.12) in the modified copy's plain-text\n",
+    "geometry file. The round-trip assertion verifies the write was successful."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
+   "id": "bc38dc37",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T00:21:14.921441Z",
-     "iopub.status.busy": "2026-05-12T00:21:14.921441Z",
-     "iopub.status.idle": "2026-05-12T00:21:14.975364Z",
-     "shell.execute_reply": "2026-05-12T00:21:14.975364Z"
-    }
+     "iopub.execute_input": "2026-05-12T12:22:43.066079Z",
+     "iopub.status.busy": "2026-05-12T12:22:43.065870Z",
+     "iopub.status.idle": "2026-05-12T12:22:43.102981Z",
+     "shell.execute_reply": "2026-05-12T12:22:43.102142Z"
+    },
+    "papermill": {
+     "duration": 0.042665,
+     "end_time": "2026-05-12T12:22:43.103833+00:00",
+     "exception": false,
+     "start_time": "2026-05-12T12:22:43.061168+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:21:14 - ras_commander.geom.GeomParser - INFO - Created backup: G:\\GH\\ras-commander\\examples\\example_projects\\Muncie_414_modified\\Muncie.g02.bak\n"
+      "2026-05-12 08:22:43 - ras_commander.geom.GeomParser - INFO - Created backup: G:\\GH\\ras-commander\\example_projects\\Muncie_414_modified\\Muncie.g02.bak\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:21:14 - ras_commander.geom.GeomStorage - INFO - Created backup: G:\\GH\\ras-commander\\examples\\example_projects\\Muncie_414_modified\\Muncie.g02.bak\n"
+      "2026-05-12 08:22:43 - ras_commander.geom.GeomStorage - INFO - Created backup: G:\\GH\\ras-commander\\example_projects\\Muncie_414_modified\\Muncie.g02.bak\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:21:14 - ras_commander.geom.GeomStorage - INFO - Updated 2D flow area settings for 2D Interior Area\n"
+      "2026-05-12 08:22:43 - ras_commander.geom.GeomStorage - INFO - Updated 2D flow area settings for 2D Interior Area\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Uniform Manning's n modification:\n",
-      "  Baseline: 0.06\n",
-      "  Modified: 0.12\n",
-      "  Ratio:    2.0x\n",
-      "\n",
-      "Round-trip verified: written value matches read-back\n"
+      "Uniform Manning's n: 0.06 -> 0.12  (2.0x)\n",
+      "Round-trip verified\n"
      ]
     }
    ],
    "source": [
-    "# Modify the uniform Manning's n in the modified project's geometry file\n",
     "new_n = original_n * N_MULTIPLIER\n",
     "\n",
     "GeomStorage.set_2d_flow_area_settings(\n",
-    "    modified_geom,\n",
-    "    flow_area_name=MESH_NAME,\n",
-    "    mannings_n=new_n,\n",
+    "    modified_geom, flow_area_name=MESH_NAME, mannings_n=new_n,\n",
     ")\n",
     "\n",
-    "# Verify round-trip: read back what we just wrote\n",
     "mod_settings = GeomStorage.get_2d_flow_area_settings(modified_geom)\n",
-    "mod_row = mod_settings[mod_settings['name'] == MESH_NAME].iloc[0]\n",
-    "verify_n = mod_row['mannings_n']\n",
+    "verify_n = mod_settings[mod_settings['name'] == MESH_NAME].iloc[0]['mannings_n']\n",
     "\n",
-    "print(f\"Uniform Manning's n modification:\")\n",
-    "print(f\"  Baseline: {original_n}\")\n",
-    "print(f\"  Modified: {verify_n}\")\n",
-    "print(f\"  Ratio:    {verify_n / original_n:.1f}x\")\n",
-    "\n",
-    "assert abs(verify_n - new_n) < 1e-6, \\\n",
-    "    f\"Round-trip failed: expected {new_n}, got {verify_n}\"\n",
-    "print(f\"\\nRound-trip verified: written value matches read-back\")"
+    "print(f\"Uniform Manning's n: {original_n} -> {verify_n}  ({verify_n/original_n:.1f}x)\")\n",
+    "assert abs(verify_n - new_n) < 1e-6, f\"Round-trip failed: expected {new_n}, got {verify_n}\"\n",
+    "print(\"Round-trip verified\")"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "91e89ca3",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003334,
+     "end_time": "2026-05-12T12:22:43.110643+00:00",
+     "exception": false,
+     "start_time": "2026-05-12T12:22:43.107309+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## Step 4: Run Both Models\n",
     "\n",
-    "Both runs use `force_geompre=True` to regenerate the geometry HDF from the plain-text\n",
-    "geometry file. The baseline gets the original n values; the modified copy gets 2x n values.\n",
-    "HEC-RAS preprocessing converts the land cover table into per-face property tables."
+    "Both runs use `force_geompre=True` to regenerate the geometry HDF from the\n",
+    "modified plain-text file. HEC-RAS preprocessing converts the uniform n into\n",
+    "per-face property tables."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
+   "id": "433ed937",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T00:21:14.975364Z",
-     "iopub.status.busy": "2026-05-12T00:21:14.975364Z",
-     "iopub.status.idle": "2026-05-12T00:21:52.027042Z",
-     "shell.execute_reply": "2026-05-12T00:21:52.027042Z"
-    }
+     "iopub.execute_input": "2026-05-12T12:22:43.119375Z",
+     "iopub.status.busy": "2026-05-12T12:22:43.119188Z",
+     "iopub.status.idle": "2026-05-12T12:23:16.672716Z",
+     "shell.execute_reply": "2026-05-12T12:23:16.672049Z"
+    },
+    "papermill": {
+     "duration": 33.559633,
+     "end_time": "2026-05-12T12:23:16.673514+00:00",
+     "exception": false,
+     "start_time": "2026-05-12T12:22:43.113881+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:21:14 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 7.0 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\7.0\\Ras.exe via filesystem (x86)\n"
+      "2026-05-12 08:22:43 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 7.0 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\7.0\\Ras.exe via filesystem (x86)\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:21:14 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 6.7 Beta 5 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.7 Beta 5\\Ras.exe via filesystem (x86)\n"
+      "2026-05-12 08:22:43 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 6.7 Beta 5 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.7 Beta 5\\Ras.exe via filesystem (x86)\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:21:14 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 6.5 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.5\\Ras.exe via filesystem (x86)\n"
+      "2026-05-12 08:22:43 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 6.5 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.5\\Ras.exe via filesystem (x86)\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:21:14 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 6.3.1 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.3.1\\Ras.exe via filesystem (x86)\n"
+      "2026-05-12 08:22:43 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 6.3.1 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.3.1\\Ras.exe via filesystem (x86)\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:21:14 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 6.2 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.2\\Ras.exe via filesystem (x86)\n"
+      "2026-05-12 08:22:43 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 6.2 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.2\\Ras.exe via filesystem (x86)\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:21:14 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 6.1 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.1\\Ras.exe via filesystem (x86)\n"
+      "2026-05-12 08:22:43 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 6.1 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.1\\Ras.exe via filesystem (x86)\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:21:14 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 6.0 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.0\\Ras.exe via filesystem (x86)\n"
+      "2026-05-12 08:22:43 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 6.0 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.0\\Ras.exe via filesystem (x86)\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:21:14 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 5.0.7 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\5.0.7\\Ras.exe via filesystem (x86)\n"
+      "2026-05-12 08:22:43 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 5.0.7 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\5.0.7\\Ras.exe via filesystem (x86)\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:21:14 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 5.0.6 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\5.0.6\\Ras.exe via filesystem (x86)\n"
+      "2026-05-12 08:22:43 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 5.0.6 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\5.0.6\\Ras.exe via filesystem (x86)\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:21:14 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 5.0.5 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\5.0.5\\Ras.exe via filesystem (x86)\n"
+      "2026-05-12 08:22:43 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 5.0.5 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\5.0.5\\Ras.exe via filesystem (x86)\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:21:14 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 5.0.4 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\5.0.4\\Ras.exe via filesystem (x86)\n"
+      "2026-05-12 08:22:43 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 5.0.4 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\5.0.4\\Ras.exe via filesystem (x86)\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:21:14 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 5.0.3 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\5.0.3\\Ras.exe via filesystem (x86)\n"
+      "2026-05-12 08:22:43 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 5.0.3 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\5.0.3\\Ras.exe via filesystem (x86)\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:21:14 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 5.0.1 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\5.0.1\\Ras.exe via filesystem (x86)\n"
+      "2026-05-12 08:22:43 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 5.0.1 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\5.0.1\\Ras.exe via filesystem (x86)\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:21:14 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 5.0 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\5.0\\Ras.exe via filesystem (x86)\n"
+      "2026-05-12 08:22:43 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 5.0 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\5.0\\Ras.exe via filesystem (x86)\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:21:14 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 4.1.0 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\4.1.0\\Ras.exe via filesystem (x86)\n"
+      "2026-05-12 08:22:43 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 4.1.0 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\4.1.0\\Ras.exe via filesystem (x86)\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:21:14 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 4.0 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\4.0\\Ras.exe via filesystem (x86)\n"
+      "2026-05-12 08:22:43 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 4.0 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\4.0\\Ras.exe via filesystem (x86)\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:21:14 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 6.6 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.6\\Ras.exe via filesystem (x86)\n"
+      "2026-05-12 08:22:43 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 6.6 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.6\\Ras.exe via filesystem (x86)\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:21:14 - ras_commander.RasUtils - INFO - Discovered 17 installed HEC-RAS version(s)\n"
+      "2026-05-12 08:22:43 - ras_commander.RasUtils - INFO - Discovered 17 installed HEC-RAS version(s)\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:21:14 - ras_commander.RasPrj - INFO - HEC-RAS 6.6 found via version discovery: C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.6\\Ras.exe\n"
+      "2026-05-12 08:22:43 - ras_commander.RasPrj - INFO - HEC-RAS 6.6 found via version discovery: C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.6\\Ras.exe\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:21:15 - ras_commander.RasMap - INFO - Successfully parsed RASMapper file: G:\\GH\\ras-commander\\examples\\example_projects\\Muncie_414_baseline\\Muncie.rasmap\n"
+      "2026-05-12 08:22:43 - ras_commander.RasMap - INFO - Successfully parsed RASMapper file: G:\\GH\\ras-commander\\example_projects\\Muncie_414_baseline\\Muncie.rasmap\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:21:15 - ras_commander.hdf.HdfBase - INFO - Found projection in projection file: G:\\GH\\ras-commander\\examples\\example_projects\\Muncie_414_baseline\\GIS_Data\\Muncie_IA_Clip.prj\n"
+      "2026-05-12 08:22:43 - ras_commander.hdf.HdfBase - INFO - Found projection in projection file: G:\\GH\\ras-commander\\example_projects\\Muncie_414_baseline\\GIS_Data\\Muncie_IA_Clip.prj\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:21:15 - ras_commander.RasPrj - INFO - Updated results_df with 3 plan(s)\n"
+      "2026-05-12 08:22:43 - ras_commander.RasPrj - INFO - Updated results_df with 3 plan(s)\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:21:15 - ras_commander.RasPrj - INFO - ras-commander v0.93.0 | An open-source project of CLB Engineering Corporation (https://clbengineering.com/) | Docs: https://ras-commander.readthedocs.io | GitHub: https://github.com/gpt-cmdr/ras-commander\n"
+      "2026-05-12 08:22:43 - ras_commander.RasPrj - INFO - ras-commander v0.96.2 | An open-source project of CLB Engineering Corporation (https://clbengineering.com/) | Docs: https://ras-commander.readthedocs.io | GitHub: https://github.com/gpt-cmdr/ras-commander\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:21:15 - ras_commander.RasPrj - INFO - Project initialized: Muncie | Folder: G:\\GH\\ras-commander\\examples\\example_projects\\Muncie_414_baseline\n"
+      "2026-05-12 08:22:43 - ras_commander.RasPrj - INFO - Project initialized: Muncie | Folder: G:\\GH\\ras-commander\\example_projects\\Muncie_414_baseline\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:21:15 - ras_commander.RasPrj - INFO - Using HEC-RAS executable: C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.6\\Ras.exe\n"
+      "2026-05-12 08:22:43 - ras_commander.RasPrj - INFO - Using HEC-RAS executable: C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.6\\Ras.exe\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:21:15 - ras_commander.RasCmdr - INFO - Using ras_object with project folder: G:\\GH\\ras-commander\\examples\\example_projects\\Muncie_414_baseline\n"
+      "2026-05-12 08:22:43 - ras_commander.RasCmdr - INFO - Using ras_object with project folder: G:\\GH\\ras-commander\\example_projects\\Muncie_414_baseline\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:22:43 - ras_commander.RasCurrency - INFO - Deleted geometry HDF: G:\\GH\\ras-commander\\example_projects\\Muncie_414_baseline\\Muncie.g02.hdf\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:22:43 - ras_commander.geom.GeomPreprocessor - INFO - Clearing geometry preprocessor file for single plan: G:\\GH\\ras-commander\\example_projects\\Muncie_414_baseline\\Muncie.p03\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:22:43 - ras_commander.geom.GeomPreprocessor - INFO - Deleted geometry preprocessor file: G:\\GH\\ras-commander\\example_projects\\Muncie_414_baseline\\Muncie.c02\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:22:43 - ras_commander.geom.GeomPreprocessor - INFO - Geometry dataframe updated successfully.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:22:43 - ras_commander.RasCmdr - INFO - Force-cleared all geometry preprocessor files for plan: 03\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:22:43 - ras_commander.RasUtils - INFO - Using provided plan file path: G:\\GH\\ras-commander\\example_projects\\Muncie_414_baseline\\Muncie.p03\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:22:43 - ras_commander.RasUtils - INFO - Successfully updated file: G:\\GH\\ras-commander\\example_projects\\Muncie_414_baseline\\Muncie.p03\n"
      ]
     },
     {
@@ -786,693 +1089,670 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:21:15 - ras_commander.RasCurrency - INFO - Deleted geometry HDF: G:\\GH\\ras-commander\\examples\\example_projects\\Muncie_414_baseline\\Muncie.g02.hdf\n"
+      "2026-05-12 08:22:43 - ras_commander.RasCmdr - INFO - Set number of cores to 2 for plan: 03\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:21:15 - ras_commander.geom.GeomPreprocessor - INFO - Clearing geometry preprocessor file for single plan: G:\\GH\\ras-commander\\examples\\example_projects\\Muncie_414_baseline\\Muncie.p03\n"
+      "2026-05-12 08:22:43 - ras_commander.RasCmdr - INFO - Running HEC-RAS from the Command Line:\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:21:15 - ras_commander.geom.GeomPreprocessor - INFO - Deleted geometry preprocessor file: G:\\GH\\ras-commander\\examples\\example_projects\\Muncie_414_baseline\\Muncie.c02\n"
+      "2026-05-12 08:22:43 - ras_commander.RasCmdr - INFO - Running command: \"C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.6\\Ras.exe\" -c \"G:\\GH\\ras-commander\\example_projects\\Muncie_414_baseline\\Muncie.prj\" \"G:\\GH\\ras-commander\\example_projects\\Muncie_414_baseline\\Muncie.p03\"\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:21:15 - ras_commander.geom.GeomPreprocessor - INFO - Geometry dataframe updated successfully.\n"
+      "2026-05-12 08:23:16 - ras_commander.RasCmdr - INFO - HEC-RAS execution completed for plan: 03\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:21:15 - ras_commander.RasCmdr - INFO - Force-cleared all geometry preprocessor files for plan: 03\n"
+      "2026-05-12 08:23:16 - ras_commander.RasCmdr - INFO - Total run time for plan 03: 33.24 seconds\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:21:15 - ras_commander.RasUtils - INFO - Using provided plan file path: G:\\GH\\ras-commander\\examples\\example_projects\\Muncie_414_baseline\\Muncie.p03\n"
+      "2026-05-12 08:23:16 - ras_commander.hdf.HdfResultsPlan - INFO - Using existing Path object HDF file: G:\\GH\\ras-commander\\example_projects\\Muncie_414_baseline\\Muncie.p03.hdf\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:21:15 - ras_commander.RasUtils - INFO - Successfully updated file: G:\\GH\\ras-commander\\examples\\example_projects\\Muncie_414_baseline\\Muncie.p03\n"
+      "2026-05-12 08:23:16 - ras_commander.hdf.HdfResultsPlan - INFO - Final validated file path: G:\\GH\\ras-commander\\example_projects\\Muncie_414_baseline\\Muncie.p03.hdf\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:21:15 - ras_commander.RasCmdr - INFO - Set number of cores to 2 for plan: 03\n"
+      "2026-05-12 08:23:16 - ras_commander.hdf.HdfResultsPlan - INFO - Reading computation messages from HDF: Muncie.p03.hdf\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:21:15 - ras_commander.RasCmdr - INFO - Running HEC-RAS from the Command Line:\n"
+      "2026-05-12 08:23:16 - ras_commander.hdf.HdfResultsPlan - INFO - Successfully extracted 2157 characters from HDF\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:21:15 - ras_commander.RasCmdr - INFO - Running command: \"C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.6\\Ras.exe\" -c \"G:\\GH\\ras-commander\\examples\\example_projects\\Muncie_414_baseline\\Muncie.prj\" \"G:\\GH\\ras-commander\\examples\\example_projects\\Muncie_414_baseline\\Muncie.p03\"\n"
+      "2026-05-12 08:23:16 - ras_commander.hdf.HdfResultsPlan - INFO - Using existing Path object HDF file: G:\\GH\\ras-commander\\example_projects\\Muncie_414_baseline\\Muncie.p03.hdf\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:21:51 - ras_commander.RasCmdr - INFO - HEC-RAS execution completed for plan: 03\n"
+      "2026-05-12 08:23:16 - ras_commander.hdf.HdfResultsPlan - INFO - Final validated file path: G:\\GH\\ras-commander\\example_projects\\Muncie_414_baseline\\Muncie.p03.hdf\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:21:51 - ras_commander.RasCmdr - INFO - Total run time for plan 03: 36.64 seconds\n"
+      "2026-05-12 08:23:16 - ras_commander.hdf.HdfResultsPlan - INFO - Extracting Plan Information from: Muncie.p03.hdf\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:21:51 - ras_commander.hdf.HdfResultsPlan - INFO - Using existing Path object HDF file: G:\\GH\\ras-commander\\examples\\example_projects\\Muncie_414_baseline\\Muncie.p03.hdf\n"
+      "2026-05-12 08:23:16 - ras_commander.hdf.HdfResultsPlan - INFO - Plan Name: Unsteady Run with 2D 50ft Grid\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:21:51 - ras_commander.hdf.HdfResultsPlan - INFO - Final validated file path: G:\\GH\\ras-commander\\examples\\example_projects\\Muncie_414_baseline\\Muncie.p03.hdf\n"
+      "2026-05-12 08:23:16 - ras_commander.hdf.HdfResultsPlan - INFO - Simulation Duration (hours): 24.0\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:21:51 - ras_commander.hdf.HdfResultsPlan - INFO - Reading computation messages from HDF: Muncie.p03.hdf\n"
+      "2026-05-12 08:23:16 - ras_commander.hdf.HdfResultsPlan - INFO - Using existing Path object HDF file: G:\\GH\\ras-commander\\example_projects\\Muncie_414_baseline\\Muncie.p03.hdf\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:21:51 - ras_commander.hdf.HdfResultsPlan - INFO - Successfully extracted 2157 characters from HDF\n"
+      "2026-05-12 08:23:16 - ras_commander.hdf.HdfResultsPlan - INFO - Final validated file path: G:\\GH\\ras-commander\\example_projects\\Muncie_414_baseline\\Muncie.p03.hdf\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:21:51 - ras_commander.hdf.HdfResultsPlan - INFO - Using existing Path object HDF file: G:\\GH\\ras-commander\\examples\\example_projects\\Muncie_414_baseline\\Muncie.p03.hdf\n"
+      "2026-05-12 08:23:16 - ras_commander.RasPrj - INFO - Updated results_df with 1 plan(s)\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:21:51 - ras_commander.hdf.HdfResultsPlan - INFO - Final validated file path: G:\\GH\\ras-commander\\examples\\example_projects\\Muncie_414_baseline\\Muncie.p03.hdf\n"
+      "2026-05-12 08:23:16 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 7.0 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\7.0\\Ras.exe via filesystem (x86)\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:21:51 - ras_commander.hdf.HdfResultsPlan - INFO - Extracting Plan Information from: Muncie.p03.hdf\n"
+      "2026-05-12 08:23:16 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 6.7 Beta 5 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.7 Beta 5\\Ras.exe via filesystem (x86)\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:21:51 - ras_commander.hdf.HdfResultsPlan - INFO - Plan Name: Unsteady Run with 2D 50ft Grid\n"
+      "2026-05-12 08:23:16 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 6.5 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.5\\Ras.exe via filesystem (x86)\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:21:51 - ras_commander.hdf.HdfResultsPlan - INFO - Simulation Duration (hours): 24.0\n"
+      "2026-05-12 08:23:16 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 6.3.1 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.3.1\\Ras.exe via filesystem (x86)\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:21:51 - ras_commander.hdf.HdfResultsPlan - INFO - Using existing Path object HDF file: G:\\GH\\ras-commander\\examples\\example_projects\\Muncie_414_baseline\\Muncie.p03.hdf\n"
+      "2026-05-12 08:23:16 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 6.2 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.2\\Ras.exe via filesystem (x86)\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:21:51 - ras_commander.hdf.HdfResultsPlan - INFO - Final validated file path: G:\\GH\\ras-commander\\examples\\example_projects\\Muncie_414_baseline\\Muncie.p03.hdf\n"
+      "2026-05-12 08:23:16 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 6.1 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.1\\Ras.exe via filesystem (x86)\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:21:51 - ras_commander.RasPrj - INFO - Updated results_df with 1 plan(s)\n"
+      "2026-05-12 08:23:16 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 6.0 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.0\\Ras.exe via filesystem (x86)\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:21:51 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 7.0 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\7.0\\Ras.exe via filesystem (x86)\n"
+      "2026-05-12 08:23:16 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 5.0.7 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\5.0.7\\Ras.exe via filesystem (x86)\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:21:51 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 6.7 Beta 5 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.7 Beta 5\\Ras.exe via filesystem (x86)\n"
+      "2026-05-12 08:23:16 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 5.0.6 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\5.0.6\\Ras.exe via filesystem (x86)\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:21:51 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 6.5 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.5\\Ras.exe via filesystem (x86)\n"
+      "2026-05-12 08:23:16 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 5.0.5 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\5.0.5\\Ras.exe via filesystem (x86)\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:21:51 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 6.3.1 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.3.1\\Ras.exe via filesystem (x86)\n"
+      "2026-05-12 08:23:16 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 5.0.4 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\5.0.4\\Ras.exe via filesystem (x86)\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:21:51 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 6.2 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.2\\Ras.exe via filesystem (x86)\n"
+      "2026-05-12 08:23:16 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 5.0.3 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\5.0.3\\Ras.exe via filesystem (x86)\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:21:51 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 6.1 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.1\\Ras.exe via filesystem (x86)\n"
+      "2026-05-12 08:23:16 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 5.0.1 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\5.0.1\\Ras.exe via filesystem (x86)\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:21:51 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 6.0 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.0\\Ras.exe via filesystem (x86)\n"
+      "2026-05-12 08:23:16 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 5.0 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\5.0\\Ras.exe via filesystem (x86)\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:21:51 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 5.0.7 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\5.0.7\\Ras.exe via filesystem (x86)\n"
+      "2026-05-12 08:23:16 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 4.1.0 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\4.1.0\\Ras.exe via filesystem (x86)\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:21:51 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 5.0.6 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\5.0.6\\Ras.exe via filesystem (x86)\n"
+      "2026-05-12 08:23:16 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 4.0 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\4.0\\Ras.exe via filesystem (x86)\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:21:51 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 5.0.5 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\5.0.5\\Ras.exe via filesystem (x86)\n"
+      "2026-05-12 08:23:16 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 6.6 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.6\\Ras.exe via filesystem (x86)\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:21:51 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 5.0.4 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\5.0.4\\Ras.exe via filesystem (x86)\n"
+      "2026-05-12 08:23:16 - ras_commander.RasUtils - INFO - Discovered 17 installed HEC-RAS version(s)\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:21:51 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 5.0.3 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\5.0.3\\Ras.exe via filesystem (x86)\n"
+      "2026-05-12 08:23:16 - ras_commander.RasPrj - INFO - HEC-RAS 6.6 found via version discovery: C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.6\\Ras.exe\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:21:51 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 5.0.1 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\5.0.1\\Ras.exe via filesystem (x86)\n"
+      "2026-05-12 08:23:16 - ras_commander.RasMap - INFO - Successfully parsed RASMapper file: G:\\GH\\ras-commander\\example_projects\\Muncie_414_baseline\\Muncie.rasmap\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:21:51 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 5.0 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\5.0\\Ras.exe via filesystem (x86)\n"
+      "2026-05-12 08:23:16 - ras_commander.hdf.HdfBase - INFO - Found projection in HDF file: G:\\GH\\ras-commander\\example_projects\\Muncie_414_baseline\\Muncie.g02.hdf\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:21:51 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 4.1.0 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\4.1.0\\Ras.exe via filesystem (x86)\n"
+      "2026-05-12 08:23:16 - ras_commander.hdf.HdfResultsPlan - INFO - Using existing Path object HDF file: G:\\GH\\ras-commander\\example_projects\\Muncie_414_baseline\\Muncie.p03.hdf\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:21:51 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 4.0 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\4.0\\Ras.exe via filesystem (x86)\n"
+      "2026-05-12 08:23:16 - ras_commander.hdf.HdfResultsPlan - INFO - Final validated file path: G:\\GH\\ras-commander\\example_projects\\Muncie_414_baseline\\Muncie.p03.hdf\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:21:51 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 6.6 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.6\\Ras.exe via filesystem (x86)\n"
+      "2026-05-12 08:23:16 - ras_commander.hdf.HdfResultsPlan - INFO - Reading computation messages from HDF: Muncie.p03.hdf\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:21:51 - ras_commander.RasUtils - INFO - Discovered 17 installed HEC-RAS version(s)\n"
+      "2026-05-12 08:23:16 - ras_commander.hdf.HdfResultsPlan - INFO - Successfully extracted 2157 characters from HDF\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:21:51 - ras_commander.RasPrj - INFO - HEC-RAS 6.6 found via version discovery: C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.6\\Ras.exe\n"
+      "2026-05-12 08:23:16 - ras_commander.hdf.HdfResultsPlan - INFO - Using existing Path object HDF file: G:\\GH\\ras-commander\\example_projects\\Muncie_414_baseline\\Muncie.p03.hdf\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:21:51 - ras_commander.RasMap - INFO - Successfully parsed RASMapper file: G:\\GH\\ras-commander\\examples\\example_projects\\Muncie_414_baseline\\Muncie.rasmap\n"
+      "2026-05-12 08:23:16 - ras_commander.hdf.HdfResultsPlan - INFO - Final validated file path: G:\\GH\\ras-commander\\example_projects\\Muncie_414_baseline\\Muncie.p03.hdf\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:21:51 - ras_commander.hdf.HdfBase - INFO - Found projection in HDF file: G:\\GH\\ras-commander\\examples\\example_projects\\Muncie_414_baseline\\Muncie.g02.hdf\n"
+      "2026-05-12 08:23:16 - ras_commander.hdf.HdfResultsPlan - INFO - Extracting Plan Information from: Muncie.p03.hdf\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:21:51 - ras_commander.hdf.HdfResultsPlan - INFO - Using existing Path object HDF file: G:\\GH\\ras-commander\\examples\\example_projects\\Muncie_414_baseline\\Muncie.p03.hdf\n"
+      "2026-05-12 08:23:16 - ras_commander.hdf.HdfResultsPlan - INFO - Plan Name: Unsteady Run with 2D 50ft Grid\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:21:51 - ras_commander.hdf.HdfResultsPlan - INFO - Final validated file path: G:\\GH\\ras-commander\\examples\\example_projects\\Muncie_414_baseline\\Muncie.p03.hdf\n"
+      "2026-05-12 08:23:16 - ras_commander.hdf.HdfResultsPlan - INFO - Simulation Duration (hours): 24.0\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:21:51 - ras_commander.hdf.HdfResultsPlan - INFO - Reading computation messages from HDF: Muncie.p03.hdf\n"
+      "2026-05-12 08:23:16 - ras_commander.hdf.HdfResultsPlan - INFO - Using existing Path object HDF file: G:\\GH\\ras-commander\\example_projects\\Muncie_414_baseline\\Muncie.p03.hdf\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:21:51 - ras_commander.hdf.HdfResultsPlan - INFO - Successfully extracted 2157 characters from HDF\n"
+      "2026-05-12 08:23:16 - ras_commander.hdf.HdfResultsPlan - INFO - Final validated file path: G:\\GH\\ras-commander\\example_projects\\Muncie_414_baseline\\Muncie.p03.hdf\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:21:51 - ras_commander.hdf.HdfResultsPlan - INFO - Using existing Path object HDF file: G:\\GH\\ras-commander\\examples\\example_projects\\Muncie_414_baseline\\Muncie.p03.hdf\n"
+      "2026-05-12 08:23:16 - ras_commander.RasPrj - INFO - Updated results_df with 3 plan(s)\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:21:52 - ras_commander.hdf.HdfResultsPlan - INFO - Final validated file path: G:\\GH\\ras-commander\\examples\\example_projects\\Muncie_414_baseline\\Muncie.p03.hdf\n"
+      "2026-05-12 08:23:16 - ras_commander.RasPrj - INFO - ras-commander v0.96.2 | An open-source project of CLB Engineering Corporation (https://clbengineering.com/) | Docs: https://ras-commander.readthedocs.io | GitHub: https://github.com/gpt-cmdr/ras-commander\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:21:52 - ras_commander.hdf.HdfResultsPlan - INFO - Extracting Plan Information from: Muncie.p03.hdf\n"
+      "2026-05-12 08:23:16 - ras_commander.RasPrj - INFO - Project initialized: Muncie | Folder: G:\\GH\\ras-commander\\example_projects\\Muncie_414_baseline\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:21:52 - ras_commander.hdf.HdfResultsPlan - INFO - Plan Name: Unsteady Run with 2D 50ft Grid\n"
+      "2026-05-12 08:23:16 - ras_commander.RasPrj - INFO - Using HEC-RAS executable: C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.6\\Ras.exe\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:21:52 - ras_commander.hdf.HdfResultsPlan - INFO - Simulation Duration (hours): 24.0\n"
+      "2026-05-12 08:23:16 - ras_commander.hdf.HdfResultsPlan - INFO - Final validated file path: G:\\GH\\ras-commander\\example_projects\\Muncie_414_baseline\\Muncie.p03.hdf\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:21:52 - ras_commander.hdf.HdfResultsPlan - INFO - Using existing Path object HDF file: G:\\GH\\ras-commander\\examples\\example_projects\\Muncie_414_baseline\\Muncie.p03.hdf\n"
+      "2026-05-12 08:23:16 - ras_commander.hdf.HdfResultsPlan - INFO - Reading computation messages from HDF: Muncie.p03.hdf\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:21:52 - ras_commander.hdf.HdfResultsPlan - INFO - Final validated file path: G:\\GH\\ras-commander\\examples\\example_projects\\Muncie_414_baseline\\Muncie.p03.hdf\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-11 20:21:52 - ras_commander.RasPrj - INFO - Updated results_df with 3 plan(s)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-11 20:21:52 - ras_commander.RasPrj - INFO - ras-commander v0.93.0 | An open-source project of CLB Engineering Corporation (https://clbengineering.com/) | Docs: https://ras-commander.readthedocs.io | GitHub: https://github.com/gpt-cmdr/ras-commander\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-11 20:21:52 - ras_commander.RasPrj - INFO - Project initialized: Muncie | Folder: G:\\GH\\ras-commander\\examples\\example_projects\\Muncie_414_baseline\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-11 20:21:52 - ras_commander.RasPrj - INFO - Using HEC-RAS executable: C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.6\\Ras.exe\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-11 20:21:52 - ras_commander.hdf.HdfResultsPlan - INFO - Final validated file path: G:\\GH\\ras-commander\\examples\\example_projects\\Muncie_414_baseline\\Muncie.p03.hdf\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-11 20:21:52 - ras_commander.hdf.HdfResultsPlan - INFO - Reading computation messages from HDF: Muncie.p03.hdf\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-11 20:21:52 - ras_commander.hdf.HdfResultsPlan - INFO - Successfully extracted 2157 characters from HDF\n"
+      "2026-05-12 08:23:16 - ras_commander.hdf.HdfResultsPlan - INFO - Successfully extracted 2157 characters from HDF\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Baseline complete (74 message lines, no errors)\n"
+      "Baseline: 74 messages, 0 errors\n"
      ]
     }
    ],
    "source": [
-    "# Run baseline (independent RasPrj instance)\n",
     "baseline_ras = init_ras_project(baseline_path, RAS_VERSION, ras_object=\"new\")\n",
     "print(\"Running baseline model...\")\n",
-    "RasCmdr.compute_plan(\n",
-    "    PLAN_NUMBER,\n",
-    "    ras_object=baseline_ras,\n",
-    "    num_cores=2,\n",
-    "    force_geompre=True,\n",
-    ")\n",
+    "RasCmdr.compute_plan(PLAN_NUMBER, ras_object=baseline_ras, num_cores=2, force_geompre=True)\n",
     "baseline_ras = init_ras_project(baseline_path, RAS_VERSION, ras_object=\"new\")\n",
     "\n",
     "messages = HdfResultsPlan.get_compute_messages(PLAN_NUMBER, ras_object=baseline_ras)\n",
     "if messages:\n",
     "    lines = messages.splitlines()\n",
-    "    real_errors = [l for l in lines if \"ERROR\" in l.upper()\n",
-    "                   and \"VOLUME ACCOUNTING\" not in l.upper()\n",
-    "                   and \"WSEL ERROR\" not in l.upper()\n",
-    "                   and \"ITERATIONS\" not in l.upper()]\n",
-    "    if real_errors:\n",
-    "        print(f\"ERRORS ({len(real_errors)}):\")\n",
-    "        for e in real_errors[:5]:\n",
-    "            print(f\"  {e}\")\n",
-    "    else:\n",
-    "        print(f\"Baseline complete ({len(lines)} message lines, no errors)\")\n",
+    "    errors = [l for l in lines if \"ERROR\" in l.upper()\n",
+    "              and \"VOLUME ACCOUNTING\" not in l.upper()\n",
+    "              and \"WSEL ERROR\" not in l.upper()\n",
+    "              and \"ITERATIONS\" not in l.upper()]\n",
+    "    print(f\"Baseline: {len(lines)} messages, {len(errors)} errors\")\n",
     "else:\n",
-    "    print(\"Baseline complete (no compute messages file)\")"
+    "    print(\"Baseline complete\")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
+   "id": "080f653f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T00:21:52.028788Z",
-     "iopub.status.busy": "2026-05-12T00:21:52.028788Z",
-     "iopub.status.idle": "2026-05-12T00:22:29.278664Z",
-     "shell.execute_reply": "2026-05-12T00:22:29.278208Z"
-    }
+     "iopub.execute_input": "2026-05-12T12:23:16.686938Z",
+     "iopub.status.busy": "2026-05-12T12:23:16.686751Z",
+     "iopub.status.idle": "2026-05-12T12:23:50.419481Z",
+     "shell.execute_reply": "2026-05-12T12:23:50.418570Z"
+    },
+    "papermill": {
+     "duration": 33.740192,
+     "end_time": "2026-05-12T12:23:50.420299+00:00",
+     "exception": false,
+     "start_time": "2026-05-12T12:23:16.680107+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:21:52 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 7.0 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\7.0\\Ras.exe via filesystem (x86)\n"
+      "2026-05-12 08:23:16 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 7.0 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\7.0\\Ras.exe via filesystem (x86)\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:21:52 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 6.7 Beta 5 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.7 Beta 5\\Ras.exe via filesystem (x86)\n"
+      "2026-05-12 08:23:16 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 6.7 Beta 5 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.7 Beta 5\\Ras.exe via filesystem (x86)\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:21:52 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 6.5 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.5\\Ras.exe via filesystem (x86)\n"
+      "2026-05-12 08:23:16 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 6.5 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.5\\Ras.exe via filesystem (x86)\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:21:52 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 6.3.1 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.3.1\\Ras.exe via filesystem (x86)\n"
+      "2026-05-12 08:23:16 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 6.3.1 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.3.1\\Ras.exe via filesystem (x86)\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:21:52 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 6.2 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.2\\Ras.exe via filesystem (x86)\n"
+      "2026-05-12 08:23:16 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 6.2 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.2\\Ras.exe via filesystem (x86)\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:21:52 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 6.1 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.1\\Ras.exe via filesystem (x86)\n"
+      "2026-05-12 08:23:16 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 6.1 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.1\\Ras.exe via filesystem (x86)\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:21:52 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 6.0 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.0\\Ras.exe via filesystem (x86)\n"
+      "2026-05-12 08:23:16 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 6.0 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.0\\Ras.exe via filesystem (x86)\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:21:52 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 5.0.7 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\5.0.7\\Ras.exe via filesystem (x86)\n"
+      "2026-05-12 08:23:16 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 5.0.7 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\5.0.7\\Ras.exe via filesystem (x86)\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:21:52 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 5.0.6 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\5.0.6\\Ras.exe via filesystem (x86)\n"
+      "2026-05-12 08:23:16 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 5.0.6 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\5.0.6\\Ras.exe via filesystem (x86)\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:21:52 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 5.0.5 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\5.0.5\\Ras.exe via filesystem (x86)\n"
+      "2026-05-12 08:23:16 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 5.0.5 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\5.0.5\\Ras.exe via filesystem (x86)\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:21:52 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 5.0.4 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\5.0.4\\Ras.exe via filesystem (x86)\n"
+      "2026-05-12 08:23:16 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 5.0.4 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\5.0.4\\Ras.exe via filesystem (x86)\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:21:52 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 5.0.3 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\5.0.3\\Ras.exe via filesystem (x86)\n"
+      "2026-05-12 08:23:16 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 5.0.3 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\5.0.3\\Ras.exe via filesystem (x86)\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:21:52 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 5.0.1 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\5.0.1\\Ras.exe via filesystem (x86)\n"
+      "2026-05-12 08:23:16 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 5.0.1 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\5.0.1\\Ras.exe via filesystem (x86)\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:21:52 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 5.0 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\5.0\\Ras.exe via filesystem (x86)\n"
+      "2026-05-12 08:23:16 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 5.0 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\5.0\\Ras.exe via filesystem (x86)\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:21:52 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 4.1.0 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\4.1.0\\Ras.exe via filesystem (x86)\n"
+      "2026-05-12 08:23:16 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 4.1.0 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\4.1.0\\Ras.exe via filesystem (x86)\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:21:52 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 4.0 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\4.0\\Ras.exe via filesystem (x86)\n"
+      "2026-05-12 08:23:16 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 4.0 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\4.0\\Ras.exe via filesystem (x86)\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:21:52 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 6.6 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.6\\Ras.exe via filesystem (x86)\n"
+      "2026-05-12 08:23:16 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 6.6 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.6\\Ras.exe via filesystem (x86)\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:21:52 - ras_commander.RasUtils - INFO - Discovered 17 installed HEC-RAS version(s)\n"
+      "2026-05-12 08:23:16 - ras_commander.RasUtils - INFO - Discovered 17 installed HEC-RAS version(s)\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:21:52 - ras_commander.RasPrj - INFO - HEC-RAS 6.6 found via version discovery: C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.6\\Ras.exe\n"
+      "2026-05-12 08:23:16 - ras_commander.RasPrj - INFO - HEC-RAS 6.6 found via version discovery: C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.6\\Ras.exe\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:21:52 - ras_commander.RasMap - INFO - Successfully parsed RASMapper file: G:\\GH\\ras-commander\\examples\\example_projects\\Muncie_414_modified\\Muncie.rasmap\n"
+      "2026-05-12 08:23:16 - ras_commander.RasMap - INFO - Successfully parsed RASMapper file: G:\\GH\\ras-commander\\example_projects\\Muncie_414_modified\\Muncie.rasmap\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:21:52 - ras_commander.hdf.HdfBase - INFO - Found projection in projection file: G:\\GH\\ras-commander\\examples\\example_projects\\Muncie_414_modified\\GIS_Data\\Muncie_IA_Clip.prj\n"
+      "2026-05-12 08:23:16 - ras_commander.hdf.HdfBase - INFO - Found projection in projection file: G:\\GH\\ras-commander\\example_projects\\Muncie_414_modified\\GIS_Data\\Muncie_IA_Clip.prj\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:21:52 - ras_commander.RasPrj - INFO - Updated results_df with 3 plan(s)\n"
+      "2026-05-12 08:23:16 - ras_commander.RasPrj - INFO - Updated results_df with 3 plan(s)\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:21:52 - ras_commander.RasPrj - INFO - ras-commander v0.93.0 | An open-source project of CLB Engineering Corporation (https://clbengineering.com/) | Docs: https://ras-commander.readthedocs.io | GitHub: https://github.com/gpt-cmdr/ras-commander\n"
+      "2026-05-12 08:23:16 - ras_commander.RasPrj - INFO - ras-commander v0.96.2 | An open-source project of CLB Engineering Corporation (https://clbengineering.com/) | Docs: https://ras-commander.readthedocs.io | GitHub: https://github.com/gpt-cmdr/ras-commander\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:21:52 - ras_commander.RasPrj - INFO - Project initialized: Muncie | Folder: G:\\GH\\ras-commander\\examples\\example_projects\\Muncie_414_modified\n"
+      "2026-05-12 08:23:16 - ras_commander.RasPrj - INFO - Project initialized: Muncie | Folder: G:\\GH\\ras-commander\\example_projects\\Muncie_414_modified\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:21:52 - ras_commander.RasPrj - INFO - Using HEC-RAS executable: C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.6\\Ras.exe\n"
+      "2026-05-12 08:23:16 - ras_commander.RasPrj - INFO - Using HEC-RAS executable: C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.6\\Ras.exe\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:21:52 - ras_commander.RasCmdr - INFO - Using ras_object with project folder: G:\\GH\\ras-commander\\examples\\example_projects\\Muncie_414_modified\n"
+      "2026-05-12 08:23:16 - ras_commander.RasCmdr - INFO - Using ras_object with project folder: G:\\GH\\ras-commander\\example_projects\\Muncie_414_modified\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:21:52 - ras_commander.RasCurrency - INFO - Deleted geometry HDF: G:\\GH\\ras-commander\\examples\\example_projects\\Muncie_414_modified\\Muncie.g02.hdf\n"
+      "2026-05-12 08:23:16 - ras_commander.RasCurrency - INFO - Deleted geometry HDF: G:\\GH\\ras-commander\\example_projects\\Muncie_414_modified\\Muncie.g02.hdf\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:21:52 - ras_commander.geom.GeomPreprocessor - INFO - Clearing geometry preprocessor file for single plan: G:\\GH\\ras-commander\\examples\\example_projects\\Muncie_414_modified\\Muncie.p03\n"
+      "2026-05-12 08:23:16 - ras_commander.geom.GeomPreprocessor - INFO - Clearing geometry preprocessor file for single plan: G:\\GH\\ras-commander\\example_projects\\Muncie_414_modified\\Muncie.p03\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:21:52 - ras_commander.geom.GeomPreprocessor - INFO - Deleted geometry preprocessor file: G:\\GH\\ras-commander\\examples\\example_projects\\Muncie_414_modified\\Muncie.c02\n"
+      "2026-05-12 08:23:16 - ras_commander.geom.GeomPreprocessor - INFO - Deleted geometry preprocessor file: G:\\GH\\ras-commander\\example_projects\\Muncie_414_modified\\Muncie.c02\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:23:16 - ras_commander.geom.GeomPreprocessor - INFO - Geometry dataframe updated successfully.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:23:16 - ras_commander.RasCmdr - INFO - Force-cleared all geometry preprocessor files for plan: 03\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:23:16 - ras_commander.RasUtils - INFO - Using provided plan file path: G:\\GH\\ras-commander\\example_projects\\Muncie_414_modified\\Muncie.p03\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:23:16 - ras_commander.RasUtils - INFO - Successfully updated file: G:\\GH\\ras-commander\\example_projects\\Muncie_414_modified\\Muncie.p03\n"
      ]
     },
     {
@@ -1486,656 +1766,666 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:21:52 - ras_commander.geom.GeomPreprocessor - INFO - Geometry dataframe updated successfully.\n"
+      "2026-05-12 08:23:16 - ras_commander.RasCmdr - INFO - Set number of cores to 2 for plan: 03\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:21:52 - ras_commander.RasCmdr - INFO - Force-cleared all geometry preprocessor files for plan: 03\n"
+      "2026-05-12 08:23:16 - ras_commander.RasCmdr - INFO - Running HEC-RAS from the Command Line:\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:21:52 - ras_commander.RasUtils - INFO - Using provided plan file path: G:\\GH\\ras-commander\\examples\\example_projects\\Muncie_414_modified\\Muncie.p03\n"
+      "2026-05-12 08:23:16 - ras_commander.RasCmdr - INFO - Running command: \"C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.6\\Ras.exe\" -c \"G:\\GH\\ras-commander\\example_projects\\Muncie_414_modified\\Muncie.prj\" \"G:\\GH\\ras-commander\\example_projects\\Muncie_414_modified\\Muncie.p03\"\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:21:52 - ras_commander.RasUtils - INFO - Successfully updated file: G:\\GH\\ras-commander\\examples\\example_projects\\Muncie_414_modified\\Muncie.p03\n"
+      "2026-05-12 08:23:50 - ras_commander.RasCmdr - INFO - HEC-RAS execution completed for plan: 03\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:21:52 - ras_commander.RasCmdr - INFO - Set number of cores to 2 for plan: 03\n"
+      "2026-05-12 08:23:50 - ras_commander.RasCmdr - INFO - Total run time for plan 03: 33.36 seconds\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:21:52 - ras_commander.RasCmdr - INFO - Running HEC-RAS from the Command Line:\n"
+      "2026-05-12 08:23:50 - ras_commander.hdf.HdfResultsPlan - INFO - Using existing Path object HDF file: G:\\GH\\ras-commander\\example_projects\\Muncie_414_modified\\Muncie.p03.hdf\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:21:52 - ras_commander.RasCmdr - INFO - Running command: \"C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.6\\Ras.exe\" -c \"G:\\GH\\ras-commander\\examples\\example_projects\\Muncie_414_modified\\Muncie.prj\" \"G:\\GH\\ras-commander\\examples\\example_projects\\Muncie_414_modified\\Muncie.p03\"\n"
+      "2026-05-12 08:23:50 - ras_commander.hdf.HdfResultsPlan - INFO - Final validated file path: G:\\GH\\ras-commander\\example_projects\\Muncie_414_modified\\Muncie.p03.hdf\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:22:29 - ras_commander.RasCmdr - INFO - HEC-RAS execution completed for plan: 03\n"
+      "2026-05-12 08:23:50 - ras_commander.hdf.HdfResultsPlan - INFO - Reading computation messages from HDF: Muncie.p03.hdf\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:22:29 - ras_commander.RasCmdr - INFO - Total run time for plan 03: 36.80 seconds\n"
+      "2026-05-12 08:23:50 - ras_commander.hdf.HdfResultsPlan - INFO - Successfully extracted 2157 characters from HDF\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:22:29 - ras_commander.hdf.HdfResultsPlan - INFO - Using existing Path object HDF file: G:\\GH\\ras-commander\\examples\\example_projects\\Muncie_414_modified\\Muncie.p03.hdf\n"
+      "2026-05-12 08:23:50 - ras_commander.hdf.HdfResultsPlan - INFO - Using existing Path object HDF file: G:\\GH\\ras-commander\\example_projects\\Muncie_414_modified\\Muncie.p03.hdf\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:22:29 - ras_commander.hdf.HdfResultsPlan - INFO - Final validated file path: G:\\GH\\ras-commander\\examples\\example_projects\\Muncie_414_modified\\Muncie.p03.hdf\n"
+      "2026-05-12 08:23:50 - ras_commander.hdf.HdfResultsPlan - INFO - Final validated file path: G:\\GH\\ras-commander\\example_projects\\Muncie_414_modified\\Muncie.p03.hdf\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:22:29 - ras_commander.hdf.HdfResultsPlan - INFO - Reading computation messages from HDF: Muncie.p03.hdf\n"
+      "2026-05-12 08:23:50 - ras_commander.hdf.HdfResultsPlan - INFO - Extracting Plan Information from: Muncie.p03.hdf\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:22:29 - ras_commander.hdf.HdfResultsPlan - INFO - Successfully extracted 2157 characters from HDF\n"
+      "2026-05-12 08:23:50 - ras_commander.hdf.HdfResultsPlan - INFO - Plan Name: Unsteady Run with 2D 50ft Grid\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:22:29 - ras_commander.hdf.HdfResultsPlan - INFO - Using existing Path object HDF file: G:\\GH\\ras-commander\\examples\\example_projects\\Muncie_414_modified\\Muncie.p03.hdf\n"
+      "2026-05-12 08:23:50 - ras_commander.hdf.HdfResultsPlan - INFO - Simulation Duration (hours): 24.0\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:22:29 - ras_commander.hdf.HdfResultsPlan - INFO - Final validated file path: G:\\GH\\ras-commander\\examples\\example_projects\\Muncie_414_modified\\Muncie.p03.hdf\n"
+      "2026-05-12 08:23:50 - ras_commander.hdf.HdfResultsPlan - INFO - Using existing Path object HDF file: G:\\GH\\ras-commander\\example_projects\\Muncie_414_modified\\Muncie.p03.hdf\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:22:29 - ras_commander.hdf.HdfResultsPlan - INFO - Extracting Plan Information from: Muncie.p03.hdf\n"
+      "2026-05-12 08:23:50 - ras_commander.hdf.HdfResultsPlan - INFO - Final validated file path: G:\\GH\\ras-commander\\example_projects\\Muncie_414_modified\\Muncie.p03.hdf\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:22:29 - ras_commander.hdf.HdfResultsPlan - INFO - Plan Name: Unsteady Run with 2D 50ft Grid\n"
+      "2026-05-12 08:23:50 - ras_commander.RasPrj - INFO - Updated results_df with 1 plan(s)\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:22:29 - ras_commander.hdf.HdfResultsPlan - INFO - Simulation Duration (hours): 24.0\n"
+      "2026-05-12 08:23:50 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 7.0 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\7.0\\Ras.exe via filesystem (x86)\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:22:29 - ras_commander.hdf.HdfResultsPlan - INFO - Using existing Path object HDF file: G:\\GH\\ras-commander\\examples\\example_projects\\Muncie_414_modified\\Muncie.p03.hdf\n"
+      "2026-05-12 08:23:50 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 6.7 Beta 5 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.7 Beta 5\\Ras.exe via filesystem (x86)\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:22:29 - ras_commander.hdf.HdfResultsPlan - INFO - Final validated file path: G:\\GH\\ras-commander\\examples\\example_projects\\Muncie_414_modified\\Muncie.p03.hdf\n"
+      "2026-05-12 08:23:50 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 6.5 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.5\\Ras.exe via filesystem (x86)\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:22:29 - ras_commander.RasPrj - INFO - Updated results_df with 1 plan(s)\n"
+      "2026-05-12 08:23:50 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 6.3.1 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.3.1\\Ras.exe via filesystem (x86)\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:22:29 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 7.0 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\7.0\\Ras.exe via filesystem (x86)\n"
+      "2026-05-12 08:23:50 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 6.2 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.2\\Ras.exe via filesystem (x86)\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:22:29 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 6.7 Beta 5 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.7 Beta 5\\Ras.exe via filesystem (x86)\n"
+      "2026-05-12 08:23:50 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 6.1 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.1\\Ras.exe via filesystem (x86)\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:22:29 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 6.5 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.5\\Ras.exe via filesystem (x86)\n"
+      "2026-05-12 08:23:50 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 6.0 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.0\\Ras.exe via filesystem (x86)\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:22:29 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 6.3.1 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.3.1\\Ras.exe via filesystem (x86)\n"
+      "2026-05-12 08:23:50 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 5.0.7 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\5.0.7\\Ras.exe via filesystem (x86)\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:22:29 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 6.2 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.2\\Ras.exe via filesystem (x86)\n"
+      "2026-05-12 08:23:50 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 5.0.6 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\5.0.6\\Ras.exe via filesystem (x86)\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:22:29 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 6.1 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.1\\Ras.exe via filesystem (x86)\n"
+      "2026-05-12 08:23:50 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 5.0.5 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\5.0.5\\Ras.exe via filesystem (x86)\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:22:29 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 6.0 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.0\\Ras.exe via filesystem (x86)\n"
+      "2026-05-12 08:23:50 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 5.0.4 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\5.0.4\\Ras.exe via filesystem (x86)\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:22:29 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 5.0.7 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\5.0.7\\Ras.exe via filesystem (x86)\n"
+      "2026-05-12 08:23:50 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 5.0.3 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\5.0.3\\Ras.exe via filesystem (x86)\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:22:29 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 5.0.6 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\5.0.6\\Ras.exe via filesystem (x86)\n"
+      "2026-05-12 08:23:50 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 5.0.1 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\5.0.1\\Ras.exe via filesystem (x86)\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:22:29 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 5.0.5 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\5.0.5\\Ras.exe via filesystem (x86)\n"
+      "2026-05-12 08:23:50 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 5.0 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\5.0\\Ras.exe via filesystem (x86)\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:22:29 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 5.0.4 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\5.0.4\\Ras.exe via filesystem (x86)\n"
+      "2026-05-12 08:23:50 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 4.1.0 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\4.1.0\\Ras.exe via filesystem (x86)\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:22:29 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 5.0.3 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\5.0.3\\Ras.exe via filesystem (x86)\n"
+      "2026-05-12 08:23:50 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 4.0 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\4.0\\Ras.exe via filesystem (x86)\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:22:29 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 5.0.1 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\5.0.1\\Ras.exe via filesystem (x86)\n"
+      "2026-05-12 08:23:50 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 6.6 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.6\\Ras.exe via filesystem (x86)\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:22:29 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 5.0 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\5.0\\Ras.exe via filesystem (x86)\n"
+      "2026-05-12 08:23:50 - ras_commander.RasUtils - INFO - Discovered 17 installed HEC-RAS version(s)\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:22:29 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 4.1.0 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\4.1.0\\Ras.exe via filesystem (x86)\n"
+      "2026-05-12 08:23:50 - ras_commander.RasPrj - INFO - HEC-RAS 6.6 found via version discovery: C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.6\\Ras.exe\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:22:29 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 4.0 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\4.0\\Ras.exe via filesystem (x86)\n"
+      "2026-05-12 08:23:50 - ras_commander.RasMap - INFO - Successfully parsed RASMapper file: G:\\GH\\ras-commander\\example_projects\\Muncie_414_modified\\Muncie.rasmap\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:22:29 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 6.6 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.6\\Ras.exe via filesystem (x86)\n"
+      "2026-05-12 08:23:50 - ras_commander.hdf.HdfBase - INFO - Found projection in HDF file: G:\\GH\\ras-commander\\example_projects\\Muncie_414_modified\\Muncie.g02.hdf\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:22:29 - ras_commander.RasUtils - INFO - Discovered 17 installed HEC-RAS version(s)\n"
+      "2026-05-12 08:23:50 - ras_commander.hdf.HdfResultsPlan - INFO - Using existing Path object HDF file: G:\\GH\\ras-commander\\example_projects\\Muncie_414_modified\\Muncie.p03.hdf\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:22:29 - ras_commander.RasPrj - INFO - HEC-RAS 6.6 found via version discovery: C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.6\\Ras.exe\n"
+      "2026-05-12 08:23:50 - ras_commander.hdf.HdfResultsPlan - INFO - Final validated file path: G:\\GH\\ras-commander\\example_projects\\Muncie_414_modified\\Muncie.p03.hdf\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:22:29 - ras_commander.RasMap - INFO - Successfully parsed RASMapper file: G:\\GH\\ras-commander\\examples\\example_projects\\Muncie_414_modified\\Muncie.rasmap\n"
+      "2026-05-12 08:23:50 - ras_commander.hdf.HdfResultsPlan - INFO - Reading computation messages from HDF: Muncie.p03.hdf\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:22:29 - ras_commander.hdf.HdfBase - INFO - Found projection in HDF file: G:\\GH\\ras-commander\\examples\\example_projects\\Muncie_414_modified\\Muncie.g02.hdf\n"
+      "2026-05-12 08:23:50 - ras_commander.hdf.HdfResultsPlan - INFO - Successfully extracted 2157 characters from HDF\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:22:29 - ras_commander.hdf.HdfResultsPlan - INFO - Using existing Path object HDF file: G:\\GH\\ras-commander\\examples\\example_projects\\Muncie_414_modified\\Muncie.p03.hdf\n"
+      "2026-05-12 08:23:50 - ras_commander.hdf.HdfResultsPlan - INFO - Using existing Path object HDF file: G:\\GH\\ras-commander\\example_projects\\Muncie_414_modified\\Muncie.p03.hdf\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:22:29 - ras_commander.hdf.HdfResultsPlan - INFO - Final validated file path: G:\\GH\\ras-commander\\examples\\example_projects\\Muncie_414_modified\\Muncie.p03.hdf\n"
+      "2026-05-12 08:23:50 - ras_commander.hdf.HdfResultsPlan - INFO - Final validated file path: G:\\GH\\ras-commander\\example_projects\\Muncie_414_modified\\Muncie.p03.hdf\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:22:29 - ras_commander.hdf.HdfResultsPlan - INFO - Reading computation messages from HDF: Muncie.p03.hdf\n"
+      "2026-05-12 08:23:50 - ras_commander.hdf.HdfResultsPlan - INFO - Extracting Plan Information from: Muncie.p03.hdf\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:22:29 - ras_commander.hdf.HdfResultsPlan - INFO - Successfully extracted 2157 characters from HDF\n"
+      "2026-05-12 08:23:50 - ras_commander.hdf.HdfResultsPlan - INFO - Plan Name: Unsteady Run with 2D 50ft Grid\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:22:29 - ras_commander.hdf.HdfResultsPlan - INFO - Using existing Path object HDF file: G:\\GH\\ras-commander\\examples\\example_projects\\Muncie_414_modified\\Muncie.p03.hdf\n"
+      "2026-05-12 08:23:50 - ras_commander.hdf.HdfResultsPlan - INFO - Simulation Duration (hours): 24.0\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:22:29 - ras_commander.hdf.HdfResultsPlan - INFO - Final validated file path: G:\\GH\\ras-commander\\examples\\example_projects\\Muncie_414_modified\\Muncie.p03.hdf\n"
+      "2026-05-12 08:23:50 - ras_commander.hdf.HdfResultsPlan - INFO - Using existing Path object HDF file: G:\\GH\\ras-commander\\example_projects\\Muncie_414_modified\\Muncie.p03.hdf\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:22:29 - ras_commander.hdf.HdfResultsPlan - INFO - Extracting Plan Information from: Muncie.p03.hdf\n"
+      "2026-05-12 08:23:50 - ras_commander.hdf.HdfResultsPlan - INFO - Final validated file path: G:\\GH\\ras-commander\\example_projects\\Muncie_414_modified\\Muncie.p03.hdf\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:22:29 - ras_commander.hdf.HdfResultsPlan - INFO - Plan Name: Unsteady Run with 2D 50ft Grid\n"
+      "2026-05-12 08:23:50 - ras_commander.RasPrj - INFO - Updated results_df with 3 plan(s)\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:22:29 - ras_commander.hdf.HdfResultsPlan - INFO - Simulation Duration (hours): 24.0\n"
+      "2026-05-12 08:23:50 - ras_commander.RasPrj - INFO - ras-commander v0.96.2 | An open-source project of CLB Engineering Corporation (https://clbengineering.com/) | Docs: https://ras-commander.readthedocs.io | GitHub: https://github.com/gpt-cmdr/ras-commander\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:22:29 - ras_commander.hdf.HdfResultsPlan - INFO - Using existing Path object HDF file: G:\\GH\\ras-commander\\examples\\example_projects\\Muncie_414_modified\\Muncie.p03.hdf\n"
+      "2026-05-12 08:23:50 - ras_commander.RasPrj - INFO - Project initialized: Muncie | Folder: G:\\GH\\ras-commander\\example_projects\\Muncie_414_modified\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:22:29 - ras_commander.hdf.HdfResultsPlan - INFO - Final validated file path: G:\\GH\\ras-commander\\examples\\example_projects\\Muncie_414_modified\\Muncie.p03.hdf\n"
+      "2026-05-12 08:23:50 - ras_commander.RasPrj - INFO - Using HEC-RAS executable: C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.6\\Ras.exe\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:22:29 - ras_commander.RasPrj - INFO - Updated results_df with 3 plan(s)\n"
+      "2026-05-12 08:23:50 - ras_commander.hdf.HdfResultsPlan - INFO - Final validated file path: G:\\GH\\ras-commander\\example_projects\\Muncie_414_modified\\Muncie.p03.hdf\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:22:29 - ras_commander.RasPrj - INFO - ras-commander v0.93.0 | An open-source project of CLB Engineering Corporation (https://clbengineering.com/) | Docs: https://ras-commander.readthedocs.io | GitHub: https://github.com/gpt-cmdr/ras-commander\n"
+      "2026-05-12 08:23:50 - ras_commander.hdf.HdfResultsPlan - INFO - Reading computation messages from HDF: Muncie.p03.hdf\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:22:29 - ras_commander.RasPrj - INFO - Project initialized: Muncie | Folder: G:\\GH\\ras-commander\\examples\\example_projects\\Muncie_414_modified\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-11 20:22:29 - ras_commander.RasPrj - INFO - Using HEC-RAS executable: C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.6\\Ras.exe\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-11 20:22:29 - ras_commander.hdf.HdfResultsPlan - INFO - Final validated file path: G:\\GH\\ras-commander\\examples\\example_projects\\Muncie_414_modified\\Muncie.p03.hdf\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-11 20:22:29 - ras_commander.hdf.HdfResultsPlan - INFO - Reading computation messages from HDF: Muncie.p03.hdf\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-11 20:22:29 - ras_commander.hdf.HdfResultsPlan - INFO - Successfully extracted 2157 characters from HDF\n"
+      "2026-05-12 08:23:50 - ras_commander.hdf.HdfResultsPlan - INFO - Successfully extracted 2157 characters from HDF\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Modified complete (74 message lines, no errors)\n"
+      "Modified: 74 messages, 0 errors\n"
      ]
     }
    ],
    "source": [
-    "# Run modified (independent RasPrj instance)\n",
     "modified_ras = init_ras_project(modified_path, RAS_VERSION, ras_object=\"new\")\n",
     "print(\"Running modified model (2x Manning's n)...\")\n",
-    "RasCmdr.compute_plan(\n",
-    "    PLAN_NUMBER,\n",
-    "    ras_object=modified_ras,\n",
-    "    num_cores=2,\n",
-    "    force_geompre=True,\n",
-    ")\n",
+    "RasCmdr.compute_plan(PLAN_NUMBER, ras_object=modified_ras, num_cores=2, force_geompre=True)\n",
     "modified_ras = init_ras_project(modified_path, RAS_VERSION, ras_object=\"new\")\n",
     "\n",
     "messages = HdfResultsPlan.get_compute_messages(PLAN_NUMBER, ras_object=modified_ras)\n",
     "if messages:\n",
     "    lines = messages.splitlines()\n",
-    "    real_errors = [l for l in lines if \"ERROR\" in l.upper()\n",
-    "                   and \"VOLUME ACCOUNTING\" not in l.upper()\n",
-    "                   and \"WSEL ERROR\" not in l.upper()\n",
-    "                   and \"ITERATIONS\" not in l.upper()]\n",
-    "    if real_errors:\n",
-    "        print(f\"ERRORS ({len(real_errors)}):\")\n",
-    "        for e in real_errors[:5]:\n",
-    "            print(f\"  {e}\")\n",
-    "    else:\n",
-    "        print(f\"Modified complete ({len(lines)} message lines, no errors)\")\n",
+    "    errors = [l for l in lines if \"ERROR\" in l.upper()\n",
+    "              and \"VOLUME ACCOUNTING\" not in l.upper()\n",
+    "              and \"WSEL ERROR\" not in l.upper()\n",
+    "              and \"ITERATIONS\" not in l.upper()]\n",
+    "    print(f\"Modified: {len(lines)} messages, {len(errors)} errors\")\n",
     "else:\n",
-    "    print(\"Modified complete (no compute messages file)\")"
+    "    print(\"Modified complete\")"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Step 5: Verify Face Property Tables Reflect Modified n\n",
-    "\n",
-    "After preprocessing, the geometry HDF contains per-face property tables with Manning's n\n",
-    "values derived from the land cover table. We verify that the modified model's face tables\n",
-    "have higher n values than the baseline."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 8,
+   "id": "c935d7b9",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-05-12T00:22:29.278664Z",
-     "iopub.status.busy": "2026-05-12T00:22:29.278664Z",
-     "iopub.status.idle": "2026-05-12T00:22:29.480658Z",
-     "shell.execute_reply": "2026-05-12T00:22:29.480658Z"
-    }
+    "papermill": {
+     "duration": 0.008045,
+     "end_time": "2026-05-12T12:23:50.436109+00:00",
+     "exception": false,
+     "start_time": "2026-05-12T12:23:50.428064+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-11 20:22:29 - ras_commander.hdf.HdfMesh - INFO - Using existing Path object HDF file: G:\\GH\\ras-commander\\examples\\example_projects\\Muncie_414_baseline\\Muncie.g02.hdf\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-11 20:22:29 - ras_commander.hdf.HdfMesh - INFO - Final validated file path: G:\\GH\\ras-commander\\examples\\example_projects\\Muncie_414_baseline\\Muncie.g02.hdf\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-11 20:22:29 - ras_commander.hdf.HdfMesh - INFO - Using existing Path object HDF file: G:\\GH\\ras-commander\\examples\\example_projects\\Muncie_414_baseline\\Muncie.g02.hdf\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-11 20:22:29 - ras_commander.hdf.HdfMesh - INFO - Final validated file path: G:\\GH\\ras-commander\\examples\\example_projects\\Muncie_414_baseline\\Muncie.g02.hdf\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-11 20:22:29 - ras_commander.hdf.HdfMesh - INFO - Using existing Path object HDF file: G:\\GH\\ras-commander\\examples\\example_projects\\Muncie_414_modified\\Muncie.g02.hdf\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-11 20:22:29 - ras_commander.hdf.HdfMesh - INFO - Final validated file path: G:\\GH\\ras-commander\\examples\\example_projects\\Muncie_414_modified\\Muncie.g02.hdf\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-11 20:22:29 - ras_commander.hdf.HdfMesh - INFO - Using existing Path object HDF file: G:\\GH\\ras-commander\\examples\\example_projects\\Muncie_414_modified\\Muncie.g02.hdf\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-11 20:22:29 - ras_commander.hdf.HdfMesh - INFO - Final validated file path: G:\\GH\\ras-commander\\examples\\example_projects\\Muncie_414_modified\\Muncie.g02.hdf\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Baseline geom HDF: Muncie.g02.hdf (exists: True)\n",
-      "Modified geom HDF: Muncie.g02.hdf (exists: True)\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "Mesh: '2D Interior Area'\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Baseline faces: 11164, rows: 47055\n",
-      "Modified faces: 11164, rows: 47055\n",
-      "\n",
-      "Manning's n statistics:\n",
-      "  Baseline mean: 0.0600\n",
-      "  Modified mean: 0.1200\n",
-      "  Ratio (mod/base): 2.00x\n",
-      "\n",
-      "Sample face 1050:\n",
-      "  Baseline n range: 0.0600 - 0.0600\n",
-      "  Modified n range: 0.1200 - 0.1200\n",
-      "\n",
-      "Verified: Modified face tables have higher Manning's n (2.00x baseline)\n"
-     ]
-    }
-   ],
    "source": [
-    "# Resolve geometry HDF paths\n",
-    "baseline_geom_hdf = baseline_path / f\"{baseline_ras.project_name}.g{str(geom_num).zfill(2)}.hdf\"\n",
-    "modified_geom_hdf = modified_path / f\"{modified_ras.project_name}.g{str(geom_num).zfill(2)}.hdf\"\n",
+    "## Step 5: Face Property Table Comparison\n",
     "\n",
-    "print(f\"Baseline geom HDF: {baseline_geom_hdf.name} (exists: {baseline_geom_hdf.exists()})\")\n",
-    "print(f\"Modified geom HDF: {modified_geom_hdf.name} (exists: {modified_geom_hdf.exists()})\")\n",
-    "\n",
-    "# Read face property tables from both\n",
-    "base_tables = HdfMesh.get_mesh_face_property_tables(baseline_geom_hdf)\n",
-    "mod_tables = HdfMesh.get_mesh_face_property_tables(modified_geom_hdf)\n",
-    "\n",
-    "mesh_name = MESH_NAME\n",
-    "base_df = base_tables[mesh_name]\n",
-    "mod_df = mod_tables[mesh_name]\n",
-    "\n",
-    "print(f\"\\nMesh: '{mesh_name}'\")\n",
-    "print(f\"Baseline faces: {base_df['Face ID'].nunique()}, rows: {len(base_df)}\")\n",
-    "print(f\"Modified faces: {mod_df['Face ID'].nunique()}, rows: {len(mod_df)}\")\n",
-    "\n",
-    "# Compare Manning's n values across all faces\n",
-    "n_col = \"Manning's n\"\n",
-    "base_n_mean = base_df[n_col].mean()\n",
-    "mod_n_mean = mod_df[n_col].mean()\n",
-    "\n",
-    "print(f\"\\nManning's n statistics:\")\n",
-    "print(f\"  Baseline mean: {base_n_mean:.4f}\")\n",
-    "print(f\"  Modified mean: {mod_n_mean:.4f}\")\n",
-    "print(f\"  Ratio (mod/base): {mod_n_mean / base_n_mean:.2f}x\")\n",
-    "\n",
-    "# Show a sample face\n",
-    "sample_face = base_df.groupby('Face ID').size().idxmax()\n",
-    "base_sample = base_df[base_df['Face ID'] == sample_face]\n",
-    "mod_sample = mod_df[mod_df['Face ID'] == sample_face]\n",
-    "\n",
-    "print(f\"\\nSample face {sample_face}:\")\n",
-    "print(f\"  Baseline n range: {base_sample[n_col].min():.4f} - {base_sample[n_col].max():.4f}\")\n",
-    "print(f\"  Modified n range: {mod_sample[n_col].min():.4f} - {mod_sample[n_col].max():.4f}\")\n",
-    "\n",
-    "# Verify that modified n values are consistently higher\n",
-    "assert mod_n_mean > base_n_mean, \\\n",
-    "    f\"Modified Manning's n ({mod_n_mean:.4f}) should be higher than baseline ({base_n_mean:.4f})\"\n",
-    "print(f\"\\nVerified: Modified face tables have higher Manning's n ({mod_n_mean/base_n_mean:.2f}x baseline)\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Step 6: Compare Simulation Results\n",
-    "\n",
-    "Higher Manning's n increases flow resistance, which should produce higher water surface\n",
-    "elevations (more ponding) in the modified model."
+    "The face property tables encode Manning's n as a function of elevation for\n",
+    "each cell face. After doubling the uniform n, every face should show 0.12\n",
+    "instead of 0.06. We visualize a representative face to confirm."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 9,
+   "id": "873253bb",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T00:22:29.482669Z",
-     "iopub.status.busy": "2026-05-12T00:22:29.482669Z",
-     "iopub.status.idle": "2026-05-12T00:22:29.489488Z",
-     "shell.execute_reply": "2026-05-12T00:22:29.489488Z"
+     "iopub.execute_input": "2026-05-12T12:23:50.454443Z",
+     "iopub.status.busy": "2026-05-12T12:23:50.453784Z",
+     "iopub.status.idle": "2026-05-12T12:23:50.836670Z",
+     "shell.execute_reply": "2026-05-12T12:23:50.835545Z"
+    },
+    "papermill": {
+     "duration": 0.393233,
+     "end_time": "2026-05-12T12:23:50.837625+00:00",
+     "exception": false,
+     "start_time": "2026-05-12T12:23:50.444392+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:23:50 - ras_commander.hdf.HdfMesh - INFO - Using existing Path object HDF file: G:\\GH\\ras-commander\\example_projects\\Muncie_414_baseline\\Muncie.g02.hdf\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:23:50 - ras_commander.hdf.HdfMesh - INFO - Final validated file path: G:\\GH\\ras-commander\\example_projects\\Muncie_414_baseline\\Muncie.g02.hdf\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:23:50 - ras_commander.hdf.HdfMesh - INFO - Using existing Path object HDF file: G:\\GH\\ras-commander\\example_projects\\Muncie_414_baseline\\Muncie.g02.hdf\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:23:50 - ras_commander.hdf.HdfMesh - INFO - Final validated file path: G:\\GH\\ras-commander\\example_projects\\Muncie_414_baseline\\Muncie.g02.hdf\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:23:50 - ras_commander.hdf.HdfMesh - INFO - Using existing Path object HDF file: G:\\GH\\ras-commander\\example_projects\\Muncie_414_modified\\Muncie.g02.hdf\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:23:50 - ras_commander.hdf.HdfMesh - INFO - Final validated file path: G:\\GH\\ras-commander\\example_projects\\Muncie_414_modified\\Muncie.g02.hdf\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:23:50 - ras_commander.hdf.HdfMesh - INFO - Using existing Path object HDF file: G:\\GH\\ras-commander\\example_projects\\Muncie_414_modified\\Muncie.g02.hdf\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:23:50 - ras_commander.hdf.HdfMesh - INFO - Final validated file path: G:\\GH\\ras-commander\\example_projects\\Muncie_414_modified\\Muncie.g02.hdf\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Baseline: 11164 faces, 47055 rows\n",
+      "Modified: 11164 faces, 47055 rows\n",
+      "Baseline mean n: 0.0600\n",
+      "Modified mean n: 0.1200\n",
+      "Ratio: 2.00x\n"
+     ]
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAABKMAAAIDCAYAAADYNt3FAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjgsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvwVt1zgAAAAlwSFlzAAAPYQAAD2EBqD+naQAA2XlJREFUeJzs3Qd4FFUXxvE3Cb2DdKQJUlRAadYPRBERG0VAxIa9i11UpNh7xa6oqCgKiKAgqNhREURAmlIEASH0TiDZ7zl3nGSz2UASkt1N8v89z2Z3Zja7s3dmd+6cuffcuEAgEBAAAAAAAAAQAfGReBMAAAAAAADAEIwCAAAAAABAxBCMAgAAAAAAQMQQjAIAAAAAAEDEEIwCAAAAAABAxBCMAgAAAAAAQMQQjAIAAAAAAEDEEIwCAAAAAABAxBCMAgAAAAAAQMQQjAIAAGG9+eabiouLc/dZVa9ePXdDwRYIBNSqVSt16tQpautg++aJJ56YYf6ff/6pbt26qUaNGoqPj1eFChWisn7I3d+WrO4D99xzj8qWLas1a9awCQAghhGMAoAYtmzZMlfZ3tdt06ZNyg/shCF4ve0ksWLFivrf//7nTkjs5Lagyq0Tr6yW7f5uX3/9tfKr7du368EHH1TLli1VpkwZFS9eXAcffLDbjwYMGKDFixfni+CY/92++OKLlR+9/fbbmjlzpoYOHRp2X7TPl5msPCenkpOT1bVrV3322Wc6/fTTde+99+rOO+9UYRd8LKlevbr27t0b9nnz589PfV4sfm+y4pZbbnHHl0GDBkV7VQAA+1BkXwsBALGhQYMGOv/888MuK1GihPLbiYIFEeykccmSJRozZoy+//57zZgxQ88991y0Vy9fsoBGaOuAjz/+WL///rsuuuiiDCeV+fUkc+vWrTrhhBM0e/ZsNWzY0H0nDjroIK1bt06//PKLHn74YfddsRvyTkpKigYPHuwCgMccc0zUitoCJ6VKlUo3b+nSpZo3b54uv/xyvfLKK1Fbt1hVpEgR12LIgnVnnXVWhuWvv/66C+TkZ3aR47LLLtMzzzzjAtR169aN9ioBAMIgGAUA+YCdeNvJX0Fw6623uivzvjlz5ujoo4/WsGHDdPPNN6t+/fpRXb/8KFzrGmsJYcGocIGq/Orpp592gSg70bRAg7XeCA1E7N69O2rrV1hMnDjR7V933313VNejSZMmGeatWrXK3desWTMKaxT7jjvuOPe78MYbb2QIRllrqXfeeUcdO3bUN998o/zMAtVPPvmkXnvtNd13333RXh0AQBj5+9IHAMCxVkXXXXedjjjiCJUvX14lS5ZUs2bNXEuRPXv2hC2ltWvXulZKjRs3ds+vVKmSCwo9/vjjGZ5rAYBzzz3X5WApVqyYu9J8/fXXa/369Qe8BWw927dv77rp/frrr26eBVAs0GAtp5544gkddthhrjtWcNBl7ty56tWrl6pWreqWWRCrf//+YdfJ76plXRqvvPJKFwyzFmVHHXWURo4cGXa9bH3shO34449XuXLlXAuM1q1bu3mhLFDod3+zrnjWhcyeb0EgW+d+/fq559l9cHc5Yy19rLXC6tWrw67HhRde6J47bdo0HaikpCTX+uzUU09V7dq1XblZ+XXv3l2//fbbPv933Lhxatu2rftcVapU0SWXXJKtnCzZKc/M+GVw7bXXZghEGdsH/ACF3y3p77//drfgcvcDu7a9/Okff/zR5T+y/EL+awcvz043u/19t2wf8YOub731VtgulP53IFxXtuD9zbe/z5Jb28AMHz7cvW6PHj2UF11ZJ0+e7IImtn7W8s1a94X7XofmC7LvuP2WmCFDhmTY3sZa0dnvhJW/v//b74j9noTa3++Q/7uyefNmXX311e73sXTp0mrXrp3rwugHxywwYu9j+4JtF8tplVV+l0b7HbfPYe9n69CoUSO98MIL2SxluXWw3/JPP/3U7afBJkyY4L7T9t3eVzdZ6/5m3zP7DbV927pD/vDDD2Gfv2HDBl111VWqVq2a255t2rTR2LFj97mOuXG8sd92u4iTV12jAQAHjpZRAFAAvPrqqxo/frw7CerSpYt27NjhTk6ti8L06dM1evTodM9fuHChOnTo4AIgFgyxHCt2kvHHH3+4fDzWesn3ySefuJM167px9tlnuyCGdYN5/vnn9fnnn+vnn3923SJyQ2iAwU5AfvrpJ3eyc+aZZ7oTOmPd+iygYsGVc845x52gWaDCumXYCZX9T+XKldO9lj3Xrvhv27ZNF1xwgfu8o0aN0nnnnedOUO29gk/a+/bt6wJVhx56qHuOnRRNmTJFl156qfv84YJ2jz32mKZOnerKyU46ExIS3MmXBcEsmGPzjzzyyHT/Y8ExO5GzE/y77ror3TL7v48++kiHH364jj322AMuXzsxtBNx615l+4ltNzvRtm1srV2+/fZbt76hbP+xbW1lbWVo5Wvr+91337nucfvb/jktz1AWmDCLFi3KUI6hLBBjJ83WmsrY5/aFthSz4I3t9/aduOKKK7R8+XLlVFa+W7buN954o9tfW7Ro4Z6TW10oM/ssubUN7HVsH7dAW25974PZvmiBEvu+W0DK9knLT2W5wOx7vy+2jWfNmuUCfBaU8rezf5+YmOi+R/ZaNs8CHtaazr5j9p62j9s2C5XZ75D/u3LKKado165d6t27twvm2O+KfU9sW9jvlAVVLCD1119/ud9pex3rYmi/D1nVp08f91077bTT3P/Ze1hQtmjRoq5LYnZYsOnll1/WiBEjXNDUZ0FJCy4F74/B7DOedNJJbj0s4G7lbZ/3gw8+cGVn+1bPnj1Tn2/HIStna/1q5W7bZMWKFa6cMkt8n5vHG3tP+4z2e2HBOwBAjAkAAGLW0qVLLat3oEGDBoFBgwZluE2bNs097++//w7s3bs33f+mpKQELrnkEvf/33//fbplrVu3dvNfeeWVDO+5YsWK1Mfr1q0LlCtXLlCrVq3AsmXL0j1v5MiR7jWuu+66LH2W9u3bu+evXr063fy5c+cGSpYsGYiLi3Of11x00UXuuQcffLD7bMGSk5NdedjySZMmpVt22223ufn2uYPVrVvXzW/Xrl1g9+7d6T5r5cqVA8WLFw/8888/qfOtXOz5/fr1CyQlJaXOt/8988wz3bJff/01db5tC5tXunTpwOzZszN89uHDh7vldh9q586dgUqVKgUOOeQQt82CPf/88+7/nn766UB2+WU4derU1Hm7du1K9zmDt0GZMmUCHTt2DLve4cr6zjvvDLv9raztFiy75ZmZcePGueeWLVs2cMsttwQ+//xzt4/uS7j18VnZ+J/vjTfeyHS5bd/MvptWzjn5bmX2/6Hbz/9OBPP3t+Btu7/Pklvb4I8//nDP7du37z6/5+HWe1/P8fe1IkWKpPu9st+1E0880S3zf+98Ns9eK6vbzD67LRswYEC6+Z9++qmb37BhQ/f74tvX71Dw70rPnj0De/bsSZ3/yCOPuPkVKlQI3HTTTem+11dffbVbNnr06EzLJ1xZHX300YHNmzenzl+wYIErq8aNG2fpdfz97dRTT3XTRxxxRODwww9PXW6/y/Z6119/vZu238TQ782QIUNSt33wZ5o5c2agWLFi7vNu2bIlw356+eWXp3sd+y3x99Xg38ScHG/C7QO+Z555JtPvAwAg+ghGAUAM808gMrs99dRT+/z/GTNmuOcNHjw4dd7PP/+cGpjZnyeffNI99+233w67vGXLli6Yk52TKgsi2EnKPffc405qLBBl82+44YYMJ4F2MhHq22+/dctOO+20DMu2bt3qAjslSpRIF3TyTxpDg3Lmvvvuc8sef/zx1HnNmzd3gaUdO3ZkeL4Fm/zPEXrSZSee4ewrGGXs/2z5F198kW7+UUcd5U4K169fH8iNYNS+WEDCTiiDAxX+eocGqfyytpNPO3kMPoEPF/zJbnnuyxNPPOECZ8HfAwtOXnvttYFFixblKBhl+/G+lmc1GJWd71ZeBaMy+yy5tQ0sAGjPvfnmm/MkGHXhhRdmeL6/7Nlnn81xMMp+D+x34aCDDgps3749w3uccsop7v/s9yUrv0PBvyuhgarly5e7+bafhr6X//t17733BrLCL6uvvvoq02XBAaCsBqP83/affvrJTT/88MNu+rfffss0GGUB86JFi6YLqvos4BR6rKhfv777TQm9AGFOPvnkDL+JOTne7CsY9f7777vlQ4cO3WfZAACig256AJAPWFePSZMmZbrcuopYN4b3339fCxYscF3RvHp6+qS+xrpYmMy6SQSzrinGukZY15Zw3Tasi5vdQrvFZcZyr/hd8ixvjeWssW5ClhsplOUoCuXnNgqXlNtG6bPXs5wz1l3K8lH5LC9TuK5u1mUt+HWta4l1K7EEyI888kiG5/s5uKycs7K+WWHdqZ566inX3fLkk09OzQNm62TdqazrTG6xbkyPPvqo6/L077//ZsgpZtvSuhWFK6PQsrbuZtYd1Lr6WX6WcA6kPMOxJPfWLcm+D9YNyvKM2f5pCfBtJDDrMhRulLB9Cdc1MSey893KK+E+S25uAz9vj3WDzAutWrXKMO/ggw9O7baaU/bZ7PfKui+GjsBnbL51WbTvR+j+vq/vtXUZq1OnTrp5/vfHukOGvpe/LPg3OTfKpWzZstl6Pes2eMcdd7iueZbPzLrdWp6lzLq/btmyxX3PmzZtmvq+oeVnv19WftYN2p5vXSAtz1bwgBU+K+Mvv/wyT483/u+mPR8AEHsIRgFAAWC5fCwXieXFsHwcltPEconYSYrlpQkeYcyS7ZpatWplKceQsRP9fbGcOFkNRlkunXAnJ+FY0ttQdpKT2bLgkz3/eT5bv3BDlvuv45fLxo0bXSBv5cqVLgnyvj5zVtY3KywZsOVT+fjjj93JvuVGslGgTHbzweyLBW8s54sfMLGTZQsqWWDQ3ttG2Qo3Gl1mnyu07MI5kPLMjJ14W24aPz+Nvb/l27KEzhbYtPeyfEhZldPtFio73628Eu6z5OY2sATYfmAgHP87lpKSkulr+MvCfR8tQB3KAskmOTlZOZXT3419/c/+1ndfyzIbWCIn75OTcrFBCCz/lV3AsO+RBe9tcIPcKj//Pji/VrBwr5Pbx5udO3e6+3DBRwBA9BGMAoB8zhKUWyDKWk9ZEt7gpLh2pdmCUcH8Fg12YprVEyBrVWEj9UVauBHT/HXKbCQ3a+0T/DyfXR23k+DQE2D/dWwUwuD/s5YI/uh+B7K+WWUjTtlw6pas2ZKa+4mmw7UAy6kHHnjABZss8XhoombbVywYFU5mZR1aduEcSHlmlb2/tQy0/d9GzrP9NVxLkuxuN39fsSHvQ4ULwGXnu7U/2X3vrHxncmMbWBAjOHAQyt8XLKh6yCGHhH2O31JlX/tNbsvp78aBfq9jmQVux4wZ40YHtJHxLMF9bpWffx86Yp8v3Ovk9vHG30f9fRYAEFsyXpICAOQrfncGG6EpdHQmCzqE8rucWFe2/bHuG8ZGqosV1pXEBA9rH3zF3E62rfWGjfYVzE7qw30Ov4z817VWN9YVxUa7OpBuQcH87bKvFgzdu3d3J03WIurDDz90AYfLLrtMub2vWNeV0ECUdePyh6IPJ9x+ZF1BrUuOnUBmFnTIq/IMxwIGpUuXDlv2OW1R44/aFS645HfrzOl3a3/7RHbfe19ycxvYyI4WKLOWNOH4XWMz+82wINWff/7purZFMhhlrQ8t4GLBe9vfQ/m/J/sbpbEgsQsY1orP9jEbQW9fo9T533MbETDcPhlafvb8+vXru+f7gar9/abk9vHG30eDu2sDAGIHwSgAyOfq1q3r7kOHPbeh5B966KGwOWXsZkOmW46PUMEnGv369XMnsnfffbd7vVB2Uufn+YiU448/Xg0aNNDEiRP1xRdfpFt2//33u5NdGwY9XDct68pl+bV8//zzj2s5Vrx4cTfMu++GG25wn826yIXrumS5UJYtW5bldfZzl9iw5pmx9bUWCjaMua2ndbO06dzeV6zLVvC2tGDIrbfe6oa9z4yVsw2rHtrKygIblusrXHerYLlVnjYcvQUTwrFuhhZssdZJwa0qrOytJU5m3cr2xQKatv/bcPPBLYGsVYftawfy3bITfwugZbZP+Lmf3nzzzXTzP/roI9eCLrtyaxtY+TZv3twFfcN1xbPWNbY/PPbYY+77Fcyef9ttt7nAcLgccXnJvl/2u2D7QujvouUfs/3b8p7Z70thYQFR+96MHTs27LEi1EUXXeS6Fw4YMCBdTsLZs2e7/dSCixbU8lnuKPu9vffee9O9jgVrQ/NF5cXxxnJPWVfG4447Lsv/AwCIHLrpAUA+Z60x7DZq1CiXj+mYY47R8uXL3Qm0tZayk9dQ7777ruv+ZYmzR4wY4RJ728m6nQBYqws/SbG11LHuYpZTpEWLFurcubNrYWBdvezE1U6KraK/r+Tquc1OdO3Ex67qd+nSxa2bBVnsarpdnbdA1cMPPxw2p4mdhNuJtOVKscdWZvZZn3322XR5fqybnJ30vPXWW/rhhx/UsWNHl/zZghCWCNlOct577z3Vq1cvS+ts5WuttZ5++mkXDPK7jdxzzz3pnmfv+/jjj7vkxj169Mg030pOXX/99e5E0FpG9erVy7UUsTKzIIntD+Fam5kzzjjDlZnlJrPPbGUzdepUV9ZDhw7d7/vmVnlaANK6M/pBA3sN2462z1pLC9s3LG+UBRd9liPLAiennXaaS5psQYl27dq52/7Yc63MHnzwQbVs2VJnn322tm7d6rrFWo6vcEmWs/rdslxdfuDKTtqtS6atvz22/dney8rX9nULWFnLPQu2ffXVV26//+yzz/a7/nmxDUy3bt00aNAg93qhJ/oWwLN9+JZbbnHJq+1z2OexHEKWINzey8rEAq6RZsnb7TfLAomWP81a4tjvmLVEtLxClsR7f4HVgsYGfLBbVtx+++2uK6zt17Yv2mAL1g3PBg2wAKMFYIMTqdvzrRugzbf9375zti/b764dm+y1guXm8cZabtr+ecopp4RtMQkAiAFRGsUPAJAFocNxZ2bt2rWBSy65JFCzZk03fHmzZs0Cw4YNCyxZsiTT4eP//fffwI033uiG67bhtytVqhQ4+uij3fDaoRYsWBC49NJL3VDf9tyKFSu697jhhhsCv/zyS5a2pT8MebhhvrMzrH3wcPTnnHOOG+rbhhu3dbPPk5iYmOG5tsxuGzZsCFxxxRWBatWquaHLW7RoEXjvvfcyfY8PPvgg0LFjR/d57T1q1aoVOPHEEwNPPPFEuvexYeRtfW1Y+cx8+umngTZt2gRKlizpnpvZIfiEE05wyyZNmhQ4EH4Zhq7TRx995IZIL1WqlCu7Xr16BRYvXhy2zG3YdX/49Y8//jh1/Q866KDAxRdfHHZb+mV9IOWZGdsPH3300cApp5ziho23fd1uDRo0cOv/66+/ZvifrVu3umHna9SoEUhISHCfx7aXsbIJng4nOTk5MHjw4EDt2rXdvt+oUaPAM888kyvfrYULFwa6dOkSqFChQiAuLi7D9rJt0bVr10DZsmUDpUuXDpx88smB6dOnh93fsvJZcmMbmJUrVwaKFCkSuPrqqzN9zldffeXWvXr16u655cqVC7Rt29a9z65duzI8P3hfC5XZZ7N59ruSlef67DPa75bto/b57TtgvyNz5szJ9u/Qvvb1cOsW/Jsebr/Z1+9mTn8ns3ss8dnvY7jPtm3btsDAgQPd98D2bdt3TzvttMB3330X9nXWr1/vfnOrVKnivqutWrUKjBkzZp/bOzvHm8zK+c0333TL7HcLABCb4uxPtANiAADkJb+1R3a61kWDtaCxYdOt1YwNo17YWmkg/7AWXH7C+ODWMEAssFaQ1urPWnCF5lIEAMQGarkAAMQI6yZk3bisSxWBKMQy6+q2c+dOPffcc9FeFSAdy0dlORStWyaBKACIXeSMAgAgyizHlSUQtwTdlifqmmuuifYqAftkeaAs/5S1PgFiiY1EannLLLcZACB20U0PAFDgxXo3PRtVzUbPs6S91tLEktADAAAABRXBKAAAAAAAAEQMOaMAAAAAAAAQMQSjAAAAAAAAEDEEowAAAAAAABAxBKMAAAAAAAAQMQSjAAAAAAAAEDEEowAAAAAAABAxBKMAAAAAAAAQMQSjAAAAAAAAEDEEowAAAAAAABAxBKMAAAAAAAAQMQSjAAAAAAAAEDEEowAAAAAAABAxBKMAAAAAAAAQMQSjAAAAAAAAEDEEowAAAAAAABAxBKMAAAAAAAAQMQSjAAAAAAAAEDEEowAAAAAAABAxBKMAAAAAAAAQMQSjAAAAAAAAEDEEowAAAAAAABAxBKMAAAAAAAAQMQSjAAAAAAAAEDEEowAAAAAAABAxBKMAAAAAAAAQMQSjAAAAAAAAEDEEowAAAAAAABAxBKMAAAAAAAAQMQSjAAAAAAAAEDEEowAAAAAAABAxBKMAAAAAAAAQMQSjAAAAAAAAEDEEowAAAAAAABAxBKMAAAAAAAAQMQSjAAAAAAAAEDEEowAAAAAAABAxBKMAAAAAAAAQMQSjAAAAAAAAEDEEowAAAAAAABAxBKMAIAuWLVumuLg4DR48mPKKMbZdLr74YuUn+XGdAQCIhjfffNMdN7/++ms2QC6rV6+eTjzxRMoVUUEwCgWCHZzsIJXZ7aefflKs+uWXX3TDDTfo+OOPV5kyZdz62kE3M7t379a9996r+vXrq3jx4mrQoIHuv/9+7dmzJ+wBJrMyWbduXYbnr1q1ShdeeKGqVKmikiVLqnXr1vrwww8P+DNaAMd/348++ijsc8aOHZv6HAI+aft0Yax47e/7XKRIEcW6TZs2uf24MG4/ANFBXSi260K+f//9V3fffbdatWqlChUqqGjRoqpatapOPvlkPf7441q/fr0KKjsufvzxx4oFdkEoeF9ISEhw2+Gss87Sjz/+qIIklsodCBb7NXogG/r06aMuXbpkmN+wYcOYLcfPPvtMw4YNU5MmTdSiRYv9HgB79+6tcePG6ZJLLtGxxx6radOmaeDAgfrrr7/CBrHsda3SE6ps2bLppjds2KATTjhBa9eu1c0336yDDz5Y7733nnr16qU33nhD/fr1O+DPWqJECQ0fPlznnHNOhmX2HrZ8165dikV169bVzp0780UgpKB/n+Pj4/NFMGrIkCHucbgrjrYvWcUXAHIbdaHYrQtNmjRJ5557rnbs2KHu3bvrggsuUPny5V1QzOpzto6vvvqqFi5cqILIjosXXXSRunbtmq3/s3KycitWrFiur9OLL77oLgbbxd45c+a48p84caK++OILtW/fXgW93G1fs2AcEBUBoACYOnVqwHbnxx57LJDf/Pvvv4Ft27a5xx9++KH7HMOHDw/73E8//dQtv/nmm9PNt2mb/8MPP6SbX7du3UD79u2ztB633Xabe41PPvkkdd7evXsDbdq0CVSqVCmwdevWQE4NGjTIvXafPn0CCQkJgVWrVqVbvnr16kCRIkUC5513nnuePb+w8/dpuy9ssvt9tudedNFFgViydOlS9mUAEUVdKLbrQnPnzg2UKlUqULt27cC8efMyrRPeddddgYIqu8frLVu25Nm62HrY+iQmJqab/9FHH7n5Xbp0yfR/U1JSDmhfiISkpKTAzp07Y7aeBJjYv7wM5GJ3OGuS26hRI5UqVcpdDbOucdY9LLNm1NZ97pBDDnHd4azp7imnnKIpU6ake96ff/7prtjUqFHDXbGx5uC33Xabtm/fnqX1qlatmkqXLp2l59rVOdO/f/908/3pd955J+z/7d27V1u2bNnva1uXvzPPPDN1nrXcuP76692VQmvBFWzBggVavHixsuP88893rVrefvvtdPNt2q7K2PJwXnjhBXXq1Em1atVyZWxlbc+1PE6Z5eKxK4x2RcvK9qCDDtJll12mbdu2hW2ivXnzZl199dVuG1vrLNsvfv755/3mjAqeN2HCBLVp08b9v62f7QNW7qFGjx7tWsDZ8+rUqeOuVtnVt/11zzTWaszeq3Hjxm4ftub9zZo1c++V1e4b9h7WOu3www93+7W1+Hr00Uez1NLH1tmu5IYzYMAA9/qzZs1y07bP3HTTTW6fsv+zbWBdEh577DFFipWr7TdWTrYOzZs310svvZTuOUcffbT7DobbVp9//rn7TE8//bSbTklJ0QMPPKB27dqpevXqbl+0bWj7TnC3Citr60ZrbPv6XQDst2F/OaNee+01tWzZ0nUNsavltv7ff//9Ae3nAOCjLhS9upClWLAWUa+//rqaNm0a9jl2PLLjTKjs1DVnz56tbt26uWOCHfsOO+wwd5xPTk4OWwey45c9rly5sqsbW+sZqwObV155xa2rvY61LrOW+eF88MEHrkWZ/b/VT+zYGpyWwa8vmbfeeitd97jQ49qXX37pXstaK/nbIbOcUUlJSe6zHXnkke597bhp3Sqff/555dSpp57q7q3HQWj9yXoyWHlaeViXSmP1h0ceeSR1vpW7lb+1sgoWXGccOXKkq5P4dUGbF64esnr1alfHsOfYdq9Zs6auuOIK13IvXDqMP/74I7VFn732+++/v99yzyxn1K+//uo+h+0XVl+0uqftm6Hrae/Zs2dPV0e351n9qEOHDvr0009zvA1QeNDfBAWKHeRD+//bD6MdHC3oZJUGa2ptJ+B28LUfZju5fvfdd3XeeeelO2BYQGLNmjUub4Ad2OyAb7mn7ATXglJmxowZOumkk9zJ7pVXXul+iH///Xc9++yz+uGHH/TNN9+4XAC5Zfr06e49ateunW6+TdsBypaHsqCKHaAtj4IdpM8++2w99NBD7vnBB7uVK1eqb9++Gf7/mGOOSX1vKzufVU6sHMMFhDJjwZ7TTz/dBUPuuOOO1Pk2fcYZZ7j8DOHYAd/Ww4KDlSpV0ty5c91J+1dffeUO9nbgD2YBEXs9a05v29UqElb5s0CYVazCVTzsva2iaPvFk08+6dZz6dKlGZrwh2OVUwuYXXXVVa77pFXWbJ0rVqyou+66K11lzbpPWEV30KBBrsuf7YPjx4/PUvlde+21rpuA7ZNW2bAKgVVQrRyyyoIxtl9feumlbr+1AKZtC6u4BH8HQtlzLY+CfTarkNt28FmQxr5DVrGyCqGxism3337rysTmW7e0+fPnu22RleBZZt9nYxWycuXK7fN/bTvbe9t+Y90eLFhjgWSr1NmJgx8Us2brVq7WdcL2mdAgqW0jv1ys0mv/16NHD/c9ste074XtWxYwst8DWzf7bjz11FMuGGcVOT+AZxXrfbHtYJXqtm3b6sEHH9TWrVvd57BKnZV7aJfF7O7nAAoH6kKxVxeyi0l2cm7P9euQWZWduqYFEOwChU3bsc0CA1bHsOOL/Y8dq0N17tzZ1QGGDh3qAjD2uv6xy44lVl+wwIbNtzQLixYtSr3gYu655x4XpLDXue+++9wxyOrcVg+woJCth9WxRowY4QJq//vf/1xAJRxbf7tod/nll7vj877YMdnqb3bssws3dpHS1tPqhWPGjNF1112nnLB6lbEgTDC7MGV1RFs3K1e/Lm77y6hRo9x2tTqGBfIsaGWpNL777jsdddRR6V7nk08+0ZIlS1K3j03bhau///7b1Yd9y5cvd69hn9O2gdUdbftYt8KpU6e6srJ9OZiti13MuuWWW1zAyd47K+UeyvZV2/6W5sRey+p8dvHL6slW9/BzqFl52L5prM5l+7fV22zd7DtndWlgn2gghoLUND3crXfv3u45fle4YNu3bw80atQo0LRp03TzTzvtNPe/kyZNyvA/ycnJqY+bN28eaNy4cYZmxGPGjNlnd7vM7K+bXpkyZQJt27YNu8yakNeoUSPdPGtifN9997kmxyNHjgxceeWVrptcrVq1AitXrkx93q+//ure9/bbbw9bRn4Xu2A2z5q+Z6eb3vTp013T9+Bm9HZv0+PHj3fLw3XTC7ftvvjiC/fcRx55JMN6xcXFBX766acMZWFdAYObVftNtK+++up0zx01apSb/9JLL+2z25U/z5rd2+Pg5tuHH354oHr16qnz9uzZE6hZs2agatWqgQ0bNqTOt/WpX79+lvaXihUrun3zQL4jto9s2rQp3fatXLly4Jhjjtnva0yYMMG9xrBhw8JuiyeeeMJN2+uHK9fsrmtmt9NPPz3d80Obn1s30OLFi2fYZ80NN9wQiI+PDyxevNhNr1+/PlCsWLFAz5490z3PvtO2Xc8888x023XHjh0ZXvO1115z6/DBBx9kuZte6DovWLDA7bfHH398YPfu3anz7Xtavnx5912zriI52c8BFA7UhWK3LjR79mz33LPOOivDMutKZV3Fgm9WZ8hJXfO4445zn+33339Pd+yyY5w9147XoXWga665Jt3r3nTTTW6+dSfcvHlz6nx7TZt/5513ps6bMWOGmzdgwIAMn+vss88OlC1bNt1676u7mH+MnzJlSoZl9hlDUxdY/S+z9w6uq2fG//wLFy50ZW77wsSJEwOHHXZYujqg/72yOtiaNWvSvcbkyZPdsl69erly9s2aNctthxNOOCFDvcDqIFZuPvu/rl27umXTpk1LnW/7SpUqVQIrVqxI955WV7bXDq5f+PVs644avO9kpdxDu7Ha/litWrXA//73vwyv9eSTT6bbDuPGjctQ/wGyg256KFAs4m+tH4JvdsXGBHeFs6uGFs23e4voW4sNvxubtfqwVhJ2hcdvqhsuebJdebGm0NYiwZIe2pUA/2bNi+39Jk+enKufz9bXWnqFY1eDbHnolQ37/NaSwxI/WqsYa+1hV/6sZU7w65pwr22vG/wcnx3bstMqynfaaae5K0H+1R+7t2bnNj8z/razFjjWpc7K2Lq62RWh0O50xq4kWRPxYLadrSVRuHW2Fiyhzw2+OrY/1qQ9tAuWtWaxq2N+lym7smkj9FgTdGsx5bPWMnY1KSvs81pzaGsZllPWiib4SppdKbYrvln5rPZ9sC4E4bpZWgsi/2qyXZWzfcm2TU72kX19n+0WrgtDMOsaYN9Ju5IY/L20mzX5t/3IWjgau9pn8+zKsXVFDH4N2+eDr8zadrXPZqy7gz3fXtPfX8Lti1llLZ/sO3X77benS9BqV+1tm9kV099+++2A9nMAhQN1odirC/l1zHCteq2lt7UcCr75Xd6zU9e0rls2CI61YrYWycHHLj95e7jUFKGpH6wFjbFW2MHra69p08H1BWtpZa9vx8rQ462th7XwtRY1WWV1u44dO2bpufbeVp+y1joHMtCJdT+zMrcWZ1YXtbraww8/7FqhBbPysBb+wfzytPIN7vpmn8PqFtZqOjExMd3/WAsq647vs/+zY3/w61ld19I/WBnavhdcrlbftBZL4c4xbFse6EA7Vs+yFvRW9/DrOf7Nb6Htv7dfn7SE7/tLBwKEQzc9FCiHHnpopgcxO0hbZcRO+kL7Whv7wbWDrDWBtcpFaLPaUBbAMlaRCa7MBLMf89xkgQOrjGTWBNyW749VaOygGdyX2/+/cK/tj26XldfOCjtIWnPhl19+2XVFsq5r1qx5XyOLWTc0az5uJ/uho+1t3Lgxw/Mtz1covytfuCGTQ5+/r+eGs7/3s4CTdfnzKz2hws0Lx5qIW9lZnih7Twt4WWXHblmteGW2rln5rH7AyboxWjN9y79m3VetObw1kbdAlbFgiq3rjTfe6JryWx4FC5JY0M6Grs6N73NWvpv7+t/g76ZVoq1bgDWz95uw24mKVXKD84YYe84TTzzhAkOhQ4iH2xezyt8/LJdXKH+eNeu3LsM53c8BFA7UhWKvLuQHdcKdsNux0fIx+cce61aVk7rmvo4j1p3Q6gl2HAkVeizxL5gFd8ULXhZ8fLH1szqzv/77Wr+ssHpFVllQzFID+IHCnLLjv20fq4faMdTKKlyKjXDrZmVu5RouB5hth48//tg9JzgNRbjnWj3J+NvHRrizC2fW9d5u4YSrA2Sn/DLj73OWdmJ/29S6hFqQzvJpWXDQcqda3ctG/vY/E7AvBKNQKNiB0k6W7QfWTpDthM6i+XbgsZY5lrDSfvSz+5rG+lJbK6pwglvA5AZrJWFX8sKx+XZVJyvsqorlGQh+Xf81wr2uyeprZ4Ud4Cz3jgU27KrZvg54lp/Btp1dBbIrVVY5stYpdiXJrnCG2277Cmz52y0rzw/33HCy+345ZTku7Aqs5aiyHBHWuscqKXYV0x5nZcjjfa1rVlilw4JRVmG+//77XSDKWn+F5naw1l62vlbRt3W1lkaWO8IqKJZQMy/5ZW7raK3u9leJsyuhVlG051swyvI02DrbZwguU/ustv6W0+mZZ55x+SKsEmytpOw3ILu/IQcqUvsdgIKBulD06kIWILQWV5a3KZTla7KbCR2wIhJ1zcyOJVmpG9ljq49Zy5jMnh8uOJaZ3LrwmR02KElofqhor5tfxpYHK7PcWX5L7dxeR/+9rZ7u5wENFZxrzXKfWi5Q2wcsR5ZdsLMW7HZRMqd5u1B4EIxCoWBNnK0CYE15LUlgaPPoYBb0CB4VbF8VC2MH35y03sgJu+JgVx5WrFiRLom5TVuzYmvOmxXW+stvxWLshN0qWJagPZQ/L7hFxoGyK2jWxciaAh933HH7bBlkgUI72beDXPBVOmuRcyAtUSLN78ZnV7tChZuXGetWZpUTu1mF4c4773RJr63FnyULzWvW9NxulvjcEpVaAMdPbh7K9isb3c1utg2tVZeNIGOVatuX84r/3bTKZVa+m36Scgsw2VVJW0cr29AKoF2ttuCTJQ4NrvDZwAihgpvrZ4UfHLNumJakNNi8efPSPQcAcoK6UPTqQnbssGTOdlHD6j5ZTWKenbqmX0ey40goO07ZBZPcPo7Y+llqCxvtLbMRAvOKtQKyz2Ut2TJLYZHXrDytXO1id3DXyOBjd2gLM7/lUbjn+tvHPxex5OWROscI3eesC2hW3/uII45wNwtKWU8TSyFg9VNL0p7d+hAKF3JGoVDwr9aEthaw3Duh/eftZN9aSljww88rE8x/DevGZz+8lnsgXLNny9ti+adyk43EZvyh5n3+dPAIMJm9t43w8c8//2TofmSvbaOMBY/sZgGE5557zgUbQkfyys5wxuFYKydrcm6j2eRk21kXv0i3RDkQVoG1iq41ZQ4OolmrItuH9sfPURTMHynF5Pa+ti8WpLEcRhYotC6U1loouJm85dQIzath29GvqOX1utpIR1Yxtf3LRvELZbkYQrth+IEnv4uEBUhD8zHZZ7AyD97vbL+0FmKh/JHzsvpZLZhnr21XIoO7/9noTtZ600ao2V/XYQDYF+pC0a0LWboBu5Bh+QzDBSTC1XWyU9e0fEZ2gc/WPTi3pL2mX9eyUfJyk11kMjZysJXT/rro2bExt+oAVue1+lS4Y3CkWgdbF0tj5Rv8nlb+Nkqe5fUKHSnagpEzZ85Mt652UTH49ay7oO1rFrwMFxy1/wnNRbUv2Sl3yw9q+5LV08P9j9WrrFeDseWhdXH7nlgAzuqBoak1gFC0jEKhYFdrrJmw/djbj6OdaFrOG8tbZPl3LLl0MOtOZAd0C0rZSWqrVq3cj6/lLLIWLo888og7cbSTVsuFYyfZ1tXM3sNe36622QHEDk6WsHpf7KTezw/gX82yioRVkvwDvZ2IGruqZkO5WzcpO6G21kWWGNK6allLGTvo+eyk2uZbs25bZ6uw2PC31n/dWl6EthCzKxg2VKu1ELn55pvd1UFrIWLd5Kz1WNmyZTOUaVaGM95Xs2i77Y9VnJ566il3ULYuVNZtyg7kdoU3K82qY4W1vnn88cdd5cm6eVll1OZZcMoqHZZTYF9Xj+zAb8EsC1pY5dQqCvY/NsRvuNxGeck+gyXbvOaaa1wlJLQFkX23LI+AbTurRNv6WcXb1tUqKH5y1P2xypq1wArHKmx+wCeUdXew97IWWbaf+t8hq7hZMlj7DthVyOCk81am9ltg+5rl9LBgZygb0tpyS9h33rorWtDIXis08GZsm9qVTeuSaN83u/puVxkz2072m2RXFO03yr4XFuCzbW7DalvA0lpEHmgXSwCFG3Wh6NaFrI5oxxBLMWAtjLt37+7qcZavyI5P9h7WytnSSPhd77Jb17QWvnb8teOstUqxAWMsEfbnn3/uPlN28jZmhbVyHjx4sLtZly5roW1duOxCitWtLa2Ate7x2YApdqHX6tHWmspPuZATlnbD6ssWjPJTOtiFMatLW4vzcBeUc5u1cLMLYHast8CY1dFt8BoLdtq6PPvssxn+x7a9bU/bPlavs21u62p1FdsffFaPsXq91QmszmH1FKtzWVDS/sfmWblnRXbK3eoqdg5h9Syrm9g+Z/UZuyBqwVfb5+xC/oknnuieZ/Umq+/ZcyzXlqU5sP3NyiVcV0IgnWyNvQfEKH/Y1cceeyzT5yxbtixwzjnnuGHsS5Ys6Yb/tWFx/eFQbcjVYP/8848b/teGti1atGigatWqgVNOOSXdsLj+69rzbGhUe16lSpUCLVu2dEPfLl++PMvrntkteBhbf8jVu+++272fDUlfv379wNChQwNJSUnpnvf999+7Yelt/UuUKOGGum/SpEngjjvuCGzcuDHsuthnPv/88wMHHXSQe/5RRx0VeP/998M+N6vDGRu/jG042n2x5fa84OFqzdixY12ZlipVyq1b7969A3///XeG4Wj3NXxtuGGB/WF9M/t8wa/jD8kbvG7h5oV+5tD9atSoUYFmzZq5bWfbZvDgwanDM+9raNzdu3e7fcr2W9vH7P/t8/fr1y+waNGiQFb3s+AhoLNSDpk544wz3P8ceuihGZatW7cu0L9//0CLFi0C5cuXd/tfgwYNAjfeeGNg1apVWV7Xfd3+/PPP/W5z+w7YcMk2NLJ9N2247xNPPDHw+OOPu+9RKJvvD7uc2Xf3lVdeCTRt2tR9P6pXrx64/PLLA+vXrw+7Dj///LMbZtv229DvS2brbK9/5JFHute3IbE7duwY+PbbbzM8Lzv7OYDCgbpQbNeFfHYcvOuuu9zrlitXLlCkSBF3nOrQoYOrx9oxNFR26pqzZs0KnH322YGKFSu6uoJ93kceeSSwd+/eLB3791VfCFfvMhMmTAh06tQp9T0PPvjgQOfOnQMvvvhiuudZfcXq0nZ884/n+zuu7evYZsfy+++/P3DYYYe5bWV1jtatWweGDRsW9nXCff7ExMR9Pm9f5WH27NkTePjhh10522e3MrDynz17drrnBdcZ33vvvdS6oJXVwIEDM+y7xtbt1ltvdXUt//MdccQRgRtuuCHwxx9/7LfOmZVyz2ybzpkzJ9C3b99AzZo1U8+Djj32WHfOYfUe89tvvwUuvPBCV8ezuo69fvPmzV19ateuXfssV8DE2Z/04SkAQCRZssdbb73VtXKzq1cAAAAoOKz1nLUOtxQCWW3RBBR05IwCgAixpuqhORWsC5Y157ZuXS1btmRbAAAAACjwyBkFABFi/fwtD5n107erY5ZTwYbE9XM/WT4sAAAAACjoCEYBQITYiCrWDc+SUa9du9YlMLek2TZiiSV6BAAAAIDCgJxRAAAAAAAAiBhyRgEAAAAAACBiCEYBAAAAAAAgYsgZFUZKSopWrVqlsmXLKi4uLnJbAwAAFDqBQEBbt25VzZo1FR9/4NcJqccAAIBYr8sQjArDAlG1a9fO7e0DAACQqRUrVujggw8+4BKiHgMAAGK9LkMwKgxrEeUXZLly5XJ36/x3xTIxMdGNrJUbV0ALM8qScowl7I+UY6xhn8wf5bhlyxZ3Ecyvf8R6Pcawb8UetklsYrvEHrZJbGK75O/tkpO6DMGoMPyueVaBy6tg1K5du9xrE4yiLGMB+yTlGEvYHynLwrpP5lZqgLyuxxi+p7GHbRKb2C6xh20Sm9guBWO7ZKcuQ7McAAAAAAAAREzMBaMs6VX//v1Vt25dlSxZUscdd5ymT5+eunzw4MFq0qSJSpcurYoVK6pjx476+eefw77W7t27deSRR7ro3KxZsyL4KQAAAAAAAJAvglGXXXaZpkyZohEjRmjOnDnq1KmTCzitXLnSLW/UqJGef/55t+z7779XvXr13HOsH2Oo22+/3WVzBwAAAAAAQGyIqWDUzp07NXr0aD366KNq166dGjZs6FpC2f2LL77onnPeeee54NQhhxyiww8/XE8++aRLljV79ux0rzVx4kRNnjxZjz/+eJQ+DQAAAAAAAGI6gfnevXuVnJysEiVKpJtv3fWsFVSopKQkvfLKKypfvrxatGiROn/NmjW6/PLL9fHHH6tUqVIRWXcAAAAAAADks2CUDQN47LHH6r777lPTpk1VrVo1jRw5UtOmTXOto3wTJkzQueeeqx07dqhGjRquW1/lypXdskAgoIsvvlhXXXWVWrdurWXLlu33fS23lN181tLKzxxvt9xmr2nrmRevXdhQlpRjLGF/pBxjDftk/ijHA33dSNdj/NemLhNb2Caxie0Se9gmsYntkr+3S07qGzEVjDKWK+qSSy5RrVq1lJCQoJYtW6pPnz6aMWNG6nM6dOjgEpKvW7dOr776qnr16uWSmFetWlXPPfecS4I+YMCALL/nQw89pCFDhmSYb3mobBjD3GYbavPmzW6j5uUQ0YUBZUk5xhL2R8ox1rBP5o9ytHrLgYh0Pcawb8UetklsYrvEHrZJbGK75O/tkpO6TFzAXjUGbd++3V3Zs5ZPvXv31rZt2/Tpp5+Gfe6hhx7qAlgWgOratavGjx/vRtDzWdc/C2z17dtXb731VpauKNauXVsbN25UuXLl8mSDWgWxSpUqBKMoy5jAPkk5xhL2R8qysO2TVu+wEYKtspeTekek6zGG72nsYZvEJrZL7GGbxCa2S/7eLjmpy8Rcyyhf6dKl3c0qUp9//rlLar6vAvIrYc8++6zuv//+1GWrVq3Sqaeeqg8++EBHH3102P8vXry4u4Wyws6rlksWLMvL1y9MKEvKMZawP1KOsYZ9MvbL8UBfMxr1GMO+FXvYJrGJ7RJ72Caxie2Sf7dLTuobMReMssCTNdZq3Lix/vrrL912221q0qSJ+vXr51pLPfDAAzrrrLNciynrpjds2DCtXLlSPXv2dP9fp06ddK9XpkwZd9+gQQMdfPDBUflMAAAAAAAAiNFglDXrsu52//zzjypVqqQePXq4AFTRokVdd7sFCxa4rnYWiDrooIPUpk0bfffddzr88MOjveoAAKAgWb5cWrfOmmCryIYNUqVKdulPskFTQi5+AQAAIB8HoywZud3CKVGihMaMGZOt16tXr55raRUrbPWHDInTwoXV1LixNGiQ1L17tNcKAABkCETZgXrXLlnDc2/M3v+UKCEtXEhACgXOF0u+0A0Tb9Czpz2rjod0jPbqAAByJf4gLVokNWoUW/EHEhZFeEfo0UOaM8eSjca5e5vOZnwNAADkNWsRldlIdDbflgMFiF28vevLuzR/3Xx3H0sXcwEABxZ/sKpLrMUfCEZFkEUkbZC/QMAb6c/ubXro0EiuBQAAAJDeu3Pe1fRV091ju5+8eDJFBAD51D//SNde6z32ry3YfSzFHwhGRZA1jQu9yGTT1tIfAAAAiAZrBfXsz88qIS7BTdv9wKkDaR0FAPnIjh3Se+9Jp57qZRL499+Mz4ml+APBqAiyPpoWiQxm05aSAgAAAIgGawVlraGSA8lu2u5pHQUAsS8QkL7/Xrr8cqlGDalvX2ny5IyNYGIx/kAwKoIsWZi3U/h7RsBN23wAAAAgGq2irBVUfMhpgU3TOgoAYtPff0v33ec1ePnf/6TXXpO2bElbXr++DQ7nPfYbxHgpg2In/kAwKoIsa/3o0VKR/8YwtHtLHtatWyTXAgAA7Fflyt6oeeHYfFsOFAC79+7W8s3LlaKUdPNtesWWFUpKToraugEA0mzbJr31lnTSSVK9etK990p//ZW2vEwZqV8/6ZtvvPkffODFH5o396oudh9L8Yf/wiKIZECqWjVp5UrvPlZ2BAAAEMSSLVhShXXrFOjcWXGJiQpUqaK4SZO8QJQtBwqAxRsXKz4uXr0P760zG5+pppWbpi6rWrqqihcpHtX1A4DCLCXFCy5ZEOqjj6Tt29Mvt9ZOFpy66CIv1lC6dPrlNs9usYhgFAAAQDgWcLJbsWLetN23bElZoUAZu2CsVm9brQ/++EDHHnysWjZjHweAaFu82AtAvf221yUv1KGHegGoCy7Iv9fHCEYBAAAAhTgY5evapGtU1wUACrMtW6RRo7wglCUlD1WunHTuuV4Q6thjMw6Olt8QjAIAAAAKob83/a2Zq2e6xy1rtFTdCnWjvUoAUKgkJ0tffSW9+aY0dqy0c2f65fHx0imnSBdfLJ19tlSypAoMglEAAABAIfTxgo9TH3drQiJTAIiUBQu8FlAjRnj5pEM1beoFoM4/X6pZs2BuF4JRAAAAQCHvokcwCgDy1saN3gh31grq558zLq9YUTrvPK8bXuvW+b8b3v4QjAIAAAAKmcTtifpu+XfucaODGumwKodFe5UAoMDZu1eaPNkLQH3yibR7d/rlCQnSaad5raDOOEMqXogGMCUYBQAAABQynyz8RCmBlNRWUXEF/RI8AETQ3LleN7x33pH+/Tfj8ubNvQCUtYSqVq1wbhqCUQAAAEAhQxc9AMhd69ZJI0d6raBmemNDpFO5stS3rxeEOvJISp9gFAAAAFCI7EnekzqKXs2yNdWmVptorxIA5Et79kiffea1gpowwZsOVrSo1/3OAlDWHc+m4SEYBQAAABQiRROK6u/+f+ubv7/R+h3rFR8XH+1VAoB8IxCQZs3yAlDvvuu1iArVqpWXiLxPH69FFDIiGAUAAAAUwoBUx0M6Rns1ACDfWLPGCz5ZEGr27IzLq1eXzj/fC0IdcUQ01jB/IRgFAAAAAAAQwka/Gz/eC0BNnCglJ6dfbqPfnX22F4Dq1EkqQoQlyygqAAAAoJAIBAKMnAcA+/ydlH791UtEbgnJN27M+JxjjvECUL17SxUrUpw5QTAKAAAAKCSun3i9lmxcom5Nuqlv874qVbRUtFcJAGLCypXSO+94raDmz8+4/OCDpQsu8IJQjRtHYw0LFoJRAAAAQCGQnJKsUX+MUuKORH297GsXjAKAwmznTmncOK8V1JQpUkpK+uUlS0rdu3sBqJNOkhISorWmBQ/BKAAAAKAQ+HHFjy4QZTo37EyrKACFthvetGleAGrUKGnz5ozP+d//vABUz55SuXLRWMuCj2AUAAAAUAiMmT8m9XH3pt2jui4AEGnLl0sjRnjd8P78M+PyunW9ANSFF0oNGrB98hrBKAAAAKAQJC4fu2Cse1wkvohOP/T0aK8SAOS57dulMWO8VlBTp3qtooKVLu21frIgVLt2Unw8GyVSCEYBAAAABdysf2fp781/u8cd6nVQxZIM/wSgYLK8T99957WA+vBDadu2jM+x/E8WgLJ8UGXKRGMtQTAKAAAAKOD8VlHGRtIDgIJmyRLp7be9INSyZRmXW9e7iy/2RsSzLnmILoJRAAAAQCEKRp3d5OyorgsA5JatW73WTxaA+vbbjMst+Xjv3l4rqOOOk+LiKPtYQTAKAAAAKMD+2vCX5q6d6x4fc/Axqlm2ZrRXCQByLDnZy/9kAajRo6WdO9Mvt4DTKad4raC6dpVKlqSwYxHBKAAAAKAA+/bvtOYCdNEDkF8tWuQFoGxEvBUrMi5v0sQLQJ1/vlSrVjTWENlBMAoAAAAowC456hKdVP8kfbzgY3Vt0jXaqwMAWbZpk/TBB14Qatq0jMsrVpTOPdcLQrVpQze8/IRgFAAAAFDA1atQT/2P6R/t1QCA/dq7V5oyxQtAffyxtHt3+uUJCVLnzl4A6swzpeLFKdT8iGAUAAAAAACIqoULi+iJJ+L07rvS6tUZlzdr5iUi79tXql49GmuI3EQwCgAAAAAARNz69dLIkdYKKk6//lo5w/LKlaXzzvNaQR15JN3wChKCUQAAAEABtHHnRp0w/ASdcegZOveIc3VUjaOivUoAoD17pIkTvW5448d701JcaskUKSKdcYbXCqpLF6lYMQqtICIYBQAAABRAn/75qeYlznO3pOQkglEAour336U335TrhpeYmHF5s2Z7dOmlCTrvvHhVqRKNNUQkEYwCAAAACqAx88ekPu7etHtU1wVA4bR2rfTee14QyoJRoapVk84/X7rgghRVq7ZeVatWVXx8NNYUkUYwCgAAAChgduzZoUl/TXKPq5SqouNqHxftVQJQSCQlSRMmeN3wPvvMGx0vmHW7O/tsrxveqad63fJSUrzAFQoPglEAAABAATN58WTt3LvTPT678dlKiE+I9ioBKMACAWnGDC8AZS2hNmzI+Jyjj/YCUL17S5UqRWMtEUsIRgEAAISzfLm0bp13idfY/cyZ3tA+depQZohpYxeMTX3crWm3qK4LgIJr9WrpnXe8INQff2RcXrOmdOGFXhCqSZNorCFiFcGoCBszRlqzxnts9zbdnS78AADEXiCqcWNp167U8X3iLNtqq1ZSiRLSwoUEpBCz9iTv0Zh5Xr6okkVK6uT6J0d7lQDkY3bOOmSItGiR1KiRNGCAFBfnBaA+/9zrYhfMDpPdukkXXyydfLKUQMNMhEEwKsJf4h490qat76xNjx5NQAoAgJhiLaJ27Qq/zObbclpHIUZ9s+wbbduzzT0uUaSEiiUwLjqAAzuHteCTdcWbPVvq0yf8c48/3gtA9ewplS9PiWPfyFMfQRZNti+x0q6xuumhQyO5FgAAACjInvn5mdTHG3dtdPmjACAnBg1KC0SFY9dl7rnHazX1/ffSZZcRiELW0DIqguwLGvoltmlr6Q8AAAAcqJSUFH2x5IvU6YS4BA2cOlCdGnRSnHdVFAD2y85RX3hBmjs3/PL4eOmLL6T27b3HQHax20SQ9a8NrQPYtKWkAAAAAA7UlKVTtCs5rYtpciBZ01dNp3UUgP1KTpbGj5dOPdVLNv7ss+GfZ+ewzZpJHToQiELOEYyKcBNHr2WU3zwq4KZtPgAAAHAgAoGA7p16r+JDqvg2ba2jbDkAhNqwQXrsMalhQ+mss6TJQT17i/2Xcs5vVOF32eMcFgeKYFQE2ah5lqy8yH+dI+3eEsLZSAMAACCGVK7sDQcUjs235UCMSUpJ0ootK5Si9ENb2bTNT0pOitq6AYg9s2Z5OZ5q1ZJuv11atixtWf360uOPS//+653DNm/uHf7snnNY5AZyRkUhIFWtmrRypXdPIAoAgBhkGVktYca6dQp07qy4xEQFqlRR3KRJXiCKkfQQg4rFF9PPl/6s9bvWZ1hWtXRVFS9SPCrrBSB27NnjBZOee0764YeMyzt3lq67zrtPSEg7h7UbkJsIRgEAAIRjASe7+X0U7L5lS8oKMevqL69WICGgvs37qnvT7ioST1UfgGf1aumVV6SXX/YeBytXTurXT7rmGi/PMRAJHKEAAACAfG7Trk2auHSi66r3y6pf1KNpj2ivEoAos9xO06Z5raA++kjauzf98sMP91pBnX++VKZMtNYShRXBKAAAACCfGz1/tAtEmXMPP1cJ8f/1rwFQ6OzcKY0cKT3/vPTbb+mXxcdLXbt6QagTT8w42jsQKQSjAAAAgHzu/bnvpz4+r9l5UV0XANFhCchffFF67TVvhLxglu7wiiukK68k7SFiA8EoAAAAIB9btXWVpi6b6h43rNRQrWu2jvYqAYhgV7wvvvBaQY0f700Ha91auv56qVevzAeJBaKBYBQAAACQj30w9wMF5J2B9jm8j+LodwMUeFu2SG+/7QWhbPDXYDbehgWfLAjVtm201hDYN4JRAAAAQD727px3Ux/3OaJPVNcFQN6aP18aNkx66y1p27b0y2rVkq6+WrrsMqlaNbYEYhvBKAAAACCfWrhuoWasnuEeN6/cXI0rN472KgHIZcnJ0oQJXiso65IXqn17rxXU2WdLRTjDRz7BrgoAAADkUyPnjkx93O3QblFdFwC5a/16Lxm5JSX/++/0y0qVki64QLr2WqlZM0oe+Q/BKAAAACCfmpc4z93HKU5nNzg72qsDIBfMnOm1gho5Utq1K/2yBg28AFS/flKFChQ38i+CUQAAAEA+NarnKC1Yt0Df/f2dapSuEe3VAZBDSUnSRx95Qahp0zIu79JFuu466dRTpfh4ihn5H8EoAAAAIB9rUrmJGlVqpLVr10Z7VQBk06pV0ssve7c1a9IvK19euuQS6ZprpIYNKVoULASjAAAAAACIkEBA+v57rxXUmDHS3r3plx9xhJeQvG9fqXRpNgsKJoJRAAAAQD6zY88OlSxSUnFxcdFeFQBZtGOH9N57XhDq99/TL0tIkLp187ritWsn8dVGQUcwCgAAAMhnrvvsOk37Z5rOO+I83XjMjSpTtEy0VwlAJpYskV54QXrjDWnjxvTLqlaVrrhCuvJK6eCDKUIUHgSjAAAAgHxk195dGj1/tLbs3qLHfnxMtx53a7RXCUCIlBRpyhSvFdSnn3pd84IdfbTXCqpnT6l4cYoPhQ/BKAAAACAf+XTRpy4QZbo37a6SRUsqxc58AUTd5s3SW29Jw4ZJixalX1asmNSnj3TttVKbNtFaQyA2EIwCAAAA8pH35r6X+rhvs75RXRcAnj/+8AJQb78tbd+evlRq15auvlq67DKpShVKDDAEowAAAIB8YtOuTa5llKlWupo61O8Q7VUCCi0bBW/8eK8r3ldfZVzeoYM3Kt6ZZ0pFOPMG0olXjNm6dav69++vunXrqmTJkjruuOM0ffr01OWDBw9WkyZNVLp0aVWsWFEdO3bUzz//nLp82bJluvTSS1W/fn33/w0aNNCgQYOUlJQUpU8EAAAA5I6x88dqd/Ju97j34b1VJJ4zXCDSEhOlhx6SDjlE6t49fSCqdGmvFdTcud58GyGPQBSQUcwdvS677DLNnTtXI0aMUM2aNfXOO++4gNO8efNUq1YtNWrUSM8//7wOOeQQ7dy5U0899ZQ6deqkv/76S1WqVNGCBQtcn/mXX35ZDRs2dK91+eWXa/v27Xr88cej/fEAAACAXOmid16z8yhJIIJ+/VV67jnp/fel0LYOhx7q5YK6+GKpfHk2C5CvglEWXBo9erTGjRundu3apbaEGj9+vF588UXdf//9Ou+89AfdJ598Uq+//rpmz56tk08+WZ07d3Y3nwWtFi5c6P6fYBQAAADyq9VbV+urpV4TjAYVG6htrbbRXiWgwNu9W/rwQ68rXlCHHCcuTjr9dG9UvFNOkeJjrt8RELtiKhi1d+9eJScnq0SJEunmW3e777//PsPzrevdK6+8ovLly6tFixaZvu7mzZtVqVKlPFlnAAAAIBI++OMDpQRSUltFxdmZMIA88c8/0ssvS6+8Iq1dm35ZhQrSpZdK11zjddUDkM+DUWXLltWxxx6r++67T02bNlW1atU0cuRITZs2zXW5802YMEHnnnuuduzYoRo1amjKlCmqXLly2Ne07nvPPffcPltF7d692918W7Z4Q+Vad7+8GSY3reLAMLwHxsovEAhQjpRjTGB/pBxjDftk7gg+3c+L4/aBvmbk6zHsW9GycedGlSpaSjv27NC5h5+bbvvyfY9NbJf8tU0CAenbb21UvDh9/LGUnJw+4Nu8eUDXXhuQddYpVcp/vUitecHGdyV/b5ec1DdiKhhlLFfUJZdc4vJDJSQkqGXLlurTp49mzJiR+pwOHTpo1qxZWrdunV599VX16tXLJTGvWrVqutdauXKl67LXs2dPlzcqMw899JCGDBmSYX5iYqJ27dqVy5/QftRsPM8EJSenaO3axFx//cLEdnpr+WZfkHjaxVKO7I8FAt9ryjJWxP/zj+I3bFDFXbuUYPvmrl3a+MUXSqlUSSkHH5yrg7cciEjXYwzf0+i4uunVurDhhfph5Q+qlFJJa4Oaa7BNYhPbJX9skx074jR6dAkNH15K8+cXTff8IkUC6tJlly65ZIfatt3juuZt2+bdkLfbBflnu+SkLhMXsFeNQZZw3K7sWcun3r17a9u2bfr0U28Y21CHHnqoC2ANGDAgdd6qVat04okn6phjjtGbb765z4ILd0Wxdu3a2rhxo8qVK5ern2vMGKlPnzjt3RvnfthGjgy4ERiQ8y+HVbYteT0/WjlHOeYOypFyjDXskwdg+XLFNW2quDDBnECJEgrMny/VqaPcYPUOGyHYKns5qXdEsh7jY9+KvC+WfKH+n/fX06c+rY6HdGSb5BN8V2Jzm7z11lY980wFLVwo2c/kjh1eQCpYtWoBXXGFdPnlAdWqFbXVLTT4ruTv7ZKTukzMtYzylS5d2t2sIvX555/r0Ucf3WcBBVfCrEWUtZ5q1aqVhg8fvt8gRfHixd0tlP1fbgY4LBDVs6c98uJ/e/fadLxGj/aGBEXOWL6E3N5WhRHlSDnGEvZHyjLqNmyQMmlVZAGqOFter16uvNWBHr8iVY8Jxfc0cuza8T1T79H8dfPd/SkNTgmbL4ptEpvYLrHFzskuu6zif+dkcVq3Lv3yY4/1EpKfc06cihWzOeRmixS+K/l3u+SkvhFzwSgLPNkBt3Hjxi7f02233aYmTZqoX79+rrXUAw88oLPOOsu1mLJuesOGDXPBJ+uKZ+yxtYiqW7euyxNlUTxf9erVo/jJJGtBb/WGQMD/QYtz00OHEowCAABAeGPmj9H0VdPdY7ufvHiyTm14KsUFZIP1B/ryS+nii9POxYLZeFeTJ0utWlGsQCTEXDDKmnVZd7t//vnHjYDXo0cPF4AqWrSoG2lvwYIFeuutt1wg6qCDDlKbNm303Xff6fDDD3f/b8nMLYhlt4ND8jlEu0fiokXej2Awm7bmoQAAAEAoq79eP/H61On4uHgNnDpQnRp0YjQ9IAvsfGvCBOmBB6Sff868pZN11SMQBRTiYJQlI7dbOCVKlNAYa1e5DxdffLG7xaJGjaQ5c9IHpKxlVOPG0VwrAAAAxCprBbV62+rU6ZRACq2jgCxITva65FkQ6vffQ5d6XfR8nJMBkUeSnQgaNMgPRPnRqICbtvkAAABAaKuoWyffmqFQ4uW1jop2q38gFlle3hEjpCOOsIYO6QNRzZpJN92U8l+6FO/746VR4ZwMiDSCURFkScotWXmR/9qj2b1F67t1i+RaAACA/apc2Zpkh19m8205kMeSkpO0dNPSDPNTlKIVW1a45QA8Np7VK694vVEuvFBasCCtZNq0kcaNk2bNkh5/XHrttY0uMGU/582bc04GREPMddMrDAGpatUs0bp3TyAKAIAYVKeOl9Rx3ToFOndWXGKiAlWqKG7SJC8QZcuBPFa8SHHVq1BPfyT+4aYn9JmgGmVruMdVS1d1y4HCznI9vfaaZIOv2zlWsHbtpLvvlk45xWsBZVJSpNNP361+/QKKj2ekPCBaCEYBAACEYwEnu3lje3v3LVtSVoiYJRuXpAaiWtdsrdMbnU7pA//ZulV64QXpiSekoAHUnU6dvCCUBaMAxCaCUQAAAEAMGjt/bOrjHk17RHVdgFixcaP07LPSM894j4OddZYXhGrbNlprByCrCEYBAAAAMWj0/NGpj7s37R7VdQGibe1a6amnpGHDvFZRPut+Z4nK77rLy/8EIH8gGAUAAADEmJVbVmraP9Pc4yOqHqFGBzWK9ioBUWF5oB57zEtOvnNn2vyEBOn886UBA6TGjdk4QH5DMAoAAACIMcs3L1fDSg3114a/1L0JraJQ+CxdKj3yiDR8uJQUNHCkpe/r10+64w6pfv1oriGAA0EwCgAAAIgxx9Y+VouuW6S5a+eqUslK0V4dIGIWLJAeekh6910pOTltfsmS0pVXSrfeKtWqxQYB8juCUQAAAEAMiouLU7NqzaK9GkBEzJ4tPfCA9OGHUiCQNr9sWenaa6WbbpKqVmVjAAUFwSgAAAAAQFT88osXhPrkk/TzK1aU+veXrr/eewygYCEYBQAAAMSQxO2JqlK6SrRXA8hT334r3X+/NGVK+vnW+umWW6Srr/ZaRQEomOKjvQIAAAAAPJt3bdbBTx2sVq+00su/vkyxoECx7neTJ0vt2knt26cPRFkeqGef9RKX3347gSigoKNlFAAAABAjPv3zUyUlJ2nm6pmalzgv2qsD5IqUFGnCBK8l1PTp6ZfZiHgDBkgXXigVL06BA4UFwSgAAAAgRoyePzr1cfem3aO6LsCBstHwPvrIywk1Z076ZU2aSHfdJfXpIxXhrBQodPjaAwAAADFge9J2TfxzontcpVQVnVDnhGivEpAje/ZI770nPfigtGhR+mUtWkj33CN16yYlJFDAQGFFMAoAAACIAZ8v/lw79+50j7s26aqEeM7Ukb/s3i0NHy498oi0bFn6ZUcf7QWhTj9diouL1hoCiBUEowAAAIAY66LXo2mPqK4LkB3bt0uvvio99pi0alX6ZSeeKN19t3TyyQShAKQhGAUAAABE2e69uzVh0QT3uEKJCupQv0O0VwnYry1bpGHDpKeekhIT0y/r3NkLQp1Ab1MAYRCMAgAAAKLsy6VfasvuLe7xmY3OVLGEYtFeJSBTGzZIzzwjPfustGlT+mVdu3pBqNatKUAAmSMYBQAAAETZ6Hl00UPsW7NGevJJ6YUXpG3b0ubHx0u9e0sDBkjNmkVzDQHkFwSjAAAAgChLSklS0fiirkVUpwador06QDorVnj5oCwv1K5dafOLFJEuuEC6806pUSMKDUDWEYwCAAAAomxEtxF67rTnNHvNbJUsWjLaqwM4S5ZIDz8svfmmtGdPWqEUKyZdeql0++1SvXoUFoDsIxgFAAAAxABLXN6ubrtorwag+fOlhx6S3ntPSk5OK5BSpaSrrpJuuUWqWZOCApBzBKMAAAAAAJo1S3rgAWn0aCkQSCuQcuWk666T+veXqlShoAAcOIJRAAAAQJRs3rVZpYqWUtGEomwDRM1PP3lBqAkT0s+vVEm66SYvEFWhQrTWDkBBFB/tFQAAAAAKq/u+vU/Vn6iufuP6acXmFdFeHRQi1vLp66+ljh2lY49NH4iqVs1LWP7339I99xCIApD7CEYBAAAAURAIBDRm/hht2LlBI34fodLFSrMdEIH9Tpo0Sfrf/6QOHaQvv0xbVru29Pzz0tKl0q23SmXKsEEA5A266QEAAABRMOvfWVq6aal73KF+B1UqWYntgDyTkiJ98ol0//3SjBnplzVoIA0YIF1wgTdSHgDkNYJRAAAAQBSMnj869XGPpj3YBsgTNhreqFFeTqg//ki/rGlT6e67pd69pSKcGQKIIH5yAAAAgCiwLnomTnHq2qQr2wC5as8e6Z13pIcekv78M/2yo47yckF17SrFk7gFQBQQjAIAAAAibH7ifM1fN989Pr7O8apepjrbALli1y7pjTekRx6Rli9Pv8wSlVsQ6rTTpLg4ChxA9BCMAgAAACKMLnrIbdu3Sy+/LD3+uLR6dfplJ53kBaFOPJEgFIDYQDAKAAAAiFIXPdOtSTfKHzm2ebM3At5TT0nr16df1qWLlxPquOMoYACxhWAUAAAAEEFLNi7Rb//+5h63rtladSvUpfyRbevWSc88Iz33nBeQCta9uxeEatmSggUQmwhGAQAAABG0bNMy1SpbSyu3rlT3Jt0pe2TLv/9KTzwhvfii1zXPZ4nI+/SRBgyQDj+cQgUQ2whGAQAAhGOZf63pQVKSN233M2dKlStLdepQZsixk+qfpOU3Ldevq37VweUOpiSR5Z+kRx+VXntN2r07bX6RItJFF0l33ik1bEhhAsgfGMgzwsaMkdas8R7bvU0DAIAYPOtr3Fhq1UpxiYlulrtv1cqbHzpEFZBFXyz5QocNO0xfLf1KbWu1Vc2yNSk7pGPnBy1aSCVLevfDhkmXXSY1aOA99gNRxYtL110nLV7sBagIRAHIT2gZFeEDS48eadN793rTo0d7/boBAECMsBZRNj56ODbfltM6CtkUCAR015d3af66+e7+5PonKy4ujnJEhvMF2y0CAWn2bC/gFKx0aenqq6Wbb5Zq1KDwABSSYNSOHTs0ZcoU/fDDD5o3b57WrVvnDqKVK1dW06ZNdfzxx6tjx44qbb+SSGfIEP/A4lc64tz00KEEowAAAAq6yYsna/qq6e6x3dv0qQ1PjfZqISbPFzIuK1dOuuEG6cYbvd7CAFAoglFz5szRE088oTFjxmjbtm0qWbKkateurYoVK7qrPIsWLdKXX36pxx9/3AWievTooVtuuUXNmjXL20+QjyxalPHAYtMLF0ZrjQAAABAJVl++88s7U6fjFa+BUweqU4NOtI6CYz2B//gjfCDK8kJZ7+Dy5SksAIUoZ1Tv3r111FFHacGCBRo8eLB+//13bdmyxU1PmzZNP/30kxYuXKitW7e6ZfYcm7b/6WNDOsBp1Mi70hHMpi31BAAAAAouawU1699ZqdMpSkltHYXCbccO6YEHvJxQyckZl9v5go2ORyAKQKELRsXHx+vXX391Qaebb77ZtXZKSEjI8DybZ8usRZQFqex/kGbQIP9Kh3+5I+CmbT4AAAAKbqsoawUVym8dZctR+Fj+WEs8fuih0j33SFu3ZnyO32WP8wUAhTIYNXLkSB155JHZfnH7H/tfeCxJuSUrt2a2xu4tSWG3bpQQAAAxxRKylCgRfpnNJ2ELsiEpOUnLNi3LMN9aR63YssItR+FhwaXx472R8i6/XFq1ypsfHy9dcYUXoLJl9lPTvDnnCwAKcTAq1Ntvv61lyzIeUH22zJ6D8AGpatW8x3ZPIAoAgBhkI+VZUscZMxSoUsXNcvczZnjzGUkP2VC8SHENbJfWMurcw8/VjCtmuNv0y6e75Sgcfv5Zat9eOussad68tPlnny3NnSu9/LJ06aXSrFnSzp3ePecLAAqiHAWj+vXrpx9//DHT5T///LN7DgAAQL5lAaeWLaVixbxpu7dpAlHIga///jr18VWtr1LLGi3d7eByB1OehcCff0o9e0rHHCN9913afH/644+lpk2juYYAEKOj6QXbX7/27du3q4jfFw0AAAAoxHbs2aGJf050j6uUqqIT6pwQ7VVChKxZI911V1m9806cyxEVPLDRQw95rZ5CBzgCgMIgyxGj2bNna5a1E/3Pd999p73Bv6j/2bRpk1566SU1sl9YAAAAoJCb9Nck7dy70z3u2qSrEuIzDgSEgmXbNunJJ6XHHovTtm2lU+dbmg5LRn7ZZVLRolFdRQDIH8GosWPHasiQIe5xXFycXn75ZXcLp0KFCuSMAgAAACSNnj86tRx6NO1BmRRge/ZIr78uDR7stYqSvGZPpUsHdNttcbrlFqlMmWivJQDko2DUFVdcoTPOOMN10Wvbtq3uu+8+de7cOd1zLEhVunRpNWjQgG56AAAAgKWwSNqu+Lh4lSteTh3qd6BMCiDLYmJ5nwYM8MY48CUkBHT++Tv14IMlVLMm/fEAIFvBqJYtW+rBBx9MDT4NHz5chx12mFq1apWVfwcAAAAKrY/P/Vhrt6/VH2v/ULGE/xLio8D44Qfp9tul0PGdbBTt++8PqGLFLapatUS0Vg8A8u9oepYvat26danTl1xyif60ISEAAAAA7FfV0lVpFVXALFjgJSA/4YT0gSh/evRoqXHjaK4hAOTzYFTdunX1xRdfKDk52U1bVz3rkgcAAAAAhcnq1dJVV0lHHOF1zfM1aeJNf/utdOyx0VxDACggwairrrrKJSQvUaKEypUr5wJRl156qXuc2a18+fJ5v/YAAABAjNq6e6tSAinRXg3kkq1bpXvvlRo2lGwcp/+u06t6demVV6Q5c6Szz7Y8uhQ5AORKzqjbbrtNLVq00NSpU7VmzRq99dZbatOmjQ455JCs/DsAAED+s3y5ZGkKkpK8abufOVOqXFmqUyfaa4d8YMCXAzRm/hh1bdJV97a/V9XLVI/2KiGHI+RZsMkGFk9MTJtftqyXK+qmm2y0PIoWAPJkNL1OnTq5m3nzzTd15ZVX6rzzzsvWm0EaM8Yf5tW7t2lLbggAAGIsEGXJXnbt+m9gdinOzkJt8JYSJbzhsghIYR+sRdTIOSO1YdcGvTrzVT3S8RHKKx+wurkFnRYtkho1kk45RRo3Tvrrr7TnFCkiXX21NHCgVKVKNNcWAApBMCpYSgrNjXN6cOvRI216715v2pIbEpACACCGWIuoXbvCL7P5tpxgFPbhpxU/uUCUKV20tMoUK0N55ZO6unWzCwRsECfvFqxXL+mBB7yuegCAPM4ZtWLFihy/wYH8b0FjV1m8PuSp11jd9NCh0V0vAAAA5K4nf3oy9fHm3Zs1efFkijif1NUtEBWqfXvp55+lDz4gEAUAEQtGNWzYUJdccol++eWXLL/wjz/+qAsvvFCHHnrogaxfgWLNfUMPbjZtLf0BAABQMCSnJOuThZ+kTifEJWjg1IFuRGrEbl6oefPCB6KKFpWmTpXato3GmgFAIe6m99133+mee+7RMccco7p16+qkk05Sy5YtVb9+fVWsWNEdWDdu3KilS5fq119/1VdffaWVK1eqQ4cO+tbGNoVj/c5tlI3gg5xdfbGUFAAAACgYnpz2pPak7EmdTg4ka/qq6a511KkNT43quiGjH3+00cO9FBqhrK5+2GGMkAcAUQlGtW3bVpMnT9asWbM0fPhwjRs3zt2buP/GLvWv9NSuXVtdu3Z1LamOPPLIXF/h/GzQID9nlJWVlVtAgUCcmw8AAID8z+rEj/74aIb58Yp3raM6NeiUWn9GdG3YIN15p/Tqq+GX+132qKsDQJQTmFtw6ZlnnnG3VatWacGCBVq/fr1bdtBBB6lJkyaqWbNmHqxmwWBJyi1Zee/e3pUXG4lj1CipW7dorxkAAEincmVv1LxwScxtvi0Hwti6e6vW7/Dqx8FSlKIVW1YoKTlJxYsUp+yiyAJMI0ZIt9zijUXgO+oor54+cqSXRsN6L1ggiro6AMTIaHrGgk4EnnIWkKpWTVq50rvn4AYAQAyykfLsbHTdOgU6d1ZcYqICVaoobtIkLxDFSHrIxJdLv7S27+5xl4ZddN9J96Uuq1q6KoGoKJs/X7rmGunrr9PmlS0r3XefdO213sXiO+6I5hoCQOGQ42AUAABAgWYBJ7sVK+ZN233LltFeK8Q4GzmvWulqWrN9jW485ka1rME+Ewt27pQeeEB69FEvWbmvZ0/pqaekWrWiuXYAUPgQjAIAAAByycVHXqzzm5+vqUunqkP9DpRrDLAGjdbqacmStHn160vDhkmnnRbNNQOAwis+2isAAAAAFCRF4ovolAanuHtEj6XF6NXLCzj5gaiiRaW775bmziUQBQDRxBESAAAAQIGRnOy1errnHmnr1rT57dtLL74oNW0azbUDAMRky6itW7eqf//+qlu3rkqWLKnjjjtO06dPT10+ePBgN2pf6dKlVbFiRXXs2FE///xzutfYsGGD+vbtq3LlyqlChQq69NJLtW3btih8GgAAABQGG3Zu0L/b/o32ahR6dtrQtq10441pgSgbc+DNN6WpUwlEAUCsiLlg1GWXXaYpU6ZoxIgRmjNnjjp16uQCTiutna2kRo0a6fnnn3fLvv/+e9WrV889JzExMfU1LBD1xx9/uNeZMGGCvv32W11xxRVR/FQAAAAoyF6d8apqPVlLnd/prNlrZkd7dQqdzZul666Tjj5amjkzbf7ll0sLFkgXXSTFxUVzDQEAudJNb+PGjRo5cqSWLFniHgcC3hC2vri4OL3++uvZes2dO3dq9OjRGjdunNq1a5faEmr8+PF68cUXdf/99+u8885L9z9PPvmke5/Zs2fr5JNP1vz58zVp0iTXmqp169buOc8995y6dOmixx9/XDVr1szpRwYAAADCenfOu0oJpOjzxZ/rhdNfoJQixE5BPvhAuukm6d+ghmnNmnld8o4/nk0BAAUmGPX555/rnHPO0fbt211XOOsuF8qCUdm1d+9eJScnq0SJEunmW3c9awUVKikpSa+88orKly+vFi1auHnTpk1zXfP8QJSxllXx8fGuO1+3bt2yvV4AAABAZqwl1Jy1c9zjYw8+VodUPITCioA///RGyZsyJW1eqVLSkCFeNz1LVg4AKEDBqFtuuUXVq1fXmDFj1MwuO+SSsmXL6thjj9V9992npk2bqlq1aq71lQWYGjZsmPo863p37rnnaseOHapRo4brjlfZOoPLroj8q6pVq6Z73SJFiqhSpUpuWTi7d+92N9+WLVvcfUpKirvlvrRAXd68fuFh5Wet8ihHyjEWsD9SjrGGfTJ3BF9ey4vjzYG+ZuTrMexboUb8PiL1cd9mfaNSLylM33fb3R99VHrooTjt3p32DT3rrICeeSagOnW86VgoisK0XfILtklsYrvk7+2Sk9+4HAWj/vrrLz322GO5GojyWa6oSy65RLVq1VJCQoJatmypPn36aMaMGanP6dChg2bNmqV169bp1VdfVa9evVyrp9AgVFY99NBDGmKXUEJYHqpdu3YptyUnV5GUoOTkFK1dm5brCtlnO/3mzZvdF8RavyFnKMfcQTlSjrGGfTJ3VElOVoKVZ3KyEteuVV4M3nIgIl2PMexbQWURSNG7s991j4vEF9GJVU7U2jzYT9gmnu++K6YBA8pp8eK005iaNZP1wANb1LmzF5SNQvFniu9K7GGbxCa2S/7eLjmpy+QoGHXooYcecMUpMw0aNNA333zjugDalT1r+dS7d28dckhac2cbSc9aStntmGOOcetjeaMGDBjgWmyFVgCs+5+NsGfLwrH/u/nmm1On7X1r166tKlWquG6IuS0hwbuCk5AQn+MAGtK+HNYl1LYVwaicoxxzB+VIOcYa9sncEZdgoSgpPiEhT47boekJsivS9RjDvpVm6rKpWr19tXt8aoNT1bRu0zwp88K+TdaskW69NU7vvZfWEiohIeByRQ0cGKcyZcorFhX07ZIfsU1iE9slf2+XnNRlchSMskTi1157rUsmbqPZ5QULONnNkqNbjqpHrS3uPgrIb55u3fw2bdrkWlK1atXKzfvqq6/cc4624TXCKF68uLuFssLOm4NGWrJ3DkoHzr4cebetCg/KkXKMJeyPlGUsCR6iJS+ONQf6mpGvx3j4nnrem/Neaplc0PyCqNZHCuI2sZ4fr7wi3XmnN2Ke77jjLEF5nJo3t6nYHiavIG6X/I5tEpvYLvl3u+Tk9y1Hwagvv/zSRcYsr9Mpp5zirr5Zl7rQFX7mmWey/doWeLImYI0bN3bdAW+77TY1adJE/fr1c62lHnjgAZ111lmuxZR10xs2bJhWrlypnj17uv+3dercubMuv/xyvfTSS9qzZ4+uu+46l2OKkfQAAACQW3bt3aWP5n/kHpcpVkZnNj6Tws1Fs2ZJV10l/fxz2jwbN8muUV9yiZ38UNwAkF/lKBj1/PPPp0smHk5Og1HWH9Gam//zzz8u6XiPHj1cAKpo0aJupL0FCxborbfecoGogw46SG3atNF3332nww8/PPU13n33XReAOvnkk12Ezl7j2WefzclHBQAAAMKasGiCtuz2Esb3aNpDpYqWoqRygWUDGTRIslOJ4Jy4F10kPfaYVMXSrwIACl8wKi9Hg7Bk5HbLrB+ijeC3PxbEeu+9tCbTAAAAQG4rW6ysjq99vH5Y8YMbRQ8HJhCQxo6VbrhBWrkybX6TJtYlTzrxREoYAAp1MAoAAAAo7E5teKq7Ld24VHXK14n26uRrS5dK118vffpp2jzLhztwoCUul4oVi+baAQBiKhi1dOlSTZw4UX///bebrlu3rk477TTVr18/t9YPAAAAiGn1K1L3zamkJOnJJ6WhQ6WdO9Pmd+4sDRsmBQ2oDQAoQHIcjLrllltcTqjQLnuWo6l///56/PHHc2P9AAAAABRA334rXX21NG9e2ryaNb1cUT16WA7aaK4dACAv5WgMiieeeEJPPfWUunfvrmnTpmnTpk3uZo/POecct8xuAAAAQEHz77Z/9cPyH9wI0Mi+deu80fDat08LRNnIeDfeKM2fL51zDoEoACjochSMevXVV3XWWWdp1KhROvroo1WuXDl3s8fvv/++zjzzTL388su5v7YAAABAlA3/bbhOGH6CDnn2EH2z7Jtor06+YR0q3nhDatxYGj48bX6bNtL06dLTT0vlykVzDQEAMR2MWrZsmU499dRMl9syew4AAABQkFhrqHfmvOMeL9u0THUr1I32KuULc+d6LaEuvVTasMGbZ4Enyws1bZrUsmW01xAAEPPBqKpVq+r333/PdLktq1KlyoGsFwAAABBzfl/zu+Ylen3LTqhzgupVqBftVYpp27dLd94pHXWU9P33afP79JEWLpSuuUZKSIjmGgIA8k0wqmfPnnrttdf08MMPa7sdYf5jjx955BG3rHfv3rm5ngAAAEDUvTPbaxVlzm92flTXJdZNmCAdfrj0yCPS3r3evIYNpcmTpffek6pXj/YaAgDy1Wh69913n2bNmqW77rpL9957r2rasBeSVq1apb1796pDhw4aauOzAgAAAAVEckqyRs4d6R4XjS+qnof3jPYqxaQVK7xk5GPHps0rVkwaMMBrJVWiRDTXDgCQb4NRpUqV0pdffqlx48Zp4sSJ+vvvv938zp07q0uXLi6BeRxjsQIAAKAA+XrZ11q1dZV73OXQLqpUslK0VymmWOunZ5+V7r3X657nO/lk6YUXpEaNorl2AIB8H4zynX322e4GAAAAFHTvznk39XHfZn2jui6x5qefpKuustyxafOqVpWeesrLD8V1agDAAeeMAgAAKPCWL5dmzpSSkrxpu7dpm49CZ+eenfpo3kfucbni5XRGozOivUoxYeNGLwh13HFpgSgLPFlicktQft55BKIAADlsGVW/fn3Fx8drwYIFKlq0qJveXzc8W7548eKsvHyhMmaMtGaN99jubbp792ivFQAASMcCTo0bS7t2ya/xxCUmSq1aeQlv7Cy7Th0KrRB54LsHtDVpq3vco2kPlSxaUoWR1V2HDJEWLZJs8OzNm6UtW9KWH3mk9NJL0tFHR3MtAQAFIhjVvn17F1yygFTwNLJ/8O7RI32/epsePZqAFAAAMWXdOheICsvm23KCUYVGIBDQxws+do/j4+ILbRc9vy5rpwGBgJeo3FemjA1yJF13nVTkgBKBAAAKgywdKt588819TiNr7CqSd/BOvcbqpm3gQVpHAQAAxKbJiyfrj8Q/3OOUQIp2J+9WYa3LGgtEBStfXpo7Vzr44KisFgCgsOSMevvtt7Vs2bJMl9voevYcpGfNmUMP3jZtLf0BAAAQm62iBk4dqIS4BDdt94O/HuzmFyZr13oBp3B27yYQBQCIQDCqX79++vHHHzNd/tNPP7nnID0bzja0d6NNW0oKAAAAxGarqOmrpis5kOym7d6mbX5h8fnnUvPmUkpKxmXUZQEAEQtG7e9K0Pbt21WEzuIZDBrkt4zyyy/gpm0+AAAAYovVeW//4nZLrJBufrziXWupgt46ylo83XKL1Llz2gA8xr+46ueOoi4LAMiuLKcXnD17tmbNmpU6/d1332mvZeAOsWnTJr300ktqZM2AkI7lhbJk5b17e8nLLV43apTUrRsFBQBATKlc2Rs1L1wSc5tvy1HgJSUnafGGxXb5MN38FKVoxZYVbnnxIsVVEC1YIPXpIwVV/3XaadI550jPPuulmbDW/RaIoi4LAMizYNTYsWM15L+shTaS3ssvv+xu4VSoUIGcUfsISFWrJq1c6d1z8AYAIAbZSHl2tr1unQKdOysuMVGBKlUUN2mSF4hiJL1CoVhCMVUvU12LNy520xP6TFCNsjXc46qlqxbIQJS1dHrtNenGG6WdO715xYpJjz0mXX+91xrqkkuivZYAgEITjLriiit0xhlnuObIbdu21dChQ3WaXR4JYkGq0qVLq0GDBnTTAwAA+ZsFnOxmZ+LG7lu2jPZaIYJmrp6ZGohqV7edTm90eoEu/w0bpMsvl8aMSZvXtKk0cqTUokU01wwAUGiDUTVq1HA3M3XqVDVt2lRVq1bNy3UDAAAAoubdOe+mPu7brG+B3hJffy2df77Xet931VXSE09IpUpFc80AAIU6GBWsffv2ub8mAAAAQIzYm7JXI+eOTO2u1/OwniqI9uyRBg+WHnrIH2hHqlRJev11qWvXaK8dAKCgylEwyvz77796/fXXNXPmTG3evFkpIWO9Wpe9L7/8MjfWEQAAAIior5Z+pX+3/esedzm0iyqWrFjgtsDixdJ550m//JI2r0MHacQIqVataK4ZAKCgy1EwykbWO/HEE7Vz5041btxYc+bM0WGHHeZG0lu5cqXLGVW7du3cX1sAAAAgwl30zm92foErcws4XXONtG2bN22jPN93n3TbbVJCQrTXDgBQ0MXn5J/uvPNOlSlTRgsXLtQXX3zhkpo/88wzWrFihT744ANt3LhRDz/8cO6vLQAAAJDHduzZoTHzvSze5YuXL1CJy7ds8XJDXXhhWiCqQQPphx+sjk8gCgAQw8GoH374QVdeeaXq1Kmj+HjvJfxuej179lTfvn11m11WAQAAAPKZTxZ+om1JXqTmnMPOUYkiJVQQ/PSTdOSR0rtpjb500UXSb79JbdtGc80AAIVNjoJRFniqVq2ae1yhQgUlJCRog40F+59mzZppxowZubeWAAAAQIS0q9tOj3R8RM2rNdf5zfN/F73kZOn++6UTTpCWLvXmlSsnvfee9OabUtmy0V5DAEBhk6NgVP369bX0vyOZtYyyaeuu5/vxxx9dkAoAAADIb2qWranbj79dv1/1u9rXzd+jSK9YIZ10kjRwoBeUMscdJ/3+u9SnT7TXDgBQWOUoGNWpUyd9+OGHqdNXX321XnvtNXXs2FEnn3yy3nrrLZ1nQ3MAAAAA+ZiNEJ1fffSR1Ly59O233rRl1xg0SPrmG6levWivHQCgMMvRaHp33323+vTpoz179qho0aLq37+/tm/frtGjR7suewMHDtRdd92V+2sLAAAQKcuXS+vWSUlJ3rTdz5wpVa4s1anDdkDM2r5d6t9feu21tHm2y1quKOuqBwBAvmwZVbFiRbVq1coFovwrRvfcc49+++03/frrrxo8eLCKFSuW2+taIIwZI61Z4z22e5sGAAAxGIhq3Fhq1UpxiYlulrtv1cqbb8tR4Iz4fYQqP1pZr8x4RfmJ1SePOipO9epVU+PGcTr00PSBqF69vG55BKIAAPk6GPXCCy8o8b+KGbJXUejRQ9q715u2e5smIAUAQIyxFlG7doVfZvNtOQqUQCCgO7+8U+t3rteVE67Uy7++rPxUv5wzR9q9O05//SWtXu0tK11aeuMN6f33bdChaK8pAAAHGIy67rrrVKtWLZ1yyil6/fXX042kh8wNGWKtyOyRn3sgzk0PHUqpAQAARNPnf32uVVtXpU6XLlpa+al+GQik1S9NyZJer9J+/fz6JwAA+TwYtWDBAtctb/Xq1br88stVo0YNdenSRSNGjNCWLVtyfy0LiEWLrKKQfp5NL1wYrTUCAACAtYq6dcqt6Qri2V+edfNj3YIFGeuXJiVFatQoGmsEAEAeBaMaNWqke++9V3PnztWcOXN0++23a8mSJbroootUrVo1de3aVe9be2CElFvGK1M2baknAAAAEB2TF0/WH4l/pJs3fdV0Nz+W/fCDlJyccb7VL5s0icYaAQCQh8GoYIcffrjuu+8+11rKEpjbyHpTp07V+eeff6AvXeDYULrelSv/8lXATdt8AAAARJ61fho4dWCG+fGKd/NjtXXU229LJ50UHIzy1jMujvolAKAQBKN8s2fP1qhRo/TRRx9p69atKl68eG69dIHRvbs0erRUpIg3bfeWdLJbt2ivGQAASKdyZalEifCFYvNtOQqEpOQkLdm4JMP8FKVoxZYVbnksse53AwZIF10kJf23as2a2QViqXjxgHtM/RIAEOv+C4vkzLx58/TBBx+4INSiRYtUtGhRnXrqqRoyZIjOOuus3FvLAhaQqlZNWrnSuycQBQBADKpTx0vquG6dAp07Ky4xUYEqVRQ3aZIXiLLlKBCKFymufkf20+PTHnfTNx1zk85v7rXwr1q6qlseK7Ztky64QPr447R5V18tPfOMlJAQ0Nq1a1W1alXFx5OxHABQAINR1i3PAlAWjEpISNDJJ5+sO++80+WKKl++fO6vJQAAQKRZwMluxYp503bfsiXboQD6atlXqY9vOPoG1atQT7FmxQrJrvXOmuVNx8d7Qahrr/VyRFmLKQAACnQwaujQoWrfvr1uuOEGde/eXQcddFDurxkAAACQx5ZuXKqZq2e6x61qtIrJQNQvv0hnny39+683Xa6cNGqUdOqp0V4zAAAiGIxauXKlawIMAAAA5GfVy1TXRz0/0pgFY3R0raMVa2yA6n79pF27vOlDDpHGj5cOOyzaawYAQISDUX4gavfu3Zo5c6brn3788cerMsk8AQAAkI+ULFpSPQ7r4W6xxAbxGzLEu/natfMGw6HKDQAotKPpPfvss6pRo4ZOOOEE11XPRtMz69atc0GpN954IzfXEwAAACgUdu6Uzj03fSDKWkdNmUIgCgBQiINRw4cPV//+/dW5c2e9/vrrCtilm/9YIOqkk07S+9amGAAAAECWrV4ttW/v5YQylpz8scek119Py6UPAEChDEY98cQTOvvss/Xee+/pzDPPzLC8VatW+uOPP3Jj/QAAAIA8cd8392nUH6O0LWlbTJTwb79JbdpI06d702XKSOPGSbfe6gWlAAAo1Dmj/vrrLzeSXmYqVaqk9evXH8h6AQAAAHkmcXuiBn8zWCmBFDWr2kyzr/ZSTkTL2LHS+edLO3Z403XqeInKmzeP6moBABA7LaMqVKjgckNlZt68eapevfqBrBcAAACQZ8YtHOcCUabLoV2iVtKW7eKhh6Tu3dMCUcceK/3yC4EoAEDBlaNgVJcuXfTKK69o06ZNGZZZ97xXX31VZ511Vm6sHwAAAJDrRs8fnfq4R9PojKS3e7d00UXSXXelzevbV/rqK6lataisEgAAsRuMuv/++5WcnKwjjjhC99xzj+Li4vTWW2/p/PPPV+vWrVW1alXde++9ub+2AAAAwAHatGuTvlzypXtcp3wdta7ZOuJlunatdNJJ0ogRafMeeMCbLlEi4qsDAEDsB6Nq1qypGTNmuNH0PvjgAzea3ogRIzR+/Hj16dNHP/30kxtVDwAAAIg14xeO156UPe5x9ybd3YXVSJozR2rbVvrxR2+6ZEnpo4+8FlIkKgcAFAY5SmBurPXTa6+95m6JiYlKSUlRlSpVFB+fo/gWAAAAEBFjFoxJfdzjsMh20fv0U+ncc6Vt/w3gV7Oml6i8ZcuIrgYAAPkzGBXMglAAAABArNuWtE2T/prkHlcvU13H1T4uYonKn3pKuvVW77Fp3VoaN84LSAEAUJhkKRg1dOjQbL+wNXceOHBgTtYJAAAAyBMT/5yoXXt3ucddG3dVfFzet+pPSpKuvVZ67bW0eT17Sm++KZUqledvDwBA/gxGDR48ONsvTDAKAAAAMT2KXgS66K1fL51zjvT112nzbJyfQYMkslsAAAqrLAWjLB8UAAAAkN8NbDdQTSo30VdLv1L7uu3z9L0WLJDOOENavNibLl5cGj5c6tMnT98WAIDCkTMKAAAAyA8Or3q4uw0+Mfst/7Nj8mSpVy9p82Zvulo1Lz/U0Ufn6dsCAJAvZLmT/C+//KINGzZk6blLly7V22+/fSDrBQAAAORLw4ZJXbqkBaJatLC6NIEoAACyHYw69thjNWmSN/KIscBUqVKl9M0332R47o8//qh+/fpl9aUBAACAfG/vXi9R+XXXScnJ3ryzzpK+/16qUyfaawcAQD4MRgX8MWiDpnft2qVk/0gLAAAAxKif/vlJD3z7gBasW5Anr79pk9ca6oUX0ubdfrs0dqxUpkyevCUAAPlW3o9lCwAAkB8tXy7NnCklJXnTdm/TNh/5zvDfhuueqfeo6bCmmvjnxFx97b/+ko45RpoyxZsuWtRLVP7II4yYBwBAOASjImzMGGnNGu+x3ds0AACIMRZwatxYatVKcYmJbpa7b9XKm09AKl9JTknWqHmj3ONi8cXUrm67A3o9q79ZHqiSJaUGDaSjjpIWLvSWVa4sffWVdPHFubHmAAAUTASjIsgqLj16ePkEjN3bNAEpAABizLp10q5d4ZfZfFuOfOO7v7/Tpl2b3ONSxUqpVNFSB1yfmzPH2xWWLJG2bfOWHXaY9PPP0gkn5NaaAwBQMBXJzpOXLVummdY8XTY6iDc8yJ9//qkKFSpkGE0PGQ0ZIsXFWb6tuP/mxLnpoUOl7t0pMQAAgLzw1E9PpT62oNTkxZN1asNTD7A+l35+2bLStGlSuXIHurYAABR82QpGDRw40N2CXXPNNRmeZ8nN4+wojXQWLcpYcbFpv1k3AAAAcr+L3sS/0nJEJcQlaODUgerUoFOO6qvh6nN+SjECUQAA5HIwarhlYcQBadTIa9IdXIGxOpClngAAAEDue/6X57UnZU/qdHIgWdNXTc9R66iUFKlUqYw9OK0+16RJbq0xAAAFX5aDURdddFHerkkhMGiQl2NAsmiUXYkLuC57Nh8AAAC5y1rrP/z9wxnmxys+262jLBB1xRXShg3p5/td9qjPAQCQTxOYb926Vf3791fdunVVsmRJHXfccZo+fbpbtmfPHt1xxx1q1qyZSpcurZo1a+rCCy/UqlWr0r3GokWLdPbZZ6ty5coqV66cTjjhBE2dOlWxwPJCjR4tFfkvBGj3lgSzW7dorxkAAEjHhkQrUSJ8odh8W46Yt3vvbiXu8EZDDJaiFK3YskJJyUlZep3kZKlfP+n119MCUHXqeLtC8+bU5wAAyNOcUXntsssu09y5czVixAgXbHrnnXfUsWNHzZs3T2XKlHHJ0y1nVYsWLbRx40bdeOONOuuss/Trr7+mvsYZZ5yhQw89VF999ZULaD399NNu3uLFi1W9enXFQkCqWjVp5UrvnkAUAAAxyCINltRx3ToFOndWXGKiAlWqKG7SJC8QZcsR8xauX+i65Zk2NdvopTNeSl1WtXRVFS9SfL+vYaMfWweB997zphMSpJEjpZ498269AQAo6GImGLVz506NHj1a48aNU7t27dy8wYMHa/z48XrxxRd1//33a8qUKen+5/nnn1fbtm21fPly1alTR+vWrXOj+73++utqbpepJD388MN64YUXXJArFoJRAAAgn7CAk92KFfOm7b5ly2ivFbLhkIqH6J1u72j0/NE6o9EZalkje9tvzx6pb1/pww+96aJFpQ8+4GIiAAAFJhi1d+9eJScnq0RIk3hr3fT999+H/Z/Nmze7fv4VKlRw0wcddJAaN26st99+Wy1btlTx4sX18ssvq2rVqmrVqlVEPgcAAABiQ9niZdW3eV93yy4bHe/cc6WxY9NikR99JJ15Zu6vJwAAhU3MBKPKli2rY489Vvfdd5+aNm2qatWqaeTIkZo2bZoaNmyY4fm7du1yOaT69OnjckMZC0x98cUX6tq1q3u9+Ph4F4iaNGmSKlasmOl779692918W7ZscfcpKSnulvvSEmXmzesXHlZ+lpyUcqQcYwH7I+UYa9gnc0dweuu8ON4c6GtGvh5T8PctK85eveI0YYK39YsXD2j06IBOO81LZB6LCvo2ya/YLrGHbRKb2C75e7vk5NgTM8EoY7miLrnkEtWqVUsJCQmudZMFm2bMmJHueZbMvFevXq5QrAufz6avvfZaF4D67rvvXKuq1157TWeeeaZLhF6jRo2w7/vQQw9pyJAhGeYnJia6oFduS06uYhkHlJycorVrMybVRNbZTm8t5GzbW/AROUM55g7KkXKMNeyTuaNKcrISrDyTk5W4dq3yYgCXAxHpekxB37d27pQuvbSipk718kmVKBHQm29uVKtWScqDzZ9rCvI2yc/YLrGHbRKb2C75e7vkpC4TF7BXjTHbt293V/UseNS7d29t27ZNn376abpA1JIlS1yScuua5/vyyy/VqVMnl9zcby1lLKH5pZdeqjvvvDPLVxRr166d4XVyS506cVq5Mk61agW0fHnMFX+++3JYZbtKlSpUvCjHqGN/pBxjDftk7oirU0dxK1cqUKuWAsuXK7dZvcNacFtlLyf1jkjXY/LLvjXo60Euafkph5ySpUTlZscOqWvXOH35pdciqlSpgD75JKAOHRTz8sM2KYzYLrGHbRKb2C75e7vkpC4TUy2jfKVLl3Y3q0R9/vnnevTRR9MFoixJ+dSpU9MFoswOq0FIGQrJpvfVbMxyS9ktlP1f3hzM0wJQVBYOnHXPzLttVXhQjpRjLGF/pCxjSfBlo7w41hzoa0a+HhP739MlG5fo/u/ud4/b1W2nby7+Zr//s22blw/q66+96TJlpM8+i9P//hfcUTO2xfI2KczYLrGHbRKb2C75d7vk5LgTU8EoCzxZQy1LQv7XX3/ptttuU5MmTdSvXz8XiDrnnHM0c+ZMTZgwwSU7//fff93/VapUScWKFXM5pywad9FFF+nee+913fReffVVLV26VKeffnq0Px4AAAAiYMz8MamPOzfovN/nW++CLl0kf8wcu6g7caJ03HF5uZYAABReMXXZxJp0Wc4nC0BdeOGFOuGEE1yAqmjRolq5cqU++eQT/fPPPzryyCNdFz7/9uOPP7r/r1y5sktWbt36TjrpJLVu3dqNxDdu3Di1aNEi2h8PAADkJ9Ylb+ZMb1g1Y/c2nQdd9ZB3wageh/XY53M3b5ZOPTUtEGWDNE+ZQiAKAIC8FFMto6wLnt3CqVevnms1tT8WgLIAVqwaM0Zas8Z7bPc23b17tNcKAACkYwGnxo1t+N7U0fTiEhOlVq0so7W0cKElgaTQYtDKLSs17Z9p7nG9CvXU6KBGYZ9ndbB775XmzbNBcLx5lSp5gaiWLSO5xgAAFD4x1TKqoLNKT48e0t693rTd27TNBwAAMWTdOheICsvm23LEfKuopOSksBcz/TrZH3+kBaLM3XcTiAIAIBIIRkWQjboc5y6vpl5jddNDh0ZyLQAAAAqu1357LfXxqq2rNHnx5AzPGTQo4/9Zneztt/N67QAAgCEYFUGLFqW/+mZs2lr6AwAA4MCs3bZWs9fMTp1OiEvQwKkD07WOspbp1jUvFHUyAAAih2BUBDVq5LeMSmPTlpICAAAAB+bB7x5MN50cSNb0VdNTW0dZwOnKK6WUlIz/S50MAIDIIRgVQdYk3Lsw51+dC7jpcE3FAQAAkHXW+mn478MzzI9XfGrrqLvukt54I22Zf5HQ7qmTAQAQOQSjIshGzRs9Wiry3xiGdm8JNLt1i+RaAACA/apc2Rs1Lxybb8sRUyxZeZH4jANFpyhFK7as0BNPJ+nhh9OCT7fcIjVv7m1Ou6dOBgBA5GQ8YiPPA1LVqkkrV3r3BKIAAIhBdep4SR3XrVOgc2fFJSYqUKWK4iZN8gJRthwxpXiR4pp15Swl7kjMsOz7yVV148XFU6eff1665poIryAAAEhFMAoAACAcCzjZrVgxb9ruW7akrGJY7fK13S2YxQ9vuSxt2tIjEIgCACC66KYHAACAAunnn6UePbwR9MxVV5GrEwCAWEAwCgAAAPna1KVT9dS0p/T3pr9T5y1YIJ1+urRjhzd9zjle97zQkY0BAEDkEYwCAABAvvbyjJd18+SbVe+Zepq2Ypr++Ufq1Elav95b3qGD9M47UkJCtNcUAAAYckYBAAAg39q1d5c+/fNT97hSyUo6pERrnXSitGKFt/yoo6SPP5aKp+UvBwAAUUYwCgAAIJzly91oekpK8qbtfuZMRtOLMZMXT9a2pG3u8ekNzlb3rkU1b563rEEDaeJEqVy56K4jAABIj2BUhI0ZI61Z4z22e5vu3j3SawEAAPYbiGrcWNq1S36KobjERKlVK6lECWnhQm+kPUTdc788l/r4nbt7KLDQe1ytmjR5sncPAABiCzmjIsgCT8Ejuti9Tdt8AAAQQ6xF1K5d4ZfZfFuOqNu9d7e+WjLVm0iJV+Cvk1OX3XabdMgh0Vs3AACQOYJRETRkiD+CS+o1Vjc9dGgk1wIAAKBgeOyHx5SiZG8iPkWq9417aPWrESOiu24AACBzBKMiaNEiKRBIP8+mraU/AAAAsi4QCOjpn59Om5ESL5000JZQvwIAIMYRjIqgRo38llFpbNpSUgAAACDrxi8ar/U716fNsJZRtaZLDSZTvwIAIMYRjIqgQYP8llF+8yjvyp3NBwAAQNZbRd342c0ZF/zXOsqWU78CACB2EYyKIBs1b/Roqch/YxjavSUv79YtkmsBAAD2q3Jlb9S8cGy+LUfUbN+VpJXrtmRcEJ+iIget0AcfJVG/AgAghv0XFkEkA1I2xPDKld49gSgAAGJQnTrSV19JS5YocN11itu0SYEKFRT3/PPeEG22HFEz4Pbi2vP2DKl0oipWlN55R6pe3VtWtXRVHVyuOFsHAIAYRjAqwqwl1Jo13mO7t2kLUAEAgBiyfLl00knSrl1pY+Bu2iSdf77XMspGHyEgFVFWZ7KRiefNk/bW+UK64AYlTH5WE17tqOOOiuy6AACAA0M3vQhXonr0kPbu9abt3qZtPgAAiCHr1rlAVFg235Yj4nWoOXOs/hSQTr5LqjJflXrdpWOPDRmqGAAAxDyCURFkV/O80fRSr7G66aFDI7kWAAAA+bMO5QaCOXyUN2qepMSi0zV58eRorx4AAMgmglERtGiRP5peGpu2lv4AAADYXx0qIHW6NagiFaeBU73R8wAAQP5BMCqCGjXyW0alsenGjSO5FgAAAPmLn5xcDSdK5f9JWxAX0PRVtI4CACC/IRgVQYMGBV3VcwJu2uYDAAAgo507vZurP53WP8PyeMXTOgoAgHyGYFQE2ah5o0dLRf4bw9DuLSFnt26RXAsAALBflSt7o+aFY/NtOSLi4Yf/G4k4IUkq/3eG5SlK0YotK5SUnMQWAQAgn/gvLIJIBqSqVZNWrvTuCUQBABCD6tTxkjquW6dA586KS0xUoEoVxU2a5AWibDny3J9/So884j1OqLRcyUW8gFONMjU07txxSohPcNNVS1dV8SLF2SIAAOQTBKMAAADCsYCT3YoV86btvmVLyipCLJXB9ddLu3d700dd8aJ+/W9Z/2P6q02tNmwLAADyKbrpAQAAIOZYaoPPP/ce16q/XX+WecM9LlGkhC496tLorhwAADggBKMAAAAQU7ZulfoH5So/8673tHn3Zvf43CPO1UGlDoreygEAgANGMAoAAAAxZehQL7+mOe00aVulb1OXXdvm2uitGAAAyBXkjAIAAEDMmDtXevpp73Hx4tJzz0mHHPK2rm17rSb+OVGta7aO9ioCAIADRDAKAAAAMZO0/Nprpb17vekBA6QGDexRnI45+Bh3AwAA+R/d9AAAABAT3nlH+va/HnkWhLrjjmivEQAAyAsEowAAABB1GzdKt96aNv3889Kmvf8qYM2lAABAgUIwCgAAAFF3zz3S2rXe4x49pJNP2aPWr7RWq1da6a1Zb0V79QAAQC4iGAUAAIComjFDevFF73Hp0tJTT0njFo7Tyq0r9du/v2nsgrFsIQAAChCCUQAAAIia5GTp6qu95OVm0CCpdm1p2PRhqc+5ru110VtBAACQ6whGAQAAIGpee02aPt17fNhhUv/+0h9r/9DXy7528xof1Fgn1z+ZLQQAQAFCMAoAAABRkZgoDRiQNv3CC1LRoulbRV3T5hrFxcVFZwUBAECeIBgFAACAqLjjDm8UPXPBBVL79tKW3Vs0YvYIN6900dK6qMVFbB0AAAoYglEAAACIuO+/l4YP9x6XLy899pj3+O3f39a2pG3u8QXNL1D5EuXZOgAAFDAEowAAABBRe/dK11yTNv3AA1K1apbEPJCui961ba9lywAAUAARjAIAAEBEPfecNGeO97hlS+mqq7zHXy39SgvWLXCP29VtpyOqHsGWAQCgACIYBQAAgIhZuVK6917vseUlf/FFKSHBm65cqrLOOewcJcQl6Lo217FVAAAooIpEewUAAABQeNxyi7TNSwmlK66Q2rZNW9aiegt92PND/bPlH1UrXS1q6wgAAPIWwSgAAABExBdfSB984D2uXFl68MHwzzu43MFsEQAACjC66QEAACDP7d4tXRuUj/zRR6VKlSh4AAAKI4JRAAAAyHOPPy4tWuQ9Pv546aKL0pZNXjxZ785+V7v37mZLAABQCBCMAgAAQJ5aulS6/37vsSUrf+EFKT6oFjro60E6f+z5qvN0Ha3YvIKtAQBAAUcwCgAAAHnqxhulXbu8xzfcIDVvnrZsxqoZ+umfn9zj6mWqky8KAIBCgGAUAAAA8swnn0jjx3uPa9aUBg9Ov3zY9GGpj69tc63i4uLYGgAAFHAEowAAAJAnduzwWkL5nnxSKlcubXr9jvUaOXeke1y+eHn1bdaXLQEAQCFQJNorAAAAEJOWL5fWrZOSkrxpu585U6pcWapTJ9prly888ID099/e444dpV690i8fPmu4du31+u/1O7KfShcrHYW1BAAAkUbLqAgbM0Zas8Z7bPc2DQAAYjAQ1bix1KqV4hIT3Sx336qVN9+WI1NWv2nSRHrwQW+6SBFp2DApuAdeckqynpj2ROr0NW2uoUQBACgkCEZFuGLWo4e0d683bfc2TUAKAIAYYy2i/IzboWy+Lcc+6zsLF6bNszrP3Lnpnzfxz4n6d9u/7nG54uXUsFJDShQAgEKCYFQEDRniXxH0LwvGuemhQyO5FgAAAJGo76QJV98Z8s2Q1Mdbdm/R5MWT2SwAABQSBKMiaNEiKRBIP8+mg68cAgAAFPT6zuqtq/Xr6l9TpxPiEjRw6kAFQv8RAAAUSASjIqhRo/BXCi31BAAAQEHQMExvu9D6zuw1s9MtTw4ka/qq6bSOAgCgkCAYFUGDBvlXCv2rfgE3bfMBAAAKgi5dMgaigus71vrJWkHFh1RDbZrWUQAAFA4EoyKoe3dp9GhvRBlj95bks1u3SK4FAADYr8qVpRIlwi+z+bYcYS1blva4aFGpefP09Z2k5CQt37xcKUpJ9382vWLLCrccAAAUbP+FRRDJgFS1atLKld49gSgAAGJQnTpekqN16xTo3FlxiYkKVKmiuEmTvECULUcG27ZJ48d7j62YVq3yAlI+axWVEJ+g6ZdPV+KOxAz/X7V0VRUvUpySBQCggCMYBRRSycnJ2rNnj3uckpLiHu/atUvx8TSYzCnKMe/KsWjRokpISMildwCyyAJOditWzJu2+5YtKb59sEDUzp3e43POSR+IMtP+maZeH/bSla2u1BWtrlC1MtUoTwAIqZsXRtSjY3u72P6Z2+eJBKOAQsauSv/777/atGlTunn2Q7N161bFhWbZR7bKlnLMu3KsUKGCqlevzj4KxLD33097fO65GZc//8vzWrl1pe79+l7VrVBXF7a4MKLrBwD5oW5eGFGPjv3tUrFixVytixOMAgoZ/2BXtWpVlSpVyv2Y2I/M3r17VaRIEU70DwDlmDflaNM7duzQ2rVr3fIaNWrk0jsByE0bN0oTJ3qPa9aUTjgh/fI129boo3kfuceVS1VWr8N7sQEAFHrh6uaFEfXo2N0u1jIqKSlJiYmJuVoXj6lglEXbBg4cqLFjx7qTjqOOOkrPPPOM2rRp4wrgnnvu0WeffaYlS5aofPny6tixox5++GHVtBpPkE8//VRDhw7V7NmzVaJECbVv314ff/xx1D4XECuseaV/sDvooINS5/Pjnzsox7wrx5IlS7p7OzbY/kuXPSD2WFXL72HSq5cU2rP21Zmvak+K94RLj7pUJYpkkiAeAAp53bwwoh4du9vF6uRly5Z19fLcrIvHVHKYyy67TFOmTNGIESM0Z84cderUyQWcVq5c6a6Kz5w50wWr7H7MmDFauHChzjrrrHSvMXr0aF1wwQXq16+ffv/9d/3www8677zzovaZgFji90O3qy5AfuPvt4U5nwKQX7vo7U3Zq5d+fck9jo+L11Wtr4rw2gFA7KFujsJcF4+ZllE7d+50gaRx48apXbt2bt7gwYM1fvx4vfjii7r//vtdoCrY888/r7Zt22r58uWqU6eOu5J+44036rHHHtOll16a+rzDDjss4p8HiGWFtfkv8jf2WyB2WS/aL7/0HterJ7Vtm375uAXjXK4oc0ajM1SvQr0orCUAxCbqOCiM+2nMBKMskGTNFK1bXTDrmvH999+H/Z/Nmze7ArGktsZaTFkrKsvybl38rP/tkUce6YJTRxxxRKbvvXv3bnfzbdmyxd1boi675b60jZg3r194WPn5SdWQ9fLyb8H86dD5yB7KMe/K0d9v8+63ueDhNzJ3BFe98mLfO9DXjHw9JuO+9eGH1t3Ea3Dfu7d/nEl7/rDpw1IfX93qar7DEdgmiA1sl9gTS9tkX3Xzwoh6dOxvl8zq4jn5PsVMMMr6IB577LG677771LRpU1WrVk0jR47UtGnT1LBhwwzPtyG/77jjDvXp00flypVz8yyXlN+i6sknn1S9evX0xBNP6MQTT9SiRYtUqVKlsO/90EMPaciQIRnmW4Iue5/clpxcRVKCkpNTtHatlwQMOWM7vQUl7UuR20NNFkTWpNLKzIK/dvNZ+Vkw2HBlZt8OPfRQXX/99brhhhvcdLFixfThhx/q7LPPzvNyPOmkk3T55Ze7372C5oQTTtDNN9+s7t27Z1qOts/a/rt+/XoVDR0vHmHxG5k7qiQnyzIjpCQnK/G/RPq5nTPzQES6HhNu33rnHatjFXPLOnZcr7Vr044xCzcs1NRlU93jBuUbqHmZ5qkDEiDvtgliA9sl9sTSNsmsbp6f/PTTT+58+9RTT3W9nHKK85HYFLxd9lUXz0ldJmaCUcZyRV1yySWqVauWS4jVsmVLd9I1Y8aMDF/aXr16uYKxLnyh0bi7775bPXr0cI+HDx+ugw8+2J0sXnnllWHfd8CAAe4kKPiKYu3atVWlSpXUQFduSkjwTq4SEuJd8i/knG1zO1m1bRXtg0l+YCcl9kNhSejsFiqWT/AtD9xbb72VOm3BZRvc4JFHHlHz5s0jui62r/nlt2rVKjfMaXB55kU5fvLJJ+7krW/fvnm6r9tv5b333qtly5a5wJsNEtGlS5d9/s/XX3+tW265RX/88Yf77bTf4Isvvjjdc6zV6p133qmJEye6HIB2keGNN95Q69at3XIboMJ+h88555zUzxdajlbGtswSfIa2okV4/EYeoOXLpXXrFPdfJSw+OVlV//lHqlxZqlMn13a7A92fI12PCd23Vq2K188/e3Wbxo0D6tChkoLj8UNnDE19fN3R16l6tep5sk6FHd/32MR2iT2xtE32VzfPD958801dd911rl5nddXQwcVCgxr7+5yxfD5SmBUtWtRtv8zq4jmpy8TUHt+gQQN988032r59u6tI2ZCBvXv31iGHHJIhEPX333/rq6++SlfJ8ocYDM4RVbx4cff/llcqM/Ycu4Wygs7tH6gxY6Q1a7xmbmvW2Mgz8erePVffotCxg0lebKuCyMrIysu/BR8c/OmstuixfdkuxC9aJDVqJA0apDzflzt37uwCzMa64VoA48wzz9zn9zsvBJdf8NCmOSnHrHruuedcQC4vR5H78ccf3YAP1srijDPO0Hvvvadu3bq5LtCZdXVeunSpe+5VV12ld999V19++aVrvWUVEbtCZjZu3OhaPnXo0MEFo6zy9+eff7qAol9OFvCy/5s0aZJ7HK4c/XLn+549lFkO2e9K06Z2ppBWlomJimvTxmpc0sKFuRaQOtDjVyTrMaH7ltVjbrghPrVLXosWcakX3cwXS77Qh398qNJFSyuggC4+6mKO13mI73tsYrvEnljZJpnVzbMrGvVys23bNo0aNUq//vqr1qxZ4y4c33XXXakXK63u99lnn7k6uw1QNnnyZJcf2i4mv/LKK64+36hRIzdImTUmsTKwgIc1IrFzfVtuuaGvueYalxsakRd6fpPZdycn36WYPHsvXbq0O8GzE5jPP//cdX8JDkTZScwXX3yRYfjLVq1aucqYjbLns/+xK/x169ZVtNmPhDXY8ltg2r1N23wgP/H35TlzvPM0u4/Evmzf7+rVq7ub5YOzljYrVqxwXVF81n3XDmo22oMFou3gFjzig42yaQdG6xpswWz73bADqM9y1P3vf/9z+eqsZYF1x7MA+b5Pxj52j+23xrrt2Wif9h62Di1atHDdjYNl9z3s89kB2QJvoe/92muvuYCRvZe1ZLIWVDn1zDPPuIDfbbfd5rpLW7dpa6Fqg0Vk5qWXXlL9+vVdl2j7H7syZq2bnnrqqdTnWIXDPqcFEm3QCXu+jZZqFyB8FmSzINT7wcNxAdG0bl26QFQ6Nt+WF3KfflpcPXvGa/XqtHmjRqUdC6wCe9eXd2ndznVqXLmxPjvvM1Uo4eX5BADk73q5sUBUkyZN1LhxY51//vmudVRo7iurr1tL+/nz57veDHbR8+2333Z1SGtVf9NNN7n/tUYpfss1v2fTvHnzXIt9C3DZe6FgiamWURZ4sp3Xdua//vrLnRDZzm2tAexk0k5w7Ar9hAkTXMTUIqXGrq7bCaCdWNrV+UGDBrkTHwtAWfJy07Nnzyh/Oi9abUHFQMCPeltkURo6NDKRayAzdqH/33+z/nNgrfqMf6zx73v3lqpVy9prVK8uBcWAcnQl5p133nHdvYID0xZksubC1jLHrsBYaxubd/vtt7vl1s3NBjiwLr4WAJk1a1Zqc+DFixe7YIyN3mkHUwsCWXDFbn6LrKywqz+PP/64Cw5ZlzXrbmy/adYsOSfvYcErCzZZsCeU5Yl59NFH3W+dtZ6yz2ctR/0ceWXKlNnnutrB3yoDxoJmwV19jLVu8oNt4dj/dOzYMcP/9O/fP3XaAmQ2z36HraJhXbHtCpdtm2AWqLLKCoD84YknyiguzpKZBrdgTKvXTF48WdNXTXfzZ66eqV178yZ/FQAUNJbF4L9T3YjUy3NaN3/99dddXdJY/dZycVldz3JI+YYOHapTTjnFPbbBNh588EHXsMTyRRu7eGx1XWspdfzxx7t6eXAeRLuIafVNC0ZZwxQUHDEVjLKd1/Ie/PPPP+5EyprqPfDAA26HtBYH/hV/axERbOrUqak7vJ2Q2QnfBRdcoJ07d+roo492LQosp0u0WbPJ0EESbDqoIRcQFXawW7nywLuVWWu/ld7I3XnCAtF+cMVaElkLSpsX3CzUAkE+G8Tg1ltvda1t/GCUdenzA93GAkY+u1JjwRw/kGLLnn32WbVv394Fr7LaF9ryJ51++unusR1MDz/8cBeMsvfMyXtYcMkGdQjX/NVyM/kJze3gbq/1yy+/uAqBsWDbvgR3dbYAv71PMJv2A//hZPY/1tXafoOt9ZcNLmGfzQJddmVr+vTprjWYXUS46KKLUv/PAojW0i0WRrcBsH9LlhRJF4gKrtfYxcWBUwcqIS5ByYFkd2/TnRp0YqAMAMhS3Ty26+XWG8nqnGPHjnXTdg5uKXYsQBUcjPLzgxqrD1vuUD845UtKSnIXi33Dhg1zF22t3m71SVseGgNA/hdTwSiLdGYW7bSTyqwMd2mBK2uRYLdYY/13rdlk8MewK4iNG0dzrQDvSojk75hxWboCE27AD8tHmJ2WUdllXd/8QQusG+8LL7yg0047zR0I/a64H3zwgQvIWAskaz1loz4EB1wsIHLZZZe5AROsRY+11vG7i1kXvtmzZ7vcRz5/+FLLjRSuZVI4wQnV/ZxSltDRglE5eQ87CGcWCAt+L+vibJ81eJSqcKORRpp9NquIWLDMWGVj7ty5rkVWcDDKAlf2XLtqRvJKIPYdcshezZ9vVcm4DPWa4FZRxgJSNm3zT23o5ZMDABx4PTk36uXZfU9jQSerZwcnLLc6raXVCE7xYPVTn9XNzaeffupaygezi5TGLiLbxWRLAWGtp6yHgzU4+fnnn7O3goh5MRWMKugskZw3yF/gv4qb17Td5gPRNH26N1SnXdHISu5Ev2+61+007d66cnfrlnfraQez4OCK5UsqX768Xn31VdftzZrwWqsja41k3cJsmR3Q7GDmGzx4sEvSbQdBS6Zt3XrtOZZ3yQ6QljDRWu2EsuSJWRUcSPET/vmtfXLyHpUrV3bBt/29l/9+wS2LstNNz3JxWfLJYDZt8zOT2f9YUMyCS35ALnhgCWNBt9GjR6ebt2HDBreN7f/y6/DGQGFyyy3bdNllaS3P/WPBvfcGdPsXXmvUYPGKp3UUAGRBdrrLRaNebvU0y/tkdWzLAxqsa9euGjlyZGovhGBWH7RglbV4sl4BwSyQZa/7ww8/6LjjjnMpHXx2kRkFD8GoCLL8CXbuZf137TzLotV5ffIO5OW+bHlBrDuGXQW3oGqk92V/NAdrOeSPBmctpCxPU3AXt1CW4NxuljDRurhZriYLRlmybkuUmJetiXLyHtaSyLrDWUAqu12Os9NNz64+2Wh4wfmepkyZktqnPxxbZqOkBAv9H+v/HzywhFm0aFGGgSWstVRwE20gqipX9kbNC5fE3Obb8kKuY8fdSkiwobq9HJjWUNOOBV3OTNKFj2Y8cUhRilZsWaGk5CQVL5Jx9D8AQP6ol1uaDKuXXnrppe7ibzBLtWOtpvzczcGslZO1erI6uF08tdGWLVWPBaBsmV1UthQW1oPB8klbvih7bCke7DEKFoJRUfixsOaS1n/X7glEIT/vy5FOvG/dt/z8RXYAtCbA1tLIH2XODl52pcVaOrVp08a1fvL7sRsLWlm+KBsMwQ5olp/ODm520PRH4jvmmGNcMnHrymetdCxwZMGVfY0olx05eQ8L0FjrKDtQn3HGGdl6v+wEvWzIXLtKZVe5LOeVlaONNGgJJX2W12/lypXuapixQSNsvS0n1yWXXOJy9FmCSSt7n1U47AqXddOzrtjWrdJeM/h1zXfffZfh6hoQNdZS0Wr169Yp0Lmz4hITFahSRXGTJnmBqGy0liyo5s0r6gJR5oILpLfe8ubv3iuVKFJC2/dsd7miPj3vU1UpXcUtq1q6KoEoAMhlka6XW7DJ0l2EBqKM1attcB1LSxGOjdZcpUoVl0fV8opWqFDBXay1OqaxHgR2MdXyT9mFZ7twbK2krEcDChaCUQDyjUmTJqXmYLKrJ9b814Z99ZMknnXWWS7wYYEeC1xZQGXgwIGua56x0fPWr1+vCy+80HUlswBP9+7dU0fssPxLNgKItaz63//+55oLWz4pOxjmlpy8h623jSpqeaayG4zKDgsYvffeey4JvCUat+CejaR3xBFHpD5n9erVLuDns6CeBZ6s3J955hk3FK91n7Rukj4LDFpQ0CoZNqKK/c/TTz/trn75LMBlLdtshEQA+cPMmWndhI8+Om3+R/M+0vqd693jHof1IEcUABQw48ePz3SZjY7s53oOl5bCAkx2AdRu4brpWTc+67UQOsq0Ba9QsMQFspIVvJCxUaAsymtNBoO7sOQG69Pbu7d90eJUpEhAH3wQF/HWJQWJNe+0ZM1Vq1YNO9IY0tu1a5dLkm3BgOCE2P6Pv5cz6sBH1Sus8rIcrUWYjco3c+bMDN3bCgJrMWat3ay1VGblmNn+i8zxG3kALOhqfR0y66ZnraZyqXVUbtc78rIe4/vooxRddpmNhOwdex95RPpv0FIdNuwwzV833z3+5uJv1K5uuzxZB6TH9z02sV1iTyxtE+o2aTgfif3tYhf7M6uL56Tuwdl7BPnJ5fy8vHZv0zYfAPbFEoVbk+jgVkkFiVUIrdk2EDPWrQsfiDI235YXUlZv6dkzXps3pwWL77jDmz9j1YzUQFTJIiV1Qu0TorimAAAgVhGMiiDrCeRd5Pcrb17CT0s2BwD7Y6OTWNe+guiWW25RteyMPwwgyvUZf2Rgj1+fuevLu1Ln7dy7U1OWTInSWgIAgFhGMCqCFi3yhtkMZtMhg0wBAADEeH0mLkN9Zv7f69MFnyx5+cCpA1NzhwAAAPgIRkVQo0Z+y6g0Nm0pKQAAQAxZvfrAlhfw+owUyFCfKd77QgWC5icHkjV91XRNXjw58isJAABiGsGoCLLBpbyLg35FLeCmgwadAgAAsWDTpgNbXoB59ZbQllEp2ll9aobnxiue1lEAACADglER9Pnn/qO0nFHp5wMAgJiQlHRgywuwUaPsb0jXu/89oL1xOzM8N0UpWrFlhZKSC295AQCAjIqEmYc8Mt8bXCaDefMocgAAYsqWLQe2vICyEfP+/ju0ZVSK1O6BdK2hmlRuore7va24uDhVLV1VxYsUj8bqAgCAGEUwCgAAINSKFQe2vIC6+eYwM//f3nmAR1V8bXxCCZ3QCb0X6UVBQECKgCL9U0SqIAoiAiodpP0FKaKISpOigigoTRQQAREVCE0E6UWRDtJ7SOZ73qN3vbvZmmzL7vt7ns1mb5k7d2bunTNnzjnTvJtSqe9aWUPtu7hPXbx1UTUuzlgEhBBCCEkI3fT8SGysZ9sJIYQQEiBu3Ura/hDlH6soM3FKVZ6X4DjGiiKEEBJsPProo6pv375+v+68efNUlixZ/H7dYIfKKEII+ZcffvhBXEqu/BuY2F7HMXPmTFWgQAGVIkUK9e6776qRI0eqSpUqJakM//jjD7nur7/+6vS4gwcPqujoaHX9+vWQq7N9+/ap/Pnzq5s3bwY6K4T8Q/r0SdsfLjz6hm0sc4GxogghJDSZPn26ypQpk7p//75l240bN1Tq1KlF2WNPtj569KjLdHFsZGSkRQ4PhAIJsj/yiw9kfcimzz33nDp//nyS0m3btq06dOiQ8jUjvTAu8SdURhFCPOfECaV27kz4wXYf0aVLF+kYevTokWBfr169ZB+O8Sa2Hce1a9fUyy+/rAYOHKhOnTqlXnjhBfX666+rdevWKX8wePBg1bt3bxEAfMWdO3ekPLNnz64yZsyo2rRpo86dO+f0nCVLlqhGjRrJOfaUapcuXZJ8lypVSqVLl04VLFhQvfLKK+rq1auWY8qUKaMefvhhNXnyZJ/dGyEe4WoGkzOc/8SKqj3BbvEUzFxQxTwfw1hRhBASYtSrV0+UT9u3b7ds27Rpk0yYbt26VWRJgw0bNojcV6xYMZVcyJw5szpz5ow6efKkmjVrllq1apXq2LFjotOLjY0V+TdXrlwquXDPT4u0UBnlRwoVsr+9cGF/5oKQJAKFU6lSSlWtmvCD7T5USMEi6fPPP1e3b/+3YhM6vM8++0w6Om9j23GcOHFCOpSmTZuqPHnyqPTp04vCBkoYX4Nrr1y50usKN1v69eunvv76a7V48WK1ceNGdfr0adW6dWun58Ca6ZFHHlHjx4+3ux9p4DNp0iS1d+9emXVavXq16tatm9VxmHmaNm2a1UwbIQHDldLXh0rhZCPLlFipVEr7z+uZG2dUzvQ5/ZYvQggJd74/9r0q80EZ+fYlmFyEHAxLJgP836JFC1WkSBG1ZcsWq+1QXoH4+Hg1btw4OQYydsWKFdWXX35p8RKoX7++/J8tWzbLJDM+kEenTJlisVjCsQAy5eOPPy6yeO7cuUVhdPHiRSv5tFOnTrIf+X377bfduj9cA4q1vHnzSvqYQP3+++8t44+PPvpIPfDAAypt2rSqdOnS6sMPP0zg7fDFF1+ounXryjELFixI4G1hWDDNmTNHxjDI40svvaTi4uLUhAkT5PoYg7z55n+LgwBYjT3//PMqZ86cojRDme3evVv24RqjRo2S30ZZYZur88z5wb2hfpBvf0BllB/5b8JfW33TEIAkK/CSN814WIHtpk7A21SpUkUUUrDEMcD/eIlXrlzZ6ti7d+9K54EXOV6oUJZs27bN6phvv/1WlSxZUjpEdJRG52Zg7jjwf/ny5eX/okWLWjpDe+awzjopEBMTI/nF/gcffFDt2rXL5b0vWrRIOu18+fIlyN+aNWvkeujImjRpIrM5iQGWSrNnzxbrJHRSVatWVXPnzlW//PKLlWBhCzr/N954QzVs2NDu/nLlyqmvvvpKNWvWTGbGkDY6Vyi9zIqnxx57TKyoIHQQEnCKF0/a/nCQZRr1d3hcljRZ5D1JCCHE92it1ZB1Q9T+i/vlG799CeRmWD0Z4H+400EBY2yH8gaWUoYyCoqoTz75RNz8fv/9d5kA7dChg8h9kO8NxdSBAwdEloUCCp8aNWqo7t27yzZ8cCyUK5AnIU/DQguTnLDkf/rppy156t+/v6S9fPly9d1334libCc8OTwE4wQo0iCzQrEEmRdy7P79+9XYsWPV8OHD1ccff2x1zqBBg1SfPn3kmMaN7S/kcfToUbG6Qt4XLlwoMjgmvGGRhXxjknfYsGFShgZPPfWUuAzivB07dsjYqEGDBiI/w6PjtddeU2XLlrWUFba5Os/gyJEjIq9jbOUqdIi34Gp6fgTGBV99BdcfpTD+SpUKA0ylWrXyZy4IscNDD6lUZ8+6VzSuzDabNFEqMtJ1OtHRSpnMe92la9euoiBp3769/MaMAixqzLMzYMCAAfJCRedQqFAhmWVAZ4AXLWZc/vrrL7H4gUsa3O3QkeEF7gi8zNH5QeECZRL+x+yCLbDSGjFihHr//felg4SiCR1ohgwZVOfOncWs+cknnxTFy/z589Xx48els3IFzJ+huLLl1q1bYnH06aefim87OnW4DqKzBPh+8cUXnaaNjql27drSOcHyy6xUgjINyr7NmzeLG523gOILMzOp8CL8F8QJgGIP9wphhpCAAuVzmjTQbCfch+3/KqfDUZYZOVKpkWPuKZXFviVs9nTZ1ebnN9NFjxBCksDkzZPl44oqeaqoXg/1UttO/zPpiu8as2uok9dOujz31RqvysdToGBCHCcoaKB0grwL2Q1yJJRNALIjJodxLL6huIGFEZRLxuTuTz/9pGbMmCHnQj4HmEjOmjWrlXwIbwRYCxkYcjbSNMCYAPI5QmzAqgnKHcjaULoAjAkQA8oTDh8+LPcDGRxhMiDjw8LK8BqAFRHinuIeIOcboGxceRbEx8dLnpEuwlWgnBAfFpPlkOlhgQaFFJR71atXl7LCGARKpTSQQ5SSMcCyZctEkYfxDCamIVuby8qd8wzXPCgL7Y1vfAWVUX4GbTJ3bqVOnfrnm4ooEhScPasi0Ci9wYULypdA2YLYSX/+u6TTzz//LK57ZmUUzHLh7gXLIZjXAvh8r127VjomzJRgP6x0DJNdvPD37Nnj0NUMsyKGOx5e0uaXvJkxY8bIC95RJwVlFTof5AOWUZi9wAxIz549nd437teeMsro9A1ffMS0Gj16tGV/8+bNpQNzhmFtdfbsWenwbYO2w/QZ+7wFTKhRTkbnZwbCA1wSCQk4cP3F7O6xY0q//LKKuHJF6SxZVMT770OC/md/mFKlilIq7RWlUvxj2RiVJkqtar/KonzKlSGXyp/ZM4GfEEKINdfuXlOnrruWz/G+Hb5huEoZkVLF6Tj53nt+r7oZe9OtayQGWEFB3obXweXLl8XTAPIxlEqYJEYYDcjmUDhhUhOWUJhAxWSsGShAbL0b3AEuZlDSQPliz+IICjKkbZaBoeyCvO/OhCnShbyO+4B3BbwecL9IG2EmMNFsAIVcVFSUVRr2ZHZbChcubBUHFvJ2ypQpRRFl3mYET8c9Y1LbNjwI7tVZgHh3z8PkvT8VUYDKKD8D7yIjFjC+8duF0pQQ3xMdbXEejXDHMsqZwgkvMXctoxIBXpIwYYWiCSbI+D9HjhxWx+DFCiVNrVq1LNuwwke1atXEXBbg21ZJY8zUJBajk4JPtlnRYu6kcN0KFSpY+WK7c110GPb8tzFTZA4KCZ9484of6OR8GfDcUxAEHnWGGSC4ONpT+kFYISTgQCmK+BV37ljei1BIqQ4dlMKzePBg2CqkRPffcJAlXlS9zD1UjQJJe38SQgixJnOazCpfpv/CMzjDsIoCUEhBEQUr1bSp0rq8RmIoXry4WBlBIQRllGHRjklFWCchxAP2GXGgoAwB33zzjVXICWBY63gC0kP4B3uTyJCF4QmRWCA3w50PSiGkBdkUGAv6YILbdgwBJZIZeES4InXq1Fa/4dpubxuUYsY928bqMrCdSDbj7nnu5NnbUBnlR6B4atPmv99w1cNvuO5RIUUCyrZtojARlylXMT7ga41g5Y5YvfrfaXPfAVc9WACBDz74QAULRkc7c+bMBC5ttp2Up0Dhhs7eFnudljlOgCduerD2wiwS/PDNnRM6X0eWYJ5w/fp1iWmFTn7p0qUJ8g7gu45ZNEKSRXy8MFRGQZaZ/G6sUkP+cQXGTMayoS+qJdGUZQghxJu440IHma/6R9VVCpVCxWOF03/B76JZi6qtz2/1Wfw+uJVBwQH5FF4HBnXq1BHZEq5hhuU/JiGhdIL1u6NQDLDOBwjibbvddhtiHiEcB6yLzCEfDDBRCzkT8ZaMRY6QT7jwuQoFASUUlG22wEoJyrZjx45ZwoX4kypVqoinAu4X920PR2Xl6rxAwQDmfmTUKGOcb5ljld8mjxpCgh9YITlaYQHbbayUfAEUGlCawPrJXlBAdEB4GcOFzwDHwpQYnSFAwG90kmacBel2B3MnhU7M/IG7nnHd3377zWrZW3euCxNmuPt5Ctz0EITQ2ccwJUbAcnTc69ats5wP33UIDkm1GoNFVKNGjaReVqxY4XCVDqyMkhhzbUKI/2QZVWG+Uqli/9kAkSbHIcoyhBASAO7F3VMnrp6wUkQB/P7r2l+y31dAGYV4RJAlzQoe/I/wFJDVjeDlmIhETFMELUfsJngSwPpo6tSpluDfcBOD4gyrR1+4cMEyyQsFCpRKWDgIoR5gKYSYr5jAbNeuncj3SA8L+sBFEMoYuNnBnQ5KsvXr14t8iZX5zC5wiQGr1SEQ+3vvvSeKLYT4QCxbLP7jaxo2bCjyeMuWLSUgO8oDFmhDhw6V2LdGWSEeLeoEZYVYXe6cFyhoGeVHDh2C9tp6G37D0p+QZANmF9Bo7a2aB0WUHywFYGVkuNvZsziCmSlmYtABwT8cMyIIYA73L3RMoEePHhIvCsfArQ7Bu43lT5MCVthARwvLIijN0AngRY/ZmFdffVU9++yz8vKHrzliX6FDQIwpV0Dphnyig/XEysoTNz24EqJ8kE+UGwKM9+7dWzows6UXgpqjI271b9A7CANQWJ0+fdqiwAKwpsLHUESh/BFIEr/xMdwujftBWZw6dcrhqnyEkMBz8JBWquM0peJTKpUiTqn4FErVG64OfNrIHUdvQgghXgSx+rZ136Yu3EoYQgPx+4xYfr4AiiaEkYBciAlZszIK1vCIzwT3MAPEC4XcBxkSE7eQlWG1M2TIENkP9z3I0ZCP4QXRqVMnkc2hxELcVUwo43pQtkDpgknngQMHiowJeRvKLMjehsJp4sSJFnc+yMJYqAjxoJICZHGEyEDaGENgzIHVthGw3NdERERIcHOMI6B0g8IOcjYs0Yzyb9OmjayGh7qBpwMUZVDCuTovYGiSgKtXr0JlJN/epEIFrSMioH7674PfFSuyEhJLXFycPnPmjHwT19y+fVvv27dPvs3Ex8fre/fuyXew0rlzZ92iRQuH+7EPxxjgHnv37q1z5Mih06RJo2vVqqVjYmKszvn666918eLFZX/t2rX1nDlz5Nm/fPmy7J87d66OioqyHL9r1y7Zf/z4ccu2ESNG6Ir/PsRGOc6fP19XqlRJR0ZG6qxZs+o6deroJUuWWM7ZvHmznIP9OO6rr76SdJG+I2JjY3XevHn16tWrLdts8weWLl0qaSUWlNtLL70k+U6fPr1u1aqVPGNmkD6ubc7HP8461h+UDdiwYYPd/bZlOXbsWN24cWOH7dFR+yWO4TsyCezYYd1h236wP0jlDl/JMaBIw9VajVQJPkUe++/dRAIDn/fghPUSfARTnVC2SV7jkXCvl9tOZPHEyB4R+BNYdVjwgRl7WAgYS497O2ZURISGGsryje1cVS9xwEwTwZqxBGhSzS7DAbiGYTYBLmNmNym8BoyYUb7yKw8HfF2OiI8FFzeYIYcaMOUuUaKErDZYs2ZNu+XoqP0Sx/AdmQRcxcfbscNr8fG8LXf4So7BO67ExOrq6M0dSqUwuYTEp1DFM1RVh/r7LjYJcQ2f9+CE9RJ8BFOdULb5D45Hgr9eYIHmSBZPjOzB0bsfQZByBCsvXx6rBmj5piKKEOIuCEQOk1qYPocacPODmbZ5BURCwj0+XrCB2CM3UpywVkSBFPHqRkrfxiYhhBBCSGjBmFEBUEi1bKlN2njOIBJC3AMzEvD3DkWMQO+EBGN8PMyiIzYaYqnJLLqf4uMFc2wS2zLxdWwSQgghhIQWVEYRQgghhNgDCid84uPV/fPnlcqVC2s+h3VZFYgqIB9xc0kZHG4uhBBCCEl+UHoghBBCCCGEEEIIIX6DyihCwhCuW0CSI2y3hBBCCAlFKOOQcGynVEYREkakTp1avm/duhXorBDiMUa7NdoxIYQQQkhyhrI5CWdZnDGjCAkjUqZMqbJkySIB9EH69OllGW4upeodWI6+KUf8RueHdov2i3ZMCCGEEBKqsnk4Qjk6eOslNjZW3bt3T124cMGrsjiVUYSEGdHR0fJtdHrGSwbBaBGENlw7QG/AcvRtOaLzM9ovIYQQQkioyubhCOXo4K+XrFmzelUWpzKKkDADg/s8efLICkjQcgO8YP7++2+VPXt2roqUBFiOvitHmAPTIooQQggh4SCbhyOUo4O7XqCE8naoDCqjCAlTMLA3Bvd4yeDlkjZtWiqjkgDL0TuwHAkhhBASzrJ5OEL5L7jrxRdtkwHMCSGEEEIIIYQQQojfoDKKEEIIIYQQQgghhPgNKqMIIYQQQgghhBBCiN9gzCgHEePBtWvXfOZ3ef36dcbnYVkGDWyTLMdggu2RZRlubdKQNwz5I9jlGMDnNPhgnQQnrJfgg3USnLBekne9JEaWoTLKDihsUKBAAc9rixBCCCEkkfJHVFRUksuOcgwhhBBCgl2WidDemoYLMe3f6dOnVaZMmWSpTW8DrSEUXX/99ZfKnDmz19MPJ1iWLMdggu2R5RhssE0mj3KEKAbhLW/evF6xvPK1HAPYtoIP1klwwnoJPlgnwQnrJXnXS2JkGVpG2QGFlz9/fuVrUJlURrEsgwm2SZZjMMH2yLIMpzbpDYsof8sxgM9p8ME6CU5YL8EH6yQ4Yb0k33rxVJZhAHNCCCGEEEIIIYQQ4jeojCKEEEIIIYQQQgghfoPKqACQJk0aNWLECPkmLMtggG2S5RhMsD2yLIMNtkmWSXKA7TQ4Yb0EH6yT4IT1En71wgDmhBBCCCGEEEIIIcRv0DKKEEIIIYQQQgghhPgNKqMIIYQQQgghhBBCiN+gMooQQgghhBBCCCGE+A0qo7zEBx98oAoXLqzSpk2rqlevrmJiYpwev3jxYlW6dGk5vnz58urbb79NcMz+/ftV8+bNVVRUlMqQIYN66KGH1IkTJ1Qo4+1yjIiIsPuZOHGiCmW8XY43btxQL7/8ssqfP79Kly6dKlOmjJo+fboKB7xdlufOnVNdunRRefPmVenTp1dNmjRRhw8fVqGOJ+X4+++/qzZt2sjxeF7ffffdJKcZKni7HH/88UfVrFkzaY84ZtmyZSoc8HY5jhs3TvroTJkyqVy5cqmWLVuqgwcPqlAlHJ+9YMKd9nbnzh3Vq1cvlT17dpUxY0Zpw+h/iH9466235H3Rt29f1kmAOXXqlOrQoYM8C5BhIZtt377dsl9rrd544w2VJ08e2d+wYcOwkMsCRVxcnBo+fLgqUqSIlHexYsXUmDFjpB4MWCe+x5X8504dXLp0SbVv315lzpxZZcmSRXXr1k3GjB6hSZL5/PPPdWRkpJ4zZ47+/fffdffu3XWWLFn0uXPn7B7/888/65QpU+oJEyboffv26WHDhunUqVPrPXv2WI45cuSIzpYtm+7fv7/euXOn/F6+fLnDNEMBX5TjmTNnrD5IOyIiQh89elSHKr4oR6RRrFgxvWHDBn38+HE9Y8YMOQdtMpTxdlnGx8frhx9+WNeuXVvHxMToAwcO6BdeeEEXLFhQ37hxQ4cqnpYjyub111/XCxcu1NHR0fqdd95JcpqhgC/K8dtvv9VDhw7VS5YsgRSoly5dqkMdX5Rj48aN9dy5c/XevXv1r7/+qp944omQfa7D8dkLNtxpbz169NAFChTQ69at09u3b5e+p2bNmgHNd7iAd0bhwoV1hQoVdJ8+fSzbWSf+59KlS7pQoUK6S5cueuvWrfrYsWN6zZo1Mq4yeOutt3RUVJRetmyZ3r17t27evLkuUqSIvn37dgByHPq8+eabOnv27HrlypUypli8eLHOmDGjnjJliuUY1onvcSX/uVMHTZo00RUrVtRbtmzRmzZt0sWLF9ft2rXzKB9URnmBatWq6V69ell+x8XF6bx58+px48bZPf7pp5/WTZs2tdpWvXp1/eKLL1p+t23bVnfo0EGHE74oR1tatGih69evr0MZX5Rj2bJl9ejRo62OqVKlirzEQhlvl+XBgwflhY8BhDnNnDlz6lmzZulQxdNyNAMh0t7gPylpJld8UY5mwkUZ5etyBOfPn5fy3Lhxow41wvHZC3Zs29uVK1dkIgSDPIP9+/fLMZs3bw5gTkOf69ev6xIlSui1a9fqunXrWpRRrJPAMHDgQP3II4843I9JQkwyTJw40bINdZUmTRqZgCDeB3Jy165drba1bt1at2/fnnUSIGzlP3eeC0y647xt27ZZjlm1apUYfZw6dcrta9NNL4ncu3dP7dixQ0zXDFKkSCG/N2/ebPccbDcfDxo3bmw5Pj4+Xn3zzTeqZMmSsh0m2DCDD2X3CV+Uoy0wT0e5woQwVPFVOdasWVOtWLFCTJ3xztqwYYM6dOiQatSokQpVfFGWd+/elW+4tpjTTJMmjfrpp59UKJKYcgxEmsFOON5zci7Hq1evyne2bNlUKMF2GJzYtje08djYWKt2DvfxggUL8n3hY+Aa2bRp0wSyAOskMEB2ffDBB9VTTz0l46nKlSurWbNmWfYfP35cnT171qq+EB4F4y72rb4BY4p169bJOALs3r1bZODHH3+cdRIkuPNc4BuueXi+DHA8ZKqtW7e6fS0qo5LIxYsXxfc1d+7cVtvxG5VoD2x3dvz58+fF3xL+5ogn891336lWrVqp1q1bq40bN6pQxBflaMvHH38s8RVQjqGKr8px6tSpEicKMaMiIyOlXSJmSJ06dVSo4ouyNAYDgwcPVpcvX5aB3fjx49XJkyfVmTNnVCiSmHIMRJrBTjjec3ItR0woIU5MrVq1VLly5VQowXYYfNhrb2jL6KsxUDDD94Vv+fzzz9XOnTslppctrJPAcOzYMTVt2jRVokQJtWbNGtWzZ0/1yiuvyJjAqBfAvtV/DBo0SD3zzDMiE6dOnVoUhHiHIfYQ6yQ4cOe5wDcUvGZSpUolkyKeyFOpvJJj4nXBArRo0UL169dP/q9UqZL65ZdfJGh03bp1WeKJYM6cOfKiM1ulEPeAMmrLli0yw1SoUCEJeofZPwS9s539I45Bp7tkyRKxzsPLOmXKlFJ+mA0yB24khCRf8G7cu3dvyFo7kuCC7S04+Ouvv1SfPn3U2rVrKWcG2ZgKlhtjx46V31B84P2M8VTnzp0Dnb2wZNGiRWrBggXqs88+U2XLllW//vqrKKMwpmCdhB+0jEoiOXLkkAGl7Qol+B0dHW33HGx3djzShGYRlihmHnjggZBdTc8X5Whm06ZNstLM888/r0IZX5Tj7du31ZAhQ9TkyZNl1YUKFSrIynpt27ZVkyZNUqGKr9pk1apVpeO9cuWKWEOtXr1a/f3336po0aIqFElMOQYizWAnHO85OZYj3o0rV64UV2ZYkoYabIfBhaP2hrYMy1v0M2b4vvAdcMODZ0OVKlVEhscH3gzvvfee/A+LAtaJ/8FKYM7GU8Z7n32r/+jfv7/FOgorG3bs2FGMLwyLQtZJ4HGnDvCNd56Z+/fvywp7nshTVEYlEZhBY3AJ31ezFh6/a9SoYfccbDcfDzCTYhyPNLFkr+0yvfCthVVKKOKLcjQze/ZsSb9ixYoqlPFFOSLuBD7wATaDAZ1hxReK+LpNwvc6Z86cskwqlhiGJWQokphyDESawU443nNyKkdYNkIxsHTpUrV+/XpZsjoUYTsMDly1N7RxWOKa2zlkSgzA+b7wDQ0aNFB79uyRySbjA4scWOQb/7NO/A/cV52Np/DsYOBsflauXbsmMW/4rPiGW7duOR1TsE4Cjzt1gG9MeEARb4D+CPWI2FJu47Uw7GEMljlGdPl58+ZJZHks1Y5ljs+ePSv7O3bsqAcNGmS1/HuqVKn0pEmTZHWTESNGWC3/DrDMIrbNnDlTHz58WE+dOlWWjMeyiaGKL8oRXL16VadPn15PmzZNhwO+KEesCIMV9TZs2CDL4mJJ6bRp0+oPP/xQhzK+KMtFixZJOR49elSWS8XqXFhFJJTxtBzv3r2rd+3aJZ88efLo119/Xf7Hu9DdNEMRX5QjVn4yjoFIMHnyZPn/zz//1KGKL8qxZ8+esgTyDz/8oM+cOWP53Lp1S4ca4fjsBRvutLcePXroggUL6vXr1+vt27frGjVqyIf4D/NqeqyTwBATEyNy2Ztvvinv7AULFsiYYP78+VZL2OMdtnz5cv3bb7/Jytu2S9gT79G5c2edL18+vXLlSn38+HEZ8+bIkUMPGDCAdeJHXMl/7jwXTZo00ZUrV9Zbt27VP/30k6wk2q5dO4/yQWWUl4CyCJ1+ZGSkLHu8ZcsWq84ID54ZDEhLliwpx2OQ/8033yRIc/bs2bp48eIy6K9YsaIMXEMdX5TjjBkzdLp06WRJynDB2+UIIbdLly6yfDfaY6lSpfTbb78tS3+GOt4uyylTpuj8+fOLkgrpDhs2TAa7oY4n5QjhBB2j7QfHuZtmqOLtcoRi1N4xtu061PB2Odrbjw8U96FIOD57wYQ77Q0DhpdeeklnzZpVBt+tWrWSvpwEThnFOgkMX3/9tS5Xrpwo0UuXLi0T/WYgyw4fPlznzp1bjmnQoIE+ePBggHIb+ly7dk2eC/QhGFMULVpUDx061EoWZp34Hlfynzt18Pfff4vyKWPGjDpz5sz6ueeeEyWXJ0Tgj3cNuwghhBBCCCGEEEIIsQ9jRhFCCCGEEEIIIYQQv0FlFCGEEEIIIYQQQgjxG1RGEUIIIYQQQgghhBC/QWUUIYQQQgghhBBCCPEbVEYRQgghhBBCCCGEEL9BZRQhhBBCCCGEEEII8RtURhFCCCGEEEIIIYQQv0FlFCGEEEIIIYQQQgjxG1RGEUJIEilcuLDq0qULy5EQQghJIjdu3FC5cuVSCxYs8Pt1n3/+eRUdHa0iIiJU3759HR4bGxurChQooD788EO/5jG5M2/ePCnbP/74QwUL4SjDOXrGVq9erSpVqqTSpk0r9XTlyhWHaUyfPl0VLFhQ3b171w85JqEKlVGEkKATUvD56aefEuzXWovwh/1PPvmkCid++OGHoBPgCCGEJB+gOEE/Ur16dRXMTJkyRWXKlEk988wzfr3u2LFjRQ7p2bOn+vTTT1XHjh3VL7/8okaOHJlgUJ46dWr16quvqjfffFPduXPHo+u0adNGPfHEE3b3xcTESB298847Cfa1aNFC9s2dOzfBvjp16qh8+fJ5lI9vv/1W7s2WW7duyXbIHYEC1zfkQXzSp0+vypQpo4YNG6auXbumQumZRJsLhmfs77//Vk8//bRKly6d+uCDD+QZyJAhgzwXy5YtS5AGFHj37t1TM2bM8HPuSShBZRQhJOjAjMxnn32WYPvGjRvVyZMnVZo0aVQwcfDgQTVr1qxAZ4MQQghxCKwgYAUChceRI0eCsqRgcYSBMiyUUqZM6ddrr1+/Xj388MNqxIgRqkOHDqpq1aqijBo1apRdC5HnnntOXbx40a684uz+1q5dq5o2bWp3f5UqVUTxYm9CDnlJlSqV+vnnn622QyGwbds2VatWLeWpMgr3Zk8Zhe2BVEYZTJs2TZQikydPVqVLlxblX5MmTWRyMhRkuEAooxw9Y2hD169fV2PGjFHdunWTZwBKV0fKKMjqnTt3lrrxZn2Q8ILKKEJI0IEZw8WLF6v79+9bbYfAB+EQJvTBBJRj6LAJIYSQYOT48eOizMDAMWfOnG67wKEfhrLDX6xcuVJduHBBLDT8zfnz51WWLFncPh7HNmrUyCNlwqZNm2TA70gZBWUTLNdsFU5QmEDxhXKxVVTt2LFDrLMeeeQRFWr83//9nyhFevTooZYsWaJat26tNm/erLZs2ZKkdKE8uX37dkjKcK6eWUfPGNo/8OQZQBp//vmn2rBhQxJyTMIZKqMIIUFHu3btxFwYs4cG6Fi//PJL9eyzz9o9Z9KkSapmzZoqe/bsYmIMpRWOtwXm3i+//LLM8pQrV06EkLJly4qfvD0TccwewxQZnXNUVJTMhGLW0Fm8AcPdEMIkzPgh+MPUuVWrViIAmImPj5dr5c2bV2ZD69Wrp/bt2+dWDIPDhw+LuT+Uc5ihyp8/v5hcX7161el5jz76qNw7roPr4bow758wYYLT8wghhCRPoHzKmjWrKEEwwLenjIIbOPou9KfvvvuuKlasmPSR6CvAgQMH5Nxs2bJJn/Pggw+qFStWWKVx6dIl9frrr6vy5curjBkzqsyZM6vHH39c7d692618om9G/4drmzl79qz0v+jnkKc8efKI25rZdR0Khv/9739yjNGf/v777y77U8MNHgq7b775xuIahnP69+8vxxQpUsSy3XzNxx57TJRDuG93QPpwN0OeHAGl0rlz56ys1yBPoCxfeOEFi2LKvM84z2DVqlWqdu3aInvAHQv1jrIwwL3BFQuY3eFwb5BZAKyjjO1mdz532gHA9erXry8yGeoEdQOZJykgPYC6AkgPbRVyHPKSO3du9eKLL6rLly9bnYfyRniHNWvWSH6RJ8O9zJEMh3p95ZVXpDwgAyJdyKKwkuvUqZM8T/gMGDAggWWQO/nCdVFGsPo3yhnymQGug7hlCE+BNl+8eHE1fvx4qzJ09cy6+4zhurByAg899JCl/eP75s2b6uOPP7Z6Lgwga6MdLF++3KN6JMQgleU/QggJEtBJ1qhRQy1cuFCEWEOwgpIFypb33nsvwTkwOW7evLlq3769CAuff/65euqpp2QGyHYGEgIGZtheeuklEdKQHpQ6J06cEGWW7awPhNBx48apnTt3qo8++kiCPkIgcEXv3r1FUIHJPwQGCApQhH3xxReWYwYPHixKoGbNmqnGjRuLwI5vVzEocI84DoEjcR0opE6dOiX3CwEGijNnQCCCqTtmGXGPUNwNHDhQBhBGmRNCCAkNoHzC+z4yMlImfOD+BLccDDxtQUwi9EFQfGBgi8EmBs1wA8PExaBBg0TJsWjRItWyZUv11VdfyWQLOHbsmAx20f+i74RSBYP+unXrygAZEy/OgPUWXNVsQR+NPKC/g4wAKw5MWKHfNhQ7b7zxhig8YF2ND/psWC65sux64IEHxBWsX79+ojR57bXXZDv6Q5wLWQQxnHLkyCHbDWWNMRiHIgL5dieWJVzjXB1nKJUgq0ABYSic4EIIqylY8eB6kHmMfZBlKlasKL9xL1AsQEaArIIJNNQ30t21a5eUFxQjp0+fljLE8Qa4NxyLuFmoU7QZUKFCBfl2tx1AeQhlIKx0jONmzpwpSqCkcPToUfk2ZDXcB5RHUFRCcQQl1fvvvy/3iXIxWzxBiYe2j3O6d++uSpUq5fRahmwFpRwssZB/KKVQ9gjcDfc11OfEiRNlgg8KKgN38gWZENeA0nbo0KFyHpRWAHWGZwZyHdLC9XBdyIxnzpyRc109s548Y7g+ygP3OHr0aHl2oaxq2LChuPNVq1ZN0ga2imKkZWvJR4jbaEIICRLmzp2LqSW9bds2/f777+tMmTLpW7duyb6nnnpK16tXT/4vVKiQbtq0qdW5xnEG9+7d0+XKldP169e32o70IyMj9ZEjRyzbdu/eLdunTp1q2TZixAjZ1rVrV6vzW7VqpbNnz261Dfnp3Llzgvto2LChjo+Pt2zv16+fTpkypb5y5Yr8Pnv2rE6VKpVu2bKlVXojR46U881p2rJr1y45ZvHixdpT6tatK+d+8sknlm13797V0dHRuk2bNh6nRwghJHjZvn27vPPXrl0rv9Ev5c+fX/fp08fquOPHj8txmTNn1ufPn7fa16BBA12+fHl9584dyzakU7NmTV2iRAnLNuyPi4tLkG6aNGn06NGjneYzNjZWR0RE6Ndee81q++XLlyVfEydOdHgu8ou+HbKBud8dMmSIy/7UwJ5sgWvifNyDPU6fPi37x48f7zL9Y8eOybEbNmxwety1a9dEVujWrZtlW6lSpfSoUaPk/2rVqun+/ftb9uXMmVM/9thj8v/169d1lixZdPfu3a3ShLwRFRVltb1Xr16SH1suXLgg2yEH2eJuO+jbt6+ksXXrVqs6Qh6claetDHbw4EHJD46fMWOGtKPcuXPrmzdv6k2bNskxCxYssDp39erVCbajbrEN+2xxJMM1btzYqi3VqFFD2mePHj0s2+7fvy/PEuQqA0/yVbZsWatzDcaMGaMzZMigDx06ZLV90KBB0jZOnDjh8pn15BmzlcHNIB/Onp8XXnhBp0uXzuW1CbEH3fQIIUEJrHXgzw9LH8RXwLcjFz1gnm2D1Q+sqGCijplRWzDTY57ZwYwfzN8xo2sL4hSYQZpwIXRnNRfMIsGk2XxuXFyc+NeDdevWyawhLLTMYKbMFYblE0zObd0G3QEzcYjDYIDZcsx82SsDQgghydsqChYXsFQB6Jfatm0rFsTok+xZIZmtf+CChuDe6JfRH8NFDB/0hbC+gcs4LDgArDJSpPhneIG0cQz6G1hd2OuPzeA6mDOCRbFt/44+Cu50tu5XBt9//71YMaH/NPe7cHPyJUZezW5zzlz00He7iu0EKyfIJUZsKKQNqx6EIgCwTDIsUQ4dOiTu/0aasHSCdTQsgIx6wgeBqmFVlZTYPp60A1gMwZILcoUB2hSs1z0B7QbnwVIHFkKwFEM5wg0TsUVRnnCVNN8rrNXQ5mzvFWkgn+6CIN7mtoTyQ/vEdgOUK9z+zLKTp/myB9KAzIj2ZU4D8iueqx9//NHpM+vpM5YUkBbk9cTIooTQTY8QEpSgU0Wni6Dl6ODQ+SJGgSOgrIJ5/q+//iquawZmQcIA5s72OlN7Qq7tsUYHjmOhwHKGs3OBoZQyzPANYF7tSlCAUIV4VAhGi4EGhBaY7EPB5MpFD8AVwbZscM3ffvvN5bmEEEKSB+g7oXSCIsqIs2MMrN9++22ZFIErm23/YgaxizCAHT58uHzsAbc5uG4hng3c5rFKGK5nVnbZusE7wjb+DhRccDeD+xyUalBywNUNblHGgiZGf1qiRIkEsoQ3B96O8mpP1rAFShSUNYKUuwLKpalTp4oCAm5VUHrgvgGUUihfyDq28aKgEDLHVrLFldziDE/aAeoDbcwWV65xtsD1D3mGWxvkFvNEIu4VE48IneAoL87atStsZThDtkIMJ9vtZvnR03zZA2lAHnOkYErqvXlz9TtPngFCbKEyihAStMASCn79iD2AOEaOVvjA6jRQxNSpU0cENAQ2heACH3p7Sy47Wi7aXufsybHePNcdMJBAIEkEjvzuu+8kLgFiWyG2AYS2QOaNEEJI4IElC2LMQCGFjy2YzLBVRtnG9TECJiMwuSPLEmNSBXF0oKjo2rWrLBGPyRVYSsFCyVXwahyLAa29iSGcj9iKiEcFi2BcA/0d7q9y5coqUBh5NeJJOQKTarDsQjwmdzCUUVA2QRllBIQ3lFFQRCHmF6ynoNwyFFVGGSMOlL2Vh91RhDnCk3bgLSDXOSpb5AcKH0crQ9oqcjyNV+VITrK33Sw7eZoveyANWFYhOLo9SpYsmah7c/aMJRakBUu1pMYDI+EJlVGEkKAFgTBhlg3lijnot72ZM6xWAgEVM6gGUEYFM4UKFbLMNppntWDy7q6gAAEVn2HDhonACvP96dOni5UYIYSQ8AYDYgyMjZXTzGAhj6VLl0qf4WwgWbRoUfnGJA8slp2BxTBghTV79myr7XAdc6WwgaIEli9mCy4z2AfrKHxgOVKpUiWZlJk/f76lP8V2I78ALmxJGXi7svYw8oog6M6A0gwKJHcXCDEHMd+8ebP07QYIAo/7haIKHyjjoAwAhuUQ6txVXTm6N0fbPWkHyJ9hpWUG7obeAvcK90yUTTApQjzJl6OyRho3btxwWc6e4uoZS+wz4Kr9E+IIxowihAQtmAXELCKWFMaMqCMwS4XO0uwOgNXrMIMazDRo0EAEA9uZUqy44grErEK8KTNQSmEG2uymSAghJDxBHBconODSBjd32w9Wd0XsnxUrVjhNB4oNLP2OVfFgZWULFD7m/tjWwhbxb4xYQq7ASrrbt29PYFVku8IsBtSIrWT0dxi0Q0kCayLz9W1XHfMUrAJnKNPssWPHDpE/kG9nIIYSYgsZq6W5AgonTFLBjRLlYcSLMsBvyDhQ7phjUMFiCW5tsFCLjY11WleO7s1QbNlu96QdYDVDTCTGxMRY7XdkLZQYELsKch8s8GyBfOSoznyNJ/lCHdjLJ9KAEhKTrLbgeFv5zxPsPWPOcJRHA8SCs22fhLgLLaMIIUENlid2RdOmTSV2UpMmTcS1D770mAWGuXgwx0CCUNqnTx+Z2YWbIfK/e/dutWrVKplBdjYbhVlWDCSwfDbMtSGYwCwfAwEEsiSEEBLeQMkEZRP6F3vAtQsuQ1AQIKC5M9CnQumBSQ+4z8NK5ty5czJgPnnypPRdAIovLA2PJe0xQN2zZ4+kb7ZWckaLFi2kL0NgbsMVCf9j8gYD9DJlysgkDiy6cP1nnnlGjsF9wH0MrnvIA5Qhu3btsvSniQVBp8HQoUPlWlB4YXLMUOQgYDgsYFzFw4IyCmXiCShvlAUwW0YBlO3ChQstxxlAEYUJro4dO6oqVapInlE2J06ckJhVSMeY8DLuDS7+UGJBfsDxsOZBOcMiHXUA165y5crJx912APcy5B1yDeQclNfMmTPFYspbclndunXFeh51jnihcDdF/cAiCwpQxC5zFmvUV3iSL9QB6gvW7JBZofBDvK/+/fvL84u2jHAMOO7mzZvyPMH6EBOuiW3X9p4xZ+DasPSCnG0oSY14YFDGIig60iQkUdhdY48QQgKAo2Vl3Vl+efbs2bKsMJb9LV26tKRlLA1sBr+xnLG9NM1L1xrnYklhe3k0L0vsaFlg2/vAcs62yzpjWeDhw4fr6OhoWRq3fv36ev/+/Tp79uxWywfbWyK6a9euulixYjpt2rQ6W7Zsul69evr777/XrsAywlhO2BbcA+6FEEJI8qdZs2bSP9y8edPhMV26dNGpU6fWFy9etCwTP3HiRLvHHj16VHfq1En6K5yTL18+/eSTT+ovv/zScsydO3dk2fg8efJIn1arVi29efNm6XfsLWFvy927d3WOHDlkaXsD5A39Nvp2LDMfFRWlq1evrhctWmR1blxcnB41apTl2o8++qjeu3dvgj7aE9kCIC+41xQpUlj1/1euXNGRkZH6o48+cpou8oDzYmJitCfMmDFDzsO1bdm5c6fsw+fcuXMJ9kPOaNy4sZQV2gBkBdT19u3breSP3r1765w5c+qIiAgreemXX37RVatWlfvDdshEnrQD8Ntvv0md4/o4BuUIWc1WhrKHIxnMHjNnzpS8os4zZcqky5cvrwcMGKBPnz7tsm49keEc5Qnnol0mJl9nz56VfGE/0jY/I9evX9eDBw/WxYsXl3rAc1GzZk09adIkfe/ePTnG1TPr7jPm7L4PHDig69SpI/eB/eayGjhwoC5YsKCOj493+/qEmInAn8SpsQghhPgCmENj9R/MlGE2lhBCCAkX4N6EmI+wJHEURNoTChcuLO5l8+bNU94ELoATJkxQR48edRobCMfAqgSubVxxjITKMwYXWTxbgwYNEus3QhIDY0YRQkiAY3rYYsS4gPBMCCGEhBP9+vWT4M32Vv8LFhCPCQomLB7iKkg1BuzvvPMOFVEkpJ4xKLPgftijRw+v5o2EF7SMIoSQAIKZWnwQ3wIB27FyDuJAIMaAvcCVhBBCCAm8ZRQhhJCkwQDmhBASQCpUqCDBWGHGjxXyjKDmcNEjhBBCCCGEkFCEllGEEEIIIYQQQgghxG8wZhQhhBBCCCGEEEII8RtURhFCCCGEEEIIIYQQv0FlFCGEEEIIIYQQQgjxG1RGEUIIIYQQQgghhBC/QWUUIYQQQgghhBBCCPEbVEYRQgghhBBCCCGEEL9BZRQhhBBCCCGEEEII8RtURhFCCCGEEEIIIYQQv0FlFCGEEEIIIYQQQghR/uL/AdAymY1/SLB4AAAAAElFTkSuQmCC",
+      "text/plain": [
+       "<Figure size 1200x500 with 2 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
     }
+   ],
+   "source": [
+    "baseline_geom_hdf = baseline_path / f\"{baseline_ras.project_name}.g{GEOM_NUMBER}.hdf\"\n",
+    "modified_geom_hdf = modified_path / f\"{modified_ras.project_name}.g{GEOM_NUMBER}.hdf\"\n",
+    "\n",
+    "base_tables = HdfMesh.get_mesh_face_property_tables(baseline_geom_hdf)\n",
+    "mod_tables = HdfMesh.get_mesh_face_property_tables(modified_geom_hdf)\n",
+    "\n",
+    "base_df = base_tables[MESH_NAME]\n",
+    "mod_df = mod_tables[MESH_NAME]\n",
+    "n_col = \"Manning's n\"\n",
+    "\n",
+    "print(f\"Baseline: {base_df['Face ID'].nunique()} faces, {len(base_df)} rows\")\n",
+    "print(f\"Modified: {mod_df['Face ID'].nunique()} faces, {len(mod_df)} rows\")\n",
+    "print(f\"Baseline mean n: {base_df[n_col].mean():.4f}\")\n",
+    "print(f\"Modified mean n: {mod_df[n_col].mean():.4f}\")\n",
+    "print(f\"Ratio: {mod_df[n_col].mean() / base_df[n_col].mean():.2f}x\")\n",
+    "\n",
+    "# --- Figure: Face property table comparison for a sample face ---\n",
+    "sample_face = 1050\n",
+    "base_sample = base_df[base_df['Face ID'] == sample_face]\n",
+    "mod_sample = mod_df[mod_df['Face ID'] == sample_face]\n",
+    "\n",
+    "fig, axes = plt.subplots(1, 2, figsize=(12, 5), sharey=True)\n",
+    "\n",
+    "# Left: Manning's n vs Elevation\n",
+    "ax = axes[0]\n",
+    "ax.plot(base_sample[n_col], base_sample['Elevation'], 'b-o', markersize=4,\n",
+    "        label=f'Baseline (n={original_n})', linewidth=2)\n",
+    "ax.plot(mod_sample[n_col], mod_sample['Elevation'], 'r-s', markersize=4,\n",
+    "        label=f'Modified (n={new_n})', linewidth=2)\n",
+    "ax.set_xlabel(\"Manning's n\", fontsize=12)\n",
+    "ax.set_ylabel('Elevation (ft)', fontsize=12)\n",
+    "ax.set_title(f'Face {sample_face}: Manning\\'s n vs Elevation', fontsize=13)\n",
+    "ax.legend(fontsize=10)\n",
+    "ax.grid(True, alpha=0.3)\n",
+    "\n",
+    "# Right: Area vs Elevation (unchanged between runs)\n",
+    "ax = axes[1]\n",
+    "ax.plot(base_sample['Area'], base_sample['Elevation'], 'b-o', markersize=4,\n",
+    "        label='Area', linewidth=2)\n",
+    "ax.plot(base_sample['Wetted Perimeter'], base_sample['Elevation'], 'g--^',\n",
+    "        markersize=4, label='Wetted Perimeter', linewidth=2)\n",
+    "ax.set_xlabel('Area (sq ft) / Wetted Perimeter (ft)', fontsize=12)\n",
+    "ax.set_title(f'Face {sample_face}: Geometric Properties', fontsize=13)\n",
+    "ax.legend(fontsize=10)\n",
+    "ax.grid(True, alpha=0.3)\n",
+    "\n",
+    "fig.suptitle('Face Property Table Structure (Uniform n Model)', fontsize=14, y=1.02)\n",
+    "fig.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "833766e3",
+   "metadata": {
+    "papermill": {
+     "duration": 0.008462,
+     "end_time": "2026-05-12T12:23:50.854314+00:00",
+     "exception": false,
+     "start_time": "2026-05-12T12:23:50.845852+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Step 6: Compare Simulation Results\n",
+    "\n",
+    "Higher Manning's n increases flow resistance, producing different water surface\n",
+    "elevations. We quantify the impact across all mesh cells."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "e52c02da",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-12T12:23:50.872282Z",
+     "iopub.status.busy": "2026-05-12T12:23:50.872065Z",
+     "iopub.status.idle": "2026-05-12T12:23:50.997996Z",
+     "shell.execute_reply": "2026-05-12T12:23:50.997168Z"
+    },
+    "papermill": {
+     "duration": 0.136384,
+     "end_time": "2026-05-12T12:23:50.998906+00:00",
+     "exception": false,
+     "start_time": "2026-05-12T12:23:50.862522+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Baseline plan HDF: Muncie.p03.hdf (exists: True)\n",
-      "Modified plan HDF: Muncie.p03.hdf (exists: True)\n",
+      "Wet cells compared: 5765\n",
+      "Mean delta WSE:     +0.1110 ft\n",
+      "Max delta WSE:      +0.8646 ft\n",
+      "Min delta WSE:      -0.0919 ft\n",
+      "Cells with |delta| > 0.001 ft: 4980/5765 (86.4%)\n"
+     ]
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAxYAAAGGCAYAAADmRxfNAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjgsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvwVt1zgAAAAlwSFlzAAAPYQAAD2EBqD+naQAAYKVJREFUeJzt3Ql4U1X6x/G3LZRC2XdRBhUXEEUUBFERUUYE3HFFEfcNXMDBbVBEB1T07zoorqCjuI64AAKKoqIoghuCoiCIOqwqW4Gu+T+/U29J0rRNmrZJk+/neUJvbm6Sk3tvwnnvec85KT6fz2cAAAAAEIXUaJ4MAAAAAAQWAAAAACoELRYAAAAAokZgAQAAACBqBBYAAAAAokZgAQAAACBqBBYAAAAAokZgAQAAACBqBBYAAAAAokZgAaDaWrFihZ188snWrFkzS0lJsfPPPz/WRUIIHBvIbbfd5s6FlStXskOABEVgAcTQnDlz3H+09957b8Idh40bN7qKhD5jZVEg8cEHH9gNN9xg//nPf+yyyy4rcdsffvjBbr31Vjv00ENdIFKvXj3r1KmTjRkzxrKysiJ63+nTp9thhx1mmZmZ1rhxYzv99NNdkFPRJk2a5M6P0s6RL7/8smgbAitzlVbtC+27ZHbUUUe5/VCzZk1bs2ZNyG2uueaaonOnMr+nyWLGjBluX44cObLYY59++ql7rFatWrZt27Zijx933HGWmppqGzZsKFr34Ycf2oknnmi77767e17z5s2tS5cudvXVV9tPP/1U7Jwv7fbrr79W4icHdqrhtwwAFRpYjB49uqiSU9Gys7Pto48+sqFDh9o//vGPMrd/+umnbfz48e4/6nPOOcdVuN5//31XCXj55Zfdf/y1a9cu83Vee+01O+200+zAAw+0e+65xzZt2mQPPPCAHX744bZgwQJr1aqVVbSMjAybOHFiyM+pz6XHd+zYYfFq+/btlpaWFutiJJ0aNQr/i1fQPWLEiIDHcnJy7Pnnn6/Sc0fftRtvvNFVkhPREUcc4fZ5qCBNvzV6TPv9k08+sd69exc9lpeXZ3PnzrX999/fmjZt6tY9+uijduWVV9qee+5pgwcPttatW9v69evtu+++sxdeeMGOPPJI95i/v//973beeeeFLJsugABVgcACQLW0du1a8/l8Yf+HqWDgpptusgYNGhStu/zyy23vvfd2rRZPPfWUC1JKk5uba1dddZX7T15BTd26dd36vn37WufOnV0LzeOPP24V7ZRTTnGVifnz51vXrl0DgqvJkyfbqaee6v7GK1VeUfVUgT/66KNdUBocWLzxxhv2+++/28CBA6vs3FHF2gt2EpF+Dw455BD7/PPPXatEnTp1ih5TsKGKv1oYtewfWGh7tZp6F2AUaNx88832t7/9zW1fv379gPdRcLJ169Zi77/PPvvYueeeW6mfESgLqVBAnPGatVVJ1ZV0pevoSvpee+3lKgiyatUqV1FWpVopPfrPZMuWLQGvo7QYvY6ucukqVpMmTVzqzjHHHGNffPFFsfd95JFH7Nhjj7Vdd93V0tPTbZdddnGvW1I+tK7A9e/f372uKo66enbRRRe5pnz9x7nHHnu47dRq4TXHq0m/LHr+kCFDXOVd5dBf3VclyP+ztWnTptjrl5bOoRQC/6DCc+aZZ7q/3377bZllU9rV//73P7v44ouLggrRMVKl4KWXXnLBh0ybNs2lNmif+FOFYN9997UWLVqUmKIS7IQTTnBXMr3j7185/OOPP+yCCy4I+TyVRy00qqCokqnXUJ+Ub775pti2Ojb6DN9//707rjqvtL90ngWX08uVX7p0qasA7bbbbu711YqjNLFgodK0vHXz5s2znj17unNT55L2bahKk/Z99+7d3XehZcuWLo1n8eLFRd+V0hQUFLhWpY4dO7rPpYqajoGOjXe8wvk+Tp061VUcdb7r+6HKuiqB4XryySft4IMPdp9B+1bfN12pLml/hbtvSqNzQ1e5P/vss4D1Opd0vA466KBiz9FviVoXunXr5s4ZHVv9/qi1ITiNR98ftUYFf/dmzpzpzn//K+ih+lh465YsWWLXXnut26+qkOt3SueX10ro7Tedp8HBu/8xChbqPb3fRv2maFmfUeeFvhveua73aN++vTvW7dq1c9+1cPTq1ctV/D/++OOidTpHdF/HUjf9dvrz9p2e6/0GqsVX51pwUCH6XaQFAvGKwAKIU6rEKJdWV6OVcqP/+C688EKXvtCjRw93f+zYsXbGGWe4dcOGDQv5OsrdXb16tfsPVv9xK11H/7kFV6SVw6//YPWeShnS606ZMsX1JfCv1Mtjjz3m/uNXBfWKK66whx9+2KUXLVy40OXy6j/k+++/v+hqu1IxdFPlrjRKK9L7KQ2gT58+bnuVX/eVZuAFT+pLEer19b6R8nKPVdEvi64siiq4wdR3Y/Pmza4vh6hyrv2tVKUXX3yxaDulN/z444/2zDPPuApyOJS2pSBPr+OftqLXVsVQgU0o//73v13l7tJLL3XH9JJLLnEtLUrbUhmC/fbbby64UCCic05Xs1WpKym9Qikaej2laN1xxx0uiFXlLNzOuV999ZUdf/zxrgJ13333uYq2Wo6GDx8esJ0q33pM/VhUuVXLk85jvX841CKl74cqpXfffbf7bDpvVHFXq084FDDp+6fWKZ17qpTrOzNu3Liwnq9+QNr/Opb63l533XWuMq3KZKhgLNx9Uxa9hnLzda74H+dZs2a5zxOKHlcQpGD8lltuce+vir0+q/abP1XAFeTr/PT6B6hyrnNGwYguWIRDx/Lrr792garOJ6Um6jdA32tdWNB5pePWqFEj9/0PFZBFSr8t+s25/fbb3bHRb64+n95HN5XprrvucoGCAuxw+lF5wYF/oOW1SHiBhXc/uK+dHvN+i3ThQn0svOAqHPpt0DEIvilIAaqMD0DMvP/++z59De+5556idStWrHDr6tSp41u5cmXR+nXr1vlq1arlS0lJ8f3f//1fwOuccsopvpo1a/q2bNlStG7w4MHudfRYQUFB0foFCxa41+jTp0/Aa2zdurVY+d599133GnfffXfRul9++cWXnp7ua9++ve/PP/8s9pz8/PyAzzFq1Kiw98fNN9/snjN+/PiA9f/+97/d+pEjRxbbT5G8frC8vDxf9+7dfTVq1PB9//33ZW4/dOhQ955Lliwp9pjKrMdmzpxZtC47O9vXuXNnX/369X3Lly/3Pfvss26b6667LqzyTZw40W3/yiuv+L755hu3/Pzzzxcdh9TUVN/DDz/sW79+vXtMx7ysY6qy6/hdccUVAevbtGnjXuOll14KWH/llVe69f77R/tc6/r37x9wbs2fP9+tv/HGGwNeI1TZtE7n4aeffhqwvl+/fu54+J/LhxxyiDv3tQ89OTk5vsMOOyysc+Cggw5y52t5+H8ftezR5+7QoYOvZcuWZb6G9p0+6+GHH+7OCc9vv/3ma9Cggdv3OhfLs29K0rNnT19mZqZbHj58uHufbdu2uftjxoxx58CGDRvcb4/eT79FHpVR+zeYvn/a9rPPPgtYr3Lq9+f444933//evXu711+4cGHAdt55478fvXV6rv+59OCDD7r19erV861atarY7+BZZ50V1m9BqPf0fht1bvsbNmyYW9+6dWvfpk2bitZ//fXXIc/rULSP9dn1u+IZO3asr27dur7c3Fz3/fP/ndA6HacDDzww4HXuvfdet11aWpo7/6+++mrfc88951u9enWx9/Q+f0k3nadAVaHFAohTukLnpfuIRjJS+oauQOsKnj+1YCilI9SV4uuvv95dDfOoL4Byfd99992AtAqlW3hpI7qKpytduiqrlA3/NIpXXnnFXcEbNWqUNWzYsNj7qXzlpRYSfU5dYfenK5Rar8crkloUdNVaVyy1b8vipYGE6nzq9SPwTxVRyoLSkVRX1JVQtVboKvCdd94ZcVkPOOAA91wvHUotHrr6rZaiknjHVO+v1hQdU+88Ck6NEXU8V0uVP+XoS6gWDm9UIY+urutKa6htQ1HLj9Jtgt9PqSPeuay+NLrCe9JJJwV0VtVn1/uHQ+ewrsJHc5Vb30f/VD59bl2d1tX5stKTlEajY6Dvos4J//2tVKWff/7Z5dJHum/CpZYJfafV+iQaMUv7U+lVoaiM2r+i9/vzzz/dueP1Cwg+d1TOf/3rX+6KvzoV67dFV/rVyhEutZT6n0v6TROl8ikd0uOdv+GeY2V9//1576nWFv8UJKXQ6X4476l0Le0Ptah5rRJqkVBLrPqXqFVVLUhei4bXeuG1dHjUovXmm2+6liq1bD300EOuVUhph0rhCzWylI7pO++8U+ym1iegqhBYAHEqeMQPURqAcpCDK7ZaL8EpSxIqPWi//faz/Px8V6HxvPfeey4NRpVRBQz6D1w3VUhUsfB4/7mGys2OllINVGkI7uCp++qY6D/EYrSU4qFUIQUxSq0Jh9cZM1T6jJei5N9hU9q2betSSZQ2pn2uTthepS1SqoTqOOm4eZVD79iHosqqUmG8/hLeMV20aFHAMS3tnPMqn6HOrZK2D7VtKOG8n5d+EirwCycYFKUeKfBTxVF9iBSMqcOyAuRwRbpv/HmfoUOHDsUe89YFn9vRvF+o91DQp6BUqWv6DpfUL8ejFCZVqPVbo3x+nTde5+JQ5476m2j/qi+BKsPBlfayBH9e77z2+moFPxbpPqjK91SQoAs9CmT9+1d4FHx5/Sy8ACPUyHnqW6U0Of0G6/dDKXgKspTWFir1VUGHgr/gm9I0gapCYAHEqZKG5yxt2M7CLIrI6aqZKgO6+qorjbrCqhxsXe1SZUatGIlE/U10hVWVqwkTJoT9PG8oWV39DuatU8U12FtvvVU07GokOdPB1OdBV5OVD75s2bISc+S9Dv6qwCi4UBCl1h7vmKqiGeqYRnpulbR9uOdhZZzLoejq//Lly+3VV191LUfqv6DgQn1T1Pk9nspaWe+nc0VBqQY70Dmq/gslUSCsVlFdxFB/Kg1EoPPGmxsk1LmjVhRvUACdm5F2Mo/0985/H/i3dAQrrXN9NO8Zbj8L//4VHi2rRUP7SNuolVff1dLKqRZLBWt6PV0kUIulLlQA8YbAAkhwGhEmmJrW9Z+Vl2qlq7f6T+rtt9926SVKP1C6lCpkwVcn1XIgqpyVprT/7Eu7gqiKd3BlQPfVKTrUVdzyBBWqXKljplIEIimnrvqK0qeCqbOp0iW8/eNRx3alNKjTsR7TKDTqTF8eaklSxViVPF251DEqiQIJVVyee+4513FYqTzaXlcwK+Jqb1Xx0o9CBWSRBGlK0RowYIBrpdJoUurMru+GOkRXNu+81fuG+i76b1NZzj77bNdqM3v2bHful5ayqA7T2u/6PdBIVP369XPnTUkDHOj7qdfXX6XsqIVGgzpUFW+EpFBBYkW2coZLv5va12qVUOCg9Cjvt8MLLLSv9JhaMxTgltby6E8DbKgVVK2m/pPpAfGCwAJIcBrJxf9Km4aaVQ60RnXyhkz1rtAFX5FTCknw1UmNjqKr5qqcK28/mPca3muHe0VYVPnVyELBOcFPPPGEWx88Ik2k1JdC5R40aJBLJyitcqXKv4Ze9c9lVoVAV3FVPv8rshrNRpUEzcDtn+ak9UoR0RVMjUykUZ20z/T+5W0FUoCi/i3eiE8lKemYal+GO8xtPNDIWepbolY0/0qiUk0efPDBsF4jVAXMy/+P5PwsLwXqCmA10pD/8LY6x5SepAC/MlIL/ekqt1rndO6UNkO9d+6ovP7njirCas0MRUPTqt+FzknN86L+ARqpTlfVq4JS/XSeqEXGv8w6X15//XWrakofU3ChUfLU70TL/n1rNBGeWoJ1PvjPX+HRb46GVw5FaWwKRhVgKD0NiDeJO1MNAEf5+Ep7UOVGFRn9568raPpPzaMKu/J3dWVSfQ70n6Cuiiu1wZsJ1j+PV8PAKlVCzfPq6KiKkVKBVPlThV1X4PQfp4abVGVaV9h0tVP9N5Q3XBJ1blXncL22AiBVtpTKo6vKyqfX4+WlK9SqVGkoVV19DZ4UTOXzbwFQvwtVjHTV0fuPX0GDKrMau1/55EpJUqCgfaf/5L2ZxkUVhrPOOsu1YqjVQEGAPo+GO1V+tP6G27fDn/LedSuLhkVVfw8FMZr4T1dEdXVUOds6HpHMvxBrGtZVx0YdYNUBXpVkzfHi9ZEoq9VJ/YyUZ65OtUpn0/dAw6TqPNcxqmw6dxVgKshXyovOHw2drDIoQFUlvCpmJi9p2OCSJpPUOaThrnWO6/sSqm+Qfif0uZSm581VogsSqhjrvNMx0ySUlU3vpQBHZdYFCs03o0BKlXhvmOiqpIsJ+u3QLNv+vwve+arfDy/oCe64rcBCvzkqu4bE1f5TwKQLHc8++6zrz6Xfs+ALC2rV1W9NKPrNC3d4ayAaBBZAgpsxY4Yb+16VauX4q4KloMK/cqp5Df773/+6uQiUj6/AQ/8RqXIQKvdXaQ6qnOp1lPqgZnlV2NQK4j+Cize/hsam13+WCkBKCyxUYVTlV2VV+pCu5qrCrxmy9Z+zrkyWl1e5UN+DUPMfqDWitNQij1oltH/UR0Pj7evqpD63AgX//hW6cqtUHV2x9PpmiFLN1GJ06623ulF+gkf+qSg6Pkpl0b5XRU8VVx1nr8IX6chCsaRjo/PY+yxKCVPlXJVZnc86HqXRFXQFVDpX1RFWo/Loeao8a+SzqqDzw5vXQa1OCmp07FVh90YjihcKglSRVUCv81UVUu1v9UnSwA+edevWuWBFaVz+fZUUgGiQAgXSSpFS5dr/in1lULqfjq3SuNR6qHKq/Go1iFVg4fHvX+G/ToGFvpfBx1/nty7QqE+UfgcVCCuY0MULPU+/LcHBiHijQIWi9QQWqAopGnO2St4JQJXS1UNdcecrjkSlYFhX11WJrYqWBwBA6ehjAQCIawqO/WccF/VV0OhFGoo41FCdAICqRyoUACCuKdVOaXQaIlb9FTSqlSYeVB8gpcCQ4gEA8YHAAgAQ15Sz379/fzc4gPLN1YKhAEMdWNWZGwAQH+hjAQAAACBq9LEAAAAAEDUCCwAAAABRo49FOWjGXE2+ozH1y5qYCQAAAKiu1K9Nk3pqTqbgiRmDEViUg4IK/0nAAAAAgET2yy+/2G677VbqNgQW5eDN/qsdXL9+/fIdHURs8+bNLqBjv5ciK8vMm+X5f/8zy8zkTAMAAFHXv7z6b2kILMrBS39SUEFgUfXY76WoUcOsTZvC5QYNzOrUqaKjAgAAElk46f8EFkAiUSCxcmWsSwEAAJIQo0IBAAAAiBqBBQAAAICoEVgAiWT7drNDDim8aRkAAKCK0McCSCQFBWYLFuxcBgBELD8/33Jzc9lzSHg1a9a0tLS0Cns9AgsAAIC/JgJbs2aNbdy4kf2BpNGwYUNr2bJlhUz6TGABAABgVhRUNG/e3OrUqVMhFS0gngPpbdu22bp169z9XXbZJerXJLAAAABJT+lPXlDRpEmTpN8fSA61a9d2fxVc6NyPNi2KztsAACDpeX0q1FIBJJM6f53zFdGviMACAADgL6Q/IdmkVGDKH6lQQKJp2jTWJQAAAEmIFgsgkWRmmq1fX3jTMgAg6dx2223uKvSuu+5qBSGGHj/88MPd4+eff35MyhevPvnkE+vevbvrd9CmTRu7++67XQfnstxxxx3297//3Y2upP26wBv23c+yZcvs8ssvt06dOlmNGjVs//33D/laL730kg0YMMB2220391r33ntv2OWfPHmy7b333m4IWb3PV1995c4FddCuKgQW1dT2nDzblJUd0U3PAQAAiU+Vyw0bNtiHH34YsP7nn3+2efPmWd26dWNWtnikin+fPn3cyEhTp061a6+91m699Vb7v//7vzKf+9hjj1lOTo717t27xG0WL15s06ZNs7322sv222+/Erd79dVX7aeffrLjjz8+ovJv3brVLrzwQjviiCNszpw59p///McFFqNHj67SwIJUqGoqJzffnv9omf2+ZUdY2zepl2Hn9NjLaqdzyAEASHTp6emuovvCCy/YUUcdVbT+xRdftA4dOlTopGjxbuXKlbbHHnvYihUrbPfddw+5zT333ONGA9P+0b475phjbP369TZmzBi76qqrrFatWiW+/qpVqyw1NdVV6P/73/+G3OaEE06wk046yS2rpShUq4bXYqHX8gKWSD5jdna2DRo0yLVIycKFC62q0WJRjSmoWLtpe1i3cAMQVHPbt5vpPxDdtAwASFpnn322uwLuP9qP0mUGDhwYcvvvvvvOVX4bNGhgmZmZ1r9/f1u+fHnANrqCf8ghh7htNDyprqz/8MMPAduo4qxUH1W0DzroIPdaXbt2jUlFN1xvv/22nXzyyS6o8Jx11lluCGK18JTGCwSi3SaS7fwp3emAAw5wywqIlEKlAOqCCy5w65o1a1a0rrIRWACJRLm0H3xQeAuRVwsASB66Sq6r2LNmzXL3lyxZYt98842rMAdT+s1hhx1mf/zxh02aNMkFILpir4qqXsPz66+/2tChQ+2NN96wJ5980vXh8J4XPNng1VdfbSNGjLCXX37ZduzYYaecckqZQ5pqPpG8vLxSb6H6jUQjKyvLfvnlF2vXrl3Aet1Xhfz777+3eHbxxRfbs88+65bHjx/vAqGPPvrIRo4c6dbNmDHDrZsyZUqll4W8GAAAgNJkZZX8mFKKMjLC21ZXo/+akCzibcs5P4FaIJTeo9YHpUWpc7LSgoIpF79x48b2zjvvWMZfn0cBw5577mlPPfWUXXnllW7d/fffHxAEqNOyWi7UMnLppZcWPaZA44MPPnBpV6JWi169etlnn33m+gGUpG3btq4fSGkGDx7sgp+SqMO1yuZfTu+vAhOP0sEUOKhVQtT52p9aL7QPg4OmeLPbbrsVtVio/8ahhx5atC+lc+fO1rSKRowksAAAAChNaR2d+/UzmzZt5/3mzc1K6izbs6fZnDk77ys1ZcOG0Nt26WL2+ecVkg6l1Kft27e7AEOtCKGoVUMtGRqxyKt8N2rUyKUyfe5Xjk8//dRuueUW++KLLwIq3MHpUK1atSoKKsTrsKwWj9K89dZbAS0koZRVSVZAoyAmmDpO+3v//fcD+p8gegQWAAAACUojHWmEKI1wpM7LZ5xxRsjtNILUAw884G7BvH4H6qR87LHHWpcuXVzHYgUPekytIUp18hfq6r8EbxdMAUhZQ7yW1Q9BV+j9g6HVq1fbiSeeaG+++aYb9cmz7777BpR106ZNAa+jkZ40opJachAeAgsAAIDSbN1a8mPBoyutW1fytsEV4pUrw9+2nBRUaF6E++67z/WXaNGiRcjtVHlWgOClPPmrV69eUa6+hjV97bXXiirjat2oyFShikiFUnkV/PiPmCRKFwrVgVlpWq1bty7Wl2Lp0qUuyAnue4GSEVgAAACUJpIJRytr2yg7965bt84uueSSErfR0LTffvutS30qaShapVOpT4KCFY86Zvv3W4hWRaRClUffvn1dh/Rx48YVfT4N/aoASn1NqqP0MFuJKhKBBZBo6tSJdQkAAHFEQ72+/vrrpW6jztsaRlapU+qErZYNjeyk/go9evRwfTWOPvpot62GMb3sssvcpG8afjY47SkaXifkqqbRq55//nn3OdVqs2jRIje3heax8B+CVv00NCv37Nmzi9ZpH2kErcWLF7v77733nmslUeuI13KilKrp06e7ZbXIbN682XV4l549e7ohYb2Ru3TzqBzaTq0qCn4i0b59+6KRojSUrjqiV/b+JbAAEomufpU2yggAACGowjx//nw3RKkq1kp5Un+EI4880jp27Oi2UaVUKUiaN0HzV3Tq1MlVek8//fSE+PzqwD58+HDr16+fq+gr2LruuusCtlPrjP+IUzJq1CgXXHhuuOGGYilbajEK3k/eff9O5GoB0vt6NIysbgpmvJSucKn1ScdKwwKrJUbpXpG+RqRSfGX1kEExijI1MYw6+dSvXz8me2hTVrY9NP1bN/ldOFo0qG1X99vfGmSWPHNkvIuH/Q4ASExKF1HnZg3F6g23CiSDHWWc+5HUv5ggDwAAAEDUCCyARKIOWv37F96qsLMWAAAAfSyARKK8z786h7llAACAKkKLBQAAAICoEVgAAAAAiBqBBQAAwF8YLBPJxleBA8TGVWBx5513uslZNBV78+bN3WQemk7dn8b51ayP/rfLL788YJtVq1a5aek1EYheR5OeBM8KOWfOHDv44IOtVq1abuzi0qaGBwAAic2bbVkTmQHJZNtf57z/jOoJ0Xlbk4sMGTLEBRcKBG6++WY79thj3QyEmnHQoynpb7/99qL7CiA8mrREQUXLli3tk08+sdWrV9t5553ndtbYsWPdNhqrV9soINEsi5o9UdPdayIYzTgJAACSS1pamptBWhOZeXULXbwEErmlYtu2be6c17mv70BCBRYzZswIuK9WBLU4LFy40M386NGXXYFDKJo1UYHIu+++66aj16yQd9xxh5sFUbMPalr2CRMmuElANA29N+X53Llz7f777yewAAAgSXl1Cy+4AJJBw4YNS6xXV+vAIphm+JPGjRsHrFcrw3PPPed2wgknnGC33HJLUavFvHnz3JTzCio8aoW44oorbPHixW56c23Tu3fvgNfUNtdee23IcmRnZ7ub/wyEUlBQ4G6xUPi+PkuxcPPifDEtb0Xwyl7dP0elql07cJhZ9hMARET1h6ZNm1pubi57DgmvZs2arqVCrRcl9bWIpM4Vt4GFPoQq+ocffrjtv//+ResHDhxobdq0sVatWtk333zjWiLUD+O1115zj69ZsyYgqBDvvh4rbRsFDNu3b7faqpwF9f0YPXp0sTKuX7/eTYMeC1k7cq1eyg7LTw/vh69eSor98fsGy86KPn8uVrZs2RLz/Q4AAJBMtvxV/6rWgYX6Wnz77bcuRcnfpZdeWrSslgn1izjmmGNs+fLl1rZt20opy0033WTDhw8vuq8ApHXr1tasWTOrX7++xcKmrGzb4ltrv+eE12KRVjvDGjdpag0ya1l1lZGR4f7Gcr8DAAAkk4y/6l/VNrAYOnSoTZ061T788EPbbbfdSt22W7du7u+yZctcYKH0qPnz5wdss3btWvfXyx/TX2+d/zaqrAa3VohGjtItWGpqqrvFQuH7KhEq3I5lKTEtb0Xwyl7dP0elUkvOoEGFy//5j34NYl0iAABQjUVS54qr2plyuxRUTJkyxd577z3XwbosX331lfurlgvp3r27LVq0KKDj1TvvvOOChv32269oG40E5U/baD1Qral/xauvFt78+1oAAABUstR4S39Sp+zJkye7uSzUF0I39XsQpTtphCeNErVy5Up788033VCyGjGqY8eObhsNT6sAYtCgQfb111/bzJkzbeTIke61vVYHDTP7008/2fXXX2/ff/+9PfLII/byyy/bsGHDYvr5AQAAgOoqrgKLRx991I0EpUnw1ALh3V566SX3uIaK1TCyCh7atWtn1113nQ0YMMDeeuutotdQz3alUemvWiDOPfdcF3z4z3uhlpBp06a5VooDDzzQDTv75JNPMtQsAAAAUE41qtOU4uowrUn0yqJRo6ZPn17qNgpevvzyy4jLCAAAACDOWywAAAAAVE8EFgAAAACiRmABAAAAILH6WACIUp06Zlu37lwGAACoIgQWQCJJSTHLzIx1KQAAQBIiFQoAAABA1AgsgESSnW12/vmFNy0DAABUEQILIJHk5Zk980zhTcsAAABVhMACAAAAQNQILAAAAABEjcACAAAAQNQILAAAAABEjcACAAAAQNQILAAAAABEjZm3gURSp47ZunU7lwEAAKoIgQWQSFJSzJo1i3UpAABAEiIVCgAAAEDUCCyARJKdbTZkSOFNywAAAFWEwAJIJHl5Zo88UnjTMgAAQBUhsAAAAAAQNQILAAAAAFEjsAAAAAAQNQILAAAAAFEjsAAAAAAQNQILAAAAAFFj5m0gkdSubbZixc5lAACAKkJgASSS1FSz3XePdSkAAEASIhUKAAAAQNQILIBEkpNjNmJE4U3LAAAAVYTAAkgkublm995beNMyAABAFSGwAAAAABA1AgsAAAAAUSOwAAAAABA1AgsAAAAAUSOwAAAAABA1AgsAAAAAUWPmbSCR1K5t9u23O5cBAACqCIEFkEhSU806dIh1KQAAQBIiFQoAAABA1GixABJJTo7Z2LGFyzffbJaeHusSAQCAJEFgASSS3Fyz0aMLl0eMILAAAADVMxXqp59+su+++67cz7/zzjvtkEMOsXr16lnz5s3t5JNPtqVLlwZss2PHDhsyZIg1adLE6tatawMGDLC1a9cGbLNq1Srr37+/1alTx73OiBEjLC8vL2CbOXPm2MEHH2y1atWyvfbayyZNmlTucgMAAADJrlyBxUMPPWRnnXVWwLoLLrjA9t57b9t///2tS5cutm7duohf94MPPnBBw6effmrvvPOO5ebm2rHHHmtZWVlF2wwbNszeeuste+WVV9z2//vf/+zUU08tejw/P98FFTk5OfbJJ5/YM88844KGW2+9tWibFStWuG169eplX331lV177bV28cUX28yZM8uzOwAAAICkl+Lz+XyR7oWOHTu6SvmDDz7o7qtC3rdvX7vsssvsgAMOsJEjR9rZZ59t48ePj2oHr1+/3rU4KIA48sgjbdOmTdasWTObPHmynXbaaW6b77//3tq3b2/z5s2zQw891N5++207/vjjXcDRokULt82ECRPshhtucK+Xnp7ulqdNm2bfesNymrlAaePGjTZjxowyy7V582Zr0KCBK0/9+vUtFjZlZdtD07+1tZu2h7V9iwa17ep++1uDzFpWXcXDfo97CsLr1i1c3rrVLDMz1iUCAADVWCT1r3K1WPz888+uMu95+eWXbY899rBHH33UrrzyShs6dKhNnz7doqUPII0bN3Z/Fy5c6FoxevfuXbRNu3bt7G9/+5sLLER/Fdx4QYX06dPH7ZTFixcXbeP/Gt423msAAAAAqILO28GNHLNmzbKTTjqp6P7uu+9ua9assWgUFBS4FKXDDz/cpVeJXlMtDg0bNgzYVkGE93766x9UeI97j5W2jYKP7du3W+2gicWys7PdzaPtvDLqFguF7+uzFAu3wckX0/JWBK/s1f1zVKqCgqKrBW4fsZ8AAEAUIqlzlSuw2GeffWzKlCl2+eWXuzQopR0pFcrz66+/Fqv8R0p9LZSqNHfuXIs1dSof7Y2040epVepMHgtZO3KtXsoOy0/PDWv7eikp9sfvGyw7q6ZVV1u2bIn5fo93Kdu2mRcyaz/5/PonAQAAlLf+VWmBxT/+8Q8bOHCgNWrUyHWsVlqUUok87733nnXq1MnKS6lUU6dOtQ8//NB22223ovUtW7Z0nbLVF8I/cNGoUHrM22b+/PkBr+eNGuW/TfBIUrqvvLHg1gq56aabbPjw4QEtFq1bt3b9PWLZx2KLb639nhNei0Va7Qxr3KRpte5jkZGR4f7Gcr/Hvfx8K/j0U7fYrHVrs7S0WJcIAABUY179q9ICC3V01nCv6kehCr76VdSoUfhSf/zxh+sTMWjQoHKlWF111VWuNUTDwarfhr/OnTtbzZo1bfbs2W6YWdFwtBpetnv37u6+/o4ZM8aNSqWO36IRplQR3W+//Yq2Ce4Dom281wimIWl1C5aamupusVD4vkqESgnzGSkxLW9F8Mpe3T9HpdJ+6dYt1qUAAAAJIpI6V7knyPv73//ubsEUVLz22mvlTn/SiE9vvPGGm8vC6xOhnuhqSdDfiy66yLUe6H0ULCgQUUCgEaFEw9MqgFBgM27cOPcaGqVKr+0FB0rh+ve//23XX3+9XXjhha6FRR3QNVIUAAAAgGo+87ZGlZKjjjoqYP3EiRPt/PPPd8v333+/i5zUYqEO1UrBeuSRR4q2TUtLc2lUV1xxhQs4MjMzbfDgwXb77bcXbaOWEAURmhNDQ+Yq3erJJ58MSOcCqqWcHLO/hoG2a65h5m0AABBf81ioIp6SkhLZC6ek2PLlyy0RxcN8CsxjQR+LkJjHAgAAxKjeG1aLRc+ePSMOLAAAAAAkj7ACi0mTJlV+SQAAAABUWwytAwAAAKBqWiw0n0R5HHnkkeV6HgAAAIAEDCw0SlMkfSzUH1zb5+fnR1M2AAAAAIkUWLz//vuVXxIAAAAA1VbYo0IBqAYyMnQlYOcyAABAdZkgb/Xq1bZu3Trba6+93GR0AGIoLU25ixwCAABQfUaFeuONN6xdu3Zu1uqDDz7YPvvsM7d+w4YNdtBBB9nrr79ekeUEAAAAkGiBxVtvvWWnnnqqNW3a1EaNGuU6a3u0btddd7WJEydWZDkBhCM312z8+MKblgEAAOI5sLj99tvdULJz5861IUOGFHu8e/fu9uWXX1ZE+QBEIifHbOjQwpuWAQAA4jmw+Pbbb+2MM84o8fEWLVq4fhcAAAAAkkO5Aos6depYVlZWiY//9NNP1qRJk2jKBQAAACDRA4tevXrZM888Y3l5ecUeW7NmjT3xxBN27LHHVkT5AAAAACRqYDFmzBj79ddf7ZBDDrHHHnvMzbI9c+ZMGzlypB1wwAGuM7c6dQMAAABIDuUKLPbdd1/XcVvpTrfccosLJO655x4bO3asCyw++ugj23333Su+tAAAAAASa4K8Dh062Lvvvmt//vmnLVu2zAoKCmzPPfe0Zs2aVWwJAQAAACT+zNuNGjVyKVEA4kCtWmZTp+5cBgAAiLdUqB9//NEyMjLs+uuvL3W7ESNGWO3atW3FihUVUT4AkahRw6x//8KblgEAAOItsHjooYesZcuWruN2afS4ttP2AAAAAJJD2IHFrFmz7KyzzrKaNWuWul16errb7u23366I8gGIRG6u2aRJhTctAwAAVJGwcyVWrVrlRoMKx957720///xzNOUCUB45OWYXXFC4fPrpZmVcCAAAAKjyFotatWrZ1q1bw9pWs3Kr5QIAAABAcgg7sGjXrp0bXjYcs2fPtvbt20dTLgAAAACJGFiceeaZNnXqVHv99ddL3e6NN95w22l7AAAAAMkh7MDiyiuvtIMOOshOP/10u+KKK+zjjz+2zZs3u1m39Vf3tf60006zAw880G0PAAAAIDnUiKSPxcyZM23w4MH22GOP2eOPP15sGwUZxx13nD377LNuewAAAADJIaIZtJo0aeLSnObPn29vvvmmfffdd661on79+q4PxgknnGCHHnpo5ZUWAAAAQFwq19S8Xbt2dTcAcUYthS+/vHMZAAAgngMLAHGqRo3C+SsAAADitfM2AAAAAJSEFgsgkeTlmU2ZUrh8yimFLRgAAABVgFoHkEiys83OOKNweetWAgsAABBfqVAPPfSQ/fDDD5VfGgAAAACJG1gMGzbMFixYUHQ/LS3NJk+eXJnlAgAAAJBogUWjRo1s7dq1ARPhAQAAAEBEfSyOOuoou+222+yrr76yBg0auHWaXfvTTz8t8TkpKSn24IMPhvPyAAAAAJIhsHjkkUfs2muvtVmzZtm6detc0KBl3UpCYAEAAAAkj7BSoZo3b+76VKxevdry8/NdKtRzzz1nBQUFJd60HQAAAIDkUK7hZidOnGiHHXZYxZcGQHTS0/UF3bkMAAAQz4HF4MGDi5aXLFliP//8s1tu06aN7bfffhVXOgCRqVnT7Pzz2WsAAKD6TJD3xhtv2PDhw23lypUB6/fYYw+777777MQTT6yI8gEAAABIlD4WwaZPn24DBgxwy2PHjrUpU6a4m5bV/+LUU0+1GTNmRPy6H374oZ1wwgnWqlUr1/n79ddfD3j8/PPPd+v9b8cdd1zANn/88Yedc845Vr9+fWvYsKFddNFFtlUzEPv55ptvrEePHpaRkWGtW7e2cePGlWc3APEnL89s2rTCm5YBAADiucXijjvusI4dO9pHH31kmZmZRevVSjF06FA74ogjbPTo0cUq/WXJysqyAw880C688EIXnISi11QfD0+tWrUCHldQoU7m77zzjuXm5toFF1xgl156adGEfps3b7Zjjz3WevfubRMmTLBFixa591MQou2Aai072+z44wuXFVDXKHejJAAAQETKVevQFX+1TvgHFR6tU8vCzTffHPHr9u3b191Ko0CiZcuWIR/77rvvXEvJ559/bl26dHHrHn74YevXr5/de++9riXk+eeft5ycHHv66actPT3dOnTo4ObnUPoWgQUAAABQhalQSiFSylFJ9Ji2qQxz5sxxw9/uu+++dsUVV9jvv/9e9Ni8efNcy4MXVIhaJlJTU+2zzz4r2ubII490QYWnT58+tnTpUvvzzz8rpcwAAABAoitXi8XRRx/tZtVWWlL37t0DHlMF/qGHHnLpRhVN76cUKXUQX758uWsVUQuHgoW0tDRbs2aNCzr81ahRwxo3buweE/3V8/21aNGi6LFGjRoVe9/s7Gx38yidSrw5O2Kh8H19lmK+MJ/hi2l5K4JX9ur+OSpVQUHR1QK3j9hPAAAgCpHUucoVWKizswIK9aXo2rWraz0QXfWfP3++q9zffffdVtHOOuusouUDDjjA9fNo27ata8U45phjrLLceeedrs9IsPXr19uOHTssFrJ25Fq9lB2Wn54b1vb1UlLsj983WHZWTauutmzZEvP9Hu9Stm2zwjC5cD/5srJiXCIAAFCdefWvSgssdMVf/SxU4X777bftpZdeKprH4pprrrEbb7yxWMtBZdhzzz2tadOmtmzZMhdYqO/FunXrArbJy8tzqVlevwz9Xbt2bcA23v2S+m7cdNNNbmhd/xYLjSbVrFkzN/pULGzKyrYtvrX2e054LRZptTOscZOm1iAzsLN7deKl18Vyv8c9v0BC+8lC9IMCAAAIVyTdG8o9ZIwCh/vvv9/dYuXXX391fSx22WUXd1+tKBs3brSFCxda586d3br33nvPNeF069ataJt//vOfbsSomppMzMyNIKVWl1BpUF6H8eDRp0R9N3SLhcL3VSJUSpjPSIlpeSuCV/bq/jkqld9+cfuI/QQAAKIQSZ0rrmpnmm9CIzTpJitWrHDLq1atco+NGDHCPv30Uzcp3+zZs+2kk06yvfbay3W+lvbt27t+GJdccolLyfr444/d8LdKodKIUDJw4EDXcVvzWyxevNi1tqi/iH+LBFBtaVCCf/+78OY3QAEAAEBli6tB7hcsWGC9evUquu9V9gcPHmyPPvqoS7965plnXKuEAgV1ENecGv6tCRpOVsGEUqMUYWkiP3Um9zRo0MBmzZplQ4YMca0aSqW69dZbGWoWiUGtcEOGxLoUAAAgCcVVYHHUUUe5mbtLMnPmzDJfQyNAeZPhlcSb3A8AAABAAgYWAKKUn2/mBc09epilpbFLAQBAlSCwABKJhuH10gm3bmVUKAAAUGUi7ry9bds21zdhwoQJlVMiAAAAAIkfWNSpU8eN1pSSEu4wpwAAAAASXbmGm9WQruF0pAYAAACQHMoVWNxyyy32ww8/2KBBg2zu3Ln222+/udmtg28AAAAAkkO5Om936NDB/V2yZEmpQ7vma4QaAAAAAAmvXIGFJpSjjwUAAACAqAKL2267rTxPA1AVM2+PG7dzGQAAoDrNY7Fp0yarW7eupTEZFxBb6elmI0ZwFAAAQPXovC0LFixwo0Np+NkmTZrYBx984NZv2LDBTjrpJJszZ05FlhMAAABAogUWn3zyiR1xxBH2448/2rnnnmsFBQVFjzVt2tS1YDz22GMVWU4A4dCACZ9/Xnhj8AQAABDvgcXNN99s7du3d6NCjR07ttjjvXr1ss8++6wiygcgEjt2mHXtWnjTMgAAQDwHFp9//rldcMEFVqtWrZCjQ+266662Zs2aiigfAAAAgEQNLGrWrBmQ/hRME+apMzcAAACA5FCuwOLQQw+1V199NeRjWVlZNnHiROvZs2e0ZQMAAACQyIHF6NGj3ahQ/fv3t7ffftut+/rrr+3JJ5+0zp072/r16+2WW26p6LICAAAASKR5LLp162bTp0+3K664ws477zy37rrrrnN/27Zt6x7r2LFjxZYUAAAAQOJNkHf00Ufb0qVL7csvv7Rly5a5PhcKKtRiEapDNwAAAIDEFfXM2wcddJC7AYgDNWuajRq1cxkAACDeA4vs7Gx74oknXNrTypUr3brdd9/d+vXrZxdffLFlZGRUZDkBhCM93ey229hXAACgenTe/vXXX61Tp0529dVXu07bzZo1czcta50e0zYAAAAAkkO5AoshQ4bYzz//bC+//LKbs+KDDz5wNy2/9NJLtmrVKrcNgCqm+WUWLy68lTLXDAAAQFykQs2ePduGDRtmp512WrHHTj/9dPviiy/s4YcfrojyAYjE9u1m++9fuLx1q1lmJvsPAADEb4tFvXr1rHnz5iU+3rJlS7cNAAAAgORQrsDiggsusEmTJtm2bduKPbZ161Y38/ZFF11UEeUDAAAAkCipUK+99lrAfQ0vO23aNGvXrp0NHjzY9tprL7f+xx9/tGeffdYaN27MBHkAAABAEgkrsFBfCk165/P53H3/5TFjxhTbXiNCnX322XbGGWdUdHkBAAAAVNfA4v3336/8kgAAAABI7MCiZ8+elV8SAAAAAMk38zaAOFSzptk//rFzGQAAIN4Di7lz59rTTz9tP/30k/35559FfS486oehmbgBVKH0dLN77mGXAwCA6hFY3HfffTZixAjLyMiwfffd140CBQAAACB5lSuwuOeee+zwww+3t956yxo0aFDxpQJQPgUFZqtWFS7/7W9mqeWaqgYAAKBqAgtNjHfOOecQVADxZvt2sz32KFzeutUsMzPWJQIAAEmiXJcze/XqZYsWLar40gAAAABInsDi4YcfttmzZ9u9995rf/zxR8WXCgAAAEDiBxatW7e2yy67zG688UZr1qyZZWZmWv369QNu9L0AAAAAkke5+ljceuutNmbMGNt1112tS5cuBBEAAABAkitXYDFhwgTr37+/vf7665bKqDMAAABA0itXKlROTo4LLAgqAAAAAJQ7sDj++OPto48+Yg8C8aZGDbMrryy8aRkAACCeA4tRo0bZkiVL7Morr7SFCxfa+vXr3ehQwbdIffjhh3bCCSdYq1atLCUlxaVa+fP5fK5/xy677GK1a9e23r17248//hiwjd5Xc2yoA3nDhg3toosusq0az9/PN998Yz169HAzh6sj+rhx48qzG4D4U6uW2fjxhTctAwAAxHNgse+++9pXX33l+lp07drVWrZs6UaHCr5FKisryw488EAbr0pRCAoAHnroIfe+n332mRuNqk+fPrZjx46ibRRULF682N555x2bOnWqC1YuvfTSosc3b95sxx57rLVp08YFRZpF/LbbbrPHH3+8PLsCAAAAQDSjQqlFoaL17dvX3UJRa8UDDzxgI0eOtJNOOsmte/bZZ61FixauZeOss86y7777zmbMmGGff/65G63Km3OjX79+bs4NtYQ8//zzro/I008/benp6dahQwcXJN13330BAQhQLfl8Zhs2FC43bWpWCd9TAACACgssdIW/qq1YscLWrFnj0p88miujW7duNm/ePBdY6K/Sn7ygQrS9OpmrheOUU05x2xx55JEuqPCo1ePuu++2P//80xo1alTsvbOzs93Nv9VDCgoK3C0WCt/XZynmC/MZvpiWtyJ4Za/un6NSZWVZavPmbrFA52lmZqxLBAAAqrFI6lzVpnenggpRC4U/3fce09/mf1WqPDVq1LDGjRsHbLPHHnsUew3vsVCBxZ133mmjR48utl59S/zTsKpS1o5cq5eyw/LTc8Pavl5Kiv3x+wbLzqpp1dWWLVtivt/jXcq2beZ9Q7SffFlZMS4RAACozrz6V6UFFrfffnuZ2yhV6pZbbrFEcNNNN9nw4cMDWizU6Vv9SNRJPBY2ZWXbFt9a+z0nvBaLtNoZ1rhJU2uQWX079KqzvcRyv8c9v0DC9XOixQIAAFRA/SsmqVAKKNQfoqIDC3UQl7Vr17pRoTy636lTp6Jt1q1bF/C8vLw8N1KU93z91XP8efe9bYLVqlXL3YIpxSpWc3kUvq8SocLNoU+JaXkrglf26v45KpXffnH7iP0EAACiEEmdq1y1My/H3f+mCvzy5ctt2LBhro9DcAU/WkpfUsV/9uzZAS0H6jvRvXt3d19/N27c6EZ78rz33nuufOqL4W2jkaJyc3emEGkEKY10FSoNCgAAAEDZUisymlHlX6Mv7b333nbVVVdF/Bqab0IjNOnmddjW8qpVq1wLyLXXXmv/+te/7M0337RFixbZeeed50Z6Ovnkk9327du3t+OOO84uueQSmz9/vn388cc2dOhQ17Fb28nAgQNdx23Nb6FhaV966SV78MEHA1KdAAAAAESmUjpva9SlG264IeLnLViwwHr16lV036vsDx482CZNmmTXX3+9m+tCw8KqZeKII45ww8v6535pOFkFE8ccc4wLdgYMGODmvvAfSWrWrFk2ZMgQ69y5szVt2tQNn8tQswAAAECcBRYKEMqTA3/UUUe5/hklUauFOo6X1nlcI0BNnjy51Pfp2LGjffTRRxGXD4h7NWooEt+5DAAAUEXKVfPQxHShqBVB/Rdee+01u/jii6MtG4BIaZCBSZPYbwAAoHoEFueff36Jjym16MYbb3TpRQAAAACSQ7kCC3WqDpWmpFGV6tWrVxHlAlAeSiXctq1wuU4dfTHZjwAAIH4DizZt2lR8SQBET0FF3bqFy1u3MkEeAACoMswyBgAAAKDqWiw0klIklBr19ddfl6dMAAAAABI1sNAwrgoWyrJmzRpbunRpWNsCAAAASLLAYs6cOWUGFHfffbc99thjlpaWZoMGDaqI8gEAAACoBqKeQWvt2rV211132eOPP265ubl27rnn2j//+U9r27ZtxZQQAAAAQOIGFl4LhX9AMXLkSNtzzz0rtoQAAAAAEi+wUEChFoonnnjCBRRKeVJAsccee1ROCQGELy3N7LTTdi4DAADEW2CxevXqooAiLy/PzjvvPJfyREABxJGMDLNXXol1KQAAQBIKO7BQn4ns7Gzr1KmT3XzzzS6g+PPPP92tJAcffHBFlRMAAABAIgQWO3bscH+//PJLO+OMM0rd1ufzueFm8/Pzoy8hAAAAgMQJLCZOnFi5JUHS2p6TZzm5ZQehm7Oy3d9NWdlWMyPPaqdHPahZ4snKMqtbt3B561azzMxYlwgAACSJsGtmgwcPrtySIGkpqHj+o2X2+5bCVrGS7Ni21f19+ZOf7OLjOhFYAAAAxBEu+SIuKKhYu2l7qdvkbC8MPP7YWnoAAgAAgKqXGoP3BAAAAJBgCCwAAAAARI3AAgAAAEDUCCwAAAAARI3O20AiSUsz69dv5zIAAEAVIbAAEklGhtm0abEuBQAASEKkQgEAAACIGoEFAAAAgKgRWACJJCvLLDOz8KZlAACAKkIfCyDRbNsW6xIAAIAkRIsFAAAAgKgRWAAAAACIGoEFAAAAgKgRWAAAAACIGoEFAAAAgKgxKhSQSFJTzXr23LkMAABQRQgsgERSu7bZnDmxLgUAAEhCXNIEAAAAEDUCCwAAAABRI7AAEklWllmzZoU3LQMAAFQR+lgAiWbDhliXAAAAJCFaLAAAAABEjcACAAAAQNQILAAAAAAkV2Bx2223WUpKSsCtXbt2RY/v2LHDhgwZYk2aNLG6devagAEDbO3atQGvsWrVKuvfv7/VqVPHmjdvbiNGjLC8vLwYfBoAAAAgcVS7ztsdOnSwd999t+h+jRo7P8KwYcNs2rRp9sorr1iDBg1s6NChduqpp9rHH3/sHs/Pz3dBRcuWLe2TTz6x1atX23nnnWc1a9a0sWPHxuTzAAAAAImg2gUWCiQUGATbtGmTPfXUUzZ58mQ7+uij3bqJEyda+/bt7dNPP7VDDz3UZs2aZUuWLHGBSYsWLaxTp052xx132A033OBaQ9LT02PwiYAKlJpq1qXLzmUAAIAqUu1qHj/++KO1atXK9txzTzvnnHNcapMsXLjQcnNzrXfv3kXbKk3qb3/7m82bN8/d198DDjjABRWePn362ObNm23x4sUx+DRABatd2+zzzwtvWgYAAKgi1arFolu3bjZp0iTbd999XRrT6NGjrUePHvbtt9/amjVrXItDw4YNA56jIEKPif76BxXe495jJcnOznY3jwIRKSgocLdYKHxfn6WYL8xn+GJa3or4LDsfj9/PAgAAkEgiqW9Vq8Cib9++RcsdO3Z0gUabNm3s5ZdfttqVeHX2zjvvdEFMsPXr17sO47GQtSPX6qXssPz03LC2r5eSYn/8vsGys2pavAn3s2TnFz5eLyU7bj8LAABAItmyZUtiBhbB1Dqxzz772LJly+zvf/+75eTk2MaNGwNaLTQqlNcnQ3/nz58f8BreqFGh+m14brrpJhs+fHhAi0Xr1q2tWbNmVr9+fYuFTVnZtsW31n7PCa/FIq12hjVu0tQaZNayeBPuZ8nJKQwktvhqxe1niblt2yxl//3dou/bb83q1Il1iQAAQDWWkZGRHIHF1q1bbfny5TZo0CDr3LmzG91p9uzZbphZWbp0qeuD0b17d3dff8eMGWPr1q1zQ83KO++844KD/fbbr8T3qVWrlrsFS01NdbdYKHxfJQelhPmMlJiWtyI+y87H4/ezxFxKitnPP/+1mEIHbgAAEJVI6lvVKrD4xz/+YSeccIJLf/rf//5no0aNsrS0NDv77LPd8LIXXXSRa1lo3LixCxauuuoqF0xoRCg59thjXQChQGTcuHGuX8XIkSPd3BehAgcAAAAACRhY/Prrry6I+P33310a0hFHHOGGktWy3H///S6qUouFOltrxKdHHnmk6PkKQqZOnWpXXHGFCzgyMzNt8ODBdvvtt8fwUwEAAADVX7UKLF588cUyc8DGjx/vbiVRa8f06dMroXQAAABA8iJJHQAAAEDUCCwAAAAAJFcqFIAyaCQob4QzLQNAnNqek2c5ufkRPSe9ZprVTqfqAsQrvp1AItG8FYsXx7oUAFAmBRXPf7TMft8S3kSzTepl2Dk99iKwAOIYgQUAAIgJBRVrN21n7wMJgj4WAAAAAKJGYAEkkm3bzDp0KLxpGQAAoIqQCgUkEp/PbMmSncsAAABVhBYLAAAAAFEjsAAAAAAQNQILAAAAAFEjsAAAAAAQNQILAAAAAFFjVCggkaSkmLVps3MZAACgihBYAImkTh2zlStjXQoAAJCESIUCAAAAEDUCCwAAUC2Q4QnEN1KhgESyfbvZkUcWLn/4oVnt2rEuEQBUiMxaNSw1NdU2ZWVH9Lz0mmlWO53qDlAV+KYBiaSgwGzBgp3LAJAgMtLTLDcv316Yu9x+37IjrOc0qZdh5/TYi8ACqCIEFgAAoNpQULF20/ZYFwNACPSxAAAAABA1AgsAAAAAUSOwAAAAABA1AgsAAAAAUaPzNpBomjaNdQkAAEASIrAAEklmptn69bEuBQAASEKkQgEAAACIGi0WAAAgKttz8iwnNz/s7VNTUowpPIHEQ2ABJJLt28369i1cfvtts9q1Y10iAElAQcXzHy0Le0bsti3rW9+DWld6uQBULQILIJEUFJh98MHOZQCIwxmxm9SrVenlAVD16GMBAAAAIGoEFgAAAACiRmABAAAAIGoEFgAAAACiRudtAAASWKRDwabXTLPa6VQPAESOXw4g0dSpE+sSAKimQ8E2qZdh5/TYi8ACQLkQWACJJDPTLCsr1qUAUI2HggWA8qKPBQAAAICo0WKRRFJSYl0CJHJetpCbDVR//F8BoLwILJJEZq0alpqaapuysiN6HhXFambHDrMBAwqX//tfs4yMKsnL9nKzzz2S3GygsoJ3VfjTUlMtL78g7OekpqRYQSX/XxHpewBIXAQWSSIjPc1y8/LthbnLqSgmsvx8s+nTdy5XYV42wSuSWaRBgirjeT6fvRBB8N62ZX3re1DriH7HvedU5v8Vkb4HgMRFYJFkqCiishC8xi/S2ipfpC18XmU8kt/kJvVqub/leU6kquI9ACSepA4sxo8fb/fcc4+tWbPGDjzwQHv44Yeta9eusS5Wta8oMlRhciN4jb85BsqT1sb3OHJUxgEku6QNLF566SUbPny4TZgwwbp162YPPPCA9enTx5YuXWrNmzePdfHiSjIPUxhJpa88+c9V2Y8lks9SVTnT5Qled2tS104/bM+wc8Dj/bhEUumP9LP7H8tIv8fJ3oE3Hr8vABDvkjawuO++++ySSy6xCy64wN1XgDFt2jR7+umn7cYbb4x18VAJlZ7KzoEuT/5zeSqKpVaUs7KtwV+Lha9ZI6rPEq9XeiMJRuLiuFRQpT/Sz17eY1me/jKRfv7y7K+qek68f18AIF4lZWCRk5NjCxcutJtuuqlonf4T7d27t82bNy+mZUsElX2ls7yjlpS3o2Qklb7KriT7lyvUc2ru2G5eWPzozCWWm1E7qs8Sz6rTcSnrOfGWchNNB97KDPiq+jmJ9H1JZsne+gZUpaQMLDZs2GD5+fnWokWLgPW6//333xfbPjs72908mzZtcn83btxoBQWxaQBXpbpOaq41qJkX1vbpvhzbtHFjpT+nSS2fbd682f78syDsCn++zxfWe2TnFT5er2a+bdjwu723eLVt2ZYT1vvs0riOdW3bzLZnbbEd28KrXGzbmhLR549mH5enXKGek5+9wzb/tbxj+1bLLcir8s8Sb8+Jh+NS1nPi9bhU5uePZn8l+3GJ1+9LIvyfFO+pk0As6DskPp+vzG35FoThzjvvtNGjRxdb36ZNm/Icn4Q3pJJf/+rTetrVlfwe1VnRmXpZ39gWBACS4P8kIFls2bLFGjTwEq5DS8rAomnTppaWlmZr164NWK/7LVu2LLa9UqbU0dujVoo//vjDmjRpYim0sVZpxNy6dWv75ZdfrH79+lX3xohbnBPgnAC/FeD/j8qllgoFFa1atSpz26QMLNLT061z5842e/ZsO/nkk4uCBd0fOnRose1r1arlbv4aNmxYZeVFIAUVBBbgnEBp+J0A5wXCwW9FeMpqqUjqwELUAjF48GDr0qWLm7tCw81mZWUVjRIFAAAAIHxJG1iceeaZtn79erv11lvdBHmdOnWyGTNmFOvQDQAAAKBsSRtYiNKeQqU+IT4pHW3UqFHF0tKQvDgnwDkBfivA/x/xI8UXzthRAAAAAFCK1NIeBAAAAIBwEFgAAAAAiBqBBQAAAICoEVggbowfP9523313y8jIsG7dutn8+fNL3f6VV16xdu3aue0POOAAmz59epWVFfF5XjzxxBPWo0cPa9Sokbv17t27zPMIif9b4XnxxRfdpKbe/EVI7vNi48aNNmTIENtll13cQBD77LMP/48k+TmhqQf23Xdfq127tpuQd9iwYbZjx44qK29CUOdtINZefPFFX3p6uu/pp5/2LV682HfJJZf4GjZs6Fu7dm3I7T/++GNfWlqab9y4cb4lS5b4Ro4c6atZs6Zv0aJFVV52xM95MXDgQN/48eN9X375pe+7777znX/++b4GDRr4fv31Vw5Tkp4TnhUrVvh23XVXX48ePXwnnXRSlZUX8XleZGdn+7p06eLr16+fb+7cue78mDNnju+rr77ikCXpOfH888/7atWq5f7qfJg5c6Zvl1128Q0bNqzKy16dEVggLnTt2tU3ZMiQovv5+fm+Vq1a+e68886Q259xxhm+/v37B6zr1q2b77LLLqv0siJ+z4tgeXl5vnr16vmeeeaZSiwl4v2c0Hlw2GGH+Z588knf4MGDCSwSUKTnxaOPPurbc889fTk5OVVYSsTzOaFtjz766IB1w4cP9x1++OGVXtZEQioUYi4nJ8cWLlzo0lY8qamp7v68efNCPkfr/beXPn36lLg9kuO8CLZt2zbLzc21xo0bV2JJEe/nxO23327Nmze3iy66qIpKing/L958803r3r27S4XSxLj777+/jR071vLz86uw5Iinc+Kwww5zz/HSpX766SeXGtevXz8OVASSeoI8xIcNGza4H/PgWc91//vvvw/5HM2WHmp7rUfynhfBbrjhBmvVqlWxIBTJc07MnTvXnnrqKfvqq6+qqJSoDueFKo3vvfeenXPOOa7yuGzZMrvyyivdhQhNxIrkOycGDhzonnfEEUcom8fy8vLs8ssvt5tvvrmKSp0YaLEAkJDuuusu11l3ypQpruMeks+WLVts0KBBrlN/06ZNY10cxJGCggLXivX4449b586d7cwzz7R//vOfNmHChFgXDTEyZ84c12r1yCOP2BdffGGvvfaaTZs2ze644w6OSQRosUDM6T/8tLQ0W7t2bcB63W/ZsmXI52h9JNsjOc4Lz7333usCi3fffdc6duxYySVFvJ4Ty5cvt5UrV9oJJ5wQUKGUGjVq2NKlS61t27ZVUHLE22+FRoKqWbOme56nffv2rtVbaTTp6ekctCQ7J2655RZ3IeLiiy929zXaZFZWll166aUu6FQqFcrGXkLM6QdcV4xmz54d8J+/7isHNhSt999e3nnnnRK3R3KcFzJu3Dh3hWnGjBnWpUuXKiot4vGc0HDUixYtcmlQ3u3EE0+0Xr16uWUNJ4nk/K04/PDDXfqTF2jKDz/84AIOgorkPCfUJy84ePACT6VGIUyx7j0OeMPCaZi3SZMmueFjL730Ujcs3Jo1a9zjgwYN8t14440Bw83WqFHDd++997phRUeNGsVwswko0vPirrvucsMLvvrqq77Vq1cX3bZs2RLDT4FYnhPBGBUqMUV6XqxatcqNGDd06FDf0qVLfVOnTvU1b97c969//SuGnwKxPCdUj9A58cILL/h++ukn36xZs3xt27Z1o1AifKRCIS4ov3X9+vV26623uqboTp06uSvOXserVatWBVxJ0OgNkydPtpEjR7qOVXvvvbe9/vrrbmQPJI5Iz4tHH33UpTGcdtppAa+jzpi33XZblZcfsT8nkBwiPS/UWjVz5kw3AZrSJXfddVe75ppr3IAPSM5zQvUJTaCpv7/99ps1a9bMpVGOGTMmhp+i+klRdBHrQgAAAACo3risAwAAACBqBBYAAAAAokZgAQAAACBqBBYAAAAAokZgAQAAACBqBBYAAAAAokZgAQAAACBqBBYAAAAAokZgASDp7b777nb++ecH7Icff/zRjj32WGvQoIGbjVUzu8vnn3/uZn7PzMx067/66quk33/xYs6cOe6Y6K9Hx1XH19/WrVvt4osvtpYtW7rtr732Wlu5cqVbnjRpUoWVR6+l19RrJ/P3KdRxqWr9+vWzSy65JKzveChLliyxGjVq2LffflsFpQWqLwILAKV6+eWX3X+6U6ZMKfbYgQce6B57//33iz32t7/9zVXAPTk5Ofbggw/aQQcdZPXr17eGDRtahw4d7NJLL7Xvv/++WGWspNunn35aanmPOuqoom1TU1Pde+277742aNAge+edd8I+2oMHD7ZFixbZmDFj7D//+Y916dLFcnNz7fTTT7c//vjD7r//fre+TZs2Yb9mslClUvtf+3779u3FHleFzjtG9957b5WXb+zYse48u+KKK9wx1LlRXYT6fjRv3tx69eplb7/9dqyLF5c+/vhjmzVrlt1www1lfscnT55sDzzwQLHX2G+//ax///526623VmHJgeqnRqwLACC+HXHEEe7v3Llz7ZRTTilav3nzZnf1Tlfx9B+3KjaeX375xd3OOuusonUDBgxwFZ+zzz7bXTlUJV0BxdSpU10A0q5du4D3vf32222PPfYoVp699tqrzDLvtttuduedd7rlrKwsW7Zsmb322mv23HPP2RlnnOH+1qxZs2j7pUuXuiDEo8rwvHnz7J///KcNHTq0aL3K+/PPP9sTTzzhrnijZDovtm3bZm+99Zbb5/6ef/55y8jIsB07dlT6LtSxKigoCFj33nvv2aGHHmqjRo0qWufz+dxx9z8v4pn3/VC5165d6wIOXZXX/j7++OMtnhx55JFu36anp8fk/e+55x475phjAn47SvqOK7DQ75pasYJdfvnlbh8vX77c2rZtW2XlB6oTAgsApWrVqpWrwCiw8Kf/lFWp0RX84Me8+15QovQhBRC6MnjzzTcHbPvvf//bNm7cWOx9+/bt664glodSG84999yAdXfddZddffXV9sgjj7hUjbvvvrvosVq1agVsu379evdXrSr+1q1bF3J9NBT4KK0q0WifHn744fbCCy8UCyxUedPV3//+97+VXo5QgYKOo65A+9OVfwU71UXw9+Oiiy6yFi1auP0db4GFgvZY7Vsd62nTptmECRPC+o6Xpnfv3taoUSN75plnXGAHoDhSoQCUSQHCl19+GZDWolYKpTKpgqP0JP+rwnpMFTVVLEVX+MS77y8tLc2aNGlS6UdB7/PQQw+5CqWCmU2bNoXMCb/tttuK0ptGjBjhPof3eM+ePd16BVNar7Qr/9aM0047zRo3buwqUar0vfnmmyHTWD744AO78sorXQqLWlc8atHp0aOHCzTq1avnKt+LFy8OeA2Vo27duvbbb7/ZySef7JabNWtm//jHPyw/Pz9gWx0TpZ8dcMABrkza7rjjjrMFCxYEbKcWnM6dO1vt2rVd+dXSpBYnf2p90GfcsGFD2Pt84MCB7jP5B44KMpUKpcdC+emnn9z+VTnq1KnjWhZUMQz266+/us+vfaX9OGzYMMvOzi62nX8fCy/Xf8WKFe41vVQi9YEoqY9FOMdVdJyOPvpotw91TP/1r38VaympTKog673VUuRPqWZqEdR3TI/rOL/66qvFnq80QX3P9To6p5Q+GHwRQPtXrTy68q/AsXXr1nb99deH3O/+QvWx0Hdn//33d30X1NqpY73rrrvauHHjij2/vO8rOs55eXkuKPCU9B1XmbS9WiW9c8O/f46CVG3zxhtvlPm+QLKixQJAmVThUA7yZ599VlSZVvCgCotuqqQrfaBjx45Fjym1yQsYvP/ElQKj4CK48hOKXjO4Eqv/6KMJQhRcKBXrlltuca0qqrgHO/XUU13lShVVbavUB1W0dDVYFR/l56vl45BDDnHrvEqlPpcev/HGG11lV31TVPHVVXn/FDJRUKFKvvK11WIh2r/K+e7Tp49rTVFF/tFHHy0K6vwrOAogtF23bt1cxfHdd9+1//u//3PpGeo34H8VWxVlBX9K3VIF66OPPnKBoHe1W61I2h9qVdA2upL78MMPu/QVva93RXf+/PmuAqgKnipm4dC+VPqI0tAuvPDCotYKnRsHH3xwse2V0qPzSZ9d+1jHWleHTzzxRFcZ9vajAlyltqxatcptp1Y17T+lOJWmffv2bjsdW1X+r7vuOrdex8K7gu0v3OO6Zs0at2+0f73tHn/8cVeRryze90Othroqr2OmTunBLXUKLLX/zjnnHNfP6cUXX3SBm1oQvfNfn1OtHPr+6kq8Ku9KH9T32KMgSa+j7436RWlfqn+C+hr98MMPpXZ8Lsmff/7pAl2dJzr/dIzVD0KBsM7ZinjfTz75xJ1H/n2hSvqO67hpvypo1euL1vtTYKbAQqmg6kMEIIgPAMqwePFin34u7rjjDnc/NzfXl5mZ6XvmmWfc/RYtWvjGjx/vljdv3uxLS0vzXXLJJUXPLygo8PXs2dO9hrY9++yz3fY///xzsfeaOHGi2y7UrVatWmUeK71Phw4dSnx8ypQp7rUefPDBonVt2rTxDR48uOj+ihUr3Db33HNPwHPff/99t/6VV14JWH/MMcf4DjjgAN+OHTsCPvNhhx3m23vvvYt9tiOOOMKXl5dXtH7Lli2+hg0bBuwzWbNmja9BgwYB61VOvcbtt98esO1BBx3k69y5c9H99957z2139dVXF9sHKpusXLnSHasxY8YEPL5o0SJfjRo1AtZ7n33UqFG+sqiMOj/ktNNOc/tH8vPzfS1btvSNHj065D6+9tpr3bqPPvooYN/ssccevt133909Xx544AG33csvv1y0XVZWlm+vvfZy61VW/7Lo+PrT/f79+wes88qjYxTpcfXK/dlnnxWtW7dunTt2Wq/XriglfT/03Zg0aVKx7bdt2xZwPycnx7f//vv7jj766KJ1999/v3uN9evXl/i+//nPf3ypqakBx0YmTJjgnvvxxx+X+H3yzh3/4+L9Hjz77LNF67Kzs935MWDAgHK9byj6rvl/L8r6juu8CD5f/E2ePLnYsQawE6lQAMqkq4S66uf1nfj666/dlXZv1Cf99a5uqu+Frqh7/Su8loaZM2e69BDlKCsPfMiQIe4q4plnnhmyj8X48eNdeob/rSJGvfGuQG7ZsqVCjrxGiNKVcl1x1WvqKrJuv//+u2tVUNqP0pb8qfO6Wk88+mzaB7p66j1fN22jVolQo26pJcCfUqiURuTRFXXtd/8Oyh6tF7Uk6Iqwyu7/vhqGde+99w54X7VU6ep4uK0VHqU8KQVGV/W1n/S3pDSo6dOnW9euXQPOHR0vXalWqpLSZrztdtllF5ei5FEqjbarKJEcV5VHKVsqu0etIGolqCz+3w+lsqnFRC1OOqb+/FtN1EKgK/I6V7744oui9V6rlK7El5S+9corr7jfAbU2+Z8rSv+SUOdoWXRs/VtY1Llb+9D/PI72fXW89JtTUbzXiiQlEEgmpEIBKJMqogoePvzwQ1fxUBChvHZvlBU9pn4L4gUY/pVDUXqFRmDRbfXq1a6fgdI0lFqi3GVVjvypglHeztulUbqIqA9DRVDKiCrcSifSLRSlqiidxhM82pUqqeJVloIFp1x4/SWCKzyqOHrUr0UpQuobUBK9r8quICKUihghSWkm2tcvvfSSm/NDKWQ6b0LN7aDcdgVSwVSx9B5XXr7+6jW8AMmjfgEVJZLjWlK5wymP0rr8+/uIAruyBH8/FJRqKGeNcKS0Jm8EJqU8KaDXvvfvk+C/7xTcP/nkky4wUSqX0syULqTAzRstTefKd999V+y8898XkVI6WvAx1Hn8zTffFN2viPfVcawo3msFlxtAIQILAGFRoKChLJXf7PWv8GhZnSB1BVetGqrQ7rnnniW+lq42q4OwhqBVB3AFF+oLEE7fi2h5E1yFM2xtOLwrvOo8rSvZoQS/V3Duvfcayv8PVakM3i/+rR3R0PuqgqSWoFCvGZxfXh4KKFVJVV8JXYmOtMUjVspzXMtDAdcFF1wQdUVYAYBaLRSsqzKu75X606h/gvrLaDQ0fe8ULE6cONH1dfE/H3XRQFf/1Xl5xowZrlwKdDX/g84N7Q/1fbjvvvtCvr86VEeqpPPY//NH+75qafUPuKPlvVbTpk0r7DWBREJgASDi+SwUWPiP864OjapAKuVFHbx1lTocquSow6gqQl4KTmVSipYqVEqbCW5RKS8vgNJn8R95JhLemPhqBSrva4R6TaWfKaWnpFYLbaNKnFpQ9tlnH6ssSn16+umnXeXXf26TYEqN05wiwbwJFL0OuPqrAFFl979yHOq5VXFcVR6v1clfOOVR0BLJxI2lUedx/1Y5pcOpdUvngf+QygosgunYqKVCN1XiNUiBWhcVbOjz61xRCqQer8qr9dG+r1KoIhnWuKz30Ihi2leV+X0BqjP6WAAIi9IuVEnRyE5qmfBvsVClRaP8KO9bfS+CK+2qdGkEn2DqV6A+GUp/KCnVoSKDCo0gpLQK/a2oEV0UDKj/wWOPPeZSvIKFGm0oVOVS5VFlThMHluc1gqk1SBXv0aNHl3hFWC0JumqsbYKvkuu+8tOjGW7Woyvpd9xxh0uXKy14VECq0ad0Tnh0PmmEJY2K5c09oe3+97//BQybqvJpu4oSyXFVeTTSlsru/7i+K2VRK4Iq7v638tB5o9YFpUB5qWM6tqoo+w9DrBS04JGUFHwG69Spk/vrpU+pr4m+95pwMFQ6lze6WUWL9n27d+/uWhn8+22UxhsZqiQLFy50rUGaKwdAcbRYAAiLKizKj1d6hQIJtVL4U6ChIU8lOLDQFUddtdYQkuo4qivoqiwoPUYVxAceeKBYWoTSc7wr1cHvU1qalahi4PXZUIXTm3lb/Q50xVyV3IqkgEqfWSkb6pit8mnoVFWQNXSlPn9pFFRoaNlBgwa5AE1lVKClYEypKRry1OvDEkllXq+nuTsU2GlYT6WV6PjpMeXi62qw8u9vuukmV+HUMKrqD6GrslOmTHGdoZUKVN7hZj26wjty5Mgyt1N+vzr26zxR8KfzROeIyqOrzl6+v/ax9sd5553nKnqqnCuNTC1RsTiumlNB7699fM011xQNN6uWDP/+AhXJ//uhfgZqidNx1j70gmYNJ6vWB5VL3z9tp8+kFC7/cmmIWaVCaXuVWdspdUp9ILzvss4lpSxq0AC1YuicVMCiMmi9WkUqo09UtO+rz6RUQg3JHE7nfv2uKQ1s+PDh7vdO6YAnnHBCUfDmzUEDoAR+I0QBQKluuukmN9SihtsM9tprr7nH6tWrFzCUqqxdu9Z31113uSEmd9llFzeUaaNGjdyQl6+++mrYw80GDwcaijeMpXerW7euGxr03HPP9c2aNSvkc6IdblaWL1/uO++889xwmTVr1vTtuuuuvuOPPz7g83mf7fPPPw9ZDr1+nz593DClGRkZvrZt2/rOP/9834IFC0IO5epPw8AG/6TrOOgztGvXzpeenu5r1qyZr2/fvr6FCxcGbPff//7XDcup19VN2w8ZMsS3dOnSqIebLUlJ+1j7UUPUavhd7YOuXbv6pk6dWuz5Gqr4xBNP9NWpU8fXtGlT3zXXXOObMWNGhQ43G+5xlW+++cadeyqzttHQzE899VSVDDer9+zUqZPv0UcfLRpK2KMy6PzXcLQ6rnp+8Lkye/Zs30knneRr1aqVO0/0V0NC//DDD8WGqr377rvdcM56PX2HNZSrhg/etGlTxMPNhhoWOtTxCvd9S6LzxBvyuKzzb+vWrb6BAwe680+P+5fl7bffdut+/PHHMt8TSFYp+qekoAMAAKA6Uyud0trUylHSCGjhUIueUsvUmgcgNAILAACQ0JRep9SuUH01wqG+WUqJ07C9GvIYQGgEFgAAAACixqhQAAAAAKJGYAEAAAAgagQWAAAAAKJGYAEAAAAgagQWAAAAAKJGYAEAAAAgagQWAAAAAKJGYAEAAAAgagQWAAAAAKJGYAEAAAAgagQWAAAAACxa/w+bdh8zzWJnDQAAAABJRU5ErkJggg==",
+      "text/plain": [
+       "<Figure size 800x400 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "\n",
-      "Read Maximum Water Surface: 5765 cells\n"
+      "Edit-run-read loop verified: 2.0x roughness impacted 4980 cells\n"
      ]
     }
    ],
    "source": [
     "import h5py\n",
     "\n",
-    "# Resolve plan HDF paths from plan_df\n",
     "base_hdf_path = Path(baseline_ras.plan_df.loc[\n",
     "    baseline_ras.plan_df['plan_number'] == PLAN_NUMBER, 'HDF_Results_Path'\n",
     "].iloc[0])\n",
@@ -2143,10 +2433,6 @@
     "    modified_ras.plan_df['plan_number'] == PLAN_NUMBER, 'HDF_Results_Path'\n",
     "].iloc[0])\n",
     "\n",
-    "print(f\"Baseline plan HDF: {base_hdf_path.name} (exists: {base_hdf_path.exists()})\")\n",
-    "print(f\"Modified plan HDF: {mod_hdf_path.name} (exists: {mod_hdf_path.exists()})\")\n",
-    "\n",
-    "# Read Maximum Water Surface directly from HDF summary output\n",
     "summary_path = (\n",
     "    f\"Results/Unsteady/Output/Output Blocks/Base Output/\"\n",
     "    f\"Summary Output/2D Flow Areas/{MESH_NAME}/Maximum Water Surface\"\n",
@@ -2154,479 +2440,2595 @@
     "\n",
     "with h5py.File(str(base_hdf_path), 'r') as fb, \\\n",
     "     h5py.File(str(mod_hdf_path), 'r') as fm:\n",
-    "    base_data = fb[summary_path][:]\n",
-    "    mod_data = fm[summary_path][:]\n",
+    "    base_wse = fb[summary_path][:][0, :]\n",
+    "    mod_wse = fm[summary_path][:][0, :]\n",
     "\n",
-    "# Summary output shape is (2, num_cells): row 0 = value, row 1 = time index\n",
-    "base_vals = base_data[0, :]\n",
-    "mod_vals = mod_data[0, :]\n",
-    "print(f\"\\nRead Maximum Water Surface: {len(base_vals)} cells\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 10,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-05-12T00:22:29.489488Z",
-     "iopub.status.busy": "2026-05-12T00:22:29.489488Z",
-     "iopub.status.idle": "2026-05-12T00:22:29.496643Z",
-     "shell.execute_reply": "2026-05-12T00:22:29.496643Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "============================================================\n",
-      "WSE Comparison: Maximum Water Surface\n",
-      "============================================================\n",
-      "Total cells:         5765\n",
-      "Wet cells compared:  5765\n",
-      "Mean delta WSE:      +0.1110 ft\n",
-      "Max delta WSE:       +0.8646 ft\n",
-      "Min delta WSE:       -0.0919 ft\n",
-      "Std delta WSE:       0.2615 ft\n",
-      "\n",
-      "Cells with |delta| > 0.001 ft: 4980 / 5765 (86.4%)\n",
-      "WSE increased (more ponding): 2117 cells\n",
-      "WSE decreased:               2863 cells\n",
-      "\n",
-      "*** EDIT-RUN-READ LOOP VERIFIED ***\n",
-      "    Manning's n modification (2.0x) impacted 4980 cells\n",
-      "    Higher roughness -> higher WSE (more ponding) as expected\n"
-     ]
-    }
-   ],
-   "source": [
-    "# Compute and display WSE differences\n",
-    "n_cells = len(base_vals)\n",
-    "delta = mod_vals - base_vals\n",
-    "\n",
-    "# Filter to valid (wet) cells — exclude dry cells with placeholder values\n",
-    "valid = np.isfinite(delta) & (base_vals > -100) & (mod_vals > -100)\n",
+    "delta = mod_wse - base_wse\n",
+    "valid = np.isfinite(delta) & (base_wse > -100) & (mod_wse > -100)\n",
     "delta_valid = delta[valid]\n",
     "\n",
-    "print(f\"{'='*60}\")\n",
-    "print(f\"WSE Comparison: Maximum Water Surface\")\n",
-    "print(f\"{'='*60}\")\n",
-    "print(f\"Total cells:         {n_cells}\")\n",
-    "print(f\"Wet cells compared:  {valid.sum()}\")\n",
-    "print(f\"Mean delta WSE:      {np.mean(delta_valid):+.4f} ft\")\n",
-    "print(f\"Max delta WSE:       {np.max(delta_valid):+.4f} ft\")\n",
-    "print(f\"Min delta WSE:       {np.min(delta_valid):+.4f} ft\")\n",
-    "print(f\"Std delta WSE:       {np.std(delta_valid):.4f} ft\")\n",
+    "print(f\"Wet cells compared: {valid.sum()}\")\n",
+    "print(f\"Mean delta WSE:     {np.mean(delta_valid):+.4f} ft\")\n",
+    "print(f\"Max delta WSE:      {np.max(delta_valid):+.4f} ft\")\n",
+    "print(f\"Min delta WSE:      {np.min(delta_valid):+.4f} ft\")\n",
     "\n",
     "n_changed = np.sum(np.abs(delta_valid) > 0.001)\n",
-    "n_higher = np.sum(delta_valid > 0.001)\n",
-    "n_lower = np.sum(delta_valid < -0.001)\n",
+    "print(f\"Cells with |delta| > 0.001 ft: {n_changed}/{valid.sum()} ({100*n_changed/max(valid.sum(),1):.1f}%)\")\n",
     "\n",
-    "print(f\"\\nCells with |delta| > 0.001 ft: {n_changed} / {valid.sum()} ({100*n_changed/max(valid.sum(),1):.1f}%)\")\n",
-    "print(f\"WSE increased (more ponding): {n_higher} cells\")\n",
-    "print(f\"WSE decreased:               {n_lower} cells\")\n",
+    "# --- Figure: WSE difference histogram ---\n",
+    "fig, ax = plt.subplots(figsize=(8, 4))\n",
+    "ax.hist(delta_valid, bins=50, color='steelblue', edgecolor='white', alpha=0.8)\n",
+    "ax.axvline(x=0, color='black', linestyle='-', linewidth=0.8)\n",
+    "ax.axvline(x=np.mean(delta_valid), color='red', linestyle='--', linewidth=1.5,\n",
+    "           label=f'Mean = {np.mean(delta_valid):+.3f} ft')\n",
+    "ax.set_xlabel('WSE Difference: Modified - Baseline (ft)', fontsize=12)\n",
+    "ax.set_ylabel('Number of Cells', fontsize=12)\n",
+    "ax.set_title(f'Impact of {N_MULTIPLIER}x Manning\\'s n on Maximum WSE', fontsize=13)\n",
+    "ax.legend(fontsize=11)\n",
+    "ax.grid(True, alpha=0.3, axis='y')\n",
+    "fig.tight_layout()\n",
+    "plt.show()\n",
     "\n",
-    "assert n_changed > 0, \"Expected non-zero WSE changes from Manning's n modification\"\n",
-    "\n",
-    "print(f\"\\n*** EDIT-RUN-READ LOOP VERIFIED ***\")\n",
-    "print(f\"    Manning's n modification ({N_MULTIPLIER}x) impacted {n_changed} cells\")\n",
-    "print(f\"    Higher roughness -> higher WSE (more ponding) as expected\")"
+    "assert n_changed > 0, \"Expected WSE changes from Manning's n modification\"\n",
+    "print(f\"\\nEdit-run-read loop verified: {N_MULTIPLIER}x roughness impacted {n_changed} cells\")"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "61681e12",
+   "metadata": {
+    "papermill": {
+     "duration": 0.007965,
+     "end_time": "2026-05-12T12:23:51.016208+00:00",
+     "exception": false,
+     "start_time": "2026-05-12T12:23:51.008243+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
-    "## Bonus: HDF Face Property Table Read/Write API\n",
+    "## Step 7: Apply Depth-Varying Manning's n\n",
     "\n",
-    "The `HdfMesh` class provides methods for directly reading and writing face property\n",
-    "tables in the geometry HDF. These are useful for:\n",
-    "- Analyzing the per-face Manning's n distribution after preprocessing\n",
-    "- Applying depth-varying n formulas (HEC-15 vegetal retardance)\n",
-    "- Extending tables to higher elevations for deep-flow analysis\n",
+    "Instead of a uniform roughness, we apply a physically-based formula where n\n",
+    "**decreases with flow depth** — consistent with HEC-15 and Limerinos. We use\n",
+    "an exponential decay model:\n",
     "\n",
-    "**Important**: Direct HDF modifications are overwritten when HEC-RAS runs geometry\n",
-    "preprocessing. To persist changes through compute, modify the plain-text geometry\n",
-    "file as shown in Steps 2-3 above."
+    "$$n(d) = n_{\\text{asymptote}} + (n_{\\text{base}} - n_{\\text{asymptote}}) \\cdot e^{-d/d_{1/2}}$$\n",
+    "\n",
+    "This captures the key physics: at shallow depths, n equals the base value\n",
+    "(set during preprocessing). As depth increases, n decays toward the asymptote.\n",
+    "\n",
+    "We apply this to the **already-preprocessed** geometry HDF using\n",
+    "`HdfMesh.set_face_mannings_n_values()`, which replaces the n column in each\n",
+    "face's property table while preserving elevation, area, and wetted perimeter."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 11,
+   "id": "72a54f1f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T00:22:29.497647Z",
-     "iopub.status.busy": "2026-05-12T00:22:29.497647Z",
-     "iopub.status.idle": "2026-05-12T00:22:29.598517Z",
-     "shell.execute_reply": "2026-05-12T00:22:29.598517Z"
-    }
+     "iopub.execute_input": "2026-05-12T12:23:51.034326Z",
+     "iopub.status.busy": "2026-05-12T12:23:51.034132Z",
+     "iopub.status.idle": "2026-05-12T12:23:53.043749Z",
+     "shell.execute_reply": "2026-05-12T12:23:53.042821Z"
+    },
+    "papermill": {
+     "duration": 2.019136,
+     "end_time": "2026-05-12T12:23:53.044424+00:00",
+     "exception": false,
+     "start_time": "2026-05-12T12:23:51.025288+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:22:29 - ras_commander.hdf.HdfMesh - INFO - Using existing Path object HDF file: G:\\GH\\ras-commander\\examples\\example_projects\\Muncie_414_modified\\Muncie.g02.hdf\n"
+      "2026-05-12 08:23:52 - ras_commander.hdf.HdfMesh - INFO - Wrote face property tables for 11164 faces in mesh '2D Interior Area' (47055 total rows)\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:22:29 - ras_commander.hdf.HdfMesh - INFO - Final validated file path: G:\\GH\\ras-commander\\examples\\example_projects\\Muncie_414_modified\\Muncie.g02.hdf\n"
+      "2026-05-12 08:23:52 - ras_commander.hdf.HdfMesh - INFO - Modified Manning's n for 11164 faces in mesh '2D Interior Area'\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:22:29 - ras_commander.hdf.HdfMesh - INFO - Using existing Path object HDF file: G:\\GH\\ras-commander\\examples\\example_projects\\Muncie_414_modified\\Muncie.g02.hdf\n"
+      "2026-05-12 08:23:52 - ras_commander.hdf.HdfMesh - INFO - Using existing Path object HDF file: G:\\GH\\ras-commander\\example_projects\\Muncie_414_modified\\Muncie.g02.hdf\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:22:29 - ras_commander.hdf.HdfMesh - INFO - Final validated file path: G:\\GH\\ras-commander\\examples\\example_projects\\Muncie_414_modified\\Muncie.g02.hdf\n"
+      "2026-05-12 08:23:52 - ras_commander.hdf.HdfMesh - INFO - Final validated file path: G:\\GH\\ras-commander\\example_projects\\Muncie_414_modified\\Muncie.g02.hdf\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:23:52 - ras_commander.hdf.HdfMesh - INFO - Using existing Path object HDF file: G:\\GH\\ras-commander\\example_projects\\Muncie_414_modified\\Muncie.g02.hdf\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:23:52 - ras_commander.hdf.HdfMesh - INFO - Final validated file path: G:\\GH\\ras-commander\\example_projects\\Muncie_414_modified\\Muncie.g02.hdf\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Face property tables for '2D Interior Area':\n",
-      "  Total faces: 11164\n",
-      "  Total rows:  47055\n",
-      "  Columns:     ['Face ID', 'Elevation', 'Area', 'Wetted Perimeter', \"Manning's n\"]\n",
-      "\n",
-      "Sample face 1050 (19 rows):\n",
-      " Face ID  Elevation      Area  Wetted Perimeter  Manning's n\n",
-      "    1050 925.238464  0.000000          0.000000         0.12\n",
-      "    1050 925.438477  0.061161          0.643449         0.12\n",
-      "    1050 925.476440  0.086584          0.765575         0.12\n",
-      "    1050 925.493713  0.099605          0.821087         0.12\n",
-      "    1050 925.548950  0.147376          0.998725         0.12\n",
-      "    1050 925.659363  0.270837          1.354001         0.12\n",
-      "    1050 925.880249  0.629689          2.064553         0.12\n",
-      "    1050 926.321960  1.794801          3.485657         0.12\n",
-      "    1050 927.205444  5.915092          6.327866         0.12\n",
-      "    1050 927.432739  7.346943          6.935455         0.12\n",
-      "    1050 927.792969  9.863969          7.830056         0.12\n",
-      "    1050 928.180542 12.901370          8.792315         0.12\n",
-      "    1050 928.955688 20.000252         10.716835         0.12\n",
-      "    1050 929.446777 25.238560         12.065067         0.12\n",
-      "    1050 930.338501 36.326725         14.513172         0.12\n",
-      "    1050 930.801758 42.858135         15.659853         0.12\n",
-      "    1050 931.899963 60.283066         18.378162         0.12\n",
-      "    1050 932.728333 75.319084         20.619568         0.12\n",
-      "    1050 933.790649 97.193497         23.203962         0.12\n"
-     ]
-    }
-   ],
-   "source": [
-    "# Demonstrate HDF face property table API on the modified geometry HDF\n",
-    "# (already preprocessed — face tables exist)\n",
-    "\n",
-    "# --- Read face property tables ---\n",
-    "face_tables = HdfMesh.get_mesh_face_property_tables(modified_geom_hdf)\n",
-    "df = face_tables[mesh_name]\n",
-    "n_col = \"Manning's n\"\n",
-    "\n",
-    "print(f\"Face property tables for '{mesh_name}':\")\n",
-    "print(f\"  Total faces: {df['Face ID'].nunique()}\")\n",
-    "print(f\"  Total rows:  {len(df)}\")\n",
-    "print(f\"  Columns:     {list(df.columns)}\")\n",
-    "\n",
-    "# Show a sample face\n",
-    "sample_face = df.groupby('Face ID').size().idxmax()\n",
-    "sample_df = df[df['Face ID'] == sample_face]\n",
-    "print(f\"\\nSample face {sample_face} ({len(sample_df)} rows):\")\n",
-    "print(sample_df.to_string(index=False))"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 12,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-05-12T00:22:29.598517Z",
-     "iopub.status.busy": "2026-05-12T00:22:29.598517Z",
-     "iopub.status.idle": "2026-05-12T00:22:32.402669Z",
-     "shell.execute_reply": "2026-05-12T00:22:32.402669Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-11 20:22:32 - ras_commander.hdf.HdfMesh - INFO - Wrote face property tables for 11164 faces in mesh '2D Interior Area' (47055 total rows)\n"
+      "Applied depth-varying n to 11164 faces\n"
      ]
     },
     {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-11 20:22:32 - ras_commander.hdf.HdfMesh - INFO - Modified Manning's n for 11164 faces in mesh '2D Interior Area'\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-11 20:22:32 - ras_commander.hdf.HdfMesh - INFO - Using existing Path object HDF file: G:\\GH\\ras-commander\\examples\\example_projects\\Muncie_414_modified\\Muncie.g02.hdf\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-11 20:22:32 - ras_commander.hdf.HdfMesh - INFO - Final validated file path: G:\\GH\\ras-commander\\examples\\example_projects\\Muncie_414_modified\\Muncie.g02.hdf\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-11 20:22:32 - ras_commander.hdf.HdfMesh - INFO - Using existing Path object HDF file: G:\\GH\\ras-commander\\examples\\example_projects\\Muncie_414_modified\\Muncie.g02.hdf\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-11 20:22:32 - ras_commander.hdf.HdfMesh - INFO - Final validated file path: G:\\GH\\ras-commander\\examples\\example_projects\\Muncie_414_modified\\Muncie.g02.hdf\n"
-     ]
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAp4AAAHqCAYAAACtLU7ZAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjgsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvwVt1zgAAAAlwSFlzAAAPYQAAD2EBqD+naQAAmmdJREFUeJztnQd4E+Ufx39pC6Vl77333htFpgzZ28VG/TtAFCfKUAEBFZxMQVDZ4ABlD9nK3nvPsqFAW9re//m+x7Vpmu4kTS7fz/O87eXucrn3sr75TYumaZoQQgghhBDiZHyc/QCEEEIIIYRQeBJCCCGEEJdBiychhBBCCHEJFJ6EEEIIIcQlUHgSQgghhBCXQOFJCCGEEEJcAoUnIYQQQghxCRSehBBCCCHEJVB4EkIIIYQQl0DhSQhJkDNnzojFYpHhw4eb+moVKVJEnnrqqdQ+DVPAa0kIsQeFp4lZv369EgtxjW3btom78u+//8obb7wh9evXlwwZMqjznTlzZpz7h4aGyscffyxFixYVf39/KV68uHz66afy6NEju1+IcV2T69evx9r/0qVL8uKLL0rOnDklICBAatSoIQsWLEjxHCHirB87bdq06jHq1Kkjb775puzbt09cye3bt9U54XXjaIYMGaLm+Ntvv8W7X8OGDcXX11fOnz8v3or1+/a1116zu09QUJB6vWAfCmUdb/hhRIgZ8EvtEyDOp0ePHtKqVatY60uUKOG2l/+vv/6S7777TsqUKSOVK1eWLVu2xLt/t27d5Pfff5c+ffpI3bp1ZevWrfLRRx/JiRMn7ApWHPfDDz+MtT5jxowxbt+8eVMaNGigvugHDx4sBQoUkF9//VW6du0qP/74o/Tu3TvFcx05cqQSzBEREXLr1i3Zs2ePTJ8+XSZOnKgec/z48eIq4TlixAi17Ggx07dvXzWPGTNmSPv27e3uc/LkSdm4caM0b95cChYsKKnB0aNHlYBxB9KlS6dea1988YX6MWXN7NmzRdM08fNz349wd7qWhBA3QiOmZd26dRqe4nHjxmmexpUrV7Tg4GC1vGDBAjWPGTNm2N132bJlavvgwYNjrMdtrN+8eXOM9YULF9YaNmyYqPMYMmSIOsYff/wRtS48PFyrWbOmli1bNu3evXtachk2bJg69n///Rdr240bN7TGjRur7WPGjNFcwenTp9Xj4bySsi2x1KtXT/Pz81PPrT2GDh2qHmP+/PmaI7h7967mye/bHj16qP/z5s2LtU/58uW1tm3baunTp0/0a9nspPT1SQhxDXS1ezlwaffq1UtKlSolgYGByuIH9/aSJUvs7n/lyhXlAi9WrJiywuTKlUuaNWsmq1atirHf8ePH5YUXXpC8efMqlyDc23C33r9/P1HnlTt3bkmfPn2i9oVVCAwaNCjGeuP2zz//bPd+4eHhcvfu3QSPDbd9mzZtotbBFfz6668raygss9YcOXJEWe5SSrZs2ZQ7P1OmTDJ69OhY1y2x1xfPLaxO165dU+EC2bNnV9e1SZMmsmvXrhjuXVhdAayehqsXx7Vl6dKlUrNmTWWRw+PjcXEtE2P1xH6w1tkSGRkpP/30kzq/du3aqdufffaZPPnkk5InTx41x0KFCskrr7wiN27ciDP+dN68eVK9enUVEoHnaODAgWobrpctly9fVhZDWMnji0s01uG5bd26tXqPZM6cWTp37qzeD7YgRAJWW1xnzKdnz54qhAPngecjsVSrVk0qVaqkrMS279mDBw/GaW1fuXKl8gDgPYrrkCVLFnU+GzZsiLUv5oX5IZwEnpGsWbOqz4Gnn35ajh07FmNfeA4wh7Vr1yrrNd4X+AzAZweeO1vc4VrOmjVLatWqpa4BjoFr8txzz6n3Q0IYjwHvCUJAjHPo16+fBAcHJ3h/Qoh9KDy9gAcPHqgPa+tx7949tQ0CE18CcB3DtQv3MwRVx44dowSd9Rc8vtS///579eXx1VdfKdEBcbR69eqo/Xbu3KniIP/55x956aWXlMv8mWeeka+//lqJVHtxlynhv//+k/z588dyz+J2vnz51HZbtm/frr5g8aWHLyV8oeHL11aYXLx4UcVc2mKssz122bJllahzBBCfHTp0kDt37simTZtSdH1btGih5gNxBkG+Y8cO9WV64MCBqPPG8wnwmBCHGBMmTIhxHAhtCLWWLVuq/REGAREyduzYBOeD1xjidW2FFMDrB3Gdzz//vBKZYWFhMm7cOClZsqR6jRlzQwgCXnvYbgviRyFMMVfsj3Ps37+/2oawCFsglhDeACGREHgd4HEhfnFezz77rCxevFiJeWsgcJ944gklVvADDSIeIgfnlBxwrSEk8fgGmAt+8OE5twcEIt7DOLdvvvlGxQsfPnxYvS4RymALfqxA4OMH1ahRo1RcKX6I4AcAro8tH3zwgXpt4LWH593Hx0cJtM2bNydqTq66ljhHvK/xAwnhLHgt4/WFEACEziQGhL3gOuOH1pdffqlEMF6DCIEhhCQTF1lWSSq67OyNbt26qX0Md7Y19+/f10qVKqWVLVs2xvqWLVuq+y5fvjzWfSIiIqKWK1WqpJUuXTqWq3Px4sXxuszjIiFXe4YMGbRatWrZ3QaXeN68eWOsa9WqlfbJJ59oCxcu1ObMmaO99NJLmq+vr5Y/f37t4sWLUfvt2LFDPe4777xj9xoZ7lBrsA6u/JS62g2++OILtc/XX3+drOvbs2dPta5Dhw5aZGRkjLlZLBbt6aefTpKrPTAwUC0b4Jhw++bJkydRc+7Tp486zvbt22Os7969u1q/d+/eqOM+ePAg1v2nTZsWy/1snBvc+IcOHYp1n7p166rXAEIkrClZsmSs17i9MAyss+fy/t///qfWHzlyJGpdly5d1LpNmzbF2Ldr165qPZ6PpITIXL9+XUubNq322WefqW24JpkzZ9beeustddueq93eexrhDdmzZ1fvYWtwXzzW559/HmP92LFjY73X8brCuipVqmihoaFR6y9cuKDOEc+hO11LvOYzZsyoPXr0SEsOeAy8R7Zt2xbr8wOvtZSE2RDizdDi6QUMGDBAucKtx9ChQ9U2a3c2LKNwY+J/48aNlZXEcEXDgrJ8+XJlbYAbzhZYPcD+/fuVewxWDGSaW1tZkaSDx4MFx5HgfG2TLwxg7cB2a5YtW6bm36lTJ+nevbtMmjRJueRgiRk2bFiM4wJ7x8ZxrfcxwPcVLMOOAtZkYDwPyb2+77zzToxED1iuYUGEpTEpbkMkBlm733HMRo0aKTdpYo4DdzuwtnoiqQnWSlhx4Vo2jgs3MYDVDftgjnhdGhZrW+C6heXW3usf1l7rsAhYi2FRM84nIWA5h8XWGuNcDDc+zhOPAdcuwlWseeuttyQ5wLXbtm3bqAQ5WAZhAbcOD7DF+j2N5wTvaVgza9eubfe64b0Li2J8c7Pmf//7n7JKG8DbAHe7vX1T81rCm4H3J97vuo5MOkhUxHWzPVeEjDjyfU6IN0Hh6QXAXdm0adMYo0KFCmobXE74YjZiKnPkyKFK+kCMAXzhA2SH48O7atWq8T4WxCqAgMNxrAfcg3DrXb161aHzg8scIsweISEhantCQMhBUOFLyvq4wN6xcVzrfZyFITgNAZrc62tPkJUrV059wZ89ezbR54MYOXviCBixlxA7EKLWw3CN16tXT1UUmDt3btQ1REgHlm3F1Pz589WXPgQoYg8xR+Pxkf1vC8SPPRDvCBECF6kBliGebN27KZk33MC4/qVLl461r711iQWxnBBkCLeAmx1iDM9dXCDGGD+ocM0QQ2m8pyHk7F03CEHjh1Rcc0vMtbC3b2peS4QEFC5cWP1YwvzxQ3PatGlRYUaOOldCSNJw31ocxOlASCJmCWIGSRiwOOELGtYRWKQgCJDkkdRjGlaJuGKx8IXoSPDFaR0DZw3WwyKTGCA8rePUcFzjGPaOCxJ77ORi1PI0vmxT4/pag9dGXBjnhphPoyyTwbp166ISTSAwYYGF9Q6CH681iEssG2AbBCNEFmKPEa8LcQShjHnbe13G9SMAx0Zs3+TJk5Uox+2FCxcqSyIEiaPm7SzgYcDrDNcU1/GHH36Ic1+IfsRrQrQhlrdixYpKfMKqiSQ1JAaldG5x7Z/Y6+Cqa4kf3IcOHZI1a9aogeQqxPziRxss3kiOcpdzJcSboPD0YiBq9u7dqwqv2woFWAZsa37C/Ylg+4Q+7I0PbFhWXQEC/3/55ReVnGKdYITbSBiCwEgMsOrC8muAjG184dsrtG+sg1h3FghvQPIXfgzAjZ6S64sfF7ZJUvhSxnFgFQKOqrkIK6JxvgZIQrLeDmsUBCdc60h0QqYx5mmdGAKhCaFlLSiRCJccYNVHEhYSigwXbGLd7IkFIhZeAySv2GJvXWLBc4RrBuEI0Yzs87iAwMJr3l6NWSO8xhNw1LVEmAxqGBt1jGH1RUgGEoXweiCEuB662r0Y49e87S93ZDrbllNChjWyhP/+++8YGewGxjHgiocbH676U6dOxdoPsVEQVI7E+CK2zcA2bkPUGMT12PgSunDhQoyyScax4br8888/o9bB6oZsYWTD2xbmd1Q5JZxnly5dlKsdlQYM8ZXc64vsY+vnGaWU8Dwi0xmZ5sD4n9LnB+5J29AOayssxD0yhWF9MzrN2IpAvDYhhK0tmzh/dKNKDhC4sJ5CkMHNjoxqWPsdCc4Z7xGUO7LN8EYR+JTw8ssvK0sdnncj7CKuc7D3nkbcr734TnfFEdfSXhcylKgCjv4MIoQkHlo8vRjE/ZUvX16JEliA4M5F7T64JOGiQ9kea7799lsVo4cvBJQpQYLKw4cP1Rca3NSff/65EguwViEAH1/2cKviMXB8WBThQoXlJqEafIg7NOo9omYhgPiDOASoYWlY6mDBgJCBFQOJF0bnIggMuFitrW9IIsJ6uGtxzhBqKB2D5Ba43mwtv++9956qpwk3MEqowAI6Z84cVUYJVmHbTke4pjivpCQeQMxDsEJkIQZv9+7dSvgjFg2lhDAMknt9cT3hsoX1F4k2eC5hPUM5G+vYNVi2EX+Ja2HE/dqKcUcAoYlrvmjRIiVUbes9oq4jtmGesPahRBT2t03mSqrV0yidBBFnJMQ5EgjjFStWqNcXyhKh0xXiho26kcm1KkMoJ6YdJF7rqHuKUAy8BvH48FLgNYP3NJLTPIWUXkv8sMCPQ5RkgicE8epGLVJ8fhBCUonUTqsnqdu56MyZM1rnzp21HDlyaAEBAar8EMryGKV+rEvnGKVTUH6oYMGCWpo0abRcuXJpzZo101avXh3ruNgP5VOwH7r8VKtWTXvvvfe0c+fOJfrc4xrYbs3Dhw+1Dz/8UD0eSrsULVpUGzlypBYWFhZjP5RmadOmjTr/dOnSaf7+/lqZMmW0d999V7t165bdc8Gcn3/+eVWOBvtXrVpVmzt3rt19k1NOyRi4TngMPAeDBg2KKi1kj8ReX6OcUlBQkJoD9sPz3KhRI1VSyRaUOUKHIZRNsp5LfKWW4nqtxAdKG+XLl0/dD8+TPaZMmaLKHeGao1xT//79VUcn21I6ie2qhDJDmTJl0nx8fNT1s0dcJYDsdQcyXqO2Zb52796tNWnSRF3nrFmzai+88IJ26tQpte8rr7wS7zkmteOYvXJKeN2gTFaWLFlUqTFs/+eff6JeC9Zgm73Xq71rapRTsn3vxXWc1L6WeP00bdpUy507t3qP4DWEclJr167VEkNcJZviuw6EkISx4E9qiV5CiHOB5RNxjXyb69UJELeLmGBY0lyJUfQf1mhY0QmvJSHeCmM8CSFeARLQEMoAl7szQfiJNRD9Rmcn1E4lvJaEeDOM8SSEmBrEBiPGFTGSqH+Juo7OpEqVKio2FTGVKGuEx0erSpSHQlw04bUkxJuh8CSEmJrXX39dlRiC6ENCWHy1GR0BepxDbCKhB8lrRYsWlU8++UTeffddpz6uGeG1JMR8MMaTEEIIIYS4BMZ4EkIIIYQQl0DhSQghhBBCXAJjPO2AQt6ICUNxcEe1ESSEEELcBVRbQJOKfPnyOaWZAiFxQeFpB4hO657fhBBCiBk5f/686gpFiKug8LSD0QYRb8j4+iInBvT1Rss6o8yKszNqYa1FS7mcOXOa5lesGecEOC/Pgc+V58DnKnHcvXtXGVhs2/4S4mwoPO1guNchOlMqPFFO5cqVK2oZb3A/Pz+nf+iGhISo8zaLSDPjnADn5TnwufIc+FwlDYaTEVdD4elkIJQqVKgQtUwIIYQQ4q1QeDoZiE10MCGEEEII8XbczgSHLLtBgwZJ4cKFJSAgQOrVqyf//fdf1Ha0vStTpoykT59esmbNKk2bNpXt27fbPVZoaKiKq4QrwYizJIQQQgghqYPbWTz79esnBw4cUO3mUObh559/VuLy0KFDkj9/filVqpR8++23UqxYMXn48KF89dVX0rx5czlx4oRKPrHmnXfeUcfYu3dvqpasePTokVpOkyYN42kISSAZz3i/uFvcIM4LscZmCpkx47zMOKfkzAvfN85OZiXE41tmQkgiAef333+X1q1bR61Hj+WWLVvKp59+ajczL3PmzLJ69Wpp0qRJ1Pq///5bBg8eLIsWLZLy5cvL7t27lfUzMRjHvHPnjkOSixYsWKCWu3Tp4pLkoqCgIMmVK5dpPnTNOCfAeUWDjyEk4d2+fVvcEZwfni+8/syUjGHGeZlxTsmdV5YsWSRPnjx293fk9xwhHmvxhEiDxSNdunQx1sPlvmnTplj7h4WFyZQpU9Sbp3LlylHrr169Kv3795fffvtNAgMDXXLuhJDkY4hO/LjAe9bdBAO+9PH5hB+O7nZuKcGM8zLjnJI6L+z74MED9YMd5M2b10VnSYiHCU9YO+vWrSuffPKJlC1bVnLnzi1z5syRrVu3SokSJaL2W7p0qXTv3l29sfCGWrVqleTIkSPqDderVy95+eWXpUaNGnLmzJkEHxexoBjWvwQBfl1ipAR8QMDSaSyn9HgJgeMbv4zNghnnBDgvHfzYvHXrlhKd2bJlE3cFbk64L82GGedlxjkldV4w4OBzE+IT34+2bnezfZ4Sz8GthCdAbGefPn1UPCfeKNWqVZMePXrIzp07o/Zp1KiRSha6fv26TJ06Vbp27aoSjPDF9c0336gEpffffz/Rjzl69GgZMWJErPUoWo54Gk8CHyZwneADxyxuaTPOCXBe0V+muBZp06ZVFh13BK89CGRgNiua2eZlxjkld154T+G9BY+CrWDF9yQh4u0xntbcv39fWR5h0ezWrZsEBwfLsmXL7O5bsmRJJVYhNtu3by9//vlnjDcm3qwQsc8995z89NNPibJ4oqMDrDCeFvtixq4dZpwT4Lx08OMOnomiRYvGCrNxJ2hF8xz4XEW/t06fPi1FihSJ9d7C9xwqwzDGk4i3WzwNUC4JA+JvxYoVMnbs2Hi/wA3h+PXXX8dIQkLf9aefflrmzZsntWvXtnt/f39/NWyByEmp0MG5GVn1iEN1hXCC6HbEubsTZpwT4Lz09xmugzHcEfw+N87NXc8xOZhxXmacU3LnZbyn7H12mu2zlHgObvfKg8hcvny5+pWG2E241VG3s3fv3soK+sEHH8i2bdvk7Nmzyv0OS+fFixej4igLFSqkOgUZA+WXQPHixaVAgQIunw+E55EjR9RgTA0hxB6oT4yYdogEJEWahfXr16s5WVcrwPwQsw8vFGo2E0K8C7cTnjD7v/rqq0psvvjii9KgQQMlRo2aZBBwnTp1UoKyTZs2cuPGDdm4caMqmeSO4Fcl5oLBX5iEmAckMVpbarNnzy4tWrSQffv2Jek4hw8fVjHmkydPlsuXL6vScakJwh7iarrx1FNPJUksogEI5oTKIwYvvfSSdO7cWc6fP68SSc3IzZs3VWgXQrVQ0qhv374qXCw+UKEF1xf3sRXrxvMyYMAAVcMalV5gTBk2bJiq7kKIJ+F2rnYkCmHYAzEqixcvTtLxENuSmmGsJ0/6yPz5VQXJ9UWKiPTpg5jUVDsdQszJzZsi9r7YM2QQcWKmPITmjBkz1DISOIYOHSrPPPOMnDt3LtHHOHnypPrfrl27FLmG3TGuEcktqCNpAPGFLGuEP6G5R3KB2MKx3RWITghueO3wvMBjB9H466+/xnkfVGnB6wkjRnIsEu4iIuTIgQMSGR4uk775RkoWLy4HjhyR/i+/rDyB48ePd83ECDGjxdNM4PuoTBmRceNE5s/X/+P2zJmpfWaEmEx0DhwoMmBA7IH12O4kEBsOYYWBBhXvvfeesuQhGc4At/FjGpYvlIuCwDTKvMHFDs8NsC4MjrCckSNHqvAgPAaOjRAkW6skYtcbNmyofpT/8ssvatu0adNUOTqsg6fl+++/d9r8cQ54vA4dOqj6q0j0/OOPP+y62rGMknmgcePGaj3WAaPRB+YKY8EXX3wR43GwDtZReMFgEYSImzlzprqmKK9XunRp9fiwpELAzZo1SyWrIXnmjTfeiMoGtweeA1xfVFTB48A6i3J9yc36hgUbzxWuC/IK4LVDtZW5c+eqnIO4gCUZr586derEFJ34EXP2rLQoXVpmDB0qzUuVkmK+vtK2cmV5e/DgJBtjCEltKDydxPHjaP+JLxBNNA310iIlIgK1KEX69hU5ccJZj0yISUDCYFzDuq0mLJ1Xr8K8hlYt0QO3sf7WrcQdN4XAmocWv4hfhNsdwNoF6x4EF0KCNm/eLBkyZFBWLVjt3n777SiLKSxkGGDixIlKfMGSBdc9jtG2bVs5jg8WKyBUBg4cqMQO9oH4/Pjjj+Wzzz5T60aNGiUfffRRjGoecOciTMBRIEwAwhrn2apVK2Xtg6vZntv96NGjUUITc8U6xOrj/hB7+/fvV0IQ5wxhaQ2uBRI00YUO2wFEJhJKIeog9iBkO3bsqJZRBQViEiEMCxcuTNDqjNhTiFiMDRs2yJgxY6K24zrieYtvGFZu1J2GIEYdaQO0fcYPC5T9SxIQzBCfSARC1zvU4sR/3A4Plzu3brl17VtCPMLVbhZ+/BHWAHxGREiXLnrLzAULukh4OLpOiEyfjvqhqX2WhLgxb7wR97YKFURefz36NgQN3MzWrmaIUwhKCDvrdrsffGDfLT95cpJPESIFogPA5Ynyb1hnxHPDIgnrJaxfhjUTQhPCBCKpefPmahlYu6Qhst59910lxsDnn38u69atkwkTJsh3330Xw0oGoWWAmD8IVmMdrH6HDh1S4qtnz55RCZiO7GQDEYtay4ZAgxD8999/lbi2Bq5x1FoGEEvGfL/88kvV7tgQk4jfxzmPGzcuhkCGlfStt96Kug0hD2H/ww8/qHhHAIsnxOaFCxfUdYUVFQmquHYoyxcXeI4gdA2L7AsvvCBr1qxRAh6gIUlcIWAGRugAQi6MeRqg2xDmjG3JAq8nHx9B0Jjl8WvrxOnT8s0PP9DNTjwOCk8nAU8aQkvthWxhfSIaKhFC3ByIGggfgNJvcGsjOQjCq3DhwqqU2okTJ6IEjXV9RSO20xbUV4RLtn79+jHW47ZRms3A2qoG4YtjIpEFLYMNUJTfOrkHbmhHUqlSpahllMCDK9xo1ZgYYJlF+IHtXCGyjRrMtnM1gHvdEJ0AlQHgLjd+DBjrEjof3Mf6OYIwt74PRKM7WRYvXrkiLfr1ky4dO8Z4rgnxBCg8nQQSiSA6w8N9ZeHCTmodlgHWYzshJB6+/jrubbY1CEuX1pOIrASHsmrC5du7d8x9R41y2GWH0LJu5wvLJkQeOqqhnjDc79WrV4+Kv7QGDREc8fgGRtY0Htu2ZrFtu8T4MJpmoMKILYjVtBaxwDahyVmtga3nGt9jJ+d8EroPLLkY8QErLazJsOTaCl2If4QfWFu1k8ulq1el0XPPSb2qVWWKE+N3CXEWFJ5OAtnres17izx6lDaWxRNxnoSQeLDT1CFeIQq3urXAwm2st830Tspxk4hRrPvhw4fqNlr+wt0O12tiu6BhP7htEQ+KxCED3K5Vq1ac94NlD/c7deqUirNMLrDsobc3Yi+tHx+WWFhvjdrIjgKJUJibNbiNx0mKYHYmSXG1161bVwl0XD/86ABr165VQjauJiYJAhGsaXLp8mVp8sILUr18eZkxejRL9BGPhMLTSaBkEuI4IUCNak6GkQbrrYwkhJCUACsnrIfIJH8s+KLAemsrqINBxzQjbg+u9m+//VZZHo1MdQhAxCrClWxkqaP5BTKR33nnnTibWgwZMkTFa8KNjIxrxIWirqY9y6ltog+yuGGVRIwlzm/Hjh3q3AYPHqz2QWZ4/vz5ZXQ8QebYFxY+iFlkWaNeMrLKYaW1jil1BIjbrFmzpjo+4jCRnIPr6Mxs/KSSFFc7hDSuPVzgkyZNUnGor732morXNcQpmp4grhVhD8aPCbyOMCDuARKtMgYESCEfH8mWIYNcPHtWGvftK4ULFJDx774r1+7e1V/zfn4OsaQS4iooPJ0I4uJ3746UdesOqttlypSXUaN8KDoJcSQQBBMnpkodT2RPG4k6iBFE+aIFCxaozHEjBvGff/5RiUIQbCjRA9EH0RGfBRTiEa5uiDK4bcuVK6fKFKFcUXz069dPPSbELsQr3NMVK1aMUfQd2dcJNbOAKEacJJKaEDcK0YW4SyTpoHi5I4FVeP78+SobH+IT1xMi3ZGZ964GPxAgNvE841qj6QmSrgwgRpHhj6x8A4hU/HAwePLJJ9X/GdOmSa/nnpNVv/0mJ86fV6PA420GqVmrmpCkYtH4io0FXEqwGOCDP7HusbgYOTJcjhzRs9p79Ogibdo4V+vDnYMvKrj2zNIpyYxzApxXdKINWuQiAxu1J90RfEwiTg/ZyWbr/222eZlxTnC1a+fOqc8MnyJFojLbU/LecuT3HCFJgRZPJ4MPvuPHDb+6ST4ECSGEEEKSAYWnk/Hx8ZUdO2o6+2EIIYQQQtwe8/gt3RRrTw/DcAghhBDizVB4EkIIIYQQl0BXu9MJl+7d9T7BERGdeckJIYQkncBA0ZxQmJ8QV0Ph6QJXu8Wil7qgq50QQkiSQRZ7zpyihYfb78NMiAdB4elkLBZf+e03vQ9x587u0YWDEEIIISQ1oPB0Mj4+Fnn4MNDZD0MIIYQQ4vYwuciF0NVOCCEkySC28+xZ8Tl/nl8kxOOh8HQ6kVK27GE1NI2B4YR4E+iiM2DAANVyEs0k0G/dWylSpIhMmDBBPAW0PbVuNUoIcQwUnk7GYomUKlX2qIF2Z4QQc7F161bx9fWV1q1b2+3lPnPmTFm6dKlcvnxZKlSooATob7/95rLzw+PjMTFwnlmzZpXatWurfuhol+iMx8uSJYt4OosXL1a94wkhjoUxnk4GH/anTxc1bjn74QjxWo4fF/nxR5EzZ2BdE+nTR6RkSec/7vTp0+X1119X/y9duiT58uWL2nby5EnJmzev1KtXz+GP++jRI0mTJk2i9kUv7qNHjyoL7O3bt2XLli0yevRomTFjhqxfv14KFSok3kJYWJikTZs2wf1gpSaEOB5aPF3QMnPbtjpqiDCrnRBnMGOGSJkyIuPGicyfr//H7ZkznXu9g4ODZd68efLKK68oiyesfQa9evVSgvTcuXPqByhczRigQ4cOUesMfv/9d6lWrZqkS5dOihUrJiNGjJBwlM95DPb/4YcfpG3btpI+fXr57LPPEn2euG+ePHmUCC5btqz07dtXiU+c//vvvx+1H7wyEKRFixaVgIAAqVy5sixcqNchBhCpONayZcukUqVK6lzr1KkjBw4ciNreu3dvZUk1rKzDhw+Puv+DBw+kT58+kjFjRiV2p0yZEuc5r1y5Uh0fQtmagQMHSuPGjdXyjRs3pEePHpI/f34JDAyUihUrypw5c2K5zF977TXlNs+RI4c8/fTT6hyeeeaZWEI+V65c6geEPVc7nqtRo0bFe/64plWqVFHnXaNGDWXZTijEIjHHJcRUaCQWd+7cQeFN9T+lfPklUor0MXeu8y92RESEdvnyZfXfLJhxToDz0nn48KF26NAh9T85HDumaT4+0e8z64H1x4+n/LmKjIzUwsLC1H9rpk+frtWoUUMt//nnn1rx4sWj9rl9+7Y2cuRIrUCBAur1GxQUpAY+W2bMmBG1Dvzzzz9apkyZtJkzZ2onT57UVq5cqRUpUkQbPnx41GPhfrly5dJ+/PFHtc/Zs2e106dPq/Xr1q2L89zxWJkzZ7a77Y033tAyZsyoPXr0SN3+9NNPtTJlymjLly9Xj4H7+vv7a+vXr1fb8Th4vLJly6pz3Ldvn/bMM8+oc8X1CQ0N1SZMmKDmgvlh3Lt3T923cOHCWrZs2bTvvvtOO378uDZ69GjNx8dHO3LkiN1zCw8P13Lnzq1NmzYtznUXLlzQxo0bp+3evVud79dff635+vpqmzdvjnoeGjZsqGXIkEEbMmSIeiwMbMd+ly5dijr24sWLtfTp00edL+43cODAqO0JnT++L7D9+eef1w4ePKj99ddfWqlSpdT1wvnFRaKuS0SEFnn6tBZ+8qQWmYTPwfjeW478niMkKVB4ulB4zpmjOR0zihkzzglwXnF/OVavrmn58yduZMhgX3QaA9sTeyw8blKEZ7169ZTQAhBvOXLkiCECv/rqKyUsrMFny5IlS2Ksa9KkiTZq1KgY62bPnq3lzZs3xv0GDRoUYx8Ir9KlS2vbt29PlvD8/vvv1XGvXLmihYSEaIGBgdqWLVti7NO3b1+tR48eMYTnXKtf0Tdu3NACAgK0efPmxft4uA4QZQa4lhDSP/zwQ5znDuHXuHHjqNsrVqxQQvjWrVtx3qd169bam2++GUN4Vq1aNdZ+5cqV0z7//POo223atNF69eoVddue8Izv/PE/e/bsMV7HU6dOTZTwTPC6UHgSE8EYT6cTLp0764kEkZHtGVZLSCK4ckXk4kXHXKrgYH04GsRM/vvvv7JkyRJ128/PT7p166ZctXDTJoW9e/fK5s2bY7jPIyIiJCQkRLmn4UYGcN9aAxfzkSNHkj0HXc/qrvgTJ06ox2rWrFmsmMiqVavGWFe3bt0YsZClS5eWw4cPJ/h4cM/buv+DgoLU7ZYtW8rGjRvVcuHCheXgwYPy3HPPKVe+ETv7yy+/qJAGI3kJ1whu6vnz58vFixfVuYaGhipXtzXVq1ePdS79+vVTLu133nlHrl69Kn///besXbs22eeP14MRfmBQq1atBK9JQseNIiBAL6tEiIdD4elk0N0sTZpHapl1PAlJHHnyJP5KITE7PmGZIYNI5syOf1wITMRgWicTQcj5+/vLt99+K5kT+6CPY0UR09mxY8dY26yFDGI7HQnEIhKPsmfPLqdPn1brEL8JQWsN5uQIbJOhILKMah/Tpk2Thw8fxtivZs2aUrx4cZk7d66Ko4XIt46jHTdunEycOFGVaUJ8J64P4jIhQK2xd91efPFFee+991RVAsRmIq71iSeeSPb5p4QEj4uWmblySWR4uPiwZSbxcCg8XdAyc+lSPYi9dWsmFxGSGHbsSFo2OxKJ7H3/4/t6926REiUce90hOGfNmiVffPGFNG/ePMa29u3bqwSXl19+OU6RAUudNUgqgsWshKNPNB5gUcN5IlnJx8dHypUrpwQmkqEaNmwY7323bdsWlQl/69YtOXbsmEpaAsgYt51fYrAVuwawesLSWaBAAXWe1mWrYCVu166dPP/88+o2xBrOpQxeEAkAsY3nCpn9EJ9IikoJsPr+/PPPyuJqCPX//vsvRcckxIwwq93ZF9jHIvfuZVSD5ZQIcTwomYREZIhMX9+Y/7HeGVoOdTkhuJAdjtqc1qNTp05RmdFxZTGvWbNGrly5oo4BPv74YyVkYfWEixmWSFj5hg4dGu95wL0MkQWXf3zAEovHQy1RHPvHH39UJZ5glTXc+8iofvvtt+XNN9+Un376SZWC2rVrl3zzzTfqtjWoAYo5IJsd2fvIFoeIM+YHCy62X79+XbnvUwKEJ84D59m5c+cY1teSJUvKqlWrlMUS83rppZeU2zyxwN2OueG+PXv2TNF5Pvvss0r4omEAjrdixQoZP358lAWTEKJD4elC6GonxDn06oUYO5EhQ0S6dtX/4zbWOwMIy6ZNm9p1p0N47tixQ/bt22f3vrCSQiwVLFgwKnYSJX4gZlFCCO5lxDV+9dVXKtYxPlACCJbShMTd3bt3VSklWBURnzl58mQltCDosN4ABdM/+ugjVVIJFswWLVoo1zvc0NaMGTNGlTVC7CQE7Z9//hlVGxOCFtZexLvmzJlTxo4dKykBVmDESuJ6QoRaA2EOazGuH+JqERtpCODEgOcQ88f9rUMmkgNCFnAdUDoJJZU+/PBD9YMC2MacJhmY88+fFx8EPvOLhHg4FmQYpfZJuBv4kMYXCmrR4cMkJXzzTaR8880JtTx0aAl58UXnan384oYLDfXo4JYyA2acE+C8dJBAg/hCiJsUf0E7CXxMwr2OBCIzWa+SOi/U6WzUqJGy1Lprd6KkzAmWWYhxuNvtxdemFIQIGHVNURc12URGinbunPrM8ClSRCyJ/ByM773lyO85QpICYzxd0DKzRo2dalnTitHITAghqQwEHMIAYH2GgEacqyNAuASK/0PMolLBu+++K127dk2Z6CTEZFB4Ohn84j5/vqBxy9kPRwghJAGQQAUrIBKWkCUP66gjQNgB3Ov4Dxd+ly5dktRhihBvgMLTBS0zN21qoJb79XP2oxFCiPNAHKUZorOQAOWMeaAmKAYhJG7MEzDnAZjg85oQQgghJNlQeDoZ69h2Ck9CCCGEeDN0tTudcGnffqlaioxEIXleckIIIUkEWelsmUlMAFWQCyyeAQF6GzhaPAkhhCQZlE/KnZstM4kpoPB0QcvM5ctbqOXGjdkykxBCCCHeC4WnC1pm3rqV1dkPQwghhBDi9jC5yIXQ1U4IISTJILbzwgXxuXSJXyTE46HwdDqRUrToKTXQLYMQYi62bt0qvr6+0rp1a/EUhg8frvqJu+p+ruK7775TheEzZsyo+t3/+++/Cd5nwYIFUqZMGdVSsmLFivLXX3/FuS960KMpyIQJE2LVBcV664F+9g4lIkIfhHg4FJ4uaJlZp852NTSNwpMQszF9+nR5/fXX5Z9//pFLsEiRVGHevHkyePBg1Tlo+/btUqlSJXn66aclKCgozvts2bJFevToIX379pXdu3dL+/bt1Thw4ECsfZcsWSLbtm2TfPny2T3WyJEj5fLly1EDrwlCSGwoPJ0MfvleupRXDU1jy0xCzERwcLASPK+88oqyeKL9ojW3bt2S5557TnLmzKn6dZcsWVJmzJihtjVu3Fhee+21GPtfu3ZN0qZNK2vWrImypH366afy4osvSoYMGaRw4cLyxx9/qP3atWun1kFg7dixI+oYOAf0H//tt9/U48GSBwF2/vz5qO0jRoxQvcR9fHzU4xnnjVaSxnEzZcqk+oxfvXo11v0Mq55xv9u3b0u/fv3UPHE/zA37xcWZM2fU/RcvXiyNGjWSwMBAqVy5srIeJ5cvv/xS+vfvL71795Zy5crJpEmT1HF//PHHOO8zceJEadGihQwZMkTKli0rn3zyiVSrVk2+/fbbGPtdvHhRCclffvlF0qRJY/dYsLLmyZMnaqRPnz7ZcyHEzFB4OvsC+/jKhg1PqYEMd0JI4ggPD1fDurUhwlWwLsLG5eiIfZPD/PnzlZu2dOnS8vzzzyuRY33cjz76SA4dOiR///23HD58WH744QfJkSOH2gah9uuvv0poaGjU/j///LPkz59fCTeDr776SurXr68schC3L7zwghKieLxdu3ZJ8eLF1W3rx33w4IHqET5r1izZvHmzEobdu3dX27p16yZvvfWWlC9fXlloITaxDtcAovPmzZuyYcMGWbVqlZw6dUpts72fYdUztqEnOSyLmOfOnTuVeGvSpIk6Vnx8+OGH8vbbb8uePXukVKlSyvqI5wbgvCCA4xujRo1S+4aFhanHbdq0adSxIapxOz4xi23W9wEQ6db3wXXBNYc4xdzjAq717NmzS9WqVWXcuHFR8yCExIRZ7U7mypXo5SVLRJo0ESlZ0tmPSojng9g70KFDB2W1AxBv+/btk2LFiknt2rWj9oXlDAKzbdu2UZamY8eOKbEGK2G9evWi9oXFEGKvVatWkjlzZrUOAqtEiRLJcrNDAAJYzu7cuaNEG3qaG+IJQqRGjRpRFkyDjh07Kovn77//riyLABbEXr16KWugAc7zpZdeUstwI0O81qxZU4k98O6770rdunWVZRKWNvDo0SNltTOu0U8//aQseoh5rFWrlhJtfn5+an8IJCyvXr1a9u/fL6dPn5aCBQuq+0G4Qmz9999/6jGt72ewadMmdVwIT39/f7Vu/PjxyuK6cOFCGTBgQJzXD6LTiI2FNRWPdeLECSXm4dKGII2PbNmyqf/Xr19Xz3/u3LljbMftI0eOxHn/K1eu2L0P1ht8/vnnas5vvPFGnMfBNohtnA/c9++//74S5rDCphgIWIzISLHgB1JYmF4g2tdXxI9f4cTz4KvWicCj9sEH0bdXrxYpUwZfViK9ejnzkQkhzubo0aNKcCH2D0CcwAIIMWoIT7jgO3XqpCyTzZs3V/GDhgiGmIYlDVZSCE/sg9hCCGNr4Eo3MEQSkmBs10H4GYIQ5wKhaAAhB/c7hDuEpz2wDYLTEJ0ALmvjftbHswYudYQcwNpnzcOHD+XkyZPxXkPrueXNmzdqHjhfzCE5PwYcCayocMfjubH+MWALYkut54TwBfxYGD16dJQYTxYQnOfO6f9DQsQCqzZuA4jOQoUoPonHQeHpJI4fhysN7p5wadXqb7Xur79aSkSEn/TtK9KggUgqf6YS4tYYFj1kjBvAage3tq0IgPXQdl+4biFcbPeFVdR2X1hQkwoEJqyF1skmcHdDaMDaCGtqy5Yt5ezZsypTGq5ruJ9fffVVZRE03O3IEr9w4YKK/YSLHRZaa6xjCo252FuXWlUzIDohGtevXx9rG0RrfMQ3D1iLIXzj44MPPlAD4Qt4Po14VANrK7A9sC2++2zcuFEJ4UIQeI+BZRUhB8hsR6yqPWBpxmsD2/F6TTYIE4HoROciX1/1+rLgdQsBivXYTqsn8TAoPJ0E4tnxOYqRIUOwWmd8/+E/rJ6jRzvr0QnxfGDxsgVxexjO2DcpQFTADf3FF18oS6Y1sGrOmTNHld4BSLjp2bOnGk888YSKFTSEJyyXcMNPnTpVxXvaJrUkF5wfEo4M6yass4jzhHAHsMjZxr5iGxKQMAyrJ+JTcT9DANq7H1zMcE3julqHEqSUpLjacV7Vq1dXSVmIUzUELG7bJnBZgxAF7DNo0KCodfiBgPUAFml7MaBYjySmuMB54zWVK1cucQh4faZPLxrc7ViGOGd5PuKhUHg6CfwQxo/SyEhfWbVK/+CKiNAtLFgfxw9lQogHsHTpUpWxjjI8RpyoAVzrsIZCeCImE4IIsYuIK8X9DPFnAKsnxBFiUxHP6ghgSUQW9tdff60EIY6PupaGEIVARCwnBBKse1mzZlUCC0IYWfiw5kG8/u9//5OGDRvGiFE17legQAGVyY37QahBcI8dO1ZZmpG0tGzZMjUf475JJamudri7Ie5xvY3M9Pv378cQiEjCQvIWXOBg4MCBan74AYFY07lz5yrBPmXKFLUd4QO2IQS4trhmhiUTiUgo34TsfFwP3H7zzTdV7C+uKyEkJsxqdxL44Q/LJkooXb+eUw2jnBLWO9AwQAhxMRCWEFy2otMQnhAvSIKCJQ6JJoj7e/LJJ5U7GOLGGmRyQ2Thv5FElVJQRghJR88++6zKiEdSEMo+WZ8jkqHg2odlERZauLqR6ASxhHPF/BCCYO9+EFmw5Br3QygB7gORB+GJDHqEGNgm7jgTxNfCkjxs2DAVj4rY0+XLl8c4B7jvkfRjgHhbWJohNFHOCclQSIqqUKFCoh8XoRV4TiFg8QMD1QQgPA3xSgiJiUWzrsFBFHfv3lVfKMhQRU265MZ4IpHInjcEnpKjR50T4wn3EmKS4OJJqvvQXTHjnADnpRMSEqKsaOg44yjh5WjwMWlkf8eXZJIcEAeIkkjIHIelLqUgMx6uY7jIU3NeqYWp5oRSW2fPKmuFFhqqx3gGBupJRvhyQTxwPMlL8b23HPE9R0hyMM+3uJuBkkmI4/TxiZRChc6p4esbqUQn1jOxiBDvBiWPEBs5dOhQ5QZ3hOgkJsMomfRYaKpySoixxX+st0qQI8RTYIynE0HJpODgSNmyZbO6ffVqF5k82YeikxCiCrvDZQ3XNFy8hMT+hn5cMgkZ7Jcu6clFBQqwjifxaCg8nUy+fBYJCsqplps2tVB0EkIUqPXpjEgnFKDHICYSn3CV+fgIXi2WtGn124R4KBSezr7Afr6yZo2e1W7VBY8QQgghxOvgzyZnX2CrK8yya4QQQgjxZig8nX2BKTwJSRSp1XmHELPC9xRxR+hqdzoR0rLlSrUUGYkOJ8xCJMQa1LpEmSwUHUdtSNx2tzI4pirRY/J5mXFOcJdpFotEWizig57tCcR44hqEhYXJtWvX1HsL7ylC3AUKTyfj46NJlix6Pb3ISJZMJST2e8RH1RlEYW+IT3cEX+SwHuFcTSNmTDovM84pxrzOnEn0vNBIAH3mzVT/mHg+FJ5OBp1K1q1rpJaLFaO1kxB7wCKDL0hYqmx7gbsD+MK/ceOGap9opi9xM87LjHNKzrzw3WMqqy8xDRSezr7Afha5ciWPWmYIGyFxgy9I9MHGcMcvfZwXur+YTcyYbV5mnJOZ50W8D756nX2BmVxECCEkJYSFiWXECMkwfrxaJsSTocXTyVgskZIv32W1HBGRl1qfEEJI0kCjgcuXxefhQ32ZEA+GwtPpRErDhv/oS5FdKDwJIYQQ4rVQeDoZX1+L3LyZTS3nzs0gb0IIIYR4LxSezr7Afr6yYsXTarl0aWc/GiGEEEKI+8LkImdfYCYXEUIIIYQoKDydDIUnIYQQQogOXe1OxmKJkGbN1qrlyMjGbJlJCCEkqV8kItmzS+T9+/oyIR4MhaeTsVg0yZHjulpmy0xCCCFJJm1a0T77TIKDgiSQfdeJh0Ph6ewL7OcjGzc+oZZbtGBkAyGEEEK8FwpPJ+Pr6yMXLhRQy2yZSQghhBBvhiY4Z19gqyscEeHsRyOEEGI6Hj0SGT1a0k+cqC8T4sHQ4umCGM9cuYLUcmRkLqxx9kMSQggxE5GRYjl7VnzRMpOuM+LhuJ3F8969ezJo0CApXLiwBAQESL169eS///6L2j58+HApU6aMpE+fXrJmzSpNmzaV7du3R20/c+aM9O3bV4oWLaruX7x4cRk2bJiEhYWl0owipEmTtWpoGk2ehBBCCPFe3M7i2a9fPzlw4IDMnj1b8uXLJz///LMSl4cOHZL8+fNLqVKl5Ntvv5VixYrJw4cP5auvvpLmzZvLiRMnJGfOnHLkyBGJjIyUyZMnS4kSJdSx+vfvL/fv35fx48eniqv97t1MajlzZpc/PCGEEEKI22DRNE0TNwFCMmPGjPL7779L69ato9ZXr15dWrZsKZ9++mms+9y9e1cyZ84sq1evliZNmtg97rhx4+SHH36QU6dOJeo8jGPeuXNHMmXSRWNyOXtWpEgRfblbN5G5c8WpQHQHBQVJrly5xMc6wNSDMeOcAOflOfC58hxM+VyFhor2+uvqOzLdlCniExCQ4kM68nuOkKTgVu/K8PBwiYiIkHTp0sVYD5f5pk2bYu0P9/mUKVPUm6dy5cpxHhdvrGzZsklqwM5FhBBCCCFu6GqHtbNu3bryySefSNmyZSV37twyZ84c2bp1q3KbGyxdulS6d+8uDx48kLx588qqVaskR44cdo8JF/w333wTr5s9NDRUDetfgsYvZwxH6fuICM3pReRxvjBiO+a83QMzzglwXp4DnyvPwZTPFeaiaYJvDzUvB8zNVNeHeBRuJTwBYjv79Omj4jl9fX2lWrVq0qNHD9m5c2fUPo0aNZI9e/bI9evXZerUqdK1a1eVYATXijUXL16UFi1aSJcuXVScZ1yMHj1aRowYEWv9tWvXJCQkJEXz2bnTRxo1OqCW9+2rL9u23ZVixZyXZIQPE1h48cFrFjeTGecEOC/Pgc+V52C258py65Ya6R88kLDQUAnevVss6dKJlj69aFmzpiiRlxDx9hhPa5AMBMsjLJrdunWT4OBgWbZsmd19S5YsqcTq+++/H7Xu0qVL8tRTT0mdOnVk5syZ8X4A2bN4FixYUG7dupWi2JcZM0ReeSVCOndeqG4vWNBZIiP9ZOpUTXr1Eqd96EIwI9HKDB+6Zp0T4Lw8Bz5XnoOpnqubN8UyaBCsIMraifCytGnT6kX5cuYUbcIEkWSGkeF7DpVhGONJxNstngYol4QB8bdixQoZO3ZsvB801sIRlk5YRZGUNGPGjAQ/fPz9/dWwBfdL7gfX8eMiAwYo74hs3VpXrYuI8BVNs0j//hZ58kkRq+gBh2KxWFJ07u6IGecEOC/Pgc+V52Ca5+rBA5Hr10UCA5HsIFpIiLJ2WlDP8/p1sWB7HGFmCeHx14Z4LG4nPCEyYYQtXbq0is8cMmSIqtvZu3dvZQX97LPPpG3btsoSClf7d999p4Qm3OkAy7B0og4o4jrxy9cgT548LpvHjz/iww+i2EfOnHmc1v4YrJ8+XTWiIIQQQuIHwhOudV9fJUDVlwjEJyEeiNsJT5j94TK/cOGCykTv1KmTEptp0qRRGe+o0/nTTz8p0Zk9e3apWbOmbNy4UcqXL6/uj0QjCFaMAgX0HukGrowqOHNGt3baA+uxnRBCCEkQJALt2yd+aJdZtSovGPFo3E54IlEIwx4os7R48eJ479+rVy81UhvU7sSPUrTMzJr1plp361Y25WrHeqO2JyGEEBIvsFbcuSOW8PC4LRqEeAgM8nASffronw++vhHy9NMr1cAywPq+fZ31yIQQQkwFYjlh7cQIDtZvE+KhUHg6iZIl9ThOWDfv3w9UA4IT8dxY76zEIkIIISYhQwaVvS4o6xcaKj5hYSrTXcV3Yj22E+JhuJ2r3UzA49+ggZ+ULt1OheigzOjmzRSdhBBCEgFKJU2cKHLjhsiwYRIWEiL+Y8aozHYlOlOpIx8hKYHC08nAsomERHhHUPWClk5CCCGJBuIyfXolNFVWe8GCemY7IR4KXe0uIG1a/T/CcwghhBBCvBVaPJ0MSkDVrr1Z7t8XOX++voj4OvshCSGEmI20aUWLcF67ZUJcBYWnk0Ht0Lx5L6pY8FOnWAaDEEJIEvH3F+3rr+VeUJAE2OmyR4gnQeHpZNCW7NixmnL5MpISGdlACCGEEO+FwtMFwvP69RJy8qRIpkzOfjRCCCGEEPeFJjgXJhehBBshhBCSJJCZ+u23Eogi0MxSJR4OLZ4uiPHMlOmuZM6MkkoweVqc/ZCEEELMRGSkWA4cED8kC6AoNCEeDC2eLshqr1TpL2nV6i+xWCL4mUEIIYQQr4XC0wVERvpLaKieiUgvCSGEEEK8FbranX2B/fzkxImOsnp1dJwnq2EQQgghxBuhxdOFyUWACUaEEEII8VYoPF0sPOlqJ4QQQoi3QuHpguSiPHm2SL16W8TXN4IWT0IIIYR4LYzxdEE5pQwZzkrhwiL//luLwpMQQkjSW2ZOmiR3g4IkHZMEiIdD4emCzkX371eVXbuQ3e5DVzshhBBCvBYKTxcIz4iIMnL0qH6byUWEEEII8VYY4+kCmFxECCEk2SArdfJkCZg1ixmqxOOhxdMFMZ5p0z6Q9OlF7t8PlLAwtswkhBCSxJaZu3dLGrbMJCaAFk8XZLWnT/+HtG37h/j5MaudEEIIId4LLZ4uwMfHVyIi9GXW8SSEEEKIt0Lh6ewL7Ocnvr5dZf58/TaTiwghhBDirdDV7gLYMpMQQgghhMLTJaRJE71MVzshhBBCvBVaPF2QXBQRsV1q1douPj5MLiKEEEKI98IYTxeUU4qIOCXFi4vs2lWdMZ6EEEKSRtq0ok2cqLfMtI7dIsQDofB0QeeiDBkqyb59bJlJCCEkGVgsql+7GlgmxIOh8HSB8MyatbwcPKjfZlY7IYQQQrwVxni6ALbMJIQQkmzCw0VmzpSAefP0ZUI8GFo8XRDj6eMTqjwkoaH+bJlJCCEkaUREiGXbNr1lptGNhBAPhRZPF2S1nz+/RDp2XMKWmYQQQgjxaig8XXGRra4y63gSQgghxFuhq93ZF9jPTypX7iEDB+q3mVxECCGEEG+FFk8XwJaZhBBCCCEUni6BLTMJIYQQQig8XZJcdPHiTqlWbSdbZhJCCCHEq2GMpwvKKQUFHZPSpUX27avM5CJCCCFJb5k5bpzcu3aNLTOJx0Ph6YLORUWKlFOdiyIjfZhcRAghJGmgTWbGjKKhjidbZhIPh8LTBcLT37+y6tUOdu4UOX5cpGRJZz8yIYQQj+fmTZHgYFguxOf6dZGQEL1GX4YMItmypfbZEZJkKDydzIwZIv36Rd8+dkykTBmR6dNFevVy9qMTQgjxaNGJWnxBQWK5fFmyhoeLpUABXXjmzCkycSLFJ/E4WE7JicCy2a8fWmaGi58f+utqomnqh6v07Sty4oQzH50QQohHA0vntWuiei4/eKCPrFlFAgL09dhOiIdB4elEfvwRBeQjpEuXBWpg2QBhOrB6EkIIIfESGKjX5cOAix23CfFQKDydyJkzyGq3vw3rsZ0QQgghxFtgjKcTKVIEbnVfWbCgi7odHu4bw+KJ7YQQQggh3gItnk6kTx9YNi0SHu6nhoglhsUTcZ6EEEJIvCC289EjfSCuE7cJ8RaL54MHD2TVqlWyefNmOXTokFy/fl0sFovkyJFDypYtK/Xr15emTZtK+vTpxdtBySTEcUJgIqHIAAmJWF+iRGqeHSGEELcG8ZzIXr96VSQ0VHwiIvRMd19ffT22E2JW4bl//3754osvZPHixRIcHCwBAQFSsGBByZo1q+rOc+zYMVmzZo2MHz9eic5OnTrJW2+9JRUrVhRv5sUXIyVfvv0ycqTI1q0VVV3Pw4cpOgkhhCQA6nSiZNKNGyLDhklYSIj4jxkjlnTpWMeTmFt4duvWTRYtWiQ1atSQ4cOHS7NmzaRcuXLii19dNn3JYQVduXKlLFy4UKpWrSpdunSROXPmiLcSGRkpN24cksqVRbZvLy/h4T5StGhqnxUhhBCPEZ8w8EycKHevXZOcxYvrFk9CzCw8YaXbsWOHVKlSJd79IERh4cSAtXPPnj3y+eefizeDMIRSpUrJsmUQoXqMJ8JzMmZM7TMjhBDiESAbNXt20eBqZ8tM4g3CM7kWSwhVb7Z2GmK8evXqRsczBZYpPAkhhBDibSQrq33WrFlyJp4ilNiGfUg01jHg9+/zyhBCCEkk4eEiixaJ/9Kl+jIh3iY8e/fuLVu2bIlz+/bt29U+xL7wZJczQgghiSYiQiyrVon/hg1qmRCvKyCPLPb4uH//vvj5sTY9CA8PlwULFqjKF35+XVQ9TwpPQgghhHgjiVaH+/btU8lCBhs3blSiypbbt2/LpEmTVEINicY6CZHCkxBCCCHeSKKF55IlS2TEiBFRmdqTJ09Wwx5ZsmRhjKdVclGHDh3k66+jW2ZSeBJCCCHEG0m08BwwYIA888wzys1eq1Yt+eSTT6RFixYx9oEgRfH44sWL09VudU3SpUsXI4udyUWEEEII8UYSJTyrVasmo0aNihKaM2bMUAXkUSaIJA4mFxFCCCHE2/FJbHwnerIb9OnTR44fP+7M8zJV56KDBw/KtWsHxcdHL+S5cKEILx8hhJAEQW/2c+dUjJYF7rLz5/XbWE+IWYVn4cKFZfXq1aolJoC7HS5kkjjhuXTpPtmxY1+U8ERFjDJlRGbO5BUkhBASBxCXAweKvP66yKVL4nPliliwPGCAvp7ik5hVeL788ssqWQixipkyZVKis2/fvmo5rpE5c2bnn70HcPKkRZYsKSYnTxaLapmJalToYtS3r8iJE6l9hoQQQtwSZKJeuyYSECCSL59E5smjWmeq21jPTFVi1hjPIUOGSOXKlWXdunVy9epV+emnn6RmzZpSrFgx55+hhzNzpq/s2FHbbs1fGI2nTxcZPTo1zowQQohHEBgokj69aKjLB9GJL4+HD1P7rAhxblZ78+bN1QAzZ86Ul156SZ599tnkPaoXgc6icdXbx/p4Oo8SQgghuovs7FnxDQsTKV6cV4R4NH7JjVskiaNIEf3HqT2wHtsJIYSQOIGV4tw58UHTFnoaiTfEeJ5HFl0yScl9zUDPnuHSqdN86dp1vvj5hcf6LEGcJyGEEBInDx6IPHqkD8R14jYhZhaeJUqUUCWU/v3330QfeMuWLfLiiy9KyZIlxZspUUKkevUI8fOLGeTp46PHd2I7IYQQYrcAdM6cIiEhIqGh4gNXOzLZEd+J9dYFogkxk6sdfdmHDh0qderUUaWVGjdurIrKFy1aVLJmzarKK926dUtOnz4tO3bskLVr18rFixelUaNG8s8//4i3t8x89dW2cvo0yij5ysWL+vp9+0TKl0/tsyOEEOK2ZMsmMnGiyI0bIsOGSVhIiPiPGSOWdOl00YnthJhReKJF5sqVK2XPnj2qa9Hvv/+u/gOjnifEJyhYsKC0b99eWUirVKki3o7RRrRCBZE6dUQWLdLX84cqIYSQBIG4TJ9efWmorPaCBfXMdkK8IbkIQnLixIlqXLp0SY4cOSI38EtMUFosu5QpU0by5cvnrHP1eFCCzeDKFRTmT82zIYQQQgjxgKx2AIFJkZm4CgDHjh1Ty7lzl4oKq716NblXnhBCCCHEy4QnSbzw3L17t1rOk6dElPCExZMQQghJkDRpRHvvPbl/44akS5OGF4x4NBSeLojxREIWuHYtuqAnhSchhJBEgTIoRYpIBDoYYZkQD8btXsH37t2TQYMGKbEWEBAg9erVk//++y9q+/Dhw1UsKRJ2kFHftGlT2b59e4xj3Lx5U5577jnVMz5Lliyqr3xwKvW0RVY75oCRL59v1HoKT0IIIYR4G24nPPv16yerVq2S2bNny/79+1WbTohLlGcCpUqVkm+//VZt27RpkxQpUkTtc+3atahjQHQePHhQHWfp0qWqpNOAAQPE3ZKLCCGEkARBx6KVKyXt+vX6MiEejFsJz4cPH8qiRYtk7Nix8uSTT6rC9bBw4v8PP/yg9kF/eAjRYsWKSfny5eXLL7+Uu3fvyj4UxhSRw4cPy/Lly2XatGlSu3ZtadCggXzzzTcyd+5clYmfmuTKFb3M5CJCCCGJIiJCLIsXS7ply9QyIZ6MWwnP8PBwiYiIkHQojmsFXO6wbtoSFhYmU6ZMkcyZM0vlypXVuq1btyr3eo0aNaL2g1D18fGJ5ZJ31ZwWL16shq9veFS9X1o8CSGEEOJtJDu5CJ2K5syZI6dOnVLLRgF566Sa6egJmQQyZswodevWlU8++UTKli0ruXPnVo8BMQmrpwHc5927d5cHDx5I3rx5lUs9R44catuVK1ckl7VpEZP085Ns2bKpbfYIDQ1VwwAWVCMjHSMl4P4haHf2eDl3bk1u3rTIlSuaRERo8rj+vsPAY+C5SOl5uxNmnBPgvDwHPleegymfK8xF0wTfsmpeDpibqa4PMb/wXLFihXTu3Fnu37+vEniQ5GOL0dEoqSC2E12P8ufPrxJz0JqzR48esnPnzqh90IoTXZSuX78uU6dOla5duyprpq3gTCyjR4+WESNGxFqPuFFDNCYXfADWrFlTLaPYPgSwiL88eGCR06eDJEOGmILdER8md+7cUY8LK68ZMOOcAOflOfC58hxM+VyFhkrGhw+Vl+9OUJD4OKBzERJ5CfEY4fnWW29Jnjx5lPu4YsWKDj2h4sWLy4YNG5SoheURFs1u3bqpmE4DZLTDAoqB/vElS5ZU1tX3339fnVdQUFAsdzcy3bHNHrjf4MGDo27jcdH6M2fOnEpYpxRYbg0KFowW5BEROWPEfTrqQxeiH+dulg9dM84JcF6eA58rz8GUzxU8chCbFotkzJXLIcLTNqSNELcWnidOnJBx48Y5XHRaA3GJATc+LKxIOIrvg8ZwlcNVf/v2bWUhrV69ulq3du1atQ+Sjezh7++vhi340HL0B1fevNHL1675SOnS4nDwoeuMc09NzDgnwHl5DnyuPAfTPVc+PqJZLAKzhaPmZZprQ7xDeMLC6CwzPUQmXCSlS5dWAnfIkCGqbmfv3r2VFfSzzz6Ttm3bKksoXO3fffedKrXUpUsXdX/EhrZo0UL69+8vkyZNkkePHslrr72mYkJTo8UnBC/iYAGstnnyRL/ZmWBECCGEEG8iWT95Pv30U/n+++/lzJkzDj8hxOa8+uqrSmy++OKLqhwSxGiaNGlUzOeRI0ekU6dOqp5nmzZtVNzkxo0bVWklg19++UXdv0mTJtKqVSt1DGS/pwYQniiAj4Fl1vIkhBCS5JaZgwfL/ZdfVsuEeJ3Fc82aNSp+BtbFZs2aqXhIiEJbV8fEiROTfGwkCmHEFZOCuNKEQALPr7/+Ku4ArgMSpYxlq3BPWjwJIYQkDNzipUpJBPIX6CIn3ig80TnIurSRPZIrPM0GBDmK4RvQ4kkIIYQQbyVZrnajvmV8A4XgSWyshSe7FxFCCEkQfJ+uXy9pt2xh5yLi8TCtzcWgzr3hKWFyESGEkAQJDxfL3LmSbskS9mon3tu5CJw+fVr+/vtvOXv2rLpduHBhadmypRQtWtRR5+fxoIboMvTXFZHWrVurLkqo3QnRSeFJCCGEEG8i2cITReQRw2nbdgu1wQYNGiTjx493xPmZArT2tAYJRhCdcLXj8jFWnBBCCCHeQLJc7V988YV89dVX0rFjR9VHHQXbMbCMVprYhkH05KLmzZurYWT+G3Gejx6h5z2vEiGEEEK8g2RZPNEfHUXc58+fH2M9OgPNnTtX9TefPHmyvPnmm+LtILs/e/bs8SYY2WwmhBBCCDElybJ4onD8008/Hed2bHNGcXmzwJJKhBBCCPFGkmXxzJUrl+zduzfO7diGAvNELz117tw5dSkKFSqkYmApPAkhhBDijSRLeKIvOhKLihQpIq+//rqkT59erUcvdRSXnzZtmkowIrrwROwrKFCggBKe7F5ECCEkSS0zX31VHty8KenYMpN4o/D85JNPZM+ePfLBBx/Ixx9/LPny5VPrL126pMoHNWrUSEaOHOnoc/VI9DaZuaOWAS2ehBBCEg1Kn1SsKOFsmUm8VXgGBgaqfu2///57jDqeLVq0kFatWkmbNm2iRJa3g0z2xo0bx1jH7kWEEEII8UZSVEC+Xbt2apCkQYsnIYSQJLXM3LpV0qD+XosWLP5MvFd4kuSRJYsK2VF1PLdvF3n/fZE+fURKluQVJYQQYsXNmyI3bojl++8lMCREpHRpkXTpRDJkEMmWjZeKmFN4ogUmkmKOHDkiadKkUbcTcqVj+8mTJ8XbQczrihUrospMoWXmzJm66AR37oiMGycydqzI9OkivXql7vkSQghxI9E5cKBe8PnwYUkbESGWV19FDJcIKsdMnEjxScwpPBs2bKiEJMSn9W2SOO7evRu1fPy4SL9+sb0ooG9fkQYNREqU4JUlhBCvJzhY5No13cLp7y+R4eHiAytnWJi+Http9SRmFJ4zYaKL5zZJXHIRln/8EdZg+/tiPayeo0fzihJCCHlMYKAen4UvCbjY4XJ/+JCXh3hP56JZs2bF25kIWe7Yh0SXU8LAMi6bptm/MljPhk+EEEIIMSvJEp69e/eWLVu2xLl927Ztah8SmyJF4rd4YjshhBBCiBlJlvDU4jLZPQYdjJBEQ/TORRcuXFADy8hej8/iiThPQgghJIoHD/SMVAzEdeI2IR5KotXhvn37VLcig40bN6qMbVtu374tkyZNklKlSjnuLD0YiE1cK6PVaMmSPiqOEwIzMjJ6P+RtYT0TiwghhCgQz4nsdXQsyplTNAjP27d19xjWYzshZhWeS5YskREjRqhlxCpOnjxZDXtkyZKFMZ6PwbXKkSNH1DJAySRkr1erJnLvnkpWlP37WceTEEKIFchYR8mk4GDRIiPl9vXr6vvEAksF63gSswvPAQMGyDPPPKPc7LVq1VK92Fu2bBljHwir9OnTS/Hixelqfwwy2Zs1axbresKy+eSTIsuWiYSGiqRNm+LnkhBCiBnFJ0ZkpESirFKuXOxcRLxDeObNm1cNsG7dOilbtqzkwhuAJJtKlXThCfbuFSlcmBeTEEKIDYjL2rlT/FBQvkkTCk/ifclFKCBP0ZlyKleOXt63zwEHJIQQYj4ePRLL1KkS+PPP0W3vCPFQkp16fuXKFZk+fbrs2rVL7ty5o5JobN3ua9asEW8nIiJCVq9erZabNm2qXO/WFk8DWDwJIYQQQsxMsoQnMtyfeuopefjwoZQuXVr2798v5cqVUxntFy9eVDGeBQsWdPzZeiCIib0J94idMlQlS+qd0NCEghZPQgghhJidZLna33vvPcmQIYMcPXpUWfMgqCZOnCjnz5+XefPmya1bt2TMmDGOP1sPBP3tn3zySTWMXvcGKHVavnx0D3eWZiOEEEKImUmW8Ny8ebO89NJLUqhQoSgxZbjaUavyueeekyFDhjj2TD0UXJ/8+fOrYSs8reM8YQw9cMD150cIIYQQ4tbCEyITvceNmp2IWzTcyaBixYqyc+dOx52libGO86S7nRBCCCFmJlnCs2jRonL69Gn9AD4+6raRQAPQxx2ClOhxnUjEwrDXatQ6s50JRoQQQggxM8kSns2bN5cFCxZE3X7llVdk2rRpKmu7SZMm8tNPP8mzzz7ryPP06Kx21D3FwLIttHgSQgiJFz8/0V58UR527aonBxDiwSTrFfzhhx9Kjx495NGjR5ImTRoZNGiQ3L9/XxYtWqTc7h999JF88MEHjj9bDwRlpQzrr9Ey0xo0pChQQOTCBd3iCaOond0IIYR4KyjDV6+ePELPdquSfIR4jfDMmjWrVK9ePeo2BNXQoUPVIDGBELdtLWrP6gnheeeOyPnzIoUK8SoSQgghxHwky9X+/fffy7Vr1xx/Nl6Ktbv9+edF3n9fL69ECCHEy0Hi7pkzIitXStr16/Xlc+f09YR4i8XztddeU+51tM7s3r27dOjQQbLBZ0ySxa1b0cubNiE5S2TsWJHp00V69eJFJYQQrwTicuBAkatXxXL4sGSOiBALij/D3Z4zp8jEiXq8FiFmt3geOXJEudUvX74s/fv3l7x580qrVq1k9uzZcvfuXcefpQlaZmLYSy6CZXPq1OjbiPHEbiiL2revyIkTrj1fQgghbkJwsAi8i2hx5+8vkWnT6kIzIEBfj+2EeIPwLFWqlHz88cdy4MAB1S7znXfekVOnTknPnj1Vfc/27dvL3LlzHX+2HghKKCEsAcNeOaUff4w7mQjrYfUkhBDixQQGiqRJo48MGfTbhHiT8LSmfPny8sknnygr6O7du5ULHqWDnkewIlF1TuvXr6+Gvc5FCNexo0cVWI/thBBCCCFmwGEFwfbt2yfz58+XhQsXyr179yQArgCixCZai8ZFkSLxWzyxnRBCCCFEvN3ieejQIRk2bJiULVtWqlatKl988YWUK1dOfv75Z7l69arjztLE9OkTv8UTcZ6EEEK8mAcPRB490gfiOnGbEG+yeMK1DusmhCfqVKJb0XvvvadiOzNnzuz4s/RgENd5/fp1tZwjR45YReRLltTjOCEwkVBkAK881pco4eozJoQQ4hYgnhPZ6zDkhIaKDzJPkeluZLVjOyHeIDxHjhypSim98cYb0rFjR8mePbvjz8xkWe2gS5cu4men3RlKJjVoIPLSSyJr1+rr/vc/llIihBCvBhnsKJl0545o27bJvbt3JVPTpmIxkoxYSol4i/C8ePGi5MqVy/FnY1IyJOJXKSybs2fr7TPhYl+xgu0zCSHE64G4xChcWEKCgiQTvnvtJKoSYmrhaYjO0NBQ2bVrlwQFBamsbbiSic0F9vOTNm3aJOqy5Msn0rChCJpToL7nrl0iVp1JCSGEEEI8mmT/bPr6669V4fgGDRoodzuy2gHiGSFAf0SBSpJkevSIXmYpVEIIISoB4Ngx8T15MmYyACHeIjxnzJih6nW2aNFCpk+fHqMwOkRn48aNWUA+mXTqBCtptPDkZwwhhHg5jx6J5csvJf2kSXpmOyHeJjxRNqldu3by66+/2nUjV69eXQ4ePOiI8zNFctH69evVsNcy0xbkaTVvri9fuCCyebPzz5EQQgghxG2F54kTJ6Rly5Zxbs+WLZvcuHEjJedlGmANRk97DHstMxNyt8+Z47xzI4QQQghxe+GZJUuWqNqU9kB9zzx58qTkvEzVuah27dpq2GuZaY927UTSpdOXFywQCQ937jkSQgghhLit8GzVqpVMmTJFbt++HWsbXOxTp06Vtm3bOuL8PB6IzWLFiqmRWOGZMaOIEcEAfb9mjXPPkRBCCCHEbYXnp59+quIVK1SoIEOHDlXdeH766Sd5/vnnpUaNGqrc0scff+z4s/Ui6G4nhBBCiNlIlvDMly+f7Ny5U2W1z5s3T8Uuzp49W/7880/p0aOHbNu2jTU9H4Nrc+vWLTUSG+MJEEKbKZO+vGSJSEhIcp4pQgghhBAT1PGEVXPatGly8+ZNuXr1qkqegbhC/U52NYoGluHly5erkZisdgPEeHbooC/fvSvy11/JfaYIIYR4NL6+onXsKCGtW+t92gnxYBzSdytnzpySO3fuRMcwehsBAQFqJBUWkyeEEKKKOzdvLmFPPRVd6JkQDyVRr+CRI0cm+cCI+/zoo4/E20HLzPbt2yfrvk2aQNSLXLsm8uefIvfu6YlHhBBCCCGmFZ7Dhw9P8oEpPFMOfth26SLy/fd6jOfvv4s8/7wDDkwIIcRzQAu7M2fEF/Wxc+RAuZTUPiNCkk2iXr2RkZFJHkmJZyRxw+x2QgjxctAyc8wYSf/112yZSTwe/mxyMhDgmzZtUiM5YrxePZECBfTllStF2BCKEEIIIaYXnv/++6/KYE8Mp0+fllmzZqXkvEwDSiidP39ejaSUUzKAR6V7d30ZHYwWLXL8ORJCCCGEuJXwrFu3rioJZAARGhgYKBs2bIi175YtW6R3796OO0sPBpn+1atXVyO5Wf90txNCCCHEDCRaCdla63A7JCSEsZwJXWAfHylVqpQayRWeVauKlCqlL0PnX7yYrMMQQgghhKQqjPH0ACyWaKsn9P/8+al9RoQQQgghSYfC08nAMnzv3j01khPjaWDEeYI5cxxzboQQQgghroTC08kgk33p0qVqpKTEVJkyIlWq6Mv//Sdy8qTjzpEQQoibt8xs3VpCmzVjy0zi8SSp99aZM2dk165davnOnTvq//HjxyVLliyxstpJNGnSpHHI5YC7fc8efXnuXJEPP+RVJoQQr+gm0qaNhAYFsWUm8XgsWiL9v0iMQTcia3BX23XW6z21iPzdu3clc+bMSlxnypRJ3IVz50QKF9aXy5cXOXAg9j4o3h8UFCS5cuVKdjKTu2HGOQHOy3Pgc+U58Lny7O85Yn4SbfGcMWOGc8+EJEihQiL164ts3ixy8KBIy5a6+71PH5GSJXkBCSHEdKB+9r17IleuiB+WEXfl6yuSIYNItmypfXaEOE949uzZM+lHJw6nSBFdeIIVK0RWrRIZO1Zk+nSRXr14wQkhxDRAaA4cKHL1qlgOH5asERFigbsLwjNnTpGJEyk+icdhHr+lm4Jwg23btqmR0tCD48djZrQjSAKHjIwU6dtX5MSJlJ8vIYQQNyE4WOTaNZF06UT8/SUybVpdaAYE6OuxnRAPg8LTySDeFclWGCkppwR+/FGv6WkPrIfVkxBCiMkIDESWqj7gYsdtQrwhq50kHSTDVHlcBymliTFnzuhWTntgPbYTQgghhLgrFJ5OBmKzbNmyDovvjM/iie2EEEIIIe4KXe0eBLLX47N4Is6TEEKIyXjwQOTRI30grhO3CfFQ3Ep4oq3koEGDpHDhwhIQECD16tWT/9CmR/B+eyTvvvuuVKxYUdKnTy/58uWTF198US5duhTjGMeOHZN27dpJjhw5VG2yBg0ayLp161I1xvPBgwdqpDTGEyWTEMcJjz2SGq2tn08+KVKiRMrPlxBCiJuAeE5kr4eEiISGik9YmJ7p/vChvh7bCfEw3MrV3q9fPzlw4IDMnj1bCcuff/5ZmjZtKocOHZIMGTKorkkfffSRVK5cWW7duiUDBw6Utm3byo4dO6KO8cwzz0jJkiVl7dq1SrxOmDBBrTt58qTkyZPH5XNCJvvvv/+ulrt06SJ+6ECRAlAyqUEDXYAePizy998i+CzasEFk+3aRmjUddOKEEEJSF2Swo2TS7duirVgh9+7elUydOokF2e2s40nM3rnI2Tx8+FAyZsyoRFrr1q2j1levXl1atmwpn376aaz7wBpaq1YtOXv2rBQqVEiuX78uOXPmlH/++UeeeOKJKCsqLJ+rVq1SItbVHR3Cw8Nl4cKFarlz584pFp62TJgg8uab+nLVqhCfkXLjhrm6/LATiWdhxufLjHMy67zMOCdnzIudi0hq4TbvSgg0WAfToV6ZFbBabtq0ye59IAzRmtPoFZ89e3YpXbq0zJo1S+7fv6+OOXnyZPVGhYBNDSA0u3fvroajRSd47TWRSpX05d27RSZNcvhDEEIIIYSYy9UOa2fdunXlk08+UVnguXPnljlz5sjWrVulhJ3gxZCQEBXz2aNHjyirJETo6tWrpX379up4+FUI0bl8+XLJmjVrnI8dGhqqhvUvQeMXJoY7gx++336LGE/9N8TQoRZ58kmL5Mjh3uedFPAcwDDv7s9FUuG8PAc+V56DKZ8rzOf6dZEbNyQye3aHHNJU14d4FG4jPAFiO/v06SP58+cXX19fqVatmhKWO3fujLEfEo26du2qPlx++OGHqPW4/eqrryqxuXHjRmUtnTZtmrRp00a55fPmzWv3cUePHi0jRoyItf7atWtK4Lo7SDrq0SOTzJkTKHfvWmTo0HQyeXKQadxM+ICEdRvPr1nmBDgvz4HPledgyucqNFQyfvih+IeFSdDnn4sPOhelEIShEeLVMZ7WwE0OqyOEYrdu3SQ4OFiWLVsWQ3SeOnVKJRDBvW6wZs0aad68uUo8so7NRLJR37595b333ku0xbNgwYKxjpMcED6wGz5wFYNZVQlqZ4Afw2XLWuTmTT3VfdWqCGncOI6inx74RYIfAYjfNc0XCeflUfA16DmY8rnC99Mbb8jDkBDxnzTJIcIT33PwBDoil4EQj7V4GqBcEgaE34oVK2Ts2LExROfx48dViSRr0QlQsgjYftjgdnxuBX9/fzVswf1S+sGFx0VGPYAF11kfhLlyiYwZIzJggH77jTd8ZM8eiyD50QwgjMIRz4e7wXl5DnyuPAfTPVc+PqJZLAJTgqPmZZprQzwOt3rlQWQiHhN9zZGF3qhRIylTpoz07t1biU5khaN00i+//KIsiVeuXFEjDPWERFSMKH7B9ezZU/bu3atqeg4ZMkQdzzpT3pXgzV2hQgU1nP1GRwH52rV1A/bhwxb56iunPhwhhBBCiOcKT5j8EaMJsYni8Cj+DjGaJk0auXjxovzxxx9y4cIF1fscbnhjbNmyRd0fReMhXOGab9y4sdSoUUNlxKNEE2p/pgYQmyh6j+Fs4YnDf/cd4pp08TlypMjZs059SEIIIYQQz3S1w42OYY8iRYokqvMPxCbEqreCWp69ez+Q6dPTq65qzZqhFqrexx0tN5GIRAghxENAp6IbN1SrTAuSXc+fF0HZQRaQJx6KWwlPMwKxjDABAMstYo+czTvvBMuCBXqG+/HjIidO6NZQhMqi4xG6HxFCCPEA0TlwoMjVq6pVXdqICLG8+qreMxktM9HVCN2NCPEg3MrVbkYQi7po0SI1sOwKrl/3EetKGTAU46GRX4U4UAhRQgghbk5wMOr6oZOKSMGCEp4/Pzql6LexHtsJ8TAoPE3InDkBysJpDxhcYfUkhBDiIcCtXqGCRJQpI4LSR4GBqX1GhCQbutqdDOp2ohYpcIWbHVy44KusnPbA+jNnXHIahBBCCCExoMXThfXkXCU8CxSIUJbNuECiESGEEA8BFgPkCjzOFyDEk6HwNCE9ejyM0+KJOM8CBVx9RoQQQpINYjk3bpQ027ah7iC6pfBiEo+FwtPJoHMRWmZixNc9yZEUKxYhU6einqee/Ij/1hbQt98W2bzZJadCCCEkJbGdyF5HGaXQUPFBsxRkuj98qK/HdkI8DMZ4OhmIzSNHjqhlVxSRN0DJpCef1BOJENNZuLDI0aMiv/2mf4a1bauLT8SqE0IIcUNQKgklk1DHc9gwCUOv9jFjxMI6nsSDofB0MhCa6MRkLLuSEiVERo+Ovo0fy888I7Jqlf6juWVLka1bRfLkcelpEUIISYr4TJ9eWTc1uLAKFtTLKRHiodDV7uwL7OMjVatWVcPVwtOWtGlFFi4UqVJFvw1LKFrYW9f8JIQQQghxFhSeXgZKwC1bJlKokH571y60KmWyJCGEEEKcD4WnC1pmIs4TIzG95l1Bvnwif/8tkiWLfnv5cpGXXtIrdhBCCCGEOAsKTyeDNpnz5s1Tw1UtMxNDuXIif/yhu9/BjBkiI0ak9lkRQgiJha+vaHXqyKMaNfRSJYR4MBSeXswTT4j8/HP0bQhPttMkhBA3w89PlSp5iC54WCbEg+Er2AUtMzt16hS17G506SLy5Zcigwfrt+FyR7nRU6f05CN0OerTR6RkydQ+U0II8UJQggQF5CMjxef6db0eHhJVUcMTGe+EeBgUnk4GbTLTGv5sN+XNN0XOnxf56iuEBogMGKB7cxDzicLzY8fqllDUBiWEEOJC0TlwoMi1a2KJiJDMYWF6DU98MKOAPGp8UnwSD4OudqIYP16kRYvoiwEBCsun8b9vX5ETJ3ixCCHEZcDSee2aHox/+rT4nD2rZ4WijifWYzshHgaFp5NBNvv+/fvVcFXLzOQAz02FCnFvxw9sxn8SQkgqEBgokiaNPuBix21CPBS62p0MxOaBAwfUctmyZVO9iHx8XLigC1B7+hhud8R8EkIIIYQkFwpPF8R4lkDvysfL7gwSieI7RWwnhBBCCEku7mt+MwnIZK9Zs6Ya7pjVbg2y1+MqIg8r6KVLIuHhrj4rQgjxch480NvLYSCuE7cJ8VAoPEkUKJmEOE6426GR8d/aAjprlkjbtiJ37/KiEUKI00E8J7LXUUIpNFR8wsL0TPeHD/X12E6Ih0FXO4kBSiY1aKALUKOOZ8aMIsOG6dZOtNqsX19k6VKRwoV58QghxGmgVBJKJt24oT6Ew0JCxH/MGL2kEut4Eg+FwtPJhIeHy8KFC9Vy586dxc8Duk4gJHX06Jjr6tUT6dhR5NYtEeRK1aol8vvvInXqpNZZEkKIl4jPjBlFe+IJCbt3T/zxi9/fP7XPipBk4/4qyARocQVOehBPPSWybZvIM8+IHD8uEhSkr4NAxTK7HBFCiBM7F7VsKaHXr0vGy5fZuYh4NBSeTgYJRe3atYta9mRKldLFJzqArl+vQo5Uq03EgRqDXY4IIcQJnYs0Te9chGLy7FxEPBgmFzkZlFAKDAxUw93LKSXW67NihS4+DWDQZZcjQghxUucidCrKnl0is2ZV/9m5iHgyFJ4kyeAHN+JA46qFzy5HhBDiQBDTuXu3+O3fr4tOdi4iHgyFpws6Fx0+fFgNd26ZmVTQMjgu0N99zhwRfEYSQgghhBhQeDoZiM09e/aoYSbhmVCXIwjTSpX0ZKTNm115ZoQQQghxVyg8nQziOosWLaqGGWI8E9PlyJply/S6oE8+KfLXX4m7DyGEECvYuYiYCApPJ4NM9jp16qjh6VntCXU5Mv5PmqTXPC5YMHr/jRtFWrcWqVJFd8Oz9SYhhCQAOxcRE8JySsShXY769tUTj8Arr4j8+qvI55+LHD6sr9u3T+TZZ0WGDhUZMkQ/BppwEEIIsYGdi4gJocWTOKTLEayY+G+ITpAmjUjPnnqnoyVL9G5HBqdO6cK0aFG99if7vxNCSBzis1AhZf3U0qfXXUm4jfWEeCAUni5qmYmBZW8E7vf27fXi82vXijRrFr3tyhWRd9/VP0c//FDvgkQIISTmh6hWoYKElykTdx07QjwEvoJdwKNHj9TwdpBb1aiRyMqVIjt2oHd9dGb8nTsio0aJoA3xa6/prntCCCGP3UevvSYPEMuEZUI8GApPJ4OEomeeeUYNMyUXpZTq1UUWLBA5ckSPCzU+S0NCRL77TnfZv/CC7qYnhBBCiDmg8HQyKKGUMWNGNcxUTsmR/d+nTRM5fVrv+44QJqMI/c8/i1SsKNKunUV27OCvfEIIIcTTofAkbkH+/CJffCFy7pzIiBF6O2KDpUst0qZNdmnUyCLLl7MWKCHEywgNFcsbb0hGBMKHhqb22RCSIig8nQy6FR07dkwNM3UuchZI1Pz4Y73z0YQJIgUKRG/75x+LtGwpUq2ayLx5ulWUEEK8grAwsYSFpfZZEJJiKDydDMTmzp071aDwTDxwuQ8cKHLyJOqERkqJEtEVAfbsEeneXaR0aZEpU/S4UEIIIYS4PxSeTgZxnQULFlSDMZ5JJ21avcj8hg3XZeHCSKlZM3obROlLL4kUKyYybhxrgRJCCCHuDoWnk0Eme4MGDdRgVnvyQem6Dh1Etm8XWbNGpGnT6G2XL4u8845eigkdkVgLlBBCCHFPKDyJR4HCAI0bi6xaJfLvvyKdOkXXAr19W+Szz/TWna+/rseJEkIIIcR9oPAkHgvc7gsXihw6JNKnT3Qt0IcPRb79VqR4cZEXXxQ5eDC1z5QQQghxT9avXy9z58512eP5ueyRvBS0yVy6dKlaRhF5Pz9eckeDLnLTp4sMHy7y1VcikyeLPHigZ73Pnq2Ptm1F3n9fpE4dhz88IYQ4v2VmqVISHhzMlpkexMyZM+XChQvi4+OjcjwyZ84sDRs2lPLly4s3QxXkAh7CBEecTsGCIl9+qfd8h8Xz669Fbt7Ut/3xhz4aNtQFaPPm0S56Qghxa+DOGTxYHgQFSQa2zPQomjZtKnXq1BFN0+T48eMyb948yZ8/v2TJkkW8FQpPJ4OEohYtWkQtE+eD4vPDhom89ZbI1Kl6YfqLF/VtGzboo2pVkffe02NE+bQQQghxJrB4lipVStKlSyc3btxQwjMsLEwWL14s58+fl4iICMmdO7e0bNlS8uTJo+5z+fJlWbZsmVy7dk3pB1TH6dGjh9p2//59WbFihZxG2z8RZUWFyI3Lq4pjrVy5Uq5cuSIBAQFSv359qY7e1XaI79iTJk2SunXrSuXKlaP2/+WXX6RQoULyxBNPJOpaMMbTBS+2rFmzqsFySq4lQwaRN98UOXVKd8WjPafB7t0i3brpbnqIUzYDIYQQ4ixg8Txy5IgKvzOEJdZVqFBBBg4cKG+//bZav3DhQrUe/PXXX0qsvvfeezJ48GCpV69e1P3mzJkj6dOnlzfeeENeeeUVuXr1qvzzzz92Hzs4OFhmz54tNWrUkCFDhkj37t1VXOcpfDnaOc/4jl2pUiXZt29fjGPjOFifWCg8iVfUAkXyEZKQkIxk/SPvxAmRAQNEihYVGT9e5N691DxTQgiJo2Xm229LRgSy81eyR7FmzRoZM2aMjBo1SubPn6+sghB1wN/fXwnPtGnTKmtio0aNlDX03uMvIlg579y5o25je2HUDBSRS5cuyc2bN6V58+aSJk0aCQwMVCUbDxw4YPcc9u7dq+4LyyXiTXPlyiVVqlSR/fv3x9o3oWNXrFhRzpw5I3fv3lW3cQwcG/GriYWudieDbkV4kkCRIkXUk05SB7jU4Vrv2FGvBTpmjP7fqAU6ZIhejum110TeeEMkZ04+U4QQNyE4WCzMF/A4mjRpomI8AQTdnDlzlLsd1sdHjx4p9zdiP5ELYnhFHzx4IJkyZZK2bdvKhg0bZMqUKeo+tWrVUuP27dsSEhIin3/+eYzHiqs7IvbHY0AAW1s24R63t298x86YMaMULVpUCU6462H9rF27dpKuCYWnk8GTtR1Vz0XUk0zhmfrgvY0C9BioBYr315IleCPqtUA//VSPC+3XT+Ttt/G8pfYZE0II8XSyZcsmJUuWVCIQwnPr1q0q9rJPnz5KaNoKPuzfoUMHJRIRBzpr1iwpUKCAsi7CavoWEhkSAfYvU6aMdO7cOVH7JnRsuNU3b96s5gILbbly5SQp0PzmZPALJm/evGowxtP9qFVLZNEivdYnWnMacdkwLHzzjV4LtGdP3U1PCCGEJBfD8pgrVy51OzQ0VLnQYc1EohHc8rYucsRQQjtgH/yH8SpfvnxKqK5du1YdA8LUOHZcQhGJQocOHVJJTBhIMrpoZN1akZhjly1bVq2DtRaCFqECSYEWTyeDGI2nnnrK2Q9DUkjZsiIzZoiMHKlbO5FwhFqg4eEis2bpo317PRM+iV4FQgghXsrq1auViAMQj2XLllW1PAGywxctWiTjx49XsZSI8dyxY0fUfZG0s2rVKiVKM2TIIM2aNYtKTHr22WfVsb/77jslEGGpjCtLHULy+eefV/ujrjjEZM6cOe1qEwjbhI6N2E9YOffs2aOOm1QsmpE+RaJA0CwuNIJ68YR5mms/KChI/aIyi1s/NeZ0/bpu8cS4dSvmtkaNdAHarFnKaoGa8bky67zMOCezzsuMc0JCkfb66yoOMN2UKeITEODV33PEszHJu5IQx5Ijh8iIESLnzukW0Hz5oretWyfy9NMiNWqILFigd0gihBBCSMJQeDoZ1Oz6888/1cAy8bxaoIMH67VAp00TKVkyetuuXSJdu+puemxjlRNCiNNaZhYuLBEFCrBlJvF4KDxdAIKDMYjn4u8v0revyOHDupWzWrXobYi57t9fpFgx3TrKWqCEEIeCNpnvvy/3Bw7UlwnxYCg8XZBchFZTGGyZaY5aoKhIgfjvlSv1eE+DS5f08kuo8fvxx3qcKCGEEEKiofB0Mih/gOwxDJZTMg9IKkJyEZIVt23TM94NkIz0ySe6AB00SI8TJYQQQtyJo0ePyoQJE1RXJbTzdBUsp0RICkF5JRSghxsetX9/+UUvw4RyTBMninz3nQgqTrzzjh4PSgghSSIsTCzDhkmG+/dFxo5FXR5eQA8AnYr+/vtvuXDhgipBhA4/9evXV9vu378vK1asUJ0NUbIIxeJR3qh06dJR94coxH6G0QpVGtC33R4o5I4SSCg0j3wSVHWAp9VedyIDPD5KOFWuXFndHjFihLz00ktRJZucBYWnC0p74EUH0HHANOU9SCwgKmfO1LPhv/xSrwWKQvQQoVj/00/RtUBRuB6cOuUrEyZY5OxZtFTVe8pbJzARQrycmzehKgQfEr4hIboLBcITmY/ZsqX22ZF4vvvnzp2rhGT37t3l1q1bMnv2bFW6Cv3OUZsTAg/iEG0ojx07pmp69u/fX3lIDTp16qSKtCcEuh6VKFFCnnnmGQkICJDdu3fLr7/+Km+88YaqEWoPFIHPnTu3y59DCk8XvPjQWgp06dKFwtMLgIsdls6hQ6NrgaIVJyrmwjKK0bixSJUq+EWbQ7ntsQ3/YcyYPl3vokQI8XIgOpFQdPWqcqmkjYgQy6uv6sHmECf4oKH4dEtggbx+/bqyICK/I0eOHFK1alXZuXOnEp5Zs2aVevXqRe0PgZo9e3ZlqLIWnoklf/78ahig4DssoFevXlW91a1BL3hYU1HGffr06cqiiscGxu0nnnhCDWdA4emiGE9jmXgPeNrRCWnIEJEpU/SM98uX9W2IDV271r71G9nzDRqIlCjh2vMlhLgZqIZy7Zpu4fT3l8jwcPGB0AwL09djO4WnW2L05rHu0YPlq/gRYQe41CFUbS2Q6DT0xx9/KGH45JNPqv7oiQGPA6uqPRELC+gHH3ygXOt9+/aNcq3b3nYW9Ps6GWa1k4wZRd56S+T0ad39npCgxO8T1AUlhBAFXKUoo4QBF3scrlPiPkAoZsmSRdatW6diLtFNCy0mQ+0UfEbv9IULF0r58uVVr3SDDh06yMCBA2Xw4MFSq1YtmT9/vt3+6vbc7nDbN2jQQLXadDcoPAlxYS3Qfv1EkDyoe1jsd6tFJ6SvvxZ54QXd7X7ihO6KJ4QQ4jlGJ8R2XrlyRb788ktZvHixVKlSJVa8JUQnBCWSj9q0aRNjW+HChdV6Pz8/5Z4vVaqUHEYWawKi8+eff5aCBQva7cXuDtDVToiLQXjWk0+KbN8ed7tNJCX9/LM+AEJ38BnSsKH+H1ZTRm4QQoj7gszyF2BBeMyqVauUmLQWnQsWLFD/IVITqvWdULieITrhXkeSkbuG99Hi6WTwgkI5BQwsEwKQva5bMe2bMm2rpcC7gjJNAwaIlCqFCgkizz6rx44eO0aLKCGmBrXZ/Pz0gZJKuE3cHiPOEt/9sFTC1f4krA5WohPbITph1bTmzp07cvbsWeWmx74HDx5UdTfjynCHC/+XX35RLv62bdsmS3TCLY8SUM6GFk8ng2BilCwwlgkBiA+fOlWT/v0tYrFoomn4rwtIuNchKtEdacMGkfXrRTZtivldgy5Jc+boAyAWHJZQwyqKUnBu+mOXEJJYEJ+H5BAkEuXLJ5FIKkKHCry5sd4N4/dINBCLO3bsUOIRSUPdunWLSh5CvU0ISQjOsShn8hgjmxyCFAYrCEGUYYSg7Ny5syrLaPD999+rOM5KlSopYYuMeIhda3c8LJ/YnhhQ03P58uXy559/qnqjOLYzsGhUQ7G4e/euZM6cWf3iQM2tlGCdxYYXnLNN3yjfhCBmmPjNUjPUjHMy5rV9+w35/fcccvasRdXxREa7veSjR49Edu7URaghRGH4iAt8tlm75vEj2VVC1IzPlxnnZNZ5mW5OsEAFB6t5IesZZXnUvFJYx9OR33OEJAVaPJ0MhKazSxMQz6Vo0QgZNUoTH5/4VSGSWevU0QcK0EOI7tqli1BYRTdu1CurGOC3zrx5+gC5ckWLUAwUu6dFlBAPAOISIzJSIhGDgzezGQQ18VooPAnxQCBE0aoT49139e5IEKKGax5C9N696P2DgkQWLNAHgJcOQtQQo+XK8buMELdumfnZZ3rLzE8/ZctMNwAW6BMnTsj+/fulQoUKMVpdkvih8HTBi/Py46rhefPmNYfrh7gdiEtHG04MFKyHEN2zJ9o1DyF69270/ggZW7hQHyBHDj3T3rCIli9PIUqI24Dg78uXxQflLpgrkKog5hLtKPfu3Sv37t1THs306dOn7kl5GBSeLhCe//zzj1pmy0ziSiFao4Y+3n5bL9tkCFFYRfGSvHMnev/r10UWL9YHQPc0ayFaoQKFKCHEO0FyEBJ2du3aJWfOnBF/f39VV7NatWrKoESSBoWnC2I8sz0OAHfXmlrE/KA8XPXq+kAXJQjRvXujXfMQoo+LLyhu3IjuKw/wEoYQNVzzSJKk8Z4QYmZQ/B1iE+501MhEDU50Eypbtqwq7E5MIDxhtv7oo49kyZIlKiuxatWqMnHiRKlZs6Y8evRIhg4dKn/99ZecOnVKZeM1bdpUxowZE6PFFFi2bJmMHDlS9u3bJ+nSpZOGDRvKb7/9lipzQkHYp59+OlUem5D4hGi1avp4801diO7fH+2ahxBF1RbrxFq8hYy3UdasKPsRbRGFEE2g9jEhhLg9EJgQmnCnI0wOtS2rV6+u9AhKGhGTCc9+/frJgQMHZPbs2UpMogI/xOWhQ4fUk49fHhCmlStXllu3bqkepiiUijpZBuhP2r9/fxk1apQ0btxYmchxTEJI3EA0Vqmij0GDVAJtLCFqXVcYovSPP/QBMmeOds1DkNr8FiSEELcFZQ/PnTunNAb0Bgq2lyxZUhmt8J+5GSat4/nw4UPJmDGj/P7779K6deuo9fil0bJlS/kUmXw2/Pfff1KrVi1V3b9QoUJKZBYpUkRGjBghfVEQ0Qvrm5muhp1J5+Rp84IQxe83I0YUA+74uMiUKVKeeMIiTz2FoQtam8YcHoUnPVfePi8zzklCQ0V7/XX1PZluyhTxCQhI8SE9+XvOUQQHB6tuQrBuImkoa9asyrKJnurQI8Q5uM1XgdEWCq5xawICAmQTqmXbAW8YxE1myZJF3cavlYsXL6oPG7x4EJ+BF9C4ceNUuYO4QKspDOs3pPEBhpESMKd169ZFdQVIqBdrSsH54rdESs/bnTDjnDxxXngLYbz2mi5EDx0yYkQtyiJ6/Xp0DPPduz6ybBnCXvTbmTJpUr8+LKKaihOtWtWzhKinPVfePC8zzkllsmfLJpEPHkgklh0wN1NdnyTO+/jx40psHjt2TH0nlytXTtq0aaNiOJmL4UUWT1CvXj1Jmzat/Prrr6rLz5w5c6Rnz55SokQJ1VrKNg4DLZ3QtxT9ScHcuXOlR48eyvr55ZdfKuvnF198IStXrlQvMCPJx5bhw4crK6ktuE9Kf/VAUK9atUotN2vWLFY/Vme8qSDI8UvWLL/2zTgns80L32HHj/vJli1pZfPmNLJ1axq5eTPu13qGDJFSq9YjqVcvTOrWDZNKlR65tRA103Nl9nmZcU7OmBdyKkqVKuU1Fk+jDBIsnLB0ogwSstKRnW5r8CJeJDxPnjwpffr0UeWH8CsELwq8MXbu3Bmj9ygSjTp16qT6kq5fvz7qTQPB+txzz8nkyZNlwIABah0smehtClf9Sy+9lGiLZ8GCBVUcaUrfkPiwuITG2oK4t3xO/yDE4127dk1y5sxpmg9dM87J7PMKCrom16/nlI0bfWTDBouyjAYFxV3VIUMG3SLasKFuEUX2vb2k0ePHRWbMsMiZM6JajPburam+987GzM+V2eZlujlZtcy8ceOGSnBxVMtMuJbNLDyhFaAdIDhZBsl9cCsbQ/HixWXDhg1y//599aZAfaxu3bpJsWLFYryQunbtquI6165dG+MNY9TTgtncAPW2cH8EDscF9sGwBW/ulH5w4f6wwLoSuAocce7uhBnnZOZ5oQVohQo+UqmSj7z6qu4pPHIkunwTBtp6GgQHW2TFCpEVK3RxinrMumteH6hH+vPPSEDUW33iePg/bpxFpk8X6dXL+XMy63NlxnmZZk4QnSg7ce0arESSJSxMfNOm1d3BaD82cWKyxafHX5sklEGC95NlkNwHtxKeBugCgAGL44oVK2Ts2LExRCfiMxA3aVvaAIlIEJBwyzdo0CDqPvilg9gNQkjqgO9J9IfHePllXTgeOxYtQiFIHzf4UqAz4MqV+gDwhIWE2D828gjxdi9RwjVzIcRlBAfrbcZgGDl9Wiyoe1axoko2UuuxPQVWT7OXQapRo4bK94grzI6kDm4lPCEy4flHz1P0QB0yZIiK4ezdu7cSkJ07d1a/YpYuXaqSdvCrBuBFhdhQWD9ffvllGTZsmHKVQ2wiscjoGpQaYD7IsATIsmTgMiG6EEVrYwxEwECIwo1uiFD8fxyhoohLdOrvMZH33oP1UwS/L01syCHeCrLYHz0SC3rhwh2AJFW0z/Ry8P0K7yfEplEGCeF5LIPk3riV8ESsyfvvv69iNyEmEcf52WefqQ4BsFr+8bhoIDLVrYH18yn44wRfPuNUAs8LL7ygSk/Url1bueQRy5Ia4I2AxzfEr7OTiwjxVCFaqpQ+EJ4NMXniRLQIRSvPuL5nse+iRfpALiAMQihobwzcNmkIGyFeiW0ZJOgFiE3U+GYZJPfHrVQQ3OgY9kCMRmLyoCBSx48fr4a7YNbAbUKcKUSRNISBuE5YNPGWhqcxPu7dE9myRR/WIBHJWoxiwDXPbkuEeAYsg2Qe3Ep4mhFYOK0L4hNCkg7iOB9HzdgVqYgbvXBBZN8+kbNnY++DLHgMo9OSETeKuqS21tEcOfgMETfjwQPlahe42hHXGRYm3oJtGSQkEaOpDMsgeS4UnoQQtweWT2SvQ4BaZ7Xjv21W+507ertPDAhRY+D72hrEjaLbrlXHXQXafdpaR11RsomQWKBkErLXUQIiNFR8YPJHpjtM9ViP7V5SBqlSpUoqUcioXkM8FwpPQohHAHGJ7HUITaOOJ4SobTY7+sZjv8eFLaIK3MMSundvTDGKOFLbCB4kNWEsXx69Lk0ai5QsmV2qVrVI5crRgjRPHl0AE+IUkI2NkknoTztsmISFhIj/mDFigbk+hXU83RFko0NssgySuaHwdEFyEWqTAgQ/O7tlJiFmBiJz9Oik3w+Z7kWL6qN9+5hlmw4ejClGMW7dinn/R48scuhQGtUm9HGjNAXc8rbWUZQRdkArbUJ0IC6RyZ4nj2qZKQULmuoFxjJI3geFp5NBQtTVx5Wy3ahJFCHkcaH6WrX0YYC36cWLMYXo/v2aKoAfHh7TvHn9ugiKVjwuXBElcpGdbytI0UfC1jqKElI//hhtwe3Th259Yr9zkfbGG3L/+nUJwPeJAzoXpSYsg+TdUHg6GXSHqFu3btQyIcS9gTgsUEAfrVrp6yIjNTl/Pkhu3MglBw74xBCl1h2Y9H31Lk0Y8+dHr0dxC2shimZqY8bEjFlFrwxXdWIiHiI6Bw6M6lyUOSxMLGnT6i+WFHYuSg3QH37v3r0sg+TlUHg6GYhNlIIihHg2aB6DEsLVqsVcD+Fpm8gE971t4vHduyKbNukjPhC3WqaMSO3ajB/1eozORXCtBwRIJDLiEN+JorYe0rmIZZCILRSehBCSAnLn1kfTptHrUPUGLUFtY0fPn0/4eLCYwkmCJCmju5P1QIY9tAfxIvCEnzolviipVLWq/ovEzTsXsQwSiQsKTxfEsuANCNBdgS0zCTE/aFCGJCOM7t2j1yNp6cABkTffFNm1K3ZGvTUoC/Xvv/qwBpoDrUFhFbUVpSgFldgse8SXTp9ukaNHM0vp0hZlaWXZKDcEYhOWzevX9XJKWIblE+vdDJZBIomBwtMFWe0rV65Uy2yZSYh3g869Tzwh0qyZyJ499jsxGcISlk/EgdoCsWoUxLcu+QSQb4LEJltBinVIpDKYMUPvCKXHl6ZT/1Ggn/Glbsbt2yKHD+svhuBg8cGTj1gNvHDwpGE7stbcoAzSrl27VBmk0NBQFV7WoUMHKVu2rOomSIg1FJ4uIDAw0BUPQwjxEJC9jkQie0BPrFqll45C9RxYJo8ejT3QHtQWGMNgScWwBclSEKEIC5gzx7C2xjSPwuqJ+qe2tVFJKoF6XwgWhgndYlEeNAtK8kGIYj22u1EZpJo1a6oi7/DuERIXFJ4uaJnZrl07Zz8MIcREnZgM4YffrChYj2EN9rtyxb4gPX1a1yW2oKUoRnzguP/7n8hbb+nnAMsrNI894ioFxRJRDgRmalRDedwuE5ntKrYTTzDWW5uxXQDLIBFHQOFJCCFu3InJHhCp6ByI8dRTMbeFhoqcPBlTjKK0E/7bFsa3BboG1lYMANGJ88I5WQ90gProo9iloDCnmTNZIsphINAXpm241iE8jXW46LB8YtkFsAwScSQUnoQQ4mGdmBIq+2QkNlkDrYKC90hsgqvdnlXUFmTno60oRmKABdQe8bnwaSGNBzxheBIgMjHwJOLXwGMhqrY7CZZBIs6CwtMFyUWbN29Wy/Xr12fLTEJIqmDUHB82TBee9oD39pNP9JqjhuDESGkoIfTS66+LvP223rYUXR+RcxIzyYlF9O0G7UJkYhglEGDSNn41YLuDQRUWJAqh0HtwcLDkzZtXWrZsKRUrVpR0rONFHACFpwtiYi6i/x5bZhJC3C6+VLOKL7XYzWrH9qCgaBEKlzp61icFHAMZ+EYWPox3CBOIK+aUSU5WFw7gCbLufGcodQe1YTbKIEFwnj17Vvz9/aVSpUoqUQjCkxBHQuHpgs5FyPQzlgkhxF3iS6dNQ+xniJQunU5ZHu25wqFxjCL59etHx4vaKwWVWHDf+BKdYNCrXl1PqkK1IFhI8d96oMC+6cmYUVfpcK+nTavc3+p7BBntcLVjewrIkyePrF27Vo4cOcIySMRlUHg6GXxIlGBtEkKIm4GPpVGjNAkKuiO5cvmLj48lxaWg4gLidfhw3TN86pSeeY82o/HVQIe7f+PGuLdnyhRbjEKgomxU+vS+qmYq4l09HqMjANS4dWBuYjsFxFEGaceOHfLyyy/LiRMnWAaJuBQKT0IIIQ4pBdW7tx63aa9ElK0L//339aL1cVlO0Z48vq6QEKboAoURE3iWcqowAnRyshWm1rdRbjKZ+s015MihWzwhOENC9HJKsH4aWe3YnswySMWKFZMJEybI9u3bJUuWLE6fCiEGFJ5OBm/4u/iEVL/QM7FlJiHE1KWg3nsvcSWi4rOcwpuM3vYQjuhvjw5OtsNYj1wbeyBmFeH1GFu32t8HdVLtWU2NZVhPUzWfBoVUa9TQhebp00ow+pUvr5uKsQ7bVb5RqCxZskRZLosXLx6jDNKePXvUQNIQCrs3bNhQKleurL6bXnjhBYaAEZdD4elk8EHx119/qWW2zCSEmL0UVGJLRCW2iL7R9tMe2PfatZiC9OxZTY4fD5WgIH85f96iCu3HBTpDIWYVIy4Q2xqfOM2Vy4lWU/RAhXq/elWpcdUyE6ocihklCjJkkPDwcJk3b55cunRJmjZtGlUGCYlC+O/r6yvlypWTNm3aSOHChaOMH4ZBhBBXQ+HpApAhSAghxHFF9AE0FIQfBgyDIDIScau3JVeuXCpuFRZRJDLZs5oaAwI0LqD5MP77L67Pd/vJT8Y6/E92gyHEAkycKHLjhqqDFRYSIv5jxogFZtgMGUTLmlV+W7RIzp07J23btlWWTZZBIu4OhaezL7Cfn3Ts2NHZD0MIIR6JM4ro2wpDeJ+tPNAxgBERHZ3iE6aXL8ddcB/CNqEi+9mzxxam1uI0Tx49ZDMujp9JI9P3dJNT97JJsS9ySN9nQ6REBU2WLVsmBw8elJw5cypXO8sgEU+AwpMQQojXAqspDIsYVarY3wchlZcuxS9O4/Ncw2CJsXu3/e3IF0I8aSxxmvWe7Bi1Vobv7SgWKSCaWMQyVWTclCwyts94CS6kZ1+FhYWpupuI78yePTtrbxK3hsKTEEIIiQd0WUIez+NcHrugbXpciVAYcPfHlcGPkpwINcCICep0dn68/LgOtKoZr8miQw2kc+l/JTBTOlUiCZbPfcjIElFlknIjOJUQN4TC0wXJRShXAWrXrs2WmYQQYkJQ0B6jQgX72yE6kegUn9X05s3EPppF/t1eWxpWKy+jv9Mr6SNLHdntsH6iggoh7gqFp5Mx6qeBWrVqOfvhCCGEuCGI4cyfXx9169rfBwX2YTU1LKcTxoXJoWNplIvdXmzqmQvRX+HIVkcvdfZTJ+4OhacLOheh362xTAghhMRVPalsWX2Ak7sfypHjvhKh+dqNTS1SIJwXkngcVELOvsA+PlKmTBk1KDwJIYQklj5d76tC+I8DO63Q1Pq+3e7zYhKPg8KTEEIIcUNKVkwn0+tOEx/RxNcSIT4SIb6C/5paX6JCarZVIiR50NXughjPB4+rEwcGBrJlJiGEkMSRLZv0WtpZGhy4ItPmBsrRkxFSuriv9Ov+QEpU6KzXgCLEw6DwdEFW+x9//KGW2TKTEEJIksiWTUo8KTKqQaQEBQVJrlxZxccnCy8i8VgoPF0AeuUSQgghhHg7FJ7OvsB+ftK1a1dnPwwhhBBCiNvD5CJCCCGEEOISKDwJIYQQQohLoKvdBclFO3bsUMs1atRgvCchhBBCvBZaPF1QTunUqVNqYJkQQgghxFuhxdPJoFtRpUqVopYJIYQQQrwVCk8nA7FZvnx5Zz8MIYQQQojbQxMcIYQQQghxCbR4OhnEdYaGhqplf39/tswkhBBCiNdCi6cLstqXLFmiBpYJIYQQQrwVWjztYGSf3717N8UXODw8XB48eBB1PHQyciaRkZFy7949SZcunWmSmcw4J8B5eQ58rjwHPleJw/h+Y7UV4mosGl91sbhw4YIULFjQ5U8GIYQQ4krOnz8vBQoU4EUnLoPCM45fzJcuXZKMGTN6XEwmfsVCNOPDJFOmTGIGzDgnwHl5DnyuPAc+V4kDNid4kvLly2cqTxJxf+hqtwPehJ7+CxACzUwizaxzApyX58DnynPgc5UwmTNndsEzQUhM+DOHEEIIIYS4BApPQgghhBDiEig8TQZqhQ4bNkz9NwtmnBPgvDwHPleeA58rQtwbJhcRQgghhBCXQIsnIYQQQghxCRSehBBCCCHEJVB4EkIIIYQQl0Dh6eZ89913UqRIEdUusnbt2vLvv//Gu/+CBQukTJkyav+KFSvKX3/9FWN7r169VFF869GiRQvx9HmBw4cPS9u2bVVtuvTp00vNmjXl3Llz4qlzsn2ejDFu3DhxJY6eV3BwsLz22muqVm5AQICUK1dOJk2aJK7G0fO6evWqen+hIHdgYKB6Xx0/flzcdU4HDx6UTp06qf3xupowYUKKj+kp8/rnn3+kTZs26rnCPr/99pukBo6e1+jRo9XnHpqf5MqVS9q3by9Hjx518iwISSJomUnck7lz52pp06bVfvzxR+3gwYNa//79tSxZsmhXr161u//mzZs1X19fbezYsdqhQ4e0oUOHamnSpNH2798ftU/Pnj21Fi1aaJcvX44aN2/e9Ph5nThxQsuWLZs2ZMgQbdeuXer277//HucxPWFO1s8RBo5tsVi0kydPumROzpoXjlG8eHFt3bp12unTp7XJkyer++D58tR5RUZGanXq1NGeeOIJ7d9//9WOHDmiDRgwQCtUqJAWHBzslnPCeb799tvanDlztDx58mhfffVVio/pKfP666+/tA8//FBbvHixhq/BJUuWaK7GGfN6+umntRkzZmgHDhzQ9uzZo7Vq1cqlr0FCEgOFpxtTq1Yt7dVXX426HRERoeXLl08bPXq03f27du2qtW7dOsa62rVray+99FIM4dmuXTvNbPPq1q2b9vzzz2tmmpMteN4aN26sefq8ypcvr40cOTLGPtWqVVNCwFPndfToUSVg8IVvfcycOXNqU6dO1dxxTtYULlzYrpBJyTHdeV7WpJbwdPa8QFBQkJrfhg0bUny+hDgKutrdlLCwMNm5c6c0bdo0RitP3N66davd+2C99f7g6aefjrX/+vXrlRumdOnS8sorr8iNGzfEk+cVGRkpy5Ytk1KlSqn1mBvcVq5ynznzubJ242KOffv2FVfhrHnVq1dP/vjjD7l48aLqF71u3To5duyYNG/eXDx1XqGhoeo/XKbWx0RNyU2bNok7zik1jumJ5+DJ87pz5476ny1bNocdk5CUQuHpply/fl0iIiIkd+7cMdbj9pUrV+zeB+sT2h9xZ7NmzZI1a9bI559/Lhs2bJCWLVuqx/LUeQUFBam4wTFjxqj5rVy5Ujp06CAdO3ZU8/PU58qan376ScVtYU6uwlnz+uabb1RcJ2I806ZNq54zxLo9+eST4qnzQuxnoUKF5P3335dbt24pYYH314ULF+Ty5cvijnNKjWN64jl46rzwg3zQoEFSv359qVChgkOOSYgj8HPIUYjH0L1796hlJEhUqlRJihcvrqygTZo0EU8EH7CgXbt28uabb6rlKlWqyJYtW1TSSsOGDcXT+fHHH+W5556LYVHzVCA8t23bpqyehQsXVoker776qkr0sLUqegpp0qSRxYsXK4s0rEu+vr5qLvhRp3tzCXEteE8dOHDAJRZ3QpIChaebkiNHDvXlBRerNbidJ08eu/fB+qTsD4oVK6Ye68SJEy4Rns6YF47p5+enrGjWlC1b1iUfus5+rjZu3KgyU+fNmyeuxBnzevjwoXzwwQeyZMkSad26tVqHHz979uyR8ePHu0R4Ouv5ql69upoH3JuweObMmVOFfNSoUUPccU6pcUxPPAdPnBeqRixdulT9qINngRB3gq52NwUuSHyRwSVubdnD7bp169q9D9Zb7w9WrVoV5/4ArkDEeObNm1c8dV44JkqI2JYNQdwgLGqe/lxNnz5dHb9y5criSpwxr0ePHqmBeDZr8CVsWK49/flCOS+ITpRS2rFjh7LEu+OcUuOYnngOnjQvWNchOvHDbu3atVK0aFEHnTEhDsRhaUrEKeU2/P39tZkzZ6oSLijPgnIbV65cUdtfeOEF7b333otR8sXPz08bP368dvjwYW3YsGExSr7cu3dPlePYunWrKmOzevVqlU1csmRJLSQkxGPnBVAWBeumTJmiHT9+XPvmm29U+ZuNGzd67JzAnTt3tMDAQO2HH37QUgNnzKthw4Yqsx3llE6dOqXKv6RLl077/vvvPXpe8+fPV3NCuavffvtNZR537NjRbecUGhqq7d69W428efOqzwYs4/2T2GN66rzwWWjsg6/BL7/8Ui2fPXvWo+f1yiuvaJkzZ9bWr18foxTbgwcPXDYvQhKCwtPNgYBCHTbUe0P5jW3btsX4Akd5JGvw5VeqVCm1P77cly1bFrUNHz7NmzdXJV7wpYkvRtSOc+WXiDPmZTB9+nStRIkSSsRUrlxZffl7+pxQ4zIgIEC7ffu2llo4el74IuzVq5cqHYPnqnTp0toXX3yhamF68rwmTpyoFShQQL23cFzU+oRYcNc54ccnRJftwH6JPaanzgs/EOztY/uce9q87G3HwI87QtwFC/440oJKCCGEEEKIPRjjSQghhBBCXAKFJyGEEEIIcQkUnoQQQgghxCVQeBJCCCGEEJdA4UkIIYQQQlwChSchhBBCCHEJFJ6EEEIIIcQlUHgSQgghhBCXQOFJCEk1ihQpIr169eIzQAghXgKFJyEmYObMmWKxWNTYtGlTrO1oUFawYEG1/ZlnnhFvYv369WreZ86cSe1TIYQQr8fP668AISYiXbp08uuvv0qDBg1irN+wYYNcuHBB/P39xZ04evSo+Pjw9y8hhHgL/MQnxES0atVKFixYIOHh4THWQ4xWr15d8uTJI+4EhHCaNGlS+zQIIYS4CApPQkxEjx495MaNG7Jq1aqodWFhYbJw4UJ59tln7d5n/PjxUq9ePcmePbsEBAQogYr9bYG7+rXXXpPffvtNKlSooERj+fLlZfny5TH2Gz58uNr3xIkTKn4zS5YskjlzZundu7c8ePAg3hhPI2Rg8+bNMnjwYMmZM6ekT59eOnToINeuXYtx38jISPVY+fLlk8DAQGnUqJEcOnQoUXGjx48fl06dOikhDitxgQIFpHv37nLnzp147/fUU0+pueNx8Hh43Pz588vYsWPjvR8hhBAdCk9CTAREV926dWXOnDlR6/7++28lqCCs7DFx4kSpWrWqjBw5UkaNGiV+fn7SpUsXWbZsWax9ET/6v//9Tx0LYiskJEQJOIhdW7p27Sr37t2T0aNHq2WIyhEjRiRqHq+//rrs3btXhg0bJq+88or8+eefSvRa8/7776vj1ahRQ8aNGyclS5aUp59+Wu7fvx/vsSHEsd+2bdvU43z33XcyYMAAOXXqlNy+fTvBc7t165a0aNFCKleuLF988YWUKVNG3n33XXWdCSGEJIBGCPF4ZsyYoeHt/N9//2nffvutljFjRu3BgwdqW5cuXbRGjRqp5cKFC2utW7eOcV9jP4OwsDCtQoUKWuPGjWOsx/HTpk2rnThxImrd3r171fpvvvkmat2wYcPUuj59+sS4f4cOHbTs2bPHWIfz6dmzZ6x5NG3aVIuMjIxa/+abb2q+vr7a7du31e0rV65ofn5+Wvv27WMcb/jw4er+1se0Zffu3WqfBQsWaEmlYcOG6r6zZs2KWhcaGqrlyZNH69SpU5KPRwgh3gYtnoSYDFgXHz58KEuXLlUWR/yPy80O4F63tubBOvrEE0/Irl27Yu3btGlTKV68eNTtSpUqSaZMmZS10JaXX345xm0cE5bRu3fvJjgHWCDhcre+b0REhJw9e1bdXrNmjYpjhfXVGlgwEwJuf7BixYpYrv/EkCFDBnn++eejbqdNm1Zq1apl9xoQQgiJCYUnISYDcZEQiEgoWrx4sRJsnTt3jnN/CNM6deqoWMds2bKp+//www924x0LFSoUa13WrFmVYE1oX+wH7O2b1PsaArREiRIx9sP5G/vGRdGiRVX86LRp0yRHjhzK7Q53e0LxnQaIB7UWxcb5JWZehBDi7VB4EmJCYOFEzOGkSZOkZcuWKsHHHhs3bpS2bdsq0fn999/LX3/9pRKTcH/dux4TX19fu8dJ6b6OvG9iQGzmvn375IMPPlDW4TfeeEMlSqHkVGqfGyGEmBkKT0JMCLLAUR8TCTTxudkXLVqkRCfczn369FEiFdZSd6dw4cLqPzLnrYErP7GWx4oVK8rQoUPln3/+UQL84sWLSqgTQghxHiwgT4gJQRwi3OXo1tOmTZt4rXdwG8Mdb4D7oGSSO9OkSROVfY85NmvWLGr9t99+m+B9EWOKMki4v7UIhVAPDQ112jkTQgih8CTEtPTs2TPBfVq3bi1ffvmlKg8Ey2hQUJCKd0TsJFzR7kru3Lll4MCBymWOUAGcP8ovIbwAcZu2MZjWrF27VpVmQsmoUqVKqSSl2bNnKxGO0lCEEEKcBy2ehHgxjRs3lunTp8uYMWNk0KBBKvHm888/V1ZPdxaeAOcJy+XUqVNl9erVqn7pypUrVbtQhA/EBepvIqEItUHhXscxsA6iFUlWhBBCnIcFNZWceHxCCHEZKACPDPNPP/1UPvzwQ155QghxM5hcRAjxSJCNbsuECROiWlsSQghxP+hqJ4R4JPPmzVNtOFu1aqWSqdDOE61CmzdvLvXr10/t0yOEEGIHCk9CiEeCrknITEfPeGSqGwlHcLMTQghxTxjjSQghhBBCXAJjPAkhhBBCiEug8CSEEEIIIS6BwpMQQgghhLgECk9CCCGEEOISKDwJIYQQQohLoPAkhBBCCCEugcKTEEIIIYS4BApPQgghhBDiEig8CSGEEEKIuIL/A84BueBR28PMAAAAAElFTkSuQmCC",
+      "text/plain": [
+       "<Figure size 700x500 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Applied depth-varying n to 11164 faces\n",
       "\n",
-      "Face 1050 after depth-varying n:\n",
-      " Face ID  Elevation      Area  Wetted Perimeter  Manning's n\n",
-      "    1050 925.238464  0.000000          0.000000     0.120000\n",
-      "    1050 925.438477  0.061161          0.643449     0.106404\n",
-      "    1050 925.476440  0.086584          0.765575     0.104117\n",
-      "    1050 925.493713  0.099605          0.821087     0.103104\n",
-      "    1050 925.548950  0.147376          0.998725     0.099982\n",
-      "    1050 925.659363  0.270837          1.354001     0.094234\n",
-      "    1050 925.880249  0.629689          2.064553     0.084476\n",
-      "    1050 926.321960  1.794801          3.485657     0.070381\n",
-      "    1050 927.205444  5.915092          6.327866     0.055491\n",
-      "    1050 927.432739  7.346943          6.935455     0.053358\n",
-      "    1050 927.792969  9.863969          7.830056     0.050830\n",
-      "    1050 928.180542 12.901370          8.792315     0.048957\n",
-      "    1050 928.955688 20.000252         10.716835     0.046823\n",
-      "    1050 929.446777 25.238560         12.065067     0.046115\n",
-      "    1050 930.338501 36.326725         14.513172     0.045457\n",
-      "    1050 930.801758 42.858135         15.659853     0.045288\n",
-      "    1050 931.899963 60.283066         18.378162     0.045096\n",
-      "    1050 932.728333 75.319084         20.619568     0.045042\n",
-      "    1050 933.790649 97.193497         23.203962     0.045014\n",
-      "\n",
-      "n varies with depth: True\n"
+      "n at base (d=0):   0.1200\n",
+      "n at top  (d=8.6 ft): 0.0450\n"
      ]
     }
    ],
    "source": [
-    "# --- Apply depth-varying Manning's n (HEC-15 vegetal retardance) ---\n",
-    "# n decreases with flow depth: n(d) = n_asymptote + (n_base - n_asymptote) * exp(-d/d_half)\n",
-    "N_ASYMPTOTE = 0.045  # Deep-flow Manning's n\n",
-    "DEPTH_HALF = 1.0     # Depth at which n decays to ~37% of range\n",
-    "\n",
     "def vegetal_retardance(elevation, depth, current_n):\n",
-    "    \"\"\"HEC-15 vegetal retardance: n decreases with depth.\"\"\"\n",
+    "    \"\"\"Exponential decay: n decreases from current_n toward N_ASYMPTOTE with depth.\"\"\"\n",
     "    if depth <= 0:\n",
     "        return current_n\n",
     "    return N_ASYMPTOTE + (current_n - N_ASYMPTOTE) * np.exp(-depth / DEPTH_HALF)\n",
     "\n",
     "num_modified = HdfMesh.set_face_mannings_n_values(\n",
     "    hdf_path=modified_geom_hdf,\n",
-    "    mesh_name=mesh_name,\n",
+    "    mesh_name=MESH_NAME,\n",
     "    mannings_n_func=vegetal_retardance,\n",
     "    face_ids=None,\n",
     "    pin_tables=False,\n",
     ")\n",
     "print(f\"Applied depth-varying n to {num_modified} faces\")\n",
     "\n",
-    "# Verify: read back and check that n now varies with depth\n",
+    "# Read back and visualize\n",
     "after_tables = HdfMesh.get_mesh_face_property_tables(modified_geom_hdf)\n",
-    "after_df = after_tables[mesh_name]\n",
+    "after_df = after_tables[MESH_NAME]\n",
     "after_sample = after_df[after_df['Face ID'] == sample_face]\n",
     "\n",
-    "print(f\"\\nFace {sample_face} after depth-varying n:\")\n",
-    "print(after_sample.to_string(index=False))\n",
-    "print(f\"\\nn varies with depth: {after_sample[n_col].iloc[0] != after_sample[n_col].iloc[-1]}\")"
+    "# --- Figure: Before vs After depth-varying n ---\n",
+    "fig, ax = plt.subplots(figsize=(7, 5))\n",
+    "ax.plot(mod_sample[n_col], mod_sample['Elevation'], 'r--s', markersize=4,\n",
+    "        label=f'Before: Uniform n={new_n}', linewidth=1.5, alpha=0.6)\n",
+    "ax.plot(after_sample[n_col], after_sample['Elevation'], 'b-o', markersize=5,\n",
+    "        label='After: Depth-varying n', linewidth=2)\n",
+    "ax.axvline(x=N_ASYMPTOTE, color='gray', linestyle=':', alpha=0.7,\n",
+    "           label=f'Asymptote n={N_ASYMPTOTE}')\n",
+    "\n",
+    "base_elev = after_sample['Elevation'].iloc[0]\n",
+    "ax.annotate(f'Base elev\\n{base_elev:.1f} ft',\n",
+    "            xy=(after_sample[n_col].iloc[0], base_elev),\n",
+    "            xytext=(after_sample[n_col].iloc[0] + 0.02, base_elev + 1),\n",
+    "            arrowprops=dict(arrowstyle='->', color='gray'),\n",
+    "            fontsize=9, color='gray')\n",
+    "\n",
+    "ax.set_xlabel(\"Manning's n\", fontsize=12)\n",
+    "ax.set_ylabel('Elevation (ft)', fontsize=12)\n",
+    "ax.set_title(f'Face {sample_face}: Depth-Varying Manning\\'s n', fontsize=13)\n",
+    "ax.legend(fontsize=10, loc='upper right')\n",
+    "ax.grid(True, alpha=0.3)\n",
+    "fig.tight_layout()\n",
+    "plt.show()\n",
+    "\n",
+    "print(f\"\\nn at base (d=0):   {after_sample[n_col].iloc[0]:.4f}\")\n",
+    "print(f\"n at top  (d={after_sample['Elevation'].iloc[-1] - base_elev:.1f} ft): {after_sample[n_col].iloc[-1]:.4f}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "55997a13",
+   "metadata": {
+    "papermill": {
+     "duration": 0.010027,
+     "end_time": "2026-05-12T12:23:53.063958+00:00",
+     "exception": false,
+     "start_time": "2026-05-12T12:23:53.053931+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Step 8: Extend Tables to Higher Elevations\n",
+    "\n",
+    "The preprocessed face tables only reach the terrain elevation at each face.\n",
+    "For deep flood events, water may rise above this — and HEC-RAS extrapolates\n",
+    "with the last n value (constant, not depth-varying).\n",
+    "\n",
+    "`HdfMesh.extend_face_property_tables()` appends rows from the current maximum\n",
+    "up to a target elevation, using a rectangular cross-section assumption for\n",
+    "area and wetted perimeter. The Manning's n function receives `(depth, base_n)`\n",
+    "so it can implement any depth-varying formula."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 12,
+   "id": "5fd47d09",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T00:22:32.403675Z",
-     "iopub.status.busy": "2026-05-12T00:22:32.403675Z",
-     "iopub.status.idle": "2026-05-12T00:22:36.531971Z",
-     "shell.execute_reply": "2026-05-12T00:22:36.531971Z"
-    }
+     "iopub.execute_input": "2026-05-12T12:23:53.083856Z",
+     "iopub.status.busy": "2026-05-12T12:23:53.083660Z",
+     "iopub.status.idle": "2026-05-12T12:23:56.469012Z",
+     "shell.execute_reply": "2026-05-12T12:23:56.468256Z"
+    },
+    "papermill": {
+     "duration": 3.396178,
+     "end_time": "2026-05-12T12:23:56.469740+00:00",
+     "exception": false,
+     "start_time": "2026-05-12T12:23:53.073562+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:22:35 - ras_commander.hdf.HdfMesh - INFO - Pinned property tables for mesh '2D Interior Area'\n"
+      "2026-05-12 08:23:55 - ras_commander.hdf.HdfMesh - INFO - Pinned property tables for mesh '2D Interior Area'\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:22:35 - ras_commander.hdf.HdfMesh - INFO - Wrote face property tables for 11164 faces in mesh '2D Interior Area' (476525 total rows)\n"
+      "2026-05-12 08:23:55 - ras_commander.hdf.HdfMesh - INFO - Wrote face property tables for 11164 faces in mesh '2D Interior Area' (476525 total rows)\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:22:35 - ras_commander.hdf.HdfMesh - INFO - Extended 11164 face tables in mesh '2D Interior Area', total rows added: 429470\n"
+      "2026-05-12 08:23:55 - ras_commander.hdf.HdfMesh - INFO - Extended 11164 face tables in mesh '2D Interior Area', total rows added: 429470\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:22:35 - ras_commander.hdf.HdfMesh - INFO - Using existing Path object HDF file: G:\\GH\\ras-commander\\examples\\example_projects\\Muncie_414_modified\\Muncie.g02.hdf\n"
+      "2026-05-12 08:23:55 - ras_commander.hdf.HdfMesh - INFO - Using existing Path object HDF file: G:\\GH\\ras-commander\\example_projects\\Muncie_414_modified\\Muncie.g02.hdf\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:22:35 - ras_commander.hdf.HdfMesh - INFO - Final validated file path: G:\\GH\\ras-commander\\examples\\example_projects\\Muncie_414_modified\\Muncie.g02.hdf\n"
+      "2026-05-12 08:23:55 - ras_commander.hdf.HdfMesh - INFO - Final validated file path: G:\\GH\\ras-commander\\example_projects\\Muncie_414_modified\\Muncie.g02.hdf\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:22:35 - ras_commander.hdf.HdfMesh - INFO - Using existing Path object HDF file: G:\\GH\\ras-commander\\examples\\example_projects\\Muncie_414_modified\\Muncie.g02.hdf\n"
+      "2026-05-12 08:23:55 - ras_commander.hdf.HdfMesh - INFO - Using existing Path object HDF file: G:\\GH\\ras-commander\\example_projects\\Muncie_414_modified\\Muncie.g02.hdf\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-11 20:22:35 - ras_commander.hdf.HdfMesh - INFO - Final validated file path: G:\\GH\\ras-commander\\examples\\example_projects\\Muncie_414_modified\\Muncie.g02.hdf\n"
+      "2026-05-12 08:23:55 - ras_commander.hdf.HdfMesh - INFO - Final validated file path: G:\\GH\\ras-commander\\example_projects\\Muncie_414_modified\\Muncie.g02.hdf\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Extended 11164 faces\n",
-      "Total rows added: 429470\n"
+      "Extended 11164 faces, total rows added: 429470\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\n",
       "Face 1050: 19 rows -> 71 rows\n",
-      "  Elevation range: 925.24 - 959.79 ft\n",
-      "  n range: 0.0450 - 0.1200\n",
-      "\n",
-      "Pinned attribute: True\n"
+      "Elevation range: 925.24 - 959.79 ft\n"
      ]
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAABKUAAAIDCAYAAADVKK2CAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjgsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvwVt1zgAAAAlwSFlzAAAPYQAAD2EBqD+naQAA06BJREFUeJzs3QeYE9XXx/GzSxfpHaQqXVBQVBDFgoq+KiIKghXsHfGPBRsCNuyiYkexICrYFSuCCiiCCFJFKYIgHaTDbt7nd7Ozm2SzPZuy+/08T2AzM5nM3Mwkd87ce26Sz+fzGQAAAAAAABBFydF8MwAAAAAAAEAISgEAAAAAACDqCEoBAAAAAAAg6ghKAQAAAAAAIOoISgEAAAAAACDqCEoBAAAAAAAg6ghKAQAAAAAAIOoISgEAAAAAACDqCEoBAAAAAAAg6ghKAQCAfHn11VctKSnJ/Z9bjRo1cg+gsA0ZMsQdn9999x2FXUQ/g2XLlrn1X3LJJYWyfgBA4SMoBQAJzKuQZ/fYvHmzJYLjjjsuaLuTk5OtSpUqdswxx7igh8/ns6IqP8GdgpRtTo+ieBGvi9bQ/axYsaJ16NDBHn/8cdu7d2+sNxHF+Hu6IIFagm8AgERWMtYbAAAouAMPPNAuuOCCsPPKli2bUEV888032/77728pKSn2119/2YQJE+yHH36wmTNn2siRI2O9eQkbkFFgKtAHH3xgv/32m1188cWZLoiLckumSy+91A444AAX5Pz777/d8TVw4ED79ttv7eOPP4715qGYfk9Xrlw56tsDAEA8ICgFAEXAQQcd5O6WFwX/+9//rHbt2unP586da0ceeaQ988wzLnjQuHHjmG5fIgrXtUWtNxSUChewKsouu+wyO+qoo9KfDx8+3Nq1a2effPKJayFWnMoCOVPrxX79+tmkSZMKfGwUpe9pAAAihe57AFAMqJXRddddZwcffLBVqlTJypUrZ23atLEHH3wwy25La9euda2Wmjdv7pavWrWqCw498sgjmZadM2eOnXfeeVanTh0rXbq0NWzY0K6//nrbsGFDgbdd29mlSxfXsuWXX34J6oqlllSPPvqotWrVysqUKRMUfPn999+tV69eVrNmTTdPwawBAwaE3SYvz5G6Ol555ZUuKKYWZgpWjB07Nux2aXteeeUVO/roo103sP32288OP/xwNy277jW6yG3fvr1bXhe52mZd9Ir+D+zSI507d7aSJUva6tWrw27HRRdd5JadNm2aFdSePXtca7RTTjnF6tev78pN5Xf22Wfbr7/+mu1rP/zwQzviiCPcftWoUcP69+9v//77b67fOy/lGUl169Z1+yczZszI8fPy/Pfff3bPPfdY69at3fmhli4qN7Xqy6r75K5du+y2226zBg0auOOrZcuWrrxDu6YGdudU6y2VSYUKFYJasK1fv94dzzquvc9Jx7uO+6w+W3VTVHdFrUutEXXeKNC7adOmTOf+TTfd5IIoWnf16tWtZ8+eYdf9xx9/uOPW2w59TxxyyCFu2wL3S8fvjTfeaE2bNk0vL+3/VVddZVu2bMm0rY899pgr9/Lly7vtVTfejz76KOy+qcVbnz593Htrv/R9MWXKFEtU+l7W56+yyWre1VdfnX5s3Xvvve7v448/PsvugHn5TL3vw23btrnPTOeIXtO2bVt77733IvYZaP4ZZ5zhtkXr17Fx55132o4dOzItq5azDz30kNt+nTv6/4EHHrDU1NQcShMAEO9oKQUAxcCLL77oLm6PPfZYO+2001ylXxfct99+u7sQHz9+fNDyixYtchc4upBUUOSss86y7du327x58+z+++93rZk8ulDUxbByQHXv3t0FM+bPn29PP/20ffHFF/bTTz+53FCR4AVqPAp8TZ8+3f7v//7PXdzowlwUGFCAQBe355xzjrvAUtDmySefdC1i9BpdCAXSsl27dnUXYhdeeKHb33feecf69u3rAgB6L48uts8//3wXsNKFlJZRMO6rr75y3cO0/+GCdw8//LBrcaFyOvnkk61EiRIuSKBgmII6mn7ooYcGvUZBsh9//NFGjx5tgwcPDpqn1+kiUYGRjh07Frh8N27c6IIJCgDoONHnpsCfPuPPP//cXURqe0Pp+NFnrbJWGap8tb3ff/+9/fzzzzl+/vkpT+9YiGSusdDjK9zn5ZWTziWdDwoYKXiwdetW9xnqvHn33XfdORNK54mCewoGeOV2ww03uFZrCq6G0nq+/PJLO/300+2aa65x7yHr1q1zn/eff/7pghIKCC9dutQdC59++qn7LHTeenbu3GknnXSSO45UvgoiKQiggNLzzz/vApveZ+Stc+XKlW6ftR8KaHif8TfffOOC0/LPP/+4QKTOFZ2DvXv3dn9rvc8++6z7zBRQ1feNykn7qXX26NHDnW/a5tdff919nyhYLrt377Zu3bq57yedC/r8FTjXfulzUBBPAXaPvqNUFqtWrXLnvAJZCxYscPurzyIR3XLLLe7Y12ejsvCOJZ1Ld999twsmKmgnXiB+8uTJQV1xA7sD5uUz9ajMtawCljpe9Rm+/fbb7hieOHGim1eQz2DUqFF27bXXuu30vrt10+G+++5z55we+g7wXHHFFS5AreCnXqcAr8pg6tSpES17AEAM+AAACWvp0qW6IvcdeOCBvnvuuSfTY9q0aW655cuX+/bt2xf02tTUVF///v3d63/44YegeYcffrib/sILL2R6z7///jv97/Xr1/sqVqzoq1evnm/ZsmVBy40dO9at47rrrsvVvnTp0sUtv3r16qDpv//+u69cuXK+pKQkt79y8cUXu2UPOOAAt2+BUlJSXHlo/sSJE4PmDRo0yE3Xfgdq2LChm37sscf6du/eHbSv1atX95UpU8a3cuXK9OkqFy3fr18/3549e9Kn67VnnHGGm/fLL7+kT9dnoWnly5f3zZkzJ9O+jx492s3X/6F27tzpq1q1qq9JkybuMwv09NNPu9c98cQTvrzyynDSpEnp03bt2hW0n4Gfwf777+/r2rVr2O0OV9a33XZb2M9fZa1HoLyWp3jvm9f99c4Jj463WrVquXmTJ0/O1efVt29fN//FF18Mmv7vv//66tev76tRo4b73EKP7ebNm/s2b96cPl1/a5qO7RkzZmQq1+TkZN9XX32V6f1VTpp/++23B03/9NNP3fSDDjrInQeem2++2U2/8MILM30PaBv++++/9OedOnXylShRItPnuWjRIl+FChV8bdq0SZ/21FNPZXn8bdiwIf3vjz76yC03YMCATMvpvXXceQYPHuyWveuuu4KO961bt7rvpdKlS/tWrVqV6XMdPnx40Hqff/759GMk8BjPK++zKMg6cvqe1uPzzz8Peo3Ow2rVqrlzX39r//V6fRf99ttvQct6x2tW25iXzzTw+7B79+5B34dff/21m37KKacELZ/Xz2DevHm+kiVL+g455BD3GxLogQcecMs/8sgj6dP0Wk3T8tu2bQsqI30/a562AQCQmAhKAUAC8y52sno8/vjj2b5+5syZbrkhQ4akT/vpp5/SAzQ5eeyxx9yyY8aMCTu/ffv27qIhN7wLd11A6yLrzjvv9J1//vkuIKXpN9xwQ6aLoCeffDLTeqZMmeLmnXrqqWEvgHWRV7Zs2aCLLe8iLDQ4J8OGDct0kdS2bVsXsNixY0em5RXE8PYj9KLxpptuCrvv2QWlRK/TfF0UBmrXrp27SA0MABQkKJUdBYcUEAgMGnnbHRqs8sq6cuXKLmgZGCAJF5TKa3nKggUL3COv+3vppZe6z+Puu+92wUlto3cBnpvPa926de4C/4QTTgj7Pl6g5uOPP850bL/xxhuZln/99dczBe+8cu3Ro0em5XXc6vhVwGL79u2Z5p900knutToPZO/evS7wUKlSJd/GjRuzLaNZs2aFDdp6Bg4c6ObPnTs3aF8VfMiOF5QKDaKF0nFSpUoVF3wJDcAGrmfkyJFBZVGzZs2gIKC3rqZNm8ZVUCq7x4033pjpdR988IGbd9xxx/kuuOCCLL/zsgtK5fUzDfw+/OuvvzItr3n6DvXk5zPQd3ngMRr6GgV1DzvssExB2PHjx2f5/UxQCgASF933AKAIUJcJdanIirrKqDudul8sXLjQdVEL7PakbjgedRGRwO4ZWVE3LVEXPXURCaUuFur6pkdod7mseN2Y1JVKuYWUV0hdeNTFKJS6DoXych+FS0qsXCdan7pEqYui8lV51M0oXBc4dWULXK+6sSj5uvKsKMdJKC9Hl8o5N9ubG+q6onxA6oZ54oknpucJ0zapq5vyuETK7NmzbcSIEa4L5Jo1azLlHNNnqdxh4cootKzV/UrdsNQFUDlgwslvebZo0SJf+/fyyy8HbaPyGqnroLoE5ebzUndX5bdRN7NwSavVdc3bXnW7y6mcQo+vnN5f69V5pW5RynMVStPV9Uufo9at5ZX/St0qc+pG6Z3PygUWbt+8z0D/Kz+dul2pC7DKTl3A1NVMuYSaNGkS9Dp1ddQxo3xISq6vctFyKvvALpM6J9VdTMeClycpkLotBm6HlldZnHDCCZlGGVV3YnUZ9D6P3FBXuNdeey3svHDd0NRdTnm/IvU9HUrdFdU19LnnnnPP1aVW3T3zIq+fqUfd6sINKqGRKwPz1+XnM/C2yes6GKpUqVJB57uOmZzOHwBA4iIoBQDFgHL9KKdUs2bNXN4X5e9QxV85iZRnSRfYHi/pcL169XJcr3LriEbGy47yzOQ2KKX8JIGj72WnVq1amaZ5eXfCzRMvoOIt59H26SIqq/fwykUXzQroKX9KuAvnwH3OzfbmhgIwuoj/4IMPXKL2atWq2UsvveTmXX755RYpys+ii0svKKn8QwrcKHCg99bFYeCxktN+hZZdOAUpz/zQBXXg6HvZCbdf3jGv/Ex6FPTzz66MInF85+d8Vv4mPXLaN+UvUoBBwY7PPvvM5WDzjtehQ4faueee654rX5SWUz4kfQ9pWVH+OSV+V76swPdXri49cnp/b9+8XHIFPd+Uayk0QbiCe8oVFpivyROa/60wKP+WF5QKzKWVW3n9TD1ejq9QCt4HJhfPz2fgbZPyR+WG3kPfzeF+Q/L7nQoAiB8EpQCgiFPLDl0I6i69Lkq8ZM2iC0UFpQJ5CXIVJMiJWjKJWroE3mWPltDE1IHblNXIb2r9E7hcYAsgXWyFBqa89XgXad7rDjvssPTRAAuyvbmlFhNKZjxmzBiX/NxLCl7QYeoD6SJRQSclKA9MlO0dK16LhVBZlXVo2YVTkPKM5fGlkSnDJbPPjspDI++FTsuqjCJxfOfnfA5NJp4dnfdKsK4WbWq9p4T4Tz31lAt+q8WTWsqI9lutinSOabROtVbUcmplpRZcGrnNe38l1s5qlLdAXpkpaXc4eRn90QtKhSao1zYrKKVWVJE813JDNw0UdNYIhGqdp8EW1KJOoxHmVn4+07zIz2fgbZMCp7nZF72Hjht9R2tkz5zWDwBILJlvCQMAihSvW51GxwoMSImCD1l1GdJFY068EZsCu3PEWrt27dz/6jYWrjWAAh8akr558+ZB8/bt2xd2P7wy8tariyh1O9LoUrpojATvc9GFZ1bOPvtsd0GmFlIalU2tBy677DKL9LGiroChASl1sZs1a1aWrwt3HKmLqFqZ6AI0tDtXoMIoz8Kk0QcVLMrPMR+unEKPr5yoFZK6SSnYrM8llHfce614dJzrM9DyapVWWOezWl6qBZpauynYpNZvGukylIK+2jaNMKfAqmh0R9FxoG3VORrabTQctfxUWWh5dSELpCBGoo/Mpm67K1ascDcONBKkzs9w3Uyz+/4o7O/o/HwG3jZ53fhycsghh+R4/gAAEhdBKQAo4ho2bOj+V46gQOoe88ADD4S96NZjypQpLodRqMAWFxpaXkGFO+64I2x3G1005/bCI1LUMuPAAw90LTa+/vrroHnDhw933d/UKiNwuHHP4MGDXf4tj4ZQ1wVhmTJl7Lzzzkufrrwu2je1YgjXTUtD3S9btizX2+zlhPr777+zXEbbq9Ya8+fPd9upIIA3HHwkjxUFLgI/S13o/u9//0vP5xOOyln5YUJbXSnIpFxg4bpFBspPeSrnTLi8XYVNXUt79erlLrYVKAjMzeZRjrVwAaNhw4YFddPT3zomFeRS97Dc0HGg41etRkLPX+Ur0ueg/F1eCyV1t1LLOr3XjTfemClwoekKIHoBaQUMFCwaN25cpvdWkEGt9TxqGRXaDTaw9YqXY0jHU7gWLaHLaVuvvvpqW758uTvmwgWmfv/99/RWOTov9VnouZeLzqPg7eLFiy1RKfeZgs/qAqmcemrlpFxcr7/+ur311lu5/v7I62eaV/n5DNRdU5+1Wn4p6BZK3xuBOdYuvPBC97+6hAZ+P+i3KLSlLwAg8dB9DwCKOF2U6KF8L8rXpNYMuhBQ6wS1ngrXTebNN990XVV0p14XQUoArrvgurjUxYICO6KWO7rY0YWT7mYr0bFacqgLmIIIutjp1KlTnpL7FpQCIOpyo+6KSgysbVOwRS0F1IpEASslXA6Xi0cXPG3btnUJnPW3ykz7qpYfgTl5dJGvYJuSIiuvkJJIq6uSLrIVKFFQQheOoTlosqLyVeutJ554wgWFvC4qd955Z9Byel91GVNienVxyiqPS37pIlEt5NRSSheaChaozHTxp+MhXOsz0cWyyky5y7w8Q5MmTXJlrQvJnOSnPNWqRsIFhQrbs88+6xI8q7WPd36om5yCAmoxosTOOtdCE5GrVYm6u+mzk/Hjx7vA58CBA10C/txSQnidWwpoKTimoIPONwUx9J6jR48OCgTqM1D5alv1/6mnnuqCCUpAr3NTAWuvZZXOZyX1VhBWx2P79u3dsanvDJ1DCk56LWK0vueff94lMtdnrVZOCpoqZ5QCJQpaixKvDxo0yAXKVAbKiab31neQjrHA1j9qaaVWeTrn1N1Y69ZxrmNQ3YTVhVTb4R37OpeVLFvnivZDLc7U6k7boLxouWnxGS1LliwJm2zco/xaKg8FchRAVM6tF154IX3+K6+84r6fFLjTMeclItfnpcCmgtX6jlZ3Nx2PXne9vHym+ZHXz0DngM4h7Yda8ul7WsePEvLruNCxrYC7l0tL265jSce1BqdQni39xijIpt+zcC3yAAAJJNbD/wEAfAUeavyUU07Jdrm1a9e6IcHr1q3rhu9u06aN75lnnnFDfmc1nPaaNWvcMOVNmjTxlS5d2g0DfuSRR/oee+yxTMsuXLjQd+mll7rhwrWshnXXe2jo759//jlX+9KlSxe3LatXr85xWW2vltX+Z2XOnDm+c845x1e9enVfqVKl3LZpf9atW5dpWc3TY+PGjb4rrrjCV6tWLV+ZMmV8hxxyiO+tt97K8j3GjRvn69q1q9tfvUe9evXc8O2PPvpo0PtkN2S759NPP/V16NDBV65cufRh4sPp3Lmzmzdx4kRfQXhlGLpN7733nq99+/a+/fbbz5Vdr169fH/++WfYMh89erSbpv81fL23/dWqVfNdcsklYT9Lr6wLUp6SXRllt7/Tpk3LcdncfF47duzwjRgxwg1dX758ebffjRs39p111lm+MWPG+Pbu3Zvp2N65c6fvlltu8dWvX9+dJ82bN/c99dRTvtTU1KB1B5ZrVlQeOr9UliorfVY63ufOnRt2+V27dvkeeeQR36GHHuq2df/99/e1atXKd/PNN/s2bdoUtKzOgzvvvNN38MEHpy/btGlTX9++fX0TJkxIX2769Om+K6+80i1XuXJlt6yWu+6663zLly9PX27+/Pnu3GvXrp07NnRu6XtFn8m8efMybeu+fft8zz//vO/oo4/2VaxY0S3foEEDX7du3XyjRo3ybdu2LWh5vVfv3r3dNui4PeaYY3yTJ0/O1eeYE++zKMg6vO/pnB76HHbv3u3Ov+TkZLcPob788ktfUlKS76ijjgo6xl599VX3nauy0rpCz7HcfqY5naPesRwqP5+BfhvOO+8897vkHcPa99tuu823YMGCTMfEAw88kP57pP/vv/9+35IlS7L8DQMAJIYk/RPrwBgAALHktcDJS5e7WFBrBg3JrhHx1KIgp25xiA9qZabWH1S5AAAAglGbBQAgQaj7iroTqrsbASkAAAAkOnJKAQAQ55SzRXlflL9HuXSUKBgAAABIdASlAACIc7fffrsbbU/J5EeOHOkSGQMAAACJjpxSAAAAAAAAiDpySgEAAAAAACDqCEoBAAAAAAAg6ghKAQAAAAAAIOoISgEAAAAAACDqCEoBAAAAAAAg6ghKAQAAAAAAIOoISgEAAAAAACDqCEoBAAAAAAAg6ghKAQAAAAAAIOoISgEAAAAAACDqCEoBAAAAAAAg6ghKAQAAAAAAIOoISgEAAAAAACDqCEoBAAAAAAAg6ghKAQAAAAAAIOoISgEAAAAAACDqCEoBAAAAAAAg6ghKAQAAAAAAIOoISgEAAAAAACDqCEoBAAAAAAAg6ghKAQAAAAAAIOoISgEAAAAAACDqCEoBAAAAAAAg6ghKAQAAAAAAIOoISgEAAAAAACDqCEoBAAAAAAAg6ghKAQAAAAAAIOoISgEAAAAAACDqCEoBAAAAAAAg6ghKAQAAAAAAIOoISgEAAAAAACDqCEoBAAAAAAAg6ghKAQAAAAAAIOoISgEAAAAAACDqCEoBAAAAAAAg6ghKAQAAAAAAIOoISgEAAAAAACDqCEoBAAAAAAAg6ghKAQAAAAAAIOoISgEAgixbtsySkpJsyJAhlAwAAIiI7777ztUvXn31VUoUQDqCUkCC/qBn9Zg+fbrFq59//tluuOEGO/roo23//ffPsWKye/duu/vuu61x48ZWpkwZO/DAA2348OG2d+/eTMs2atQoyzJZv359puX/+ecfu+iii6xGjRpWrlw5O/zww+3dd98t8D4qkOO973vvvRd2mffffz99GQI/Gce0/gcAIBR1n8Sp+4Q+ypYtmzAH9KhRo9w2V6xY0Xbs2BHrzQGKjZKx3gAA+dOnTx877bTTMk0/6KCD4rZIP/vsM3vmmWesRYsWdsghh9jUqVOzXb5379724YcfWv/+/a1jx442bdo0u+uuu2zJkiVhg1la7x133JFpeoUKFYKeb9y40Tp37mxr1661gQMH2gEHHGBvvfWW9erVy1555RXr169fgfdVlbDRo0fbOeeck2me3kPzd+3aZfGoYcOGtnPnTitZkp8IAED8oO4T33WfoUOHuhuJgUqUKGGJ4uWXX3Y3QP/8808XrLv44otjvUlA8eADkFAmTZrk06n78MMP+xLNmjVrfNu2bXN/v/vuu24/Ro8eHXbZTz/91M0fOHBg0HQ91/Qff/wxaHrDhg19Xbp0ydV2DBo0yK3jo48+Sp+2b98+X4cOHXxVq1b1/ffff778uueee9y6+/Tp4ytRooTvn3/+CZq/evVqX8mSJX19+/Z1y2n54s47pvU/AABZ/U5Q94nvus+MGTNy9TlmVfeLpdmzZ7ttGzNmjK9du3a+Y489NtevVTlu3769ULcPKMrovgcUQeomd8kll1izZs1sv/32c3fL1GVO3cbCWbNmjetW16RJE9dNrmbNmnbSSSfZV199FbTcH3/8YRdeeKHVqVPHSpcu7ZqNDxo0yLZv356r7apVq5aVL18+V8vq7p0MGDAgaLr3/I033gj7un379tnWrVtzXLfuhJ1xxhlBd/Kuv/56dydRLboCLVy40N01y4sLLrjAkpOTbcyYMUHT9VxNwzU/nGeffdZOPvlkq1evnitjlbWWVZ6nUFqPPme1IOvSpYsr22rVqtlll11m27ZtC1pWy2n5LVu22NVXX+0+Y7XW0nHx008/5ZhTKnDaJ598Yh06dHCv1/bpGFC5hxo/frxrEaflGjRoYPfee699/fXXuconoVZkeq/mzZu7Y7hy5crWpk0b9155yVmh1mqtW7d2x7VagI0YMSLH1wMAEg91n9jXffJL9cjbb7/dbZ9+r2vXru26GS5fvjwopYO6HIa2Xrryyivdb/6NN96YqbW9uuGFq59k1UpKqSXOPvtsV2eaMmWKa5kfSnULvZ/qM8OGDXPbrHrOO++84+b7fD7XDfCwww5z9Ret8/jjj7dJkyYVqM4HFGX0zQASlPq6h+YL0A+5AlAKPqkyoSbZuhDfsGGDvfbaa+6H9s0337S+ffumv0Y/fApM/Pvvv64CoPwCqhwoN5V+cBWckpkzZ9oJJ5zgggOqAOgH9LfffrOnnnrKfvzxR5s8ebKVKlUqYvs3Y8YM9x7169cPmq7ndevWdfNDKbiiCoDyLlSqVMm6d+9uDzzwgFves3r1alu1apWdf/75mV5/1FFHpb+3ys7TsmVLV455qSQo6PN///d/Lihy6623pk/X89NPP93lcwjnkUcecduhIGHVqlXt999/t5deesm+/fZbmzt3rgs6BZo9e7Zbn5rd63NVQEYVKwXEXnjhhUzrP+WUU9x7K1eXjovHHnvMbefSpUszNfUPR5VWVaKuuuoq161S3Su1zVWqVLHBgwenLzdu3DjXzUKVtXvuucd1BdQx+PHHH+eq/K699lrXnUDHpLoZqFKpoKjKIbeee+45d1xfeuml7rhVIFOfhbosBJ4DAIDEQN0nvus+uvEVWjdVUCa7vFLabtVNVJdUyoObb77Z/d4rsPPll1/aL7/84n63Vcft1KlTpuDON9984+o8gfUDBYZUHzrmmGNylYpAAS/Vj/X+usGnOsL//vc/Vw+5//77w75G87Xtl19+uQt+6Saa6Obt2LFj3bpUN/PWrfr0hAkT7Mwzz8x3nQ8osmLdVAtA3nhNn8M9evfu7ZbxusgFUrPiZs2a+Vq2bBk0/dRTT3WvnThxYqbXpKSkpP/dtm1bX/PmzX1bt24NWmbChAn5aoqdU/e9/fff33fEEUeEnaem5nXq1Amadtppp/mGDRvme++993xjx471XXnlla77XL169XyrVq1KX+6XX35x73vLLbeELSOv610gTVMT+bw2YVcT+cCuhvpfzz/++GM3P1z3vXCf3ddff+2WfeihhzJtV1JSkm/69OmZykJdBAOb4l988cVu+auvvjpo2XfeecdNf+6559KnLV26NNO2edP2228/97cnNTXV17p1a1/t2rXTp+3du9dXt25dX82aNX0bN25Mn67tady4ca6OlypVqrhjsyDniI6RzZs3B32+1atX9x111FH5Wi8AIDao+yRG3SfcY9SoUZk+x8A6wAsvvOCmqXthoE8++cRNv+CCC9KnDR8+3E1bvHixe758+fL0ZfS/0kTInDlz3PNHHnkkV9v/9ttvZ0ojcNZZZ7m6jLrmBdK2a1nVqUO77Hl14ueffz5ouupFhx12mK9Ro0au3pSfOh9QlNFSCkhQV1xxhZ177rlB09TcWQK7yOmuopJWq36hlk5qPaLubbqro+baEydOtG7durm7VKF050l0t2bOnDmu+5Xu+OjhUdJMvZ/uZqm5c6Rou3VXLBzdcQsdFeXTTz8Nen7eeefZscce6+4KqqXOiy++mL5eCbdu705e6Lr9dbO8O/XUU91notZRurun/9U0W9N//fXXsK/xPrvU1FT777//3F04dYHT3c/QbnaiBPBHHnlk0DR9zmrRpLubBx98cNC8m266KdOyoruSuXHWWWe5bpseNWFXs/Snn37adRnUHVG1qtMIP7fccotrQeXRPLWwCmw5lhXt77x589xdw9B9yC3dodR6PLqTrDuS6u4IAEg81H3iu+6jwWyUOiKQWlxlR637Vd9U971AasV96KGHuhbZqhNpGa/OopZETZs2df+rC6K6+6s1kp6rlbbXmspbPidqYa66jVIheFSn/eCDD1w9WdsSSqkQVK8IpBbZanWuulJoizF1m9R2qr7llVFe63xAUUVQCkhQ+jHu2rVr2HkaWeXOO+90P+T6O9TmzZtdUEp95VXpaNeuXbbvtWDBAve/Kjh6hKNuUpGkH/rA4FdovqHQikA4an6tEWkCK23e68Kt2xsNLzfrzg01GVcz7ueff941/1aXNlVishuJRhUqjV6jykjo6HybNm3KtLzygIXymnure15Oy2e3bDg5vZ8CT+oKKF5T9kDhpoXzxBNPuLJTHim9pwJfqtDp4QVL87utud1XAEB8oe4T33WfI444wqWByAvVGdTVMPAmlkc5IZWmQAEepUVQPksFfVRXUioJ/a/3U6oA1Re8oJT+V3c4BbVyorxV6gKofJyBObQUONJ7KWAVLigVGnzz6ssKLimHalZUX/Zem9c6H1BUEZQCihgFmZQ0UT+MSvqoH2vdcVEgRC11lOhSd2Tyuk5RP3+1qgonXGWiIFRBUf6DcDRd+aZyQ3e+lKcgcL3eOsKtV3K77txQ3qWHH37Y3bVURUXPs6J8DvrsDjroIHvwwQfdsMpK6qnWSLr7Ge5zyy7AFe4uZ1bL5/aOaF7fL7+UE0MtvdTiS/nKlN9MFUPlh9DfSghakG0FABQd1H3iq+5TWHSzT/UAtYTSZ66gjnJPeq2ivFZVqjfouepPOVHdWK9RHs5wuTg1uMu6desy5QINF8TTNmk5b7CecLzW3/mp8wFFFUEpoIhRNzslIFcia3W3C6TkiYH0Q6gfP92FyunOpHeRn1XrrEjT3TA1xf7777+Dkp3rubqGBSaKzI5agwXesVL3OVW8lMg9lDctr3f5stOiRQvXxU4jGaoLX3YthVSJSUlJsc8//9xVTjxKPJ9Id8y87n2LFi3KNC/ctKzoLqdGodFDFb3bbrvNjZ6nSmdo11UAQPFF3Se+6j55oVbN6iKnVvwalCTQ/PnzXcv+6tWrZ0pR8N5777mA2oknnuim63+1slYyca0rN133VLfQaHpqUaXWZeFGp9bohBo5WTdmc6L68uLFi12qALUcz05RqfMBkZC7PhAAEobXOiS01Ypy86jffuhFv/Ib6QdRrU9CeetQ9z7d2VE+qr/++ivTchoZTfmpIknNr0UVjEDe88ARZLJ6b+U2WLlyZdDwx9661UQ7cCQ4VQxGjhzpKkSnnXZaRIdF1h0wdXvUaDj5+ezU9S+R7pipYqsKsCp6gRUr5ZzSMZQTfRaqUAZS8NTrZhrpYw0AkNio+8Rf3Se3lH9JdRzVlQKpbqr8m7oJGdht3ws2qV6lHFkaQVqUS0vHgZdmIjdBKdV91X1P6QI0Wl7o47rrrnM32jQKX26o1Zb2JTQ/VrhUF0WlzgdEAi2lgCJGCSXVB18tSpS0Ui1zdNdGeY3U315JqAMpQbVa8Cg4dfHFF9thhx3mEqOrf7t+iB966CEXEHj99dfdD3zbtm1dFzS9h9avu3G6K6WAS06JzvXDr/WIkliLKkeqPIkqBRp+WNR///TTT7fHHnvMDTGs1kZKUK0uXGo5owTrHt3B0nR1LdQ2K0imoYCVoFJ5BkJbjKnFzbvvvuvyLgwcONDdPdTwvWpKrdZkyiEQWqZ5HRY5kCpKeuSkR48e9vjjj7uKoZK5qouaWljpDnDgXcJEaF6vYY4VOFR+iUsvvdRNU5BKOZ2UPyK7JvXq5qigliqiCkQpj4Reo+Gh1U00tKINACjeqPvEX90nt1R3fO2111x9U++l+pLqls8++6xr7aUgTSC1atJNVaWpOO6449ITtatFlW6Kqf6qOkROCdZFdUc5++yzs1ymZ8+e9uijj7oWZWoBlR0FsjTIiurWs2bNcvVY1d9Uz1UdVvvl3dwtKnU+ICJiPfwfgLzxhtN9+OGHs1xm2bJlvnPOOcdXvXp1X7ly5dwwwhqm1huyd+nSpUHLr1y50g0jXL9+fV+pUqV8NWvW9J100kluWNrQ9Wo5DRGs5apWrepr376977bbbvOtWLEi19ue1SNwKF7ZuXOn74477nDvV7p0aV/jxo19Q4cO9e3ZsydouR9++MF3xhlnuO0vW7asr0yZMr4WLVr4br31Vt+mTZvCbov2WUMIV6tWzS3frl07NyRwOPkZFnnGjBnZLqf5Wk7LB3r//fddme63335u23r37u2GPNb7d+nSJdN2XXzxxZnW7Q1XHFieWi6rr/zQ9ej4CN22cNNC9zn0uHrnnXd8bdq0cZ+dPpshQ4akD5c8bty4LMtm9+7d7pjScatjTK/X/vfr1y99GOjshBtyOjflAACIT9R9ikbdJ6vf523btrnffdXzVL+sUaOG207VO8M5++yz3XpUJww0ePBgN71v3745bvOGDRtcGajOlZ2pU6e6dV5++eVZ1rFCjRkzxte5c2dfhQoV3HuoHHv06JGprPNS5wOKsiT9E5nwFgAA2dPdxv/973/ujmFOdxwBAAAAFG0EpQAAEbdnzx6XLyFwBDzllFL3z61bt7pk9bkZQQ8AAABA0UVOKQBAxClngvKUaVhjjSqzevVqlzPCyw1FQAoAAAAAQSkAQMTVqFHDdc978803be3atS7RuRLta3SdXr16UeIAAAAA6L4HAAAAAACA6EuOwXsCAAAAAACgmCMoBQAAAAAAgKgjp1QYqampbmSoChUqWFJSUvQ/FQAAUCz5fD7777//rG7dupacXPB7h9RpAABAPNdpCEqFoYBU/fr1C/PzAQAAyNLff/9tBxxwQIFLiDoNAACI5zoNQakw1ELKK7yKFStG/lNJ2WO24FH/3y1vNitR2mJBd0/XrVvnRsmKxN3YREU5UA4cD5wXfD/wPRkvvxdbt251N8a8ukjc12n4HaVcOGY4n6KEOjvlwjFTNOs0BKXC8LrsqfJWKBW41H1m9Y/0/12psllyyZgdiLt27XL7WNyDUpQD5cDxwHnB9wPfk/H0exGp9AGFXqfh94Ny4ZjhfIoS6uyUC8dM0azTEJSKBQWh6p8Vk7cGAAAAAACIB8W3eQwAAAAAAABihpZSseDzmaXu9f+dXErt2WKyGQAAAAAAALFCUCoWFJCad7//79aDY5boHACKqpSUFNu7Ny34X8D+9lqP+twX99x7lEPkyqFEiRJWsmTJiOWNKuhwzfv27XPnTH5xfFAuiXLMxNO5BwDwIygFAChStm3bZitXrnQX2wWldeji6b///ivWFzGUQ+TLYb/99rM6depY6dKxuzG1Z88eW716te3YsaNA6+H4oFwS6ZiJh3MPAJCBoBQAoMhQaw8FpHTRoSFuC3qx47UiKe531imHyJWD1qFgkIZhXrp0qTVt2jQmrfAUEND7q+VI3bp13QV6QfaJ84RyifdjJl7OPQBAMIJSAIAiQ91BdOGhgFS5cuUKvD4utimHwjgedGyWKlXKli9f7i6Sy5Yta9Gm91Vgqn79+i6IWxCcJ5RLohwz8XDuAQCCxdXtATXhHTBggDVs2ND9aHTq1MlmzJgRtMyCBQvszDPPtEqVKln58uWtQ4cOtmLFivT56pt+7bXXWrVq1Wz//fe3nj172r///huDvQEAxEpxbtWExBAvLTTiZTuAaOGYB4D4Elc1kcsuu8y++uore/31123u3Ll28sknW9euXW3VqlVu/p9//mmdO3e2Fi1a2HfffWdz5syxu+66K+gux0033WQff/yxvfvuuzZ58mT7559/7Oyzz47hXgEAAAAAACBuu+/t3LnTxo8fbx9++KEde+yxbtqQIUNcgGnUqFE2fPhwu+OOO+y0006zESNGpL/uwAMPTP97y5Yt9vLLL9tbb71lJ5xwgps2evRoa9mypU2fPt2OOuqoGOwZAACIJLWq3rx5s7366qsULMB5AgBIYHHTUsobjji0b7e68f3www8u78Gnn35qzZo1s1NOOcVq1qxpRx55pH3wwQfpy86cOdPlE1HrKo9aVTVo0MCmTZtmcSMp2axSK/9DfwMAipXjjjvOypQp47qZV61a1T3XbxgAzhUAAIqTuGkpVaFCBevYsaMNGzbMtWyqVauWjR071gWTDjroIFu7dq0b5vvBBx90raYeeughmzhxouuaN2nSJOvSpYutWbPGjR5TuXLloHVrXZqXld27d7uHZ+vWre5/BcL0iLgVK83WN/H/vW62WfXqZg0aWLRp37wheYszyoFy4HgoOueFt93eI68mTDAbOtRs8WKzZs3M7r7b7Iwz/OvJz/qyo98ztfhRLsTbb7/dunfvbn///Xem5XSzRYl5IyW/6/P2P9LlkB952ZZIl1+kysE7RkPrGgU953JbpynouRJ6vjRtWsLuucfs7LMjf3zk5lyJl/Mkns6beDpn42n7sjr34kWi/v5GA2VDuXDMRMiKFZa6dq2V2LTJUqtUMatZs1DiEbn9HouboJQol1T//v2tXr16boji9u3bW58+fdzdY2+HVBFR3ig59NBDberUqfbcc8+5oFR+PfDAA3bvvfdmmq4hY1UBiqTklSutRseOlrRvX/o0X5kytk6twQ44wKJJZaouj/rhK85JHykHyoHjoeicF7qQ1Lar9a0eefH++0nWu7dGgtIFS5LNneuzc85Jsrfe8lnPnnsjmjzdu+DwRp+6+OKL7cknn3QDc9xyyy3uN1CDf3z55Zc2dOhQu+KKK+y+++6zt99+23Vb002cZ555xurWrevWpxsyjz76qPs91E2ck046yXV916Agy5Ytc62MX3zxRXdxr/WuXLnS5XAcPHiwGxq9SZMm7rfwxBNPdOvTtj377LNufcrNqJs7Wv+pp57q5uu9NU/be8ghh9jIkSPdDSV54okn3PNNmza5QUcURNBvu97n6quvtl9++cXtn1oyf/75527kN910Uhf9Tz75xP3uKqek1qPtl++//95uuOEGty9qDV2lSpX08guV1f7edttt9t5779nGjRvtgAMOsLvvvtvOOecc9xrloNTfuuGlG187duywSy65xL3eo31WGWiePo/PPvvMbdNFF13k5n/zzTcuz+Uff/zhPhet54wzzsjyGNC2ax82bNgQFPzQ9hZEbus0BTlXwp0vv/9u7nwZN26f9ejhK/Rz5fTTT3et5uPpPKldu7Y9/vjjrkW/tvvpp5+2559/Pi7Pk1hT+aiHRCwGpsjq3IsXifr7Gw2UDeXCMROheETnzlZy926rUcjxiNzWaeIqKKX8UKoYbt++3d3Zq1OnjvXu3dtVAqpXr+4qI61atQp6jX7c1b1PVBnQ8K6qiAS2llJlQPOyoorAwIED05/rvTVEsoYUr1ixYmR3cuXKoICUJO3ebdX1hyKUUf5iV0VA+1mcf/QoB8qB46HonBe6UNMPoH4v9JAOHcyyaSybzj9Qq/8C2/3l/vfZRReVtkGDcvf++qkJGTQ2LJWtylXbqCCHciNp5FkFfzR93LhxNmHCBPe/9umee+6xWbNmuYtOXcDqIvnCCy90v5ke5VNUy2FdvOq3c9CgQfbKK6+kl4O6wGtEW12Y66JVo9O+8cYbbkRbdYVXy+Pff//dGjdubE899ZS7YH7nnXfcDSK1StFvqy7gdBGu7VXORy2r53rtvHnz3Hq1rbqZpItp/f7qoW1Qnki1fNYFtmhb1GVf86688kr3/2+//ebe4/LLL3c3oMaMGeMu2rV+BQouvfRS9/pzzz3X3bTy9i1QuP3VtHbt2rmAn8pPg6H069fPpQHQPnhBwIULF9rixYtdYECj+yrwoa6VCjgp0KMW2q1bt3bBq/nz56d/hhp4RdujoJeW1w0zvfann36y5s2bhz0G9Dq9XtsTmLqgoEPU57ZOU5BzJbvz5fzzS1itWoV/rmh/4vE8UR1W69J58dprr7ntU7Ar3s6TeBGLoFBW5168SNTf32igbCgXjpkI+O03F3+IRjwi19+xvji2ceNGX6VKlXzPP/+8e96xY0ffBRdcELTMWWed5evTp4/7e/Pmzb5SpUr53nvvvfT5Cxcu1O0637Rp03L9vlu2bHGv0f8RN3Omz1fCfL6z0x76Wx+DpkdZSkqKb/Xq1e7/4oxyoBw4HorOebFz507f/Pnz3f+eevX8X7PReOi9cqNLly6+smXLut+4WrVq+U455RTfb7/95uZdfPHFvu7du6cvm5qa6itfvrxv9uzZQfuZnJzsW7FihXuu36xx48alz58+fbqvdOnS7vNbunSpm//rr7+mzx8+fLivW7duQdt00kkn+e677z73d4sWLXyvvfZa0Dbs2bPH/d+qVSvfBx98EPTaunXr+qZMmeJbsmSJ2y/9Du/YsSNomYsuush35pln+hYvXhw0fe3atW5f9Jvv0TL6Pd+3b59vzJgxvpYtWwa9Rtuucgon3P6Gc8ghh/jeeOMN9/ekSZN8SUlJvu3bt6fP79q1q++RRx5xf/fv39937bXXppfD7t273Wc3evRoN/+aa67xDRgwIGj9ffv29Q0dOjRPx2ph1EGyWl+inyvxeJ4E0nny/vvvp5838XaexFrgd0q0ZXXuxYtE/f2NBsqGcuGYKYA9e3y+xx7z+cqXD//DXAjxiNzWaeLq1skXX3zhmqrqruKSJUvc3SvdQdLdTNFz3dXS6HzHH3+8u2OpO7Xfffedm6/my7o7pDuEShyrO4LXX3+9a77NyHsAUDxl01A2U8uPzL1cfKZGBv6WH0kRey9RNyDlyQlHA3R41q9f71pf6LcvsJuLWnKoZYZawYhaj3j0t1oOq8tWuHWqW1KjRo2C3lOtkjVdli9fbk2bNg27bWrlccEFF7jWRR69l157zDHHuNYh6rak32799mrEXHW3f/jhh10rEHUr0n6oe5y60Gl9uvutlieB1EJA+SDVLSpw37z9y6l7feD+irpVvfTSS2479f7qCqWy9ajOoNYznvLly6c3O9c2qAVUYOsOteYOLJNvv/3Wjfgb2EUo4q2tC1lejt+sz5ekXLeUKui5Eu/niVppxft5AgAoBr76yuzGG80WLLB4FFdBKfWfVrNz/WArqKQm08oN4DXt7dGjh+u3r8qJ+swreDV+/Hjr3LlzUKVTP9B6rRJ9ql+/mkzHDSU1D72uKVPGPx0AEHG//JL7pM09e6q7kP+Wkf9/5ZTaZ+ecU8I9j5bALhvqYqJgibqC6UZNVnSBrO5osmLFCncxru4f+jt0ncqp5HV99+iiVxf03sWsbg7ppk4oXdwrj023bt3CbkevXr3cY+fOne5iWhfmc+fOdfl/vN9jPVc+nzZt2tjRRx/ttk0X1YFBIY/yAWnfAmmftL7sBO6v9lUX+gocqRuf5ikAkNsEy9qGwMTaCjitXr06qExuvPHGoBxURflcCX+++LvyvfOO6msWFfF+nqhOquCSuouF5k2Kl/MEAFAErVihuzVmq1YpQGI2aVLwfN0wScvr56ibXQzjEXHVUVk/zn/++acLJqmypztIXvJGj5JAKomofsRnz57tEp+H9ltUUkslMtUdM/Xlzy6fVEzE5yAoAFCsnX222fjxZm3b+n+b9f/48T4766zYfmnrQvSqq66ym2++OT0wogS9yqMTSC0sdMGq3E+6yD3vvPOyzEeiVsdqZfzhhx+6AIt+K6dMmeJeI8pdoxxK+p1V4EYXtwvS7q5de+21bv2LFi1Kz1mk9ahVkaYpMbR+o3Wxv//++6fns1HeHa1H61PeR7Ug0Tz9Rp911ll23XXXpbdcUsuP999/3/39f//3f7Zq1SqXgFrbqpw/Ci7lhbZR76fgg1qbKIeQ8gLllvLyKBeRkk8rQbiSmKuO4VF5qZWUchUpebPqMRo92Cuzon+++KxNG587X6IVkEqE80R5oxLpPAEAFJGAVLNmZocdZnbmmcEBqaOO8id0/OsvS50xw9Z/8YX73/RbVQij7yVkUKpYCOgqkE6JxsJNBwBE/UJ79myznTv9/8fqAjuUWgirNcYJJ5xgFSpUsMMOO8yNOBZIXerUtV2tN7SMRijLihIp6wJbF81qmayRy3Rxq65JotbIGgFMN4u0LrXW8C70dVGsLkVKqqzuaRpwRAEbr3uSRqBTwna1XNFFsRJTi5I6d+rUyV2Aa1/U3V7Jo0XL6AJcycW1TnVv0vKi7dPFvPZHy6gL3vnnn5+n8lOrLo2upxYnalGiZNNqeZJbau2islKLbbWA0UW/kleXUUtnM9f6auzYsXbnnXe6wJdGEVY5KDhVHM6XHTvUyiol5udLrM8THSdeiyudJxopUPN0gzURzhMAQILz+czGjvXHF0JpZN4ffzQ7/HB/AKp9e9unO0vt28c0ICVJSiwV0y2IQ7qbpQqEuhNGPB/ErFlmRxxm5jXw+tDM1HJOlQodEFGku8UaEllNu4vz6B6UA+XA8VB0zgvlT9HIacq7EolRlfQT6Q1FH+1hy/NC2/brr7+6LmmFIVHKobB55aDzQ6MCK7dlXoJbuTlWI10HyWp9kTxXEuX4KOzzJFHLJRZiWTaR/p2ItET9/Y0GyoZy4ZjJxty5ultilpZvO5OQeEM0zqfc1mn4pgMAAMiBWsyou5W67d16662uhYtarAAAAMTMpk3+YFS7dlkHpOJcXCU6Lxa8BGJr0p6rnRqJzgEAiGuvv/66y2upFh5qafPRRx+5fEAAAABRtWKFfxjcDz80e/ppjRiXMU9d8TQYy969cZPIPCcEpWJB3fWmxuSdAQBFED3xC59yCdEdK7FxngAAikRAqmlTJSgMnq7A0113mQ0caLZ2bXDOagWkYpw3KjsEpeIp0XkcHygAAAAAACBG/vnH7KqrMgekZMIEs1NP9f+tuEICxRbIKQUAAAAAABCPdu82GzHCrHlzs88/D79MrVqWqGgpFQslzOz0tL8/SevOBwAAAAAAircVKzJ6WP34o9ljj5ktW2ZFFUGpWEQ5vcBUuOkAAAAAAKB4BqSaNzfbtSvzvKQks759zd57Lzh+EOeJzHNCUCraNNJeXqYDAAAAAIDiEZTaFSYgdeihZq+8Ytaundn99ydUIvOckFMKAAAEGTBggF1yySX5LpVDDz3UXn31VUoVRV5hnyspKSnWtm1b+/333604GDJkiJ111ln5fv1///1nBx54oK0PN7AQAMQzn8/srbfMevQIP/+ll/wBKVEAqn37jEcCB6SEoBQAAFF23HHHWZkyZWz//fdPf1TPZbNrXQDrQhgoDor7uTJmzBhr2rSpHXzwwYWy/kaNGtkHH3xgRUWFChXsoosusvvuuy/WmwIAuTd7ttmxx5qdf35wC6jQrntFFN33ok0VqaQwXfcSuA8oABTJxJJSrZpZ3bqF8lYPPfRQwl8wR8LevXutVKlSsd4MFOR80d3dlBT/yD8NG0a8LIvzufLMM8+41kNZ4fzJXBYXX3yxa4GmwNR+++0Xlc8JAPJV19y82d8lb+xYs9TUjGWSk4OfJ3jOqJzQUioWfDF5VwBAbhJLHnZYxqNFC//0KJo1a5ZVqlQpvbvOpk2brEGDBvbaa6/ZU089ZW+++aY9++yzrsVI69at0y/G7r77btdtpVq1anbmmWfaP//8k77OpKQke+6551xri4oVK7r5W7ZsSZ8/ZcoUa9OmjVvn2Wef7brABPrzzz9dl5qaNWtaw4YNbfjw4ZYaUFl6+umnrX79+u6977jjjmz3T12VdMF4zz33WO3ate28886zbdu2Wffu3d36te/HHnus/fbbb+mv0UX5GWecYdddd51VrlzZlce4cePS5+/evduuuuoqq1q1qjVu3Nhefvllt8/L0kaq8fl8ruxatGjhXq/WNwsWLCjAp4TA8yXp8MOt1JFHRv18iddzRcdqjRo1XCuk+++/P9/nirbr119/tS5dugSdC6effrpdffXV7ni/7bbbcjy+t27d6s4dnbvapw4dOtjff/9t5557rq1YscL69Onj9kfnkNxyyy1uWbU6atWqlb377rvp6/ruu+/ce7z00kvp+6HlA40cOTJ93p133hnURTFc9zytT+sNJzfbMmrUKPe5d+rUyU1Xueu9J0+enG35AkDM65onnmj25psZAaimTc0+/dRs6VKzmTMzHosWJXwXvewQlIo2Lyqq/7yb8cqcT993ACgchx9udsABOT+0XEhiyaRdu6xkx45m9evnfh0F1L59exewUbBm586ddumll9oxxxzj7v7fcMMNdv7559s111zjAjnz5s1zr9HF7Y8//mg//PCDrV692po1a+ZeH+idd96xb7/91l2Erly50h5//PH0C3ldeOuidfPmzdavXz9744030l+3Y8cO69q1q51wwgnudd9//729/fbbNnr0aDdf69T7a/16b8kp/43mlyxZ0m3L66+/7i7a+/bta0uXLrV///3X2rVrZ7169XIX254vvvjCBas2bNjggmKXXXZZekBAz3/55RdXHrNnz7b3338/6P100apA1ccff+xyzSiYoMDBnj17CvhpFdNzJZvzJU/nWxE8V0488UT3WLVqlQtgaV35PVd0LNerV88FZAJNnDjRjjzySFu7dq0NGzYsx+Nb3RiXLFli06ZNc9v9wgsvWLly5VyAR8GcsWPHujJSME4OOeQQmzFjhltWAbwLL7zQnZsenXfz58+3P/74w5WjWnN5QaVvvvnGvWb8+PFuH5OTk9PLPj9ysy0KYC9cuDAoCKUAlsoPAOKKrvnDJTEvV07NgvWjYHbaaUUuZ1SOfMhky5YtqgW7/yNu5kxVsTM/ND3KUlJSfKtXr3b/F2eUA+XA8VB0zoudO3f65s+f7/5PV69e+O/dwnjovXKhS5cuvrJly/oqVaqU/ujatWv6/NTUVF+3bt18bdu29TVp0iTo9+jiiy/23XjjjUHLli9f3jd79uygckhOTvatWLHCPddv2ueff54+f/jw4b7TTz/d/T1mzBhfy5Ytg7ZP7633kXfeecd36KGH+vbs2ePeS1544QXfCSec4P7u37+/7+qrr05/rZarWLGib/To0WH3XdOrVq2a7bG1adMmt80rV650z++55x7fkUceGbTPpUuX9v3yyy/uucro3XffTZ//888/u9cvXbrUPW/VqpXvgw8+CHqPunXr+qZMmeLLC71vYDlE/FgthDpIVuvjXCm8c8Wj42TUqFH5PlfeeOMNX+vWrYOm6Vw45JBDgqZld3yvWbPG7dPy5cvDvkfDhg1977//vi87ej9ti0yaNMmXlJTk2759e/p8fXc98sgj6ft47bXXBu2jvt+8fdT2d+/ePehc0nytN3B+brdF+6bvi1B9+/b1DRo0KE/nXrxI1N/faKBsKJeEPmb0O3PyyeHrjxMnFsmyyW2dhpxSAICirXbt3C2nVgXr1mWa7KtRw6x06UzpAAv0Xmb2wAMPZJknR12I1JVG3VweeeQR1+UmK2oZsX37dteKSK/zlC5d2nXRUTca/6ZlbFv58uXTWxmpi5C6xwTS811pd/LUBU6tOdQdyaOWTd569Xp1F/Iop0udOnWy3Xe1/lALCo9audx888322Wef2caNG9Pnad+0bOj2az/V0iNwH7ztEbX+CKR9uOCCC6xEiRLp09SKRK1gkL/jN6vzxdLOl+J8rqhLWSTOlSpVqriud6HycnwrSbweoa/JjlqGqXueXq9yUiuqwNHsVMaBuZpCyyiv3wcF2Ra1Igssb4/KrbCSwwNAnug34tFHze6/X01qwy9TI6OOVRwRlIpJovMkf0zUQ6JzACg8v/ySt37+Ac2qfWXL2r5p06xkkyZRHfVE3YSuv/56u+KKK1xOGuV+8S4qA4M5otwpukD86aefXE6ZvKpbt64tX748aJq6LSm/k+iC+rDDDnPd9tTlLvBiPtzrlbPH65qUldB9ePTRR23mzJmuK9ABBxzguurogjyw+15O+6Cggro0edsfSPvwxBNPWLdu3XK1vmIrt+dKNudLktYRxW4G8XiuTJ8+3T3X8btv3z533uTnXFEuJnUDVCBGOZ88ofuV3fGt7rDKuRYYdAsUui6dg8r7pK6G6kar+dqOvJ6LHu1/4D5qP9TN0aMgYbjAW263JXT7PepeqK6bABDTQUCmTDF74ons8y2WLdpJzHODnFIxKXWf2enmf2Tc1AIAxJIuZJVIMjCx5MKFMenHr3xJas3x/PPPu7w1yo2TotHNTAOc1bK//vor/cJMF2VqKaKWRt7FoPIuBSYCz87//d//uQvfF1980V1Afvrpp+4i0KOkyrqwVb4ZtQjRdixatCg9h4ySJCuhtC701Tpj6NCh7kIzL3RRWrZsWReI0gX44MGD8/R6bcOIESNszZo1Lim18uwEuvbaa10+Gm23934ffvhhpiTVyN/54vvlF9v7008xOV/i8VxRcvVInCsK8CgIk1PC7uyOb5WBBhHQfis4pJZbSp6u/fbKSMnZPXqtWlypZaSWfeWVV3LMERdI+/jWW2+5HG8KuinfW+A+Kg+YclspB5TKSOd6aKC7oNuiwJ9aU+m4AICYJTJX7sSBAzMCUmrNev31ZnPmFKsk5rlBUCravCbHatnutW4n0TkAxIcoJpa89dZbXauBwIcuFHVxrYtGXdh6XZd08aaLO+8iXBfGGnmrbdu26ct07NjRJSNXdxa11vjyyy9ztR1ajy5gn3zyyfRRtXRh79F2ffXVV+7iWyPbqbWJkpIrACRKgq4gUM+ePV03HV085rXbzMCBA93Fpy6Q9VrtS15ohC8lRFZyY13En6Ykoa4hchn3vxJTK9mzEkCr61HLli3dhTMieL60a1do50sinStff/21S/atEeCqV69uF110UYHOFQWcvETpWcnp+NZohGoldfjhh7vtVoBKXWZFQSGNCKjpalmk1lbnnHOOG2FQQTElKT/66KNzVT7ePir5vLpTqhukgndKJu+diyr3K6+80q1T26n3CU3k7snvtowZM8aVh7oVAkBUadTfcInMFaT69Vezp54ya9OmeCUxz4UkJZbKzYLFie7MaIhh3W3NLjdBvsyaZXbEYWbd055/aGa6oacoqQ7KKFJlSCO3qNl5Vs2fiwPKgXLgeCg654UuSDUyk4InanlTUIHdb7K6m18cJFo5qCWG8troeIjk9kayHLI6ViNdB8lqfZE8VxLt+IiWSJSLWlup65pGyGvdurUlGrUIUyBbIwYGBpQK65hR6zCVl74DAvPgFebvRKQl6u9vNFA2lEvcHjOpqWYajVUto9JaogZR13YFpopZ2WzNZZ2GbzoAAJDQVKmaNGmSu4BXouXbb7/dtUYhQIJEpxaEc+bMSaiA1IQJE1xLLHXbUys3BaU6dOgQlfdWq6slS5ZkGZACgIhTwKlzZ7OLLw4fkBJu2GSLoFRMEp2HTCPROQAA+aZg1E033eTuxqn7nkbsGzlyJCUKxMDrr7/uuieqy92sWbPso48+ciMcAkCRoBxR6v309ddmPXqYKeg+bVrG/NBWRyQyzxGj78UCHSYBAIgYXQDPnj2bEgXiwPvvvx/rTQCAwhFm5Nl0LVuaPfmkf76XR9prlELeqGwRlIq2wAPUQhKdc7ACAAAAABB/PvssfEBKuaQefNCsVCn/c67r84Tue7GyKe0BAAAAAADi0/LlZuecY3b11eHnayRWLyCFPKOlVCxotL1JMXlnAAAAAACQk507zUaM8LeCCtdCChFBUComic6TNBZuxjQSnQMAAAAAEPu8UevWmX37rdljj5mtWZMxr1o1s61bzfbuzZhGIvMCIygVC4EBKQAAAAAAEPuAVNOmZnv2BE8vUcLsxhvN7r7bbMsWEplHGDmlok0JzUuYWbe0R4mAROcAAACIiNatW9snn3ySq2XffPNN69SpU0Te97vvvrPKlStbIjruuOPsiSeeiPVmAED0bd5sdtttmQNSMm6c2aOPmlWq5E9i3r59xoOk5gVGUCpW9kt7AACKrf79+1tSUpItWLDA4tGQIUPsrLPOytNrtD+zZ8+2eLB371677rrrrEqVKla1alW7/vrrbd++fQVefufOnXbQQQdlCjzogr5MmTK2//77pz/++eefQtm34uTrr7+2Y445xpVnpUqV7NRTT7VZs2bl+Lp58+bZ6aefnqv3OP/8823q1KkR2FoAQEJJTTV7+WWzZs3Mxo4Nv0zjxtHeqmKFoBQAADHw33//2TvvvOOCHy+rMoSIGz58uP3www82f/58F6D4/vvv7f777y/w8nfffbc1bNgw7Doeeugh27ZtW/qjbt26Ed2n4uajjz5ygdGLLrrIVq9ebcuWLbNjjz3WPX755Zewr1Eg0UeqBABATqZPNzvySLPLLvPnkUJMEJSKSaLzkGkkOgeAYmfcuHFWvnx5F8R4/fXXXSsdz9KlS61r166uVYiCVkcffbTt2LHDnnzySdcaJ9Dbb79trVq1Sm/ZpJYhV155pXtt48aNXVeiDz74wLXsUQugO+64I/21r776qh166KE2ePBgq1atmjVo0MCeffZZN0+vUUBG3Z8qVKjgXivazttvv90tW6NGDevdu7etS6vIHXHEEe5/dYNSqxYvoPPnn3/aGWec4ZZXMEfBn1TdmQzD26Zhw4ZZzZo1rVatWvnuTvTKK6/YnXfeaXXq1HEP7Xt2AcDcLK8WOl988YXdeuut+dom5J4CSzfeeKPddtttdvnll6cfhzr+dNz973//C2qh9/TTT9vBBx/szisFBBs1auSOY8/IkSOtfv367ljX56zjTMdb4HHn0WtHjBhhRx11lHvfLl262N9//50+/5ZbbnHHsubp/Hv33XdzvV86h/X6E0880W2r3mPVqlXu/NU5csABB9j777+fvvyXX35phx9+uDundVxec801rrWeaJuqV69uX331lXu+Z88ea9++vd17771Zvr++M9q2beta+nXo0CHbFmI63o8//nj3PaTvkBdffNFNX7t2rZUuXdqWa5j0NLt373afz7Rp03JdFgAQk7xRX35pdsYZZh07mgXe4Pi///NfmwcikXmhIygVC+Q5B4DoStmT9SM1pHtWpvmBf+/Netk8UrBDXYbOO+882759u3388cfp8xQM0QXg+vXr7d9//7WHH37YSpYsaRdccIH99NNPLmjlGT16tPXr1y/oAvaUU06xjRs32oUXXuhe8+GHH9pvv/1mP/74oz366KNBXZ9+//13d0GvVigKlCkAMGXKFNc6RcEqBbnUqmvTpk1u+QceeMAFqtSiSNuh12o/5Oeff3b/6yJXQQG9XsE0XXzroQtvtT7SRbG2OytqpbTffvu55bVNgwYNcoEt0fvqYjqrhy7YRdu7cuXKoECD/l6xYoVtUZLSELlZXi1wrrrqKhf80AV5OAq46QK+Xbt2NmbMGEs02sfQlkYKIGpaSkpKRJfNyeLFi13LqL59+2aap2k6FrzgjLz11lvu+N+6dasL9gT65ptvXAu38ePHu2M9OTnZHWfZeeONN2zs2LEu6Kr13XXXXenzDjnkEJsxY4Zt3rzZrVfnWuB5mROt96mnnnLnqRf00nGjbVNASUE4L1Bdrlw5FwzSsjqHJ02aZI9pRCgzF2R7/vnnXUsyBYoULNX6FHQL57PPPnPBPAXhtD4F+BQw3rBhQ6Zl16xZYyeddJJdffXVrgwU4LvnnntcWSpgfPLJJ7sy8ug7TEG1jrrIA4B4tGSJ2YEHmp1yillgzkF13dNoe5q2eLHZzJkZj0WLyBtVyAhKRVu4hOYkOgeAwjXv/qwfy8cFL7vg4Yx58++35AUPuv/d82VvBi+76ImMZfNA3cOmT59uF198sWtR1KNHj6AWOaVKlUrvqqS/1fJIQRC18DjzzDPttddec8spaDN58mR3Qew57LDD7Oyzz7YSJUq4gJeWUaBJF9Vq0aEWEoFBKU1XCw2tXxeTCjBlF0xRqy5d8KqllLZdF8dqpZFV7qRPP/3UtZ4YMGCAew+9Tq1fFEDIilp+3HzzzW7f1apErVa8PFWdO3d2gYCsHl5LLwXFJDDvk/e3gmyhcrO8goMKVKnrWDgK2Cl4pkDigw8+6HJSBbZ4SQRq8aOHWr14lPNM00K7y02YMMFNV+AxMJCkaQqehnbD03QFjHJLQVkJ1wVS0xT4UmDFo9ZHmq68Xgo6BdLxpmNbrfl0HCrAFBq4CqUAp1obli1b1r12pi5O0ui5AjPeedaiRYs85aRSsFiJ2LWtOv8VmL7hhhtc8LlPnz4uSOS1QlI+LQU59V5NmjRxLSHVAtLTs2dP972g1pU6dxUo0rLhPPPMMy7Iq9ZUKiN9V2jbFawKd67rWO/Vq5dbn1qhKQDunbsKhGmZwOUDv4sAIK588YVZ1666S5J5nr7Ljj/e/zeJzKOOoBQAAFGmAJRaWughCk6pS5gCSF7wo169eu4iUwEZBY287m5Kjq4LT7U40f9qrVC7du30dau7m0etjcJN8wIwoot4BX886pLkbUc4ak2kbQp8vS6sNT0cBdbUGiuwNZMCTmqFkZXA7RUFD8IFkrKjgJkEtory/lZLkrwuv2TJEtciRcGmrCiopy5WKk+1VlPwQC29kD8KTkq4gKemKVCi1kUeBTyzouXVqsijz0hd4bITeF6FHoOPP/64Cyrp89YxrWPcC6LlRug5Ge689c5TtcjSd4GWqVixomuBGPpeCqDNnTvXtSAL3M9w56NeH3g+KuAb7pzXsgpWBS6r1l0KmIsCYTqP1UJS2zNx4kSCUgDiTonlyy1Jg7Z062YW0OU4SMmS0d4sBKD0YyVvdWsAQEG0Hpz1vKSQ+zMtB2X87fNZaso+Sy5RUklr/I9AzQfkeVPUJUctCnTB6V30KsCkVh/qUqOue2qB4bX40YWmutC0adPGtYjQ3+oGpRZSajGl1jkFoYt1bZMXmFJ3NQXEJLS1iSjfjS5Wj1Ri0LQuPmpVo+mi7nyBdIGs1ltqGRYJ6v6n0deya4Hy3HPPudZZ2iZdcB+opvpm7m9tjwIJoXJaXi2e1AJKgQhRmSlIocCJWoN55REoXPnFu3PPPdf9H9jSpmXLlta8efNMn61a2Xj76XXXa9asmet6GrqsAhih682J1qUgqbq6BeZCE01TrjV1bctNeSt4GpgTSueQF1zJK3UbVKD422+/dS2Y9L5qQVdYydXVckotlNQNV8Ex5VjzcmF5eaQUrFZwW4HqSy65xJ1z4eh4Vgs+dUPNiZZVKy51tw1HLch0vOj7TMeHzoHAgDUAxCRflBe037nTksaOteovvWRJAa1/EX8Sr7aU6HRCqN72VdrDS7nAiQIAhadE6awfySH3ZzLND/y7VNbL5pK6MakLk7rQKeihh/I9qTuREm3rwlaj8ik4pL/VOkEX8urWI7oA1gWqusOp61Juh7zPiroNKam4LmzV5erNN99MzxGllhnqQqQL+MCgjxKY6wJfgbWBAwe6VhxeFyu9xsv/JNo+BXMUZNu1a5cLXixatCio+1FeqCtT4Oh2oQ8FpDwqp/vuu88FzvTQdl+mEXaykN3y6sL0xx9/uFYrv/76q7300kuuBZU+PwUm1HVQrUrUlU37qLw72hYFEhOJjjM9AoNKOuY0LTSgVNBlc6Jl1SJJgVe1LtTnq3LW4AAKlCgReV4CO+p2pi6ICigq95eO/fzQ+av9U/4ktWDUeauWUoVF76fvAQWk1JVy1KhRQfPVPVct/bQdOn61r4GtIQNde+21riWmuiLq+0XH69dffx22paO64inwpjxcKjM9dLzrHPCoC5+XI05/A0BMA1LNmyuPgf/RubMlPfNMRkBKrWMff9yfuDwQicxjLu6CUrrrqIq27ozp7pfyaAT++OnujyopgY9uaooXQHdpQpfJrrl9VIVm889pOgCgSNHFtS4alcdFLaW8h/LJqNWSkhjrgtEbwU5dwi699NL0liZe8GTOnDkuQBTY9S4/lCdGQSd1ZTrnnHPcRa1G2xK1glB3IbXc0gW4KDGyuqZpu/R7qwvVwGTHCnBpX9TySL+92gdd9CpIo+WVF0tdjLLrvhcpCvRpO9XSRw+1rFHXJY9aiwS2GMlueXWpUksq76HyUP1CfytHkcpBCar1WWrfb7rpJpdvy2t5hPxRSx0FRRT0UNmqi54CJTpPwrVOy4oCp0rSrQT+Wo+OebXEUtfTvFK9U+eKWi8qGKuE6TpWCou6jT7yyCPuXNLxqhxWHnWZU4tJnYMKCF533XXu2FVrqHCU1FznpRKp6zhVziyN6hluNEy1mFS3Yr2/vh8UcFZQKzAvmHK8KTirPHkc6wBiSi2kdu3KNNlXsqT5brnFn7B8wAD//yQyjytJvsJqa5xPGuJXd5t0F0g/9PqR1V0y/djpx1FBKd1xDRy1RxUKb6hqUaVXFXj94Hr0g5lTQkuPfmzVVF+5JFQZjygllw3XpFonRvv2Fk2qgGikFl1sJGIXg0ihHCgHjoeic16oJY5GwPKSExeUfiJ18ZrXFh6FTa0b9NmoS5yCSvmlLkDqCuQlEU+0coi2SJZDVsdqpOsgWa0vkudKIh4fahmoAKmCOoUVUErEcomWWJZNpH8nIi1Rf3+jgbKhXLKkQS90k+nddzPN2vTyy1bpkks4n2JwPuW2ThNX33Qa1ld3w9QcW6N9KCeB+uzr/8CmygpCBd5dDgxIBQahApfJbUAqKtSi/aS0R+5TKwAA4C7mRo4c6bqMFSQgBRQ3Gi1QdU1127v11ltdUKpDhw6x3iwAQH4pn6G67TdtGjYg5RZJy3mJ+BVXic51x0R5GELvWqgbn5JKepSHQhE9BaNOOOEElxdAFYtAapqsLgRq5q1uAmpG7+XjCKUErYFDH3vNkhU9DNecuUCqVvXnyg0Y+MdXpoz5NHpMpN8rB9o3XdxEfB8TDOVAOXA8FJ3zwttu7xEJ3nrioWGxfiP126fk2u+9916Btykv+xZP5RBLkSoH7xgNrWsU9JzLbZ0m0udKIhwfSsithODaRiUmV+JwdX8tzG1OhHKJlViVTVbnXrxI1N/faKBsKJegROazZ1vS449b0vz56QWjb5PAtpe+smUtpUoVzqcYnU+5XXdcBaXUukm5HBRMUn949V3X6CrTpk1zraW8fvwa7UVNbpVIVbkeNAqPlvGSaiqXRfv27d0wwVOnTnX5LzTCinI7hKMEmsoDEWrdunWuiW8kJa9fbzVCf3t9PjeUbmqUmxDrIFFTOh2Mxbl5MOVAOXA8FJ3zQnl9tO26yRGYnDu/vFHxJF663yi5uaeg+6icVHrktJ54LIdYiGQ5qMx1rG7YsCEoL5hyaxZEbus0kTxXEuX40AACoSLxPZHo5RILsSybrM69eJGov7/RQNkU73JJXrnSaih5eRYDhO3s0cO2a3CSgIYoCkht3H9/S1m7tkiXTbweN7mt08RdTikFmnQXa8qUKS7IpOCSElEq6atGHAn1119/uaGblUT1xBNPDLtOjUZy5ZVXupFIwiW0DHdXUcPgbtq0qVBySiUf1cGse9rzD/0j8KUqmXsMckqpkqpkrcX5JKUcKAeOh6JzXuiie9myZRHNFaKL93i8cIk2yiGy5eDltVEezNCcUmoNl9+cUrmt00T6XOH4oFwS5ZjJ6tyLF4n6+xsNlE0xL5fp0y05TA5AX7Nm5nvxRTfaXrEtm3yIRtnktk4TVy2lRAGmyZMnu/7+2gmN9qHk502aNAm7vKarG8OSJUuyDEppdBbdFVHlq7mGiQyhQFW4YJU+nIh/QFmsz71PDE4U3Z0qlP1MMJQD5cDxUDTOC21r4MirBaX7Nt56inNLB8oh8uXgHaOh51hBz7fc1mkiea5wfFAuiXTMZHXuxZN4375YomyKabl88onZ1VeHnZX0xhuWlE1+wCJfNgVQ2GWT2/XG7SejxOQKSOnOnoaj7d7da1oUbOXKla75rZbNikYVUoEoDxUAoOiLs0bAQCbxki8mXrYDiBaOeSCBLF5s9n//Z3bGGbrwD79MWgofJK64aymlAJQuJtSiSa2fBg0aZC1atLB+/fq57nfKk9CzZ083op66+t1yyy0u39Qpp5ziXq/cUj/99JMdf/zxLkeVnivJuXJmhBulL+qqVw/Ovia6o6npAIACUVcQ3fXxmiNHogUIQ7pTDpE8HrSOPXv2uGNUN8xKly5tsaD31fv/888/7lzR84LsE+cJ5RLvx0y8nHsAcpHIfPt2s5deMnvrLSWCy5iv74vAG4/qgst1dMKLu6CU+hsqMblaQClRuQJQ9913n7vQ0I/XnDlz7LXXXrPNmzdb3bp17eSTT3aJ0b2m6vr/7bfftiFDhricCsqVoKDUwIEDLW7oPNoR640AgKJHuQgPOOAA9xuiLtsF5Y1K4nV1Kq4oh8iXw3777edGCI5VdwK9r+pIGghGgamC4PigXBLpmIn1uQcgm4CUUu2EG2jsgAPMHnnE7KijzDZsyJiugFSDBhRpgou7oFSvXr3cI5xy5cq5llTZUWL06dOnW9xS5FeDjUwMmJay2z+dEwoACmz//fe3pk2buiS6BeWN0FStWrVifQFDOUS2HBQ8jWYLkayopYguznXTzxsJLT84PiiXRDlm4uXcAxDG99+HD0hdeqnZk08qv4//ecOGFF8RE3dBKQAAInHhoUckLpzUUlcjNBX3oBTlUDTLQRfn2qeCjIJWFMslEigXygZALqxbZ3bnnWYvvBB+/jXXZASkUCQRlAIAAAAAANGjXFGjRpndfbfZ5s2UfDFGUCra1O9VpX5M2vMp+hRIdA4AAAAAKAaJzH/5xWzECLM//8yYp9ZQu3cHJzYnkXmxQFAqVonO42AgQAAAAAAAohKQatbMH3gKdcklZg88YLZnjz9o5SGRebFAUCraAk8yj05MEp0DAAAAAIoaJTBX0ClcQOrVV80uvjjjOYN/FTtkowQAAAAAAJHl85l98IFZq1Zmzz0Xfpk2bSj1Yo6WUgAAAAAAIHIWLDAbMMDsyy8pVWSLllLRpn6xSSHTypDoHAAAAACQ4HmjJk82u+ACfwuowIBUp05mpUsHL08ic9BSKoaJzgEAAAAAKAqWLfMnMt+7N3h6vXpmTz1l1qOH2d9/k8gcmdB9L1aJzvcETCPROQAAAAAgEf38s1n//pkDUjJunNnRR2ckMSeROUIQlIqFFDP7JCbvDAAAAABAwf37r9ngwWavvJL1MuXKUdLIFkEpAAAAAACQfb4or9fPvn1mn3xi9uSTZlu3UmooEIJS0aauenmZDgAAAABALANSzZub7doVfn6lSv6R9h56KHgZEpkjFwhKRZtG2ithZmndau3HtO58mg4AAAAAQDxRC6msAlKXXWZ2331mNWv680p5ram8kefJIYUcEJSKleoxe2cAAAAAAHK2Y4fZc8+FnzdmjNmFF2Y8J5E58iE5Py8CAAAAAABFlM9n9u67Zi1amL34YvhlWreO9lahCKKlVLSpCWNSyDR13dN0AAAAAABimch8yRKzJ54wmzYt6+XJF4UIISgVC76YvCsAAAAAAHlLZH7KKWa33GJWuXLGNPJFIUIISkVbYOK3wJH3NJ0kcAAAAACAaPr33/ABqXr1zJ591uyMM8ySQrv7AJFBUAoAAAAAgOJo6lT/CHrhKKdUx47R3iIUMyQ6j5WUtAcAAAAAANG0erXZRReZHX202YIF4ZdR7mOgkNFSKtrU9zY1yezDgMRSJDoHAAAAABR2IvO9e83eesvspZfMduzImK/ueRpxz0Mic0QJQalYCDzZAQAAAACIRSLzKlXMhg8369bNbPPmjOkkMkeUEJSKNhKdAwAAAACi5ddfwwekevY0e/55s2rV+CwQM+SUilWpd0p78AkAAAAAACJt2zazO+4wO+ec8PMHDyYghZijpVQsaDTN2gF/AwAAAAAQqXQxb79tNmiQ2apVlCniGkGpaFPf3NBAFInOAQAAAAAFyRu1caPZ4sVmI0b4u+x5SpUyS001SwkY/p1E5ogTBKVigTznAAAAAIAISF650pI6dzbbvTvzzNNPN3vsMX9DiMD8xiQyR5wgKBVtJDoHAAAAAERCSoqVGzPGksIFpJ580uyGGzKeN2hAmSPuEJQCAAAAACDRTJliSTfcYBV++y38fLWeAuIcY78BAAAAAJAoVq4069vXrEsXS8oqIAUkCFpKRRuJzgEAAAAAeUlirjQw6qL3xhtmr7xitmtX+uy9zZpZyWXLLGnPnozXkMgcCYKgVCzsM7MJfAoAAAAAgBwCUs2bBwWh0lWrZqnDh9uGM86wmnv3WpJG3/OQyBwJgqBUtJHoHAAAAACQG7/8Ej4g1bu32ahRZpUqma1da1anjlmjRpQpEg45pQAAAAAAiCdbt5oNGmTWq1f4+bfcYlalSrS3Cog4WkrFKhTYIe3vGWaWGpOtAAAAAADEk9RUf96oW281W7Mm1lsDFDqCUtGmvr0KStVLe/6LmZUp458OAAAAACieicznzzcbMcJs7tyMeaVLm6Wk+B8ekpijCIm77nv//fefDRgwwBo2bGjlypWzTp062YwZak7kd8kll1hSUlLQo1u3bkHr2Lhxo51//vlWsWJFq1y5sl166aW2bds2ixu+WG8AAAAAACAuAlLNmpkddpjZhRcGB6TOOsts4UKzv/4ymzkz47FokVmDBrHcaqDotpS67LLL7Pfff7fXX3/d6tata2+88YZ17drV5s+fb/Xq+ZsXKQg1evTo9NeUUUujAApIrV692r766ivbu3ev9evXz6644gp76623LOZIdA4AAAAA2LvXbORIs927M5fF00+bXXttxnOCUCii4qql1M6dO238+PE2YsQIO/bYY+2ggw6yIUOGuP9HaWSBgCBU7dq10x9VAhK8LViwwCZOnGgvvfSSHXnkkda5c2cbOXKkvf322/bPP//EaM8AAAAAAEjz7bdm7dqZPfJI+CLp2JGiQrEQVy2l9u3bZykpKVZWfWQDqBvfDz/8kP78u+++s5o1a7pg1AknnGDDhw+3atWquXnTpk1zXfYOP/zw9OXV0io5Odl++ukn69GjR6b33b17t3t4tmqkA5djLtU9Iio1NWwk0L1PpN8rx01JNZ/PF/l9TDCUA+XA8cB5wfcD35Px8ntR0HVHtU6Tht9RyoVjhvMpGhL6u8bLGSWrV1vSqFGW9Pnn2b4kt9eHCV0uhYyySYw6TVwFpSpUqGAdO3a0YcOGWcuWLa1WrVo2duxYF2hSaymv697ZZ59tjRs3tj///NMGDx5sp556qlumRIkStmbNGhewClSyZEmrWrWqmxfOAw88YPfee2+m6evWrbNdu3ZFdB9LrlljCp8lhaSY2rhmje1bu9aiSQfJli1b3MGooF1xRTlQDhwPnBd8P/A9GS+/F8qtWRDRrNN4+B2lXDhmOJ+iIVG/a5JXrrQanTtbUrguema2p1UrK/XHH5akrnxpfGXKmEJYqbm4PkzUcokGyiYx6jRxFZQS5ZLq37+/yx+lIFP79u2tT58+NlMJ3czsvPPOS1+2TZs21rZtWzvwwANd66kTTzwxX+95++2328CBA4PuKtavX99q1KjhkqVHVO3aQQEp0fOqtWubhQTTonEgKlG89rM4f4FRDpQDxwPnBd8PfE/Gy+9FaGvxuK7TpOF3lHLhmOF8ioaE/a75+++wASlf5crme/hhK3nJJeZbudJ8gbmHq1e36rnMIZWw5RIFlE1i1GniLiilANPkyZNt+/btriJVp04d6927tzVp0iTs8ppevXp1W7JkiQtKKcfU2pCIsroFakQ+zQtHOapCk6WLPpyIf0Ban0bz/DDtedrInu59YvAlogOxUPYzwVAOlAPHA+cF3w98T8bD70VB1xvVOk0AfkcpF44ZzqdoSLjvmvnzza67LuyspA8+sKQuXfxPGjXyP4pLuUQRZRP/dZq4PWrLly/vAlKbNm2yL774wrp37x52uZUrV9qGDRvcsqLuf5s3b05vWSXffvutiwQq8XncSMkISAEAAAAAiogtW8xuusmsbVuzn38Ov0yFCtHeKiAuxV1LKQWg1K+xefPmrvXToEGDrEWLFtavXz/btm2by5PQs2dP1+pJOaVuueUWl2/qlFNOca9XLirlnbr88svtueees71799p1113nuv3VrVs31rvnmmJaUpKZT5mk0uiOpqYDAAAAABIzkbkSO3/8sdkzz5ht2JD18urWxPUfEJ9BKSXbUj4EtYBScnIFoO677z4rVaqU64Y3Z84ce+2111xrKAWZTj75ZJcYPbCp+ptvvukCUerOpyZjWsdTTz1lcSPJZ9Y+7e9fY7wtAAAAAID8B6SaNzcLN5iEgk+3367EyGbbtmVMV0AqlzmjgKIu7oJSvXr1co9wypUr51pS5UTBrLfeesvikiLoymzeMO35bDd+s386X0wAAAAAkDgWLgwfkNIgXC+/bNbQu/ADkFA5pQAAAAAAiEt79pg9+qhZjx7h548YQUAKSMSWUgAAAAAAxK0vvzS74QazRYtivSVAwiMoFZNE5yHTSHQOAAAAAPGdyHzlSrPHHjObPDl4fokSZikBQ6uTyBzINYJSsRAw8B4AAAAAII4DUs2a+fMAh+rY0WzkSLMaNfxBKw+JzIFcIygVbYFfVh4SnQMAAABAfPH5zDSAVriA1LBhZnfcYZaU1g2GQauAfCEoBQAAAABAoDlz/HmjQrvqeU47LSMgBSDfCErFgrobfxrwNwAAAAAg9jZuNLvnHrNnnzVLTY311gBFHkGpmCQ6TzLbHZBYikTnAAAAABC7JOZKVP7BB/5g1ObNGfPVLW/1arO9ezOmkcgciBiCUrHqmwwAAAAAiG1Aqnlzs127Ms/bbz+zO+80GzjQ7N9/SWQOFBKCUtGmKHyymbVNez6HROcAAAAAEHXz54cPSJ1yitlLL5kdcEBGaykSmQOFQuERRJvy4TVJe5AbDwAAAACiR6PpPfSQWY8e4efff39GQApAoaKlFAAAAACgePj0U7MBA8yWLIn1lgAgKBWrROch00h0DgAAAACFl8hc/z/6qNkPP2TM0wBUycn+JOcekpgDUUVLqVggzzkAAAAAFC4Fopo183fXC3XMMWZPPWVWtSpJzIFECkrt2LHDvvrqK/vxxx9t/vz5tn79ektKSrLq1atby5Yt7eijj7auXbta+fLlC2eLE52i9KH0JanpJM8DAAAAgMiMeD5mTPiAlHJG3Xabv6WUcB0GxH9Qau7cufboo4/ahAkTbNu2bVauXDmrX7++ValSxXw+ny1evNi++eYbe+SRR1xAqmfPnnbzzTdbmzZtCncPAAAAAADw/Pqr2fXXm/34Y/gy0eh6XkAKQPwHpXr37m3jx4+3ww8/3IYMGWInnXSStWrVykqUKBG0XEpKims99eWXX9p7771n7dq1s3PPPdfGjh1bWNsPAAAAACjuOaNk0yazV14x0/WnWkoBKBpBqeTkZPvll1/s0EMPzXY5BanUMkoPtZKaPXu2PaShNpFBzUeVR29i2nMvp164ZqUAAAAAgKwDUs2bm+3aFX5+48ZmK1ea7d2bMY1E5kDiBaXy29JJQSxaSYUZaU92ZDEdAAAAAJAztZAKF5AqV85s6FCzG24wW7OGROZAURt9b8yYMXbsscdao0aNws5ftmyZTZkyxS666KKCbh8AAAAAAMH+/tufrDyc99/3543ykpiTyByIW8n5eVG/fv1s6tSpWc7/6aef3DLIgnLqtUl7kF8PAAAAAHJHLaOGD/d32/vqq/DL1KhBaQJFuaWURtvLzvbt261kyXytuuirXt1M+eGbpj2fr0+hjH86AAAAACBzIvOUFNvv008tSYnM1UoqK+SMAhJKriNHc+bMcYnLPd9//73t27cv03KbN2+25557zpo1axa5rSxqGAgCAAAAAHKdyFxdfCoGztNI8NddZ3bppcGJzHWzn+56QNELSr3//vt27733ur+TkpLs+eefd49wKleu7PJOIQxvuNJAGnlP0/nyBAAAAAC/ZcvCJzLv0MFs9Giz1q0pKaC4BKWuuOIKO/30013XvSOOOMKGDRtm3bp1C1pGwary5cvbgQceSPc9AAAAAEDepaZqdC2zm28OP3/UKAJSQHEKSrVv397uv//+9CDU6NGjrVWrVnbYYYcV9vYBAAAAAIqLGTPMrr9eo2dlvUwSo0UBxWr0PeWTWh/Q7ax///72xx9/FOZ2FV3q4xz6HVqGROcAAAAAimneqFmzzL7+2qx7d7MjjggOSCUHX7L6SGQOFL+WUg0bNrSvv/7a+vTpYyVKlHBd+NRVD/lEonMAAAAAxV1AIvNMWrUye/JJMw2gtX69paam2saNG61qs2aWRC5eoHi1lLrqqqtc4vKyZctaxYoVXUDq0ksvdX9n9ahUqVLhb30icsOZmtnXaY+UgETnAAAAAFBcfPZZ+ICUcklp5PeuXf2DQbVv7x772rZlcCigOLaUGjRokB1yyCE2adIk+/fff+21116zDh06WJMmTQp/C4uqrbHeAAAAAACI0ah6CjxNmBB+ft++ZqVKRXurAMTz6Hsnn3yye8irr75qV155pfXVlwUAAAAAADnZscNsxAizhx4K30IKQLGT66BUIPXnRQESnavTZPO05wvNrDSJzgEAAAAUwZxRSlPi85l9+63ZE0+Y/fNP8LXRli1me/dmTCOROVCs5Coo9ffff1v9+vXz9QYFeW2RpRzxLdP+XhzjbQEAAACAaCYxL1nSbMAAs7vuMtu8OTi/rgJVJDIHio1cJTo/6KCDrH///vbzzz/nesVTp061iy66yJo2bVqQ7St6wiU0J9E5AAAAgKLkr7/CB6SOOsps7lyzhx82q1gxKJG5exCQAoqVXLWU+v777+3OO++0o446yho2bGgnnHCCtW/f3ho3bmxVqlQxn89nmzZtsqVLl9ovv/xi3377ra1atcqOP/54mzJlSuHvBQAAAAAg9lJSzEaP1mhZ4ec//bRZixbR3ioAiRyUOuKII+zLL7+02bNn2+jRo+3DDz90/0tSkvqiqZuwz/2vrnpnnXWWa1l16KGHFua2AwAAAADixbRpZtdfbzZzZtbLpF0/AkCeE50ryPTkk0+6xz///GMLFy60DRs2uHnVqlWzFi1aWN26dSnZ7KiPdOj3cBkSnQMAAABI0ETm69aZPfWU2WefBc9PTtYoWRnPSWIOID85pcJR8End+M4991z30N+RCEj9999/NmDAANdNsFy5ctapUyebMWNG2GWvuuoq11LrCY3iEKBRo0ZueuDjwQcftLjhb1QGAAAAAIkbkGrWzOyww8y6dQsOSLVpY/bdd2ZLl/pbTXmPRYvIGQUg/y2louGyyy6z33//3V5//XUX5HrjjTesa9euNn/+fKtXr176cu+//75Nnz49y0DY0KFD7fLLL09/XqFCBYv7ROck9QMAAACQCD76yH8dE+rWW82GD/ePsCdc4wAojJZShWHnzp02fvx4GzFihB177LFu1L8hQ4a4/0eNGpW+nJKoX3/99fbmm29aqVKlwq5LQajatWunP8qXL29xQy1YJ6U9AlqzAgAAAEBcW7LE7Mwz/bmjwunVKyMgBQCJFJTat2+fpaSkWFn1NQ6gbnw//PCD+zs1NdUuvPBCGzRokLVu3TrLdam7nvJctWvXzh5++GG37rjqvrcp7UFXPgAAAADxbts2szvuMNM12Mcfx3prABQRcRXCVuumjh072rBhw6xly5ZWq1YtGzt2rE2bNs21lpKHHnrISpYsaTfccEOW69G89u3bW9WqVW3q1Kl2++232+rVq+2xxx4Lu/zu3bvdw7N169b0AJgeEVW1qj/PVdpoheIrU8Z8VasGJwGMAu2bRk2M+D4mGMqBcuB44Lzg+4HvyXj5vSjouqNap0nD7yjlwjFThM8n5Y1SEvMvvrCkp56yJP2dxlezptmmTZa0d2/GtLJlC+26Ju7KJk5QLpRNotdp4iooJcol1b9/f5c/qkSJEi641KdPH5s5c6Z7aOS/WbNmucBOVgYOHJj+d9u2ba106dJ25ZVX2gMPPGBlNNJdCE2/9957M01ft26d7dq1K4J7Z5a8fr3VUPOoZmkT/tC3t8/Wr19vqSEtxAqbDpItW7a4gzFZI2MUU5QD5cDxwHnB9wPfk/Hye6EBXwoimnUaD7+jlAvHTNE8n5JXrrQanToFBZ3EV7Kkbb/qKts+YIAlbdpkyRs3ps9LrVrVf02zdm2RLpt4QrlQNolep0nyaSvi0Pbt293dvTp16ljv3r1t27ZtdtJJJ7mAU2ChqbufntevX9+WLVsWdl3z5s2zgw8+2BYuXGjNmzfP1V1FrW/Tpk1WsWLFyO7YrFmWfFQHs+5pzz/UTpilaoTB9u0t2geiKqk1atQo1l/slAPlwPHAecH3A9+T8fJ7oTpIlSpVXEUxP3WQqNZp0vA7SrlwzBTB82nDBku65hpLeu+9TLNSx483O+us4ls2cYZyoWwSvU6T75ZSqtyoa91ff/3l/g6Nbakl08svv5zf1bvE5Hpo3V988YVLft6zZ083El+gU045xeWY6tevX5brmj17tivommpiGoZaT4VrQaXXRPwDymJ97n1i8OWqz6lQ9jPBUA6UA8cD5wXfD3xPxsPvRUHXG9U6TQB+RykXjpkicj6lpJi98ILZnXeaBbSACpTcqFFMrluE7xrKhWOm6NVp8hWUUpDonHPOca2ZFPFS9CtUdt3rclq3Alxq0bRkyRKX0LxFixYu6KSR9pS8PJCmaXQ9rwWU8k/99NNPdvzxx7scVXp+00032QUXXBB2OwEAAACgWFLOqPXr/X/PmmWmHLwLFsR6qwAUI/kKSt18880uEDRhwgRr06ZNRDdITbuUmHzlypUuUblaR913330u+JQbujv49ttv25AhQ1zz9caNG7ugVGCeqZgKaFKfq+kAAAAAUBgBKd3YzyrfXI8eZp99FnydonxR1avzWQCIbVBKLZgefvjhiAekpFevXu6RW6F5pJQYffr06Ra3wjSpz3Y6AAAAAETaqlXhA1IKVCkNy9FHB7ekEgWkGjTgswAQ26BU06ZNCzw6DAAAAAAgypQL+JNPzK65Jvz8118369DB/7cCUAShABSifGW0Gj58uD377LNZjnYHAAAAAIgzixaZnXaa2Zlnmq1cGX6ZEiWivVUAirF8tZT65ptv3NCBLVu2tJNOOskNNVwi5MtLic6ffPLJSG1n0aEmrxqocEra89S0rnv0zQYAAAAQSV73u23b/F3y3nrLbN++jPkaHStVFyRpyBkFIBGCUk8//XT635+o6WcYBKWyoe/9gK7ZAAAAABC1ROYHHGD2yCNmRx1ltmFDxnRyRgFIhKBUamA0HXkTmCjQoxEtNJ3+2gAAAAAi4fvvwwekLr3UTD1aypf3P2/YkPIGkFg5pVBASWbWJO2hvwEAAAAgEtatM7viCrMLLgg/XwnOvYAUACRiSynP0qVL7fPPP7fly5e75w0bNrRTTz3VGjduHKntK7qhwEPT/lbRpcR4ewAAAAAkNuWKevZZs7vvNtuyJdZbAwCFG5S6+eabXSLz0K58ycnJNmDAAHtEfZSRmfpph7aOItE5AAAAgPwkMZeffzZ77DGzP/7ImK/WUEoTEpjYnETmAIpCUOrRRx+1xx9/3M455xwXnNIofLJgwQI3XY969erZTTfdFOntLRo0+h4AAAAARDqJuVxyidkDD5jt2ROc05ZE5gCKQlDqxRdftDPPPNPeeeedoOlHHnmkvf3227Zr1y57/vnnCUqFQ6JzAAAAAAWxcmX4gFSrVmavvKILs4xpDKYEoKglOl+2bJmdcsopWc7XPC0DAAAAAIgQn89swgSznj3Dz3/tteCAFAAUxaBUzZo17bfffstyvubVqFGjINsFAAAAAPDMn2928sn+gNSaNeHLJZnB1QEUg+575557rkty3qhRI7v++uutfNqQotu3b7enn37aXnrpJZfsHGGQ6BwAAABAbhOZ//ef2QsvmI0bZ5aSEhyAChx0iiTmAIpLUGrYsGE2e/ZsGzx4sN19991Wt25dN/2ff/6xffv22fHHH29Dhw6N9LYWHfotmZr2d/DghQAAAACKOwWkNJhUuLxRjRr5R9pr395sw4aM6SQxB1BcglL77befffPNN/bhhx/a559/bsuXL3fTu3XrZqeddpqdccYZlpSUFOltLRp0t0Oj7wW2uNVQrZpOEkIAAAAA330XPiB15ZVmjz9uVq6c/3nDhpQVgOIXlPJ0797dPQAAAAAABbRmjVUcONCS1VUvnCuuyAhIAUARQCa8WFAjsoZpDxqUAQAAAMXbnj1mjz5qSS1a2H5ZBaQAoLi2lGrcuLElJyfbwoULrVSpUu55Tt3zNP/PP/+M1HYWHerrXcLMDkt7vlKfQhn/dAAAAADFK5H5tGlmjzxitmxZ+v1qX8WKlrRjh9m+fRnLk8gcQHENSnXp0sUFmRSYCnyOfFJOKQAAAADFNyDVrJk/t2zIZcLO88+3smo15eWd9ZDIHEBxDUq9+uqr2T5HHgT+sHhIdA4AAAAUD9u3m2mk8pCAlPjGjLGtJ51kZWvUMFODAAZCAlDE5Sun1JgxY2zZsmVZztdofFoGAAAAAKCIk8/snXfMWrY0e/nl8EWieQBQjOQrKNWvXz+bOnVqlvOnT5/ulgEAAACAYm/OHLPjjzfr3dvs77+LfXEAQIGCUj5F+bOxfft2K1kyVz0Dix/1BQ9Nx1WGROcAAABAkcsbNWmSPxB16KFmkydnzOvSxax06eDlSWQOoBjKdeRozpw5Nnv27PTn33//ve0LHA0izebNm+25556zZkrch/BIdA4AAAAUXUuX+hOZh14vKUfU00+bnX66v8VUaCLzAw4wW7s26psLAHEflHr//fft3nvvdX9r5L3nn3/ePcKpXLkyOaWyoh+eVDP7Ke25/ibROQAAAFA0/Pij2aWXZg5Iydtvm3XsmBGgCk1knqqLAwAoPnIdlLriiivs9NNPd133jjjiCBs6dKideuqpQcsoWFW+fHk78MAD6b6XU0upVfn/0AAAAADEmX/+Mbv1VrM33sh6GaXtAADkPShVp04d95BJkyZZy5YtrWbNmrl9OQAAAAAUnXxRXte7PXvMPvzQbORIJdeN9ZYBQELJVzbyLkrMh/xRVz0lOq+b9vyftJZTmg4AAAAg/gNSzZub7doVfn7VqmYDB5oNHx68DInMASCTfA+Rt2bNGnv55Zdt1qxZtmXLFksN6f+srnzffPNNfldfdKnJrsY8PDLt+YdmlkJTXgAAACAhqIVUuIBUUpLZ1VebDR1qVq2a2YUXZk5kHppDCgCKuXwFpTQS33HHHWc7d+605s2b29y5c61Vq1Zu5L1Vq1a5nFL169eP/NYCAAAAQKxs2+bvphfOm2+a9emT8TxcInMAQBC12cmz2267zfbff39btGiRff311y75+ZNPPml///23jRs3zjZt2mQPPvhgflYNAAAAAPHF5zN76y1/t71XXw2/jOYBAAq/pdSPP/5ot9xyizVo0MA2btzopnnd984991z74YcfbNCgQTZ58uT8rL5oU7Nd5ZQK7dKn6QAAAADiK5H5woVmjz9u9ssvWS9PvigAiF5QSgGoWrVqub8rV65sJUqUSA9OSZs2bVy+KWRBic0BAAAAJF4i8zPOMBs0yKx8+Yxp5IsCgOgFpRo3bmxLly51fycnJ7vn6sbXq1cvN23q1KkuWIUwApMdejTynqbT5xwAAACIrTVrwgekVFd/7jmzU0+NxVYBQJGUr5xSJ598sr377rvpz6+++mp76aWXrGvXrnbiiSfaa6+9Zn379o3kdgIAAABA4VL6kfPPDz/vnXcISAFAPLSUuuOOO6xPnz62d+9eK1WqlA0YMMC2b99u48ePd1357rrrLhs8eHCkt7XoUPqtmQF/AwAAAIidv//2d8kbNy7rZUqViuYWAUCxkK+gVJUqVeywww5Lf56UlGR33nmneyAHLqF5ktnygMRSJDoHAAAAop/IXGk03njD7JVXgrvsJSX5R9zzkMgcAOKn+96zzz5r69ati/zWmNl///3nWl41bNjQypUrZ506dbIZM2aEXfaqq65yAbEnnngiaLqSrp9//vlWsWJFl9vq0ksvtW3btlncCPyBAwAAABD9ROa6yd6pky5uMgJSuoH8wgtmf/5pNnNmxmPRIvK/AkC8BKWuu+46q1evnp100klulL3AkfcK6rLLLrOvvvrKXn/9dZs7d67LX6VcVatWrQpa7v3337fp06db3bp1M61DAal58+a59XzyySc2ZcoUu+KKKywu6I5MkpnVTnskBSQ6BwAAAFC4dMM7XCLz884zW7zY7PLLNbKTWfv2GQ8GJAKA+AlKLVy40HXVW716tV1++eVWp04dO+2001wgaevWrfnemJ07d7q8VCNGjLBjjz3WDjroIBsyZIj7f9SoUenLKUB1/fXX25tvvulyWgVasGCBTZw40SVeP/LII61z5842cuRIe/vtt+2ff/6xuCn1TmmPfH0CAAAAAPJE1yn/+59Z797h5yunVJUqFCoARFG+QiLNmjWzu+++237//XfXmumWW26xv/76yy6++GKrVauWnXXWWS4IlFf79u2zlJQUK6s+2wHUje+HH35wf6emptqFF15ogwYNstatW2dax7Rp01yXvcMPPzx9mlpaJScn208//ZSf3QUAAACQqFJTzV57TRcxZo8+apaSEustAgAUJNF5IAWGhg0b5h6//fabC0Yp55S6zZ2nJrB5UKFCBevYsaNbV8uWLV2Aa+zYsS7QpNZS8tBDD1nJkiXthhtuCLuONWvWWM2aNYOmafmqVau6eeHs3r3bPTxeay8FwPSIqKpVXd5E9drz+MqUMV/Vqv4fzCjSvvl8vsjvY4KhHCgHjgfOC74f+J6Ml9+Lgq47qnWaNPyOUi5xecx4icznz7ekRx6xpLlz02f5Spd2gamkgOCUr2zZmNTHQ3E+UTYcM5xPxa1OU+CglGfOnDn2zjvv2HvvveeSlat1U36oC2D//v1dzqoSJUpY+/btrU+fPjZz5kz3ePLJJ23WrFkuwXmkPPDAA3bvvfdmmq5k7rvC9TcvgOT1661GaJ5zn8/Wr19vqSEtxAqbDpItW7a4g1EtyYoryoFy4HjgvOD7ge/JePm9UB0qUeo0Hn5HKZd4O2aSV660GkcfbUl79mSat+u00+y/e+4xX3KyJQfkxU2tWtVfF1+71mKJ84my4ZjhfCpudZoCBaXmz59v48aNc8GoxYsXu/xOp5xyiqsMnXnmmfla54EHHmiTJ0+27du3u7t7ylfVu3dva9KkiX3//fe2du1aaxCQaFDd/W6++WY3At+yZcusdu3abpnQboFKxq554dx+++02cODA9Od63/r161uNGjXcCH4RtXJlUCsp0Q9mdf0R0sIrGgeignvaz+IelKIcKAeOB84Lvh/4noyH34vQFAZ5FdU6TRp+RymXuDpm9u41e/jhsAGp1JEjrfQ111g1i1+cT5QNxwznU3Gr0+QrKKXudQpEKSil1kwnnnii3XbbbS6XVKVKlSwSypcv7x6bNm2yL774wiU/79mzp8sPFUhBMOWY6tevn3uu7n+bN292raoO0zCvZvbtt9+6Qlfi83DKlCnjHqH04UT8A8pife59YhAY0oFYKPuZYCgHyoHjgfOC7we+J+Ph96Kg641qnSYAv6OUS1wcM998Y3bjjWbz5oWdndypU0zq23nF+UTZcMxwPhWnOk2+glJDhw61Ll26uLxOZ599tlWrFrn7DQpAqQlZ8+bNbcmSJS6heYsWLVzQSS2xQt9L09QCSsuLclF169bNjQr43HPP2d69e+26665z+a3q1q0bse0EAAAAEAeWLfOPqjd+fKy3BACQR/kKSq1atSpTMvFIUb9GNT1fuXKlS06u1lH33XefCz7l1ptvvukCUWrBpeic1vHUU09ZXKhe3Uw5pWanPVfuL93R1HQAAAAAuUtkvnKlf1S9V181C+yud8ghZgsWBE9TNxLq2wBQNIJSXkBKo7so6bhyOB199NFWPQJf9L169XKP3FIeqVAKZr311lsWtxSI+ivWGwEAAAAkoOXLzZo29eePCqQeFY88YnbRRf6AlUbf8+g6JSAvLQAgPuS786BaHikJeefOnV0XPo2+JxpFTsGpV155JZLbWXQE/jh6NHRzuOkAAAAAMihf1LnnZg5IibrvXXKJP2+UAlDt22c8CEgBQNEJSo0ePdoGDBjgcje9/PLLLgeURwGpE044wd5+++1IbmfRouH3qqc9QofiAwAAABBs82azAQP8XfNmzAhfOhUqUGoAUBy67z366KPWvXt310Vuw4YNmeZr1Lu4yeEUr6HAY9P+/tDMUmK8PQAAAEA85YvyehGkpGgobX+3PHoWAECRk6+glEbF08h7WVFOp3DBKqR11cvLdAAAAKA4BaQ0qvauXeHnlytnds01Zk8/HVx/JpE5ABSfoFTlypVd7qiszJ8/32rXrl2Q7Sq6NNJeXqYDAAAAxYWuMbIKSGkwpIcf9ueH0g1yEpkDQPHMKXXaaafZCy+8YJvVtzvEvHnz7MUXX7QzzzwzEtsHAAAAoDjYs8fstdfCz3v+ebNx4zISlpPIHACKb1Bq+PDhlpKSYgcffLDdeeedlpSUZK+99ppdcMEFdvjhh1vNmjXt7rvvjvzWAgAAACh6Jk40a9NGQ3yHn3/44dHeIgBAvHbfq1u3rs2cOdMGDx5s48aNc6Pvvf7661ahQgXr06ePPfjgg24UPoShckkK03WP8gIAAEBxsGKFlVy8WIlozVat8ueH+vrrrJcnXxQAFFn5CkqJWkO99NJL7rFu3TpLTU21GjVqWHJyvhpfFS++WG8AAAAAEAMrVlhSy5ZWPau8UZ06mQ0ebFanTsY03bz1uu0BAIqUfAelAikYhVxSQsZUM/s97bn+1sghms6PLQAAAIqydessKVxASoGnJ54w69vXLCm0WwEAoFgHpYYOHZrnFSvP1F133ZWfbSoeLaUWx3ojAAAAgCj67Tezyy8PP2/CBLNjjuHjAIBiJldBqSFDhuR5xQSlAAAAANiGDWYaBOm558xS1U0gjPLlKSgAKIZyFZRSvihEiJomK+1WpbTnm82sNInOAQAAUESsWOFPTZGS4m8BNWqU2ZYt6bN9SUmW5AtIskoicwAotiKSUwp5pG7yx6f9/SGlBwAAgCIUkGre3Cxc3ii1hrrrLvP16GEbli2zqlWr+gdJIpE5ABRbuQ5K/fzzz3bQQQe5H4+cLF261L7//nu76KKLCrp9RY/uGoUi0TkAAACKgvnzwwekTj3V7KWXzOrWdV349lWsqOG8zRi5GwCKNXUky5WOHTvaxIkT059v3LjR9ttvP5s8eXKmZadOnWr9+vWL3FYCAAAAiF+6yfrAA2Y9eoSfP3y4PyAFAEB+Wkr5Avt9pz3ftWuXpaivOAAAAIDi6ZNPzAYMMPvzz1hvCQAgwZBTKtrUZ145pQKVIdE5AAAAEiyR+fLlZo8+avbjjxnzkpL8XfICb1yTyBwAkAWCUrEQ3OgMAAAASJyAVLNm/u56obp0MXvqKbPKlYPzqJLIHACQBYJS0UaicwAAACQipfMYMyZ8QEr5pG691d9SSho0iPrmAQCKeFBq2bJlNmvWLPf3li1b3P9//PGHVdbdkJDR95CNVDNbEPA3AAAAEM90DXD99RrRKPz8k0/OCEgBAFAYQam77rrLPQJdc801mZZTEvQkfpSy777nBaUAAACAeLVundmdd5q9+KK/pRQAALEISo0ePTqS71vME50nBf+ok+gcAAAA8ZQ3as0as/feMxs1ymzbtox5TZqY/f232d69GdNIZA4AKOyg1MUXX5zf90AoBaQqpv29leIBAABAHAWkmjY127MneHr58mb33uvvwqeAFYnMAQARQKLzaNMPeAkz65r2/EPzJ4vUdBJCAgAAIJYBqUsvzRyQkgkT/HmjRHVW6q0AgAhIjsRKAAAAACSonTvNhg0za9HC7Ouvs05BAQBAhNFSCgAAACiuKSU++MBs4EANsx3rrQEAFEO0lIpJovOQaSQ6BwAAQLS66M2aZTZ+vFnHjmZnn50RkCpRwqx/f3/dNBCJzAEAhYSWUrHAaLoAAACIRUCqWTN/PtNQJ55o9tRTZq1amd1zD4nMAQBRQVAq2gJHKvGQ6BwAAACFKTXV7JVXwgekHn7Y7OabzZLSmvOTyBwAECUEpQAAAICi7Oefza6/3v9/OCeckBGQAgAgighKxUKqmf0R8DcAAAAQqS56Xsv8DRvMXnzR7N13KVsAQFwiKBVtajKtnFJzw0wHAAAAChKQat7cbNeu8PObNjVbvtxsz56MaSQxBwDEEEGpaAsdzSSn6QAAAEBuqIVUuIDU/vub3Xef2dVXm61eTRJzAEDcICgVK/ul/b8jZlsAAACAomLpUrP//S/8vA8+8I+uJyQxBwDEkeRYb0CxVMLMuqU99DcAAACQHzt2mN19t1nLlmaTJoVfpkoVyhYAEJdoKRVt1aubJYXpuqfpAAAAQG4Smft8Zl9/bfbkk/4ueVkhZxQAII7FXUup//77zwYMGGANGza0cuXKWadOnWzGjBnp84cMGWItWrSw8uXLW5UqVaxr1672008/Ba2jUaNGlpSUFPR48MEHLW4o0TkAAACQn0Tmhx1mdvjhZrfdlhGQKlXKbNAgs99/N5s5M+OxaJG/yx4AAHEo7lpKXXbZZfb777/b66+/bnXr1rU33njDBZ7mz59v9erVs2bNmtnTTz9tTZo0sZ07d9rjjz9uJ598si1ZssRq1KiRvp6hQ4fa5Zdfnv68QoUKFhe8IXpDR97TdCoMAAAAyMpff4VPZN6xo9no0f6AFQAACSSuWkopyDR+/HgbMWKEHXvssXbQQQe5llH6f9SoUW6Zvn37uiCVglKtW7e2xx57zLZu3Wpz5swJWpeCULVr105/qGUVAAAAkHBSUsxeeMHsrLPCzx85koAUACAhxVVQat++fZaSkmJl1fc9gLrx/fDDD5mW37Nnj73wwgtWqVIlO+SQQ4LmqbtetWrVrF27dvbwww+7dQMAAAAJZepUsyOOMLvySrMtW8IvkxSasBQAgMQQV9331LqpY8eONmzYMGvZsqXVqlXLxo4da9OmTXOtpTyffPKJnXfeebZjxw6rU6eOffXVV1Y9IFH4DTfcYO3bt7eqVava1KlT7fbbb7fVq1e7VlXh7N692z08anklqamp7hFRVau6ekNg1cFXpoz5qlbVG1o0ad98Pl/k9zHBUA6UA8cD5wXfD3xPxsvvRUHXHdU6TRp+RyNcLl4i83XrLGnkSEv6/POg2b7kZEsKWKevbNmY1CMLgmOGsuG44Xziuya2UuOoThNXQSlRLqn+/fu7/FElSpRwwaU+ffrYTCVqTHP88cfb7Nmzbf369fbiiy9ar169XLLzmjVruvkDBw5MX7Zt27ZWunRpu/LKK+2BBx6wMhrpLoSm33vvvZmmr1u3znaF67dfAMnr11sNfTZ/BSQ99/ncvqSGtBArbDpItmzZ4g7G5OS4ajQXVZQD5cDxwHnB9wPfk/Hye6EBXwoimnUaD7+jkSuX5JUrrUbnzpYUEFj07G3VyrYOH24p9etb8saNGe9Ttaq/Drl2rSUKjhnKhuOG84nvmthKjaM6TZJPWxGHtm/f7u7uqSVU7969bdu2bfbpp5+GXbZp06YukKUWUeHMmzfPDj74YFu4cKE1D5MAMtxdxfr169umTZusYsWKEdwrM5s1y5I7dMg0OVUjDLZvb9E+EFVJVYL44h6UohwoB44Hzgu+H/iejIffC9VBNLqwKor5qYNEtU6Tht/RCJbLyJGWPGBA5nXdeqtG8TErGXf3k/OFY4ay4bjhfOK7JrZS46hOE7e/bEpMrocqUV988YVLfp5dgQZWwEKpVZUK2mtJFUqtp8K1oNJrIv4BZbE+9z4xCAwlJSUVzn4mGMqBcuB44Lzg+4HvyXj4vSjoeqNapwnA72gBy2XJErObblKOirCzk3v1Mitd2ooSjhnKhuOG84nvmtiKlzpN3AWlFIBS4y21aFqyZIkNGjTIWrRoYf369XOtp+677z4788wzXQsqdXl75plnbNWqVXbuuee61yv/lLryqYufclTp+U033WQXXHCBi9LFDa++mHUsDQAAAEXZtm1m991npryne/bEemsAAIi6uAtKqWmXuuGtXLnSJSrv2bOnC0SVKlXKjcynLnivvfaaC0hpdL0OHTrY999/b61bt3av193Bt99+24YMGeJaTzVu3NgFpQLzTMWUErKr1P8v7fmH+hTK+KcDAACgaFMi83XrzCZONHviCX9Sc0+tWmbKF7V3b8Y05YuinggAKKLiLiilpOV6hFO2bFmbMGFCtq9XYvTp06dbXIvLLF4AAAAo9IBU06aZW0WVKmX2v/+ZDR7sD0oFBqoUkGrQgA8GAFAkxV1QqsgLrGR4lA9L06lwAAAAFE0bNmiI6PDd9N5916x7d//f++9PnRAAUGwU7+zWAAAAQGHat8/s2Wf9LaTGjw+/TP36fAYAgGKJllIAAABAISg1daol3Xuv2Zw5lC8AAGHQUiraqlfPlFIqhUTnAAAACe/z51dY76azrHupz2xapVOtWs+elhQYkDr7bI3KE/wiEpkDAIoxWkplY9++febz+SwpKck9T01NdQ89L1GiRNByomk5LfvpZ/vspJIlrJSlmH9Js92pSTbps33W7fKUfK83L8tqFEPtVyA91/Sslk1OTnaPwGXdAVSyZEItG658wpVDYZR7PCzrlU+4ZUOPiUT4PAtj2dCyiOfPszCPE68sivt3hMotXDkUt+8IrcPb71h/RrFcVuXg1Q08kf6MEqlO4y3rLRfLYzbc5xrt76svX1ppJ1zdwk613e4GZMqukravZEkrqf1p395s5EhLOfJI8y1fbskbN2ast1o1S6lb13XzK2idJi/Lxvo7yPte8bY3v599QY+TSHz2hbGsykLTCqPuG+vPPhLLal8T7TuisJYNVJS+IyJVn83Nb3Y8fZ7JxbBOQ1AqG++//76df/75btQ/WbBggc2ZM8eaNGliRx55ZPpyGhFQH/aZZ55p5cuXd9MWL15sv/76qzVs2NA6deqUvuw307+1/3qeY2es/NjKb9/hRuL7p3E9mzTzS6vQqpUde+yx6ct++umntmPHDjv55JOtWrVqbtqKFSts2rRpVqtWLTvhhBPSl/3iiy9s69atbprmyT///GPff/+9Va9e3U466aT0Zb/++mvbuHGjHXPMMekH7L///muTJk2yypUr26mnnpq+rKatW7fOjj76aGuQloh9/fr1bh3777+/nXHGGenL6r1Wr17tykZlJJs3b7aJEydauXLl7KyzzkpfVvvw999/22GHHWbNmjVz07Zt22affPKJlSpVys4555z0ZWfMmGFLly61Qw891Fq2bOmm7dy50z788EN3Epx33nnpy86aNcuWLFliBx98sLVp08ZN27t3r41Py+HQu3fv9BPpt99+s4ULF1rz5s2triqDaSfou0o2amY9e/a00qVLu7/nzZtnv//+ux100EHWoUOH9Pd777333Gu6d+9u++23n5u2aNEimz17tjVu3NiOOuqo9GU/+OADty2nn366VahQwU3Tts6cOdPq169vnTt3Tl9W5aB97Natm1WpUsVNW7Zsmf30009Wp04dO+6449KX/fzzz13Zde3a1WrUqOGmrVy50n788Uf3XNM9X375pftMjj/+eKtdu7abps9sypQp7n1Uxp5vv/3WfdY6Tg444AA3be3atW56xYoV7f/+7//Sl508ebI7hjp27GiNGjVy03SM6f1ULiofj7Zr1apVrhxVnqJj97PPPrMyZcrY2bqLnEb7u3z5cmvXrp21aNHCTdM58dFHH7kvusCROn/55Rf766+/rG3btta6dWs3bffu3e48lj59+qQvq89H52irVq3skEMOcdN0Duuz1+cZeB7OnTvX5s+f745THa8e7zjp0aNHRL8jtG/a7tNOO80qVarkpmm/dB7Uq1cvat8RGzZscOeRd5wU1+8Ifab6fvDKobh+R+gc13Ee+BkVx+8IfZ56jeoGXmUr0t8RiVSn8b6vdBx6YvF9pWNJ76X3jOX31cTXK9tptttN21ahgn1y+ulWau9e2zC5uV35872qoduM6dMzf1/t2GEfvvtuROo0Og90PsT795XOW9U99H2g75tI12mqVq1qp5xySsJ+X+n81Hbo+6cgdRo599xz0+v7RaVOo8/iv//+S7jviMKq0+iz98qhqHxHRKpOs2nTJve775VPUfmO+KWI1Wnovhdl27frCyDZ9v1WymymQoz+6Tt3RntLAAAAUFC6Mb14sdnadeHnv7qlhwtIAQCAzJJ8oW3+4KKXiuarpYCitZFsRnhe8xn2xl+drMS+fend91KTk+38ptPtjXnto959TxHhmjVrumWKc/e90HIojHJPhO57OuZVDiq74tx9T+WgOyqaF8+fZ2E3d9Z5obvPKofi3H0vXDkUx+57unusO5ZeuSXC5xnpZXXXV3dOVQ5euUX6M9Ldf9VBtmzZ4u7OxnOdJrD7no4P/X54yxeX7nu//WbWv3+KzZnjs7aps21mqr9Vgeu+l7bMBY2n29uLD4tKnSZRuuZo2po1a9xvrVqKFOSzL2rd97T9as2hVh903wv+PPW3voPVyoXue9lf0yX6d0Qk67O5qdfH+rwv7nUauu9lQx+mV+gS+EGGLhcqq2UvHljL9l5VwkqW8H9YlqKcUqXd9NB+l3lZb16WDTzoPNrPcOsI1xe0qCzrlU9uyiES5R4Py4Yrn3DlkIifZ6SW9b5cE+HzLMzjRGUQOC+ePqNoLav9D7wgyGnZovwdoXWEzouHzygWyxZG3SDcspFWmNsd+PsRD8dsNI6XPXvM7r/f7L77VAH3L7shqabttLJWzna5G4/KJaXnFw2sVujbG6584v37Ktz3SqTqNIn2vRJu2dz+/hT0OJFEXDZ0elH67PO6bH6vZYr6ceLVZ3Pz2xdPn2dxrNMQlIqyU69sYOe+9Lt1bfCwez5pTn+7ZFAd63aFv98yAAAA4tesWWb9+pkFDqp38MFmo0c3sO9mLrLXHl1vy5ebNWjgs7OvKG3nUscDACBLBKVioGyzBrZ6Vx339wMT21njA/1J5QAAABCfdu82GzbM7MEH/XmkRDeEb7/d7I47zMqUMbPDG7gbkOJ1NQIAAFkjKBUDgS3a0rpcAgAAIE7NmOFvHTVvXsY0DWI0erRZ2kBWAAAgHxh9LwYC8jna3r2x2AIAAADkZNcus9tuM9NI515ASjcX773X7OefCUgBAFBQBKViYOXKjL/PPddswoRYbAUAAABCqV6mVlDqjle5stlDD6krnn9e+/ZmM2ea3X23WWmyLwAAUGAEpWJQ0fn664znS5aY9exJYAoAACAe6mmqlymJuUbYUx4pr3WURtqbPt2sbdtYbyUAAEUHQakoU3PvQD6fhmQ0Gzo02lsCAACAQIMHhy+PAw/0zwtMwQAAAAqOROdRtnixWaov2eavauWe628FphYtivaWAAAAwPPuu1nXx5Yvp5wAACgMBKWirFkzNQkvae/+1Ct9mlpKNW8e7S0BAACAuujdfLPZM8+ELwvqaQAAFB6670XZPfdkruiopVTodAAAABSuP/8069Qpc0BK9TPvf+ppAAAUHoJSUXb22WZXXZXxvF49f1LNHj2ivSUAAADF13vv+UfTmzXL/7xsWbMXX/RPVzJzPdf/1NMAACg8dN+LgeOO2WO11t7v/q527GDr0YMxhQEAAKLVXe9//zN7+ung9ArKKeWNrKcR+AAAQOGjpVQMzP094++HH/bfgQMAAEDhUF3rkEPMypQxq1IlOCDVp4/ZL79kBKQAAED0EJSKQaVoxIiM52vW+O/GEZgCAAAonLqX6lpz55rt2WO2c6d/esmSZi+8YPbmm2YVKlDyAADEAkGpKLv33ozkmR49Hzo02lsCAABQPOpeooTlgZo0Mbv88sz1MgAAED0EpaJs8eLMlSI9X7Qo2lsCAABQtKll1Lx54eetWBHtrQEAAKEISkWZEmmGaynVvHm0twQAAKDo2rTJrFs3s5SUzPOoewEAEB8ISkXZPfeEbyml6QAAACi4v/4y69TJbNKkjGneTUH9T90LAID4QFAqys4+22zcuGRbsamp/bGmqaX6ku3tt8169Ij2lgAAABQ906ebHXWU2cKF/uc1apjdf79/dL2yZf3/K/k5dS8AAGKvZKw3oDjq0bOkvfPe+S4YJe3axXqLAAAAEt+775pddJHZrl3+5y1amH36qT+p+e23x3rrAABAKFpKxUjDhhl/k2gTAAAg/9Qd78EHzXr1yghInXCC2dSp/oAUAACITwSlYqRBg4y/ly+P1VYAAAAktr17zS6/PLglVL9+Zp9/blalSiy3DAAA5ISgVCyk7LGmu++zwd3vs1Il9tjgwf7cBgAAAMiZ6k2HHOLPEVW1qtnLL2fMu+8+//PSpSlJAADiHTmlYuD9D8x++2GvlSrhf752rVnPnmbjx/sToQMAACDrgJTqTd4oert3+6eXLGn2xhtmvXtTcgAAJApaSsXA8OEZwxJ79Hzo0FhsDQAAQOK4996MgFSgRo0ISAEAkGgISsXAH39krkjp+aJFsdgaAACAxLFwYeZ6lKxcGYutAQAABUFQKgaaNg3fUqp581hsDQAAQGL44QezffsyT6ceBQBAYiIoFQN33um/wxcYmNLzzZtJeA4AABAuqbkSlx97rFlqanD5eF357rmHcgMAINEQlIqBHmeZ9e5ltv/+wdNXrPAn7mQkPgAAgIyk5nPnmu3dm9FtT/mj2rTxj77Xtq1/uR49KDEAABJN3AWl/vvvPxswYIA1bNjQypUrZ506dbIZM2akzx8yZIi1aNHCypcvb1WqVLGuXbvaTz/9FLSOjRs32vnnn28VK1a0ypUr26WXXmrbtm2zuJGUZC07NLJNexuZzzKaS3mtp0h4DgAAkHVS8woVzObMMdu502z2bAJSAAAkqrgLSl122WX21Vdf2euvv25z5861k08+2QWeVq1a5eY3a9bMnn76aTfvhx9+sEaNGrll1q1bl74OBaTmzZvn1vPJJ5/YlClT7IorrrC4kVzKrMkl9uiES2xfSqmgWSQ8BwAAyD6puQaNAQAAiS+uglI7d+608ePH24gRI+zYY4+1gw46yLWM0v+jRo1yy/Tt29cFqZo0aWKtW7e2xx57zLZu3WpzdLvMzBYsWGATJ060l156yY488kjr3LmzjRw50t5++237559/LJ40a0bCcwAAgHD+/DNz/ighqTkAAEVHSYsj+/bts5SUFCurBAEB1I1PraJC7dmzx1544QWrVKmSHaIMmGY2bdo012Xv8MMPT19OQazk5GTXza9HmIQDu3fvdg+PglySmprqHoXlrrvMzj1XcUHdAvR349PdwLvu0vtaodO++Xy+Qt3HREA5UA4cD5wXfD/wPRkvvxcFXXcs6jSFUS5r1pidckqS7dvnpTnw15WSknzm8yVFra5UENQvKBuOG84pvmtii+/hxKjTxFVQqkKFCtaxY0cbNmyYtWzZ0mrVqmVjx451gSa1lvKoS955551nO3bssDp16rhuetWrV3fz1qxZYzVr1gxab8mSJa1q1apuXjgPPPCA3aukBSHUJXDXrl0R309L3WPl/37RTqlv9spL19l9D1SzP/8s4Spb+++fYu3arbe1a8O0VY/0ZqSm2pYtW9zBqKBdcUU5UA4cD5wXfD/wPRkvvxfKrVkQUa/TFEK5bN2aZD17VrU///SnOKhTZ59VrOizZctK2oEH7rObb95mRx+929autbhG/YKy4bjhnOK7Jrb4Hk6MOk1cBaVEuaT69+9v9erVsxIlSlj79u2tT58+NnPmzPRljj/+eJs9e7atX7/eXnzxRevVq5drBRUajMqt22+/3QYOHBh0V7F+/fpWo0YNlyw94lL2WNI6/wd/8UWV7OJ+yda3r9m4cWbbtpWwd9+tYYMGWVQOxKSkJLefxT0oRTlQDhwPnBd8P/A9GQ+/F6GtxeO+ThPhclHc7Lzzkuz33/0tpOrX99kPPyTbAQfomW7Y6SZeJUsE1C8oG44bzim+a2KL7+HEqNPEXVDqwAMPtMmTJ9v27dtdRUotoXr37u1ySHk08p5aTulx1FFHWdOmTe3ll192FbHatWvb2pBbZ+oWqBH5NC+cMmXKuEcofTiF8gH5ktOTSSVp/cnJds89Zu+84+++9/DDyXbNNf6RZQqbDsRC288EQjlQDhwPnBd8P/A9GQ+/FwVdb9TrNBEsl5QUswsuMJs82f+8WjWzL79MsgYNMkYqTjTULygbjhvOKb5rYovv4fiv08RtJEKBJwWkNm3aZF988YV179492yiflz9B3f82b94c1LLq22+/dcso8Xm8atlSSdz9f2/YYFa1qpnSZE2YEOstAwAAKDyq66jOo1ja++/7p5Uvb/bZZ2YtWlDyAAAUZXEXlFIASqPnLV261OWKUle9Fi1aWL9+/VzrqcGDB9v06dNt+fLlLvCkrn6rVq2yc889171euai6detml19+uf3888/2448/2nXXXedyUNWtW9fi2VFHZfy9b5/Z3LlmPXsSmAIAAEU3IKW6jgZRVkspj3ogHnFELLcMAAAUy6CUkm1de+21LhB10UUXWefOnV2gqlSpUi7H1MKFC61nz57WrFkzO+OMM2zDhg32/fffW+vWrdPX8eabb7rXn3jiiXbaaae5dWiUvnj34ovBz9WVT738hg6N1RYBAAAUHuVkT8tokE7PP/qIUgcAoDiIu5xSSlquR1aJsibkoj+bRtp76623LNEsXpx5mgJTCxfGYmsAAAAKl+o4qusE0vNFiyh5AACKg7hrKVUs6BbgfnX9j4Dbg82aZb5b6FXODj7YrFw58kwBAIDEp3uMbdqY7dmTeZ7qQs2bx2KrAABAtBGUioXkUmYHXeF/6O80GoHP67IXSBW2efP8wySTZwoAABSFPFK//555nupAqgupTgQAAIo+glJx5OyzzcaPN2vbVl0V/XcJQ0dRJM8UAABI9DxS4SggpTqQglY9ekR7qwAAQCzEXU6p4k6BKT08Gh45tGm7AlPz54dvVQUAABDPssqVqTrP7NnR3hoAABBLtJSKhdS9Zguf8D/0dzZatAgfeNq71+yEE8ymTy+8zQQAAIiklBSzkmFuiZJHCgCA4omgVCyoidOezf5H6JAzIbLKMyXffWfWsaPZWWf5c04BAADEsyeeMNuxI3gaeaQAACi+CEolWJ4p/T9woNlBB2Us8+GH/hFsLrnEbNmyWG4tAABA1t327rgj47nqMl7dhjxSAAAUTwSlEiQwpRwLO3ea/fab2aOP+nNKPf+8Wd26/mXUmuq118yaNTO78UaztWtjvdUAAAB++/aZXXyx2e7d/uc33WT2xx/+uo3qOCQ2BwCgeCIolaBKlTK74gp/he6hh8yqVMnINfXUU2ZNmpj16mV28MFm5cqZHXKI/y4kAABANKn+Ub++2c8/+5/XqWM2fDifAQAAICiV8Pbbz+yWW8z++sts8GD/c9m+3ezdd/25pnbtMps716xnTwJTAAAgugEp1T/WrMmYtnq12cSJfAoAAICgVJFRubLZffeZLVlids01med7+dQvv9zs448zJxkFAACItHvvzTxNic2HDqWsAQAAQanYUG2sbA3/I9ywegWgJvHPPGNWunT4+Rs3mp15pln16mbduyfZG2+Uc3csvbuZ6uZHdz8AAFBQqlfMmRP+RtmiRZQvAAAwK0khxEByKbNm1xbqW7Ro4e+y57WQCqXEop98kmSffFLJBg0yO/BAsz//zBiW2evup5H/lGgdAAAgr932wlFdo3lzyhIAANBSqsi65x5/cMlriOX9f/vt/i58tWsHL6+AlHhBLO+1Clht2hTNLQcAAEWx255HdQzVUwAAAGgpVUSpdZNaOSlng5rI646kKoDekMupqWYzZqTauHE77Ntvy9tvvyWFrTQqgXrVqmYHHWTWoYPZEUf4/2/XLiOpOgAAQKCsuufphpfqJ159BAAAFG8EpWIhda/Zkhf8fx90hb87XyEFprLqepec7A8uNWy4zR55ZD9r3TrJVSCz6u6nBOp6jB3rf16ihFnr1hlBKj0OPtifRF13RxcvNmvWzB8Io/sfAADFq+vevn3hA1Jt2xKQAgAAGQhKxYIiP7vWZfwdBzRyn3I/eDmlvP9PO82fHP3XX812785YPiXFn7xUj5de8k8rVcps796MZchLBQBA8ZJVLimvXkG3PQAAECg56BmsuHf30x3MsmX9/6ti+emnZtOmmf33n9nMmWbPPWd26aX++WptFSgwIBUYb+vVy+yYY/y5rB591L9OtboKvIvKyH8AACS+gQPDTy9Txv9bT7c9AAAQiJZSyFV3P7WCat/e/7jySv+07dv9LahmzPA/3n47fMMvtar64Qf/I1Dp0mZNm5pVqGA2fXrmkf/eey/rkXsAAEB8UdBp+fKs5xOQAgAAoQhKId/Klzfr3Nn/kHnz/AGl0MBUyZLhc0vs2eN/jSdw5D855xyzevXMatb0P2rVyvg78KHpNWr478ICAIDYGDYs86ApHg24AgAAEIqgFCJGeSLC5aV65x2zE0/0j8SzcGHG/3r88Yc/OJWVVav8j9yoVClzsCpcEEuPKlUydz8EAACRH3FPyCUFAADCISiFiOelGjrUXzHVXVFVQr3m+t4ofaFd+zSKn0brC21hpdxWCh6tWxe+pVWoLVv8DwW6cqLWW2pdpQBVjRpJVrFiJWvQIMlq1w4fxCpXLi8lAQBA8dOwof/3PFSjRnTdAwAA4RGUigU1ISpdOePvYpKXKpwSJczuvz98C6u33vJXYlNTzTZvNlu7NuPx77/BzwMfWjYnCnKtXu1/mOkzyD7qpLxXWXUdDJ1Wtap/vwAAKE40CEpgUMr7PX/ssVhuFQAAiGcEpWIhuZRZiwExeetEbGGlbnYK9OjRokXO69u929+6KjRYlVUgK7vugx6NPqjHn3/mvKy212uFlZsglnJzAQCQyBR8mjMn47nyPOo3O/D3HAAAIBRBKSRkC6vsqCJ8wAH+R24q0Zs2pdqCBRssJaWarV+fnG0ga+PGnNepll16nR65sd9+OSdy9/6uVs3f9RAAgHjy++8lbfFif+vvLl3Mvvsu1lsEAAASAZe3KNbUtaByZbMDD0xxQZ+ckp/v3Wu2fn3Wra4Cp+tvtdrKyY4dZsuW+R+52V4FpnIbxNp//yLXQxQAEIc++qhs+t/nnRfTTQEAAAmEoFQspO41+2u0/+8m/fzd+ZAQSpUyq1PH/8hNK6xt23LuPuhN37Ahc7L3cOtUUEyP+fNz3gYli8/NaISap+6Rn35axp56KsnlBGnWzN/tIlIt2AAARdOECWbPPVc+qMUyAABAbhCUigVFFnb8k/E3iiS1UFKCdD0OPDB3ydcVmMpNEEuPnTtzXueuXWYrVvgfOVMzsSo6KN0z5QZRAvrjj/ePkKjcV2p5pUfg36HPvb9Ll6aVFgAUh4DUuecGNzPu39+sUiVuagAAgJwRlALihHJFqcWSHrmxfXvuk7kr8btyXeVOcH+/SZP8j/zsT14DWblZTsEuAEB8uPdeS7uZkRR0U0aDl9DSFgAA/H97dwLeRLX2AfxNCy37vstSZFVZBEUEFxR6EUVZREEUH5YLKuoFEfkEZBOVRRRFFFRUuIpXLqgICoIgi6IgIoIIiJRVECyylq1Ac77n//ZOSdK0TWmaTjL/3/MMaaeTSXI4mTnzzjnvyQqDUkRhCgGa6tVTl6ykpKQmac8siDV/vhFjgpeACj2/jh9PXYI9hDK7gaystsMj9ktERNmD4d6+NzPQCRyz6RIRERFlhUEpIgeIjhYpWzZ1wVA8fxo2FNm0yTswhbvddeqIfPBBan4sLOihldXP/v6WlJQaHMspJJs/ejR1CSb0wEoNVrkkNraMlCjhuuSAl2ewK6vZEjH0BT0NmMeLiMIRevfu2ZO+pxTOHURERERZYVCKiNTw4UbzgrhcqYEpXFTgbveYMSLXXpvzQsK+zp3LfjArkO0CH5qYMbw39CY7csQV1EMjks1nFLzC661adXFbK49Xnz4izZqJFCyY+nzfR3/rsgp+EREFG4Lqe/b47ymFiTKIiIiIssLLGCJSyP3xzjtH5bXXSmivHdzlxkVFx47BKSAEuTAjE5bSpYNX6Lj4SU4OLLAVWNDLSFKSkdOnXUEZzohk81iQxD5Q06alLtmBoFSgAaxAtsH/U3JyjFSoIFKoUMbbYtgj/m9zgr3FiMI5n1R6cXHBO3cQERFRZGNQKs9KvlCevTRRRtq2TZaePY1ERQUvt1RuQ0DECpaUKZPz/bndRhITE6Vs2XKSnOzKVmArkKAXHnMDcnhZrxUcmE2rVEDln51gl+/jjh2pw0OtnnmbNqX2Fhs2TKRly4uBTCxWsMx3yWlQLPNgmUu2bSufFqRl4maii7Zu9V8a+/ezlIiIiCgwDErlhegYkSv/L09emogCg0AHeghhCSYMNTx9OjU41aJFai4pBGM8X7dyZZGhQy/2sjpzJrDHjNblJrx3fB4sOd2P5+Pzz6cugeYD8w1U+QtgZRTU8rd+82aRKVOsYJlL860hWIbhrK1bX9zOem3PR/RayyhQllGvsJz0FmNPMyIiIiIKVwxKERGFUFTUxZxSCHAg0GH1ErIeJ00K3tAXa3hjIAEsz8czZ9xy+PApiYoqoj3GshsQw+IZbMtNyAeGBcn0g80awmk9IliIJZChqr4BK/w/ePYgsXKI1awpkpCQfn379iL166c+39+Cfa5fLzJhQvqeZi+/LNKmTep2GGLp7xETIBDldOKJ7KwnIiIi8sWgFBFRHkFPmE8+ERk9OnX69GDn8fId3pjdHl2JiaekXLnClzScEwESXJhmFQjr21dk7970vcXKlRPp2TM1kIPt8Oi5+Fvnb31eXBzjs2Snl5pnQMrTvHmpS6Cv6fk4cGDqkhmUc2ZBK+9H5FgrKYULu9KCYoE9L3cec2vIZmY4nJOIiIjIAUGppKQkGT58uMydO1fzujRq1EgmTZokTZo0kfPnz8uwYcNk4cKFsnPnTilevLjEx8fLuHHjpFKlSmn7iIuLkz2p08GkGTt2rAwePFhswX1eZPeHqT/HPSASlT+v3xER5WFgKhLzFFkBDyzFimW83cSJ/nuLTZ0anOAcgmuBBK981z/zjP+8OMhb1rnzxe3RQ8vz0d866/Hvv8VWrF50WLKGKFCs2AWGSIYyCIYeaG+8kX44J4LKkfj9JSIiInJsUKp3797y66+/ygcffKCBppkzZ2rgacuWLVKkSBFZv369Bq0aNmwoR48elf79+0u7du1k3bp1XvsZPXq09MG86v9TtGhRsdWVwMndF38mInKo3O4thuGSSKqOJTtwykgNlhkNQliPb7996e+tYcPU4IZvrzAEPhC48l1/+eUib755cXiiFeDyXMaPFzlwIP1rYYbLdu1Se4phu5w8Iom+3eA9YUGPu1DyHM6J/yPUWwaliIiIiCIkKHXmzBn55JNPZN68eXLzzTfrulGjRsnnn38uU6dOleeff16WLFni9ZzXX39drrvuOtm7d69UrVrVKwhVAXOZExGRrdmxt5gVLEPy8W3bjAbLRo3KWbAMwTZ/vcL69xd58cX065ErKj4+831WqeJ/n9OmBS+wh95m5865Zf/+Q1KiRFm5cCEqKMGu3Hj0XZeb932wbwRSnQxBX9QPf+uJiIiIwi4odeHCBUlJSZECPslPChYsKKtWrfL7nOPHj4vL5ZISJUp4rceQvueee04DVffff78MGDBA8qG/vx/Jycm6WE6cOKGPbrdbl6Bzu8X1v5aywf5dufAaAb0NtxhjcuczhhGWA8uB9YHfC386dEBvI7ccOnRIypYtK1FRUX4vwLOzvzlzRJ57zpU2y96IEUaDR02apF+PROdZvV5G+wzkudmRL59bChVyS/Hi7rAJOOA0m5ISnIDXyJGu/w3nvJjMCr3nEKx0u4Mb+crpOTmUbZp69VyamN+zXESMJugPdrmEI7YvWDasN/xO8ViTt3gcztuyCXTftgpKoXdTs2bNNJh0xRVXSPny5eWjjz6S1atXS01MT+Tj7Nmz8vTTT0vXrl2lmEfSkn79+knjxo2lVKlS8v3338uQIUPkwIEDMhHJS/xAvqlncTvcBy5E8BpB5z4nRTAfvIicPJQoEhUT/NcI5G243RrUQ2XExZZTsRxYDqwP/F6E6vhw440iixd7r0tMzHh9TvYZTJFynMS9KSzZHc6JfFq9e5dMN5yzX7+jkpgYUFKubOXWzIlQtmn69QtduYSjSPne5AaWDcuG9YbfJx5rIv84nBRgm8Zl8C5sZMeOHdKrVy/55ptvJDo6WoNLtWvXlp9++km2bt2ath2Snnfq1En27dsnK1as8ApK+Xrvvffk4YcflpMnT0os5tAO4K5ilSpVNGdVZvu9ZCnnxLVlrP5orhwiEp13QSnPHgBOxXJgObA+8HvB4wOPk4HMvoceaVbuM6uXW7ChDVKyZEltKF5KGyTUbZpQlUs4YvuCZcN6w+8UjzV5i8fhvC2bQNs0tuopBTVq1JCVK1fKqVOn9ENUrFhRunTpIpcj46tHQKpz5846w96yZcuybGQ1bdpUhwbu3r1b6qDF5AOBKn/BKvzn5Mp/kIlKm8/ahf3nYUAIQx9z7XOGEZYDy4H1gd8LHh94nMzMPfcg15hbZwYuV65crp03c7rfULdpQlUu4YrtC5YN6w2/UzzW5C0eh/OubALdr21bDoULF9aAFO7sLV68WNojQYZHQGr79u2ydOlSKY0phrKwYcMGLRA0lmwjKn/qQkRERERERETkQLbrKYUAFEYUokdTQkKCDBo0SOrWrSs9e/bUgNQ999wj69evly+++EKToh88eFCfh/xRMTExmn/qhx9+kFtvvVVzVOF3JDnv1q2bdh2zBQzXq/dMXr8LIiIiIiIiIqI8Y7ugFMYbIjE5ckUh0IS8US+88ILkz59fh9/Nnz9ft7v66qu9nrd8+XK55ZZbtMv6rFmzZNSoUZpToXr16hqUevLJJ/PoExERERERERERke2DUhiah8WfuLg47UWVGSRGX7NmTS69OyIiIiIiIiIiisiglCO4L4js+W/qz9W6iETxv4GIiIiIiIiInIXRkLxg3CJJ2y/+TERERERERETkMLadfY+IiIiIiIiIiCIXg1JERERERERERBRyDEoREREREREREVHIMShFREREREREREQhx6AUERERERERERGFHGff88MYo48nTpzInVJPOSdyMjn1Z7xGdIzkBbfbLUlJSVKgQAGJinJufJLlwHJgfeD3gscHHiftcr6w2h5WW8T2bRqeR1kurDP8PoUI2+wsF9aZyGzTMCjlB/5zoEqVKpL7xoXgNYiIiCjc2iLFixcPyn5C16YhIiIiyl6bxmWCdSsuwqKGf/75pxQtWlRcLpdEKkQu0Uj9448/pFixYuJULAeWA+sDvxc8PvA4aZfzBZplaLxVqlQpKHcuQ9Gm4XmU5cI6w+9TKPBYw3JhnYnMNg17SvmBAqtcubI4BSqhk4NSFpYDy4H1gd8LHh94nLTD+SIYPaTyok3D8yjLhXWG3ycea/IOj8Esm3Bt0zg3kRAREREREREREeUZBqWIiIiIiIiIiCjkGJRysNjYWBk5cqQ+OhnLgeXA+sDvBY8PPE7yfMHzKNsXbHvZAdulLBvWGX6fnHasYaJzIiIiIiIiIiIKOfaUIiIiIiIiIiKikGNQioiIiIiIiIiIQo5BKSIiIiIiIiIiCjkGpSLIG2+8IXFxcVKgQAFp2rSprF27NtPt58yZI3Xr1tXt69evLwsXLvT6e48ePcTlcnktbdq0EaeVA2zdulXatWsnxYsXl8KFC0uTJk1k79694qRy8K0L1jJhwgRxUjmcPHlSHn/8calcubIULFhQrrzySnnzzTfF7oJdDn/99ZceIypVqiSFChXSY8P27dtz+VOEviw2b94snTp10u1R31999dUc7zNSy+Gbb76Ru+66S+sEtvnss88kHAS7HMaOHavniKJFi0q5cuWkQ4cOsm3bNolU4Vj3cyqrum6MkREjRkjFihX1PBEfH5/u+HjkyBF54IEHpFixYlKiRAn55z//qeeXcBZI3T979qw89thjUrp0aSlSpIh+n3A+8YT2Vdu2bfXcgv0MGjRILly4IOFs6tSp0qBBA/3/xtKsWTP58ssvxenl4mvcuHH6nXriiSfE6WUzatSodG1utMucXi6W/fv3S7du3fTz4ziLtuq6devE6cfhuP+1T3wX1BVb1xtDEWHWrFkmJibGvPfee2bz5s2mT58+pkSJEuavv/7yu/13331noqOjzYsvvmi2bNlihg0bZvLnz282bdqUtk337t1NmzZtzIEDB9KWI0eOGKeVQ0JCgilVqpQZNGiQWb9+vf4+b968DPcZqeXgWQ+wYN8ul8vs2LHDOKkcsI8aNWqY5cuXm127dpm33npLn4M64ZRycLvd5vrrrzc33XSTWbt2rfntt9/MQw89ZKpWrWpOnjxp7Cy7ZYHP99RTT5mPPvrIVKhQwbzyyis53meklsPChQvNM888Yz799FOD5sXcuXON3eVGOdx2221m+vTp5tdffzUbNmwwd9xxR1h8Ny5FONb9YMiqro8bN84UL17cfPbZZ2bjxo2mXbt2pnr16ubMmTNp26B91bBhQ7NmzRrz7bffmpo1a5quXbuacBZI3X/kkUdMlSpVzNdff23WrVun55LmzZun/f3ChQumXr16Jj4+3vz8889a1mXKlDFDhgwx4Wz+/PlmwYIF5vfffzfbtm0zQ4cO1fMqysrJ5eJ7fI2LizMNGjQw/fv3T1vv1LIZOXKkueqqq7za3ocOHTJOLxfA9Wi1atVMjx49zA8//GB27txpFi9erNdoTj8OJyYmetWZJUuW6HkK1y12rjcMSkWI6667zjz22GNpv6ekpJhKlSqZsWPH+t2+c+fOpm3btl7rmjZtah5++GGvoFT79u2N08uhS5cuplu3bsbp5eALdaNly5bGaeWABsLo0aO9tmncuLFeoDilHNCgxgnOakxb+yxbtqyZNm2asbPsloUnNID8BSFyss9IKgdP4RKUyu1ysBqIKI+VK1eaSBOOdT/YfOs6gvYIWE6YMCFt3bFjx0xsbKwGMwHBfjzvxx9/TNvmyy+/1Bs9+/fvN5HCt+6jHBCImTNnTto2W7du1W1Wr16tv+MCKCoqyhw8eDBtm6lTp5pixYqZ5ORkE0lKlixp3nnnHZaLMSYpKcnUqlVLL6BbtGiRFpRycp1BUAoBE3+cXC7w9NNPmxtvvDHDv/M4fBG+S7iZjjKxc73h8L0IcO7cOfnpp5+0W6IlKipKf1+9erXf52C95/Zw2223pdt+xYoV2m2vTp060rdvXzl8+LA4qRzcbrcsWLBAateuretRFhieYOdhKblZHyzo5olyQTdXp5VD8+bNZf78+dptGNcjy5cvl99//11at24tTimH5ORkfcRwHc99xsbGyqpVq8SuLqUs8mKfuS0c33M4l8Px48f1sVSpUhJJWI/827Vrlxw8eNCrXmHoP9oOVr3CI4aKXHvttWnbYHvUvx9++EEihW/dx/ft/PnzXmWD4UhVq1b1KhsMwylfvrzX+efEiRM6fDYSpKSkyKxZs+TUqVM6jI/lIjqcCMOFfNseTi8bDDfDMOHLL79ch5lZqUOcXi5oh+P4ee+99+q1WaNGjWTatGlpf+dx+OJ5eubMmdKrVy8dwmfnesOgVAT4+++/9QTnWXkAv6Nh5A/WZ7U9csS8//778vXXX8v48eNl5cqVcvvtt+trOaUcEhMTdWwxxrijPL766ivp2LGj3H333VoeTqoPnv79739rzgiUg13lVjlMnjxZ80ghp1RMTIzWC+RUufnmm8Up5WCdwIYMGSJHjx7Vkx6OEfv27ZMDBw6IXV1KWeTFPnNbOL7ncC0H3NhAbpQbbrhB6tWrJ5GE9cg/q+5kVq/wiAspT/ny5dPgTaR8B/3VfXw2nDcRkMusbPyVnfW3cLZp0ybN4YIbOI888ojMnTtX2xNOLxcE6NavX685yXw5uWwQyJ4xY4YsWrRIc5Ih0HLTTTdJUlKSo8sFdu7cqWVSq1YtWbx4sXac6Nevn16fAI/DqdCJ4tixY5oDFuxcb/Ll2p4p7N13331pPyNiigSNNWrU0N5TrVq1EidAowrat28vAwYM0J+vvvpq+f777zW5dYsWLcSJ3nvvPb1j49lTxikQlFqzZo3epalWrZomvMUdPtzJ8r3DF6ny588vn376qfaUw0VUdHS0fnYErVNHsxAR4Njw66+/2roHIVFuYN1PD6MONmzYoD3IPv74Y+nevbttb3CGyh9//CH9+/eXJUuWOLJNmRm0qSy4BkOQCu3O2bNna+JuJ8P1GXpKjRkzRn9HTymca3Fthu8VpXr33Xe1HuEaxe7YUyoClClTRi8KfTPn4/cKFSr4fQ7WZ2d7QNdRvFZCQoI4pRywT9y9xJ0sT1dccYVtZ9/L7frw7bff6mw6vXv3FjvLjXI4c+aMDB06VCZOnKgzL6GRgJn4unTpIi+99JI4qT5cc8012rjGHRj0jsKdPAzvxXHCri6lLPJin7ktHN9zOJYDjg1ffPGFDvFFz8pIw3rkn1V3MqtXeERPbE+Y2QgzQUXCdzCjuo/Php61OG9kVjb+ys76WzhDD4WaNWvq+RO9gho2bCiTJk1ydLlgOBG+C40bN9b2NhYE6l577TX9GT00nFo2vtC7BelEcB3m5DoDmFEvs2szHodF9uzZI0uXLvW6XrNzvWFQKgLgJIcTHIbZeUaQ8TvGqvuD9Z7bA+5SZLQ9YGgOLjpxIHBKOWCfmN7Yd0pj5BDC3Qon1gdE3bF/NKbsLDfKAeOwsSDvhydc2Fq96pxWH5ArpWzZspr3AFPxolehXV1KWeTFPnNbOL7ncCoH9BbERTmG5ixbtkyqV68ukYj1yD/8f6Ph7lmvkIsDuaKseoVHXBTggtyCuoL6h94Q4Sqruo/vG3raepYN2le4kPQsGwxz8wza4fyDKdt9L0LDHf6/kaPRyeWCkRf4XLjJZS3oAYPe+NbPTi0bX0gnsmPHDr0Oc3KdAQwLzuzazMnHYcv06dN1mDhytVlsXW9yLYU6hXxaZszsMmPGDJ3VBdOzY1pmK3P+gw8+aAYPHuw15Xu+fPnMSy+9pFn3McOD55TvmAUD014jEz+mvV+6dKnOMIaZMc6ePeuYcgBM+Yx1b7/9ttm+fbuZPHmyiY6O1qlDnVQOcPz4cVOoUCGdhSEc5EY5YFYYzMCHqVUxBS2mvy5QoICZMmWKcVI5zJ49W8tgx44dOt0uZiK7++67jd1ltyww0wimxMVSsWJFPS7iZxwLAt2nU8oB5w1rGzQvJk6cqD/v2bPHOKkc+vbtq9NQr1ixwmta5tOnT5tIE451PxiyquuYihzlMG/ePPPLL7/obLX+piJv1KiRTme+atUqbV+F+1TkgdR9TEdetWpVs2zZMp2OvFmzZrr4TkfeunVrs2HDBrNo0SKd2TXcp7HHcQSzEKJNjTqB3zHb4ldffeXocvHHc/Y9J5fNwIED9buEOoN2WXx8vClTpozOaunkcoG1a9dqO/WFF17Q8++HH36o1yczZ85M28apx2FrJlzUDcxS6Muu9YZBqQiCYAkqWUxMjE7TvGbNGq8DfPfu3b22x0Vl7dq1dXtcZC9YsCDtb2hAoDKiEuJiFBecffr0CYuGZjDLwfLuu++amjVravAB07PiItyJ5fDWW2+ZggUL6pSi4SLY5YAGdo8ePXTac9SHOnXqmJdfflmnWnVSOUyaNMlUrlxZjw/Y77Bhw8JmiuHslAUag7jo9F2wXaD7dEo5IEjpbxvfuhXp5eDv71gQwI5E4Vj3cyqruo7zwfDhw0358uU1aNeqVSuzbds2r30cPnxYL36KFCmiU2337NlTg13hLJC6jwvCRx991JQsWVIvIjt27KjnVU+7d+82t99+u7Y3cBGOi/Pz58+bcNarVy9tS+N7grY16oQVkHJyuQQSlHJq2XTp0kVvfqDOXHbZZfp7QkKCcXq5WD7//HMNnuAYW7duXe084Mmpx2FYvHixHnt9P6+d640L/+RePywiIiIiIiIiIqL0mFOKiIiIiIiIiIhCjkEpIiIiIiIiIiIKOQaliIiIiIiIiIgo5BiUIiIiIiIiIiKikGNQioiIiIiIiIiIQo5BKSIiIiIiIiIiCjkGpYiIiIiIiIiIKOQYlCIiIiIiIiIiopBjUIqIKAji4uKkR48eLEsiIiKKGCdPnpRy5crJhx9+GPLX7d27t1SoUEFcLpc88cQTGW57/vx5qVKlikyZMiWk75GIgoNBKSKylRkzZmjjA8uqVavS/d0Yow0P/P3OO+8UJ1mxYoV+7t27d+f1WyEiIqIcQAAF5/SmTZvauhwnTZokRYsWlfvuuy+krztmzBhtE/bt21c++OADefDBB+X777+XUaNGybFjx7y2zZ8/vzz55JPywgsvyNmzZ0P6Poko5xiUIiJbKlCggPznP/9Jt37lypWyb98+iY2NFTvZtm2bTJs2La/fBhEREYUB9DxCL+u1a9dKQkKC2BF6ICEohR5L0dHRIX3tZcuWyfXXXy8jR46Ubt26yTXXXKNBqWeffTZdUAp69uwpf//9t9+2IxHZG4NSRGRLd9xxh8yZM0cuXLjgtR6NDTRM0J3bThAkw506IiIioszs2rVLAywTJ06UsmXLBjw0Dm2ic+fOhaxwv/jiCzl06JB07txZQi0xMVFKlCgR8PbYtnXr1tq7iojCC4NSRGRLXbt2lcOHD8uSJUvS1qEh9vHHH8v999/v9zkvvfSSNG/eXEqXLi0FCxbU4BW294Xu8o8//rh89tlnUq9ePQ0oXXXVVbJo0SKv7dBFHNviDibyRaHBU7x4cb0bd/r06UxzSlnDEL/77jvtUo5GZ+HChaVjx47awPPkdrv1tSpVqiSFChWSW2+9VbZs2RJQnqrt27dLp06dNEiH3mWVK1fWLvbHjx/P9Hm33HKLfna8Dl4Pr3vZZZfJiy++mOnziIiIKGcQhCpZsqS0bdtW7rnnHr9BKQzVRzsCbZtXX31VatSooe0VnLfht99+0+eWKlVKz//XXnutzJ8/32sfR44ckaeeekrq168vRYoUkWLFisntt98uGzduDOh9op2Etghe29PBgwe1LYQ2B95TxYoVpX379l7pBZBu4fnnn9dtrLbN5s2bs2zbWKkKELhbsGBBWkoHPGfQoEG6TfXq1dPWe77mP/7xD039gM9NROEjX16/ASIif9BoadasmXz00UfagIIvv/xSgy0Iurz22mvpnoMu5u3atZMHHnhAA1izZs2Se++9V+/0oeHnCY2WTz/9VB599FHNlYD9Ibizd+9eDWp5wh1CNIDGjh0r69evl3feeUeTfo4fPz7L/7x//etf2vBE93M0nNCwREDsv//9b9o2Q4YM0WDQXXfdJbfddps2FvGYVV4EfEZsl5ycrK+DwNT+/fv186JrOwJomTl69Ki0adNG7r77bv2MCOA9/fTT2ni1ypyIiIiCC0EonHtjYmL0JtzUqVPlxx9/lCZNmqTbdvr06doeeOihhzQAhCAUgjs33HCD3kwaPHiw3vSaPXu2dOjQQT755BO9AQY7d+7UwBLaQmjH/PXXX/LWW29JixYtNLiFm2GZQW+uxo0bp1uP9hLeA9oeaK+hVxNuIqINhd9hxIgRGpRCz3csaD+hJ1NWPb2uuOIKzSE1YMAADWgNHDhQ16NtgueiXfjKK69ImTJldD1u+llwMxLBMLxvp+UdJQprhojIRqZPn25waPrxxx/N66+/booWLWpOnz6tf7v33nvNrbfeqj9Xq1bNtG3b1uu51naWc+fOmXr16pmWLVt6rcf+Y2JiTEJCQtq6jRs36vrJkyenrRs5cqSu69Wrl9fzO3bsaEqXLu21Du+ne/fu6T5HfHy8cbvdaesHDBhgoqOjzbFjx/T3gwcPmnz58pkOHTp47W/UqFH6fM99+vr55591mzlz5pjsatGihT73/fffT1uXnJxsKlSoYDp16pTt/REREVHW1q1bp+ffJUuW6O9oI1SuXNn079/fa7tdu3bpdsWKFTOJiYlef2vVqpWpX7++OXv2bNo67Kd58+amVq1aaevw95SUlHT7jY2NNaNHj870fZ4/f964XC4zcOBAr/VHjx7V9zVhwoQMn4v3i3YW2mmebaChQ4dm2bax+Gvn4TXxfHwGf/7880/9+/jx47PcPxHZB4fvEZFtoffOmTNntOdPUlKSPmY0dA8wZM+zFxB6Vd100016d85XfHy8V3f0Bg0aaLd23FX09cgjj3j9jn1iaOGJEyey/Ay4s4nu5Z7PTUlJkT179ujvX3/9teaIQI8tT7j7mBWrJ9TixYvTDScMBLryI3moBXdsr7vuOr9lQERERMHpJVW+fHkdzgZoI3Tp0kV7d6N94K9XkmdvIAxNQxJwtJHQNkJybyxol6D3NIb1o9c0oGdVVFTq5R72jW1w7q9Tp47ftpEnvA7u46G3t29bC+0FDLNDW8ufpUuXaq8mtGU820BPPPGE5CbrvaI8iCh8MChFRLaFRhiCR0hujqF2aFAhf0JGELTCTC3IrYDu7Xg+usT7y69UtWpVv40Zfw0s322tRk9GjbHsPNcKTtWsWdNrO7x/34agL3TFR74qDCdEN3Y0Rt94440s80lZ0C3es7Fovb9APhcRERFlD9oxCD4hIIWcSchZiaVp06Y6tA43qvyd6z1hewSLhg8fru0czwWpAgDD6ayclRjqVqtWLQ1Qoa2A7X755ZeA2wqpHcwvwn6QvgApFRBcu/nmmzUFAfJMWay2DV7XE147q7ZNTljv1bdtQ0T2xqAUEdkaekah4fPmm29qnqOMZmL59ttvNZ8UAlJTpkyRhQsXan4DPN+3QQUZTW2c022D+dxAvPzyy9q4HDp0qPYq69evnyZt37dvX56/NyIiIroIPZwOHDiggSkEbKzFmt3OX8Jzz17gVqAJkMAc7Rx/i3Wja8yYMXrzCoGjmTNnas9q/B3tBGs/GcHNMQR3/N2oQo+n33//XXNtot2FABlyQf388895+t9tvVcr3xQRhQcmOiciW0OyzocffljWrFnjlRzcFxJ7omGEBhfu4nkmCLWzatWqpd359Lwbii72gfZYQvJPLMOGDdPknkh+iiAeEowSERGRPSDohIlS0KvZF3qEz507V8/fvoEoT5dffrk+5s+fX3uTZwYTmKBX1rvvvuu1HpOhZBW4yZcvn6Y5QI8uf/A3JCHHgiGDV199td4oQ/DLattgvfV+AbMP56Q3dlY9oKz3igAZEYUPBqWIyNaQ+wBD8DBzHWany6zXDxornvkY8BzMOmNnrVq10oYfPiOmMra8/vrrWT4XOa0wzTKeb0FwCvkjMCMfERER2QN6MyPwhJnw/KUiwEx4mFlu/vz5mmMqIwhq3XLLLTqLHnI2VaxY0evvCPxYOajQNvLt/TxnzhzNOeWbNsAfzIKM3FGekMMS7QzcCPQMUGEmY6vtgWAZgmaTJ0/WGfesYBJmIM4JzDJoBdX8+emnn/S18L6JKHwwKEVEtte9e/cst2nbtq1MnDhR2rRpo0P2kE8BdyLR6MLwNrtCPob+/fvr3UUMP8T737hxow5ZxF3MzO4KYhjA448/rg3c2rVra8J0TKOMRigSoxIREZE9INiExOQ41/uDnJgIJqE3VWZBKUD75sYbb9QbUX369NHeSMhJtXr1ah2+j3YE3HnnnTJ69Gjp2bOnNG/eXDZt2qT79+y9lJn27dtruwJD9dDOAPyMG2oYcnjllVfqjTH08MLr33fffboNPgeGF2J4H97DHXfcoUP7rLbNpbrmmmv08ZlnntHXQuALNyytYBWGJqK3eOnSpS/5NYgo9BiUIqKI0LJlS+2ePm7cOM11gKFwSMSJ3lJ2DkoB3id6PE2bNk1nrMEdvq+++kobnJ53In01bNhQk5t//vnnetcT+8A6NPrQuCUiIiJ7QDAI53TPXtGe0PsIN9iwHYbwZwbBoHXr1smzzz4rM2bM0O3Rg6pRo0YyYsSItO2Qb/LUqVM6YQxSIDRu3FgWLFgggwcPDug9I+CDINLs2bM1RQBUqVJFunbtqknZEbBCUKpu3bq6jecNMaQQwOfFcMTly5drMne0bfAZL1WTJk3kueee030uWrRI82JhyB6CUkjcjv0jrygRhReXYUZbIiLbQdd0zFCDRh3uCBIRERGFGoJAyM+J/FAZTZCSHXFxcTr8EMG0YMLQQMwCuGPHjkxzchGR/XD2PSIiG+SZ8GXlXUDDjYiIiCgvDBgwQE6ePKkzBtrV+fPnNYUDenMxIEUUfjh8j4goj6FLPe4YIucCEruvWrVKk50iOShyIxARERHlBbRLkKfTzpBbau/evXn9NojoEjEoRUSUxxo0aKA5GdDtHDPqWcnPMXSPiIiIiIgoUjGnFBERERERERERhRxzShERERERERERUcgxKEVERERERERERCHHoBQREREREREREYUcg1JERERERERERBRyDEoREREREREREVHIMShFREREREREREQhx6AUERERERERERGFHINSREREREREREQUcgxKERERERERERGRhNr/A6Ym12DobqlFAAAAAElFTkSuQmCC",
+      "text/plain": [
+       "<Figure size 1200x500 with 2 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
     }
    ],
    "source": [
-    "# --- Extend tables to higher elevations ---\n",
-    "max_elev = df['Elevation'].max()\n",
-    "target_elev = max_elev + 5.0  # Extend 5 feet above current max\n",
+    "max_elev = base_df['Elevation'].max()\n",
+    "target_elev = max_elev + 5.0\n",
     "\n",
     "def extend_n_func(depth, base_n):\n",
-    "    \"\"\"Manning's n for extension rows.\"\"\"\n",
+    "    \"\"\"Manning's n for extension rows (same exponential decay).\"\"\"\n",
     "    if depth <= 0:\n",
     "        return base_n\n",
     "    return N_ASYMPTOTE + (base_n - N_ASYMPTOTE) * np.exp(-depth / DEPTH_HALF)\n",
     "\n",
     "rows_added = HdfMesh.extend_face_property_tables(\n",
     "    hdf_path=modified_geom_hdf,\n",
-    "    mesh_name=mesh_name,\n",
+    "    mesh_name=MESH_NAME,\n",
     "    extension_elevation=target_elev,\n",
     "    mannings_n_func=extend_n_func,\n",
     "    elevation_step=0.5,\n",
     "    face_ids=None,\n",
-    "    pin_tables=True,  # Set Pinned attribute\n",
+    "    pin_tables=True,\n",
     ")\n",
     "\n",
-    "print(f\"Extended {len(rows_added)} faces\")\n",
-    "print(f\"Total rows added: {sum(rows_added.values())}\")\n",
+    "print(f\"Extended {len(rows_added)} faces, total rows added: {sum(rows_added.values())}\")\n",
     "\n",
-    "# Verify extension\n",
+    "# Read extended table\n",
     "ext_tables = HdfMesh.get_mesh_face_property_tables(modified_geom_hdf)\n",
-    "ext_df = ext_tables[mesh_name]\n",
+    "ext_df = ext_tables[MESH_NAME]\n",
     "ext_sample = ext_df[ext_df['Face ID'] == sample_face]\n",
     "\n",
-    "print(f\"\\nFace {sample_face}: {len(sample_df)} rows -> {len(ext_sample)} rows\")\n",
-    "print(f\"  Elevation range: {ext_sample['Elevation'].min():.2f} - {ext_sample['Elevation'].max():.2f} ft\")\n",
-    "print(f\"  n range: {ext_sample[n_col].min():.4f} - {ext_sample[n_col].max():.4f}\")\n",
+    "print(f\"Face {sample_face}: {len(mod_sample)} rows -> {len(ext_sample)} rows\")\n",
+    "print(f\"Elevation range: {ext_sample['Elevation'].min():.2f} - {ext_sample['Elevation'].max():.2f} ft\")\n",
     "\n",
-    "# Verify Pinned attribute\n",
-    "with h5py.File(str(modified_geom_hdf), 'r') as f:\n",
-    "    group = f[f\"Geometry/2D Flow Areas/{mesh_name}\"]\n",
-    "    pinned = group.attrs.get('Pinned', None)\n",
-    "    print(f\"\\nPinned attribute: {pinned}\")"
+    "# --- Figure: Extended face property table ---\n",
+    "fig, axes = plt.subplots(1, 2, figsize=(12, 5), sharey=True)\n",
+    "\n",
+    "ax = axes[0]\n",
+    "# Original preprocessed range\n",
+    "orig_max_elev = mod_sample['Elevation'].max()\n",
+    "orig_portion = ext_sample[ext_sample['Elevation'] <= orig_max_elev + 0.01]\n",
+    "ext_portion = ext_sample[ext_sample['Elevation'] > orig_max_elev - 0.01]\n",
+    "\n",
+    "ax.plot(orig_portion[n_col], orig_portion['Elevation'], 'b-o', markersize=4,\n",
+    "        label='Preprocessed range', linewidth=2)\n",
+    "ax.plot(ext_portion[n_col], ext_portion['Elevation'], 'r-s', markersize=3,\n",
+    "        label='Extended range', linewidth=2)\n",
+    "ax.axhline(y=orig_max_elev, color='gray', linestyle=':', alpha=0.7)\n",
+    "ax.axvline(x=N_ASYMPTOTE, color='orange', linestyle='--', alpha=0.5,\n",
+    "           label=f'Asymptote n={N_ASYMPTOTE}')\n",
+    "ax.set_xlabel(\"Manning's n\", fontsize=12)\n",
+    "ax.set_ylabel('Elevation (ft)', fontsize=12)\n",
+    "ax.set_title(f\"Face {sample_face}: Manning's n\", fontsize=13)\n",
+    "ax.legend(fontsize=9)\n",
+    "ax.grid(True, alpha=0.3)\n",
+    "\n",
+    "ax = axes[1]\n",
+    "ax.plot(orig_portion['Area'], orig_portion['Elevation'], 'b-o', markersize=4,\n",
+    "        label='Preprocessed', linewidth=2)\n",
+    "ax.plot(ext_portion['Area'], ext_portion['Elevation'], 'r-s', markersize=3,\n",
+    "        label='Extended (rectangular)', linewidth=2)\n",
+    "ax.axhline(y=orig_max_elev, color='gray', linestyle=':', alpha=0.7,\n",
+    "           label=f'Original max elev')\n",
+    "ax.set_xlabel('Area (sq ft)', fontsize=12)\n",
+    "ax.set_title(f'Face {sample_face}: Flow Area', fontsize=13)\n",
+    "ax.legend(fontsize=9)\n",
+    "ax.grid(True, alpha=0.3)\n",
+    "\n",
+    "fig.suptitle('Face Property Table: Preprocessed + Extended', fontsize=14, y=1.02)\n",
+    "fig.tight_layout()\n",
+    "plt.show()"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "7ea7bb6a",
+   "metadata": {
+    "papermill": {
+     "duration": 0.009011,
+     "end_time": "2026-05-12T12:23:56.489292+00:00",
+     "exception": false,
+     "start_time": "2026-05-12T12:23:56.480281+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Step 9: Polygon Mask API — Selective Face Application\n",
+    "\n",
+    "In practice, you want to apply depth-varying n **only to channel faces**, not\n",
+    "the entire mesh. `HdfMesh.extend_face_property_tables()` and\n",
+    "`set_face_mannings_n_values()` accept optional `polygon` or `region_name`\n",
+    "parameters for spatial filtering.\n",
+    "\n",
+    "**Precedence**: `face_ids` > `region_name` > `polygon` > None (all faces)\n",
+    "\n",
+    "### Channel Polygon Strategies\n",
+    "\n",
+    "There are several ways to identify which faces are \"in the channel\":\n",
+    "\n",
+    "1. **Calibration Regions** (recommended) — draw a region in RASMapper GUI,\n",
+    "   reference by name via `get_face_ids_in_calibration_region()`\n",
+    "2. **Fluvial/Pluvial Classification** — use `HdfFluvialPluvial` to identify\n",
+    "   fluvial cells from simulation results, then extract the fluvial polygon\n",
+    "3. **Bank Lines** — use `HdfXsec.get_river_bank_lines()` from the geometry\n",
+    "   HDF to construct a channel polygon between left and right banks\n",
+    "\n",
+    "We demonstrate strategies 2 and 3 below using the Muncie model."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "69c3db76",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-12T12:23:56.515867Z",
+     "iopub.status.busy": "2026-05-12T12:23:56.515468Z",
+     "iopub.status.idle": "2026-05-12T12:23:57.908331Z",
+     "shell.execute_reply": "2026-05-12T12:23:57.907311Z"
+    },
+    "papermill": {
+     "duration": 1.410163,
+     "end_time": "2026-05-12T12:23:57.909117+00:00",
+     "exception": false,
+     "start_time": "2026-05-12T12:23:56.498954+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:23:56 - ras_commander.hdf.HdfFluvialPluvial - INFO - Using existing Path object HDF file: G:\\GH\\ras-commander\\example_projects\\Muncie_414_baseline\\Muncie.p03.hdf\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:23:56 - ras_commander.hdf.HdfFluvialPluvial - INFO - Final validated file path: G:\\GH\\ras-commander\\example_projects\\Muncie_414_baseline\\Muncie.p03.hdf\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:23:56 - ras_commander.hdf.HdfFluvialPluvial - INFO - Loading mesh and results data...\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:23:56 - ras_commander.hdf.HdfMesh - INFO - Using existing Path object HDF file: G:\\GH\\ras-commander\\example_projects\\Muncie_414_baseline\\Muncie.p03.hdf\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:23:56 - ras_commander.hdf.HdfMesh - INFO - Final validated file path: G:\\GH\\ras-commander\\example_projects\\Muncie_414_baseline\\Muncie.p03.hdf\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:23:56 - ras_commander.hdf.HdfMesh - INFO - Using existing Path object HDF file: G:\\GH\\ras-commander\\example_projects\\Muncie_414_baseline\\Muncie.p03.hdf\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:23:56 - ras_commander.hdf.HdfMesh - INFO - Final validated file path: G:\\GH\\ras-commander\\example_projects\\Muncie_414_baseline\\Muncie.p03.hdf\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:23:56 - ras_commander.hdf.HdfMesh - INFO - Using existing Path object HDF file: G:\\GH\\ras-commander\\example_projects\\Muncie_414_baseline\\Muncie.p03.hdf\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:23:56 - ras_commander.hdf.HdfMesh - INFO - Final validated file path: G:\\GH\\ras-commander\\example_projects\\Muncie_414_baseline\\Muncie.p03.hdf\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:23:56 - ras_commander.hdf.HdfMesh - INFO - Using existing Path object HDF file: G:\\GH\\ras-commander\\example_projects\\Muncie_414_baseline\\Muncie.p03.hdf\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:23:56 - ras_commander.hdf.HdfMesh - INFO - Final validated file path: G:\\GH\\ras-commander\\example_projects\\Muncie_414_baseline\\Muncie.p03.hdf\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:23:56 - ras_commander.hdf.HdfBase - INFO - Using HDF file from h5py.File object: G:\\GH\\ras-commander\\example_projects\\Muncie_414_baseline\\Muncie.p03.hdf\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:23:56 - ras_commander.hdf.HdfBase - INFO - Final validated file path: G:\\GH\\ras-commander\\example_projects\\Muncie_414_baseline\\Muncie.p03.hdf\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:23:56 - ras_commander.hdf.HdfBase - INFO - Found projection in HDF file: G:\\GH\\ras-commander\\example_projects\\Muncie_414_baseline\\Muncie.p03.hdf\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Generating fluvial/pluvial classification...\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:23:56 - ras_commander.hdf.HdfBase - INFO - Using HDF file from h5py.File object: G:\\GH\\ras-commander\\example_projects\\Muncie_414_baseline\\Muncie.p03.hdf\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:23:56 - ras_commander.hdf.HdfBase - INFO - Final validated file path: G:\\GH\\ras-commander\\example_projects\\Muncie_414_baseline\\Muncie.p03.hdf\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:23:56 - ras_commander.hdf.HdfBase - INFO - Found projection in HDF file: G:\\GH\\ras-commander\\example_projects\\Muncie_414_baseline\\Muncie.p03.hdf\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:23:56 - ras_commander.hdf.HdfResultsMesh - INFO - Using existing Path object HDF file: G:\\GH\\ras-commander\\example_projects\\Muncie_414_baseline\\Muncie.p03.hdf\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:23:56 - ras_commander.hdf.HdfResultsMesh - INFO - Final validated file path: G:\\GH\\ras-commander\\example_projects\\Muncie_414_baseline\\Muncie.p03.hdf\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:23:56 - ras_commander.hdf.HdfResultsMesh - INFO - Processing summary output for variable: Maximum Water Surface\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:23:56 - ras_commander.hdf.HdfMesh - INFO - Using HDF file from h5py.File object: G:\\GH\\ras-commander\\example_projects\\Muncie_414_baseline\\Muncie.p03.hdf\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:23:56 - ras_commander.hdf.HdfMesh - INFO - Final validated file path: G:\\GH\\ras-commander\\example_projects\\Muncie_414_baseline\\Muncie.p03.hdf\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:23:56 - ras_commander.hdf.HdfMesh - INFO - Using existing Path object HDF file: G:\\GH\\ras-commander\\example_projects\\Muncie_414_baseline\\Muncie.p03.hdf\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:23:56 - ras_commander.hdf.HdfMesh - INFO - Final validated file path: G:\\GH\\ras-commander\\example_projects\\Muncie_414_baseline\\Muncie.p03.hdf\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:23:56 - ras_commander.hdf.HdfBase - INFO - Using HDF file from h5py.File object: G:\\GH\\ras-commander\\example_projects\\Muncie_414_baseline\\Muncie.p03.hdf\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:23:56 - ras_commander.hdf.HdfBase - INFO - Final validated file path: G:\\GH\\ras-commander\\example_projects\\Muncie_414_baseline\\Muncie.p03.hdf\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:23:56 - ras_commander.hdf.HdfBase - INFO - Found projection in HDF file: G:\\GH\\ras-commander\\example_projects\\Muncie_414_baseline\\Muncie.p03.hdf\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:23:56 - ras_commander.hdf.HdfBase - INFO - Using HDF file from h5py.File object: G:\\GH\\ras-commander\\example_projects\\Muncie_414_baseline\\Muncie.p03.hdf\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:23:56 - ras_commander.hdf.HdfBase - INFO - Final validated file path: G:\\GH\\ras-commander\\example_projects\\Muncie_414_baseline\\Muncie.p03.hdf\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:23:56 - ras_commander.hdf.HdfBase - INFO - Found projection in HDF file: G:\\GH\\ras-commander\\example_projects\\Muncie_414_baseline\\Muncie.p03.hdf\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:23:56 - ras_commander.hdf.HdfResultsMesh - INFO - Processed 5765 rows of summary output data\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:23:56 - ras_commander.hdf.HdfFluvialPluvial - INFO - Processing cell adjacencies...\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:23:57 - ras_commander.hdf.HdfFluvialPluvial - INFO - Identifying initial boundary seeds with delta_t = 12 hours...\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:23:57 - ras_commander.hdf.HdfFluvialPluvial - INFO - Starting iterative region growth with tolerance = 1.0 hours...\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Region Growing: 0iter [00:00, ?iter/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Region Growing: 1iter [00:00, 119.16iter/s, Fluvial=204, Pluvial=80, Ambiguous=0]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Region Growing: 2iter [00:00, 130.14iter/s, Fluvial=221, Pluvial=45, Ambiguous=0]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Region Growing: 3iter [00:00, 134.10iter/s, Fluvial=226, Pluvial=39, Ambiguous=0]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Region Growing: 4iter [00:00, 138.99iter/s, Fluvial=236, Pluvial=37, Ambiguous=0]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Region Growing: 5iter [00:00, 143.61iter/s, Fluvial=223, Pluvial=34, Ambiguous=0]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Region Growing: 6iter [00:00, 145.10iter/s, Fluvial=217, Pluvial=28, Ambiguous=0]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Region Growing: 7iter [00:00, 149.59iter/s, Fluvial=202, Pluvial=23, Ambiguous=0]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Region Growing: 8iter [00:00, 154.80iter/s, Fluvial=200, Pluvial=15, Ambiguous=0]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Region Growing: 9iter [00:00, 156.73iter/s, Fluvial=186, Pluvial=13, Ambiguous=0]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Region Growing: 10iter [00:00, 161.34iter/s, Fluvial=156, Pluvial=10, Ambiguous=0]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Region Growing: 11iter [00:00, 167.51iter/s, Fluvial=128, Pluvial=7, Ambiguous=0] "
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Region Growing: 12iter [00:00, 174.22iter/s, Fluvial=113, Pluvial=4, Ambiguous=0]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Region Growing: 13iter [00:00, 177.76iter/s, Fluvial=107, Pluvial=1, Ambiguous=0]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Region Growing: 14iter [00:00, 181.83iter/s, Fluvial=101, Pluvial=0, Ambiguous=0]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Region Growing: 15iter [00:00, 187.86iter/s, Fluvial=96, Pluvial=0, Ambiguous=0] "
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Region Growing: 16iter [00:00, 193.02iter/s, Fluvial=92, Pluvial=0, Ambiguous=0]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Region Growing: 17iter [00:00, 198.23iter/s, Fluvial=86, Pluvial=0, Ambiguous=0]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Region Growing: 18iter [00:00, 202.17iter/s, Fluvial=79, Pluvial=0, Ambiguous=0]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Region Growing: 19iter [00:00, 207.00iter/s, Fluvial=70, Pluvial=0, Ambiguous=0]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Region Growing: 20iter [00:00, 212.95iter/s, Fluvial=69, Pluvial=0, Ambiguous=0]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Region Growing: 21iter [00:00, 218.88iter/s, Fluvial=69, Pluvial=0, Ambiguous=0]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Region Growing: 22iter [00:00, 224.86iter/s, Fluvial=68, Pluvial=0, Ambiguous=0]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Region Growing: 23iter [00:00, 230.68iter/s, Fluvial=68, Pluvial=0, Ambiguous=0]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Region Growing: 24iter [00:00, 236.37iter/s, Fluvial=68, Pluvial=0, Ambiguous=0]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Region Growing: 24iter [00:00, 236.37iter/s, Fluvial=69, Pluvial=0, Ambiguous=0]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Region Growing: 25iter [00:00, 236.37iter/s, Fluvial=67, Pluvial=0, Ambiguous=0]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Region Growing: 26iter [00:00, 236.37iter/s, Fluvial=68, Pluvial=0, Ambiguous=0]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Region Growing: 27iter [00:00, 236.37iter/s, Fluvial=67, Pluvial=0, Ambiguous=0]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Region Growing: 28iter [00:00, 236.37iter/s, Fluvial=67, Pluvial=0, Ambiguous=0]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Region Growing: 29iter [00:00, 236.37iter/s, Fluvial=67, Pluvial=0, Ambiguous=0]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Region Growing: 30iter [00:00, 236.37iter/s, Fluvial=64, Pluvial=0, Ambiguous=0]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Region Growing: 31iter [00:00, 236.37iter/s, Fluvial=57, Pluvial=0, Ambiguous=0]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Region Growing: 32iter [00:00, 236.37iter/s, Fluvial=56, Pluvial=0, Ambiguous=0]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Region Growing: 33iter [00:00, 236.37iter/s, Fluvial=53, Pluvial=0, Ambiguous=0]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Region Growing: 34iter [00:00, 236.37iter/s, Fluvial=53, Pluvial=0, Ambiguous=0]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Region Growing: 35iter [00:00, 236.37iter/s, Fluvial=52, Pluvial=0, Ambiguous=0]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Region Growing: 36iter [00:00, 236.37iter/s, Fluvial=49, Pluvial=0, Ambiguous=0]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Region Growing: 37iter [00:00, 236.37iter/s, Fluvial=47, Pluvial=0, Ambiguous=0]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Region Growing: 38iter [00:00, 236.37iter/s, Fluvial=47, Pluvial=0, Ambiguous=0]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Region Growing: 39iter [00:00, 236.37iter/s, Fluvial=46, Pluvial=0, Ambiguous=0]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Region Growing: 40iter [00:00, 236.37iter/s, Fluvial=44, Pluvial=0, Ambiguous=0]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Region Growing: 41iter [00:00, 236.37iter/s, Fluvial=41, Pluvial=0, Ambiguous=0]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Region Growing: 42iter [00:00, 236.37iter/s, Fluvial=42, Pluvial=0, Ambiguous=0]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Region Growing: 43iter [00:00, 236.37iter/s, Fluvial=41, Pluvial=0, Ambiguous=0]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Region Growing: 44iter [00:00, 236.37iter/s, Fluvial=39, Pluvial=0, Ambiguous=0]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Region Growing: 45iter [00:00, 236.37iter/s, Fluvial=38, Pluvial=0, Ambiguous=0]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Region Growing: 46iter [00:00, 236.37iter/s, Fluvial=36, Pluvial=0, Ambiguous=0]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Region Growing: 47iter [00:00, 236.37iter/s, Fluvial=34, Pluvial=0, Ambiguous=0]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Region Growing: 48iter [00:00, 236.37iter/s, Fluvial=32, Pluvial=0, Ambiguous=0]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Region Growing: 49iter [00:00, 236.37iter/s, Fluvial=30, Pluvial=0, Ambiguous=0]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Region Growing: 50iter [00:00, 236.37iter/s, Fluvial=30, Pluvial=0, Ambiguous=0]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Region Growing: 51iter [00:00, 236.37iter/s, Fluvial=28, Pluvial=0, Ambiguous=0]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Region Growing: 52iter [00:00, 236.37iter/s, Fluvial=26, Pluvial=0, Ambiguous=0]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Region Growing: 53iter [00:00, 236.37iter/s, Fluvial=24, Pluvial=0, Ambiguous=0]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Region Growing: 54iter [00:00, 236.37iter/s, Fluvial=21, Pluvial=0, Ambiguous=0]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Region Growing: 55iter [00:00, 236.37iter/s, Fluvial=18, Pluvial=0, Ambiguous=0]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Region Growing: 56iter [00:00, 236.37iter/s, Fluvial=16, Pluvial=0, Ambiguous=0]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Region Growing: 57iter [00:00, 236.37iter/s, Fluvial=14, Pluvial=0, Ambiguous=0]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Region Growing: 58iter [00:00, 236.37iter/s, Fluvial=10, Pluvial=0, Ambiguous=0]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Region Growing: 59iter [00:00, 236.37iter/s, Fluvial=7, Pluvial=0, Ambiguous=0] "
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Region Growing: 60iter [00:00, 236.37iter/s, Fluvial=4, Pluvial=0, Ambiguous=0]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Region Growing: 61iter [00:00, 236.37iter/s, Fluvial=0, Pluvial=0, Ambiguous=0]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Region Growing: 61iter [00:00, 383.77iter/s, Fluvial=0, Pluvial=0, Ambiguous=0]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:23:57 - ras_commander.hdf.HdfFluvialPluvial - INFO - Region growing completed in 61 iterations.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:23:57 - ras_commander.hdf.HdfFluvialPluvial - INFO - Merging classifications with cell polygons...\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:23:57 - ras_commander.hdf.HdfFluvialPluvial - INFO - Dissolving polygons by classification...\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:23:57 - ras_commander.hdf.HdfFluvialPluvial - INFO - Polygon generation completed successfully.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Classification results:\n",
+      "  fluvial: 285.9 acres\n",
+      "  pluvial: 28.9 acres\n",
+      "\n",
+      "Fluvial polygon: 286 acres\n"
+     ]
+    }
+   ],
+   "source": [
+    "# --- Strategy A: Fluvial/Pluvial Classification ---\n",
+    "# Run the baseline model first (already done above), then classify cells\n",
+    "base_plan_hdf = base_hdf_path\n",
+    "\n",
+    "print(\"Generating fluvial/pluvial classification...\")\n",
+    "fp_gdf = HdfFluvialPluvial.generate_fluvial_pluvial_polygons(base_plan_hdf)\n",
+    "\n",
+    "print(f\"\\nClassification results:\")\n",
+    "for _, row in fp_gdf.iterrows():\n",
+    "    area_acres = row.geometry.area / 43560\n",
+    "    print(f\"  {row['classification']}: {area_acres:.1f} acres\")\n",
+    "\n",
+    "# Extract the fluvial polygon (river corridor)\n",
+    "fluvial_mask = fp_gdf[fp_gdf['classification'] == 'fluvial']\n",
+    "if not fluvial_mask.empty:\n",
+    "    fluvial_polygon = fluvial_mask.geometry.iloc[0]\n",
+    "    fluvial_acres = fluvial_polygon.area / 43560\n",
+    "    print(f\"\\nFluvial polygon: {fluvial_acres:.0f} acres\")\n",
+    "else:\n",
+    "    fluvial_polygon = None\n",
+    "    print(\"\\nNo fluvial polygon generated\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "ce4b06b1",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-12T12:23:57.934258Z",
+     "iopub.status.busy": "2026-05-12T12:23:57.934069Z",
+     "iopub.status.idle": "2026-05-12T12:23:58.671600Z",
+     "shell.execute_reply": "2026-05-12T12:23:58.670616Z"
+    },
+    "papermill": {
+     "duration": 0.751381,
+     "end_time": "2026-05-12T12:23:58.672325+00:00",
+     "exception": false,
+     "start_time": "2026-05-12T12:23:57.920944+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:23:57 - ras_commander.hdf.HdfXsec - INFO - Using existing Path object HDF file: G:\\GH\\ras-commander\\example_projects\\Muncie_414_baseline\\Muncie.g02.hdf\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:23:57 - ras_commander.hdf.HdfXsec - INFO - Final validated file path: G:\\GH\\ras-commander\\example_projects\\Muncie_414_baseline\\Muncie.g02.hdf\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:23:57 - ras_commander.hdf.HdfBase - INFO - Using existing Path object HDF file: G:\\GH\\ras-commander\\example_projects\\Muncie_414_baseline\\Muncie.g02.hdf\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:23:57 - ras_commander.hdf.HdfBase - INFO - Final validated file path: G:\\GH\\ras-commander\\example_projects\\Muncie_414_baseline\\Muncie.g02.hdf\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:23:57 - ras_commander.hdf.HdfBase - INFO - Using existing Path object HDF file: G:\\GH\\ras-commander\\example_projects\\Muncie_414_baseline\\Muncie.g02.hdf\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:23:57 - ras_commander.hdf.HdfBase - INFO - Final validated file path: G:\\GH\\ras-commander\\example_projects\\Muncie_414_baseline\\Muncie.g02.hdf\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:23:57 - ras_commander.hdf.HdfBase - INFO - Found projection in HDF file: G:\\GH\\ras-commander\\example_projects\\Muncie_414_baseline\\Muncie.g02.hdf\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:23:57 - ras_commander.hdf.HdfMesh - INFO - Using existing Path object HDF file: G:\\GH\\ras-commander\\example_projects\\Muncie_414_baseline\\Muncie.g02.hdf\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:23:57 - ras_commander.hdf.HdfMesh - INFO - Final validated file path: G:\\GH\\ras-commander\\example_projects\\Muncie_414_baseline\\Muncie.g02.hdf\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:23:57 - ras_commander.hdf.HdfMesh - INFO - Using existing Path object HDF file: G:\\GH\\ras-commander\\example_projects\\Muncie_414_baseline\\Muncie.g02.hdf\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:23:57 - ras_commander.hdf.HdfMesh - INFO - Final validated file path: G:\\GH\\ras-commander\\example_projects\\Muncie_414_baseline\\Muncie.g02.hdf\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:23:58 - ras_commander.hdf.HdfBase - INFO - Using HDF file from h5py.File object: G:\\GH\\ras-commander\\example_projects\\Muncie_414_baseline\\Muncie.g02.hdf\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:23:58 - ras_commander.hdf.HdfBase - INFO - Final validated file path: G:\\GH\\ras-commander\\example_projects\\Muncie_414_baseline\\Muncie.g02.hdf\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:23:58 - ras_commander.hdf.HdfBase - INFO - Found projection in HDF file: G:\\GH\\ras-commander\\example_projects\\Muncie_414_baseline\\Muncie.g02.hdf\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Bank lines found: 2 lines\n",
+      "  bank: 15,513 ft (2.94 mi)\n",
+      "  bank: 15,835 ft (3.00 mi)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:23:58 - ras_commander.hdf.HdfMesh - INFO - Found 9832 faces in polygon (mesh '2D Interior Area', method='midpoint')\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Channel faces (fluvial polygon): 9832 / 11164 (88.1%)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# --- Strategy B: Bank Lines from 1D Geometry ---\n",
+    "baseline_geom_hdf_02 = baseline_path / f\"{baseline_ras.project_name}.g{GEOM_NUMBER}.hdf\"\n",
+    "\n",
+    "try:\n",
+    "    bank_lines = HdfXsec.get_river_bank_lines(baseline_geom_hdf_02)\n",
+    "    print(f\"Bank lines found: {len(bank_lines)} lines\")\n",
+    "    for _, row in bank_lines.iterrows():\n",
+    "        length_ft = row.geometry.length\n",
+    "        print(f\"  {row.get('Name', 'bank')}: {length_ft:,.0f} ft ({length_ft/5280:.2f} mi)\")\n",
+    "except Exception as e:\n",
+    "    bank_lines = None\n",
+    "    print(f\"No bank lines in g{GEOM_NUMBER}: {e}\")\n",
+    "\n",
+    "# --- Get face IDs within the fluvial polygon ---\n",
+    "if fluvial_polygon is not None:\n",
+    "    channel_face_ids = HdfMesh.get_face_ids_in_polygon(\n",
+    "        baseline_geom_hdf, MESH_NAME, fluvial_polygon, method='midpoint'\n",
+    "    )\n",
+    "    total_faces = base_df['Face ID'].nunique()\n",
+    "    print(f\"\\nChannel faces (fluvial polygon): {len(channel_face_ids)} / {total_faces} \"\n",
+    "          f\"({100*len(channel_face_ids)/total_faces:.1f}%)\")\n",
+    "else:\n",
+    "    channel_face_ids = None"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "3a37d37f",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-12T12:23:58.699897Z",
+     "iopub.status.busy": "2026-05-12T12:23:58.699708Z",
+     "iopub.status.idle": "2026-05-12T12:23:58.807525Z",
+     "shell.execute_reply": "2026-05-12T12:23:58.806748Z"
+    },
+    "papermill": {
+     "duration": 0.122598,
+     "end_time": "2026-05-12T12:23:58.808384+00:00",
+     "exception": false,
+     "start_time": "2026-05-12T12:23:58.685786+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA90AAAJHCAYAAACNRDUXAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjgsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvwVt1zgAAAAlwSFlzAAAPYQAAD2EBqD+naQABAABJREFUeJzsnQV8G/Ubxt+6u7dzd1dgGxsOw3U4jKHDhsMYMOSPjsEY7u6DYcMGbIy5u29d3d3l/3neciXt2i5pkzZJn++HI2mSXS53v7v7Pa+6VFdXVwshhBBCCCGEEEKsjqv1V0kIIYQQQgghhBCKbkIIIYQQQgghxIbQ000IIYQQQgghhNgIim5CCCGEEEIIIcRGUHQTQgghhBBCCCE2gqKbEEIIIYQQQgixERTdhBBCCCGEEEKIjaDoJoQQQgghhBBCbARFNyGEEEIIIYQQYiMougkhh3HgwAFxcXGRhx9+2G73zpVXXqnb6KzY2zH4888/dXveffddu91Gc8FvwHbjN7UlGRkZcvnll0tsbKxuz7HHHiuOjL2MB2wDrg+E+9EZaGg8N/RaVVWVnnvdunUTd3f32vujPdwrsV3YBlwjCGmvUHQTYkOBgmX69OkNfiYtLU08PT2dYrJtLaqrq+Xrr7+W008/XWJiYnT/BAcHy1FHHSX/+9//JCsrq6030e7HGxY3NzcJCQmRAQMGyBVXXCGLFi3Sfdve9gkmejk5OWKv3HHHHfLZZ5/J9ddfLx988IE88MADrfbd3333nZxwwgnSoUMH8fLy0vMN59ndd9+txgB7BscUx7atjSZHMupgefbZZxv8zPr162s/QwPBfwYbU6OePdClSxfdrrCwMCktLW3wM2eeeWbtsWxLUfnee+/JI488IhMnTpS33npLrymtyTfffNPmBjdC7Bn3tt4AQpwZb29v+fjjj+W5557Tia0puCFCCMEibW907txZiouLW3XbioqK5MILL5Tvv/9e+vXrJ9dee61uR0FBgaxYsUJmz54tCxYskFWrVrXaNjkaU6ZMkVNPPVXHVX5+vuzcuVMnQu+//74cf/zx8sUXX6gRw5HHiblAkGECCkFT/zdfdtllctFFF6lRpy359ddf5aSTTpJZs2a16vfec8898vTTT8ugQYPkxhtvlKioKElKSpLNmzfLq6++KhdccIGEh4eLPYtuHFvQkMESYxKGJ3u4/r/zzjty5513Hvbe22+/re+XlJSIvWIv+7GtwXGCwXfhwoVy/vnn13kvNTVVfvzxx1Y/lg0dG1xPgoKC5M0336zj2X7jjTf0vLY1uNdA+DckvGfOnCn33nvvYfMgQtoT9jdTIsSJOPvss+WTTz6Rb7/9VieypmAyBoH0+++/i72BGzYmEa0JvH0Q3JigPvXUU+Lq+l8gzi233CLJyckyb968Vt0mR2PYsGFy6aWX1nltzpw56r3EI0T5Tz/95NDjxBpgsmoPYiIlJUVCQ0Otvl4YXAICAhqNsIH3deTIkbJs2TLx8PCo8z6MXI6OvYxJ4/oPQ+GoUaNqX4fHFMbYc845Rx/tFXvZj21N9+7d9X6Ee3Z90Q2DJkB0FoyabXlscD2BgbF+KDnO8frneWsDw6w9GmcJaU0YXk6IjUUQvEm4WZuCSdjWrVvlqquuavDfNRZy2FAuqpErBa/m/fffXxsuOnjwYLXAN8RXX32lHiLcoH19faV3794qbMvKyo6Ym4lw2GOOOUYn9fi3o0ePli+//PKwzyFEdceOHZKbm3vE/bRp0yb1/I8ZM0Y9cKaC2wDhr0888cRhr2P9N9xwg0RGRupE5Oijj5aVK1celuv2+OOPy/jx4yU6Olo9nJ06ddJ/l5mZWeezpr8dRgCIE6wX33/XXXdJRUVFnc9jPyIEEZ5CiFqEdWO/wIO5a9euw7YXE278jv79++t6cQwwYUO4qS2AuESkBY4Zwsz//vvvw/YfPJ89evTQcRMREaG/Y9++fUdcd0PjxNL9B3bv3q3eZyOlAPsTny0sLKzzOYwneGax74zxN3z4cPXsmIJzx/CEdu3atTb009jOxnK6MWZvuukm6dixo24HHvF3/TFi/PvFixergMWkHPuuV69e6uk5EsY5i4gEfN7YPtPQWvwmXD98fHzUe3XiiSceduxMrxUw3uEY+/v763hqDBxXnA84FxqaiOPfY7H2mDX3ugH++OMPOe200zSkF9+HHNWpU6fq8cExwzEFOMbGvsOYqb9PQGVlpebMY182xGuvvaafh5fOmr8X4N8gYqD+9R9GWHhOG7v+Y1+dccYZeo3CuMI6zjrrLL1O1ge/G9cgnBvYZ9i/GC/nnXeeijBTLL1XNJVLvHz5cpkwYYL4+fnpcbrmmmsaNNj89ddfMnbsWB3HuPbeeuuteu8zJ/cf43Tu3Ll6D8XvCgwM1HsVxkJ5eXmT/7Y516GmwLH65Zdf9DpvCo4t9jvuP41tB65tiCbBvsa1AvsekV31wX45+eSTdZ/CGHfJJZeokawhTI+NkV6E8+bgwYOHpS00ltON8YH7Ps4vbBt+A1JO4DE3navg3+PahvMWxwH3WESdmYIxaFz7TFOdjGtaYznd5u6f5sxzCLE3aHYixMZcffXVMmPGDElMTJS4uLja0ELc4CZPnmy170HuLibR8BRDPGOygokahJ/phBR5o5hQIoT79ttv10nI3r17VYgjhLupkFuEiEG8YmLw6KOPqjjGzRfW/5deekkFigH+xqQYk5Ij5Sziu8G0adMsLvgCcQuhiBBdiCN4dDEJ2r9/f623D/vjmWeekXPPPVfz7zCpWb16tea9QcisXbv2sN+NG/nLL7+sHngcQ0yUIbAgqnHTNwXiECIGRgPsW3z3Cy+8oN+1ZcuWWq8qJorYd//8849ONJDvD9GL8D9MZJYsWSIjRowQW4CJKn7rDz/8oOIH4LuRxxsfH6+/ESIDEQX43RBFa9as0RDy5mDu/sO+nzRpkgqb6667Ts+RjRs3yosvvqieWEzaDXGIySX2Ec4bCC/sd3iXMG7S09Plvvvu089hPXl5eTo2n3/++dpQaUzeG8PYF3v27NHthUiDyHrllVdUXGPyWd97jN+BME98HyaA+CzGOgwYOJ6NAQ8nPoMxMG7cOE2lAPh+0/BveEcxnuC5fv311zVXE/sRETKm4DjhHMJ+wHWgKTDBBhAiuC5BkDaFNcasJdcNiGAYwzAO8Ijxh/GJHPSEhATp27evHlNcu+BJxr4E9Q0FBjj3EP2B8x+iBmO8vqcS4wPXDGv9XgOMW3w3hAe22fBO4vo/dOhQGTJkSIP/DvsEQhbjAkIV12ccf3z/unXrpGfPnnU+j3sLRA/2B34nzh/sR5wDEIrNvVc0xoYNG/QchBC9+OKL9bzEtRTHFdtpgOsNjEU45xFajHP8888/1/PaHDBmcF2H8QLXERxLXFsR5g3DiDneW0uu402B44jzEsLSuM4g7Wn79u3y5JNPNrifIYBxDmP8wFiI44Z9hfok2AcwlBneX/wuXAvwuzDmYPDDmMdYPBI4J2C0xv6CYQpjDUDANgbELsYTwuNRzBFjGtdT/KbffvtNxTfAeQqDDiL1cC7iHot9gPPuo48+0uNvzCtgJFm6dGmdXHLjmtYQluwfa41dQtqUakKI1fnjjz9Qtar6mWeeqc7IyKj29PSsfvzxx/W9oqKi6qCgoOo77rhD//bz86ueMGFCnX+Pf3vFFVcctt533nlH38P6DR566CF97bTTTquuqqqqfX3VqlX6+r333lv72sqVK/W1iRMnVhcXF9dZN/6t8e/379+vn8O6DdauXauv3XfffYdt15lnnlkdEBBQnZeXd9h2YZuPxDnnnKOfxXeYC/YP/s0NN9xQ5/XPP/9cX3/11Vfr/Dbs9/q8+eab+tnPPvus9jXjt/v6+upz03X079+/Ojo6us46cOzw+aeeeqrO608//bS+vmjRotrX5syZc9hrIDc3t7pjx451xkFDx8Cc8dYYxvHDvja45ZZbqr29vas3bNhQ57MHDhzQ42k6Bo3vMD2eDW2jpftv0KBB1b17964zdsDXX3992PcVFBQc9rsqKyt1vwUGBlaXlZUdNv5Mt6Gp8+j+++/X1+bPn1/nsy+99JK+PnPmzMP+/ZAhQ6pLS0trX09ISNBz/aKLLqo2h4bO8x07dlS7uLhUH3300XXWnZiYqNeNzp07V1dUVNRZB5Zff/212lymT5+u/wbbOm7cuOq77rqr+osvvqjOyso67LMtHbOWXDcOHTqk29S3b9/q7OzsBo91Y9/T1H7dsmWLvobfacqePXv09ZtvvrlZv7cxjPGBfbpp0yZ9/tFHH9X+RldX1+p58+ZVp6enNzgGGhrn27Zt031T/3qH8VD/GgZuvPFGfR3jqTn3CtDQtuE1jM8VK1bUef3UU0+tdnd3r87Pz699beTIkdVeXl7Ve/furX0N5+hRRx1l1rVt6NChOhaag6XXocbA/sXnAa6dvXr1qn1v2rRpup7y8vLqm2666bDrzcUXX6yv/fDDD3XWeeedd+rruP8YTJkyRV9bvHhxnW0966yzGj0O9V/D2MT2NnavNOWUU05pcJybnmeNjcXCwkLdD/WPTUPf09T12JL9Y+nYJcQeYXg5ITYGHguEChphVqjODcsurO7WBGF7pl5ihNPB+4PQXQNYpgEsyfVzwoxwsMbAv8X7sDTDmm664PfBG4eQQ9NwMMwNzKnMC48MQPigpcDjZQq8psD0d2O7Ed5ohJuiEBO22/hs/XB0AOt5/ZBVeBoRklc/jBIeHoTpHWk7PvzwQ+nTp4+GRJvuP1js4VmAZwieU1tg7FtjX+PY4JjCQw+voun2IBIAXvuGvDfmYs7+Q+EuhMzCWwIPj+k2wBuP7TDdBvxtgKJF8LogTBfeNPwueGSaCzw6iJgwvM4G8GLj9frhlADeGdMICexHhGGaHnNLgScOxwZ5+KbrhkcankV4h+qHOSPEEoXyzAVRBPDwwgsFDz68o/A6I+oF3jycI9Yas5ZcNxC1gPU+9NBDDRb8ayjtxBzg3cb2Y1vgjaufj2saHWDtc3TgwIHqRTRCzOElhKcOocONYYxzjAOMa3w/xiBCqxu6VmFs1K8Z0tD1x5J7RVMgXByRMPW/DyHbRvgwPKiIJkK0jxFdAfDb8f3mgDB5ePEbSqswF0uu40cC92x4VOGFxRhAGgCiIRrKVcY4g0ceEQ31I1PgKTeiPYzPwquNcYJtM91WXAesDa6ZSDWCFx2RYk2dZ6bXXIR845qLRxxvePmN+4mlWLJ/rDl2CWlLGF5uJRByhokLQiURnomLBS72loAbLHIvEZ6FiRVC3jCpa802MsQ2YLKM8EVMHhBaiJAqhHdbE9OJjangN81HxY0JNyxM0i0FN1iMUUxIGwMTrZYIQkzAW/q78ZtB/TxchDXi/IJgqZ8PmJ2dfcT11l+3aTgrJr31jRgNbQf2ISZrmEA3BibYCC20NvUNGwjHxrZB1Da2Pc0VOebuP+wPAJGF5UhjCpNkGHNwLA8dOnTYZxs6juaC8E5MeutPoPE3hDTCes39jbh+t2Q7QP0waNPXkJdtGuKM7bMEXAMgFrBATMLwgXGAUE2EtUPwGiG0LR2zllw3jIkzJuLWBsIahjGEzsJIg22CwDYEuS3PUVz/b775Zh0XML5CiCK8ubHWbLhGPfjggxpqW7+ugZHPbsm5Zu7nG/psQ5jzfcY4hqGgPg291hBIrcA8CmHXuMYihB73UeSrm9t5wJLr+JGASIVhCgYUnIO4pjaWl4/rK65XDZ3HyNfGeoy6GcjbxmcbOkesPU8ASKHB+DfnPMO2IT0ExsCG8sthwG6OsdyS/WPNsUtIW0LRbSVwY4SQgSXUyDGzFFjwMPFBvhGs47BGsi+xcwBrMrxgyHFGsRPkfjaHpoq/NFaNuX5/5iN5tBsD68G/Q/Xrxr6roRuoOaCfNCIAMNm0dMJtzu/GutGODMYO5FpjwgyRDI8eJlKm3q8jrbf+ui35LJ7j3EbeeWM0NdlvCUYRJmPCa2wXPKTwblobc/aJ8Yh+1Y3lLkKcGMAjjlxkeKPhocdkC9+DvE3kMTZ0HG2JueecrUGBo+YC8QIBjwU1D5AfivxcQ3S3dMza8rphCSgOiHEG77ZRlA6TenRKqL+91j5HMW7x3ci5h+BBznZjIH8dYxtCBsIb5yu8jdiHt912W4PeWUuuVdYYt5Z+X3OBRx357D///LPeN7Gg2vtjjz2mx8+cyv/W3FasC/nPyBFHfQBEA+F8cVawf3CuwBCF+SmuEYg+wH6A4QHHor1ecwlpDhTdVuKUU07RpTEQOgmPNdqHwDIIkYGbvdFjFBc1CDEUXTImxQ1ZtIljYtysEdaNMGdMAJsCk4mGDC7mVJRuCnjEMPlFoR3TFjbmgCInCElDRV1rTzRgqEIRN0z24TlojlGgKVDYBSIbkzZTgdKScOTmgH0ICz9C81riRW4O2LfAKBgF4QCPJrw1loQmWxOjIBTOjyNtA66bENzwztbvOQvvZX0sHUPwoKAyLgxbpt5u/I2Q0oY8LLbA+B5M6usXQtq2bVudz1gb3Htg5EBIr7XGrCXXDcNjj0JdTXnvm3N9QOQYwlgRhQbhCvGN31O/xZ4tzlGcZ0b7MBj8jCJVDWFsH0JvTUONAbx5jtLn2AjpxjlVn4Zeawx4omEMwgIgeFF4D9czVCFvbeBYwdwNBcdMi8bVB9dXFF7EedxQRA4iIo1CevgsfmdD9yPjnLcmKOKIcwjn2ZEMtZgroJid0Q3CoH7HCEvPS0v2DyHOAnO6WwlUo0Te2qeffqoXMuTPwbNjhNMhnwcTKUwqIbZxw0ILDnq6nQdUT0UILQTDkcKxMOHEeDFtm4EbUf3WM5ZiVBpF1VajPZi51mKIHePfmuZ8NhZabknLMESJYP2oGAwPW0PbgRw8S6rNmgJRhwmBqVUe3wGPSWsCwwt+R2NetOaG5zcFjhUqvcIzBNFhVNWGoEBeKXJ6G2vd1Fi7GmuBqAYYIHFONGRQguA1roGGh6P+2MDkrKEJoBE2au41FGGsEFv114Wq1Xgdoqk1QJ4zxirSlUzTIPA7cf6jgnBLwq8x/hqbbKPyMPaXaUhrS8esJdcNI2wYE/yGckWNY2/psTUNMcc1FWHlyB+H+K1fvd1W5yiqd+P6Dy93U2K+sXGOcVi/BZg9g6rr8IwiLNn03MaYRrSROTQUfm+0fmuruRHuzdh+HEtETzUGjrHRZg5GJ1NQ7Rz3IuOagmOOavDoQgDDsAHGANI9rA2M+nASwQDfkMHSGHuNjUU4hxrKt7bkvLRk/xDiLNDT3QogXAyTJTwaN3hMgnGhwevIW8JNCflemAjAAo/JCQpEYRKCdjXE8YGn50h9SU2NNPDAwNuCSSu8fJh0YcLdkokXvNsIJYalHpMXTBowOUL+HYQXBFhDBYyMgiXYfiywQMNwhPEMMYBaBgjxNRXylrQMAxBeMCxg29DWCp4N/F54fbBdCBFH2GdzwHmElkrYn5hUY+KHvrwN9Uq1JQjRQw9UeGhwXmN7YIDBtQHtUQxvfHNB3jEEhZEfD48SfieuLQgTRDigKWgxg6JAKMKEBeGSED34PI4ncl1Ne0dbG4hLRCFgP6Cdl9G2DMcFYbg45ogOwfiBVwS/Ab8P0SIYj9hOtEaCobJ+Th9+C8B4h3EB+xYCH0tDoGARrr/womE/QthiQgiPGjzAtiho1BD4LowPTLYRZoxz1GgZhnMBxcCaCpk9Emi7hX2HQljHHXecGnsRiQWPFtaNQle4J1lrzFpy3UDvXeSV4xjgXMe5imsAPO8Qb6iHgXUgrQDeOhixEQ2AHr8IwW6qPzkwen9jTEDUN9RezVbnKMZ3Uy3rDCCGEI1jtCtD5AHOUewn/FZL+0u3JUiVg2EDBftQnwahyajHYBzvI3lGERmB8xhj1RgzOA9wjbroooukrahfNLMxcB5hLMGgh9+PMYv6PyjAhnPbdPzBAAwRDPGN/H+cC3DGwOBnC3B/xnHBeMN24FqPWgYo1AenD+7D2P+4HuNahGsyrk2I+sE1F+cnzl9TcKywXvxWnGu4luDYNRa1acn+IcQZoOhuBVChFyK6frgcJjpGQQ9Y9fA3BLfxOUz2cCHExNncwiPEOYBISEpK0hsYeuliYowQL1iHG6peawmwIsOzjHXjZoqxh5BHeEGPlBsK6z68F6h+jMkxahmg3ziEDF5rCfhuhFRCaEGoQ4RDSGEyjRs/fj8qSTcHTNAgXJD3C4MXJrKYoGNfGOdga4BJCAwKCJGE2DSKh2FCCYNISycZCF/FgnECrwMmbhMmTNB0hoZypjEJxoQeBeYwGYawQWg1/h2qhyPaxtZAREHcQlzj+OO4Q2Bj4gexDWFoAMENjyEmo6gCjVBgGA6wX+sXNIJHHxNHrA+5tBAr2N+NiW5jX+Az2A6MQYg5RKjAeFS/R7ctwXZjAopxgt8LkYHJK4wmKCrVElCsaf78+TrZhWiF5xZGKBQuwuQXucemnnRrjFlLrhvozQ1xCU8/3sN9Ed+FcWBavAwGAhim4UGHIIA4P5Loxn7EuYBrH4R0Q8VObX2OHgn8dogv/C6IEhhYMJbRrx4i3KgO7gjg2gPngvFbYNCFEQkRVxBoRkeJxsBYhLEB4wARUxgz+HeIhmpOMdDWBmMS92vcu3DtgvEc11ZsP4qTmaax4Lgj0gS/ed68eZpGAEGMMYjrkLWBEIZn/dFHH9V9jLkn7ovYr0YHB4w9nAu4Z+J6i/MW5yyew0hXX3Tj3MK1HNcVGDAxt8B1tDHRbcn+IcQZcEHfsLbeCGcD1lvT6uWw2kFEIXelvocCE2N4GnFjx03JNJwQVkcIERRXayoHjBBCCCHEEUDUEaKPYCBsS481IYS0JjQjtQLwGsDTjfzIxrwUsGTDE4NKnUbxHITxGNZAQgghhBBHAT4dRCqYtlOEYwH58vBiGoVkCSGkPUDRbSWQa4ccRAPkyKJYDQpWIFwcnm7kpyGMEyIceTrID0OOF3JfULkXObbIaUT4HcJykNcGD7elPVgJIYQQQtoSCG44DTD/QYoc0oUQ+YdissirR5QfIYS0FxhebiX+/PPPw9p7AOR/oRARrLsolIG8GRSFQfsS5CYhV9AoDoUcXhTQQDg58liRzwORbk4vSkIIIYQQewERfqingHx0FEGD5xviGznDKJxFCCHtCYpuQgghhBBCCCHERrBPNyGEEEIIIYQQYiOY090CkHeNkHC0kjlSv0lCCCGEEEIIIbYHKS1oF4uWj2il2tZQdLcACG7TvqGEEEIIIYQQQuyDQ4cOaQ/4toaiuwXAw20czMDAQGsdE0JaZNXLzc2VoKAgRl8Qh4RjmDg6HMPE0eEYJs5Abm6udOrUqVavtTUU3S3ACCmH4KboJvZyo8SC8ciUB+KIcAwTR4djmDg6HMPEWcYxsJf5cNsHuBNCCCGEEEIIIU4KRTchhBBCCCGEEGIjKLoJIYQQQgghhBAbwZzuVqCyslLKy8tb46tIOwf5K2VlZVJSUmI3OSzAw8ND3Nzc2nozCCGEEEIIaXUoum0sgFJSUiQnJ8eWX0PIYf3jMzMz7W6vBAcHS3R0tF0ZAwghhBBCCLE1FN02xBDckZGR4uvrS7FBWsXQg8gKeJXtRdxim4qKiiQtLU3/jomJaetNIoQQQgghpNWg6LYRED6G4A4LC7PV1xBi96Ib+Pj46COEN84JhpoTQgghhJD2Agup2QgjhxsebkLIf+cC6xsQQgghhJD2BEW3jbEnbyMhbQnPBUIIIYQQ0h6h6CaEEEIIIYQQQmwEc7rbgOLicikrq2yV7/L0dBMfH49W+S5CCCGEEEIIIXWh6G4Dwf3DT7slr7h1+nYH+njIaaf0tJrwPvbYY2XIkCEyd+5csRZdunSR2267TRdzePfdd/Wzjt6Kbfz48XL99dfLxRdfLI7OmDFj5K677pJzzz23rTeFEEIIIYQQu4Lh5a0MPNwQ3OGd/KVTnxCbLviOPAu96ldeeaXm3tZf9uzZY7N9snr1arn22muttr7GfoOxvPfee9LWLFy4UFJTU+Wiiy7Sv7OysuTmm2+W3r17a6XvTp06yS233CK5ubmH7avjjjtOe16HhITISSedJBs3bjysgvmzzz4rvXr1Ei8vL4mLi5PHH3/cpr9n5syZcu+992qPcEIIIYQQQsh/0NPdRvj6eoh/gJfYIyeffLK88847dV6LiIiw2fdZe90vvPCCPPnkk4e9ftlll6nx4LTTTpO25sUXX5SrrrpKXF1r7F5JSUm6QCz369dPDh48qF5wvPbll1/qZwoKCvTYnHHGGfLyyy9LRUWFPPTQQyq8Dx06JB4eNdEMt99+u/z222+6roEDB6qgx2JLTjnlFLnmmmvkp59+sov9SwghhBBCiL1ATzc5DHhHo6Oj6yyN9VWG5/ibb76p8xq8sAgBB0cddZTcc889dd5PT09XgbhkyZLa8HLTcPU5c+aoWPTz85OOHTvKjTfeqILTXIKCgg7b/rfeekuWL1+u2xoeHq6fg1d29uzZ0qFDB/3NCJtftGhR7XoOHDigv+/rr7+WiRMnasurwYMH63pM+fvvv2XcuHHqocb2wkNdWFjY6Pbh9y9evFhOP/302tcGDBggX331lb7WvXt3mTRpknqnv/vuOxXXYMeOHSqesc3wiPfv319FNzzmEOlg+/bt8tprr+nvhDjv2rWrDB8+XE444YQm9xmOETzj+I3dunWTBx988LDWXtiWkSNHire3t+7Ds88+u/Y9jI9TTz1VPv30UzOPEiGEEEIIIe0Dim5iUy655BIVYgh5Nvjss88kNjZWhWqDg9LVVT3BW7du1VBwCNS777672dvw/fffy6xZs9R7D9Fs6hF/7rnn1CO8adMm9RhDqO7evbvOv3/ggQfkzjvvlA0bNqgwnTJlSq0Q3rt3r3qfkcuMdeC3QYRPnz690e3B+xC3ffv2bXK7EVoeGBgo7u41ASkQ2mFhYWpAKCsrk+LiYn2O9cBwYQhjiGb8ZghuvA4P9JE83QEBAWoo2bZtm+6XN954Q55//vna93/44QcV2RDW69evl99//11GjRpVZx34e+nSpU1+DyGEEEIIIe0Nim5yGBBs/v7+tcv555/f7L10wQUXaIg0hKbBxx9/rMK1sb7NKJIGzzIEIzy+jz32mHz++efN+n54hyH877vvvsN+B8Q2PLzIq4agfeqppxosEgfBjZBpCO5HHnlEvcpGjvv//vc/XT+2uWfPnurZh8Hg/fffl5KSkga3Cf8+KiqqNrS8ITIyMuTRRx+tk+sOYfznn3/Khx9+qF51HBt45hHSbQjzffv26foRko5tgJBeu3atnHfeeUfMyca2Y5/D247fbLrP4XXHfsLvh8iH8QL71BQYUhDmzrxuQgghhBBC/oM53eQwIHhfeeWV2r8R5t2SfO0TTzxRPvroI/Vs79+/X8OzEQLdGMhHhpiFYM7Ly1OvMgRsUVGReojNBZ7is846SyZMmKAC1hSsF8aAo48+us7r+Lt+YbJBgwbVPo+JidHHtLQ06dOnj34WHm78PgN49SE88Vsb8mbDQ40Q7cbAtkHkI7f74YcfrvPvpk6dqtv4ySefSGVlpRoO8FkUWIMQx/eWlpZqhAAMCQDecISY79y5s/a1+sBDD2MBPPcI5cc+h5fdAF7+adOmSVOYfj+eE0IIIYQQQujpJg0Akd2jR4/axRCaDQFvtWnoOKifCwxPMDyveB1ebuRrY2kI5FFPnjxZhS5ynOGlnT9/vr6HkGpzgfhDKy54kyGIG/Oqm4NRoAwY6zG8uRCo1113nYpSY4EQR4g6crMbAvnQ2dnZDb6Xn5+v4erwai9YsKDOd2PfYf9ARCO3Gm268BrE/bfffqufwbGC1xteeQND+MfHxzf4nTCC4BghdBxRDggfR0i96f42R0QjhB1jh4KbEEIIIYSQ/6Cnm7QIeLKTk5Nr/4bYhEfalDPPPFPDpBEKDZF4+eWXN7o+iGwIWuRaG+HXzQktR7j0P//8I6tWrVIBWx94cREOvWzZMvWEG+Dv+rnKTTFs2DDNg4ZxwlyGDh0qKSkpKrzR9svUw428chR1++KLL9TbDCEL8QuDBUQz9g081hDjnp6etUYAiH94wseOHav/Dh5rY5t27dqlj507d25we7Cf8B6EtoFRmM0ARhDkcaPiemNs2bJFfxshhBBCCCHkPyi624iionKn+A7kXL/00ksq9hDujBxpU+8sgPcTYd6oiI3q2sjnbgwIRQjMefPmaW4xRPCrr75q0TZBpKNlGAqnQXBD4Jpi5KrfddddWv0bHmnkcuPz8FSbhoofCfxeeJxROA0Fy/BbIcJ//fVX3S8NAWEKbzeqt2P/IRw7MzNTc6YhnFHIDCHrBqGhoVodHN5tCHOEysMzjQiDN998U99DPjk83qiejrB0vI8q5zgW6J99/PHH1/F+m4J/C0GPgnf4DhRNg5fdFOwn9AfHvsJ2Qtj/+OOPdSrTo4gaUgkIIYQQQggh/0HR3cp4erpJoI+HZMSb3wKrJeC78J22Ah5peD+Rrw3PMQQjvNX1McKXx48fL506dWp0fSjQhZZhKGqGQl34PPK7m/KO1wf56BCkV155ZYPvQ0AiVxqtvZD3fccdd2iONsTqwoULVYSaCzzAf/31l3qJsQ/wvRCmF154YZ3PwSABQY3cdDzCCIG8duO74JGH4AcILzcF72Gd2G8Qwyhqhp7j8HIjTB9GAniq4RGHGEY4Pj5zzjnnaKg3tgvV31FkDbnkeA2P8KgjmgAV29HbG4YDGACQIw4DiWk++bHHHqvedwh+GDQQKYBjY5CYmKgecxR5I4QQQgghhPyHS3X9hFxiNvA6oie00drJFIgreB7Rtql+0azi4nIpK6tslT0Nwe3jU9fzTGwLBDaOvyGw8Vg/Hx29uhF2D5EPQY1QcSNkHAu8183JQ0f4Ob4P4hsC2tgGo8WZKVg/xmZ9Id6c74XHG+Hyr7/+eqOfaeqcIMQAtyRcU3FtbUktBkLaCo5h4uhwDBNnIDc3V4KDgxvUaW0BPd1tAEQwhbBz3JQgpiFu6y8NATFtCFx4pt9++20VFXFxcVbbJqwP34PvMC4w2E6IblNPOx4N7zsWo7AbPN+G+IYRwHRBgbbGRFBkZKTMmDHDar+DEEIIIYQQZ4Gim5AjYIhWw3NsKq4bCxSBSDX1IOMR3mtTEP7dGkAoG8LZVIgjd76+EIenHIXw6hfDq7+e+svNN998WC4/IYQQQgghhKKbkAZDw+t7rvF6Q0CIwitseIeN5/AK2zOGRxwLwnhNPfdGODxEufEIo4PxfmOt27BO/G5DiBsh88ZitFkjhBBCCCGkPWHfyoAQGwIRCUFthFhjaSw03BCphrA2FtO2XY6OYUDA0pi33xDhDS2G97x+n3YDiG5UaUfFdV9fX+0pbiwdOnTQMHtn2ZeEEEIIIYQYUHSTdoOR12y6NOR9NULD64tro294e8Q0tLwhDFHekBg3hDpAxMCOHTskNTX1sHWgZznaqQ0fPlwf0T6uPe9zQgghhBDiHFB0E6cGgg9V5rEgbLo+EHXItzZd7D003FFFeWFhoYputCdLSkrSJTk5WZeEhAQt5rZ48WJdjP7k6C+OFmpojUYvOCGEEEIIcUSoLojTgRDx/Pz8BoU2vNamAru5LbKIZRj53ogYOOaYYw5rGQbjyLZt22TdunWyfv162bhxo2RlZcnnn3+uC0LPL7jgAm2z5u/vz91PCCGEEEIcBopu4hTAg4o+fDk5OXWENsQe8odRtTsgIIBebDsFYnzIkCG6AISqr1q1ShYtWiR//vmnJCYmyvPPPy+vvvqqnH766XLRRRdJp06d2nqzCSGEEEIIOSIU3cThvdoIS4bYNvKzIbT9/PxUZFNoOybwih911FG6wIjy448/yqeffir79u2r9X7DYz5lyhQZNWoUoxUIIYQQQojdQtFN2oxjjz1WPZtz58616N8hP7igoEDDj5EnbAAv6B9//KHhyczLdh4Qio6e5meffbZ6vz/55BP5+++/a5du3bqp5/vUU089LGydEEIIIYSQtoalgUkdrrzySvUaGktYWJgWstq0aVOb7yl4ObFNCxculEOHDqngxt/wZnfu3Fkef/xxDUWm4HZOcKxHjx6tRpqvv/5ac7yRl49x8cQTT6jofumllyQtLa2tN5UQQgghhJBaKLrJYUBkG1Wlf//9dxWxkydPbrM9hbBxeLUPHDhQm+/r5uamBoHu3btLx44da8PJ8RpxfpDPfffdd8tPP/0kM2bMkNjYWC2c9+677+pYve+++9Qrjlx/QgghhBBC2hKK7lbEaJvU2gu+1xJQ0Ts6OloXhH/fe++96llOT0+v/cw999wjvXr10iJlCO998MEHa3sxg4cfflj/7QcffCBdunSRoKAgDQFGVfHG+OGHH/RzH330Ua3YzszMlD179khKSkqtgAoPD5eePXtKVFSUFuCq/52mXvuzzjpLnn32WYmJiVFBftNNN9XZTuSE33nnnVodG8IdnlR4yw0OHjyohbvQQxrv9+/fX/OLiX2ASuYXX3yxfPPNN3qc0eMb4+bXX3+VG2+8UU488USZPXu2LFu2TCukE0IIIYQQ0towp7sVKSoqapN2R8h/hmBs7r/98MMPpUePHnW8yPAqw6sID+PmzZtl2rRp+hq8jwZ79+5VMfT9999rsTOEAz/55JMaBl6fjz/+WK6//np9RJgwxDYWeLUB+j9HRkbqcwhz9Nc2B+R4Q3DjEeL9wgsvVGGO7QXTp0/XVlUo0oXfsmDBAvX04zdB2EOkQ6wtWbJE9yE+21YtqyAmscD4YPoITFMC8BqiE4y/sa/qP3c28LtQIwDLrl275Msvv9R+3yiwh3QELDh+48ePl0mTJmmBNhiXCCGEEEIIsTUU3eQwIJINYQlPOUQrXjMVujNnzqx9Dk82vMUQrqaiG+IPwhxiHFx22WUarl5fdM+fP18eeOAB+fbbb2XgwIGye/fuWq82xDY82xDa8fHxFh8teKiR54tw9D59+shpp52m2wDRjfW98847+gjBDfA70KYKryNPGO+de+65ul0AXn1rgN8HjzsEPQwL9YV0Q4+WRiw01S8b+wOPjT03Hh1RoCMC4/7779doDBTVg/jGkpGRoeHoWJALfvTRR6sARxV0RGwQQgghhBBiCyi6WxFM7OE5bm0sFRQTJ06UV155RZ/DQ/3yyy/LKaecojmyKFgGPvvsM3nxxRfVm43fBOGIXtimQIwbghtAvNcvcgWPJF6DEEKIt/E+wsYNsd0S4YdwcAhI022AFxvgEWIWIs0UhJwbXv1bbrlFbrjhBvnll1/k+OOPVwE+aNCgI34vBDL2CUQ11geBbYhsPLYk1xi/BwYQLMZvw/cZi+H9xqPp68bnjG0x97saE+T1n5sbfdBaYNtGjBihC4wpW7ZsUYMLBDjqFfz222+6YKyNGTNGjjvuOBk3btxh45gQQgghhJCWQNHdihj9o+0dbCPCyQ3efPNNFb9vvPGGPPbYY7J8+XK55JJL5JFHHpGTTjpJ34OX+7nnnquzHnipTTFCn02BBxneSKwbeeEQQBERES0W2+ZsA4wFEGZr166tI8yB4em/5ppr9Dci3xzC+3//+5/+zptvvrmOiDXEtfGI5UjCGkIV24fFENJHejxSeDi2B9+Lz5t+zhDehlfd9LGh54Zn3XiO33MkjO1szINufAcKnuE4t6ZIx3fBWILltttuk+3bt9d6wBHNgPQBLNhWeL6Rxw9POCvhE0IIIYSQlkLRTY6IkQtcXFysf//zzz/q8UZIuGnBMUvz20tKSrTy+Ntvv61FzyB0X3/99VYTY0OHDlUhCO86PJyNgdBzbB8KdsEwgCiAM844ozY0vLGwb+w3CGrkDuMRQtP0sTVFp5HTbVp4rikMwd2YODd9zdgHRs55Y150vIdifCjMh0eE/vfu3VurjSMX29xtaynYD/369dMFOfuI1oD4hhccz1FIDwu2DxEeONamRihCCCGEEEIcSnTDu/TMM8+otxEhnyhkhYrTTYHq1k8//bTm/sIjiokx1mFa6OuLL75QgYQ2UyiI9dRTT2mBLgOIqPfee6/OeuHRRD5vewdeTVQLN8LLkRMNrzC8fwD7E95BeLdHjhypXmAcN3OAOEMldFQxhwiDAEL4L0QOwnvR/gl9mJti586dDYaRWwrCyuGxv/zyy9V7jQJr+N0///yzvgchjjEEjydC5eGhxXbC4IBcdwOIZ0NMQ2AbS2t7c4/Ef6HmxnMI4f8MBq6uLrWLkfttjqfXENxH8qDDSGHsD6MyPQw4WJCGgErjGGM4lq2VS47vgaDGcu2116roRv0CjGm0qUNhPywovIZrBgw1jpjnTgghhBBC2rHohngZPHiwXH311XLOOecc8fNo/QOR9Pzzz+sEPTExUateozDW119/rZ/BJH7KlCkaCgwvGibNEPLr1q2TAQMG1K4LVapRMMuA1YxrgOEBuc8AYggFyGDEgDcSwPN3++23a+VvCHQUJ4M4RcuuxoD3Mzc3V8UXBLch6oKDg7UqORZ4G/EdCEWuH6puClqP1QdC3lIgFmFQQMj8rbfeKqmpqbo9GI8QV0auOt7He9gX2D78jXZqhse6LQuOQTTXiN7/lpqw9qrDBLaI8YhneL12R4i44D+IbQhRI7qh8cX09+I5jhmWprzViGzAtsFYg+fwdv/1118qcrF/v/rqK13ggcbYGjVqlLQ26PuOsYDvRxoFqp7D0GIYBxCeDvGNEHR7MqgQQgghhBD7xaXaGiWRrQQm70fydKMXL8J74ZEymDdvnnqyExIS9G+0hYKYx2TeAIWS4Ml89dVX9W9MnNFOCC2tzMXI1TWA5xPh0VhP/eJLEBXwssND6u3tLe0VeDRRNRpeQ2OoQbxCZLdWOHH97cHYgPCHqK6fd40xCOMLjhkqXOOxtT3WDXmj6/9tiO3/PquS+l8hXSVV1TWi+D+RrR+oEdcINf/3t9b8XaPCq7CuqprvqQlH17dNnpsvyhuisXMCx2TNmjV6vsLwYpxjiIBA+LepoawtgEEH/eaxfUboPMQ5riHwzlN8WxeMPxjorFXXgZDWhmOYODocw8QZyM3N1VRBPNpDkdw293RbytixY7Ud0I8//qhh5cjHRQVs09BxeKgQplw/dLy+wIYHC+IPBwStg+DBNA1Rrw885ygeVh8czPq2C4TSGiG3LalU7cjg9yMMHfsCQMSiSJohuFprv+DYQGRjQS656bGCdxaF47BNWCC460/0jfxma/OfZ9oIz/63wvi//zOEsunIUpFd+349gYxHt3/bgv2rjmt+yn9i2SwMAY7vwDbWPlbVFeUqyGvE+L//1d0Wl/9C1vG3UbU9JydXfHzqFmZDbjcWRLygL/x3330nK1eu1AVe5alTp6pYbwtwoYb4R4QFPPG4jqAXOK5DKACIbUP4OQWidcD4Mro8cJ8SR4RjmDg6HMPEGcjNzRV7wuE83QChzpicw3OG8F+EmWMybFSqhmcS+doIMTdA2ysIZoSxAoS4opVW165d1WuOCTQKeUGw169kbUBPt+UeQkyecVwQjm1UBG8tIPCQk44F48QA4wPediwwBLTOtkBcV9V51LBww3ttiNx/1bQhWg3hbCpkDS+z/u1aT5joepArr2/Y5Leo8FeDgZHP/e/fhqdcqv/zipsI8fKyMklMjJeUFFQ19xIfH3fx9fXQxcfHw+S5u6SlpWpRPRjXjNx/GNmuu+662p7qbQWMN7gGwTiA5wDe+BtvvFFrHJCWQQ8LcXQ4homjwzFMnIFcerpbxrZt2zTnctasWeq9RvG1u+66S/O633rrLbPXY5oXjLZVyNVEyKhR0KshjAJZjVWGrv9aY++1B2DcgOBG6C1C8FszxB6edRTpQti/YVNC3jUiGiC0G/JmW4Mar3VVPQ92jRe7Rlj/K1J1qRGkrm4uuni6/dsOrL6IthT8Ww0jt92Yq/GoY7uPIMoND7mxP9CyrLJKDmYUS3l5kbi7uYqHm6t4amsxF33u4e4q7q4u4u3tIccdd5WMGnWq/PjjJ7JixVIV4GjbBqMc6jq0lfiG5xve7fPPP1/Dzj/55BPtAQ7RjTx0PLZ1SLyjY1w32+O1kzgHHMPE0eEYJo6Oi53NIRwuvBwh3qgmDaENIJYRHoxK0wgPRwEweFUNj7YB/sbrjdGtWzcJDw+XPXv2NCq6iXlA7EL0Agij1hLc8GYjfxyebUNs47uRMgCxbc3c25qe12iPVfWf0DbNrzb1YP/r+YW4dnN3EXdXtxqx3Ujus6NTK8rrve7qVile3u4yeFioFJeJlJZUSklJhZQUV0hpSYXklZRJaXGFVFZVqQCHKPfx9JIJE6fJgAEnym+/fSq7dm1SLzOKJqIQIvKqce62ddg52t4h2mbVqlW6QHyj6B5C49vaM08IIYQQQtoWhxPdyMmt38bICAc3hBbyvtFz97bbbqv9zK+//qqvNwaKsEEoGlW7rQW8nO0JHB9EHwAYMVqjcAHCyHHsUKzN2N8wxCB/HOHj1rJ0QVjXCG20waqSSsOLWxsaLgId7YI8ZncXcWuk2nd7BV5v4ObhJv5e7uIf0PDnKsr/E+M5WSWSnFkklW7hctKZt8nQxF3y95JvZf++LbJgwUL5/vsfZNKkiXLppZeqAa4tiprBqAMjILYBOd4ouGaIb7Q2hFEA4hsLKuM3lr5CCCGEEEKckzbP6UYIMrzLAG2a5syZIxMnTpTQ0FDp1KmT3HfffdoW7P3339fPvPvuu9oe7MUXX6wNL4e4xmQbRZcAWvtMmDBBnnzySW1nhfztJ554orZlGL4T+d3nnnuuer+R03333XdrfubmzZvNbh2G6uWosNtQVTyIP/QRxwQb4g95xM4uvOBpRh43RDBEL/atLX8z9jH2PTzrRqEzeLYxdpCvb63v+M+jXa1C2wgRR3y4m5urLobY1pjxtgaGB3tqZ1WNsVEumRkZUlxaJuXe4RaHvxfkl0pWRrFkZhRJUUG55GbEy9oVP8jOHWvEzVXEw8NNwsND5ZhjjtKiZuhWgHHQFsCAhyrsf//9t2zYsKGO4Q0RFzD+ITIH24nrB6kLcwmJo8MxTBwdjmHiDOTm5morYHupXt7mohs51BDZ9bniiitUYCN8FG2G8DnTFmFo/bV//37dmag8jpZhcXFxtZ9BCOrMmTP13/bs2VM9TkaF8+LiYs0LXb9+vQo2hH+i9c+jjz4qUVFRZm97U6LbyC2GUQDe3/YAwrpR3A6RCPD+2crriCGLY2ja8gvfCUFjjVB2IzfbyMmuEdn/Ve3WMHE3+/Ve1xZSsyNwlalwcZdKz0DEmbdoXaWlFSrAszKKZO/ufbJx5U+yd9daqSgvUQOIp6erivB+/frK8OHDZdiwYdousC0ELq4RK1asUAGOBX8b4PxAPQl4wCHCUVPCXsdUa8LJHnF0OIaJo8MxTJyBXIpu5+FIovu/3N8Kp28bhnB+VIiH+EXeva3ybGEogTHG6MmOKIILLrhAIxuaG7Zbc3MplYyMIl3yCkqluLRSisrKpbisQvz8PCU41FuCQ3w0J9meQf54ZWmxuHn51LTysgd0M1AhzvoV1WEcgQBPScqV7Zu3SOKBLXLowBZJSzko7u414hsiHGK2R48eKsARUYPHptoD2gJ4vFFwbenSpSrAEQljCiJDDAGOHuXmRtw4G5zsEUeHY5g4OhzDxBnIpehuX6K7PYDw/wsvvFC93LfccotWlrY2iFh4/vnnZdmyZfo3IhxQQRopAgjdb45Yg8BOSSnQpaCwTPJLKqSwpFxKKipVZIeF+0pouK94ejpODq4aeUoKxd3br915TZELnpFeJBlpRZKUkCppCTskLXmPJMTvlKzMpFoRjigFgPQViG8so0ePbnURnpKSouMZIhz530Y/ewDBDUMS8sT79esn7QlO9oijwzFMHB2OYeIM5FJ0Ow8U3TXMmDFDlixZoqG8r7zyilXDyrGPUZzq888/12gBeNJRLRqCG+HkloACaKmphSqyU1MLpLCkQgpKyqWguFwqpVoFdli4jwSH+qhAc0Tas+iuH4IO8Z2RWij5+aVSXVYomal7JenQLjkUv1PS0uL1GGMxep+j3gOELroXoM1dawKD1Zo1a9QDDhFu2n0BRgEYspAD3haF4lobTvaIo8MxTBwdjmHiDORSdDsPFN2i+arTp0/X0G4UrOvatatV9i0ENlowIXffyIMdP368Fs2Dh9JciovLa73Z6RlF6snGAq+2m4ererMhtAODvZ2ihRdF9+GUlVVKdmZNDjiqobu5uIhbdalkpOyTxEM75NChHZKQsFcFOHLCAcK7zz77bK030ZxIipYew507d2r/70WLFtWmpiDnGwUfYdxyZjjZI44OxzBxdDiGiTOQS9HtPLR30Y1c9SlTpmhBu4svvlg93tYS8qhiv2/fPv0b+eF33HGHhgCbAzybENnJyQWSlV0shaUV6s2G2Pb286gR2hE+4h/gfDmzFN1Ng8J4eTklkqUivFjKSirEz9tDKkpy5cCeDbJjxxrZt2/Lv6HornpeT548Wc4///xW936DtLQ0Fd8wQBkFGdGR4dZbb22z6uy2hpM94uhwDBNHh2OYOAO5FN3OQ3sX3R9//LGKY+RXL1iwwOJw7/qgIvlDDz2k7ZYA9u0NN9ygHsemiqTh5pCdXVLr0c7JK/k3dLxMBXdAoJeERcCj7Ss+vh7izFB0W0ZxUbl6wXOySyQ3p0RrvlUW58rOLX/LhvV/SlFRjnh5IQ/cTTscXH311TYrEnikaw0KFUJ84xjjeoMIE3RhcLaQc072iKPDMUwcHY5h4gzkUnQ7D+1ZdKM9GMQw2nbdf//9cs4557RofVgPQsfR1xgCB4XZrrnmmkb3q7MWQmspFN0t23f5eWUahp6WUiDVldWSnrBNNqz9Tfbt3aTjCB5whJxDfPft21daG1Q/f+KJJ2TXrl3696BBg7TVoWm7REeHkz3i6HAME0eHY5g4A7kU3c5DexbdqCT+0UcfSe/eveWDDz5okbcN++/mm2+Wbdu2ib+/v7z44osqJhrL0d65M1MSE/OcshBaS6Hotl4YemY6qqDnSWF+uZTkJsqqf76THdvXaAsyCHAUNoNhqLGxaiuQ4/3ZZ59pvQOEnMfExMhbb70lkZGR4gxwskccHY5h4uhwDBNnIJei23lor6Ibvxt5pQgHh0CG+GgumZmZcuONN8revXs1TH3+/Pkq5BuqPL57d5bs3ZclmXmlkl1Y6pSF0FoKRbf1KSwoU/GdnloohdkpsmHVT7Jl8z/i6ekiXl7u2lcbY7hnz57SmqDCOdIv4uPjpUuXLlrlPyQkRBwdTvaIo8MxTBwdjmHiDORSdDsP7VV0Y3L/2muvSa9evdTb3dzWVKaiITw8XHNW6+fLwuN44ECO7NyZIVl5pZKeVyx+gZ7SqWuwBAV7W+kXOQ8U3bbtA56SXCDJifmSlZYsW9f+LJs2LNGcb3i+Tz75ZLn++utbNdQ7OTlZ2+eh4FqfPn3U+41oEUeGkz3i6HAME0eHY5g4A7kU3c5DexTd8G6jmjN+M3JLUVyqOSQkJKjghmhAeCz6e3fo0KHOZ5KS8mX79nTJyC6WtNxicfN0lS49QiU0zMdKv8b5oOhunX0Mr/f+PdlSmJ0qa/75RrZvWyk+Ph7i4eGu9Q0Qdh4WFtYKWyNy4MABmTZtmtZZGDp0qMybN0+8vR3XIMXJHnF0OIaJo8MxTJyBXDsT3e0z8ZU0m2+++UYHLwTycccd16x1oBUYRAkEN3puv/nmm4cJ7n37smX5ygTZdShHUvOLpWP3YBk6KpaCm7Q5iOyIjPaX4WPipFu/7nLMSdPk0qtnS0xsXykoKJXPP/9CzjzzTI3cKCwstPn2ILT8pZdeEj8/P1m/fr3cc889Ul5ebvPvJYQQQggh5kHRTSwq4IRwcnD55Zc32carMXbu3CnXXnutZGRkSPfu3TVUPSoqqs5nsrKKZfOWVEnILJDgSB8VN9GxAc0OYyfEFqBYX5fuIWoMiunaXY4/81aZcul9EhbWWfLyCuXtt99Wr/cPP/wgVVVVNj0IqIMwd+5c8fLykmXLlmnrPVt/JyGEEEIIMQ+KbmI2mMynpKRoSD1CzC1l69atct1110lOTo62W3r99dcPC8EtLa2QtWuTJDmrSILDfKRrj1Bxc+MwJfYLer/3GxQpfQZGSEhcTznjwvvk3PNuE1/fcElNTVcBjLxrVOe3JQgtf+aZZ8Td3V1++eUXefLJJzVEkBBCCCGEtC1UM8RsvvzyS31E6Kynp6fFRdNuv/127cc9ZMgQzeGGeDcFAmHdumRJyiiUKjeRHn1aJyeWEGsQEupT4/XuEiSBMf1kylWzZfyEC6Sqyl02bdokV1xxhfbUzsrKstkORycBfAeiQr7++msNOyeEEEIIIW0LRTcxi6SkJFm+fLk+P/vssy3aa6WlpXLnnXeq2EBbJbQZa6jCMvpvxyfmSWZBifQZEEkPN3E40LYurmOgDB8bJ/5hftKl3yS56ronpWevMVJSUi7ffvutnHfeebJ06VKbbcMJJ5wgDzzwgD5/77335N1337XZdxFCCCGEkCND0U3MYsGCBeqJHj16tHTs2NGivYbe29u3b1fP9nPPPSe+vr6HfSY1tUC27UiXpOwi6dknXHz9PHhkiMOCFmIYxwOHR4tnQLAcddxVctmVsyQ4OE6ys3M16uOFF16QiooKm3z/WWedJbfeeqs+h7fbiFIhhBBCCCGtD0U3OSIoyLRw4UJ9fu6551q0x7Zs2SKffvqpPp89e7bExsYe9pmionINK0/OLpLIGH+JiPLjUSFOQUCglwweESNdeoWIR1BHOe+SmTJ06PFau+CDDz7QVl+o4m8LLrvsMrn66qv1+VNPPSWLFi2yyfcQQgghhJCmoegmR2THjh2SmZmpHupx48aZvcfQtgj5pRDtp556qhx99NGHfcbI40bhNHcvN+naI4RHhDgdRosxzwBvGXzUeXL2ubdKVZWHbNy4STsBbN682Sbfe8MNN8gFF1yg59msWbNsGtZOCCGEEEIahqKbHJE1a9bo46hRo8TDw/ywb+ST7t27V0JCQmTGjBkNfiY5uUBS0gokt6hMeg+I0JxYQpw15BxVzrv2CpWQDgPk4isfkYDAWElJSdeq/osXL7b6d6KgGuopwOgF4xd6eK9du9bq30MIIYQQQhqHopsckd27d+tjv379zN5bJSUl8v777+tzTPqDg4MP+0xVVbXs2JEh6XklEtcpULy93Xk0SLvweg8bHSshsdEy+fy7pVPnQZKVVSB3332Phpxbu82Xq6urernHjx8vZWVlmk9u6/ZlhBBCCCHkPyi6yRHZtWuXPqLyuLksWbJEioqKNIcb1ZQb4tChXEnPKpLSyiqJ7RjII0HaDV5e7tJ/UJT0GhArk06/SYYOP14KCkpl7twXtL92ZWWlVb8Pvbux3hEjRuh5OX36dNm3b59Vv4MQQgghhDQMRTdpEkz+Dxw4oM979Ohh9t768ccf9fGUU05RT9vh662SXbsyJSOvRDp1CRJ3dw5F0v6IivGXQcNjZOSEi+S4Ey/RooJfffWVeqMhjq2Jp6enzJkzR/r37y95eXly0003aStAQgghhBBiW6h0SJMUFhbWet0iIiLM2lvZ2dnyzz//6HPkkjbEvn3ZkpFdLFVuItFxATwKpF1XOB84LFp6DJwk55x/q5SViZ4/11xzjaSlpVn1u1AM8cUXX5Ru3bpJenq6erzz8/Ot+h2EEEIIIaQuFN2kSQoKCvTRy8tLQ1TNYfXq1Vq0qVevXtK5c+fD3i8vr5Q9e7IkPb9EOncLZvE00u6B8O4/JErCOw6Uy66cKR4efprWccUVV8jOnTutun+CgoJk/vz5Eh0dLfHx8ZrvjfOVEEIIIYTYBopuYpbo9vMzv3e2UaRpyJAhDb6/e3eWZOaVaIuwiEj25CYEBAZ5aQV/N/9YuXrqIxIZGafe6KuuukoWLlxo1QJriFp55plnNOQcbcTefPNNHgRCCCGEEBtB0U2OGF4O/P39zd5T27dv18e+ffse9l5JSYXs3ZclGfkl0qV7iLY0IoTUEBrmI527h0iR+Mnll8+SoUNHasXx2bNnyyOPPCLFxcVW21U4P++//359/vrrr2vxQ0IIIYQQYn0ouolZnm5LRPf+/fsbLbyGiuU5BWXi4+ehAoMQUpe4joESEuErWcUiZ511m0ydep0WI/z+++813Nw4v6zB5MmT5YILLtDnDz74oIabE0IIIYQQ60LRTazq6YZXLisrS58jZ7Q+WVnFUlRawbByQpqgR+8wcfN2k+SsYund+3iZN+8lCQsL0zZfl19+uSxatMhq+w+V0gcPHqzn+p133mn1qumEEEIIIe0dim7SJCUlJfro7e1t1p5CDipArmhwcHCd95CTmp1dIsVlFRIY7MU9T0hjF2ZXF+k7MFKKKislMa1Aqqtj5aOPPtI+2wgxnzlzpvzvf/9TI1dL8fDwkKeeekrCw8NV1D/99NM8LoQQQgghVoSimzSJpcWbUlNT9TEqKuqwfO38/DIpKimXKqkWP39P7nlCmsDT0036DYyQjPxiOZiQK6mpVfLyyy9rKzGcW+jnjSJrCQkJLd6PENwQ8VgvwtiNln+EEEIIIaTlUHQTszC34FlKSkqt6K5PdnaxFJdVanskFlAj5Mj4B3hJz77hkphVJDt2ZUpCQr5cf/312msbkSRoJ3bJJZfI4sWLW7w7hw4dKlOmTNHnjz32WG09B0IIIYQQ0jIouonNPN31ycwsluLSCgkMMi9UnRAiEh7pJx06B0piVqFs2JgimZlFMnbsWPn4449l0KBBmot99913y5w5c6S8vLxFu+zGG2+UDh06SFpamsydO5e7nxBCCCHEClB0E7Mw1zPdlOiu8XQzn5sQS+nUNVgCQ7wlMbNQVq1KlLy8UomMjNRWX5dddpl+BiL82muvrY02aQ6o3TBr1ix9/s0338jKlSt5sAghhBBCWghFN7Gq6DYKqUEQ1O/PnV9QJqUVVRpeTgixjJ59w8TVy1UOpRfIypUJUlRULu7u7nLrrbfKc889JwEBAbJ582a5+OKLZdmyZc3evcOGDattI4Ywc1YzJ4QQQghpGRTdxKrh5aisDPz8/A5rFQYvt5+/h7i7c9gRYilubq7Sf1CkVLiKHErNlxUrEqS0tELfmzBhglY379evn+Tl5akQnz9/vlRWVjZrR0+fPl1iY2MlOTlZ5s2bx4NFCCGEENICqH6IWaLbXE+30cLIy6uuNzsnp0RK/i2iRghpHu4ebtJ/cKQUVlZKfEqN8C4vrxHWEMlvvvlmrZf6nXfekRtuuEEyMjIs/h5fX19tSwa++OILWbt2LQ8ZIYQQQkgzoegmVsUQ3ejTbUpFRZVUVlVrGyRCSPPx8nKXAYOjJLekTOKT82X58gTJzy+tPe9QVO2JJ55Q4bxu3ToNN1+/fr3F3zNq1Cg555xz9Pns2bNro1gIIYQQQohlUHSTJqmqqrLI011a+t/k35TKSqynWlxczVsPIaRxfHw9ZMCQKMkoKJHd8dnyx58HZOfODCkoqDF6nXjiifLhhx9Kjx49JCsrS+644w7JzMy0eJciTB1FERMTE7VHOCGEEEIIsRyKbtIkubm5+hgUFGTWnmosvLyqqlqqqkVcKboJsQp+/p4ybHSsiJer7E/NkzUbUuSX3/bKzz/vkdWrE6WqKlDefvsd6d27t+Z5P/744xbXaEBtBiPM/NNPP5UNGzbw6BFCCCGEWAhFN2mS7OxsfQwODrbI0+3h4XGY6MZ8n6KbEOuGmvcfHCVde4dKYXWlHEjPlx2HsmX99jRZuSZR1q1Ll/vum6lVzpcsWSI//vijxd+BnuBnnHGGCna0E4OAJ4QQQggh5kPRTZokJyfHItFtUD8cvUZ0V1N0E2IDIqP8ZdCwaBkzrpP0HRwlIdG+kpRTJHsO5khCgrtMmXKlfu6ZZ56RtLQ0i9c/Y8YMiYuLk6SkJHnooYdq004IIYQQQsiRoegmZnm6Q0JCzNpT8KiB+q2KVHRDjHPEEWIzEEkSGOQlHbsEy5ARMVIslbI/JU/iOoyTDh26S0FBgRZFszTM3N/fX5566imt1bB06VL54IMPbPYbCCGEEEKcDUogYhPRXVFR0z/4ME+3mQXZCCEtL7Y2eHiMBIT6yKGsIjn+xGukvFxkxYoVsmDBAovX16dPH7nrrrv0OXqAozI6IYQQQgg5MhTdxKzwcnNFt5ubWxOimzndhLS257tHnzDp3idUytyD5diJF0hJSYXMnTtXQ8Ut5ayzzpLTTjtNw8vvu+++ZlVEJ4QQQghpb1B0k0aBZ9pS0d2kp1vDy+npJqQtcr679w6VTn0nSExMT8nNLZBHHnnE4txs1Gq49957pVu3biq477///sNSSQghhBBCSF0oukmjIP/TEM/mFlJrTHRbmEJKCLEyUTH+EtsxUMafdJWUl7vIqlVr5IsvvrB4PT4+PlqQzdfXV9auXauF1Si8CSGEEEIah6KbHDGfG5NrFFAyB+NzJSUldV53d3cVpHNXVVJ9E9JWdOkeIrGdO8gxEy+UwsIymTv3BYmPj7d4PZ07d5bHHntM00kWLVqkrcQovAkhhBBCGoaim1i1XVh0dLQ+Jicn13ndzc1Fi6hVstUQIW0GwsN794+QQaMmSYfO/SQ7u6DZLcDGjx8vTz75pArvn3/+WR588EEKb0IIIYSQBqDoJo1iaT43QC9fkJiYeJinW0V3BT3dhLQlOBf7D46WCSdfKeLiIStXrpMPP/ywWeuaOHGithKD8P7ll18ovAkhhBBCGoCim1itXVhTotvN7d/w8iqKbkLsoZ3YmGP6yVGTpkhpWaXMnfuS7Nu3r1nrOvbYY+Xpp5+m8CaEEEIIaQSKbtJKorsmvLyq0vIwVkKI9QkK8ZbJ554pcZ0HSF5ekcyYcbcUFxc3a10TJkxQ4Y1CivR4E0IIIYTUhaKbWDWnu1OnTvqYkJAgeXl5dcPLXV2kkoXUCLEbYjsEypSrbxYPL3/ZunWHzJz5kLYKtIbwvu222+pcAwghhBBC2isU3aRRjOJKRhswc4iMjJTu3bvrv122bFmd8HLN6aboJsSuGDKiu5x/xQypqHKR7777Sd56651mrwvF1dBOzMvLS5YvXy5XXnmlHDhwwKrbSwghhBDiaFB0k8YHh2vN8LC0FRA8XmDJkiX1CqlhXQwvJ8TeKpqfeNoxctypl0t5RZU899wL8vff/xnMLGXcuHHyzjvvaCcDtCO74oor5Lfffmu2B50QQgghxNGh6CZWF93wdoF//vlHysvL9bmHh6u4ubpKebll6yKE2B53Dze5ZOoU6Td4gpSWVcjtt9/drP7dBr169ZL3339fhg4dKoWFhXLvvffKjBkzJCUlxarbTQghhBDiCFB0k0Yxwsot7eHbr18/CQ0N1cn2unXr9DVvb3dxd3ORslKKbkLstaL59TNuk/DobpKVnSvXX3+LFBUVNXt9uAa8/PLLcs011+i1ZOnSpXL++edrezLDGEcIIYQQ0h6g6CZW93Tj36GNEFi0aJE++vh4iLuri5SWUHQTYq9ERAXJTXfOFE+fQNm1a4/ccce9FhvdTPHw8JDrr79ePvnkE/V6ozr63Llz5cILL5Q///yTIeeEEEIIaRdQdJMjiu6KigqL99Jpp52mj8jlhLfMz89DvDzdpKqyWgoLyrjXCbFTevfvIldcf69UVrvKb78tlmefndticdy1a1d57bXXZNasWeoBR+j6nXfeKdddd51s377dattOCCGEEGKPUHSTRvH19dXH5oSYDho0SDp27KierT/++EOrl0dG+ou/t7tkZTQ/ZJUQYnvGHzdKJp87TcoqquTNN9+RefNearHwhhHvjDPOkG+++Uauvvpq8fT01PSTyy67TMV4Wlqa1bafEEIIIcSeoOgmjQKPFMjKympWReTJkyfr8++++04fo6Mhuj0kM6OYe50QO8bV1UUuvOJcmXTyZVrR/OWX35CXX37FKuHgMObdeOONsmDBAjn11FP1tR9//FHOPvtseeWVV1qUR04IIYQQYo9QdJNGCQ4O1secnJxm7SWEmEN8r1mzRpKTkyUy0k98vdylML9MSkstD1knhLRuRfPLrr1Mjj7uIikrr5T581+TN954w2rrj4qKktmzZ9dWOS8tLZW33npLzjnnHPnhhx9alEtOCCGEEGJPUHSTRgkJCWm2pxugT++IESP0OSbRqGAeHuarwjuL3m5C7B5fPw+5ZOplctTEi6S0rFLmzXtFvdHW7LmNbgevv/66PP3009KhQwfJzMyUZ599Vk444QS5/fbbVZRv2rSJFc8JIYQQ4rDU9IQipInw8uzsbJ1kw2ttKaeffrqsXr1avv/+e5k6dapERfnJ/oRczeuOiQvgfifEzgkJ9ZGzp1wkLlIty//8XF577Q1JSkqSBx98UPOyrQGuLZMmTZJx48bJ55/jO16TvLw8bTOGBeC7BgwYIEOGDFHPOOpG+Pn5WeX7CSGEEEJsCUU3OaKnGy3D8vPzJTAw0OK9NXHiRM3hTEhIkI0bN0r37n3Fz9td0tLypaKiStzdGWxBiL0T1zFQTjzjXPHx9pW/fv1AfvjhR0lMTJTnnnuu9jphDdBi7OKLL5aTTjpJUlJS9Jqxfv162bBhg6a5oPAaFqMwW8+ePVWAY4EYDwsLs9q2EEIIIYRYC4pu0ijwLEFow+OEysLNEd0+Pj5y3HHHaTE1eLtnzhwiwYHe4p1VJDlZxRIeSU8VIY5A915hUlx0gkSER8kP38yXjRs3yRVXXKF9t7t162bV73J3d5f+/furZ/uSSy7RSJuDBw/WCnA8wtu+c+dOXT799FP9d+iYYAhwLPi7ORE6hBBCCCHWxKXamsl57QyI0aCgIMnNzW2WIHUE0M4HfXTh0ZowYUKz1gHP1LXXXqse719++UX27s2T1RtTxMXXTXr3C7f6NrdncDpXlBSKu7cfxQaxOuVllbJhbbKU56bJgi+el+LiLA3xfvLJJ2Xs2LFWG8O4puLa2pRghiEQAtxYdu/efViuOVJkIL7HjBmj4etGcUhCbIm5Y5gQe4VjmDgDubm5et+3F53G2F7SJLGxsfqIUNLmgkkv1oNWQH/++ee/rcNq+nXT5kOI4+Dh6Sb9BkaK+ITJVdc8Ip0795bCwkK55ZZbZM6cOVqBvLWIjIyUE088Ue6++275+OOPZfHixfLCCy/IVVddpdcchKqjCCRef+KJJ/SzN910k3z77bd6AyaEEEIIaS0oukmTxMXFtVh0I/fStGd3aKiPBPh56uDLy2m9STohpOX4+XtK734RklPqLudfeLdMmnSqGs8gfJGPvXXr1jbZzQEBAXL00UersH7zzTflr7/+0scbbrhB+vTpoy3IVq5cKY8++qgKcBgK/vnnHxr+CCGEEGJzKLpJk6CFD0D+ZEtAz26watUqSU9P157d/t4ekplRxCNAiIMRFuErHbsESlp+uRwz7hJ59NGnJTw8XPOu4WlGW7Hy8vI2r0kBjze6Jnz44YeyYMECFeS9evXS4pAQ3BDeeB9inFE3hBBCCLEVFN3E5uHlhsd82LBhOrFFz+6aEHMP9usmxEHp2CVYAkO8JTGzEH/JK6+8q1XH4VF+6623tMga6kHYCyiqBoMAPPJff/21euUhzNEDHGJ82rRp2t6Q4psQQggh1oaimzRJly5d9BEerJKSkhbtLSPEHFXMw8N9tXVYWWmlFBaU8SgQ4oD07Bsm4uEiiRkFsmFjjlx88a3yxBP/0wJSu3btkssvv1zDuZFbbU906tRJZsyYIQsXLpQpU6ao+EYxNoSiw/udmZnZ1ptICCGEECeCops0SVRUlBYsQjhmS3M1jz/+ePH29lYBv2PHNomI8KstqEYIcTzc3Fyl36BIcfN1lwNp+bJpW5p4evaUt976QE455RT1GqNw2TnnnKMe5oqKCrEnEBJ/xx13yDfffCMXXHCBFl9bvny5esHXrFnT1ptHCCGEECeBops0CdqdIC8SwBPUEtAyDG17wJdfflkbYp6RTtFNiKPi5eUufQdGSu8B4ZKWXyJ7DmXLps35ctVVM7SQGYqYFRQUaHVzeJVXrFgh9gYMi0YVdPQch6f7xhtv1O1HuDwhhBBCSEug6CZHZPDgwfq4cePGFu+tCy+8UB9//vlncXMrlgBfDykpqpDc7JaFrhNC2pbQcF8ZOipWXHzcZH9qnqxdnyzFxWHy+utvywMPPKC9Mvfv3y/Tp09X73JL60TYgq5du8p7770np59+uortV199VW6++Wa7C48nhBBCiGNB0U3MFt0oONRSr0///v3Vc44w02+//Vq6dA6WUH8vOXSQfXMJcXQ8Pd2k/6Ao6dQ9RBKyCmTn/mz566+DMnr08Vo9HGHbaCGIdl7nnXeevPzyy1JUZF+RLj4+PvLQQw/p4uXlpZXNsd3r1q1r600jhBBCiINC0U2OSM+ePXUiihDRvXv3tniPXXrppfr41VdfSWysjwT7eWm/7oJ89uwmxBmIiQuQwSNipUSqZF9ynqxYmSB79hTILbfcJp9++qmMGjVKW4q9/fbbcu6558p3331nd2Hc8HZ/8MEH6v3OyMiQ66+/XrfX3raTEEIIIfYPRTc5Im5ubjJw4ECrhZiPHz9e2/fk5eXJ778vkk4dAyXUz0sOHaC3mxBnwdfPQwYNi5awGD85kJ4v23Zlyl9/HZDg4BiZP3++PPvss9qSMD09XR555BE1xsGrbE8gv/v999+X0047TcU2PPPIS//iiy+ksBCt0gghhBBCHEB0L1myRD0KmHyhaBeqyB6Jjz76SEOeUZgrJiZGrr766sNavGBShAI+qJYNwfjjjz82uj54MPDdc+fOtcpvckasVUwNILwU4ZrGsezWLViC/TwlO6NYigrLW7x+Qoh94OrqIl26h0j/IVGSVVIqexJyZenSg7JzZ6aMHz9BCyreeuut4u/vry3G0C8bLbuQ+20vIMrn4YcfllmzZulzRPs89dRTWp39iSee0O0mhBBCCLFr0Q1vAQQ0PB/msGzZMu39OnXqVG1hBXG9atUqmTZtWu1n/vnnH/VG4DPr16+Xs846S5ctW7Yctj7kGaKaLkQ/aZyRI0fqI3Ix4aFuKejZHRgYqMWU1q1bIXFxASq8E+Lp7SbE2QgK9pahI2PFJ9hT9qfly8YtqfL33/FSViZy2WWXaVsxXLPd3d21Zdc111yj/b3hBbcHYJQ944wz5IcfftAicF26dNFc9K+//loNiFdddZW+V1rKFBlCCCGEHI5LNRqp2gmY2EAEQyA3BkISX3nllTq5xfPmzVPPQ0JCQm2FbIj577//vvYzY8aMUW8tqtEaQPCNHj1aK2kjfPC2227TxVwgPoOCgiQ3N1cFpDODYXLJJZeoVwetdBBd0FIQqokcSUQiPPfcfPlzyUGdkA8fEyfe3u5W2e72Bo5TRUmhuHv76flEiL2Rnlooe3ZmSqC3h0SF+MqA/pHSpUuwvnfo0CG9nv/666+a1oJIJVxrYGiFILen8wyF1VCXYvHixbX9x3EfQOQW8tQ7derU1ptJ2nB8YF6A+QGvw8QR4RgmzkBubq52TrEXnWY/sxgzGTt2rNx///0aLo7wvrS0NA1RPPXUU2s/A0/JjBkz6vy7k046qU7oOvLz4GG56667tKK2OcCLYerJMDy+uDjZke3CZkB0o6IvCiHhuaenZ4vWB+PIhx9+KJs3b5Y9e7ZIdGS0ZOYXS+LBXOnWK9Rq292eMMZiexiPxDEJj/SVgCBP2bMjU/al5EpJabmkphbI4MFR0qFDB3nyySfVq/zWW2/ptQHGud9++02vPb169RJ7YdiwYbqgnRjuLViSk5M1ZQYLooPgBT/66KMpvNoZvA4TR4djmDgD1XY2F3Y40Y0JDCY0EGwlJSXqYYBnwTQ8PSUlRaKiour8O/yN1w3gGYfnBPmD5vK///1PC/7UBxYUezuwtgBRASEhIRryCQ+PqaGjOcCTZRhDEIHw4IOPS3KqiyRnZEtprIe4ubd59oPDgVFYWVaCsBGhn5vYK24i0qu3v3q9kxNypKSsSDIzs6R373AJDfWRzp07y3PPPadi+6WXXpLt27eroQ8h6DCWttTgZ01wHYNn++yzz9ZCcKjEjpQlYznqqKP0PlP/nkScF8wH0O0D0NNNHBGOYeIM5ObaV8qqw4nubdu2aeEdFLWBYINnAd5qFEODZ8Qc1q5dKy+88IKGB1pyQ7zvvvvqeNDh6UYVboSQ2UPYQmuAME/sO+QywvCBomgt4dprr9WoBfQAz89Pl7CQYEnLrZKMrCqJ6xRgte1uL6jxp7pa3L18Odkjdk9sZz8JCguWXdszJC+1TErKcqRbFxfp0MFXQ8LOP/98Oe6449RIijDuTz75RIUtrv/mRii1JieffLIuuC99/vnnGhWE7UWOOu5RuGZCpBPnxjDCM7ycOCocw4RYH4fL6YaXAx5uFFAz+Pvvv2XcuHGSlJSk1cyRSwdxbJqfjdBEeFTR8gpVyvG+qWCsrKzUvyGiDxw4YNb2tqecbgPkysPDjcfnn39e93tLmT17tixcuFDXdfvtD8vyVQmSWlAiI8fGUThaCHO6iSNSVVUtB/ZmS0pigUQFe0tkiKuMGNFNQkJ8aj/z+++/q/hGODeu1agtASNgSw1/tmTfvn1a4dzo+oCOGg888ID07du3rTeN2BDmwxJHh2OYOAO5dpbTbb+zlUZAxdj6kyzDc2DYD5D3jQmaKSjMg9cN4Q7PKiZCxoLq5fCYo6gaaRw/Pz8NpQQffPCBVXbVlVdeqcd06dKlUlSUIsEBXiKV1ZKZXsRDQUg7aS3WrWeo9BsUIZmFJXIotUCWLDkgu3dn1l7X4fGGsRURTqjJgbDzO++80yrdFGzZ5/v111+XmTNnSkBAgOzYsUOuuOIKDZ3HvYwQQggh7YM2F93IezKEL0B/VjyPj4+vDemGN8MA+dsIbUYFc3gR0EIM+XKjRo2qbfuF8PNFixbpxAaTHPRYXbNmjUyfPl3fDwsLkwEDBtRZPDw8JDo6Wnr37t0m+8GRuOiiizQfHuH5aNvWUhCZcPzxx+vzd999Rzp3DpYQPy9JPGS/k2lCiPUJDvXR1mIevu6yPz1f1m9MlX/+OSRFReX6PiKLHnvsMfUWI697yZIlcumll+p13l6BQRHRW6iDgdBzGAwQJn/eeedpC0ZCCCGEOD9tLrohhocOHaoLQNg3niNnDyA3zhDghld0zpw56uWAWEbOH4QyhLgBCtd8/PHH6mFAD3BUN0doOT5PWk5kZKROHsH7779vlV1qtCBDhIKLS44E+XlKYX65FOSz7y0h7Ql3Dzfp0j1YuvYMlcTsQtl5IFv++HO/HDqUW5uGhKJlaDcIQyvSinD9wD3AjrKlDiM0NFQNBrh3xcXFaecN9PyGtx7PCSGEEOK82FVOt6PRHnO6Dfbs2aMeb0yAUTCoa9euLV4nDC7wXE2ePFnOOOM62bA9Tdz83KV3v3CrbHN7gDndxJnGcGlJhezcliHlxZUSE+wjnTsFy6BBUeLp6VZ7DUYkE64bANek+vU67BHUJUHhTxgtUU8EXSE+++wzFebE8WE+LHF0OIaJM5DLnG7iDPTo0UMmTJigF2Zzq8YfialTp+ojqpn7+BRLsJ+nZKYVSllZpVXWTwhxLLx9PGTQsGiJ6uAvBzMKZPueTPnrrwOSnl6o78PY+eyzz9amDqFa+IMPPijl5TXh6PaKt7e33HTTTRqRBYNldna2FvgkhBBCiHNi3+4AYtdMmzZNH3/55Rc5ePBgi9eHFkDoBY6cx2+//Vwiw/3Ez8tDkpjbTUi7BdE0HbsEy6Dh0ZJXVi57EnPl72WHZOvWNK16Dq820o4Quo2imiiGCW93cXGx2Dvdu3eXRx55RH8jjI1oZ0kIIYQQ54OimzQbtL8ZP368imRre7vRQiwkpErCArwkOSFfyuntJqRd4x/gJUNGxkhAmLccSMuXTdvSZMmSg5KXV1P3AXUm0MYQXuTly5fLDTfcoKFl9k6/fv1qO0I8+eSTdu+lJ4QQQojlUHQTq3i7US3etOBdc0ERPRS/Kysrk19//Ua93b6e7qxkTggRNzdX6dE7THoPCJe0/BLZcyhb/vzrgOzbl62pLiii+eqrr2rY+ZYtW7SXd0VFhd3vOWwn8rnRvQMh54QQQghxLii6SYvo27evHHPMMertRjXhloIwS8PbjRY70dHutd7uinLmdhNCRELDfWXoqFhx8XGT/al5snZ9sqxYkSAlJRXapQKRNyhyuXPnTvnwww/tfpfBSHDbbbfp8zfeeEO7dhBCCCHEeaDoJlbzdiMnMSEhocXrGzt2rIauIydz8eLvJCLMV73dCfHs200IqQEVzPsPipJO3UPkUFaB7NyfLX/8sV9SUgq0OBnacQG0jrTGdcnWnHLKKTJs2DCtbI7icIQQQghxHii6iVUKoCGs05rebqNvN6oRx8V50dtNCGmQmLgAGToyVkqkSvYl58nKVYmSn1+qInbUqFGaqvLEE0/YdQ9v47p37733ajG4v/76q7YNGiGEEEIcH4puYlVv9/fffy9JSUktXt+xxx6r3qqCggJZsuQnCQ/1FR8PN0lKyLfC1hJCnAkf35rWYl7+HpKZVyybN6epiL3//vvF09NTVq1aJT/99JPYO926dZNLLrlEn8PbDa83IYQQQhwfim5iFQYOHChjxoyxmrcbbYCuuuoqff7JJ59Ip05+EhborQXVKiqqrLDFhBBnwtXVRXr0DpWc4jJJSsmXQ4dypUOHDnLttdfq+3PmzJGcnBxxBANmVFSUGi+tcS0lhBBCSNtD0U2shjG5/e6776zi7T7ppJMkNjZWsrOzZcWKXyU8xEe83d0kOYG53YSQw/H28dCe3qk5xbJtW7qUl1fKpZdeKj169FDB/cILL9j9bvPx8ZG77rpLn7///vty4MCBtt4kQgghhLQQim5iNQYNGqQ5lJWVlfLuu++2eH3Ibbzyyiv1OSoQd+4cIGEB8Hbn09tNCGmQuI6B4uLhImnZNcLb3d1dHnjgAQ03h0Fw9erVdr/nJkyYoF0h0O4MvbvtPR+dEEIIIU1D0U1s4u1euHChpKSktHh9kydPloiICElLS5Nt21aot9vLzUVSkpjbTQhpOMy8e+8wSc8rkX37cyQrq1jTX84//3x9H0XVSktL7XrXwUBw9913az76mjVr5Oeff27rTSKEEEJIC6DoJlZlyJAhMnLkSPXQvPPOOy1eHyad55xzjj7/5ZdfpEePUAn195akQ3lSVUXvDyHkcIKCvSU8ylfStahaqnqKb7rpJomMjJRDhw5pH297B6k111xzTW0+OopKEkIIIcQxoegmNqtk/u2330pqamqL13fCCSfo48qVKyUwUCQk0Ftcql0kI62wxesmhDgnXbuHSGFZhaSkF8q+fdni5+dXmyv93nvvyd69e8XeQT56p06dJCsrS1555ZW23hxCCCGENBOKbmJ1hg0bpgu83ZjctpQuXbpI9+7dNVd8yZK/pGvXYAn195KEeBZUI4Q0jIenm3TtEaJF1bZuS5ecnBKZOHGitiPEteTxxx/Xbgv2DCJ90LsbfPHFF7Jjx4623iRCCCGENAOKbmLT3O4FCxZoPra1vN2//fabdO4cLMF+nlJWUiE5WcUtXjchxDmJjg0Q/2AvSc4qkjVrkqSsrFJzpX19fWXTpk1aoNHeQXFKdHKAgeDRRx+1+3x0QgghhBwORTexCcOHD5ehQ4dKeXm5Vbzdxx9/vD6uWrVKSkoKpVOnIAnx89K+3YQQ0hi9+oZJuVRLcnqBrF+frIUZ77zzTn3v5Zdflu3bt9v9zrv99tslMDBQdu7cKY888girmRNCCCEOBkU3sVn1XSO3G97u9PR0q4SYI2T9r7/+km7dQiTI11Nys0qksKDMSltNCHE23D3cpO/ACEnPL5H4hDzZsydLTj/9dJk0aZJeT9BOrLjYviNmwsPD5emnn9Y2iigo+cYbb7T1JhFCCCHEAii6ic1AFfPBgwdLWVmZfPTRR1bzdiPE3M/PUzrEBWqYeVICvd2EkMbx8/eUbr1CJTG7UHt3Z2YWy8yZM7WaeXx8vFYHt3dGjBgh9913nz5//fXXVXwTQgghxDGg6CY29XZfddVVtZXMS0pKrCK6UcU8Ly9Pvd3B/l6SllKouZqEENJUfndYpK8kZRfJ2rVJ4unpK7Nnz9brFKJx/vjjD7vfeWeddZZccskl+vzhhx+WLVu2tPUmEUIIIcQMKLqJTTnqqKMkLi5O8vPz5eeff27Rurp27VonxDw01Eciw/3E38tD+3YTQkhTdOsZKtXuLpKcWSO8hw0bLpdffrm+hyJl1ij6aGtuvfVWGTdunEYQzZgxQ1JSUtp6kwghhBByBCi6iU1xdXWV8847T59/9tlnLS4AZBpiDrp3D5HQAC9JTsyXigr7bv9DCGlb3Nxcpe+ACMkuLJVDyfmydWuaXH/99dK3b1+NnkHIOcSsvV9T0e6sZ8+e2r8bRdaKioraerMIIYQQ0gQU3cTmnHnmmdpvdteuXbJ582arhZjDex4d7S9hwT7i7e4qqckFVtpiQoiz4uPrIb36hUtSZqHs2p0piYmF8thjj4mPj4+sW7dO7rrrLrsX3mh5hjz00NBQ2b17txaDs/dtJoQQQtozFN3E5qDVzcknn6zPP//8c6uGmCMfU73d/t7aPqyqqmWedEKI8xMW4SsduwVLQlahbNyYIr6+4fLCCy+Il5eXLFu2TO69915td2jPxMTEyHPPPacGzaVLl8p1113X4i4RhBBCCLENFN2kVbjgggtqw8IzMjKs4u3+9ddf9bFjxyAJCfQW1yqR9NRCK2wtIcTZ6dg5SEIifCUxq1BWr06UXr0GyPPPP68idsmSJeo9hnHPnhk4cKBuc0BAgEYRXXbZZS2OJiKEEEKI9aHoJq1Cnz59ZMiQITqJ/fjjj60aYu7q6qKVzEP9vSQxPrfFeeOEkPZBj95h4ubtpqHmK1cmyJAhw9V77OHhIYsXL5YHH3xQKivtuzPC6NGj5f3335du3bqpQfPaa6/VbhGEEEIIsR8oukmrceWVV+rjl19+qUWLrBViDjp3DpJgf08pL62U7Mxiq20zIcR5gcGu38BIKa6qksS0AlmzJklGjx4jzz77rLi7u2s0zUMPPSRVVfZdpLFjx47y7rvvysSJEzUsHpXYn3rqKbv31BNCCCHtBYpu0mocffTRWnEXlXa/+OILq4aYe3i4SdeuNbndhw7mWmV7CSHOj4enmwrvzIJSOZiYK5s2peq16umnnxY3NzdZtGiRPPLII3YvvFFcDUL7hhtu0L9xjb3xxhu1wjkhhBBC2haKbtJqoOiZ4e3+5JNPpKSkpNnrOuGEE/Rx+fLlkpmZqc8huuHtLiool9yc5q+bENK+8PP3lN4DIiQ5u0j27MuS3bszZfz48fK///1PW3T98MMPWuHc3oU3tnXq1Kla2RwiHNXYkee9ffv2tt40QgghpF1D0U1aFXio4+LiJCcnR7755ptmr6dLly5aRAiT4B9//FFf8/Z2l86dgiXEz0sS4untJoSYT2iYj3TtESIJmYWyeWuaJCbmyaRJk7QnNsTswoUL5cknn3SImhEwGCDPu1OnTpKamqpC/KeffmrrzSKEEELaLRTdpFVBuObll1+uzzEpbElv2TPOOEMfMRk2JsJoHxbi7ym5mSVSWMC+tYQQ84npEChRcf6SmFkoa9clS2ZmkUbVzJ49W4X3119/Lc8884xDCG8YJt977z0Nlcd1FkXhUOnc3gvDEUIIIc6IS7UjzB7sFBQDCwoKktzcXO1FTcwDE8CzzjpL0tLS5Pbbb5dLLrmkWbuusLBQTjzxRCktLdUiQgMGDNDX161Llg3b08TVx036DIhoV4cFp3NFSaG4e/tpOD8hjkZbj2F8/86tGVKcVyZdogLkmGM6SUCAl4aYP/zww/r+xRdfrNcuRzjHEA306quvyttvv11b7Rxh87xn2Q6MEcwLMD9whDHiaPMHVOnHgr70pgteKy4uVgMZDPxYzHmOoomxsbHSq1cvXcLDw9v9ceMYJs5Abm6uBAcH241Oc2/rDSDtD/TBve6667TC7ltvvaUea/SZtRQ/Pz857rjjNLwc3m5DdPfoESrx8bmyNzVPigrLxdfPwwa/ghDijEAk9eoXLpvXp0hiRoGsXJmowvu0005TLzG83mh7iMn6LbfcYveTc4gLFFTr3bu3VmJHq8UrrrhCXnrpJU31IcReQSX+v//+W37++Wc5ePCgGuoxebY1mKRDfKPwK84bPKIlH855QghpLvR0twB6upsPJq9TpkyRffv26QTw5ptvbtZ61qxZI9dff70WDfrll1/E29tbX1+1KlE270oXjwAP6dU3XNoLbe0lJMRZxnB5WaVsXJsi/h7u0q1DkBx1VEdxd68JMX/iiSf0M1dddZUKWkc513bv3i133HGHJCUlSWhoqLz44ovSp0+ftt4sp4Newpbtu507d8r333+vdQgaEtkw3MMbHRERUWfBazDGY36BCA8saJuHR7xmvG48N/6G9/zAgQN6fuCxoYKJmGOMGDFCI0VGjRql6RuOct43B45h4gzk2pmnm6K7BVB0t4wlS5bIjBkz9Aa6YMECiYqKsngduDkiVB2TSOQsnnnmmfp6dnax/PHXAdmfli/Dx8RpkbX2gL0IFkKcYQwXF5Wr8I4I8JYenYNl5Mg47e39+eefa0sxAKPh9OnT23xbzQUhuPDQ79q1S4UEepJDRBDrQcFiOehCApENsb1nz57a1yGkTz31VBk5cqRERkaquEZknK3ON6Sr7d27VwU4xD8eca4gnc0UbMfYsWN1zjFo0CCHOf/NhWOYOAO5FN3OA0V3yy/q1157raxfv15DzGfNmtWs9XzwwQfywgsvaPjXZ599VnvzW778kGzdkyE+Id7SvVeotAfsSbAQ4gxjOC+3VLZuSJHoYF/p1ilYRoyIFTc3V217+Nxzz+lnzj77bLnvvvs0lNsRKCgokDvvvFMjhZDPij7kJ510UltvltNAwWK+0Xzp0qXayWTZsmW1HmYY4o899liZPHmyepbbOqwb2wUBvmrVKk3P2LBhQ50isD169JDzzjtPjQMwZDkDHMPEGcil6HYeKLpbzubNmzVEE5NVTGK7d+9u8Try8/P1ZocCKvPnz9ebNMjIKJK/lh6UA+n5MmJsnHh5Ob+3294ECyHOMIazs4plx+Y0iQzylS5xgTJqVJx4eLjJt99+qy3FMClHfQnUqYBgcAQgGpDj/euvv+rfiDpCgTjScihYmgbnC8YdarogxcwAbUBPP/10bS1qD6GgTXnDN27cKIsWLdJ8c/wNILhPOeUUjX5BYTZHhmOYOAO5FN3OA0W3dbj77rtl8eLFcswxx8jcuXObtQ6ESH766ady1FFHaZ6iwbJl8bJ1b6b4h3lLt57O7+22R8FCiDOM4dycEtm2KU3C/b2lU0yAjBnTQQ15uHY98MADWvQJBj+0FHMUbxfEz5w5c/TaCdDOEaHyjuKxt1coWBoG+dUIIX/nnXckPj5eX0MO9rnnnqth2p07dxZHnAeis8FXX32l+eAAhjc4EyC+HcUIVx+OYeIM5FJ0Ow8U3dYBN1+EZmEC+Prrr8uwYcMsXkdCQoKGeOJGgXxLhJqD9PRCWfJ3vHq7Rx7VQTw9nbv6qL0KFkKcYQwXFpTJlg2pEuzjKR2jAmTs2A7i4+OhYacI1y4qKpL+/fur4Q/tohxlf7///vsyb948/RtRQ0j1Qdg5af4+Zcuw/8C9/bvvvlPPNuqvAHiy0S70ggsuaFb3Ens85mvXrpU33nhDHwG6A6Bw4fjx48XR4BgmzkCunYlumrNJm9OpUyc555xz9Dlys5vTOr5Dhw4yceJEff7mm2/Wvh4R4SdREX4S4O0hifG2bzVCCHFe/Pw9ZdCwaMktLZcDyXny99/xUlBQpoXI0AsbQnvr1q0ybdo0bW/kCMCwAY8cepDDw40WjOhBDgMCIS0FYdiXXXaZpl4YVfNRyA8F06ZOneoUgts4j1DdHNcBdDdA0bfExERN27jtttvUMUAIad9QdBO7AAXVfHx8dML6+++/N2sd11xzjT4iV8w0T6xXrzAJ8/eS5MR8KSurtNo2E0LaHz6+HjJ4eLQUV1bKwZR8+fvvg5KbWyL9+vVTgx8m27j+QFCg6rGjgKJVSO9B28Xly5drK8asrKy23izioKSnp2vEBM4DFCHz9/dX8blw4UJNY3CUFIzmiO8TTzxRvvzySzVmIWIEvcbPP/98eeWVV+oUYCOEtC8ouoldAOs3rOEAxdCQ+2UpvXr1kkmTJqmnHGHqBpGRfhIZ4Sd+nh6SdCjPqttNCGl/IJcbHu9y12o5mFogfy+Ll8zMIunatau8/fbbGr2TnJwsl156qYaao8ijI4CaGK+99pqG423btk099o6y7cQ+gKh87733NHoNURMQoWjrif72OB9g1GkPwKhw8803a0eVMWPGaM0HhNejeGFzovkIIY4PRTexG3BDhvg+dOiQ3qCbw3XXXac3+d9++037a5p6u8MDvCQpIU/K6e0mhLQQD083GTg0Wly8XCU+LV+W/XNIkpPzJTo6WifXMAAilxX50shbRUskRwA56TAcwGN/8ODBOuk6hDQFPLoXXnih1geAsQbVyCHAZ86cqff29giKw2F/PPnkk9r6DJF4KLxGCGl/UHQTu7IMw7MCUIykOTmFaDl2wgkn6HNTb3dUlL9EhNd4uxPp7SaEWAF3d1cZMCRKvPw9JT69QFasTJQdOzIkKChYnn76aXn++edVhMPrfeutt8q9996rYbf2Djz12Fbw4Ycf1knXIaQ+yNXG+Eb4OIzmYWFhMnv2bDU+Ie2ivQNHANqgIWUD4NrAHG9C2h8U3cSuQAVyTPiys7Plgw8+aNY6INxxk/vjjz9kx44ddXO7A7wkOSGf3m5CiFVwdXWRvgMjJDjCRw6m58uGLamydOlBycsrlXHjxskXX3yhqTMoUoYIHHRqQIcFeMHtGVRcnjBhglRWVqqXjiGxpD4Ywx999FFtJAfyl5GvvWDBAq2Cz9ZzdUGON7qzwKHw4IMP6rlFCGk/UHQTuwI37ZtuuqnWw5KZmWnxOpBXefLJJx/m7Y6O9pfIcD/x9XSnt5sQYjVg5OvRO0x69A2TlNxi2R2fLX/+dUB2787UHFZ4AXE9GzBggBQWFqqn68orr7T7Qmtog4btX7dunebnEmKA9C2MYURzlJSUyPDhwzV/GZXJnbVIWkuBEQIRACgqt3nzZo0EIIS0Hyi6id2BXEhMTpETZiqaLfV24wa3ZMkSLQhkQG83IcRWhEf6ybDRseLq4y77U/Nk3caU2rZiKPSIXOl77rlH/Pz89LqEOhYQLfbanismJqY25QeVzfPyWIiyvYNCaS+//LKOXYxhCEjkbKNVFvKXSdMg3eT+++/X56iXsGnTJu4yQtoJFN3ELr1GsJYDhKmhmI+lIET9lFNO0eeoxmvq7Y4I86W3mxBiEzw93aTfoEjp2itUknKKZNfBbPnjz/2yb1+2XtvQOuirr77S2hNGeC5eg4HQHrn44oulW7dumvKDzhKk/YKIh4suukiNRwiNhoEc6ROoTo6xTcwDLcUQfo/zHwYLRL8QQpwfim5ilyDvCfmQuCk1d6KHvt3wdiPXDKFcBr17hzO3mxBiUyKj/dXrXe3pKvtT8mXt+mRZvjxBiorKJTw8XP73v/9pO7HY2FhJTU2VGTNmaDg3ntsTHh4etUXV0FVi69atbb1JpJUpKCjQ8XrttddKfHy8FkpDigSWiIgIHo9mgIgXnPsoQvfMM89wHxLSDqDoJnYLelxCNC9evLhZIVgdO3aUyZMnH+btjoryo7ebENIq/bxR3bxj92A5lFUgO/ZnyeI/9svBgzm1fbFRVA25sWgn9Oeff6rX++OPP7arIkswgp522mlaTO2JJ56wq20jtuWvv/6qjc4wip1++eWX6uUmzQcpJo8++qhGCHz//ffsEEBIO4Cim9gtCGk0RDM8Qs2pngtvNyazK1askA0bNuhruMmZertLSiqsvu2EEGIQExcgw0bFSoWbyP6UPFm9NklWrEjQaw8KlU2fPl3DzAcNGqT53XPmzNFKx6b1KNoaFIMLDAyUnTt3akgxcW5QxBQRDnfccYe2uYMRG3nbDzzwgAQEBLT15jkFgwcPlokTJ+pzFFokhDg3FN3ErkFfS09PTxXMS5cutfjfI3zrzDPPbNDbHR3pL0G+nrJzazrb4RBCbIq3j4cMHBolsV2CJD6jQHbsy9LWYrm5Jfp+jx49tLASiixB1KDdITzgzz77rF0UWgsNDVXjAECBS+ahOicwbi9cuFBb26HFHaLNYAD69NNPZcSIEeLo4Fxas2aNvPPOO9q2CwZ9/F5E0+Xm5rb69qCdIEB3ABg3CCHOi0s1m282G1RyDQoK0gs1PADENrz00kvy7rvvaisw3PjhubaElJQULfRSUVGhlnpj4oDcyj9R4CglXyLj/KVT12BxdHA6V5QUiru3HwvbEIekPYzhosJy2bElTdyqXCQu3E+GD4uRmJj/vIdZWVnq7V60aJH+DS/j448/Lv369WvzvszoyXzgwAG54YYbZOrUqW26PfY8hjEvwPzAkcZwQkKCjrPVq1fr33369FFh2rt3b3HkY4Hf8+uvv2ptl3379uk4bozg4GDp0qWLLug4MHLkSH1uy+OIiDw4FmDcQFqdPeCoY5gQUzCGcU7bi06j6G4BFN2tQ35+vnqrsb8xATA815aAgi/IncSkFQIe1nuQmJgnK1YlysH0fOk/JEqCgr3FkWkPgoU4N+1lDFeUV8qOrRlSWlAusaF+MnBApPToEVrnM0iLQd4niqvB2Hjdddep99u4frUFv/zyS603Hh5Chho7vmBBjj7qCMAoXVpaqtFliDK75JJLLDZy21Pxtx9++EFTIWAkqt+2a+DAgdKzZ08No8f7WBorYojCcchhR2470t6sDToXoJAi2q/B420Pfc4dbQwT0hAU3U4ERXfrgQkBPD+olIo2YsiDtAR4juDtRmgZCgGhZYfB+vXJsm1XpmQWl8qwkTHi7uGYk4z2JFiI89KexjB+677d2ZKeUiAdQv2ke9cQGTw4WlxdXercZ1A5Gp46MHToUJk9e7b20G4L4CVE2yh4DFHNGgtxXMGya9cuNexs375d/4ZnF0YVRFc4Inv37lUDO8RrcXGxvgYRixZdY8aMkQEDBmj3gIbA51GdHQJ8//79GnIODzR6kwMYu8455xyN8sCxtUUEye23367GjrbGkcYwIY1B0e1EUHS3HrjpIccM7TVuuukmueqqqyxex1tvvSWvvPKK5nmj+iqs+aCiokr++uuA7EnIFa8AD+kzwHFboLQnwUKck/Y4hpMT8mT/nmyJCfGVTrGBMnJknPb7Nt0nEBFPPfWUGg7hEbvvvvvkpJNOapPthQEA34/t+O677+jtdkDBUlJSojUE3n//fRV9iFiA4Dv99NPtdpsbA7nQqPyPKIz169fXvg6vNLzTqLwP4Y3jUlpaKaWlFVrEsLy8Svz9PSUw0KuOoav+3GPt2rXqMYdHGiBMddasWXLsscda7Td8++23avyIjIzUCBJ3d3dpSxxhDBNyJCi6nQiK7tblp59+0vBytNrADQp5GpYAKzbanWRkZGhF1ilTptS+l51dLEuWHpT9afnStWeoRMX4iyPSHgULcS7a6xjOziqWHVvSJczPS+Ii/WXMmA7i51djGDTNucU1ELmpAN479PvFNbE1gUjD9RNexWnTpmnYO3EcwYKipOgNDSM2OO644+Suu+5q1ANsj8Aj/ccff+iyZcuW2tfhjR49+hg59tjTpEeP/iqyIbCxlJVVSkVlVc1SVS2VVdXi7e4q3l7uEhTkLSEhWHwkONhbfH09DvtOFGBDYcM9e/bo35dffrk6AawRgg9xD4MHwt0RyYJzuy2x9zFMiDlQdDsRFN3S6hM9VPpEy5qLL75Yc6As5ZtvvpHHHntMLdV4blpYYffuTFm/MVUSsgtk6MhY8WngpmvvtFfBQpyH9jyGUWBt26Y08XZ1la6xgXLMMZ2013f9/FtE7cBLiWsiqp6jAjM8ZK3J4sWL5e6771YPIvoM20ORGnvBXgULiopCNMIrDKKiolRsW9Nja0tw7//99991+5HeYEqvXv2kX78R0qPHaHHzCJDC0goV1xDWNSIbYrta0HjU09NVPL3c1btdWFAm1VUiPp6u4u3hLt6ebuLj4a6iGyIcAtwQ4u7urlqQFecbUt6MHvZI/0Ded0tBRfX58+frOf3JJ5+06dix1zFMiCVQdDsRFN2tz8qVK9WyjNAr5G116tTJon+PCSs8NLhh4xEeb9ObzPLlCbJrf7aUuFTJoGF1cysdgfYsWIhz0N7HMLxxm9amiL+Hu3TrECRHH91R3NwOL5y2ceNGFb3wjEFwz5s3T7p3795q2wnBj9zT3bt3y9VXXy033nhjq323vWNvgqW8vFxF4htvvKFh5fDM4tiharY9FO1qCohcGHiw/aYebfyG4cNHSK9ewyU2doC4uvtLXnG55BeXibi6SEiYj3h7u4uHp5t4ebmJpy7u4uHhetgxKS4ql/y8UsnLLZWC/DJdPNxcxMfTXXw83NQT7u3hpmHohgjfvn2lPP74Y5rugfMP22dp9F1Dc0qEwiMqD+fz2LFjpa2wtzFMSHOg6HYiKLrbhltuuUX++ecfGT9+vBZXa65wRxgaWpCZViMtLkYbsQOyLzlPwmL8pEv3EHEk2rtgIY4Px3CNCNi4NkUiArylZ5cQGTkytsHzGeHBuB6iABPyq+HFbM1eygjthacUwg253dYsLuXI2JNgWbdunTz55JO1nmEU4rv33ntb1UDTHLD/UDQVxvW0tDR9DXVYjjkGoePHSqdOAyUhoUQyc0slM79EqlxEwiN8JTzSV4JCvFu03ysrq2rFd35uqeTllUp5aaUKbx94wr3cJSzIR/z9i+SZZ2bJoUOHNDT8oYceavHvxpwGAn7w4MFqJGmrTgX2NIYJcRbR3XZ9RwhpJij2Ais3ipqgpY6ljB49WiZOnKieGkxSTVvV+/h4yJAh0VrQKCk+T3KyaqqfEkJIa4HUln6DIiU1p0j2x+fIli01oqM+KAr59ttvy5AhQ7RF0vTp02t7e7cGED/oZQxv3wcffNBq30vM69gBEYjq8hDcmHg+/PDD8vrrr9u14MZYgticPHmyvPTSSyq4Q0NDtYUZ0hjuuush8fXtJ9t25MuepDzJLSuT7n3DZNTRHaRHnzAJDvVpsUhEZAnah8Z1DNTCqqOO6iAjjoqTLr1DxTfMWzKLymR3Qo4kJrvJGWdcJ5WV1Wp0QsG1loLUORgXEMlSf35CCHFsKLqJw9G1a1e58MILa63CCD9rjnDHjW3VqlXqrTElJiZAuncLkagQX9m1PUPKyyqttu2EEGIOgUFe0rt/hCRmFsrO3ZmyZ09Ww58LDJSXX35Zi2HhWjhz5kytSN0ak3WIG6OI2meffSbZ2dk2/07SNDAmf/XVV3Luuedqn2ocI7S5+vrrr1XI2qvXEqlf2EYUO33ttdc0xBoGnUceeUTF9pQpl8uePcWydFm87DyYLYk5hRLXJVCGjoqVsAhfm6eCobYCvgfRb8NGx0p050BJyCqUcrco6T9gghQXV8jjjz/erPlI/R7iqGKO4wQvv5E7Tghph6IbVVMhdCB6EN6Lno4nn3yy3HrrrXqhLywstM2WEmICctFguYcFH+POUuAhQlE2gNA7hJ6YMmBApMRG+Im3m5vs3pHJfU8IaXV0kt8jRCf3m7akSmJiXoOfgwERxZzgJQMo9ITq1BBgtgbzgD59+qhIore7bdmxY4e208RYyM/PV9GKSAj03baH0MqGgHEIUWuYUz7xxBNao6BDhw56X/7oo4/kxBNPlj17cuX3xftl6+4MOZCWLwHh3jJybJzEdAhsEyMCBD684MPHxolPsKf0G3mGuLn7yvbte+Wnn1oeaQIDGubUYO7cuZrTTghpJ6IbF8X33ntPhg8frnkmsOYh5AeVL3v37q1FrVBREhfNmJgYFUTIMSPEVmACYRTuefXVVyUnJ8fidUydOlXzuRGGhxt8/fCyYcNiJDrEV/JzSiQ5Md9q204IIeYS2zFQImP8JTGrSNauS5asRlJekPuJjg5YDC8ZCq2hFVFrebvxnbiektYFqQUwsqCF1datWzXH/s4771QjyMCBA+32cKAwGsLfMWYxZ0T+MGoEoCf2pEnHyYEDObJ48X5ZvzlV9qXkSZWniwwZGSvdeoaKu0fL23S1FE9PN+nZJ1wGD+8s/YYcJ6VlFfLCC69rTnhLQaE79BjH/BvRK5s2bbLKNhNC7Fx09+/fX8NdzjrrLNm2bZtaIhGSiwvjhx9+qKE/uHiisNi7776rjwMGDGBYDLEpGI89e/ZUiz7C0SwF3iGErmGy+uuvv8ovv/xS53307RzQP1JiQ/zkwJ4sbS1CCCGtTdceIeIf5CnJWUWybl2ylJc3nvICbzc8nbi+obUSRIythTeKW/Xr108rYyO0nbQOEGQ///yzhpIjvB+RDSeeeKKGaV900UVW6R9tC9BvHsXcrrzySlm/fr2OVXjov/32W3XeZGaWakHTVWuTZFdiruSUlkmvARHSf3CU+Pp52GVEygVXXCji6in7D+yTRYvqpqw115gFw8m4ceP0/IVhAgXbCCGOi0u1GYlfyCnBBdySKoqwWiYmJsrRRx8tzgqrl7c9KFwCLwvGJsYp+ltaCgrLYIH3HBOXiIiI2vdweqxcmSg792dJYWWlDBkRY9dtxFj5mTg6HMMNU1FRJRtWJ0uQl4f07REmI0bENrkfV69eLbfddpuUlpbqfRieUIgbW7Fs2TINifXy8pKFCxdapW+xo9IalZ8PHjwoTz31lNYlAWifec8992ihUHsvkoYe1Mh9xr5B1W8USUPbLVQJ37o1TZKS8yU9r0RKKqukc7dgiY71t9tcdFNefGqOLP/jexk1coR89tl7VttniAZA6gCOMXp5t0aXAFYvJ85AriNWL4fl3NK2BV26dHFqwU3sA6Q8IP+poUrk5oIes3379lUjCiI6TNeBG/3QodESFeIjUl4lB/ayUBAhpPVxd3eV3v3DJT2vWA7E50h8fN06FPVBvZUXXnhBRTAEsa093kcddZRGuEHkIx2N2AYcQ6RUwRECwQ1Dyg033KDtL+1VcOOeirzk8847T0PeIbgxXmAonzVrlgQFhcrGjSkaSr5tb6YczCiQ4ChfGYG87bgAhxDc4OQzzpFqcZENG9ZrVKg1QKoA8rpRYC0+Pl7TOwkh7aSQGnJg0cqgIRBibtrzmJDWAN4VTDzWrFmj4ZSWgpoECDPHOtD/G6F59auWDh1ak9+dklggWZlsI0YIaX0CAr2kY9dgSc4ukk2bU6XgCCkv6NltKrwxYbdVVXPT3G6knrGui/XZvn27FgB98803pby8XIUr9jXqk9gyiqElICQa92jUF0AtoLi4OB2TKPbXvXsPrcr/++/7ZNO2NNmXli9uvu4ybEycVgmHocmR6Nq9o/TsO1pzur/++hurrTc8PFwLGMP5BeMFeq8TQhwPi69ouJHCkt1YGAxzTkhrY1qJHDemxsZnU8BYdNNNN+nz5557Tvbu3Vvn/agof+nVI0xign1k9/YMKWMbMUJIG9ChU6B4+3tIanZNfndVVfURhTeuaZiwo4WULXOux4wZo0IQgnD27NmtUj29vXi3X3nlFbniiiv03hQSEqLFPyFeIWLtdZuRtoUcbRizPTw8ZNq0aVpsD1GQycn58scf+2XNhmTZk5wnhdVV0n9IpPbF9vZ2F0fEw9NNBgwZK1XV1fLPPyusum5Uokc7NYDzmecWIU4qulEcBRVJUUANIAwXf5suSUlJ8s0336gAIqS1QUEW5IQlJyc3O7RxypQpOmHEZOG+++7TcW9K377hEhPpL34e7iq8W6MPLiGE1Pco9+oXLvmlFZKYmi/bt6ebJYYRXg5eeumlZkUEmbttaE+FkFhUW/7yyy958FoIcnlhVH7rrbdUaJ1wwgkqXI8//ni7DbuGyL7gggtUdON+ivGHeimIhCgpgSA9JP8sPyS7DuVIWn6xdOkZIoOHR0tQsLc4Ov0GDsaZoKHg8OxbE+S++/n5yc6dO7WAMSHECUU3inUgvAWiBhf5k046SYtNmS4dO3bUz6FdGCGtjY+Pj1b3BKigjyJ+lgJP0MMPP6xjHf2/YU2u30Zs+PAYze8uzC2TpAS2ESOEtD5IeenZJ0xSsotl5+5MSUsrPOK/QfshCCGjBVH9aB5rgdzTm2++WZ/PmzdPDfLEchAtAO822oAZ3m3MsVCZHs/tkdTUVA0jv+WWW7RCOeaM8MhjHERFxWre9h9/HKjN2w6J8pVho+MkMtoxCqWZQ0R0iEREd9HChyhmaE1w3I059vz58zW6lBDiZKIbrZlQMRGWVtywH3jgAXn77bfrLGgdhkrSDz74oO23mpAGQEG1UaNGqWW9vmA2l9DQUC2mhgnAggULDmsjFhDgJQMHRElsqK8c3JstBfmWh7ITQog12hRFxPhJak6RbNiQIqWlFUf8N3fccYdeIxHF01A0j7VAC6uhQ4dKcXGxPPHEE4wKaqF3G15teLdxj7NHUBgNBdJQKA05xzBgX3rppRrpgH7be/dma972xn/ztj38HTdv25y6C3Gd+kplJTqfrLT6+hGu36FDB408hYOBEOJkLcOGDRumF1T06+7atav8/fffdptH1JqwZZj9AQ81wsQrKys13625FfThYcCEB6FcqLBaf7yvXp0oO/ZmSXZJmQwdEaO5XPYA2y0RR4dj2HxQsGnjmmTxc3eX3l1DZfTouCN6DJEOhmskJu0wqMPrbQsQXosK2zCCPvTQQ9oaqr3Q3HZL8G7jvgNHBsQ2Wt2gnzVEt72CPtvwvuPeCwYPHqwGHbTvTEkp0BZgaVlFkp5bIp6+7tpz3hnCyJs69p+884P8+OXzMnBgH1mwwPopFn/88Yemi6B4HtI6EVFgbdgyjDgDuY7YMgxVyfPz82t7QzYndJeQ1gAF0TChBGgh1twWOeiLiclDYWGh5ihiMmTKkCHREhfpLz5urrJjazo9OYSQVgcpL737R0hWQYkcSsxTj6Il0TyYsNeP5rEW6CmMHFSjwKVRE4Y07d1GZXLDu43K5PYquGG8gTEFxdEguDGxxd/owx0T00lWrkyQZf/mbacXlEiXXs6Tt90UOK86dO6oxdRgeLJFwbNjjz1WHWCY32DcEEIcA1dze27jRmAUX4Flc8mSJY0uhLQlmAQgLxuV9JH20Bzc3Ny0vQ4sY1u3blXPtykeHm4ycmSsxIT6SVlhhezfw/7dhJDWx8/fU7r2DJWk7ELZui1NsrOP3NIQIeZXX321Pn/sscc0/9YWXHLJJdK3b1812iMfmRwODLrou43c7T179qh4RR40FnvM3YaIRNg4UghQDR8i85xzztFWm6eccprs3Jkpvy/eL1v3ZMrB9HzN2x4+xrnyto9Eh46IjHOV4uJSSU8/cqFDS8F+xBwFeHs7txGDkHYnulFc6qOPPtJ8IpzsN9xwg1raGlomTpxo+60mpAkQEo6+oACheikpKc0uCDRr1ix9jjY7qMhaP797+LAYiQn1ldSkAklLLeBxIYS0OtGxARIU6qOF1dBGrLy80qxoniFDhmgxpoaieawBhAHqvOARub5YyH+gCjXEtuHdxhzLqExuj6A/NLYXBgEYUnr37q31fjB+CgpctAXY+s2psi8lT6o9XWToqFjN20ZERnsiONRXAoMjNK/bVm10jSJqKCJLCHEMzLoSXnzxxZKRkSEbN27UMFoIEHi7G1pwUSakrTn55JO1kA96ds+dO7fZ64EhCRV/AULncB6YEhMTIP36REhciJ/s3ZEphQXNC2cnhJCW0KN3qJRJlSRnFMqmTakWRfNs27ZNK0zbAvQXRktHALGGWijtHRg4XnvtNRWwu3fvVu828qIRDYDwf3sDwhE5xDDUIJwZhm1UKUetn86de8ry5YfknxWHZHdCjmQWl0qv/uHSf3CU+Ph6SHvEP9BL/IPCtebC/v0HbfIdKFII0J6PEOIYmG1+xEV2wIABKjwmTZqk+a6NLYS0NYjIwKQAVVR/++03WbVqVbPXddttt+nEMTs7W7029XO0evcOk84dAyU8wEe2bkqT8rIje5kIIcSauHu4Se9+EZKWWyz7D+ZIfHzuEf9NVFSURrIBFIxcunSpTQ7K1KlTNQcVecDN7SzhLOzatUuuuOIKzX1GwU/Mp+DdRv9tewPebBit0W4OxbtwP0WFctQCOOec82T79gxZ/Md+2b43U+IzCiQ81l+GjYqV0PD2LQQ9Pd0kPCJGUKZ49+6aAnPWhp5uQhwPi2N+ILpjY2OttgHIAUdVU6zTKOxyJBDqDnEPC19MTIzmptUv0oICJH369NF8l4EDB8qPP/5Y531MNPA+jAnIm0I4ly3aO5C2o2fPnjpZAE8//XSzwydRIRReCIRxoe8mIj1MwbgdNixGC6v5srAaIaSNCAzyko5dgyUpu0g2bU6VfDNaGo4fP762+OQzzzxjk8JPuIbCYIlrJfKAzbnPO6t3G8XSILxR2Rz3Fdyb7M27DWMADAGobo+6KGgJNnbsWPn000/lnnvukYICV1m8eL9s2Jom+1LzRbzdZNjoWOnUNbjdhZI3RmyHmmJq+/bFW33dOEcRxQcYXk6I4+Bqbl/ADRs2mL1S9P586aWXtO3FkUB1aAjo+fPnm7XuZcuWaUgWLOcocAVxDS8mimcZIPcWkwh8BiHvuHFgQRV2A3gusY2bN2/WFmgoFnfiiSfapOgFaTtQPRdGlQMHDshnn33W7PV07txZPefg9ddfPyxPyyisFs3CaoSQNqRDp0DxDfCUlKwiWbMmSUNcj8RNN90k/v7+kpSUpIZFWzBo0KDa+zR6d69YsULas3cbcxd79G5j/oRWbzAGoM0OIhRefPFFTT8IC4uVZcsOyYrViRpKnl1cJr0HREi/QZHi7dM+Q8kbw7SCubUx0twQeQDjDSHEifp0I5fn5ZdfVqGK0CL0PsYN1LDOom3B/v37Ze3atfLTTz/JwoUL9bOoyDl8+HDzN8bFRRYsWKACuTHQBgqVpPfu3Vv7Gm4GyIUyKrDCSAAx//3339d+ZsyYMVo0BtvUVM9thCKjmElDwLJoWBeNf9OxY0fJycmxi/5vpGEwHtEiB5ERqLoaERHRrF2FU2X69Olq5Bk9erSOu/rVWJOT82XFqgQ5mF4g3XqFasXW1oQ9jomjwzHccsrKKmXjmiQJ8/OWfj3DtcXhkYDIghCEILRVpXEcW0TLYZ6A6zEKiCEiydkwehwj0u69997TYmMQ25hjwHgLsW1vlbzR9uv555+vNYZgW6+77jqtTF5ZiZZmGbJ/f7Zk5JdIXkmZdOwcLLEdA8XV1b5+h72wd9c+uf/mqRLg5yubN6+26vGGswgRnkgPMZ3nWhP26SbOQG5urjre7KVPt7s5H0LI2YwZM1Swohq0ESYGK5uHh0etEEVhllNOOUXDvydPnmyTDUaIEyplIlwc35WWlqZC6tRTT639zPLly3V7TTnppJMaDWmD0QDeS9xkmspJRyjYI488ctjrOJhm2C5IGzFu3Dg1Am3fvl0nljNnzmz2ulC5f82aNeoNwHjCBNUU1DTp1sVXKitL5NDeVPH2rBDfViwmg1FYWVYCC5ZwKkQcEY5h64Sw9ezpL3t3Zcm+A7gGVUpUVNMGQBibET6MCuOIDLJVu6pbbrlFI4VQmBUedhj0m2sItVcQ/ov9aNo9A/eh22+/XferPRWTg9MAUYkI+8d2u7u7q9C+9NJLNfph165kFds5BWWSXVgqwSHe0rVviHh6uElVWZFYPxnBOYiJDhUXVxcpLS2W7dt3S1xclFUNJDDiGGLCFmBOW1BQ05HF3gxEhJiLrc4Pm4pugNxpCE4s8DIjBC05OVlDyeHxRusI9P60dSVFeNkh6uHNxncj1wg54abh6bjJwQJoCv6u3zoKFkKEUaEgBX7fr7/+qv2dG+O+++6rI+YNTzfEuj1YUEjjQGgjvA+95q+66irp169fs3YXjjXSFhAmCEMNPBaYmJgyaFCglJS4SUl5tuzcWSBDhseIh2dNT01bo8af6mpx9/LljZI4JBzD1iHY208iC1wkKalAPHcXSkxMuLY5bAxEpSGCDWlbqLWCNC5b8cILL+h1FOIenm9cT52lCjPCiRGRh7Q1OCIwt4DYNlqu2gtwNsDIAsGNyEBsG2rb3HzzzTqvycoqlo0bUyUts0hSc8vEzdNVevSLk6AQ9oU2B3dvkeCQSMnPSZc9e+KlX79eVjt2EMMYW8b80xYYjiSs357GLSGOjNmi25Tu3bvr0hagtQl6MKN/MrzXEP4If0fuLqzKloCe4shVR34MbvpoDYViapGRkQ1+3svLS5f64ILEi5J9A5GNaAhY85GfhqiN5h4ziPaff/5ZJ1cYN/WjKrDe4cNjpaioQkoTc2TntgwZMCSq1caIMR45JomjwjFsHVBULTe3VFK1f3eKjBvXqclCV/BwQnQjigei21bXEEzkcR1GKzHkO8OgPWfOHPWyOipo4YQwcrTRQtE0/BYYehEGbE8GBYgpVCKH4SMxMVFfg9PkjjvukGHDhklJSYWsX58iB+JzJCOvRArLKqRLt2CJjgvgPcVCevcbIquX/SqvvfaynHrqsRoZag1SU2taAsKgY8v7PK/DxNFxsTODkcOVmUSIN7zdENqwykN4IzwN1loIcBAdHV17UTLA33jdFFQu79Gjh+Z7Q7DjJmmpcCeOA0LDUUUXtQcQHt5csI4777xTn3/11VcanlcfFlYjhNjDhKN3/wgpLK+QpLQC2bIlrcnPI3IHAhHh37hO2hJ0LEE7KhiycT1GD+idO3eKo4EwX9SiOfvss3UeAsGNOQWeI3zengQ3UqyQp428cghuRPYh0gCGgiFDhsqePVmyePE+2bIzXQ6k5otPsKeMGBMnMR0C7W7y6giceeEV4uXjL/v27dV9bC2M+W39iE5CiH3jcKIboeDIJTcFYTam4TDI+/7999/rfAah43jd3DYMxPmA0QVpCQBF0FrSGgdjCd4BjBcUH2oIhHIOHxYjMaG+kppUIGkpNflRhBDSmj2De/cLl5TsItm7L1uLPTYGBOLJJ5+sz7/++utWiUB68sknte3Rpk2btJ0WDOuo1WLvYL6BMHykqD3++OMaMQdDAkLL4cVH6K+9gP0JcY39u27dOjV0XHPNNXqMkZ6XmVksf/55QNZuSJY9SXlSXF0lA4dHS88+4a2WGuWMRMeGy/jjLpbKymotGnjw4EGrrNdIlaToJsSxaHPRjdwUhHgbLclQBR3PjTYLCDszzS3DDQI3ClQwRzEJtBBDYRbkkxv9wxF+vmjRInnuuedkx44d2pMbxa9QeRogfwnF2FClExdBWPQRAgbLr9HXmTgnCA0PCAiQPXv2HNa73RJg9UfoIEArssaMNTExAdKvT4TEhfrJnh2ZUmBG31xCCLEmwaE+EtspUJKzi2TDhhQpLi5vMsQcIAS5oSgea4MCY4gYQstOGELx/IwzzpDHHnvssNaM9gJC8OExRmoR5iyo6YLnKOp67LHH2o1XGCHvqD2CY4rUKoA0K8yhkJIn4iGrVyfK0r/jZfehHEnJK5bOPUNk0PBoCQhsPP+fmIevn4f0HjBGevYaJCUlpWqcaYmx38AwSlF0E+JYtLnohhgeOnSoLgA3LjxHzjZAyLhpn0PkgCH3Cz22BwwYoCIZHkdTq/xRRx0lH3/8sd5sUI0cN0LkqOHzhmccYvzcc8/VqtY1lt5MWbp0qfTv37/V9wFpPTA5gvAGMNygmExzQWEcGHowMf3uu+8a/Vzv3mHSuUOgRAT6yLbN6VJeVtns7ySEkObQqWuwuHm7SWoW8ruTG+240adPH10QJm0INVuDOiro3Y17NvKKUSAV92zco2FE//zzz2tbgrYl2AY4AmBwhccYqUZ4/u2338rFF1+sf9sDEHYwKmP/YZ+i6CzS8dC+bPbs2RIWFqEtwH5fvE+27sqUA+n5EhDuLcNHx0pUjL/dGA0cHezHgEBvOe30qeLm5qljBmOlpRhGfntKXSCEWKlPN5Eme3vbS/83Yv4NC/l3sBYjSqIlVXpR/RXhhJ07d1bjTmOTlfLySlm6NF72JeZItaerzQqrsccxcXQ4hm1HcVG5bFidLHEhfjJoQKT06dNwtw4YsSGCu3TpoukzrS3C0E4MRclQAdwUhGwjtQeGdVRbR1h6a5CVlaU52rjGwyCA/XHaaaept7h+rZi27nGMYrMI2ccjgGEYFclRmRwkJOSp4E7LLpb0vGLxC/CUbj1Dxc/fPgwGzsb+PVlSnF0maYf+kS+/fEu7neCcakmbPERTIEoU52mnTp3EFrBPN3EGcnNzJTg42G50GkV3C6DodlzgmUb7O4Saw/Lc3JMRqQoo5gdPAnK2hgwZ0uhn8/NLZcnSg3IgJV9Conx1omNtKFiIo8MxbFvSUgtk744s6RzhL2NHd9AUmKaua+jQYESitTYI3UbeNAqtIe0MRcsMUPi0a9euWgzVdIHX3FpCFy3N0KIUHn8jKgqCHyK2Z8+ediVYIMJQVBaCDt8PLyjS5gwPfGZmkWzdmi6p6YWSllss1W4u0rVHiIRF0FtqS9JTCyV+T7b06xIi77zzsBpDTjnlFHn00Uebvc7x48drfSMU8LNV7QCKbuIM5NqZ6La4PweKmDV2E8HruMlAeNx2220atk2IPQIvxYcffqg959999131eDcHVMBHLuLChQtVvDclulFYbdjQGCldWSkHkwrEP8BTIqPr9vgmhBBbEhnlLwV5ZZKcWiRr1yXL+HGeElgvfxfXNYhuXNMwsW8r0Q1RjQUh3BAZq1evVgGOBalnu3fv1sUUGFLR0tRUiONvvG6u2IDAR7VpCH4DpKfdeOONWj/GnsD2/vbbb1rDBsXcAEQd5mBhYWFSVFQumzYlSXxCbm0LsI5dgiS2Q6C4ujKM3NYEBntJSVml5BeUy9133ytXXnm51hzCmMbYbAn1iwoTQuwbiz3duLCjMqe3t7eKaliV0b4AnkNYxZFz/eeff2qBM1iIUdnTWaGn27FB6CImJvACIEyroTBBc0DVXXgUcE7gZorwsaZAaN+mrWmSkFmgBWv8A6xXsIZeQuLocAy3zj7esiFVpKxKusUGyfjxnbXNoSlbtmzR+zmuj99//72Ehlo/Mqcl2w/RjYKYpgsKo5p6w01B0SmIb3gGEXKN673RNxkh45jHoCr0+vXra0Oz4UiAVxFVv1EfxlyvdWt5CZFj/vTTT9e2wESo8b333quGgYqKKtm9O1N278mSrLxSySosUSNv527BrEjeyqxeniBR/j4ycXxnefbZ2dpdZ8KECTqfbg6TJk3S+SeKuGJM2wJ6uokzkOvonm7kNo0YMeKw/FXktaJoB6plGm00nnrqKacW3cSxQb93FO1BcZNXX31Vq9w3h4EDB2ruI0IRf/nll9rqv00VVsvNLZHS8krZviVdho2KFTc3WqwJIa0D7t19+kfIhrXJ2r977dpkGT06rs49HUVF0dILAhT51XfccYfdHB5sJ4QzFohiA4SAQ3jXF+MQ1MZiDjA0TJ48WS655BKt12Fv4HciUgspTXgO4wEKhMJIgufx8blq3E3PKZb03GLxD/KSwSNimLfdRgSHeEthfrmkpBRoHQB0Bvjrr7+0Cn5zivfCcIR/i7FuK9FNCLED0f3WW29pOG596y3+vvbaa7Uo1TPPPKN5REZPZELsEYxZVMZFmBdy9mAgQtXe5qznrLPOkrlz52rF3SOJbnx+2LAYyc8vk4KEcjmwN0e697IfLxIhxPlB/+V+AyNl09pk8UyAF8BL+vWLqHOduummm3SBkR339JiYGLFnIJaRa10/3zo/P19TidBmFK1B4SWHV9to34QwXRS2wu+Li4vTzhT25Nk3BS1O0cscRl4Arza82/ByZ2cXy5YtyZKCvO2cmrztXv3DJTScedttSVi4r+zNyJLU1EIZOLCbhv9jzoFCrM3J7YaRH6LbGAOEECcV3cirMm3hZQqsbggxN3LC7KV9BiGNASvzCSecIL/++quGmqNoUHMKk6D3KdrYwSuEHMOmiuwAhHIOHhwleQWlciAxX8IjfSUo2JsHihDSaqBidY8+4bJne6Z47MqQoCAviYv7LwQPgg6RbWjtCaMiotccEeRzo95GUzU37J3s7Gw9BkYbNxgFEH2AmiKlpZWyfn2yHDiYKxn5xVJQUiEduzJv214ICvGW8spKvd/n5ZVqFAWOI2oUIIzb0hQEiG5A0U2IY2FxTOsZZ5yhVlX0wYb1GOARoU54HR4/sHnz5hYXiSCkNUDfVYxVFKG54YYb1AtiKZgAGWGOP//8s1n/JiLCT7p3DZHIYB/ZvT1TKitrvC6EENJaRET5SUzHAEnKKpL1G1JUFBhADNx+++3qCUYe6uLFi3lgWhl4442e5RBqOCbnnXeefPXVV3LCCSfK3r3Z8vvv+2TzjnTZn5onXoGeMnxsnHToFMRCaXYC0sdgVC8qrZCMjCLtmY40AMw5GnNiNQVFNyHtRHSjJQV6BF566aWanI7iUXhEWDmKO8DbBxDqhBAoQuwdFFfAuEbuHkIOIbybcyM0+qBiYmpufUKEc0aF+opbtcjBfTkWfychhLQUFNfy9veQpMxCWbUqUcrK/itG1rt3b80VBuj/nJPD61RriW3k/iL96bHHHtPCWb169dL8ejg4iopc5M8/D8iaDcmyNzlPiqurZODwaOnVN1w8PesWxSNtT0BgTRVz1HPx8vLSWjBGukBLRLeFtZAJIY4kuiFQUOkZ+SRvv/229jrGTQCVTmF5NarDIa8VYU+EOALwVL/yyitamAcVYWFEWrp0qUXrOOaYYzSlAoId+YPmUBNmHi1RwT6SkpAv+SZeJkIIab3CauFSVl0tSekorJZUZzJ/zTXXSLdu3bSQanMrLhPzQPX1H3/8UWuM3HXXXbJ9+3btuT1jxgxtY9axYw9ZsSJB/v7nkOyMz5a0/GLp0itEO2FA2BH7BC1CUTw1N7fmHo+0DYDUDUtBCpybm5ume6anp1t9WwkhtqHZJZP79u2rFth77rlHBQqqnBLiyKD9HQxICP0qKCjQsEoUOSksLDTr32NiNGbMGH2OyqTmf6+fdOkULKH+3pIYn9fs7SeEkObi7uEmfQdGSEZBicQn5sm2bf9N5mFMfOihhzTM/KefftJQc2JdUIUcDo2zzz5bZs2apUXf0H4S7SjRL/3ss8+XTZvS5I8/DsjWPRlyMD1fQqJ8ZdjoOG0FZsvWZKTl+AV4Skl5peTnl2oqmanottRb7e7uLh06dNDnzOsmxIkLqRmW2JUrV6pH0CicZgpEOCGOSFhYmLYPQ5rEJ598opOdFStW6IQTRYWOxFFHHaUt81atWiVTp041+3t79AiVg/G5si8tT0pLK8TLq1mnJiGEtKiwGsKTd21DYbVMCQrylg4dAmuLTiKt7P3331djO/KKp0+frsKQNB94KxcsWKBebOT4gpCQEK0Wf/7554uXl4/s2pUp+/bvk0z0284vkbBIXxk2MFy8fWr6jBP7B/d0N3dX9Xajc8mAAQPUmIXokf3792skiaUh5iheDNFtztyEENL2WDyzR09jhI4fOnSoQescrK0U3cSRwY0QoXyoXYD0CbSYufHGG3WSecstt6hHuzGMm9+mTZuktLRUc7fMAe16IiN8JS23WFISCzTHkhBCWpvwSD8pyC+TxKQCWbc+Wfz9PSX4384K6DGcm5urxki0EUNEz9133y0TJ07kgbIQ5Gh//vnnatzFPjWirTB/QkFaDw9P2b8/R3bvTpbMvBLJyCsRv0BPGTQiWvwDGEbuuCHmVZrXjVpIgwcP1grm8HY3R3Tj/KOnmxAnDi9HkamgoCAtFpWamqptLEwXWO0IcQaGDRumEyJ4GwAmmcizg+GpqVwrTJzKy8tl48aNFn1f164hEuLvJSlJ+VJVxeIohJC2AUY/3yBPSc4qktWrEzX6xjBIPvjggxoNhGsd8kmRd4wlLS2Nh8sM0B1j3rx52jYK+xGCG/sS+xXGjAsvvFDS00tl8eL9snp9kuxOypW88grpPTBCBg6l4HZ00V1SXiE5OSUtzuvu2rWrPsJLTghxUtGNAmqoYDphwgSJiIhQAV5/IcRZgFcboZSobh4dHS1JSUly7bXX6t8NgUgP40YKC7YlREf7S0igl7iKi2Skm5dHTggh1gbXsd59w6XCpVqSMgplzZqkOoZAXOM+/fRTzTdGQSdU2YZxEoZJVN0mdUHYuLG/Tj/9dHnvvfc0rBytKp944gndb2jHmpZWLH/9dVBWrEqU3Qk5kl5YKl16hsjQkTESEurD3eoUoruyti3f8OHDa1vsWgrbhhHSDkQ3WlYgLIqQ9gTCxj/77LPaPvSo3N9YWzEjxNzSViCuri7SuXOwhPh5SnJCvhW2mhBCWlJYLVKyCkrlUHK+bNmSVielDKkzSLv58MMPNd8bBSdhkEelcxQBa+/Ag43CaNddd52ccsop8uyzz2raEQwaI0eOlDlz5sjHH38sxx9/giQk5Ktn+58VCbLzYLYkZBdKZMcAGTGGRdKcrWYCwssN0Y02pQARIyikZwmm/9bcYq+EEAfL6X7++efl1ltv1VyUPn362GarCLFD/Pz8ZObMmbJr1y7Ztm2btgVDP/r6DBkyRB/R6gU3UoRkmkunTkGyY2eGpCXnSUF+KXP3CCFthq+fh/TuHy47tmSI6+5Myc4ulgEDIiUs7L+6Fj179tSuD1988YXMnz9fhSWKgF111VW6WHL9c3TQ9eLPP/+Un3/+Wf755586FcXRFeOkk06S4447TsLDw6W8vFL27s3WvO2svBItkFZWVS2xHQKkf4cANXoQ58LDw1Uqq6o0agQL8rphvEL9F6RnGBXJzSEgIEALv2ZmZmpBNXYQIsQJRTeqlaakpGjlRfQ0xkXDFNxkLM1lJcSRgIUZohu5VA0VEIqLi9O+36hvsGPHDp1smYu3t7t0iAvUojnJifnSsw8L5hBC2o7QcF/p3jtU9u3OkpzCUsnMLpZOHYKkb99w8fOrEdRoJYZcZBSfhLd76dKl8sYbb8gvv/yihsqhQ4c67SEsLi7W34vfumzZMq3nARBmjwiAE088UU444QSJiYnR10tKKmT79nTZvz9bsgvKNJKg2lWkQ6dAiYr1Fze3ZndyJXaOi2uNEQYRIxDd7u6umrYG0Yx5tSWi2wgxh+hGMTWKbkKcUHQjB4X9IEl7xpg84WbXEDg/ILTh8YAByhLRDbp0CZYDB3Nkf0q+dO0eQo8HIaRNiYrxl9AwHzm4P0cOJOdLXmG5JCXnS88eodKzZ5iKB/1cVJSGTaOP99NPP61iYtq0adrx5Oabb1bvnDOACCZ4siG00SLStHUqClxBaI8ZM0adE8Z8CRWrDxzIkfhDuZKjYrtEPLzcpHOPYK0Yj/Qi4twYxxjlEYwaCaai21Iw1pDGxmJqhDip6H733XdtsyWEOAhGG7CmcrAM0Y1QS0sJDfWRkGBvSckpkvS0IomJc46JKiHEcfHwdJMevcP0erR/T7bsS8mT/OJyOXQoT/r0CZeOHQNVYGI5/vjjtbYFqnSjBzVym9He6KabbtL8Zg8Px+svXVFRIatWrVKhjcJxpnm0iG5C6DjEdvfu3WtzuiGsUlLyVWynpheqsSK7qFR8/T2kZ79wCQnzoROjHWGcH8CojwDRDZojullMjRAnF92EtHcQSmlMwhoDNQ8APN24uVoaHYLc7qT0QklLLqDoJoTYVTGoAUOiJCujSPbtzpacglLJyS/VcOn+/SMlPLwm3zswMFAeeOABFdmPPfaYFp6cPXu2vPbaa7W9qA0Dpr2CEPH169drjja890Y/bYDWkBDZWPr27VvnGl9cXF4jtFMzJDe/TLILS6WgtFzCwn2lX89ICfq37zlpf2CYVJt4ujGOjIJolkLRTYgTiu5bbrlF7rzzTi0ahedNgRvPCy+8YK3tI8Qu278AFDFpDEzC3N3dNa8bbcbgCbGEDh0CJWBbuqQmFUlRYbkWNCKEEHvK9Q4O9dHaE/H7c2rzvTvGBUq/fhG1+d7Dhg3Tdlmff/65fPDBB5KamirPPPOMvPXWW1pw7bzzzhN/f/9W334YQ/Pz87WAFRaIHuO58Td6auMztb85NFS9+BDaiGYyDLAGmZlFWhgtMTFPCkoKJKugWqpdXSQ6NkD6xPqLlxf9HO0dVxcXqZaanG6AeQJoTqs9Q3TDoFVZWant+wgh9otZd4DvvvtOpk6dqqIbz5uCops4O5g0mlqoGwIVeyG80X8T3m5LRTcmZ9FR/pKWUyRpKQXSpXtIi7ebEEKsnaMa1zFQIqP86uR7J6cUSI/uodKrV02+N66Hl156qVxwwQU6h0CfahgjX3rpJU1ZQxG2KVOmHFaY1RIgWiCkIT7wHK1NTUW0IaRx/TYENqpGHwnkoU+aNEnDx1HTpr6wKSwsk4SEPF1yckskp6hMcgtLJTjYRTr3DGO+NjmsmJqpp7t+uLklYA6C8YgxD2cAaioQQhxcdJsWaWDBBtLeMc6BI1UahScEoht53aeeeqrF34McyQOHciU5uUA6dwtm7h8hxKHyvSFETfO9Ib7PPfdcOfPMMzU3Gq3GcD2F1xv9vpHfCsFsCGfTBa+Ziur6fzeXoKAgFS8RERH6aLrgNXgT6+ego91XUlK+5rNnZBRJfnGZ5BWXS1lllURE+cmgvqHi5V4u7t5+vG6TOmhwxL/Vy1squhFpgfZzhiGJopsQ+4axToRY2B4GoVzgSH3qkdf90UcfNauYGoiK8pcgf09JyS6S7MxiDeckhBBHzPeG+Ea+N1piIaQWhsiTTz5ZC06+/fbb2l4RVZytBTyAECT1RTSEiSGw8WhuXjlEUlpaoRw6lCspqQVSUFSuQhu52sEh3tKxZ7DmbOP3QUBVlNS0DiPkME93je5usegGGMcQ3YjcIIQ4oejOzs6Wn376SRISEuq0yjCYNWuWNbaNELtjy5YtenNEPjfy+5oC7WLAnj17tOiakbtlSegmcrtTsookNbmAopsQ4pD53tkFpZKWWSTeHm4SFOQtISFYfPQRodsTJ06UXbt2aUVwiGV48Iyl/t/134NoMT5j+re3t/dhOdeWUlZWKekoaJlWKKmpqD5eJnlFNV5tb193iergL30ifZmrTczGRawXXg5gODKtNUMIcSLRjZAwFD4pKCgQHx8fDRczBRcQim7irKAnKxg7duwRP2t4UZA3iII8HTt2tPj7OnYMkl27s2RfWp6Ul1VqGCchhDhSvnf8gVxJSiuUyvIq8cooEB9Pd/HxcBMvTzfx9fb4V4QjDL2DinLPNrrOQfjk5paqyMaSmVUkRaUVUlhSIYWl5eLi5qLh412jw9SrT4ilwA5kC9FNTzchTii677jjDhk5cqSGg3Xu3Nk2W0WIHYKbInrNggkTJhzx87iZIu977969cujQoWaJ7sBALwkL9dGe3WmphTqJJYQQRwGGwu69QnUpKamQ/NxSyc8rlby8UilIKxI3VxfxSXUXH0838fZ0F093V/H2chd/f886i5+fh1ZEh5i3JiiElpNTUiu0ETZeWFIuhaUVKrh9/DwkNNxHOoaGSGCwF3O0iRXCy//L6TZoSXg5oOgmxAlF9759+2TOnDkU3KTdgZxDVNxFdMeYMWPM+jcQ2hDdSMVoLihClJCSryHmFN2EEEfF29tdF3iLAYRHYUGZFKgIL5O03BLtce3h5qri29PdrebR499Hdzfx9fVQEe7l5SYeHm5aHR2Lh4eryfOa1yHQS0srVOxjKS2trH2OBd9VgtfK//NmQwsFhXhLTEyghIT5MHSc2KBlGMPLCWmPWCy60XMTXjtC2htvvPGGPiL/EKkV5mBUOG+J6Nae3VvTJDWnWAryS8U/wLzCP4QQYs9AFAcEeukS8+9rlZVVUlJcIUWF5VJcVLPkFJdLcXa5inRDfMNDjn8PEfPfcxE3F4jtmnUD/JvyyiqpqESl82qpqKqUcjz/9/Wq6moV8YFhXtIxLEQCgrys7k0npBaXGq+24dluad0BhpcT4sSi+5VXXtF+m+g7fNxxx1lcHIoQRy2ghnxu3CCnTZtm9r8z+nPDQ95c4LWJjQmQtJxiSU0upOgmhDgtqP6NfOmGcqbhtS6GGC+ukIrySqmoqJLKimp9RLsu/RvCWl9Hq7FqDW9H7rinl5t4+nuI3//buw/4psruD+CnTdIk3XsBhbL3lC2guEVU/uIEFfFVEX0VX/fCvRD0RVTU14ELBzhw4EAQUUE2yN7Qvdt0pjP/zzn1hpZRkjRp701+Xz/XjGbcpg9Jzn3Oc47RVD9LztcF6MgcaECQDS2GD+icaE23q23vkF4OoB0ORcwhISGN1jFVVVVJuw8OQI6d8ePbWSwW9+8pQCt6/fXX5XTcuHHSt9VRgYH1bb64mFpzcEG1Q0eKKDWrlJI7R+BLIgD4HKNRL1t4a+8IgJuCbkVzC6mVl5fLpnznAACNBt1cPK1h0A3gSzZu3Ejr1q2TrA5nZrndcRRbERMTSGEhRsosqpAeuNGx9WsiAQAAQBvkO0Hd0T7d3N6O1dbWuvR4HGTzxgF3bm4u6i0BaD3ofvzxxz2/JwAqxEeflVnuCRMmUGJiolP3V7I+wsLCmv1BzbPdmXllUlANQTcAAID2Zrrrao5WLw8ODpZTbsPrKp7tPnLkiFQwR1chAPVyuoLD2LFjpYrziezdu1d+DuAtNm3aRFu3bpWK5VOnTnX6/kVFRW4JupUq5qHmACoqtMraRgAAANAOSX6zHQ26efkmKy4udvkxlXXdPNMNAF4UdK9cufKkbw58PRebAvAWH374oZxefPHF9rVTrgTd4eHNX4XIPWo5zTzYaKCcrLJmPx4AAAC0dJ/uo2u6Q0NDmx10R0dHy2l+fr6b9hIAPMGlXgUnW9+9evVq+xE3AK3jnvR//PGHjPdrrrnGpcfglC+WkKA0xGkeTjEPDTRQdobrqWgAAADQ8rjFHcfb7gy6jUajvcgxAGh8Tfdzzz0nG+MAhPsUH9tbkKsz19TU0PTp0z2zpwAt7OOPP5bTM844g5KSkpy+PxdP27Vrl5zv0aOHW/YpMTGEQgMDpGe3pchKYeEmtzwuAAAAeJbe4E9VdXX2JWJK0M1ruvk7gyt9u3n5G6uurnbz3gJAiwfdI0aMkArmXFTqySefpKuvvpratm173D96DizGjx/v1h0EaA2cprV06VI5f+2117r0GGlpaVRWVib/Njp27OiW/dLr/alNm1AJunOyShF0AwAAaITRpCdLrU16zTcMujngLikpcan+i8FgkFPMdAN4QdA9ZswY2Tjo5mDkgQceoDZt2nh+7wBayWeffSZHjfv27SubK7Zt2yan3bp1s7cFcQcuqHbgYAGlZJdRxy51pNO5tEoEAAAAWjjorqmto4qK+llpPijPXVEyMjKkSPHQoUNdDro52xQA1Mupb+schMyfP5+2bNniuT0CaGUVFRW0ePFiOT958mSXH4drHLDBgweTO0VFBVJ4mIkCdP6Un1vu1scGAAAAzzAadVQlQffRAFk5sM+dUlyhpJdjphvAi4Ju/ofNaeW1tbWe2yOAVvbNN99IURMe67ye2xWcKrZmzRr78gx3S0rigmoBlIWCagAAAJqa6a6qqqGamrpGQbeSHefK942mihwDgDo4nZd622230UsvvURWq9UzewTQisrLy+mdd96R85MmTXKpqAnbsWOHBO7cg7NPnz5u3kuitm1DKcRsoFJLJVn/SVMDAAAA9eK6LAaDjqpqeA13pVzXr18/e9CtBNDOUCqfKz2/AUDDa7obSklJob1790o1Z54FjIuLa3R0jc/PnTvX3fsJ0CLee+89KigooHbt2tGll17q8uMsX75cTnl9ljvXcyvMZgPFxwVTjqWCsjPLqH3H5vcBBwAAAM8KCQ2gyuo6slgqKSLCTJ07dyaz2SwVzA8fPux04VW+nzwugm4A7wq6v/vuO+kJyNv69euP+zmCbtAqLmSitAm766677MVJXFkTvmTJEjk/btw48hQuqHYkzULZWaWUlByG1DIAAACVCwoOoNI8K1ks9RmjfGC+V69etGHDBlnX7WzQrcx0K5XQAcBLgu5Dhw55Zk8AWhFX/XziiSekEMmQIUNo1KhRLj/WDz/8IK0/eE34yJEjyVMSEkIoLNhIWUXlVFRopYhIs8eeCwAAAJovJNRI+ZllVFR0dJkmr+vmoJtTzCdMmODU4yG9HEAb0GsIfB63wps1axZt3LiRAgMD6d5773V51pgf69NPP5XzV1xxhctrwh3h7+9HbdqEUJjZSDmZ9ellAAAAoF5BIZxeXkvFxZVUW1vX7ArmfJCfYaYbQN1cigjS09MlMBk+fLj0IObT++67T64H0GJP7i+//FIC7WeeeYaSk5Ndfiw+Un3w4EFZn3XxxReTp7VrF0ahQQbKyy2nmmp0FQAAAFAzk0lP/np/qvon8FaCbv4OcuTIEcrPz3fq8ZBeDuClQff27dulGvMbb7xBCQkJNHbsWDnly/ymwVWbAbSCC55xNX52xx13NCutnCmz3OPHj6fg4GDytPBwE0WGmykwQEe5OejZDQAAoIViatZ/iqkps9Q8icXWrVvn0kx3S3znAIAWDLrvuece6tSpk1Qx59nB+fPnyykfnePiD/xzAC34/fff6aGHHpIWHVypfPLkyc0uxLZq1Sp7anlL4YJqoYFIMQcAANBKMbWKqhp7MTXG9WScDbq5Dg1vDOnlAF4WdP/xxx/0yCOPUERERKPr+fLDDz8sPwdQu7Vr18qSiNraWjrvvPMk+HZ1Hbfik08+kTXdvNyiQ4cO1FKUnt1lJVVUXoae3QAAAGovpsbruhsWU1OCbv5+wt8lnEkt5/oxXJMGALwo6Nbr9VRZWZ8Ocyy+3hM9iQHcadOmTfSf//yHqqur6cwzz5Sq5c0teJabm0tffPGFnJ80aRK1JKNRTwnxwRQaGEA5mfVpZgAAAKCdYmr9+/eXVqU5OTmUmprqdGq5Jwu3AkDzOf0v9Oyzz5YZ7b179za6ft++ffToo4/SOeec44bdAvAMrkkwY8YMOUA0YsQIKZzGB5Kaa8GCBZLi1a9fPxo6dCi1NC6oFsZBd3YZ1Tl2gBwAAABUUkzNZDLZq5ivXr3aocfh5XHMHd9jAEBlQTcXneKexj179pSjcpyaO2DAAOrRo4dcrxSlAlCbPXv20L///W8qLy+nwYMH04svvkgBAQHNflw+Ks11Ddi0adOanabuitjYIAoNDiA/G1FpgzViAAAAoP5iakwp5rpixYpW3DMAUEXQnZSURNu2bZPgumvXrnKUjU9ffvll+vvvv6ldu3Ye2VGA5uDMjOnTp0sqFs9Gz5kzh4xGo1te1HfffVdS1QcOHEinnXZaq/yhuGc3r+3m2e683IpW2QcAAABwrphaw3XdZ511lpxu3ryZ8vLy8FICeBGX8lF47Qi3V+INQAsB96233koWi0UyNObOneu2giNpaWn09ddft+osd8MU87378iktv5Sqq2opwIh0MwAAALUWU8vPLGtUwZxb8Pbu3VuWwvFs96k6oSjZehUVONgOoHaougBen1LOwTAH3L169aLXXnvNbb0suboorwnnZRXDhg2Tme7WFBpqpKhIM5m5Z3d2WavuCwAAADhXTI0ptZF++eWXU758UVFR9qCbl84BgHo5NBWWnJzs8Awe3+7AgQPN3S+AZtu5cyfdfvvt0lKDjxy/+uqrbgu42bfffkvr16+XNPUHHniA1IBnuzOy8yk3p4zaJIW19u4AAADASYqp+en8qKqmjsrKquXAuRJ0//e//5VOKxkZGZSYmHjS14+z9sxmswTdnI7OS0ABQMNB9yWXXHLKoJvXc//666+tml4LoFi1apX03rZardSnTx+aN2+eWwNu/nDjOgaMZ9Lbtm2rihc/ISGYTAE6KiuopMrKGmknBgAAAOpjNOmppraOrNYae9AdGxsrxV7XrVtHP/zwA914441NPkZMTAylpKRQVlYWgm4AFXPoGzkfcTuZLVu20JNPPkkrV66kTp060YMPPujO/QNw2ueff06zZ8+WIn/cvmvWrFkUFBTk1leSH5OLsnHV/muuuUY1fyUOssPDTBRYWEsFueWU0Da0tXcJAAAATsBo1FFNrU2C7obGjRsnQff3339PU6dObXJCq0uXLhJ079q1i4YMGYLXGcDb1nRv2LCBLr74Yho0aJD8Q3///fdl/Sy/OQC0Bp7VfuqppyQg5oD70ksvlaJp7g64f/75Zylw4u/vL73pdTodqUlUlJmCTQbKz0NhFQAAALUK4KC7rn6mu6EzzzxT+nZzMM1F1ZrC9WrYjh07PLqvANDCQfdff/1FF1xwgcwgHj58mBYuXChrZydPnixBCEBrOHjwIF133XW0ZMkSOSLMa7kffvhh0uv1bn8eDuzZDTfcIO3y1CYqKlCCbkuRlWqqa1t7dwAAAOAEAgKOppcfu1Z77Nixcp5nu5vCXVkYfxcHAPXyd2aNLBd3GDFiBOXk5NDixYtlHfeVV16JddzQqrigGQfcHBBzJc/XX3+dpkyZ4vZxWVpaSvfcc48ULOEUrptvvpnUKDDQQGGhRjLpdVRYcLQVCQAAAKhspvsE6eXsoosusmfXVVVVnfQxeJkbf9/hNd0FBQUe3V8A8HDQfcYZZ0iqCwcd3333HW3cuJEmTJjQjKcFaD5uj/HYY4/RE088IanlHAh/8sknUoDE3ThdfebMmZLqFRcXJ63C1JZW3lB8fDAFmw1UkIcWIgAAAOpd0338TDc77bTTpKgad2D5448/TvoYvISOayo5MisOACoPunmWm3sS87qSq666ikJDQ0+6hYWhTRF43v79+2V2mz9geFnD9OnTpSVYZGSkR55vwYIF8u8gICCAXnzxRYqIiCA1k6DbxEF3BdXV2Vp7dwAAAMDBNd2Mv9vwck5HgmmloCt/VykrK8PrDKBCDi145dlEADXggz9ff/21BL6cbsWtMnjWeeDAgR57zjVr1tD8+fPl/P33329fP6Vm4eEmCgkKIF2Bn6ztjog0t/YuAQAAQAMBRj1Vy0x3NdXW1pFO539cFXMuVMwz3UVFRRQeHn7C10+53ZEjR+jjjz9W7fI3AF+GoBs0lU7OAfZPP/0kl7m+AKeWe3LWOSMjQwqycbD/f//3f9KzXgt4fVdcXBCl5ZZSfm45gm4AAACVCQjQSaBdXWujsrJqe69uRceOHWXNNncJ4rXdV1xxxQkfh5e73XrrrfTAAw9I8M3dheLj41votwAAR6DcOGgCt6ObNGmSBNyccnXHHXdI/3hPBtx79+6lW265RdZTcUsOLqKmJUdTzLGuGwAAQK3FT6tqaqmsrOqks9iMs/x4AuBkzjrrLMn6q6yslO9HAKAuCLpB1fgDZtGiRVKNPDU1VYqYvf3227Ke25Mt6ji455ZgmZmZ1LZtW+n9zeu5tSQmJkiKqdXW2Kis9OSVTwEAAKB1mAINVF1TR6Un+Zzmdd1ms1kmApoqqMYZbjw5wN+NfvnlF1q3bp0H9xoAnIWgG1SLq+VzqtQLL7xA1dXVNHr0aOkL37dvX489Z21trRwh5pRyPlrMKewffPCBBPta4+/vR0FBBjLo/KmqCv26AQAA1CYwUC8z3ScLurlA8eWXXy7nedKhqdnurl270sSJE+X87Nmzqabm+AJtANA6EHSDKnEPeK7GuXz5clmr9J///IfmzJnj0er43H/+3//+N3300UdymWe6OQDnqvxaxZ/N/PHs3o7lAAAA4A7mQANVNjHTzSZPnkxGo5F27NhBa9eubfLxpk2bJgXXDh48SB9++CH+SAAqgaAbVCUtLY0efPBBmjp1qhQxS0xMpHfffVcCcE6d8gQ+arx06VK68sorJR2L07h4dv22227zaAo7AAAA+DYOuqtOEXRzO1Qu5urIbDdPFNx1111y/q233pIWqwDQ+hBRgCpwKwxOheK0qGXLlkmAPX78eGl9wUXMPKWgoIDuu+8+mjlzJpWUlEg7MD4yzAVJvIF8MNtsHjtgAQAAAM0LumvrbFRZVXvCft2Ka6+9lgwGA23ZsoU2bdrU5GNeeOGFdPrpp8vSPF7nbbFY8CcCaGUIuqFVVVRU0HvvvSetuD799FNZf8TrqHntNveHDwkJ8dja7W+++Ubab/z666+k1+tp+vTpsi8dOnQgb2E/GI6YGwAAQJX1V3hdd0VVDeXklJ30drGxsfa2pe+8806Tj8kH2h9//HHJFuQMQp755jo5ANB6EHRDq+DUcV4vzUdjX3vtNSorK6Nu3brR66+/Tq+88gp16dLFYzO/vE6cU8mffPJJmWHv3LmzFEvjlHZeP+5tTp6EBgAAAK0tNiGYLGVVdOhQYZO3u/766+V7Ci+F49o3TeF13S+99JJMXvBteWKBW6ACQOtA0A0thgNeLgDCRdH4aC0XLOOUbm7JxQEwp3UPGTLEY8+9Zs0aaTV2//330+HDh2XdE/f75oCbK356o6bWfQEAAEDri4sPprKqGsovqKCCgoqT3i4hIYEuuugi+9ruU+FJhTfffFMC8J07d9LNN98sRWMBoOXpW+E5wceUl5fTd999R59//rkEu4rhw4fLjDOnk3uyYBkf4X311Vfta6ACAwNp0qRJsgUHB5PXs9WnmgEAAID6GAJ0FBMXREWlVXT4cBFFRppPelvurPLtt9/S6tWradu2bdSnT58mH5snFbigGs90c1E1zuqbN28eJScne+A3AYCTQdANHpOSkiKBNn84cPq4EvBygTReS92+fXuPvvp79+6VdPU//vhDLgcEBEihNv7AioiIIF9Q3zKMC6m19p4AAADAySS2DaFtG7MpPaOYevWKIaPxxF/ROTuQZ7u5Ls2LL75ICxYsOOXERceOHaUTzO233y7fzW688UZZ4te3b1/8QQB8Jb181apVEoRxsQeejfv6669PeR+uaN2vXz8J4DjVho/a5efnN7rNokWLqHv37mQymeQoILeEUnA1R04x5uuDgoLkuTntmNcZg3tSyDltm9tbcHE0Drg5wOYq4T/88APde++9Hg24+QPloYcekjZjHHDzh9Gll15KX331laS2+0rA3TC9HEE3AACAegWHGCkw2EDFZdWUktJ0tXEOnvn7K6eML1myxKHHV1qw9u7dW9Z2cz9v/g4OAD4SdHNAxgE0F9NyxJ9//ikBMh+l27FjhwTXXFDipptust+GU26uvvpquc3mzZsl4OJt+/bt9nRnTjV+9NFH5fTLL7+kPXv20MUXX+yx39MXgrv169fTv/71L+lvzX8DPogyatQoSe3mvxPPbvOHhKdkZ2fTM888I7PZP//8s1x37rnn0uLFi+mRRx6huLg4jz03AAAAQHMktAuhwrJKSTFvqiYL9+3moJnxdyxuf+oIXts9f/58aSdWVVUl7cT4OzAAeJ6fTUWVljhI49lIDpBPhns58xvGgQMH7Nfx2pQXXnhB2iIwXifMwTyvI1YMGzaM+vfvT2+88cYJH5cDRi7ideTIEUpKSnJof/lIYVhYmPQ/5KJcvooPXPDrqqyZ5jRunuW+6qqrJA3K0woLC6XVFwfX/CHC+AOF1y95a4G0k+F/zjweeVzyv6dlyw7QziMF1HtgPAUFB7T27gE4NIZrrGWkNwWhFgFoEsYwuKquzkbr/kyjNuGBdPqIdpSQENJk61Pu3c1L6bg2zty5cx1+z+T78iQFp6gzLrDGk1fK/Y/9LgGgRRaLRQ40qSVO09yabi6+xanDnC5+wQUXSBVGDra49ZSCq1RzGnFD5513XpOp6/wH4TcW/uOcTGVlpWwKpfUCvzmp6NhFi9m6dasE2xs2bJDLBoOBJkyYQFOmTKGYmBi5zpOvC/f45srj3NObsxcYH1jhmXY+9fTzq5EyFpXfmz/A5T8fHaOg/TEMoDUYw+Aqjm/jE4KoMK+CDh4spPj4kxd75aVzTz31lATenF3Iy/l4ssMRfF/OAOTvatzzmwutZWVl0QMPPCDf5TCGwRvYVPY9QnNB98iRI2VNN89mW61WqqmpkTXhDdPT+Y3j2FRivszXnwg/Dq/x5pT0po6EPPfcc/TEE0+cMGBX2x/WkzjA5ddbWSev1+vloMfkyZPtwTa/Jp7EVdD5b6FUQ+e2GJzaztkKfPDE08+vVjwOS0tL5Ty/DnV1FRSgq6a66gqqsVa39u4BnBK/k9ZWWeXbJ+ZXQIswhqE5YmJ0lJdVQTm5BZSRYaKgoJNnqUVFRckM9SuvvEIvv/yy1Mvp2bOnw8/F33t52R/PknOmKS+1fPzxxyk6OrrRdwkALbKoLBbQXNDNRSPuvPNOmjlzpsxeZ2ZmSmEuXtvCR+ucxUXVeK0xByuctt6UBx98sNEMOs90t2vXTtJv1JC20FKvPx8dTU1NlWCb18Hz2nkuaNdSvv/+e3r++eflYElsbKysSRo7dqxH245phXLwR0kJ8/PLpaqaCtIFBJLeZGjt3QNwbAzbbKQ3BuLL3j+sFdWUm1UmmSvNER5pprAIE0ahj47h6qpays4oodraxuMoPMpMYeGmk/4u2RmlVGmtafKx/f39KDYx+KQVt8FxehNRUJiVLOU2ys+vo8TEsCZvf/3110vNot9++00mI95//32natjwTDlXN+c6Rxx0c7Ygp57zZAbSywHcR3PvjjzbzLPdHGgzbnfAR+m4YNfTTz8twV98fLwU1WqIL/P1Jwq4eR33ihUrThk4G41G2Y5VH9yo54PVE+rq6uSNnNPJeS0QB7uc1jRo0KAW2wcOsmfNmmVfg8Sz2vw354IicPx4rB+TftwwzCfGKHjrGIYjBy1UUVxFRr3rBxY5zMpIK6XaujrS6fzkIGW7DmHUpp1vHDBuaWocwxlpJZSfWUbmAJ39Oj6Ok5NdRkNGtjvhfYotlXT4QBGFmZs+aFtZU0uVVbXUpXu02/fbFyW0CaXd23MpNbWYevSIIYPh6N/sWDzG+PsYd/LhPtx33303vf3222Q2n7zX97G4Ds6HH34oXWZ4jTgH3pxRyp1oON0cQIv8VPT+q8mgm1ObeYa1IZ1O12iWj9d9L1++nGbMmGG/zbJly+T6YwPuffv20a+//iopOnBinJbPmQVKobSzzz5b1tW35Oz+oUOHZAnAwYMH5R8RF/3gGXbMbjtGZe87AOCE2to6Cg0MoE5J4RTsYkHEiopqyswqpbpaG9WRjSqqaiknqxRBtw/hGe4go4E6JYVRRISZqqtr6dCRIirJrW7yPgE6f2oTE0xt2pz4M7+4uJIOpBRRbY3vLLPzNM5KMQToqLisitLSiik5uelWp9xC96WXXpJZb56tfuyxxyQj0JnvSFz4lluK8f24EPFHH30kHYCefPJJmQkHAI0H3bxmhI/MNQyutmzZIrOXXEWcU7rT09OlYBbj9du8foVTwZX0cg6uedaTexAyTj8fM2YMzZkzh8aNGyfFJbjYFxeKUAJubivFQSS/sfDMrbLem5+Xq2/D0YMVzz77LJWUlMibOmcYXHTRRS169IjXjnOGAxdO478Ppz0NHjwYfyKH0xzxUgF4gzZtQqhdu6ZTTZtSU1MnW3Z2Ka1elyYpweB7YmKCqHv3aCorq5Kg2xFms4F694494c8OHSqUoBvcK7FtCGWlFEv7sFMF3XL7xER68cUXZbklZ2/yd16lrZijTCaTrOnmauicSbh7926p18MTHddccw2+HwM0Q6svguVgeMCAAbIxXjPN53lmlXFQnZKSYr89V8bmo3ncl7B37950+eWXU7du3Rr1GeQ3C65ozW843AOcq5tz5XK+PeMgnlOUucUYV7nmlHRl4wqQUJ9RwG+8fNCDA+5evXpJATs+6NFSATdXiuc3fR4LHHBzoP3JJ58g4HaCEnNjphu8RU11LVVVHd14naon8Prphs/j6NbcddeepNf7k8mkl1N+b0DQDYw7XJxsPNfU1Lrt3wwf8AHHxcQHk7W6jgoKKyg3t8yh+/B32ocffljOc4q5UvDWWeecc47MenOGKLdi5e/cnB26cuVKnyocDOC1fbq1xlv7dG/btk2KpfHBCU5N4nVCXBn82LR+T+J19pxOzlkQHORzdgPvA9LJm3Zsb82lS/fR7rQiGjg0gUynWJMHoPYex6mHi+jIoSKuUnD09mSjxLah1LGL+2o7cPCw4a90qq50PqDX6f1p0NBESQ119ffnolUlxVVUVlpFJcWVsq42PjyQRg9v16yZbkVqqoVWrUmlgopKio0LJnOgnmKbaE0E3tGn+8DeAqq2VNOwQYn2me6flh2gQ9klTd6P14D37hRNo0e3P+lM95/r0ii7qKLJx+Evmz37xFBkdGCzfg9fsn9PPlmLqqhf9xgaPLiNw/fjauacIcrLLznrk9dsu/Jdgr/bcuDOQXdeXp78jGv5XHfddRKQ4zsZqJkFfbpBzcXS+MgmZwjweS48x8U5lCyElvLjjz9KCrmSTs6z3bx8AFyvooupbvAGHHwmRARRaIMDSOWVNVRQZHXr83DQW1tdR11PUTX4RA7llFB5eTWFnSLo5sC+orxatvKy+tOysmqpVE51RKYAHZkMOgoM0FNUTAgFBRpkHa478Ax3gN6fgvR6KsuroIyKaqk6jcrmvoVTxqMjA8mgazrpkQ8cNNUvOioqkGLCzRQW2PTSvFxLhfwbRtDtuIQ2IbQ1I5MyMkulLgP/zRxx++23S5DMATMXR+OgeeDAgeQs/tvzkkLuELNgwQJZ571x40bZuHsPZ5uef/75KGgLoIU13aAOGRkZksbN6+kZr5d/4IEHKCQkpMX2gdPJ+YisslSAj6Zy8M39IqF5VDTZAtBs/fvHy4xvTk4Z/brqsMdeUU7DvuCCLg7ffsWKQ8ddxym1DQNrPuXNaq0hnb+fVCQP0OskCI4yBZAh2ERGg45CQowUHm6ybyEhAW6bNeUAalD/BNmHvLxy2pdSSAX55Qi6fQwffDnZ7LUzQkONdN55nZu8zfbtOZS7pemZcDheUHAAhYQbqbi8io4csUiGgiN4Bpq/03HdpFWrVkntozfffJN69Ojh0svMNX2mT59OEyZMkDpJS5YskdaxvNyTtw4dOkhQz5M0fOpMyzIAX4GgG+inn36SYmllZWXyxsrB9oUXXtiirwyv2+fn5VYV/MWSK5Nz4Q6kLjUPFo8AtLy0FAulHCqSILuyslYCag6sJcA26Cg42EQB4f5kDKgPrrkiubJxcB0YaPBoWrJO508dO9YXZsrIKKGMnFIqyK+g5KbjJgBopdnug3sK6MiRIuraNcrhWgy8JJCL0P773/+WwsE8+80z3q4G3rIvCQl011130S233EI//PCDTJJwtfTDhw/LpkyacFE3JQDnU54VV9NSC4DWgKDbhxUVFckRSqXQBvc851RupQp8S/n555/lebl4W0REhJwfOnRoi+6Dt1JKNjj6YZedWUqF+Y1nI3R6P0pKDpf0U9AODqJyMktPebvQMCMlurlXs6PPfSwea9w72tnV0NaKGulpqzCZ9fWPc4q0WXfjL8OhpgCiKiKzXkcRYQYy6P3JbDJIMH00sK4PtLmoWWuLiQmkQKOeMvLLaNe2HJe/GPNr3r5jOL5YA7hZVEwgHdxXQEUllXKQrG1bx9+vjUYjvfzyy3TrrbfSzp07JVjm732nnXZas/aJJ2guu+wy2XjdLGdJcmDPLca44jlnT/L2/fff1/8OUVGSvThy5EjZwsPDm/X8AFrU+p/40OK4RdoXX3xBb7zxhhSD49lkLlLGs8tKz/OWwBUxOZ2c94XxEVFOJ4+JiWmxffAFNieLtsSEmBp9cS4trqQcUym164APSS05vL+ATP66U67XPLi/gGLjg0hv0LX4cx+Lx1quUUfx8Y6tWwwI0ElQGx1sIqo6OtILi8ulAFnPvrFOBd6VlTUSwPN9XdGjRzSFhRllpjooKICCggwSXBvc+Nq6G+9bTHQglVVUU001v4au1VbNzC+h6NhACg4xun0fAXwZfx7zbHdBZrkUrXMm6GZBQUHSZvfuu++WjkE88829t7lCuTtw4VZu08sb4wmUv//+2x6Eb9++nfLz82WChTf+ztmnTx+5/ahRoyQ1HbPg4AsQdPvYrOeaNWto7ty5dODAAbmuS5cu0haMZ7lbEq8F4urkSjr5DTfcIEdgWzLo95VZbq7u7OjcFRd3Cg0MoF49Y2Q9Kx9V33OogOrQ6UVz+G8WEmSgnt2iJQg82TrLHEuF25chOPLcx8rMLKXdB/OpttbxneG1ziOGtZMCQ0ef20a79+RRSk4p7fw7p1HgzT/jImm8ltlaXr+uuqKcA+3687Y6kiCeDxZwUSj+N+CMuLhg2bRmwABumRniciugvXvzqbCs0qm/HQA4Li4xhFIOWyg3v5yKiqzy3uds4M0VzbkzDffw5u99PPPNKefu/t7Fs+DDhg2TTZlg4cB73bp1sr6cv/dt3bpVNt4nzq7s2bMnde/e3b5hJhy8EYJuH8BfpH7//Xfp2chvsozbQChFMVo60P3ll1/kKCsfDeU3Vq6Qzq0nwHOczRht3z5cZhG5mjJoGwdTkZHmkwbdrfXcx3J1rJ2oqrJU+f4rVQLvvzdlyWwuB+aV1lry96uv3M2BtRJgB5mNZAgxy7prs1lvn6lOTGy5QpKtidPcOzQjk+XQoSK37g8ANMafx9ExgWQpq6LDh4ukmKSzAgIC6Pnnn6d58+bRhx9+KBt/J+R139wpxlP4eTmTkbdp06ZRVlaWfCflbf369fZUdP5uqOBCbBx88/pzJRBHUV3QOgTdXozbfq1cuVKCbT6yyEwmk6zB4VTylu4tzkc7//vf/9Lnn38ul7m4BqeTx8bGtuh++Apl0qqpySuuolxdXetQ2q2lQVsmrqjq7CwguPdAWmlJlczcNvXvX4uqqmuptLSK/Ky641IOa6rriBwYdxzoDx/WTgLvfIuVdORPYcFmMoT5k8HgLwF1fWBtaJQKzu14HC1SBCd+P1Hw6xjsxorrvo4zMThLozmqKmscznryFC4s2PCz5FR4/PA4wr9LooS2obRjSzalplmoZ88YCcSdxandd955J/Xu3ZueeOIJaf01adIkCbz79+9PLYHb0XKrMd548oVnwXkduLJxYd3s7GzZfvvtN/v9eF14w9lw3l+uAwSgFQi6vRQfPXzxxRfp4MGD9nSfK664Qt5cW+NNKi0tTaqT8xsq43RyPuKJdPLWw8Wudv+d0yh45lZFx+LU3KK8CtmEjchg1tGAwS1bcA+OOrivkHIzS0/5RZR/qqWYRxlr5YXVVFXLhdiO3/nQUL1DgRwH3qNHtaesrFIpAshBNQfXRuPxwTw0n1Gvo9SDR2e8a+tslNA2hDp0wpfi5srKKJHq1e440BkR1Dpr7vmfnJ7/fedXkOWYYp2nOsAYFmmm7r1R64WLXpoC9VRcXk0pKRbq3Nn12emzzjqLOnXqRPfeey8dOnSIbrrpJrr66qul4JrZ7Fh2kjvwd9MhQ4bIpuBOOjxRtGvXLnsgzpXReV34n3/+KZtyAIEnb/h3OeOMMzCBA6qHoNtL8ZdKDriDg4PpqquukjdTLnbR0mpqaqSnI/eHrKiokH3gdPIRI0a0+L74mkbrM08QZPCa1mCzgdrFBDeqTB4VZbYfQef02vz8cvtaTZ5ZLS6tpCN5zlemBvfhNcgxYWaKCTc3+UWcA82wMOfW/rUWZaxxX+u6ugry9zefMDjmoDk6OtChx+Qq4byBZyUnN05N5+yZnMIKKUoHzZeVUUpxEYEUaq4/cNQc/H7RGssm6v99V8i/b0fV1tZRgcVKBRVVHt03LUlsG0ppB4okxbxTp4hmHUDkAmbvv/++TNB8++23tHDhQplZfvTRR6XSeGvh9eccTPOmsFqttG/fPnsQvmPHDtq/f7/M1PM2a9YsKc42duxYKRDHs+kAaoOg20vxGya/cfIbUEhI66xL5OqVnLLEb5SM1/NwOzCkk7e8pj6XufDTwIEJJ50tHDOmg/1yWVkV/bSsvggftD5OMXS2kq1aKWONDxZxCxo+QIcZaW1ITo6QTcEVlnPWprXqPnmT8AgTleZVUNfkCBo8uA1pEddZGD26vVP3yckpo19XHfbYPmkRdwjg9mGFxVbKzi47YU0LZ2eaH3vsMQlUeblfenq6ZCH+3//9H11//fWtMllzIrw0koNq3hS8DvzXX3+l5cuXy/fNbdu2yca9yC+55BJZRslrwwHUAosyvRR/WeU3ndYIuLkN2bPPPktTp06VgJvXjs+cOVNalCHgbjk80e1qNWIAAFCHmLggKq6ooazsUodqcID34iU48YnBVFRWKbPd7sLZh1xvh2v+sC+//FKWAXJAq9bvEVz1nJdMvvvuu/TDDz/QfffdJ7Pj3BaX9//SSy+l2bNnS1o6gBpgphvcht+Y+Y3v5ZdfpsLCQrnu4osvpjvuuAPtH1pBww9KzBiq15GDRVSQX+7UfazlNWQKa7l1d6dKAd2zI0+K7SnkvG8U/gZwOy40Vl5aJcG23qCTwpUms45KK6pldtPV7BaLxSodC5xt7caZUh07RlCbNvXPy+uJ3RXwtWkTQp06ea5ytjfint0bU0ukXgVnnzV3yUHDtG5uJcaz3rwMkAuacS0ebinLxdf69etHahUTEyN1i3jbsmULvf7669InnJc3fvXVV3TllVeqauYefBOCbnCLI0eOSCr5hg0b5HJycrK8eXNKObQedR6fhoZSDhdR26ggaWXlMGOAvb1Vayu2VFKppZLiGhwEiDQGSCsuNewfgJZUV9XSjq3ZZDbo6dCBQopPDKHo2CBpd6cP9CedzvU1vGlpxXQwpYiKG/S1d4TRUJ8UqQTd+/cX0P60Iqp2Yn32iXAhyPLyagTdTjKZDRQeZSJLRX37sF693NsB5rTTTqNPPvlEavF88cUXkrrNqdpnnnkm3XzzzdSlSxdSM65qzvvOBYXnz58vKecffPABfffdd5JKP3LkyNbeRfBR+EYEzVJZWUnvvfeeFOOorq4mo9EoVTA55cdgMODVbUWnqKMGKmIO0NPg0xKln7QzvZVDQ42qGGc6Pz+KiQyk3r2PfvlTWnABgOPSU4spKMBAbaKCqLKqhgoKrJSRVkzhgUaKjw1q1hpe/rdaXVtHwRFGinHwccpKKiknrfS41pPW6lpKbB9KgS7OsnL7skN7C1Wbuqx2CW1Cad+OXDpypIi6dYt2ewtPrmDO6eX8Xe6tt96ib775RtZP8zZ06FC69tpr5VStWXS8X1wRffDgwVLt/JVXXpHiwjxjz7PefMr9wwFaEoJucNmaNWvohRdekHZgypogTkXidTagDsr3GbV+MMJRMTFBLvVdVQv+0hcbG9TauwEqkptTRuaDBtIb/GV8yGbwlwr0AUY9ei8fgyt7Z6aXULvIIBo0KEFeL55VzswuJZ2/H/XtG+eW93KjSU+RUc4sTzlxt4qQUCOFhbvWHaGi3LnZdmgsItJEOoOOLGVVksHQoUPjDgLuTNt+5JFH6JprrpHge8WKFbR27VrZOnfuLOncnI7eWgV7T4X/vZx++ukSgM+bN09m8D/77DPJyuSK5+3bO1fcD6A5EHSD0/Ly8uill16in3/+2f6mzL0eOfUIwZ16eHIGgR87O1M7bcNMZr3LXw7d/boV5ldQdXXz0jLdLTe7jHQuzpSUlaKdDzTGGRvmAB3FhJil6jb37OZ2g7U2m5yvqeXTOjnIFGDUSctCOTXpJSDnYM4caPCpFoDZmWWUn1dOJr2OoiLMMqPNn6d8MK6kpFIOoDqb2cLrfQsKjvbELm3Gv9WqqlpKTbXIeWfafp0KjwvlcRmPhZiYQHyXOAUeG4ltQyjzSDHt2pUr44WznzylY8eO9Pzzz0vFcA5cv/76a2nZxUVzuVgZ98keP368zH5z/2y14Vntu+++m4YPH06PP/44HThwgKZMmSITRw17hAN4EoJucFhdXR0tXryYXnvtNSorK5M3Vu4Bzu0luO0E+MYHvT/5UaBBT5mHjn5RUrvyyhoaMDSx1b/I5+WU04Hd+WRqkEYeYjJI+n9rJCPw3zPYZKCc1JJmPY4Zs5ZwTE/mIae1kfW6XG2bDzIppxy8VVRUy3pgLsJXU2eTlOeakhqyFlVSda2NrNU1NGh4W01nfjhj57Zc0tUShXMf7lC9tAJseADb1V7zf/6ZSrlFR4NuVllTR8H+jr/Z8E1r6uoou6CcsteUNwqWeU22q/z8/eQgZFFZFa1ak2q/3mzQ0ekjk5A144D4NiGUk11G2QUVtHlzJg0b1tbjBys4k5GDV17bzSnnS5YskbRtnoThjTvUXHjhhRKAq3EWmTMyubjaPffcI2vVb7/9dsnQ5BZpAJ6GoBscwgUpeE3Mrl275HLPnj3p4Ycfpm7duuEVVCmZ6La5N7U8MNBA3btHU4LFSlqRn19B+zMt8oXfrIIiSYFGPXWID6WwMGOjHtXOrOd2F16DHZPd/IwFHmOeSm8E7eFgLCmp6SrBHHxbrTUSgNef1p/nVNm0/DLKyy6jxHbe0YP+VCqtNdQ+Kpj69Y2TYmXumrHkLgJZheUUGm60B8jm0ACKjXd8GUhouImiYoPI2qA7AYtJCKbgENfXxPLvmJgU2ihTpqS4imJCTI06IcDJ8d+0W89o2rw+g1IzSijmQCF17twyleA5nZzXe3Pa+e7du+nbb7+lH3/8kXJycmjBggWy9e7d257azd8Z9Xp1hByRkZHSwpYrtHPHHZ6tT01NlXXeAJ6kjn8BoFp8JJBbLyhVyYODg+XIIB8VVGMKERzP3Qe+OejWkhUrDpHaREcH0sCBCa29GxIoI1iG1iCp5QG641Kmw8JMVLwhXdaD+0rQzS28uHuBOwPuhrr1inE5a4ADu87do8gTOnSKaHSZq7aj5YZzOHurY5dIOrK/kHbuypXUfP431FL4gGuPHj1kmzFjBv3xxx8yA7569Wravn27bBzgcjYk99Dmwma8cQX01vwOyenmTz75JHXo0EEqnH/44YfUp08fGjt2bKvtE3g/BN1wQjt37pQ3Sn7jZFyJnAPtqVOnUlSUZz6Awb04dQ91YQFAa6npQUY9ZWWVywy4J9epqgGvj+b3ao4/DP+05gJwBreVK8iroOyictq0KZNGj25POp1/qwSyHLTyxrV/Vq5cKVmSPGljsVikijhvLDQ0VFqTcQDOM+FJSUktvo6fn49boVmtVunCw4XVeH/UWhQOtM+7P83A6TXbv/32Gy1cuJA2b94s1/GRyEsuuUTemOLj4/GKaiy9nMNuXnu35reU435eZ7PJemJfsX1LFvnRyT/UOQWzV7+4ZqWOb9ucJf10T8bXXnMAZ3GQHRsTRNlFFVLgr137ptPUtY7XtXPLPQ4Afv75QKOCYrxGl5f0+Jq//86m7dtzjmtTBifXpXuUpJln5pbRzp251KeP659l7hAdHU0TJ06Ujb9bctE1DsB527RpExUXF0sldN6UgrzKLDhvLfl9k9vcLl++nFJSUqTC+UMPPdRizw2+BUE3UHl5uazH4WA7PT1dXhGdTkfnn38+/etf/6J27drhVdIgrgIcZDZQp/iTp2hyUTQ19Hr2JP792kUFywGIphzMLpbA2eBiGmZJSRXVVduofUzT/W994TUHaI42bULoSJqF8nK8P+jmWg46gz/tzyxudH18uJny88spMNC7f/+GgoIDKCOlmHIaFH/jLICYBLQiPBX+3OrSI5p2/Z1LpgMFUoguLs71nu7uxJM3Xbt2lY3XgdfU1Eg2Jc+Ar1u3TpYx5ubm0tKlS2Vj/L1z9OjRUhW9X79+Hk1F5xl6bovGxeG+/PJL+e47cOBAjz0f+C4/myf7Cnk5PlIXFhYmaTOcKqM12dnZ0q+Q32RKS+uLKfHvwUcmL7/8cjnyCNrC/5x5PPK45JkTnkXhFM2m1uuZzQavf024ivKp1n3vzbDQkJFtXQ66C/Ir6NCufOrVMYoGD0706dfcnWMYfA8XWfvxp/20P8Oiiq4DrozhGmsZ6U1BDo1hfp+uqjyaIbNvdz4F+eto9PB21K6d60H3t9/ukfe1wSO1UwmeP69sdUe/lvLLZ8L7pcMO7iugopxy6pgQSmeemSwZE2p/H66srJTAW5kJ37Fjh8yOKyIiIqQlLfcE597gnvLMM8/QV199JanuXOGcg3HQNovFQuHh4aqJ0zDT7aP4DY17FPLRRcZvMlyFcty4cWQ2t3aNZ3AXXtcVFOTbHxz8haElXwMOqn39NQdoDg4Q42KDpPI2p5gnJYd7/fu0OfDoTJ5O5+ezBcW8fQ2/p3Fxui2FVsourKAtW7Jo6NC2pHZGo9GeVs64Je3atWtlTTgXZissLJTJId54/Td/V+XWX+6e/b7jjjto1apVkmb+9ttv0/Tp0936+AB4d/NR/GZ16aWXytptTvcZOXIkqpEDOMFaUU05WWWyZr7+MtrcALizoNrBlCKfCLoB3N1GbOuGTEpNL6a4w0Wa61ARFBRkL8jGqei8BpwDbl7/zenovHXv3l36hXNFdHfhAmr3338/3XffffT+++/Tueee69GZdfA9KJXpw7h4BFcoHzVqFAJuACcdPlBE+ZllVJ5vla2uvIZCzQbS6/G2CtBc8fHBFGI2SGHChr2cAeDUa+Pbd4qgjMJy2r4jh8rKtPvvh3t78+z2888/T0uWLKFrr71W2o9xb3D+DssVx6uq3Pf7caDP68hra2ulj3fDNHeA5sK3Qx+GPtsAruN1mKGBAdSzczQN6Z8o28C+8dSrF2ohALijwBgXggo162W2GwAcl9g2hMzBBsoprG8jpmRkaVlCQgLdeeed9PXXX9OECRPkus8//1yWSh4+fNhtz8Mz3TzbzmvLeW03gLsg6AYAaIa2bUOpd+9Y2Xr1iqWwMBNeTwA3aNMmlELMAZSTXdZkQUgAOL6WSdee0WSxVlNGdint25fvNS9RZGQkPfzww/TKK69IkbW9e/fS5MmTZSbcHbWhY2NjJbhnr776Ku3bt88New2AoBsAoFHVZEc3b5g5AFCzuLggCg0KoECdjjb9lU779+RTZSWCbwBHcOXyTt0iKbOwnHbvzqPCwqOt2LwBF1P75JNPJP3carVKOji3/qqoaP7vyTPpp59+uqSuc99udzwmAAqpAQD8MzOwZX2mU69FUEQgXjsAD1b1HjGiHe3cmUuZ2aVUUGSljWvSKTYhmNp1CHO5HZIjlDZe9lZefvXvEVwwWWmhxKd8Vi7+c95fLtiottZGfrV1soyr/jZofwctLzYumArzKiirqII2b86iUaOSZOmGt4iOjpbZ6A8//JBef/11+umnn+jQoUM0e/ZsSkw8eevOU+F/r4899hhdffXV8ngvvfSSzK4DNAf6dPtwn27wPuhx7Jr169MpK6u+V70z+Ev/yJHt0CLMjTCG4UTy88tpz558ysoupfxSKxVXVFNCmxBqkxTqdPDNY4yzVbhIW6W1RmbPObjmDgR8nq+vrq4lvb8/6bl9l4TR9f+z/dPLi/8vmaxynXKBqK7+JxSgq6HKGt6vo8F2wyC9/nzjoL0+YOeMmxqKCwt0W59uk1lPhgDd8am3TVxUbqvsI1fFbrj5HXP5RNf5+RPp+KADX+bf099P2qHxgQid3o90fL3OX27b3AMkNTV1VFNdf8pZSMfum7+u/vmUffSlgyA11bW0aX0mRZgCqFNSOA0b1vaUr7kW34e5Gw+vx+YWY9yb+YUXXqBBgwY16zG5bzi3DuPX47nnnqNzzjnHbfsLvtenG0F3MyDoBrXR4gclQEMYw9CUvDwOvvMoK6eM8kusVGKtJnOgQYI57hzAwYRO7y+z5HwdbzzrXB9c19qDan53NOj8yaD3Iz2f+utIr/eT6/T+9Y9l0OukbzS/lXIMysGcEozWn68fr8ef8m0qyWYLkGDaHuv+E6ArgTsptz/6Y/tteD9Gj0qiqCjXs2mWLTtAeUUV9Q/YxMfBiT4rGl5Tp/xu//zefIFrOtt/X+V6stE/P7Zfr7wucnt+zZTb1Nmo9p8XRgmMGwbkfFn5e3Jgzj/j5+DAmg+I1HKQXcPn64NsnWQh/BNY+/n9s8/K36R+P/iAiPK34NsaDP7Sji4+MYS8XWlJJW3blE3xYWbq0jGSBg1KaPI7glbfh7Oysuiee+6R6uY8lmbMmCGz1c35HXgG/d1335Wq6Tyj3r59e7fuM3gOgm4vgqAb1EarH5QACoxhcERubpnMfOfklVE1z25yUNUgMOZOP3W2+ut5BlkCaw6oOZjmGWy9vwTUZjNvhhOeupqGy22GioosFBJSP7NybFCu1INoKnAPCNBRSIixWYOhvLyaioqscv7Yj4MTBtp+x/9c2V9l4wMY9ad1J7y+qZ8p1/NlDpjlsfl3lr/VP+dtR883+nvaOHW/fuacU/x1fv6k86/vwqKcchDNfzPlQMuxz6kcEFEODPC4ySgqo8iYQOrUNVIO1HizooIK2vl3LrWJDKQeXaOpb984r3wf5vXdTz/9NP34449yefTo0ZIqzr+LK7h92K233ir9wjt27EgLFiyQABzUz4KZbu+BoBvURssflAAMYxicUVxcKbPXkl7cYFMCO96ODbADAw1kNOo89h6JMewYJShW/lZKmjhfbnhe+RkHxUpgzQcllPPKqSN/l4bBeGpqMe3alSv9rMngRz16x5DJbCBvlpdTRnt35FFSTDD16RVL3bpFe+UY5v1ftGgRvfzyy1RdXS0VyTkQHzhwoEuPl5+fT5MmTaK8vDw699xz6ZlnntHk6+JrLAi6vQeCblAbrX9QAmAMg9ZhDGtrucKGDemUmV9ORRVV1K1XDEVGmcmbZaaX0OH9hdQ+OpgG9I+n5OQIrx3D3E7sgQceoJSUFMmGuOmmm+jGG2+U887aunUr3XzzzTLzzSnsV111lUf2Gbw36PbuXBoAAAAAgBOIjg6kMWM6UOekcFnvvPvvHFn/7M2UAoSp+aW0eWsWpacXk7fq2rUrffTRR3TRRRfJso8333xTUsVzc3Odfqx+/frJGnHGM+gchAM4A0E3AAAAAPgkXnIwcmQStW8TRsFmAxUV1q+D92ZcQC46PpjS88tow4YMys52vnuHVvD668cff5yefPJJMpvNtHHjRrr++utlFtxZPLvN6eU8233//fdL2jmAoxB0AwAAAIDP4mrmUVFmCtDryFpe06z2XJYia6OtrLSK1KhjlwgKjTJTWn4ZrV2XLm35vNmFF15IH3/8sRRDy8nJoX/961/0119/OfUYnGr/yCOPyGPw+u4HH3xQAnAARyDoBgAAAACfFhQUQAF6f6qoqHb5MbZsyKI9f+fSnm1Ht60bsig7U30zyRxAdukeRaZQg8x4/7U2jSwW757lT0pKorffflv6d5eXl9Odd95J33//vdMz5y+++KKcckXzV1991WP7C94FQTcAAAAA+LSgIMM/QbfrM90csHNl8F4dIql3chR1bRNO4UEBVFHueiDv6Rn+7r1iSGfSUVpuGa1Zk0qlKp2ZdxcuqDVv3jw6//zzZZaa087379/v1GNwr25OWWfcu3vFihUe2lvwJgi6AQAAAIB8faab+7lXWmukpVhznH56Eo0dm0xt27Z+xeRT4VZsPfvGUp2eJPD+66+0Zs32a0FAQAA99dRTdMYZZ0jgzS3AuNCaM8aOHUvXXnutnOcAPD093UN7C94CQTcAAAAA+DTu/W0y6smg8ydrM2a7tYh72ffuF0eVtjpKyS6RwLu62rvXKnN6/X333Sdp4tu2baOvvvrK6ce4/fbbqX///pKq/tlnn3lkP8F7IOgGAAAAAJ8XGGggg96xoNtqraHtW7Jp8/oM+6ZlhgAd9eofR6XVNZSaXUJbt2ZRWZl3p5rHxsZK4Mw45ZyLozlDp9PRlClT5PzSpUuputq7MwSgeRB0AwAAAIDPCw52vJhaYV45VZdXU6QxwL4lRQeTMUBHBoNOk6+lyaSnPv3jyGKtorScUvr99yNUUFBB3mzixInUs2dPKi0tpTlz5jh9/+HDh1NUVBQVFRXR6tWrPbKP4B0QdAMAAACAz5OZbp1jbcNsNiKdvz+1TQihM0d3OLqdmSwFyrTKHGigvoMSqMaf6HB2Cf3xZwqlpRWTt/L395c2YHy6bNky+vPPP52e7R43bpyc//bbbz20l+ANEHQDAAAAgM9zZqa74exwbGyQfePLWmc06qlLtygyhRjoSE4JrduQTrt355GNjzR4oa5du9I111wj559//nmqqHBudv+iiy6S099//50KCgo8so+gfQi6AQAAAMDnKW3Dysuqpbd2U1tJcaVXv148W9+tVwzFJAbTkdxS2rYjhzZuzGx2ZXe1uvnmmyk+Pp4yMzPpf//7n1P37dixo6SocyX0H3/80WP7CNqGoBsAAAAAfJ7SNszo70+ZhyxNbhWWKjIZdFIF+6Rfsv39yJ/8yFJk1WSwyr9bh04R1KlbJKXml9GegwW0enWqFJHzNlzF/P7775fzH330kdO9u8ePHy+n3333nUf2D7RP+zkwAAAAAABuaBvWp3csJeSVO3R7Dqo7dow46c+5T/ehw4WUklNKO//OkX7Y3Bdba2Ljg8lo0tOubblUXVMnQffQoW0pNNRI3mTUqFHSu3vlypUSeHP/bUedd9559NJLL9HevXtpz5491K1bN4/uK2gPgm4AAAAAACLq1ClSNnfgoHT4sHZEf6VK4L36txQaPjpJ+mJrTVi4ifoNipeDB4cyi6ny9yM0+LREiosLJm/CLcA46P7555/prrvuorCwMIfuFxoaKgE7F2PjgmoIuuFY2vtXDwAAAACgAZGRZurZI4aiQ00UbNLTnp25mi1IxpXNOfD2M/rTkewS+uuvNDp4sJC8Sa9evah79+5UVVVFS5YscSnF/IcffkDPbjgOgm4AAAAAAA9p3z6cunSMpISIICovrqYjB4vsP+Pza1al0JrfGmyrUigtxaLKv4feoKNe/eIoNNpEh3NLaPOWTNq2LVuzBxJOtI798ssvl/OLFy+mujrH1+IPHTqUoqOjyWKx0B9//OHBvQQtQtANAAAAAOCpL9v+ftS/f7ykY7eJDKTM1BLKzS6jQ/sLKCutmNpFBlH7mGD7Fhdqlp+r+ffp0j2a2nQIk8rmO/fk0fr1GZosFney9dkhISGUkZFBf/31l8P3Q89uaAqCbgAAAAAAD2vTJpS6d42mxMhA2rsrj3IySqlddDAN7J9A553TSbbTBiaSzv/kFdHVpG1SGHXrHUMZhWW0/3AhrVuX7hWBt8lksqeKL1q0yKWe3TzTvW7dOo/sH2gTgm4AAAAAgBbQo0c0tW8bRvHhgfaAmyugc7sy3kwmbdU4jooJpJ594yjbUkEHUy2yzrumRvuB98SJE+3BM894Oyo5OZnGjRsnaen33XcfHTp0yIN7CVqCoBsAAAAAoIXWDA8alEB9e8TQsCFtqUOH8BPerqqylg4fKLRv2Zmlqv37hEWYqFf/OMqxVNChtPrAu7q6lrQsKSlJ1mjzWvUvvvjCqfs+/PDD1LdvXyotLaUZM2ZQUdHRNfzguxB0AwAAAAC0EINBR336xFFiYshxP+N2YnqdP4UE6Kk832rfDuwpoLLSKtX+jULDjNR7QBzlllgl8F6zJo2qqrQdeCsF1biKOVczd1RAQADNmTOHEhMTKT09ne6++26n7g/eCUE3AAAAAIAKRESYqH/fOBrSP9G+JUYHk17np/q07ZBQI/UdGE/5ZZV0OJ0D71SqrKwhrRo1ahTFxsbKTPUvv/zi1H0jIiJo7ty5FBwcTFu3bqWnn37aayq8g2sQdAMAAAAAqCT9vFOnSOrdO9a+BQToSCuCggOoz4A4KqyoosMZxbR6dSpZrdoMvLka+WWXXSbn33vvPaqtdW7mntd3z5o1i/z9/Wnp0qX0/fffe2hPQQsQdAMAAAAAqFxtTZ2kbPNWo+I10xx484y3xVpFRzJKJPCuqKgmLbriiisoNDRUCqJxmrmzhgwZQtOmTZPzHICnpaV5YC9BCxB0AwAAAAComL+fH+3alkvr/0yT7a8/UikjtZjUyhxokMC7pKaaDmfWz3iXl2sv8OZ+3TfffLOcf+ONN6iszPn+6VOmTKGBAwdSeXk5vfLKKx7YS9ACBN0AAAAAACoVHx9M7WOCqWtimH2LCwukYkslqZnJbKA+A+KpvKaWjmQW059/plBZmfYKinGKOVczLygooPfff9/p+3N6+QMPPCDnV6xYQQcPHvTAXoLaIegGAAAAAFCpnj1jaPz4bvaN13lrBfcd7zMwjizWakrJLqGNGzNJawwGA91xxx1y/qOPPqLs7GynH6Njx440duxYOb9gwQK37yOoH4JuAAAAAABwO2tFNe3ZkUc6Pz8KDQygsDCjJl/lMWPG0IABA6T111tvveXSY1x33XX22W6r1ermPQS1Q9ANAAAAAKAxxRYr7d6ea9/UtsY7M72ENq3LIH0tUcf4UBoyKJH69YsnrVaVv/322+X8Dz/8QMXFzr/WvXr1kt7dHHCvXr3aA3sJaoagGwAAAABAI7iFWGCAjiLMRtJV2ezbwf0Fqqhqzr25t2/JptQDRdQ2Mpi6J0fS2DOTqX37cNKyvn37UteuXWW225X2Xxy4jx49Ws5v2rTJA3sIaoagGwAAAABAIxISQmjY0LZ0eoMtPCiA/MiP6mytu285WaW0aW0G+VXVUXJ8CJ02IIGGD29LgYEG0joOmpW+3V988QXZbM6/2NHR0XLKlczBtyDoBgAAAADQCH9/P2rTJpSSkyPsW2vj3uE7/86hQ3sLKDE8kLq2j6Azz0imjh0jJFj1FhdccAEFBgbS4cOHaceOHU7f32w2y2lFRYUH9g7UTN/aOwAAAAAAAM1XWlxJOn39nJpe709BwQEef1lzs8vowN4CCg7QU3JcKPXoHk2dO0d6VbCt4ICbZ6tTUlKosrLS5aAbM92+B0E3AAAAAIDGGQ062r8r3365ptZGnbpFUlxCsEeer7qqlg7uK6DCvAqKjwikhJggGjAggUJDtVmh3BF1dXWUmVnf9oyLojkLM92+C0E3AAAAAICGdeoUSUFBAY3SvTPyy6iivNojz1eQV077dueTWa+j5LgQ6tY1mrp2jZLUd2+Wl5dH1dXV5O/vT7GxzvdLR9DtuxB0AwAAAABoWM+eMbIptm/PkaDb3bg6+sH9hZSfU07xYWaK/2d2OzzcRL4gPT1dTuPj40mn07mUns6wptv3IOgGAAAAAIAmFRZUyOy20c+fkmNCqEuXSOrePZp0Ot+py5yRkSGnbdq0cen+JlP9wQkE3b4HQTcAAAAAgBfKziyVYNlRXPwsNjaQYmJ0jVLVUw4WUU5WGcWFmyk+KlBmtyMj64uC+RJOL2dxcXEu3R/p5b4LQTcAAAAAgBcxm/UUFhhAQUbnvk31WgEAACaASURBVOrX2WyUcriIaquNFJ1opPSUYgncQ0wG6hAbTF06RVKPHjFSGd0XlZSUyGlISIhL9zca64vMWa1Wt+4XqB+CbgAAAAAAL8L9sSMizFRTU+fU/QoLK2jHzhzKyi6klFQrhZkDJJU8NiZIUsmjo+vXJPuq0tLSZgXden196FVbW+vW/QL1Q9ANAAAAAOBFOE3clfTv2Ngg0un8iLZzD2ojJcaHytrtqCjfDrYVXLW8YfDdnKDbZrN5ZS9zOLFWzw1ZtWoVjR8/Xnrd8cD7+uuvT3mfjz/+mPr16ycVABMSEmjq1KmUn3+0LyFbtGgRde/eXQoW9OnTh5YuXdro519++SWde+65FBUVJc+7ZcsWt/9uAAAAAABaaz82aEACjT0jmYYNa4uAu4G+ffvKqatxgxJ0M8x2+5ZWD7rLysokgH7ttdccuv2ff/5J1113Hd144420Y8cOCa7XrVtHN910k/02q1evpquvvlpus3nzZrr00ktl2759e6PnPf300+mFF17wyO8FAAAAAKBFYWEm2aCxAQMGyOnu3bupvLzc6ZcHQbfvavX08gsuuEA2R61Zs4Y6dOhAd9xxh1xOTk6mW265pVHwPHfuXDr//PPp3nvvlctPPfUULVu2jF599VV644035Lprr71WTg8fPuzwc1dWVsqmKC4ullNOD+ENoLUpYxHjEbQKYxi0DmMYtA5j+ORiY2MlO5dbh23dupWGDRvm1GvbsLd3dXU1BQQENOMvBU1R23fhVg+6nTV8+HB66KGHJF2cg/WcnBxavHgxXXjhhY0C8//85z+N7nfeeec5lLrelOeee46eeOKJ4663WCyq+8OCb+JxqKwzwjoh0CKMYdA6jGHQOozhpvXo0YNSU1Ml+5bPO4NTypW0cl4aW1NT04y/FDSF4zM10VzQPXLkSFnTfeWVV0q5fR6svCa8YXp6VlbWcf3z+DJf3xwPPvhgo2CeZ7rbtWtHYWFhFBoa2qzHBnAH5eAPj0kE3aBFGMOgdRjDoHUYw6eeAFy+fDnt2bNHvm85+9oqs93BwcFO3x+0S3NB986dO+nOO++kmTNnyux1ZmampJFPmzaN3nnnHY8+N/fWU/rrNcTBDQIcUAtlPGJMglZhDIPWYQyD1mEMn9zAgQPllGtLOZsizq8rB93KjDe+q3mO2l5bzQXdnOLNs93Kem2uIhgUFESjRo2ip59+WqqZx8fHU3Z2dqP78WW+HgAAAAAAwBWc5RoZGUkFBQUSeCvF1ZwppsYBN1LLfUurVy93FlcKVHrkKZQ0DSUdRkn7aIgLqfH1AAAAAAAArs6gKrPd3CXJ1QrmCLp9S6vPdHPRp/3799svHzp0SHrf8RGkpKQkWUednp5OH3zwgfyc129ze7D58+fb08tnzJhBQ4YMkWqCjNPPx4wZQ3PmzKFx48bRp59+Shs2bKC33nrL/jx8dColJUWqDzJel8F4Nhwz4gAAAAAAcCJ9+vShX375xR4/OEOZLETQ7Vtafaabg2FOy1BSM7hQGZ/nNduMg2oOjhVTpkyhl156Sdp/9e7dmy6//HLq1q0bffnll/bbjBgxghYuXChBNvcA5+rmXLmcb6/45ptv5Hk4KGdXXXWVXFZaigEAAAAAAByrU6dOcnrgwAGnXxzMdPsmPxt6XbmMq5dz1UEuSY/q5aAG/M+ZxyOql4NWYQyD1mEMg9ZhDJ8atyzmdsW85PWPP/5wqpga34/vz1m8PXv2bNbfCk6Ovw+Hh4erJk5r9ZluAAAAAAAArYiJiZGWX3V1dXTkyBGn7qsE6Fz5HHwHgm4AAAAAAAAniqkpKeYHDx506nUzmUxyarVa8Xr7EATdAAAAAAAAToiLi5PT3Nxcl4LuyspKvN4+BEE3AAAAAACAE/Ly8uQ0NjbWqdfNaDTKaUVFBV5vH4KgGwAAAAAAwAncYYk522qYi92ywsJCvN4+BEE3AAAAAACAg7iAWnZ2tktBd2JiopxmZGTg9fYhCLoBAAAAAACcSC3nwFun01F0dLRLQbezVc9B2xB0AwAAAAAAOKi0tFROuW0Y9+p2Rv/+/eV03bp10kMafAOCbgAAAAAAACd7bVdVVTn9mnXt2pW6desmfbp//PFHvOY+AkE3AAAAAACAkxXIue2XzWZz+nW7+OKL5XTJkiV4zX0Egm4AAAAAAAAHhYaGymw3r+tevXq106/b+eefTwaDgfbu3Utbt27F6+4DEHQDAAAAAAA4MdN95ZVXyvm5c+dSbW2t023Dxo4dK+dvu+02+v777/HaezkE3QAAAAAAAE644YYbZMb74MGD9N133zn92t1zzz00ZMgQslqt9Nhjj9FLL73kUqo6aAOCbgAAAAAAACdwwP2vf/1Lzs+fP58qKiqcev0iIiLo1VdfpVtuuUUuL1y4kF544QX8DbwUgm4AAAAAAAAnTZw4Ufpuc9/ujz/+2PlAzN+fbrrpJpnp5vOLFy+mw4cP4+/ghRB0AwAAAAAAOImLqd1+++1y/oMPPqCCggKXXsPx48dT37595fzOnTvxd/BCCLoBAAAAAABccM4551DPnj2pvLyc3nrrLZdfQ+7dzXbv3o2/gxdC0A0AAAAAAOACPz8/uuOOO+Q8VyGvqalx6XXs3r27nO7Zswd/By+EoBsAAAAAAMBFAwcOlMJqXExt165dzZrp5qAbVcy9D4JuAAAAAAAAVwMqf38aNGiQnN+4caNLj9GxY0cyGAxUWlpKGRkZ+Ft4GQTdAAAAAAAAzdDcoFuv11Pnzp3lPNZ1ex8E3QAAAAAAAG4Iurds2eLyuu6GKebgXRB0AwAAAAAANEOnTp0oPDxc1nWvWrWqWcXUMNPtfRB0AwAAAAAANCeo8veniRMnyvk33niD6urqXA66t23bRlarFX8PL4KgGwAAAAAAoJkmTZpEISEhdPDgQfr555+dvn+PHj0oMTGRSkpK6JtvvsHfw4sg6AYAAAAAAGgmDrivvfZaOf/WW29RbW2tU/fX6XR03XXXyfkPP/zQ5bXhoD4IugEAAAAAANzgqquuorCwMEpJSaHvv//e6fuPHz+eIiMjKTMz06XZclAnBN0AAAAAAABuEBgYSFOmTJHzb7/9NlVXVzt1f6PRSFdffbWcX7hwIdlsNvxdvACCbgAAAAAAADe5/PLLKSoqijIyMlxamz1hwgQKCAiQKuY7duzA38ULIOgGAAAAAABwE5PJRFOnTpXz77zzDlVWVjp1f249ds4558j5RYsW4e/iBRB0AwAAAAAAuBHPVsfFxVFOTo6kmTvriiuukNNly5ZRUVER/jYah6AbAAAAAADAjTg9/L777pPz77//Pu3atcup+/fq1Yt69uxJVVVVaB/mBRB0AwAAAAAAuNmYMWPo3HPPpbq6OnryySedLqo2ceJEOV28eLE8BmgXgm4AAAAAAAAPuPfee2WN9r59+2jBggVO3fe8886j0NBQKcj2559/4u+jYQi6AQAAAAAAPCAiIsKeZs5F1fbv3+9U+7BLLrnEnqKO9mHahaAbAAAAAADAQ7gS+RlnnEE1NTWSZl5bW+vwfblnN68P37JlC61evRp/I41C0A0AAAAAAOAhfn5+9MADD1BISAjt3LmTPv74Y4fvGxsbS1dddZWcf+2117C2W6MQdAMAAAAAAHhQdHQ03X333XL+jTfeoCNHjjh83+uvv56CgoJo79699N///ldS1JFqri0IugEAAAAAADxs3LhxNGLECGkD9sQTTzg8ax0WFkZTpkyR8wsXLpSZ74svvphmzZpFv/76K+Xn53t4z6G5/Gw4TOKy4uJi+UdgsViksiBAa+N/zjweeVxyKhOA1mAMg9ZhDIPWYQx7VlZWFl1xxRVUXl5O99xzjz11/FQ4QF+6dCktX76c1q5dK4F7Q4mJidSvXz/q27cvjRw5Ui77MovFIlXj1RKnIehuBgTdoDb4oAStwxgGrcMYBq3DGPa8L7/8kp599lkymUz02WefUZs2bZy6v9VqpXXr1kkbsa1bt9KBAweOSzfv0qWL9AmfMGECxcXFka+xIOj2Hgi6QW3wQQlahzEMWocxDFqHMex5PGs9ffp02rBhA5122mk0f/78ZmUolpaW0o4dO+jvv/+m9evXS6VzJXU9MjJSHr9Tp07kSywqC7qxphsAAAAAAKClAjB/f3rkkUdkppsD76+++qpZjxccHExDhw6lm266id566y1atmyZrBnnQLugoIBuueUWKcIGrQdBNwAAAAAAQAtq27Yt3XbbbXKeK5JnZ2e77bG5tg8Xbfvf//5HPXv2pKKiIpo2bRrt2rXLbc8BzkHQDQAAAAAA0MKuvPJKKXzGRdWeeeYZt7cB47Tq119/nfr06SPLYm+99Vbavn27W58DHIOgGwAAAAAAoBXSzGfOnEkBAQG0evVqqU7ubpx6/tprr1H//v1l7TevJd+4caPbnweahqAbAAAAAACgFXTo0EHWXLPZs2dL3213z3gHBgbSvHnzpGgbz6pz4M1V09E5uuUg6AYAAAAAAGglkydPpl69elFJSQnde++9dP3110tLMHcym800d+5cOv/886m2tpZefPFFmWU/ePAggu8WgD7dzYCWYaA2aPMBWocxDFqHMQxahzHcOsrKyuj999+nTz75hCoqKuQ6DsQnTpxI5557LhmNRrf9ffk5uHib0lasffv2dNZZZ8nWtWvXZrUvUwuLylqGIehuBgTdoDb4oAStwxgGrcMYBq3DGG5d3OLrvffeo8WLF1N1dbU9PXzkyJF05pln0umnny6Xm2vTpk30wQcf0Nq1a+3Pw9q0aUNjxoyhAQMGUL9+/aTPtxZZEHR7DwTdoDb4oAStwxgGrcMYBq3DGFZP8P3NN9/QF198QZmZmfbruega9+TmAHz06NEym9scXFzt999/pxUrVkgxt8rKykY/51lwLsLGGwfiHJRrYSbcgqDbeyDoBrXBByVoHcYwaB3GMGgdxrC6cAr4zp07pcAaB8apqamNqp8PHDiQxo4dK0F4TExMs56L09o58Ob15Fu2bKEDBw4cd5vo6Gh7EM4bp6PzfqiNBUG390DQDWqDD0rQOoxh0DqMYdA6jGF1/2248BkH3xyE7927t9EM+JNPPklnn322W2OdrVu3SgC+efNmCf5ramoa3eaSSy6hRx99lNTGgqDbeyDoBrXBByVoHcYwaB3GMGgdxrB2pKenS/D9448/0u7du+W6GTNm0KRJkzySAs6p5zt27JAgnDcOyO+66y669NJLSW0sCLq9B4JuUBt8UILWYQyD1mEMg9ZhDGszBZ17fH/++edy+corr6S7777b42nf/Lw8882z7GpjUVnQrb4EfAAAAAAAAHAIB9fc35tnudlnn31G9913H1mtVo8/rxoDbjVC0A0AAAAAAKBhnE4+efJkev755yUQXrlyJU2bNo1ycnJae9cAQTcAAAAAAIB34EJqr7/+uqRUb9++XVLNly5dKssGoPVgphsAAAAAAMBLcCuv999/n3r16kUlJSU0c+ZMmjp1qrQCQ/DdOhB0AwAAAAAAeJF27drRO++8Q9OnTyez2Uzbtm2T85dddhktXLhQCkJDy/Gz4XCHy1C9HNQGFUdB6zCGQeswhkHrMIa9T15eHr377rv03XffUXl5uVzH677PPfdcmjhxosyIe6LFWGuyqKx6OYLuZkDQDWqDD0rQOoxh0DqMYdA6jGHvxQH3Dz/8QIsXL6Z9+/bZr+/YsSNdcMEFdP7551NCQgJ5AwuCbu+BoBvUBh+UoHUYw6B1GMOgdRjDvvE35nTzL774gpYtW0ZVVVX2nw0YMIDOO+88GjNmDMXExJBWWRB0ew8E3aA2+KAErcMYBq3DGAatwxj2LaWlpbRixQqpcL5x48ZGhdY47fyMM86QADw5OVlTKegWBN3eA0E3qA0+KEHrMIZB6zCGQeswhn0X9/T+8ccf6ddff5WZ8Ibi4uJo8ODBNGTIEDrttNMoNjaW1MyCoNt7IOgGtcEHJWgdxjBoHcYwaB3GMCjF11atWkUrV66k9evXU3V1daMXpn379jRnzhzq0KGDKl8wi8qCbn1r7wAAAAAAAACoR3R0NP3f//2fbFarlbZu3Sp9vjkA3717N6Wnp8vsNzgGQTcAAAAAAACckMlkoqFDh8qmZPvu379f+n+DY/wdvB0AAAAAAAD4OE7XHjhwYGvvhqYg6AYAAAAAAADwEATdAAAAAAAAAB6CoBsAAAAAAADAQxB0AwAAAAAAAHgIgm4AAAAAAAAAD0HQDQAAAAAAAOAhCLoBAAAAAAAAPARBNwAAAAAAAIC3Bt2rVq2i8ePHU2JiIvn5+dHXX399yvt8/PHH1K9fPwoMDKSEhASaOnUq5efnN7rNokWLqHv37mQymahPnz60dOnSRj+32Ww0c+ZMub/ZbKazzz6b9u3b5/bfDwAAAAAAAHxXqwfdZWVlEkC/9tprDt3+zz//pOuuu45uvPFG2rFjhwTX69ato5tuusl+m9WrV9PVV18tt9m8eTNdeumlsm3fvt1+m1mzZtErr7xCb7zxBq1du5aCgoLovPPOI6vV6pHfEwAAAAAAAHyPn42nfFWCZ7q/+uorCZBPZvbs2TR//nw6cOCA/bp58+bRCy+8QGlpaXL5yiuvlGD+u+++s99m2LBh1L9/fwmy+VfmmfW7776b7rnnHvm5xWKhuLg4WrBgAV111VUO7W9xcTGFhYXJfUNDQ5vxmwO4B49tHo88LvnfE4DWYAyD1mEMg9ZhDIM3sFgsFB4erpo4TU8aM3z4cHrooYckXfyCCy6gnJwcWrx4MV144YX226xZs4b+85//NLofz2IrqeuHDh2irKwsSSlXcJAydOhQue/Jgu7KykrZGgbdypuTio5dgA9TxiLGI2gVxjBoHcYwaB3GMHgDm8piM80F3SNHjpQ13TybzangNTU1sia8YXo6B9Q8a90QX+brlZ8r153sNify3HPP0RNPPHHc9XwERW1/WPBNPA5LS0vlPGa6QYswhkHrMIZB6zCGwRtYLBZSE80F3Tt37qQ777xTiqDx7HVmZibde++9NG3aNHrnnXc8+twPPvhgoxl0nulu166dzJKrIW0BQDn4g/Ry0CqMYdA6jGHQOoxhAPfTXNDNs808282BNuvbt68UQRs1ahQ9/fTTUo08Pj6esrOzG92PL/P1TDnl6/j2DW/D675Pxmg0ynYsnlHErCKohTIeMSZBqzCGQeswhkHrMIZB6/xUVtuo1auXO6u8vJz8/Rvvtk6na3Rkjtd9L1++vNFtli1bJtez5ORkCbwb3oZnrbmKuXIbAAAAAAAAAM3PdPP60/3799svc5GzLVu2UGRkJCUlJUlKd3p6On3wwQfyc16/ze3BuIK5kl4+Y8YMGjJkiFQkZ5x+PmbMGJozZw6NGzeOPv30U9qwYQO99dZb9iMffB+eGe/SpYsE4Y8++qjcv6nK6QAAAAAAAACaCro5GD7zzDPtl5U109dff7207+KgOiUlxf7zKVOmUElJCb366qvS8otLwY8dO1ZahilGjBhBCxcupEceeUQqnXNgzZXLe/fubb/NfffdJ23Fbr75ZioqKqLTTz+dfvzxRzKZTC32uwMAAAAAAIB3U1Wfbq1Bn25QG/TWBK3DGAatwxgGrcMYBm9gQZ9u76Ecr1D6dQOoYUzyeEQhNdAqjGHQOoxh0DqMYfAGxf/EZ2qZX2719HIt4zR3xm3DAAAAAAAAQD3y8/OllW5rQ3p5M9TV1VFGRgaFhISoriw9+Cald3xqaip6x4MmYQyD1mEMg9ZhDIO3pJcnJSVRYWGh1ABrbZjpbgZuXda2bVv3/TUA3CQ0NBRBN2gaxjBoHcYwaB3GMHgD/2NaTbcWdewFAAAAAAAAgBdC0A0AAAAAAADgIQi6AbyI0Wikxx57TE4BtAhjGLQOYxi0DmMYvIFRZd+JUUgNAAAAAAAAwEMw0w0AAAAAAADgIQi6AQAAAAAAADwEQTcAAAAAAACAhyDoBgAAAAAAAPAQBN0AreT5558nPz8/mjFjhv06q9VKt912G0VFRVFwcDBddtlllJ2dfdx9FyxYQH379iWTyUSxsbFyn4b+/vtvGjVqlPy8Xbt2NGvWrOMeY9GiRdS9e3e5TZ8+fWjp0qWNfm6z2WjmzJmUkJBAZrOZzj77bNq3b59bXwPw3XG8fv16Ouussyg8PJwiIiLovPPOo61btza6DcYxtNYYfuutt+iMM86g0NBQ+VlRUdFx9ysoKKBJkybJbXgc33jjjVRaWtroNhjDoNYxfPjwYRmzycnJ8hnfqVMnqfRcVVWFMQyaeR9WVFZWUv/+/eV2W7ZsIVW+D9sAoMWtW7fO1qFDB1vfvn1td955p/36adOm2dq1a2dbvny5bcOGDbZhw4bZRowY0ei+c+bMsSUmJto+/vhj2/79+21bt261LVmyxP5zi8Vii4uLs02aNMm2fft22yeffGIzm822N998036bP//806bT6WyzZs2y7dy50/bII4/YDAaDbdu2bfbbPP/887awsDDb119/Lc9x8cUX25KTk20VFRUef33Au8dxSUmJLTIy0jZlyhTb7t27ZZxedtllMm6rqqrkNhjH0Jpj+OWXX7Y999xzsvFXpcLCwuPue/7559v69etn++uvv2y///67rXPnzrarr77a/nOMYVDzGP7hhx/kPfinn36yHThwQL5HxMbG2u6++26MYdDM+7DijjvusF1wwQVyu82bN6vyfRhBN0AL44CjS5cutmXLltnGjBljf4MpKiqSf+SLFi2y33bXrl3yBrJmzRq5XFBQIG8Wv/zyy0kf//XXX7dFRETYKisr7dfdf//9tm7dutkvX3HFFbZx48Y1ut/QoUNtt9xyi5yvq6uzxcfH21588UX7z3n/jEajvGEBNGccr1+/Xi6npKTYb/P333/Ldfv27cM4hlYdww39+uuvJ/yyx1/M+Hoeyw2DGD8/P1t6erpcxnsxqHkMnwgHHRxIKDCGQQtjeOnSpbbu3bvbduzYcVzQraYxjPRygBbGabfjxo2T1JSGNm7cSNXV1Y2u51SXpKQkWrNmjVxetmwZ1dXVUXp6OvXo0YPatm1LV1xxBaWmptrvw7cdPXo0BQQE2K/j1N09e/ZQYWGh/TbHPj/fRnmeQ4cOUVZWVqPbhIWF0dChQ+23Ad/WnHHcrVs3ST1/5513JJWxoqJCzvOY7tChg9wG4xhaaww7gscnp5Sfdtpp9uv4cfz9/Wnt2rX22+C9GNQ6hk/EYrFQZGSk/TLGMKh9DGdnZ9NNN91EH374IQUGBh73czWNYb1LvyEAuOTTTz+lTZs2yXrWY/E/aH5T4C9yDcXFxcnP2MGDByXofvbZZ2nu3Lnyj/6RRx6hc845R9as8P35trxG69jHUJ6D18/yqXLdiZ5HOW3qNuC7mjuOQ0JCaOXKlXTppZfSU089Jdd16dKFfvrpJ9Lr6z+WMI6htcawI3h8cj2NhnjscsDS8H0U78Wg1jF8rP3799O8efNo9uzZ9uswhkHNY9hms9GUKVNo2rRpcgCU6xQcS01jGEE3QAvh2eg777xTZqu5UIMrOODmWcRXXnmFzj33XLnuk08+ofj4ePr111/lyByA2scxz2xzAZ+RI0fK+K2trZUveny0mz98uUgJgJrHMIA3jWHOnjv//PPp8ssvl1lDAC2M4Xnz5lFJSQk9+OCDpAVILwdoIZx2m5OTQwMHDpQZEd5+++03CaD5PB8x41TbY6szcuoMB9WMqyaynj172n8eExND0dHRlJKSIpf5tsdWilYuK49zsts0/HnD+53oNuCb3DGOFy5cKEek33vvPRo8eDANGzZMruMUriVLlshtMI6htcYwHwQ6FR6f/BgN1dTUSEXzU73PKj9r6jZ4LwZPj2FFRkYGnXnmmTRixAipFn3sOMcYBrWO4RUrVkh6t9FolPt07txZrudZ7+uvv151YxhBN0AL4fZI27Ztk1YGysZvDNxyRjlvMBho+fLl9vvwmhMOpocPHy6XeWZQuV7BX/Ly8vKoffv2cplvu2rVKpkRV/CRRF5Hy2k0ym0aPo9yG+V5OBWH30ga3qa4uFjWKiq3Ad/kjnFcXl4ua1+5tYdCuczZHAzjGFprDOt0ulM+Bo9PPrDEXxwbfgHk8cvr/DCGQe1jWJnh5pZMgwYNkoOg/D7cEN6HQc1j+JVXXpFWo8r9lTZfn332GT3zzDPqG8MOl1wDALc7tlIjt1pKSkqyrVixQlotDR8+XLaGLrnkEluvXr2kxQG3M7joootsPXv2tLda4oqK3B7h2muvlfYIn376qS0wMPC49gh6vd42e/ZsqSz92GOPnbA9Qnh4uLQR4crS/LxoGQbuGMc85rjq56233ipVoHmcTp48WdpxZGRkYBxDq4/hzMxMqYD7v//9T6rhrlq1Si7n5+c3ahk2YMAA29q1a21//PGHVOBt2DIM78Wg5jGclpYmbe7OOussOc+3VzaMYdDK+3BDhw4dOq56uZrehxF0A6joDYb/8U6fPl3aG/CbwoQJExp9ACo9B6dOnSr/+LnXMd+mYeslxj0ETz/9dAls2rRpI28Wx/r8889tXbt2tQUEBEgQ//333zf6ObdIePTRR+XNih+HP5j37Nnj9tcAfHMc//zzz7aRI0dKoM23Gzt2rL2lmALjGFprDPOXLv7yduz23nvv2W/DX/w4yA4ODraFhobabrjhBml/gzEMWhjDfHqinx87H4f3YVDrGHYk6FbTGPbj/zk+Lw4AAAAAAAAAjsKabgAAAAAAAAAPQdANAAAAAAAA4CEIugEAAAAAAAA8BEE3AAAAAAAAgIcg6AYAAAAAAADwEATdAAAAAAAAAB6CoBsAAAAAAADAQxB0AwAAAAAAAHgIgm4AAIAW8Pjjj5Ofn98Jt+eff96tz/X111/T66+/ftz1U6ZMod69e1NL+/7776lt27ZUVVVlv27Tpk00bNgwCgwMlNegqKhIXqOdO3c2uu/hw4cpKChITgEAALRI39o7AAAA4CvMZjOtWLHiuOuTkpLcHnRv2LCBpk+f3uj6Rx99lMrKyqgl2Ww2evjhh+muu+6igIAA+/V33HEH1dbWSkDOr0t+fj498cQTclCgZ8+e9tt16NCBJk6cSI899hi9//77LbrvAAAA7oCgGwAAoIX4+/vL7G5r6dSpU4s/58qVK2n79u103XXXNbp+9+7dclDgzDPPlMtNzWTfeOONdPbZZ9Ps2bMpJibG4/sMAADgTkgvBwAAUJE5c+bQ4MGDKSwsjGJjY+miiy6ivXv3NrrNjh076MILL6SoqChJz+7WrRvNmjXLnkLOM8J8GyV9na87UXr5ggUL5OebN2+mCy64QNK4u3TpQh988MFxs9VPPvkkxcfHU3BwMF1++eX0yy+/yH05qG4K78uYMWPswTLfnu/HM9tPPfWUnOfZ7OTkZPk5P7ay30ogfvrpp8vvunDhQre8xgAAAC0JQTcAAEALqqmpOW5rKC0tjW6//XZasmQJvf3221RXV0cjRoyggoIC+23Gjx9PhYWF9M4770h69j333GNPG+cUcg7IO3bsSGvWrJGNr2vKpEmT6Nxzz5W09AEDBkhwvmvXLvvP582bJ+ut+fovv/xSZsz/9a9/OfT7cnA+cuRI++WBAwfKPnHwzjPYfJ5/V35c9uyzz9r3OyEhoVGGwLJlyxx6TgAAADVBejkAAEAL4cDYYDAcd/3vv/8us7ns5Zdftl/Pa57POeccmfFevHgx3XzzzZSXl0eHDh2iuXPnSvDNlBRtxgExzyofOXLE4VR2DvKV9d8c4HMg/8UXX9Ajjzwi+8CF3m644QZ7wTcO0Hk/OOhvSmZmJqWnp1Pfvn3t14WGhsp+6XQ6Ka6m7CPP7DOeaT/Rfvfr149ee+01h34fAAAANUHQDQAA0EK4YNiqVauOu7579+7283/99ZfMTHN174az20qKOadZt2/fnh588EH5+VlnnSXBa3NwEK3gFHN+fJ5xZ3zKwfPFF1/c6D6XXHKJQ0E3c8c67OjoaAn0q6urT3jgAgAAQK0QdAMAALQQTpM+7bTTTvrzlJQUCYD5Nm+++SYlJiZKxe9x48aR1WqV2/Ba559//lkqgt92220yez5o0CB66aWXaPTo0S7tV3h4eKPL/JzK850scObZ91NRHsNoNFJzKY/Bj4mgGwAAtARBNwAAgEr8+OOPVFpaKuublUCY13w3nPFmXbt2pUWLFsms7+rVq+mhhx6SVHNO5ea10u6krKvOzc1tdH1OTs4p7xsZGSmn3IO7ufgx+GBASEhIsx8LAACgJaGQGgAAgEpUVFTITHbDmdzPP//8uGJrCr4dVwZ/4IEHqLi4mDIyMo6bqW4uTl3nquVc7KwhLrp2KlyVnPeF16CfitLD+2T7zZXM+WADAACA1mCmGwAAoIVwJXJes30sTtXmauNjx46Vy1y07JZbbpG2X9xCrGH6999//0133303XXnllVI0zWKx0HPPPScBrtKHu0ePHvTuu+/SJ598IoXJeD00/9wVXPCM14/PmDGD4uLipGjbr7/+KlXJlZT5kzGZTJL6vnHjxlM+Dwf2/HvyPnP7ME4n5wJsSjC+YcMGGjVqlEu/AwAAQGvCTDcAAEALzmQPHz78uI3bZLE+ffpI72wOUrk/NwegXLVcqeytBKe8caDNvbU5OG/Xrp2s8+YAmXErLu53/e9//1t6fnO7r+bgx3nsscckkJ8wYQLt3LmTXnzxRflZw307kYkTJ9JPP/0kvb6bwsH7e++9J7PiXByO91uZuedUdn5N+LEAAAC0xs92qk9BAAAAgGNwhXWehc/Pz5eq7CfDa8GVgwKuFnrjVmHcSm3fvn2Sfg8AAKAlSC8HAACAJu3atYs++ugj6eHN6d4rV66k2bNn06233tpkwK1UPefb/fe//3Up6OaUfO5JPnPmTATcAACgSQi6AQAAoEmBgYG0Zs0amj9/PpWUlFCbNm3o3nvvdThtnaur832rqqrsa7QdxSnmU6ZMocmTJ+OvBAAAmoT0cgAAAAAAAAAPQSE1AAAAAAAAAA9B0A0AAAAAAADgIQi6AQAAAAAAADwEQTcAAAAAAACAhyDoBgAAAAAAAPAQBN0AAAAAAAAAHoKgGwAAAAAAAMBDEHQDAAAAAAAAkGf8P9AGvl4uwjGiAAAAAElFTkSuQmCC",
+      "text/plain": [
+       "<Figure size 1000x600 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# --- Figure: Channel polygon and face locations ---\n",
+    "if fluvial_polygon is not None:\n",
+    "    from shapely.geometry import mapping\n",
+    "    import matplotlib.patches as mpatches\n",
+    "    from matplotlib.collections import PatchCollection\n",
+    "    from matplotlib.patches import Polygon as MplPolygon\n",
+    "\n",
+    "    fig, ax = plt.subplots(figsize=(10, 6))\n",
+    "\n",
+    "    # Plot fluvial polygon\n",
+    "    if fluvial_polygon.geom_type == 'Polygon':\n",
+    "        coords = np.array(fluvial_polygon.exterior.coords)\n",
+    "        patch = MplPolygon(coords[:, :2], closed=True)\n",
+    "        p = PatchCollection([patch], alpha=0.3, facecolor='steelblue', edgecolor='navy', linewidth=1.5)\n",
+    "        ax.add_collection(p)\n",
+    "    elif fluvial_polygon.geom_type == 'MultiPolygon':\n",
+    "        patches = []\n",
+    "        for geom in fluvial_polygon.geoms:\n",
+    "            coords = np.array(geom.exterior.coords)\n",
+    "            patches.append(MplPolygon(coords[:, :2], closed=True))\n",
+    "        p = PatchCollection(patches, alpha=0.3, facecolor='steelblue', edgecolor='navy', linewidth=1.5)\n",
+    "        ax.add_collection(p)\n",
+    "\n",
+    "    # Plot bank lines if available\n",
+    "    if bank_lines is not None and not bank_lines.empty:\n",
+    "        for _, row in bank_lines.iterrows():\n",
+    "            coords = np.array(row.geometry.coords)\n",
+    "            ax.plot(coords[:, 0], coords[:, 1], 'k-', linewidth=1.5, alpha=0.8)\n",
+    "        ax.plot([], [], 'k-', linewidth=1.5, label='Bank Lines')\n",
+    "\n",
+    "    # Create legend\n",
+    "    from matplotlib.patches import Patch\n",
+    "    legend_elements = [\n",
+    "        Patch(facecolor='steelblue', alpha=0.3, edgecolor='navy', label=f'Fluvial Zone ({fluvial_acres:.0f} ac)'),\n",
+    "    ]\n",
+    "    if bank_lines is not None and not bank_lines.empty:\n",
+    "        from matplotlib.lines import Line2D\n",
+    "        legend_elements.append(Line2D([0], [0], color='black', linewidth=1.5, label='Bank Lines'))\n",
+    "\n",
+    "    ax.legend(handles=legend_elements, fontsize=10, loc='upper left')\n",
+    "    ax.set_xlabel('Easting (ft)', fontsize=11)\n",
+    "    ax.set_ylabel('Northing (ft)', fontsize=11)\n",
+    "    ax.set_title('Muncie: Channel Delineation for Selective Manning\\'s n Modification', fontsize=13)\n",
+    "    ax.set_aspect('equal')\n",
+    "    ax.grid(True, alpha=0.2)\n",
+    "    fig.tight_layout()\n",
+    "    plt.show()\n",
+    "else:\n",
+    "    print(\"Skipping figure — no fluvial polygon available\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f878b72c",
+   "metadata": {
+    "papermill": {
+     "duration": 0.012882,
+     "end_time": "2026-05-12T12:23:58.834305+00:00",
+     "exception": false,
+     "start_time": "2026-05-12T12:23:58.821423+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Step 10: Apply Depth-Varying n to Channel Faces Only\n",
+    "\n",
+    "Now we demonstrate the key workflow: extend face property tables with\n",
+    "depth-varying Manning's n **only for channel faces** identified by the\n",
+    "fluvial polygon. Overbank faces retain their original uniform roughness.\n",
+    "\n",
+    "This uses the `polygon` parameter on `extend_face_property_tables()`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "d10a821f",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-12T12:23:58.862152Z",
+     "iopub.status.busy": "2026-05-12T12:23:58.861900Z",
+     "iopub.status.idle": "2026-05-12T12:24:37.830157Z",
+     "shell.execute_reply": "2026-05-12T12:24:37.829278Z"
+    },
+    "papermill": {
+     "duration": 38.983645,
+     "end_time": "2026-05-12T12:24:37.830862+00:00",
+     "exception": false,
+     "start_time": "2026-05-12T12:23:58.847217+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:23:58 - ras_commander.RasExamples - INFO - ----- RasExamples Extracting Project -----\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:23:58 - ras_commander.RasExamples - INFO - Extracting project 'Muncie' as 'Muncie_414_selective'\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:23:58 - ras_commander.RasExamples - INFO - Folder 'Muncie_414_selective' already exists. Deleting existing folder...\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:23:58 - ras_commander.RasExamples - INFO - Existing folder 'Muncie_414_selective' has been deleted.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:23:59 - ras_commander.RasExamples - INFO - Successfully extracted project 'Muncie' to G:\\GH\\ras-commander\\example_projects\\Muncie_414_selective\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:23:59 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 7.0 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\7.0\\Ras.exe via filesystem (x86)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:23:59 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 6.7 Beta 5 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.7 Beta 5\\Ras.exe via filesystem (x86)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:23:59 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 6.5 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.5\\Ras.exe via filesystem (x86)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:23:59 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 6.3.1 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.3.1\\Ras.exe via filesystem (x86)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:23:59 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 6.2 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.2\\Ras.exe via filesystem (x86)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:23:59 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 6.1 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.1\\Ras.exe via filesystem (x86)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:23:59 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 6.0 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.0\\Ras.exe via filesystem (x86)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:23:59 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 5.0.7 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\5.0.7\\Ras.exe via filesystem (x86)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:23:59 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 5.0.6 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\5.0.6\\Ras.exe via filesystem (x86)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:23:59 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 5.0.5 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\5.0.5\\Ras.exe via filesystem (x86)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:23:59 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 5.0.4 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\5.0.4\\Ras.exe via filesystem (x86)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:23:59 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 5.0.3 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\5.0.3\\Ras.exe via filesystem (x86)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:23:59 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 5.0.1 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\5.0.1\\Ras.exe via filesystem (x86)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:23:59 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 5.0 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\5.0\\Ras.exe via filesystem (x86)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:23:59 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 4.1.0 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\4.1.0\\Ras.exe via filesystem (x86)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:23:59 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 4.0 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\4.0\\Ras.exe via filesystem (x86)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:23:59 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 6.6 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.6\\Ras.exe via filesystem (x86)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:23:59 - ras_commander.RasUtils - INFO - Discovered 17 installed HEC-RAS version(s)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:23:59 - ras_commander.RasPrj - INFO - HEC-RAS 6.6 found via version discovery: C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.6\\Ras.exe\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:23:59 - ras_commander.RasMap - INFO - Successfully parsed RASMapper file: G:\\GH\\ras-commander\\example_projects\\Muncie_414_selective\\Muncie.rasmap\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:23:59 - ras_commander.hdf.HdfBase - INFO - Found projection in projection file: G:\\GH\\ras-commander\\example_projects\\Muncie_414_selective\\GIS_Data\\Muncie_IA_Clip.prj\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:23:59 - ras_commander.RasPrj - INFO - Updated results_df with 3 plan(s)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:23:59 - ras_commander.RasPrj - INFO - ras-commander v0.96.2 | An open-source project of CLB Engineering Corporation (https://clbengineering.com/) | Docs: https://ras-commander.readthedocs.io | GitHub: https://github.com/gpt-cmdr/ras-commander\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:23:59 - ras_commander.RasPrj - INFO - Project initialized: Muncie | Folder: G:\\GH\\ras-commander\\example_projects\\Muncie_414_selective\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:23:59 - ras_commander.RasPrj - INFO - Using HEC-RAS executable: C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.6\\Ras.exe\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:23:59 - ras_commander.RasCmdr - INFO - Using ras_object with project folder: G:\\GH\\ras-commander\\example_projects\\Muncie_414_selective\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:23:59 - ras_commander.RasCurrency - INFO - Deleted geometry HDF: G:\\GH\\ras-commander\\example_projects\\Muncie_414_selective\\Muncie.g02.hdf\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:23:59 - ras_commander.geom.GeomPreprocessor - INFO - Clearing geometry preprocessor file for single plan: G:\\GH\\ras-commander\\example_projects\\Muncie_414_selective\\Muncie.p03\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:23:59 - ras_commander.geom.GeomPreprocessor - INFO - Deleted geometry preprocessor file: G:\\GH\\ras-commander\\example_projects\\Muncie_414_selective\\Muncie.c02\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:23:59 - ras_commander.geom.GeomPreprocessor - INFO - Geometry dataframe updated successfully.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:23:59 - ras_commander.RasCmdr - INFO - Force-cleared all geometry preprocessor files for plan: 03\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:23:59 - ras_commander.RasUtils - INFO - Using provided plan file path: G:\\GH\\ras-commander\\example_projects\\Muncie_414_selective\\Muncie.p03\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:23:59 - ras_commander.RasUtils - INFO - Successfully updated file: G:\\GH\\ras-commander\\example_projects\\Muncie_414_selective\\Muncie.p03\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:23:59 - ras_commander.RasCmdr - INFO - Set number of cores to 2 for plan: 03\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:23:59 - ras_commander.RasCmdr - INFO - Running HEC-RAS from the Command Line:\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:23:59 - ras_commander.RasCmdr - INFO - Running command: \"C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.6\\Ras.exe\" -c \"G:\\GH\\ras-commander\\example_projects\\Muncie_414_selective\\Muncie.prj\" \"G:\\GH\\ras-commander\\example_projects\\Muncie_414_selective\\Muncie.p03\"\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Running selective model (original n, generating face tables)...\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:24:33 - ras_commander.RasCmdr - INFO - HEC-RAS execution completed for plan: 03\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:24:33 - ras_commander.RasCmdr - INFO - Total run time for plan 03: 34.58 seconds\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:24:33 - ras_commander.hdf.HdfResultsPlan - INFO - Using existing Path object HDF file: G:\\GH\\ras-commander\\example_projects\\Muncie_414_selective\\Muncie.p03.hdf\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:24:33 - ras_commander.hdf.HdfResultsPlan - INFO - Final validated file path: G:\\GH\\ras-commander\\example_projects\\Muncie_414_selective\\Muncie.p03.hdf\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:24:33 - ras_commander.hdf.HdfResultsPlan - INFO - Reading computation messages from HDF: Muncie.p03.hdf\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:24:33 - ras_commander.hdf.HdfResultsPlan - INFO - Successfully extracted 2157 characters from HDF\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:24:33 - ras_commander.hdf.HdfResultsPlan - INFO - Using existing Path object HDF file: G:\\GH\\ras-commander\\example_projects\\Muncie_414_selective\\Muncie.p03.hdf\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:24:33 - ras_commander.hdf.HdfResultsPlan - INFO - Final validated file path: G:\\GH\\ras-commander\\example_projects\\Muncie_414_selective\\Muncie.p03.hdf\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:24:33 - ras_commander.hdf.HdfResultsPlan - INFO - Extracting Plan Information from: Muncie.p03.hdf\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:24:33 - ras_commander.hdf.HdfResultsPlan - INFO - Plan Name: Unsteady Run with 2D 50ft Grid\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:24:33 - ras_commander.hdf.HdfResultsPlan - INFO - Simulation Duration (hours): 24.0\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:24:33 - ras_commander.hdf.HdfResultsPlan - INFO - Using existing Path object HDF file: G:\\GH\\ras-commander\\example_projects\\Muncie_414_selective\\Muncie.p03.hdf\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:24:33 - ras_commander.hdf.HdfResultsPlan - INFO - Final validated file path: G:\\GH\\ras-commander\\example_projects\\Muncie_414_selective\\Muncie.p03.hdf\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:24:33 - ras_commander.RasPrj - INFO - Updated results_df with 1 plan(s)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:24:33 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 7.0 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\7.0\\Ras.exe via filesystem (x86)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:24:33 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 6.7 Beta 5 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.7 Beta 5\\Ras.exe via filesystem (x86)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:24:33 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 6.5 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.5\\Ras.exe via filesystem (x86)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:24:33 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 6.3.1 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.3.1\\Ras.exe via filesystem (x86)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:24:33 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 6.2 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.2\\Ras.exe via filesystem (x86)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:24:33 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 6.1 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.1\\Ras.exe via filesystem (x86)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:24:33 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 6.0 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.0\\Ras.exe via filesystem (x86)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:24:33 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 5.0.7 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\5.0.7\\Ras.exe via filesystem (x86)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:24:33 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 5.0.6 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\5.0.6\\Ras.exe via filesystem (x86)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:24:33 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 5.0.5 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\5.0.5\\Ras.exe via filesystem (x86)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:24:33 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 5.0.4 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\5.0.4\\Ras.exe via filesystem (x86)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:24:33 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 5.0.3 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\5.0.3\\Ras.exe via filesystem (x86)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:24:33 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 5.0.1 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\5.0.1\\Ras.exe via filesystem (x86)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:24:33 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 5.0 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\5.0\\Ras.exe via filesystem (x86)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:24:33 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 4.1.0 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\4.1.0\\Ras.exe via filesystem (x86)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:24:33 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 4.0 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\4.0\\Ras.exe via filesystem (x86)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:24:33 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 6.6 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.6\\Ras.exe via filesystem (x86)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:24:33 - ras_commander.RasUtils - INFO - Discovered 17 installed HEC-RAS version(s)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:24:33 - ras_commander.RasPrj - INFO - HEC-RAS 6.6 found via version discovery: C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.6\\Ras.exe\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:24:34 - ras_commander.RasMap - INFO - Successfully parsed RASMapper file: G:\\GH\\ras-commander\\example_projects\\Muncie_414_selective\\Muncie.rasmap\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:24:34 - ras_commander.hdf.HdfBase - INFO - Found projection in HDF file: G:\\GH\\ras-commander\\example_projects\\Muncie_414_selective\\Muncie.g02.hdf\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:24:34 - ras_commander.hdf.HdfResultsPlan - INFO - Using existing Path object HDF file: G:\\GH\\ras-commander\\example_projects\\Muncie_414_selective\\Muncie.p03.hdf\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:24:34 - ras_commander.hdf.HdfResultsPlan - INFO - Final validated file path: G:\\GH\\ras-commander\\example_projects\\Muncie_414_selective\\Muncie.p03.hdf\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:24:34 - ras_commander.hdf.HdfResultsPlan - INFO - Reading computation messages from HDF: Muncie.p03.hdf\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:24:34 - ras_commander.hdf.HdfResultsPlan - INFO - Successfully extracted 2157 characters from HDF\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:24:34 - ras_commander.hdf.HdfResultsPlan - INFO - Using existing Path object HDF file: G:\\GH\\ras-commander\\example_projects\\Muncie_414_selective\\Muncie.p03.hdf\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:24:34 - ras_commander.hdf.HdfResultsPlan - INFO - Final validated file path: G:\\GH\\ras-commander\\example_projects\\Muncie_414_selective\\Muncie.p03.hdf\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:24:34 - ras_commander.hdf.HdfResultsPlan - INFO - Extracting Plan Information from: Muncie.p03.hdf\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:24:34 - ras_commander.hdf.HdfResultsPlan - INFO - Plan Name: Unsteady Run with 2D 50ft Grid\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:24:34 - ras_commander.hdf.HdfResultsPlan - INFO - Simulation Duration (hours): 24.0\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:24:34 - ras_commander.hdf.HdfResultsPlan - INFO - Using existing Path object HDF file: G:\\GH\\ras-commander\\example_projects\\Muncie_414_selective\\Muncie.p03.hdf\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:24:34 - ras_commander.hdf.HdfResultsPlan - INFO - Final validated file path: G:\\GH\\ras-commander\\example_projects\\Muncie_414_selective\\Muncie.p03.hdf\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:24:34 - ras_commander.RasPrj - INFO - Updated results_df with 3 plan(s)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:24:34 - ras_commander.RasPrj - INFO - ras-commander v0.96.2 | An open-source project of CLB Engineering Corporation (https://clbengineering.com/) | Docs: https://ras-commander.readthedocs.io | GitHub: https://github.com/gpt-cmdr/ras-commander\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:24:34 - ras_commander.RasPrj - INFO - Project initialized: Muncie | Folder: G:\\GH\\ras-commander\\example_projects\\Muncie_414_selective\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:24:34 - ras_commander.RasPrj - INFO - Using HEC-RAS executable: C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.6\\Ras.exe\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:24:34 - ras_commander.hdf.HdfMesh - INFO - Using existing Path object HDF file: G:\\GH\\ras-commander\\example_projects\\Muncie_414_selective\\Muncie.g02.hdf\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:24:34 - ras_commander.hdf.HdfMesh - INFO - Final validated file path: G:\\GH\\ras-commander\\example_projects\\Muncie_414_selective\\Muncie.g02.hdf\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:24:34 - ras_commander.hdf.HdfMesh - INFO - Using existing Path object HDF file: G:\\GH\\ras-commander\\example_projects\\Muncie_414_selective\\Muncie.g02.hdf\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:24:34 - ras_commander.hdf.HdfMesh - INFO - Final validated file path: G:\\GH\\ras-commander\\example_projects\\Muncie_414_selective\\Muncie.g02.hdf\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:24:34 - ras_commander.hdf.HdfMesh - INFO - Using existing Path object HDF file: G:\\GH\\ras-commander\\example_projects\\Muncie_414_selective\\Muncie.g02.hdf\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:24:34 - ras_commander.hdf.HdfMesh - INFO - Final validated file path: G:\\GH\\ras-commander\\example_projects\\Muncie_414_selective\\Muncie.g02.hdf\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:24:34 - ras_commander.hdf.HdfMesh - INFO - Using existing Path object HDF file: G:\\GH\\ras-commander\\example_projects\\Muncie_414_selective\\Muncie.g02.hdf\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:24:34 - ras_commander.hdf.HdfMesh - INFO - Final validated file path: G:\\GH\\ras-commander\\example_projects\\Muncie_414_selective\\Muncie.g02.hdf\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:24:34 - ras_commander.hdf.HdfBase - INFO - Using HDF file from h5py.File object: G:\\GH\\ras-commander\\example_projects\\Muncie_414_selective\\Muncie.g02.hdf\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:24:34 - ras_commander.hdf.HdfBase - INFO - Final validated file path: G:\\GH\\ras-commander\\example_projects\\Muncie_414_selective\\Muncie.g02.hdf\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:24:34 - ras_commander.hdf.HdfBase - INFO - Found projection in HDF file: G:\\GH\\ras-commander\\example_projects\\Muncie_414_selective\\Muncie.g02.hdf\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:24:34 - ras_commander.hdf.HdfMesh - INFO - Found 9832 faces in polygon (mesh '2D Interior Area', method='midpoint')\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:24:37 - ras_commander.hdf.HdfMesh - INFO - Pinned property tables for mesh '2D Interior Area'\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:24:37 - ras_commander.hdf.HdfMesh - INFO - Wrote face property tables for 9832 faces in mesh '2D Interior Area' (445238 total rows)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:24:37 - ras_commander.hdf.HdfMesh - INFO - Extended 9832 face tables in mesh '2D Interior Area', total rows added: 398183\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:24:37 - ras_commander.hdf.HdfMesh - INFO - Using existing Path object HDF file: G:\\GH\\ras-commander\\example_projects\\Muncie_414_selective\\Muncie.g02.hdf\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:24:37 - ras_commander.hdf.HdfMesh - INFO - Final validated file path: G:\\GH\\ras-commander\\example_projects\\Muncie_414_selective\\Muncie.g02.hdf\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:24:37 - ras_commander.hdf.HdfMesh - INFO - Using existing Path object HDF file: G:\\GH\\ras-commander\\example_projects\\Muncie_414_selective\\Muncie.g02.hdf\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-12 08:24:37 - ras_commander.hdf.HdfMesh - INFO - Final validated file path: G:\\GH\\ras-commander\\example_projects\\Muncie_414_selective\\Muncie.g02.hdf\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Extended 9832 channel faces (of 11164 total)\n",
+      "Total rows added: 398183\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Channel face 0: 7 -> 46 rows\n",
+      "Overbank face 1: 3 -> 3 rows (unchanged)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Re-extract a fresh modified project for the selective demo\n",
+    "selective_path = RasExamples.extract_project(PROJECT_NAME, suffix=\"414_selective\")\n",
+    "selective_ras = init_ras_project(selective_path, RAS_VERSION, ras_object=\"new\")\n",
+    "\n",
+    "# Run with original n to generate face property tables\n",
+    "print(\"Running selective model (original n, generating face tables)...\")\n",
+    "RasCmdr.compute_plan(PLAN_NUMBER, ras_object=selective_ras, num_cores=2, force_geompre=True)\n",
+    "selective_ras = init_ras_project(selective_path, RAS_VERSION, ras_object=\"new\")\n",
+    "\n",
+    "selective_geom_hdf = selective_path / f\"{selective_ras.project_name}.g{GEOM_NUMBER}.hdf\"\n",
+    "\n",
+    "# Read original tables for comparison\n",
+    "before_tables = HdfMesh.get_mesh_face_property_tables(selective_geom_hdf)\n",
+    "before_df = before_tables[MESH_NAME]\n",
+    "\n",
+    "if fluvial_polygon is not None and channel_face_ids:\n",
+    "    # Extend ONLY channel faces with depth-varying n\n",
+    "    rows_added = HdfMesh.extend_face_property_tables(\n",
+    "        hdf_path=selective_geom_hdf,\n",
+    "        mesh_name=MESH_NAME,\n",
+    "        extension_elevation=target_elev,\n",
+    "        mannings_n_func=extend_n_func,\n",
+    "        elevation_step=0.5,\n",
+    "        polygon=fluvial_polygon,   # <-- spatial filter!\n",
+    "        pin_tables=True,\n",
+    "    )\n",
+    "\n",
+    "    print(f\"\\nExtended {len(rows_added)} channel faces (of {before_df['Face ID'].nunique()} total)\")\n",
+    "    print(f\"Total rows added: {sum(rows_added.values())}\")\n",
+    "\n",
+    "    # Read back to verify\n",
+    "    after_selective = HdfMesh.get_mesh_face_property_tables(selective_geom_hdf)\n",
+    "    after_sel_df = after_selective[MESH_NAME]\n",
+    "\n",
+    "    # Compare row counts: channel faces should have more rows, overbank unchanged\n",
+    "    channel_set = set(rows_added.keys())\n",
+    "    overbank_set = set(before_df['Face ID'].unique()) - channel_set\n",
+    "\n",
+    "    # Pick one channel face and one overbank face\n",
+    "    channel_face_example = list(channel_set)[0]\n",
+    "    overbank_face_example = list(overbank_set)[0] if overbank_set else None\n",
+    "\n",
+    "    ch_before = before_df[before_df['Face ID'] == channel_face_example]\n",
+    "    ch_after = after_sel_df[after_sel_df['Face ID'] == channel_face_example]\n",
+    "    print(f\"\\nChannel face {channel_face_example}: {len(ch_before)} -> {len(ch_after)} rows\")\n",
+    "\n",
+    "    if overbank_face_example:\n",
+    "        ob_before = before_df[before_df['Face ID'] == overbank_face_example]\n",
+    "        ob_after = after_sel_df[after_sel_df['Face ID'] == overbank_face_example]\n",
+    "        print(f\"Overbank face {overbank_face_example}: {len(ob_before)} -> {len(ob_after)} rows (unchanged)\")\n",
+    "else:\n",
+    "    print(\"Skipping selective demo — no fluvial polygon available\")\n",
+    "    channel_face_example = None\n",
+    "    overbank_face_example = None"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "324aa933",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-12T12:24:37.864203Z",
+     "iopub.status.busy": "2026-05-12T12:24:37.863977Z",
+     "iopub.status.idle": "2026-05-12T12:24:38.050596Z",
+     "shell.execute_reply": "2026-05-12T12:24:38.049906Z"
+    },
+    "papermill": {
+     "duration": 0.20531,
+     "end_time": "2026-05-12T12:24:38.051577+00:00",
+     "exception": false,
+     "start_time": "2026-05-12T12:24:37.846267+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAABKUAAAIDCAYAAADVKK2CAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjgsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvwVt1zgAAAAlwSFlzAAAPYQAAD2EBqD+naQAA0B9JREFUeJzs3Qd4FFX3x/ETei8Sei8KiKACgiAiTVDsoiioKM2GooKoWGm+ih0bdl6pNkREX0GwICgoRQRF8Q+CCKj0TmjZ//O7yyybzSYkYZNsst/P8wxkZ2dn585usnfPnHtunM/n8xkAAAAAAACQhfJk5ZMBAAAAAAAAQlAKAAAAAAAAWY6gFAAAAAAAALIcQSkAAAAAAABkOYJSAAAAAAAAyHIEpQAAAAAAAJDlCEoBAAAAAAAgyxGUAgAAAAAAQJYjKAUAAAAAAIAsR1AKAJAp2rRpY3FxcVFzdmvUqOEWpGzIkCHuNfv666+TrNc6vZ7RQMem49Gx5ka5vX3ped/h+EXT767wWgMAQhGUAoAYtWfPHvvPf/5jjRs3tmLFilnBggWtSpUqdvbZZ9vgwYNt1apVlpPccMMN7gvYmjVrLCf5888/LW/evO7Yn3zyyew+nKgQbV+kj9e2bdtsxIgR1qJFCytTpozlz5/fypYtax06dLAXXnjBdu/end2HiDRYuXKl9evXz+rWrWtFixa14sWLW8OGDW3QoEH2999/cw4BAMiAfBl5EAAgZ9u1a5e1atXKli5danXq1LFrr73WfVnevHmz/fDDD/b4449b7dq13ZJbfPHFFxaN3nrrLUtMTHSBGP2sL7jR5tdff7UiRYpYNGjWrJk7nvj4eMsp77uuXbva1q1brX79+nbllVe637UtW7bYN998Y/3797fnnnsuxwWBY41+N2+++WY7dOiQtWvXzi6++GL3ezt//nx76qmn7JVXXrF3333XOnfunN2HCgBAjkJQCgBikL4EKyDVp08fe+2115INs1u9erXt37/fcpNoDLDpS+1///tfF2C58MIL3c/fffedtWzZ0qJJvXr1LFooOBZNx5Oan376yS666CL38/jx4+2aa65Jto2GrCkzEdHrk08+cX8rFUycOnVqst/Pjz/+2K6++mq7/PLL3e+vsk8BAEDaMHwPAGLQvHnz3P8aihKu7lPNmjXDfvHfuHGj3XXXXS67SsP9FEzp0qWL/fzzz+l6fn2xa9++vZUuXdoKFSpkp5xyiss2OHz4cIrbd+zY0X0p1PaqDXXdddcFnle333777cCxq02hQ8BCa0oNHz7cbTN27Niwz/nhhx+6+x944IFkATt9Qa1WrZo7BxUrVnRDBzUML71mzpxpa9eudV9oe/fu7da9+eabYbdVwErHo/91PpQxpACNhoH16tXL/v3332SP8c7BunXrrFu3bu710mPOOussmzVr1nEPpztw4IA9++yzdsYZZ7ihTBoGevLJJ9uAAQPckDXPV1995Y5Rw560jZamTZu6gGi4ekoye/bswOvotftYNZf0flBWUrly5dxro/fCnXfe6bKSQnnvBw2du+OOO6xSpUruMY0aNbIPPvjAIkFZUPv27XND9MIFpETnNaVaSgsXLrRzzz3XnduSJUvaZZddFnZ46pQpU9zrq99Lvb7aVsNwJ0+enGxbPV7nT+9ZDUfTPvV7qOFoGk6oQFokzpXeG88884wL0HhD3XRMCuAcD7VR+9q7d2/Y+5XBpPb9/vvvgcDvG2+84X5fTjjhBCtcuLAbpqxgYVpqWCkz6vbbbzefz2eTJk0KGzDWc44aNcoF8vV+8+h3WseijLhwdH50/+uvv55kvS4Y6G+C/rYUKFDAqlev7o4h9H0c/Foqe1Cvpf5GhhvGnNa/ATpv99xzj3vdvL+3J510kt13331hh5l6tQMPHjzofif1PtF7Q495+eWXLa30u6vXRe/FuXPnpvlxAIBcwAcAiDnXXnutTx8B7777bpofs3LlSl+VKlXc4zp27OgbOHCg77rrrvMVKVLEV7RoUd/8+fOTbH/OOee4bUPdd999bn3lypV9vXr18t11112+pk2bunVXXHFFsu0HDBjg7jvhhBPc9nr8Nddc46tQoYLv2Wefddvo/1NPPdVtd8cdd/geeeQRt4wZMyawn+rVq7vF88cff/ji4uJ85557btj2XnrppW5/v/76a2Cd2liyZElfvnz53P2DBg3yXXnlle52uXLlfKtWrfKlhx6r5/jhhx/c7Vq1avmKFSvm27VrV7Jt1RZte+GFF/ry58/v69atm2/w4MG+tm3buvV16tTxbd26NcljtL5Ro0a+atWq+Zo0aeK799573TnU65U3b17flClTkmyvc6bHfPXVV8n2o9cz2N69e31nnXWWu+/EE0/03X777b67777bd8kll7j3xI8//hjYtlOnTr7atWu7103HcNNNN7nXQo/V6+tZvXp14Bh0v/c6avH2p2PT/VoXbM6cOe559VpcffXV7n3ivQf13Js2bUqyvfZfqVIlX4sWLXz16tXz3Xbbbe7caB96X8yYMSPJ9jo277jS4v/+7//c9lWrVvUdPnw4TY8Jbl/nzp19hQsXdv/rd61du3aBtuzbty/JY+rWretr2LCh7/rrr3ft7t27t69s2bJu++effz5sO3RuypQp42vdurV7DfS6aX3p0qV9//zzz3Gdq4SEBF+bNm3c/k477TT33rj55pvdudC6F154IU3vu3C8bSdMmJDsPr3G+t1o3rx5YN0999wTOG/9+vVz50d/t2rWrOl74IEHjvl8n3/+uXv8mWeemep2hw4dcudI2+q1D34t+/btG/YxOjcFCxb0bdu2LbBu6tSpbp1ee72P9TfmggsuCPyeBf+Oe6+lfg9LlCjh/tdrqffB+vXrM/Q34LHHHnN/a7t06eL+Nuvvqc6ndw4OHDiQZHvvd0zb6/W98cYbfbfccot7b2n9a6+9dszXWr+7pUqVcp8Jy5YtO+ZrAgDIXQhKAUAM0hcffTEoXry4+8KrL5WbN29O9TEtW7Z0X2KmT5+eZP2KFSvcfvSl+FhBKe8LnoIUu3fvDqxPTEx0X1p13wcffBBYP23aNLdO+w49voMHDyb58qwvYtpWX9TCCQ1KSatWrVybNmzYkGT9li1bfAUKFHDBMo++jNWoUcO1dfHixUm215cq7UcBo7RSe/Qc+pLvefjhh10b3njjjRSDUlpCXwMv0KdgQTBv++7du7tz7Pnpp5/ccytwoeBSRoJSet9ovb7g6wt5sO3btycJrCkAGEqvnwKCOm9//vnnMZ/PEy4opaCPgg7hzo2+1Gu9vogH84JiCsbs378/sH7WrFmB9+jxBKX++9//uu0VAE4Pr31a3nnnnST36Vxr/aRJk5KsDxcM1fnX742CqHv27EnWDi2PP/54ksc8+OCDbr0CE8dzru6//363/qGHHkryvtu5c6f7ndJ7zwuapDco5QX7zj///GT3Kdil+1588cXAOgVYFCwKPgfBv+fHMmTIELfPtASw9HumbceOHetuq+0KBinQp0BdMAVfQgPx+pug4JKCM2vWrEmyvV7z0N/x4NdSfzvCSe/fgHXr1iV5jT1Dhw51+xk/fnzYv/MKXO3YsSOw/rfffnMBYgVMg4W+1vosUgBO24X+HQAAxAaCUgAQo55++mmXleN9aQnOJvj999+TbKsgTLgv9qHZTMFXucMFpS6++GK3LtyXDwUylHWhK+4effHU9l9++eUx25ORoNSrr77qHqNzEezll19265977rnAug8//NCtGzZsWNj9X3755b48efIk+WKWGmV3aX+PPvpokmw0rVNGSkpBqQ4dOoQNQCjTQF9og7NytL2CPqFfcEXZNKFBwLQGpRRQUnBOAY/Q7Kz0mDx5stu3AjipPd+xglLffPNNioEKnRsFJgoVKpTky7YXaAkXMNN9ekwwBSWVNafXKC0U8NH+FTBMD699ymBK6b7g7LLU6H2t7b/++utkgQxlCoVmcHn36b0cLD3nSvtUEEZ/S4KDIJ6PP/44WbZUeoJSot8PBTz+/fffJOubNWvmMqWCs+J0bAomhwaF0soLlr/yyivH3FZZSNp25MiRgXXKZtQ6vdeDeRlcH330UWDdM888kySoFapx48a++Pj4ZK+XskbDBZIy8jcgJQrgadsbbrghyXrv73y4v9HefQpGhnutFXzXsel1C81kBADEDgqdA0CMUt2fvn372vTp011xXtWv+f777+2ll15ydY00k5RqpYhmmBLVLQpXy+e3334L/K/6UCnRflRfRjNZhaN6L96+RDMBqj7JOeecY5lB9YdU92fcuHHufHhUlDpfvnyuBkvwscuKFSvCnoN//vnH1a9RTRbVSzoWnWPVYtHMh8HF2FWzRq+HasRotrZQqssTSjWaTjvtNFcj548//nB1dzyqfaWaNOH2o2P48ccfXV2w9NBrpBkcVYNINWCORduqZthHH33kZpnbs2dPkvs3bNhgx0NtkHB1r7z6VZ9//rl77Ro2bBi4r1SpUq7uVCjVtvHqrnny58+fpQXWmzRpEva4ZPv27clqvWnGzM8++8zVNlMdq2OdX71f8uTJk6b9p+dc6RyrnpjqTg0dOjTZ9ps2bXL/B/+ep5fqyek5VeNJNa7k//7v/9zfC9WKCp6ZUbWZVNtIf5f0c9u2ba1Fixbub01W0LE+9thj7m+MCqGL/k5MnDjR1WwKnq3P+xujv8PhZmNMSEhwM6RqCW7jqaee6mpPpSQ9fwMUxxozZoyr4aY6Tzt27HDHe6zf1WO9X1UHLJhq0am+WKdOnVztM30uAABiE0EpAIhh+qKgKeq1iL6A3H///e5LnIr0rl+/3n3Z0XT28umnn7olJaHBhlDajwoHh/uyGm4fOp7KlSsn+/IcKfqirVnv9KVo+fLlrki3vgwqKKQviyqYHXzsMmHChFT3eaxz4H3p1Bc+fUHWF8ZgPXr0cM+vwN2TTz6Z7LHly5cPu09vvc7Z8WyfFt5j9NociwpeK1i0ePFiO/30092XdH0ZV9BPxZhVoP54Z3rcuXNnqm1Vwejg7TwqCB6Oji34i3hGVKhQwf2v36GMKFGiRNjjkuAJAfS+VKF5FcxX8WoFCvW+zps3ry1ZssQVxQ93ftO6//SeK+/35JdffnHL8fyepOSqq65yBcUVPPaCUgr6iN5fwVSAXME0BVpGjBjhFhXvVkD66aefThLcSe11/Ouvv455XN423vtNFFhWwOZ///ufC9YpiKvgsQqP33rrrS7YGXrudGEgNTp3wced0vs+I38DFKR/8cUXrWrVqu6ihNqiCwOiv9sp/a6m9/00Z84c97+CUgSkACC2MfseACDJF099IdFVdV2NX7ZsWZIvHJpF7MjQ77DL9ddfn+rZ1H4UkEhtH5rdzqMv114GUmbxvsR6X2r1RTd4ffCxy7Rp01I9/rRkdXkz7GlWuuAZ5rTcfPPN7j7NCqgZrUKFm2UveH1o8CC926eFXpe0BlwUFFFASkFO/T969GgXGFC22XnnnWeR4L02KbVV76Hg7bKCAkSiAERmvn/1XlJASrNJatYy/Y7qZ53fM88807Kad46VeZPa74mCRBmlWfQUNFZ2pzKzvN9bvZeVKRUaGLn77rtdgEzvV2UoKUNIv18pzYgYzJtt74svvkh1OwVeNGOkKBMrmP6WKDj73nvvpRpA886d/u6mdu5Cs57CzaCakb8ByrhTQEyzKiqTTdlSyvLSe8n7uxTJ962CdcpQff755yO6bwBAzkJQCgCQ7AtO6JXr5s2bu/9DhzSll/ajac011CYtNI27rsx7X/ZSo8yQlK7Kp0ZfbhUo05dVBQ+UCaUMsksuuSTZsUfiHCjL4Z133nHTsitQE27Rl0J9Qfzkk09SzDAIpqnalRWjL7W1atVKcp8CFhrSldJ+lL2UXnXr1nXPtWDBApf9kRpvGFLo+UypLaLMuPS8jl4bFAAKd74VvNBwLR13VtEQytatW7vsGWWDpeZ4MsUycn4zkzKD9N7QOQ8XVI0UL6CjYNS3337rgtlXXHGFy4JKiYYUakiuhizr9Zk1a1ayoY6hlM2oIJCG1n355ZcpbqcAjoJeCngFD58VPaeCYzpWPd+HH37otgkNGkbqb0yotP4N0NBfBb2Ubae/T+G2jRRljOn8a2itst2U0QYAiE0EpQAgBr366qsuoBCO6v6onpGyYbz6UAoO6QuTario1lQoBXPSEjjS0BDp1auXC06Fy2jRc3v69evn/teXFm9oi0fDAIMzAJQ9kdZhNsE0fEbDgfTF7YknnnABM2V5hNac0Zd+DbV75pln7Jtvvkm2H30BV6bKsbz//vuuxpK+QL/xxhthF2/YnpdRFUxf5GbMmJFk3aOPPurqtmjoX+hQRwV3NCTTX/PYb+nSpS5bo2zZsklq2qSVvmDfdNNNbtiPXpvQAJLWK1AmXlZH6LnR++X1118Pu3+9lhrelJ6sJNXjUk0lnZ9gysrSe02BgdTq7hyLXl9lj4Sr9ZMSfdHW++i2224L+3vjfdlv165dho8rpfOrIKuGjGU1vTduueUWFwRRhlK4wJSGriroejwuuOACF9hQEFlZT+EyjxTs01DYcIFKvT/1u3+socFqjxcwUU0qDb0NpSHN+tumYW7PPfdcsvs1DLhjx44ueKb7NYw0uJacp2fPni4g/sADD4Qd+rh3795A3an0SOvfAO+9pHMWnN2n38XBgwdbpOkzZubMmW74qYZjhjt3AIDcj5pSABCD9OVdwzF0tV5f6JVBoC9qKnirL8n6oqa6Ul4tEVFASlkD+mKmLw+NGzd2X7gVzNGVfRUwViHe1Gi41kMPPeSGF+m5dVtfhBQ0WLlypXtuBRG8At/6sqQvtiqSfeKJJ9pll13mvuApI0HDaXSfvsyIvthruxtvvNEFlZTtpX2HflENR9uovQ8//HDgdiidiw8++MDOP/98N0RPz6ei2cos0xdwHbsyro5VwNkLNOkLaEqUqaAiwcroUGFhvT4e1cDSECUFtWrUqOG+pGoYoIIyw4YNS7YvZV0pYKEvftqvXicFSBTUe+211zJc8FnPpefWF1v9r/Oic6RsCx23nlPFtHWsOk4F/BSMUKBTQ66UBabXU+c0lM6thjpdeumlLotDWXCqb6O2hKP3qzJVVJ9G7xnVSNNrr/elsqd0blQI/HjoPaf3pfarWlhpofZruKfqF+n3RudM2VMKuinIqiCFhmqFZtakh96rI0eOtNtvv929D3R8P/30k/v9UGFtZeVkNdUe0lBNDctSwEZt9n5v1V4dn16b4Jpt6aX3ms6rAuwaCqh263mCKStJf99OOukkN1RMQWUFo/TeUwBcfz+C/8alRAFpPY+C5BrOp/en3pcK3Oi9r9dRBfX1ntXfxZReJwUJH3nkEXc7XFBKASL9ndX7V8XL9fdRxfUVXNN7ToFcPb9+v9IjrX8DVD9KfztVY08ZTO3bt3eBf50v/ZyegGx6A1P63b3rrrtc4Ez/AwBiSHZP/wcAyHq//fab74knnvCde+65bmr4QoUKuUXTuF9//fW+hQsXhn3c1q1bfQ8++KDvlFNO8RUuXNhXrFgx34knnujr3r2778MPPww7HXg4M2fO9F100UW+smXLuincNaW5pnkfPny4b+3atcm213Tqbdu29ZUsWdJXsGBBN8X7dddd5/v555+TbKc26Xi0Tz23jiF46notKdHj9JgqVaq4ae1Tsm7dOt8dd9zhttexlChRwle/fn1fnz59fF988YXvWOddz6FznpiYmOq2DzzwgNv20UcfdbfHjBnjbut/TSN/xhlnuNegTJkybpr2v//+O9k+vHPw119/+a666irfCSec4F5nnevPP/882fbB07WH20+ohIQE31NPPeU77bTTAu+Hk08+2Tdw4EDftm3bAtv98ccfvi5durjXu0iRIu7Y33nnHfc82reeN5ja0rVrV198fLwvT548gXZLSo+RpUuX+q644gr3OL0H9HrrtQo33Xxq74dw793Vq1e7dam9h1KyZcsW994+88wzfaVLl/bly5fPvW5t2rTxPf/8877du3cHtk2tfd4x6Hc02JIlS3wdO3Z0+y5evLg7/lmzZiV5zxxrH6m91uk9V3Lo0CHfq6++6jvrrLPc74h+V6pVq+Y777zzfKNHj07S5pTed8cyd+5c9zgtgwcPTnb/gQMHfCNHjnTnRr/XBQoU8JUvX97XunVr38SJE4/5OxhqxYoVvltuucX97uv9rvey935fv359qo/du3evOw86Vv3+HevvRO/evd051zHrdW3YsKGvf//+vh9++CHNr2VG/gbs2rXLtUd/Y/Waqa167+pchntvpPZ3Xsel+3Scx3qtd+zY4Y5J9+lvCgAgdsTpn+wOjAEAgNQpE0jZVcoKueGGG9J0upTFpayucLWWAAAAgOxGTSkAAAAAAABkOYJSAAAAAAAAyHIEpQAAAAAAAJDlqCkFAAAAAACALEemFAAAAAAAALIcQSkAAAAAAABkOYJSAAAAAAAAyHIEpQAAAAAAAJDlCEoBAAAAAAAgyxGUAgAAAAAAQJYjKAUAAAAAAIAsR1AKAAAAAAAAWY6gFAAAAAAAALIcQSkAAAAAAABkOYJSAAAAAAAAyHIEpQAAAAAAAJDlCEoBAAAAAAAgyxGUAgAAAAAAQJYjKAUAAAAAAIAsR1AKAAAAAAAAWY6gFAAAAAAAALIcQSkAAAAAAABkOYJSAAAAAAAAyHIEpQAAAAAAAJDlCEoBAAAAAAAgyxGUAgAAAAAAQJYjKAUAAAAAAIAsR1AKAAAAAAAAWY6gFAAAAAAAALIcQSkAAAAAAABkOYJSAAAAAAAAyHIEpQAAAAAAAJDlCEoBAAAAAAAgyxGUAgAAAAAAQJYjKAUAAAAAAIAsR1AKAAAAAAAAWY6gFAAAAAAAALIcQSkAAAAAAABkOYJSAAAAAAAAyHIEpQAAAAAAAJDlCEoBAAAAAAAgyxGUAgAAAAAAQJYjKAUAAAAAAIAsR1AKQFSIi4uz2267zXJTe4YMGZLdhwEAAOD6JOqbbN68OcvPxn//+1/33AsXLuSVAJAMQSkAmWrVqlV20003Wa1ataxQoUJWokQJO+uss2zUqFG2b9++mD77a9ascZ20cMuZZ55p0Wb//v127733WqVKlaxw4cLWvHlzmzlzZnYfFgAAUeOXX36xa6+91ipXrmwFCxZ0n5nXXHONW4/0+/rrr1PsK1199dVRdUr//vtvu++++6xt27ZWvHhxd4w6fgCpy3eM+wEgwz799FO78sorXaesR48edsopp9iBAwds7ty5NmjQINdBe+2112L+DHfr1s06d+6c5DyULVs26s7LDTfcYB988IHdeeedduKJJ7ornzrur776ylq1apXdhwcAQLb68MMP3Wf6CSecYL1797aaNWu6C1Bvvvmm+/x855137LLLLuNVyoD+/fvbGWeckWRdjRo1oupcrlixwkaOHOn6SA0bNrR58+Zl9yEBOQJBKQCZYvXq1e4KVvXq1e3LL7+0ihUrBu7r16+frVy50gWtYNa4cWN3VTWa/fDDD64z/eSTT9rdd9/t1nmBxnvuuce+++677D5EAACyNTP8uuuuc5nh33zzTZKLS3fccYedffbZ7v6lS5e6bbLKnj17rGjRopbT6fxdccUVFs2aNGliW7ZscUFJBSF1YRbAsTF8D0CmeOKJJ2z37t3u6mBwQMpTp04d10kL9dFHH7lAh7KrGjRoYNOnT09y/59//mm33nqr1a1b1w0hK1OmjPvQ15XIcPULvv32WxswYIDrHKpTpiuUmzZtSnal7cILL3QZXM2aNXPDDNVhHDt2bLLj2759u8sUqlq1qjtGtUNXxRITEy3SlFX28MMPu05OyZIl3fGrU6bMpFB6fg2J1JU5Hb/ae9555yWr3zB+/Hi3P507dZoUOPzrr7+OeSzqXOXNm9duvPHGwDo9j64E60pgWvYBAEBupYs2e/fudRngodnO8fHx9uqrr7oAkfpH3ueq+imzZ89Oti9tq/t+/vnnwLrffvvNBWX02a3P36ZNm9rHH38ctu+jfaqvVK5cOatSpUqSbVRTqmvXrq6cgvpQ6oslJCQk2WbMmDHWrl0793j1dU4++WQbPXp0suNMT/8p1LZt29xjdHzKMMqorVu3uotl6v8UK1bMtev888+3n376Kdm2aqdqa5100knuWNU/vfzyy11AMbg/9dxzz7k+qLYpX768K0Oh4z0WDdnT6wMgfciUApAppk2b5jomLVu2TPNj1KlR6rs6Uvpgf/75561Lly62du1a13GSBQsWuKwcBVPUkVEwSh2lNm3a2PLly61IkSJJ9nn77bdb6dKl7ZFHHnHbqqOhgurvvvtuku2UuaXOnoIs119/vb311ltuuJoCOOqYiDqb55xzjq1fv951UKpVq+aOZfDgwa6OgPadEdpvaOFRBaF27txpb7zxhhsK0LdvX9u1a5cL8nXq1MllLp122mmB7XXc6oyqI9anTx87dOiQzZkzx+bPn+86rvLoo4/aQw895Dqj2kbBuRdeeMFat25tP/74o5UqVSrFY9T96sSpsxdMHUpZsmSJC9QBABCr/R4FaXTxKBx91up+L0v8ggsucEGU9957z/UtgqmPor6HLtKJyh2oHqfqVKlmkS5S6XGXXnqpTZ48OdmQQPWjFBjThS0FwoKpD6DjeOyxx1wfQX0tBVyCA0nqV+n5L774YsuXL59rm/apgI2y3dPbfwqlPs+5557rAkoKoNWuXfuY51d9oNC+kgJAf/zxh7ugqQuUGi7577//uqCezqn6harpJYcPH3YBtC+++ML1IRWM0z5VG1PBP+8Y1L9Tf6pnz55uyKAy/1988UXXD9KFzvz58x/zWAGkkw8AImzHjh0+/Xm55JJL0vwYbV+gQAHfypUrA+t++uknt/6FF14IrNu7d2+yx86bN89tN3bs2MC6MWPGuHUdOnTwJSYmBtbfddddvrx58/q2b98eWFe9enW37TfffBNYt3HjRl/BggV9AwcODKwbPny4r2jRor7ff/89yfPfd999bp9r165N0p5HHnkk1TavXr3abRdu+eqrr3yHDh3y7d+/P8ljtm3b5itfvryvV69egXVffvmle0z//v2TPYfX9jVr1rhjfPTRR5Pcv2zZMl++fPmSrQ/VoEEDX7t27ZKt/+WXX9xzv/LKK6k+HgCA3Ep9irT0ey6++GK33c6dO93tbt26+cqVK+c+7z1///23L0+ePL5hw4YF1rVv397XsGFDX0JCQpLP95YtW/pOPPHEZH2fVq1aJdmnqE+i+3QMwW699Va3Xn2u1PpanTp18tWqVSvJurT2n7zjWrBggWuf+hTal/omx6L+UEp9JfWjdE4OHz6c5DFar2MIPodvvfWWe8wzzzyTYl9pzpw5bpsJEyYkuX/69Olh16fm/fffD/TnAKSO4XsAIk4ZPqJsp/To0KFDkqtljRo1cpk5ugrm0bAzz8GDB93YfQ2hU5bP4sWLk+1Tw82Uyu7RFUxdLdMwwGBKTQ++uqkrjBoiGPzc77//vttGmVe6WuctOm7tUzUkMkLHqCt1wcupp57qhssVKFDAbaOrk7qiqAwoZT4Ft1VXSdVGZYOF8tquDDTtQ1dIg4+9QoUKriBnuCGBwTRTolL4Qym13bsfAIBYpIybtPR7vPu9ftJVV11lGzduTDJDm4b16fNa94k++1WbU5/fXraQFvV/lDn9f//3fy6DO5iyq9WHCCc000kZ5fK///0vbF9rx44d7vmUeaQ+kW6nt//kWbdunduP+m/qM6nuaFop6yu0r6Q+jPomefL4v9KqL6bzogw0HUNoX0nDKL32husrqZ+nTHVlcQX3lZT1pX0eq68EIGMYvgcg4rwhXl4nLa00HC6UAkDB4/gV/FDKueodqBPmT0ryC+0ohdun9iehtQHS8tzq+KlAaUoz46ljmREKCimwFc7bb79tTz/9tKsloU6cRynqHtVCUHp6anUMdOw6V3qucI6Vjq4O6v79+5Ot9+pQBHdgAQCIJV6w6Vj9ntDglWo/Kgii4Xrt27d36/SzhudryLw3PE6f3xp+ryWl/oeG9oXrI4QK7QfoYqCCOsG1OTVMTRe6VDNSJQaCqa+lY05P/8mjQu8aDvjrr7+6gFJ6qGZUuL6SV1Pz5ZdfdkPtFJjyeKUfvL6SAlV6/tT6SmqfamlFsp8HIHUEpQBkSlBKQZLgAp1pkdJVveDAk65wKSClYuMtWrRwHSNd4VJ9gHDFxtOyz7Rup/3r6plmmwvH60BGioqSqy6DakYMGjTIdZJ0nArKBRflTAsdu87TZ599FratugKYGhUDDb0SK6qlJV7NBgAAYo36Ivqc1IWr1Oh+BY+8i3fK8tFn/JQpU1xQRfWQFBD6z3/+E3iM17dRMW9lRoWjjPFg6blQFJxNLupfKEBWr149e+aZZ1y9SGVtK5Pq2WefTdbXSms/S1RUXLWrFERSXyYSdK4UrOvVq5cNHz7cXaBTkE39xPROQqPt1deaMGFC2PtTuigJ4PgQlAKQKVRMUjPQ6CqbgkeRorR2FdJU9lBwto5mxctsupqoGQVTymqKNLVVxeI19C640xg6TE/HNWPGDJfin1K2lLZRB1FXTzMSPNNVW6Wta8hBcLHz77//PnA/AACx3O95/fXX3aQtrVq1Sna/Jh9RNpIKaQfTMD1lRasAtzKI9FntDd0T9QO8jOZI9D+UDRScSaVMLAVjVPxcVNRcmdGa2S84CyoSQ9d0YVEBNA3FUyBPRdsj0Vdq27atmwgmmPqFGq4X3A9Sn0VZ5yllh2ubWbNmuaLyZIADWYeaUgAyhbKJNDuMZnnTlb9QuhKnK2XppStyoVffNINccLp2ZlE9BwXZFAAKpc6P6j1Fknf1Mbi96lDpGIJphkJtM3To0GT78B6rq5Pan7YJPX+6rRoMqdHMOjrHCjR61GlV1lrz5s2ZeQ8AENOU0axAhoJOoZ+pumh08803uxmCtV0wBZp0QUnD9rRoVtvgoJEydzTDsGaU87KTg2km3fR46aWXkvWhRLP3ptT30JA2fd5HgrKalPWlmYs1y9/xCtcvVG2o0Oxu9ZVUH0oz6YXyHq9+nvo6yrgKpT5eVlwABWIRmVIAMoWuNk2cONFd7atfv7716NHDTW184MAB++6771yHQUPTMnIlcty4ce4Km4prKkCjq1rBdQMyizqSunKoY/CmO9ZUy8uWLXNX6nQFNPiq3PHS8yhLSlM9a+po1Up45ZVXXLuVseXRFULVadC0zroCqhoVuuqpq7K677bbbnOvx4gRI1wnUMep4QKqaaF9atiAiq2rk5gSBZ403bIer5oKutKpK7vaV+jVSQAAYo1qNelz8ZprrnH1j3r37u2CS97npAIikyZNSjKhiyhrRxeO3nnnHdeneOqpp8IGkpR9pf2qiLmyp3TBT30gFQ//6aef0nyc+ty/+OKLXV9Bj1epgO7du7sJVqRjx45uuN5FF13kAmzqbygDTMGxcEGxjHjyySddoEtF19UXufbaa4+rrzRs2DDr2bOntWzZ0vXJNPzOyzDzqB+qoYMDBgywH374wRVn1/lWH/LWW2+1Sy65xBVhV5s1tHDJkiXuXOj1Ud9K/VZdTNVFutSoryW//PKL+199VmXPyYMPPpjhdgK52jFm5wOA4/L777/7+vbt66tRo4avQIECvuLFi/vOOuss3wsvvJBkamP9OerXr1+yx2u64euvvz5we9u2bb6ePXv64uPjfcWKFXNTFP/222/Jtguefjjc1MLBU/TqsRdccEGy5z7nnHPcEmzXrl2+wYMH++rUqePao+PQlMxPPfWU78CBA0nao+mXU6Mpi7Xdk08+GfZ+TVH8n//8xx2fpjY+/fTTfZ988olrp9YF09TP2k+9evXccZUtW9Z3/vnn+xYtWpRku8mTJ7upoosWLeoWba/zvmLFCt+x7Nu3z3f33Xf7KlSo4I7njDPOcNMkAwAAv6VLl/q6devmq1ixoi9//vzuM1O3ly1bluIpmjlzpusPxMXF+f7666+w26xatcrXo0cPtz/tt3Llyr4LL7zQ98EHHxyz7yPqk+i+5cuX+6644grXHytdurTvtttuc5/vwT7++GNfo0aNfIUKFXL9t5EjR/reeust93j1XdLbfwp3XIcPH3bnJV++fL6PPvooxXPj9dvef//9sPerLzlw4EB3vgsXLuz6mPPmzQvbh9u7d6/vgQce8NWsWTPw2uhc6NwGe+2113xNmjRx+9N5atiwoe+ee+7xbdiwwXcsOtaUFgDhxemf7A6MAQAAAAAAILZQUwoAAAAAAABZjqAUAAAAAAAAshxBKQAAAAAAAGQ5glIAAAAAAADIcgSlAAAAAAAAkOUISgEAAAAAACDLEZQCEPWeeOIJq1evniUmJlpudcMNN1iNGjUiuk/tT/v1TJ8+3YoVK2abNm2K6PMAAID0iYW+TXp9/fXXFhcX5/5PrX+0e/du69Onj1WoUMFtf+edd9qaNWvcz//9738jdjzal/apfXvOPPNMu+eeeyL2HAAISgGIcjt37rSRI0favffea3ny+OPo6iCktNx8883pfo6XX345op2YaHXeeedZnTp17LHHHsvuQwEAIGaF69uI15d5+umnUwyQLFy4MN3P991339mQIUNs+/btadpegSA9V4kSJWzfvn3J7v+///u/wLE+9dRTltX+85//uPNxyy232Lhx4+y6667LsufWa/bSSy/ZP//8k2XPCeR2+bL7AAAgNW+99ZYdOnTIunXrlmT9ueeeaz169Ei2/UknnZShoFR8fHySrKLc6qabbrK7777bhg4dasWLF8/uwwEAIOak1LfxPPnkky7gUqRIkYg8n4JS+txXP6dUqVJpeky+fPls7969Nm3aNOvatWuS+yZMmGCFChWyhIQEy2yvv/56smyyL7/80mUsPfLII4F1Pp/PBdDy58+fqcdzySWXuGCd+o7Dhg3L1OcCYgXD9wBEtTFjxtjFF1/sOj+hwadrr7022dKsWbNsO9acoEuXLrZ//357//33s/tQAACISSn1beS0006zf//911555RXLTgULFrT27dvbpEmTkt03ceJEu+CCC7LkOBRk0rEE27hxY7LgmrK2dD7z5s2bqcejzLYrrrjCxo4d6wJhAI4fQSkAUWv16tW2dOlS69ChQ7of++uvv1rhwoWTZVPNnTvXdViUfi2qU/DLL7/Y7NmzA6nobdq0CWyvVHfVKqhatarrFGn4m1Lug6/aeXUMlML+2muvWe3atd22Z5xxhi1YsCDZsX300Ud2yimnuM6T/p8yZUrYNug5nnvuOWvQoIHbtnz58i7Tadu2bUm2U6doxIgRVqVKFXdVtW3btq5N4ZQrV84aNWpkU6dOTecZBQAAmd23Oeuss6xdu3au5lS4oXOhlDV09tlnW9GiRV2gRpk86gN5NGxv0KBB7ueaNWsG+jrBdZJS0r17d/vss8+SDPtTv0bD93RfOH/88YddeeWVdsIJJ7g+iTKaPv3002TbrVu3zi699FJ33Oqb3HXXXe6iWajgmlJezSmdQ+0zuC0p1ZT67bffXBBJx6O+VNOmTe3jjz9O9jzqN+m8q++o/pT6VSnV+1K2/p9//mlLliw55jkEcGwM3wMQtZRuLo0bN052n1LGN2/enGy9UqoLFChg9evXt+HDh7uOmDojuiK5Z88e17lRYVEv5VpBn9tvv90VAH/ggQfcOgV/RGnr55xzjq1fv94Fg6pVq+aOafDgwfb333+7x4ZeOdy1a5fbVh0jdSgvv/xy10Hz0sk///xzl6108sknu9pOW7ZssZ49e7oOUCjtR50r3d+/f3/XCXvxxRftxx9/tG+//Tawz4cffth1njp37uyWxYsXW8eOHe3AgQNhz2uTJk1cYAwAAERP3yY4kNS6dWsbPXq0DRgwIMXtZs2aZeeff77VqlXLPUZBrBdeeMEFttQXUDBH/ZDff//dZTw9++yzrlyBlC1b9pjHqseqVueHH35ovXr1CvR11I8Kd/zK8GrZsqXrP6nfUqZMGXv77bddH+yDDz6wyy67zG2n41QW1tq1a912lSpVcrWhFGBLjfp22k4BLPWbBg4cGGhLuElcFGjSuahcubLdd999LgD23nvvuWDY5MmTA8ej+lC6oKchld52usioAFVK/ShRX+z0008/5nkEcAw+AIhSDz74oPKifbt27UqyXutSWiZNmhTY7vDhw75WrVr5ypcv79u8ebOvX79+vnz58vkWLFiQZH8NGjTwnXPOOcmef/jw4b6iRYv6fv/99yTr77vvPl/evHl9a9eudbdXr17tnrtMmTK+rVu3BrabOnWqWz9t2rTAutNOO81XsWJF3/bt2wPrPv/8c7dd9erVA+vmzJnj1k2YMCHJc0+fPj3J+o0bN/oKFCjgu+CCC3yJiYmB7e6//3633fXXX5+sXf/5z3/cff/++28KZx4AAGRl30a0Xn0Vadu2ra9ChQq+vXv3uttjxoxx9wf3YdSnKFeunG/Lli2BdT/99JMvT548vh49egTWPfnkk+6x6q+khfoO6v/IFVdc4Wvfvn2gX6VjGjp0aKDvo3177rzzTrdOfRiP2lmzZk1fjRo13OPlueeec9u99957ge327Nnjq1Onjlv/1VdfJTmW4P6R6Lb6PcG849F58ui4GzZs6EtISAisU1+pZcuWvhNPPDHZcX///feBdepflSxZMsXzpr7XLbfckqbzCSB1DN8DELWURaRCm8piCqX09JkzZyZbdKUreNy/Mo00dbCuJKoopbKclLqdFqq7pJT40qVLu6wsb1HK/eHDh+2bb75Jsv1VV13ltvXosaJMKVF2lVK9r7/+eitZsmSSNHBlToU+t7bRfcHPratzOh9fffVV4CqpMqKU7aXsLI+GHKbEO8ZwmWYAACB7+jbBlPmkDJ6Uakt5fQplgGtomkdD9NV3+N///heR49UwPQ2b07Eok0n/pzR0T8+p2p6tWrUKrFM7b7zxRje8bvny5YHtKlas6DLZPRrqp+0iZevWre54VaRdWexeP0rnv1OnTm4IojLhvePRMMPguqTKvrrmmmtS3L/XNwRw/Bi+ByBHUtp2WmpNqb6TV09B9ZseeuihND+HOiyq+5BSirsKbQbT8L5wwR+vBpTqD8iJJ56YbF9169Z1qfbBz71jxw5XZyG1505pnzrm4ABZMK8wZ3AQCwAARA8N39OFNpUC0BC6UN7nv/oP4Ya5zZgxw5Ut0FC046GyAJqt991333VBMNXLVH3NcDWpdEzNmzcPezze/eqL6X/tI7QfEq4tGbVy5UrX31G/L6W+n/pSGtqX0nGndjzaN/0oIDIISgGIWqpFoPH9usKlDlFGqY6TbNiwwV0hq1ChQpoepwKXutp4zz33hL1fMwAGS2nGl4zMzqLnVkBK0y6Hk5ZaECnxgmReXQkAABB9fZtHHnnETb7y6quvJpttLqto4hbVllJtKGV+60JfTuAVKb/77rtdZlQ4CoxllIq/048CIoOgFICopUKaogLfSkfPCKW9a1jfo48+6gqLq3h46MxzKV3pUpaVhv5lZPa/cKpXrx7Iggq1YsWKZM+toXkq0JlSoc3QfarQqUcFP0Nn6fPofKojdTyBLQAAkLl9G022oqCUZv3VpCbhPv9D+w/ejHP6nPeypI43o0fD9d566y1XFuHqq69OcTsdU0rHE3zM+v/nn39Olm0U7rEZ5fWJNCnMsfpxOp609M08Gvan0gleBhiA40NNKQBRq0WLFu7/hQsXZujx6vBp2J5mu7v//vvtqaeectMAjx07Nsl26rQFT3fsUR2CefPmuRT4UNpeVzrTQ/UTTjvtNHe1UUPzPAqaeXUWgp9bdas0g2AoPa93vOpoqcOl2XaCM7JCZwYMtmjRosC5BQAA0du38WpLaTa4lPoUwX0YBXuUIa5hdx4vOBWur5MWGkao/ohmAE4t21zP+cMPP7i+k0dDCHXsmgnQq5+p7ZS9rhn5PJqxL7SNx0PZ5l6WmepvhQqerU/HM3/+fHfswfenlK2ufpRopkEAx49MKQBRS1e5VHtAGUPeVMQeTW88fvz4ZI8pX768G3KnAI0eoywjTaksypLSFMB33HGHC+ZoCmJR8XBtM2LECJfKrY5Mu3btXEBLQawLL7zQFRLVdupcLVu2zHWkVE8hvanbyta64IILXBFQHZ8KcSqg1KBBA5eVFXx1VMer7VXDoWPHji74pCt5KoI+atQoVyBU2U5KTdd2Ok51rH788Uf77LPPwh6b6ieoTla/fv3SddwAACBz+zbhqD+gZfbs2cnue/LJJ91ELgp09e7d2/bt2+f6FJooJXiYnfov8sADD7hMJ/UnLrroojTXm1KG1IMPPnjM7e677z6bNGmSO6b+/fu7AuwKmukiofpf2o/07dvXBbh69OjhAjwKsI0bN84VO4+kl156yfW3GjZs6J5T5/7ff/91QbN169bZTz/95LZTmQY9/3nnnef6iDovCpApg0p9plC6mKg6oqeffnpEjxeIWceYnQ8AstUzzzzjK1asWGBKZNGfrpSWc845x20zatQod3vy5MlJ9rd27VpfiRIlfJ07dw6s++eff9zUwsWLF0+yD28q48GDB7tpijX9b3x8vJtK+KmnnvIdOHDAbRNuWuTgY33kkUeSrNMx1a9f31ewYEHfySef7Pvwww/DTnksr732mq9Jkya+woULu+PT1Mb33HOPb8OGDYFtNMWypmeuWLGi265Nmza+n3/+2e1P+w02evRoX5EiRXw7d+5M1+sAAAAyr2/j9Rn69euXbPuvvvoq0M9ZsGBBkvtmzZrlO+uss9znv/o3F110kW/58uXJ9jF8+HBf5cqVfXny5HH7Ud8lJeo7FC1aNNU2pNT3WbVqle+KK67wlSpVyleoUCFfs2bNfJ988kmyx//555++iy++2PVJ1Le64447fNOnT3f7VHuDjyW0f6Tb6reFO54xY8YkO54ePXr4KlSo4MufP787BxdeeKHvgw8+SLLd0qVLXf9Px6xtdL7efPPNZOdKfS71tx588MFUzw+AtIvTP9kdGAOAlGiYm65safYZXQXE8dFVPaWzP/vss5xKAACyAX2bnOujjz5yNbZWrVrlMrwAHD+CUgCingp8jhkzxtVd8lK/kX7Tp093Q/40e46GKAIAgOxB3yZn0lDJs88+210sBRAZBKUAAAAAAACQ5Ug5AAAAAAAAQJYjKAUAAAAAAIAsR1AKAAAAAAAAWY6gFAAAAAAAALJcvqx/ytwpMTHRNmzYYMWLF7e4uLjsPhwAAJANfD6f7dq1yypVqhSzs4XSJwIAILb50tEfIigVIQpIVa1aNVK7AwAAOdhff/1lVapUsVhEnwgAAKS1P0RQKkKUIeWd9BIlSkRqt2aJh8xWj/P/XPM6szz5suWK56ZNm6xs2bIxddU3Vtsdy22P1XbHcttjtd2x3PbMbvfOnTvdRSqvXxCLMq1PFMPv2+PFeeO88Z7LGfhd5bzllvdbevpDBKUixBuyp85XxINSxQv7f9Z+sykolZCQ4NoVSx3AWG13LLc9Vtsdy22P1XbHctuzqt2xPJQ/0/pEMfy+PV6cN84b77mcgd9Vzltue7+lpT9EUCrqxZkVqXb0ZwAAAAAAgFyAoFS0y5PXrNJ52X0UAAAAAAAAEUVQCgAQmCVDKbyxNCRGacsHDx6MuXbHctsj0e4CBQrE1DkDAGSuw4cPu8+mWP1sPl6ct5zdJyIoBQCwAwcO2JYtW2zbtm0xVQtHgTh9IGvK2lhqdyy3PRLtVuerZs2ariMGAMDxfCb9888/tn379oh9RsUizlvO7hMRlIp2bva9sf6fa/bIlkLnAGKjQ6QPk8qVK1vevHktltp+6NAhy5cvX8x1/mK17cfbbnXeNmzYYH///bdVq1Ytps4dACCyvIBUuXLlrEiRIm5dLH42H69Y7dPklj4REY6cwHcou48AQC6mD6O9e/dahQoVXIcolj7MY7kTE6ttj0S7NXWyOmHaT/78+SN+jACA2Biy5wWkypQpE9OfzceL85az+0RRNVBVaWN33nmnVa9e3QoXLmwtW7a0BQsWJNnm119/tYsvvthKlixpRYsWtTPOOMPWrl0buF/jIfv16+d+sYsVK2ZdunSxf//995gvxsMPP2wVK1Z0z9uhQwf7v//7v0xrJwBEW6dI+HINpI2Xou797gAAkF6q5SNehhQQq32iqApK9enTx2bOnGnjxo2zZcuWWceOHV2AaP369e7+VatWWatWraxevXr29ddf29KlS+2hhx6yQoUKBfZx11132bRp0+z999+32bNnu6jd5ZdfnurzPvHEE/b888/bK6+8Yt9//70LdnXq1MkFuAAAAIJx9RoAECl8piDW379RE5Tat2+fTZ482QWIWrdubXXq1LEhQ4a4/0ePHu22eeCBB6xz585um9NPP91q167tsqaU8ig7duywN99805555hlr166dNWnSxMaMGWPfffedzZ8/P8Usqeeee84efPBBu+SSS6xRo0Y2duxYF8z66KOPsvQcAACQGZSFfMMNN3ByAQBAlmnQoIF98sknadp2woQJbqRUJCiBpVSpUqluo/jAmWeeaZltzZo1LnDjFbOPdh999JHVqFEjcFuJQrNmzcrU54yaoJTGICrlKzjrSTScbu7cua6I1qeffmonnXSSy2JSIKp58+ZJAkeLFi1yaZDKrvIoq0pFt+bNmxf2eVevXu0KzAU/RkMDte+UHgMAyHpt2rSxggULuqHZJ5xwgrutv/sAAADIPApKnH322a4Ppu/K559/vi1evPiYj/vll1/swgsvTNNzXHPNNS6ZJKvce++9LukFqdM5GjRokGWmqCl0Xrx4cWvRooUNHz7c6tevb+XLl7dJkya5wJCypTZu3Gi7d++2xx9/3EaMGGEjR4606dOnu6F5X331lZ1zzjmB2aNCo6Lal+4Lx1uvbdL6GNm/f79bPDt37nT/K3imJWL+XKPwqv/nbQvNylYwq1bNspLa400XGUtitd2x3PZYbreo7cH/RyN9BijrR8OrBw8e7DJc//rrryTb6OJEeupjHavd6d1fNEqpjTnhNc8Mx9tuPc77WxH69yLW/n4AQKgPPzQbOjTOVqwob3Xrmj3yiNkxqqkgin388cfWvXt3e/bZZ+1///ufSyZR2RuNblJGUtOmTZM9RttoNudoHZr4888/24oVK9woLKROr7OyvL799ls766yzLFcHpUS1pHr16hWYkrxx48bWrVs3dyXc6+TpC4jqRslpp53moqn6pVBQKis99thjNnTo0GTrN23aFLFaVHnWrbOyrc+yuHoH/Ct+esx8+QvaJmWOValiWUXnXkMj1QHPkydqkusyXay2O5bbHqvtVtDF+3Ktn9PbgZgyJc5GjMhrv/9udtJJZg8+eNguuyzyQQ4vCODNEnL99dfbqFGj3BU4Zc9qsozPP//chg0bZjfeeKM9+uij9s4777gPUl30eOmll6xSpUpuX7qA8fTTT7vPD130OPfcc91QcV39U5q1snJff/11FwTTftetW+dqHt5///0uw7ZWrVruc6B9+/Zufzqul19+2e1Pw781k6E6b8rs1XHruXWfJt449dRT7YUXXnAXYERDyHV727ZtbpIOBdv0WajnueWWW2zhwoXuM1GZv5999pkriKqLNLpypZR4feYotVr70fHLnDlzrH///q4tygQuXbp04NwFn0+vKGW0dhozQyTarfOo87lly5ZkAUu9XwAglgNSXbro76v+3sbZsmU+d3vyZAJTmXW+9ZXU64NFOgCoz8w77rjD7rvvPuvbt29gvfoqK1eutLvvvtsFprzPVPVn1N/RpGGbN2+2hg0buv7JpZde6rbR/SrFo1mf1cdRP8YrMfDf//7XbbtkyRK3rYaQ3Xrrrfbhhx+6jCvFBsaPH29Vq1Z1999zzz327rvv2tatW9061Zq++uqr0xxoU7BF/SuPjv/HH390MQbRsWhUVnD71Fd88cUX3URrythX/MLre6nNAwcOdEk16mfofh27R3WvFT/QedH5UD9TfYjdu3e7LDE9TkkvXj9R/4tKGikeosng1P4SJUrYk08+aVdddZW7X4/Ra/Tee++5Y1FZItXqVj9S51CvofanfqqSbtQ+tcPrh6qPe9NNN7nhjCeeeKKbKC6Y2q3SSDpnmRWU0kFGnd27d/s2bNjgfu7atauvc+fOvv379/vy5cvnGz58eJJt77nnHl/Lli3dz1988YW+Bfm2bduWZJtq1ar5nnnmmbDPtWrVKveYH3/8Mcn61q1b+/r375/iMSYkJPh27NgRWP7666/Acx8+fDgyy4IFuoabbNH6iD1HGpaDBw+610P/Z+XzZvcSq+2O5bbHarv37Nnj++WXX9zfssTExHQtH3yQ6P40xcUl/V/r07uvYy3nnHOO+1uun/U5ob/R1atX911//fW+woUL+z777DPfoUOH3H133323r127dr7169e7v9cDBgzwnX322YF96e91kyZNfOvWrfP9+++/vnPPPdd3ww03uPv++OMPd/+ll17q27p1q9vf77//7itUqJDvgw8+8B04cMD33nvvuefUZ4ge89xzz/lq1qzpW3Dk7/OaNWvcOdV9L774oq9Ro0a+FStWuMdq29q1a7vj+u2339x+li9f7rb9+++/fUuWLHE/d+vWzXfjjTe6zz8tc+fOdY/RfVdeeaW7X8e3a9cu39VXX+279tpr3X1btmzxlSxZ0jd69Gj3fFOnTvUVKFDAnafQc6r9Rvp1ygnL8bZ779697vXV707o75P6AXr/6PcpVqntmXUOdI71e6L/wXnLbLzf0q9RI/UFkn590e1TT82EFyiH27dvn/v81/8efcbos1v/H8vkyUfPb/D/Wh8p6qfo77n6O6FmzZrly5s3r/tMFG3XokWLQN9Lvz/qp02ZMiWwfalSpXzff/+9+xx+6KGH3Pf7MWPGuPv1/6lBbxQ9tmHDhq5fpnN0/vnnu76MZ/z48a4Pp77fxIkTfQULFgwc51dffeX6QilRP0rPHyw0JvDss8+6vmfw/W3btnXPqc/6008/3ffII4+4+9RXVMxh8ODB7me178svv3T3rV692j1W/badO3e681OlSpVAu3fs2OF755133OPUTvVvTzrppMB7QM+RP39+37vvvuva+vbbb/uKFSvm9iUPPvig69PqO8z27dt9F1xwgXs+Pa+89NJLrh+qvqy+44waNcr1Q72+UKtWrXw9evRwfZpff/3VV6NGDXfugz311FO+jh07pvl9nN6+QFQGpTzqbOvN9Oqrr7rbepOr0x1MXxr0AoteBL1g+tIQ+os0b968sM+hF6JChQruRHt04vSmnjRpUvZ2wBYtChuUcuuzUKx+IMdqu2O57bHabn2I6Au2Pty8D8AmTXy+ypWPveTLF/7PlNan5fFa9FxpoY6BAkP6XChfvryvU6dOvp9++sl1UC655JLAdmpD0aJFXXAnuI158uTxrV271t3W32t9uHudP31GKHCj197rPAR3TEaMGOE777zzkhyPAlmPPvqo+7levXqukxDOySef7Pvoo4+SrKtUqZLvm2++8a1cuTIQ7PI6dR51EC6++GLXiQi2ceNG1xZ9Rnq0jT7/1FkZO3asr379+kkeo2MP7silt+Obm0Si3Sl1wDI7IJNTEJSKPrH6+Xa8OG/pV6hQ+H6B1uPYnyVNmiT6Klf2lsztg6Wl/6ULYvpMC/d5p2PXfbrAJ/rZC0B5goNSvXr18vXr1y9wnz6L1adLLSilC2zBQahTTjkl7HHqM12Bl3HjxqUpKNWhQwffk08+me6glC6ABvcNL7zwQvezgkoK9ITrW3j9SgV8PH369PHddtttYY9t25GLW955VVCqefPmSdqqPuvChQvd7Vq1avnef//9wP0//PBDkqBUav3QP//80237zz//BO57/PHHkwWlXnvtNd8ZZ5yRaUGpqBq+N2PGDJdeVrduXZcOqIJaGq7Qs2dPd79uK01NqXZt27Z1NaWUBuel1CldrXfv3jZgwABXBFepbbfffrsbthFcWV/71LCLyy67zKWjKWVQdaqUrlazZk2X+qchHl6aIQDEGpXUW78+44/XKLHjeXxK9Ldbf7NDaUILj9Ki9+zZ4z4rgodnacie6k95ad9Kg/bo5wMHDrgh2OH2qdTm4JlIREP4tF7+/PNP9xkSjobQXXvttUlSxPVceqyKhr799tsuFVyfdfqsUlq7UquVmq2UbQ2/UzuU2v7www+7/WnomD6vgmnIqdKyNXwwuG1e+yI1tBwAgJRoCNmyZf7wiEcfxaothbT2v45vSH0k+2Dx8fHuf/Ut1O8JpnXq2+h7d7i+UyhtryFtHg1dq1ixYqrPr3IInqJFiyYZIq8yCW+88YbrT6mfpGFw6gOmhcoaeDWh0yOl41E/sHbt2qmWBQh9rDcb3759+9ywP9Xr0lBEr4SI2qKyRqGP1XNoMjjvuXVevb5tuNcgtX6oXgNNNKcyGJ7QPqToXOmcZZaoCkqplovGp+oE6c2t8YyqCeLVa1AQSWNU9aVEtTIUvJo8ebK1atUqyZtTL6Qeq/GVqueh8ZPBVNRMz+XReFR9gVENEr05tD8FvEJnAsxy+iNQuIBZkyM1pTQZQYFC/vUAkImCPvtS9e+//s5PqHz5NGFEZJ8rNcE1wFSXSXWXvv/+e3cRIiXqQDRr1sz9rNoAClqVLVvW/Ry6zypVqriZYEM/5BX48j7AdTFFF0FCqaOgugTnnXde2OPo2rWrW9QpUdDpuuuus2XLlrkOgvf5pduqe6XaDBrPr2NTJ0TtDKWLKmpbMLUpuMMBAEBmUE0jf0kaRaX0BV0jc+LceqS1T+RF9OIytQ+Wlv6Xamyqj6MJyEJnqtM69UkUIPGkVpNV/ZPgyWlUn/Hvv/+2jFCfTBfuvvzySzv99NNdoEYX9NI6gYm29WpXBQeKVOvKk55j0zlatWqVe/701qt8+umnXc0otUn9TcUjFABKa1u889q8eXN32+vHpqUfqm110VL1Vb2J30IfL8uXLw/U2soMUVXJV51yvZgKJulNoCvHXuEwj4q/qoiYOu96I6nweTAFklRQVlFGBZpUXCw4sih6gXXF2aM3jgrj6gqzXhRNealfwGynKKem2lRMTotmNlixIstn3wMQexYuVHbQsZd33/Vv733+ev+/917aHq9FzxVJ6hDdfPPN7qqT1/lRQWoVwwymTCQFdvTh/8gjj7jimCl1ppSlq6zcqVOnuk6UPlu++eabQEFNFYhU8Up9LukzRh/ov/76q7uvX79+LtikCyLe1SbtR1e4tE4F1PWZpqCYplpWEXf/OXzP7Uf706yyusKl+/SZpkze2267LXBFUJ9fU6ZMcT9fcMEFtn79eldAU8f66aefuk4bAACZTUW2VdT8yEeZ+1+1ni+7jHOfFgsWmK1efcjUfcnsPlha+l/6nqykDyWFvPnmmy4bSf2mkSNHuslklN2dVprAbOLEiW4CF02so5FK+r6eEepLqV+ki4nKHn/rrbdcMfS00iQ5mhTGm/hEVEhdhcvVd1J/Tj+nlfpeimGov6c2KRPpq6++SnNbChUq5AJROr+aVCc9dF71OqgvqMSb4cOHJ7k/tX6oAlYtW7Z0hezVF9U2r776arLnUFt0zmIiKIUwqhxNxbPixQhIAYjKzmejRroo4P8/Gjqf6jwpa0mzhRQvXtyaNGniZuYLplRm3V+nTh23jWbyS4m2USBKwStl8upChoJAXiq7snc1i4wurmhfGnLnXWlS8EgXQi6//HI3rFyznahTJuq0aMi4rk4pw0vBI80+I7pqpo6CAlVqi4anX3zxxe4+baNA1RlnnOH2qWGA2l50fOpsqD3aRqntmtUFAICs6ht4mTr6P7v7BLlVVvXBNFpJo5PGjBnjLoxpeJj6KwpUeNk5aaG+kfpRurCm/Sj4o0SQggULpvuYlPVzxRVXuAxyZQopIKU+U1o1atTIlV3QrMYezVCnGfDUd7r33nvdLM9ppb6aElvUF9P50bBEJcqkxYABA1yATX3BU045JWzWfWo0255m6jv55JNdNlPnzp3deu+8ptYPlbFjx7qRasqo7969u0sCCqbgndfXzCxxKiyVaXuPIYo4KqtL0Um9aBHz2y9mt57i/3lPU7P3J2d5YErRZ6X06Y2aWkpmbhOr7Y7ltsdqu5Uh+scff7irJfpQTW/acU7kTfurD3F1ipSBFAvtDqaP/1hseyTard8ZTbWsul6hQ/0zrT+Qg2TmOYjVv9PHi/PGectqVar4XG2kypV9tm5d7HzGHO9nSSx9NuvCnC7IqWyOhgEej4ycNwWg7rrrLps/f77lJvPmzXO1u/T+Ota5SMt5Uzmku+++25WRSE+fKD19AT7No5musjdufPS2cixVJTDMOE8AAJB7KK1eRf1Vp0L1OnQFeIHGdYSh4arqTKpmRDCVMlCWnDqDuvKrbDsNDUhLh1ZZhKqvoceqdprS+gEAOB7KOtfniYa4KRtJQSllfWcHZSTlhoDUxo0bXdaahiKqLIVqdKu+dqSCmpqMLqWAVKQQlIpmqhWy/0iRc49mT0rjrAIAACBn6tOnj6s3ppoWKnTfsWNHN/RB9cKCaRipOtUavhBKASkNadB+PvnkE1cHTZO6HCsgpWERer4ffvjBBcKU+k9WEgDgeOkzTUPb9Jm1ePFi+/jjj11NTWScglHK+FJWkobvacY+DUXMSaJq9j0AALKCN3KdEeyIRrqKrPodqg3mzfCoWYamTZtmo0ePdsVhRQGq22+/3V3FVJHVYCq0ryERCio11UQpR+plqNbEU089FTaIJerYqkaaip56NNsxAADHy5uUBZFTsWLFZDMJ5jQEpXKCXdl9AAAAIKuovoOufIbWq9IwPk0Z7dUIuu6662zQoEHWoEGDZPvwirV6ASlRppUynr7//ntXuDbcEADdpwwrDRfUjMj16tWzRx991Fq1apXi8WrGIS3BdSS8Y9QSSdqfgsmR3m9ux3njvGW9o0OH+H1N/ffSWzxcOMsYzlv2nDfv/Rv6mZ+e33uCUtEsPt4sf0GzhUc7em5qBa0HAAC5kmZwVK0LTeusWXI0I8+kSZNcoEkzQYqm41ZhUmU1haOpoVUMPJi21+yMui8cTXjgZWUpm0rDADQrT/v27e3nn392MxWlNNvl0KFDk63ftGmTK4AaSerkqmiqOsAMKeS8ZTbebxl3+HBZM8trhw9rcoJNEXxVco+DBw+695guRGgR/W3TRQnJ7YXOI4nzln3nTe9dvY+3bNli+fPnT1IbM60ISkUzzbL3009m9er5b6sI3AcfZPnsewAAIOvrbmhaZtWG0FTRjRs3tm7durnpprWMGjXK1eOI5JcW76rmTTfdZD179nQ/n3766fbFF1/YW2+95YJP4aioqqa0Ds6U0myeZcuWzZTZ99Rm7ZugFOcts/F+y7i8ef1/m/LmzZMsQA4/Be31xV1/y3TRIFjwl3ukHect68+b+ih6D6tofXCGd2i2d2oISgEAAESZ2rVr2+zZs90MRQryqGbEVVddZbVq1bI5c+a4oXbVgi5S6UrnwIED3Qx8a9assQoVKrhtQq9makY+3ReOnkNOPvnkJOuVrbU2lZl/CxYs6JZQ6qRmRuBIQanM2nduxnnjvGWto0OB+F0NT1/a9YX+77//doF2r+C3N4SbTKl0vNt8Ps5bNpw3PX7z5s3ud1z9gODf9fT83hOUimbqAJ7eyKzlkdvzF6jaqNmKFWRLAQAQA4oWLeqWbdu2uYLmTzzxhJvqWfWhgnXq1MnVmPIynDT8b/v27S6rqkmTJm7dl19+6TI/mjdvHva5atSo4Qqgr1A/I8jvv/9u559/fqa1EQBikb6016xZ0wWlNmzY4NZ5tXl0H0GptOO8Zd950+OqVKniAqwZRVAqmm3ebLb/gFnwxUfVZtB6hvABAJBrKQClzqJmvlu5cqUraK6i4wo6Kc1eafLBtE4ZUN5MecpuOu+886xv3772yiuvuNolt912m1199dWBmfc0e5/qRaluVLNmzVzHUs/zyCOP2KmnnupqSr399tv222+/2QcqHwAAiChlRynr1ctW8Wrz6G88GWZpx3nLvvOm/sfxBKSEoBQAABFw5513usyU//73vxl6vAIA2scNN9wQ9n51VlXfZ+LEiXbKKaeE3UazrX300UfWpk0bywwKWvz444/uWKPNhAkT7KWXXrLvvvvuuPelc602vvfeey64kx1UzFu1mtatW+eKkys7SrPgpafug86JAlEKPKmzqX08//zzgfsVqFJW1N69ewPr9B5UnZO77rrLDfVTcGrmzJluOCEAIHM+W/W3XYuCBPpfQ/sISqUd5y1nnzeCUgCAHEGBFs0+FvylXB+iGst+LAr0KGCjejs5lbJZNPtZSgGpSNNQLp2vSy+91HKCa665xi2RoCt+d999t91///02ZcoUyw5du3Z1S1qpjlQoBbMUxEztNQ43BfR9993nFgAAgMxGhchoFh9vVtBf8C5AVey1HgCiqf7d4sVHl1QKIh+vkSNH2u7duwNLWgJSuYWygLx6QbE8ZXFWueKKK9ysc6kV+AYAAMDxISgVzVQ3Sl/wPE2bUuQcQHTRF3bVsFEhZW/R7Sz+Ir948WIrWbKk/fzzz+62ikKrRoPq4Wi4koYxvfzyy1asWDFr0KBBYOjSww8/7Or0xMfH28UXXxwoNOql06sWjzKTNK297teQKs8333xjDRs2dPu8/PLL3bTOwVatWmUXXXSRm1GnevXqNmLECJcm7XnxxRetatWqbhz/Aw88kGr7dFwaNnfOOecE1mlfDz30kJUvX97VCFLQKtQ777xjjRo1clliZ5xxRpKhbW3btnXZMPq/ePHirjD2r7/+6u678sorXTCmW7durn0333xz4HHz589P8ZwEu+OOO6xXr17JgooqyC2ff/65NW3a1L1umvXt1ltvtX379iXJ4nnsscfszDPPtCJFirjzpZnngjN7dCzKBtJwMw2bDB5WqMerKLger/bp3P3111+B+3/55ZfAfToH99xzT5JhjyournP26aefpvraAAAAIOMISkW7KlWP/ly8GAXOAWQNBcGrVDn2ou00AUMw3U7r4719HKfGjRu74swq4qzARu/eve3ss8+266+/3vr37++GdSnooewqBSNEgSAFab766isX9DnppJPc44OpppBmLFOARrV9nn322UDQSwEZ1etRHSllMI0fPz7wONXoUR0fLSomPWfOHBcgGjNmjLtf+9Tza/+adUe8gFo4S5YsscqVK7sAikdBGC2zZ892hbAXLlyYJDD2v//9zw1B0zaqDaT6RAqSqaClR8fzn//8x61r166dXXLJJa7Y6vvvv++CepMmTXLnTMG5Y52TUJoJbvLkyUkCTePGjbMePXq4nwsXLmyvv/66O7Zvv/3WvQ7PPPNMkn3o2BVY1DHccsst7ryqvcHHr8CZhnGGo9dEbdi0aZMLMimI5wUk1VbNKKe2P/744/bWW28le/zJJ5/szj0AAAAyB0GpaLfuL7M95l927c7y7AMAMeqffzQ117GXTZvCP17r0/J4LXquNFJgRVk/3nLuuecG7lNhZmUeKfvlp59+stGjR6e4H2XbKHPq6aefdlk6mv1GmUwKjgRn0yh7ply5cu65VCR60aJFbv0nn3zispNuuukmy5cvnwv2KKjjUXZN6dKlXdFob2YdZQ559X2UuaVAmbKTdP+QIUNc0CQlCoIpMymY9nH77be7TC9lEimwEpyJpcwpzaSmgJ2KVyqbS9sqWOVRzaLgY/j3339d9lFqUjonoZQFpSmCp06d6m4r00uBrMsuu8zdVtBQhdtVv0kZUDqXX3/9dZJ9KBCl2eS0jY5RQUavkLyyo959991UhzQqEKnpthW00vn2jvX77793wSgFBrXf5s2b21VXXZXs8TrnOvcAAADIHBQ6j2YKQJ3WxGy/t2Khf1jMihVkTAHIXBUqpG27AwfCB6bKltU8x5F9LjM3nEuBnnA03E7DzFSY+6mnnkoWxAmmWlR79uxxQ7r0OI8CFApKKbjlP7Sjx6agkZeJpMwqDckLptsKlHhFp5X5pMCNRwEjb796fPBQMRVvV3AsJQpw7dy5M8m60GPQML6CBQsGbusYVKhbGWQeZQgpc8ujYFnoMQTfH05K50Tn3ssWu/baa112lbKlVKBdGWj6X0EsBdBkwYIFLsi4bNkyl02lDC0FoIIFH59oOKCCXRrKN23aNHe/bqf3WHXu1FYFFIOfy8ui8+ic69wDAAAgcxCUimYq4Ls/EJHy0xcerQ/pqANARC1cmL6aUsFD+DSUSo/P4r9TymhR5tCNN97ohqSpLpIX1Aid5lZ1nBQcUVZQnTp1XHAiODh1LMqS+vPPP5OsUxaQMohEwacmTZqkmHUU+ngFi7xhfOGoVpKCRRrGphpP4faxceNG2x/0maFj0PkIrgcVKriIt3cMGiYo6Z0aWEGo4GF+ouwkBcV07BpGFzwTnIbdKctJmVQKGGmmPy8LyhN6DApanXrqqfbBBx+4/WW08LvO3T///OMCYV5gKlxB8+XLl7uC5wAAAMgcDN8DAGScgj7K3tSwKG/JpmzOPn36WOvWre3VV191wQoFRLwZ25RF9McffwSKZCvYoWCNai55w/U0nEvDwdLiggsucIEW1URSYEPD9VRnyXPhhRe6oXAaIqjsKR3HihUrAsPTFJDR8DsNIztw4IANGzbMZW6lFkRRYCq4npL2oSF62q8yjZR1FBzE6devnz355JNuyJrarXpMs2bNcnWgPKodFXwMKsqu4Y/eOVOx9uOhwFirVq1cjS9loamgeHAWkjLJFJBSgfXUhlsG07407FKF5pWRlREarqfnVuadgnHK2lKtrGA6X1rfuXPnDD0HAAAAjo2gVE54hZodWXi1AEQjBaAaNz66ZGJA6t5773WZQsGLgkkKRKlmkYJAomCDgkGqE+UFrBRE0kxtmo3O20YBGM0Gp6F+ymzSjHBpof0ow2fUqFEuuPHGG2+4IJhHx6UA0BdffOFmgVNmVvfu3V12jnTo0MGGDx/uhrNpGJmG9mlGu9QoyOQVSveGsikoo9pMqsmk+kzBhdBV50p1pvr27euGoKm2ko43uO7UDTfc4GbgU3tmzpxpH330USBzSEP/NExO7VNtpoxSYfMZM2a4Yw3ORtNrpmGW3ux+oUXmU6I6WMoQU5FyBdEyQkMV1VbVBtO5UZ0sHV/w8EcVaVcQLXSYJgAAACInzhc8tzIyTFd8Na21psZOrY5JumgoQb0Tzc484L+tC+QFCmV5FoK+wGhYiIalpHc4R04Wq+2O5bbHarsVvFEWkbJaFCBIzzC2nE4fgd4Qrmhvt7KtFHjSsLUGDRoc9/5U00qBqwEDBkR920PVrl3bBdiUkRap11yF1vU3QNlv+l+ZaZoxUTPwhfudWb16daCIeqb3B3KYzDwHsfp3+nhx3jhvWa1KFZ+tXx9nlSv7bN26nPUZk534XeW85Zb3W3r6AnyaRzMFnhYvPnpbxVwpcg4AMUkz0C1dujQiAamcTIEiBeiUKXU85syZ44ZuqkOmjDYNp1QdMlHHTOc6XEAKAAAAkUOh82hXxT9Tk1O8GAXOAQAxq379+rZ161Z7++23XZDueCg7UHW5VCC/SpUqbqhjx44dI3asAAAAODaCUtFunb8Ar7Nrt39IHzPvAQCO01dffeWGseUkKogeKddff72rqQUAAIDsw/C9aKYAlIoGezTFuqZeDzNtNQAAAAAAQE5CUCqabd5stv9IkXNPQoJ/PQAAyBbMEQMAABAZDN/LCfZn9wEAyM282jwHDx7M7kMBcoQDB/wXjI63rhUAAECsi7qg1K5du+yhhx6yKVOmuOkJNf21pn0+44wz3P2q/6ACp8E6depk06dPdz9//fXX1rZt27D7/uGHHwL7CTc19uzZs5Os0/TQr7zyimWrRDP7LnsPAUDuli9fPitSpIht3rzZChYsGFNftJXxorpKOgdxcbE1ZXWstv14263Z+jZt2uR+Z7QPAAAAZFzU9ab69OljP//8s40bN84qVapk48ePtw4dOtjy5cutcuXKbpvzzjvPxowZE3iMvkR5WrZsaX///XeSfSrIpememzZtmupz9+3b14YNGxa4rQ5ntoqPV+PM9gelShUq5F8PABGiL+YVKlSwlStX2p9//hlzAQoFGfLkyRNT7Y7ltkei3XpstWrVYuq8AQAA5Pqg1L59+2zy5Mk2depUa926tVs3ZMgQmzZtmo0ePdpGjBgRCELpC1Q4BQoUSHKfhqNof7fffvsxO48KQqW032yhWfZ++smsXj3/bWV5ffABs+8BiDj97SxTpoyVKlUqpr5oKzixZcsW13YFGmJJrLY9Eu3W70ssnTMAAICYCEopnf7w4cNWSNlAQQoXLmxz584N3NYQvXLlylnp0qWtXbt2LlilzmU4H3/8set89uzZ85jPP2HCBJeZpcDURRdd5DKsUsqW2r9/v1s8O3fuDHR2tUTM4QOW50iCly/OZz7tO5L7TwO1x7uyHEtitd2x3PZYbbd4bc6fP39MfdlWuzUEKxaDDLHa9ki1O6W/E7H49wMAACBXBKWKFy9uLVq0sOHDh1v9+vWtfPnyNmnSJJs3b57VqVMnMHTv8ssvt5o1a9qqVavs/vvvt/PPP99tE64OyptvvulqTlWpUiXV5+7evbtVr17dDRlcunSp3XvvvbZixQr78MMPw27/2GOP2dChQ5OtV52JBM2QFwF51q2zsq3PMjvTfztu9kKXNbVp7lxLPEZ7Ikkd7B07drgv67H2xSUW2x3LbY/Vdsdy22O13bHc9sxut2pjAgAAIAcGpUS1pHr16uXqRynI1LhxY+vWrZstWrTI3X/11VcHtm3YsKE1atTIateu7bKn2rdvn2Rf69atsxkzZth77713zOe98cYbk+y3YsWKbn8KfGn/oQYPHmwDBgxIkilVtWpVK1u2rJUoUSLD7Q9pgMXt98/w44nbv99cRaly5SwrO/AazqO2xdoXl1hsdyy3PVbbHcttj9V2x3LbM7vdodneAAAAyEFBKQWANAvenj17XKBHwaGrrrrKatWqFXZ7rY+Pj3cFekODUiqGrmF9F198cbqPo3nz5u5/7TdcUEp1rYILrHvUwY1YJzeF/bj9Z/EXCHXgI9q2HCJW2x3LbY/Vdsdy22O13bHc9sxsd6ydSwAAgOMRtT2nokWLuoDUtm3bXLbTJZdcEnY7ZUOpZpS2Daa0fAWlevTo4WqkpNeSJUvc/6H7BQAAAAAAQC4MSikANX36dFu9erXNnDnT2rZta/Xq1XOFynfv3m2DBg2y+fPn25o1a+yLL75wwSrVm1LdqGBffvml20efPn2SPcf69evdPn/44Qd3W0P0VMdKQwS1XxVHVzBLMwBqeGC2iY83K1gg6ToNC9B6AAAAAACAHCzqglIqPtqvXz8XNFJgqFWrVi5QpWwn1ZhSEXINxzvppJOsd+/e1qRJE5szZ06yoXQqcN6yZUu3n1AHDx50Rcz37t3rbmsGnlmzZlnHjh3d9gMHDrQuXbrYtGnTLFtVq2a2ePHR202bmq1Y4V8PAAAAAACQg0VdTamuXbu6JZzChQu7AFVaTJw4McX7atSo4Yb3eVSgXHWsolKVqmYHj/xcvBgBKQAAAAAAkCtEXaYUQqz/22yu+Zede8zWruUUAQAAAACAHI+gVDRTAOrUU4/eXrDArG5dAlMAAAAAACDHIygVzTZvNtu/P+m6hAT/egAAAAAAgBws6mpKIUzY0EuW+snMEjlDAAAAAAAg5yMolROUyu4DAAAAAAAAiCyG70Wz+HizggWSritUyL8eAAAAAAAgByMoFc2qVTNbvPjo7aZNzVas8K8HAAAAAADIwQhKRbsqVY/+XLwYASkAAAAAAJArEJSKduv+Ovrzrt1ma9dm59EAAAAAAABEBEGpaKYAVOPGR28vXGhWty6BKQAAAAAAkOMRlIpmmzeb7T9glmj+RRIS/OsBAAAAAABysHzZfQA4BgWjZnOWAAAAAABA7kKmFAAAAAAAALIcQaloFh9vVrBg0nWFCvnXAwAAAAAA5GAEpaJZtWpmSxabNTL/0qyp2YoV/vUAAAAAAAA5GDWlop7PrMyRH/dk86EAAAAAAABECJlS0WztWrPGjY/eXrjQrG5d/3oAAAAAAIAcjKBUNNu82Wz/gaTrEhL86wEAAAAAAHIwglIAAAAAAADIcgSlAAAAAAAAkOUISkWz+HizggWSritUyL8eAAAAAAAgByMoFc2qVTNbvPjo7aZNzVas8K8HAAAAAADIwfJl9wHgGKrVNPvqyM/tShCQAgAAAAAAuQKZUtHur7+O/rxrl9natdl5NAAAAAAAABFBUCqaKQB16qlHby9YYFa3LoEpAAAAAACQ4xGUimabN5sd2G/WwPxLnJklJPjXAwAAAAAA5GAEpaKdAlHljiz6GQAAAAAAIBeIuqDUrl277M4777Tq1atb4cKFrWXLlrZAw9aOuOGGGywuLi7Jct555yXZR40aNZJt8/jjj6f6vAkJCdavXz8rU6aMFStWzLp06WL//vtvprUTAAAAAAAglkXd7Ht9+vSxn3/+2caNG2eVKlWy8ePHW4cOHWz58uVWuXJlt42CUGPGjAk8pmDBgsn2M2zYMOvbt2/gdvHixVN93rvuuss+/fRTe//9961kyZJ222232eWXX27ffvutZZv4eLOCBczswNF1hQr51wMAAAAAAORgUZUptW/fPps8ebI98cQT1rp1a6tTp44NGTLE/T969OgkQagKFSoEltKlSyfbl4JQwdsULVo0xefdsWOHvfnmm/bMM89Yu3btrEmTJi7o9d1339n8+fMt21SrZrZ48dHbTZuarVjhXw8AAAAAAJCDRVVQ6tChQ3b48GErpGygIBrGN3fu3MDtr7/+2sqVK2d169a1W265xbZs2ZJsXxqup6F4p59+uj355JNu3ylZtGiRHTx40GVkeerVq2fVqlWzefPmWbaqUvXoz8WLEZACAAAAAAC5QlQN31N2U4sWLWz48OFWv359K1++vE2aNMkFhpQt5Q3d07C6mjVr2qpVq+z++++3888/322TN29et03//v2tcePGdsIJJ7hsp8GDB9vff//tMqHC+eeff6xAgQJWqlSpJOv1/LovnP3797vFs3PnTvd/YmKiWyJm7Z+ByKFv127zrVmT5YEptcfn80W2XTlArLY7ltseq+2O5bbHartjue2Z3e5I7Vc1Nh966CGbMmWKbdy40V1kGzVqlJ1xxhnJtr355pvt1VdftWeffdbV5fRs3brVbr/9dps2bZrlyZPH1cvUPlQ7MyVt2rSx2bNnJ1l300032SuvvBKRdgEAAERtUEpUS6pXr16ufpSCTAoudevWzWUzydVXXx3YtmHDhtaoUSOrXbu2y55q3769Wz9gwIDANrpfASd1qB577LGw9acyQvsaOnRosvWbNm1yRdMjIc+6dVa29VlmZ/pvxy1cqBQu2zR3riVWqWJZRR1sDXFUJ16d2lgRq+2O5bbHartjue2x2u5Ybntmt1vBpKyqsSkKWqnUgLYJdc0117iLcjNnznQZ4T179rQbb7zRJk6cmOpzqyananN6ihQpEpE2AQAARH1QSgEmXaHbs2ePyz6qWLGiXXXVVVarVq2w22t9fHy8rVy5MhCUCtW8eXM3fG/NmjVuyF8o1Zw6cOCAbd++PUm2lGbf033hKPsqOPilY61ataqVLVvWSpQoYRGxbp3F7Ttg5l2wTDSL27/fXJnzcuUsKzvwmsFQbYu1Ly6x2O5YbnustjuW2x6r7Y7ltmd2u0NLEBxPjc2pU6e6GpuiGpvKeFKNzREjRrh169evd5lQM2bMsAsuuCDJPn799VebPn26m8G4qWpSmtkLL7xgnTt3tqeeeipsECs4CJVS/wcAACBXB6U8KkyuZdu2ba6zpeLn4axbt87VlFLwKiVLlixxHU/VoQpHhc3z589vX3zxhUttlxUrVtjatWvdcMJwlHEVLutKzxOxTq63n5CRAG7/WfwFQh34iLYth4jVdsdy22O13bHc9lhtdyy3PTPbHYl9pqXGpoJr1113nQ0aNMgaNGiQbB8qa6ALbV5ASpRppeP7/vvv7bLLLkvx+SdMmOAysxSYuuiii9wwQrKlAABATASlFIBSSr0ympT9pM6Wio4r5Xz37t1uyJwCR+ooqabUPffc4+pNderUKdAJU2erbdu2rkaVbt9111127bXXBmbp05VFZVWNHTvWmjVrZiVLlrTevXu7zCfVoVKmk648KiB15plHxs4BAABESY3NkSNHWr58+VwdzXBUEzP0Ypy2Vz8npXqZ0r17d6tevbrLpFq6dKnde++97kLdhx9+mOJjsqzOZgzXQjtenDfOW9aLS/L+Q9rwu5oxnLfoO2/p2WfUBaVU50FD45QBpY6TAlCPPvqoy2TSlUN1kN5++2031E4dpo4dO7pOm5e1pP/feecdl+auDpIKoisoFTzUTnUV1MHau3dvYJ2Kg3pFQPU4Bblefvlly1bx8WaFCpjVPOC//ZsaWMi/HgAA5Fqp1djUooLlixcvdllfkaSaU8G1O5WJrgt5uhCoEgvZVWcz1muhHS/OG+ctqx0+XNbM8trhw4m2ceOmLH/+nIrfVc5bbnm/pafGZpxPR4DjpquCyrjSixqxmlLy2y9mt57i/3lPU7P3J2fL7Hua+UdXXGOpAxir7Y7ltsdqu2O57bHa7lhue2a3O9L9gdAam8oaP/fcc93FtuDj13A/3VZ9S9XQfOutt2zgwIGuDIJHF/c0JPD9999Pdfhe6PNrtj7Vp/Ky0tOSKaXj0HNHtE905PVTsCvWaqEdL84b5y2rVasWZ+vXx1nlyj5bu5avm2nF72rGcN6i77ypL6CRamnpD0VdphQAAABSrrGprG7VhwqmgJFqTKncgWj4n7LKlVWl2pny5Zdfug6oJoBJK9XllNRqd2ZJnc0gsVoL7Xhx3jhvWetoIIrf1fThdzVjOG/Rdd7Ssz+CUtFs7Vqzxo3NvLJWCxeaafbAFSuyPFsKAABER41NlTQoU6ZMku21TvU2vVmGVYvqvPPOs759+9orr7ziShfcdtttdvXVVwdm3gutsakhehMnTnQz9Gn/KpmgEgiaAbBRo0a8/AAAIOK4xBTNNm8223+knpRHtRm0HgAA5FpKd+/Xr58LRPXo0cNatWrlAlUKPqWVZtHT4xV4UqBJ+3jttddSrLFZoEABmzVrlqvXqcdp+J+ysqZNm5YpbQQAACBTCgAAIMp07drVLWmlOlKhNGGMMp9SUqNGDZeN5VEdqNmzZ2fgaAEAADKGTCkAAAAAAABkOYJS0Sw+3qxggaTrChXyrwcAAAAAAMjBCEpFMxUz/3Gp2VzzL03OoMg5AAAAAADIFagpFe2qVjU7eOTn4sWZdQ8AAAAAAOQKZEpFu7/+Ovrzrl1ma9dm59EAAAAAAABEBEGpaKYA1GmNzE4y/7JwgVndugSmAAAAAABAjkdQKppt3mx24IBZZfMvcWaWkOBfDwAAAAAAkIMRlAIAAAAAAECWIygFAAAAAACALEdQKprFx5sVLJB0XaFC/vUAAAAAAAA5GEGpaFatmtnixUdvN21qtmKFfz0AAAAAAEAORlAq2lWpevTn4sUISAEAAAAAgFyBoFS0W/fX0Z937TZbuzY7jwYAAAAAACAi8kVmN8gUCkCd1tgs7sjthIVmdesyhA8AAAAAAOR4ZEpFs82bzfYfMEtQQOrIuoQE/3oAAAAAAIAcjKAUAAAAAAAAshzD96Kdhu7VPvLzKjPzZfPxAAAAAAAARACZUtEsPt6sUAEzTcBX9UiAqlAh/3oAAAAAAIAcjKBUNKtWzWzx4qO3mzalyDkAAAAAAMgVCEoBAAAAAAAgyxGUimZr15o1bnz09sKFZnXr+tcDAAAAAADEUqHzvXv32syZM+3bb7+15cuX2+bNmy0uLs7i4+Otfv36dtZZZ1mHDh2saNGimXPEsWTzZrP9B5KuS0jwr9fQPgAAAAAAgNyeKbVs2TK74YYbrEKFCnbZZZfZSy+9ZCtXrnQBKZ/PZ7///ru9+OKL7j5to231GAAAAAAAACBDQamrrrrKTj/9dPvtt99syJAh9tNPP9nOnTvd7Xnz5tn8+fNtxYoVtmvXLnefttFtPaZbt26WHtrHnXfeadWrV7fChQtby5YtbcGCBYH7FexSICx4Oe+88wL3r1mzxnr37m01a9Z0j69du7Y98sgjduBASMZRiDZt2iTb780335yuYwcAAAAAAEAEh+/lyZPHFi5caKeddlqq2+XNm9caNmzoloEDB9qSJUts5MiRlh59+vSxn3/+2caNG2eVKlWy8ePHu+GAGipYuXJlt42CUGPGjAk8pmDBgoGfFShLTEy0V1991erUqeP21bdvX9uzZ4899dRTqT63ths2bFjgdpEiRSxbxceb5S9g9v2RgFqimRUq5F8PAAAAAACQ24NSkyZNytDOFcRKz2P37dtnkydPtqlTp1rr1q3dOmVdTZs2zUaPHm0jRowIBKE0RDAcBayCM6dq1arlsrb0+GMFpRSESmm/2UJ1o35aalavnv/2GWeYffAB9aQAAAAAAEBszr43duxYN0wuJbpP26TXoUOH7PDhw1ZI2UBBNAxv7ty5gdtff/21lStXzurWrWu33HKLbdmyJdX97tixw0444YRjPv+ECRNcwfZTTjnFBg8e7Iq6Z7uqVY/+XLw4ASkAAAAAABCbs+9Jz5493fC6GjVqhL3/+++/d9v06NEjXfstXry4tWjRwoYPH+5m8itfvrzLtFLdKg3FE2VBXX755a5m1KpVq+z++++3888/322j4YOhVIz9hRdeOGaWVPfu3V0dKw0ZXLp0qd17770uw+rDDz8Mu/3+/fvd4lGNLdHQQS0Rs2a15Tlymn27dppPwcAsnnlP7VEx+4i2KweI1XbHcttjtd2x3PZYbXcstz2z2x1r5xMAACDLg1LqzKVG9Zvy5cvQrl2wq1evXq5+lIJMjRs3dsXSFy1a5O6/+uqrA9uqdlWjRo1cMXNlT7Vv3z7JvtavX++CWFdeeaWrF5WaG2+8Mcl+K1as6PanwJf2H+qxxx6zoUOHJlu/adMmS0hIsEjIs26dlW19ltmZ/ttxsxe6oXyb5s61xCpVLKuog61sM73uqi8WK2K13bHc9lhtdyy3PVbbHcttz+x2a8IWAAAApE2aI0fKHlLhcs+cOXPccLtQ27dvt1deecVOOukkywgFgGbPnu0CW8o+UnBIs/+pNlQ4Wq8hd8qICg5Kbdiwwdq2betm73vttdfSfRzNmzd3/2u/4YJSGt43YMCAwG0da9WqVa1s2bJWokQJi4h16yxuf9JZA+P27zdX5rxcOcvKDrxmI1TbYu2LSyy2O5bbHqvtjuW2x2q7Y7ntmd3u0BIEAAAAiEBQasqUKYHMIHXmNLudlnBKlSqVoZpSwYoWLeqWbdu22YwZM+yJJ54Iu926detcTSkFr4IzpBSQatKkiZulLyOdTi8AF7zfYCq2Hjzrn0fPFbFObgr7cfvP4i8Qes0j2rYcIlbbHcttj9V2x3LbY7Xdsdz2zGx3rJ1LAACALAlKaXjbhRde6NLdmzVr5uo+Bc9y53XyFEhSZlFGh+8pAKXnUBFzZSkNGjTI6tWr52pU7d692wXGunTp4mbJ09C6e+65x9Wb6tSpUyAg1aZNG1cfSnWkNJzO482sp22UVaXAmdqi/UycONE6d+5sZcqUcVlhd911l5sBUMMDAQAAAAAAEFlpihyprtN//vOfQBBK2Ucnn3yyy0SKNNV50NA4ZUBpxjwFoB599FHLnz+/Gy6ogNHbb7/thgmqKHnHjh1dgMzLWpo5c6YLZmmpElJ3yauFdfDgQVfE3Jtdr0CBAjZr1ix77rnn3LBBDcPT8z744IOWreLjzQoWMLOgIXwaFqD1AAAAAAAAuT0opUDQ5s2bA7dViFwFyc8444yIH1DXrl3dEk7hwoVdJlVqbrjhBrekRrMGBhdrVxBKdayijmbZW7zY7NZT/LebNjV7f3KWz74HAAAAAAAQaWkqfKChcMokOnz4sLutgI6G6iELVKl69OfixQhIAQAAAACA2AlK3Xzzza7+kmaU0cxyCkj17t3b/ZzSUrJkycw/+liwboPZQvMvO3ebrV2b3UcEAAAAAACQNcP3VGz81FNPta+++sr+/fdfV9NJQ/dq1ap1/EeAlCkAddppZvuP3F6w0KxuXbMVK8iYAgAAAAAAOVqap8hTQXEt8t///tduuukm6969e2YeG1THa78XkToiIcHceupKAQAAAACAWAhKBUtMTIz8kSA8le7yykr9pYJenCgAAAAAABAjNaX++kvRkIw5nsfiSFCq9pGF2vIAAAAAACCWglJ16tSxXr162Q8//JDmHX/33XfWo0cPO/HEE4/n+GJbfLxZwQJJ1xUq5F8PAAAAAACQ24fvzZkzxx588EE788wzrXr16tauXTtr3Lix1axZ00qXLm0+n8+2bdtmq1evtoULF9qXX35p69evt7Zt29o333yT+a3IrVQ36scfzW5p4L/dpInZBx9STwoAAAAAAMRGUKpZs2b2+eef25IlS2zMmDE2depU97/ExfnHlCkwJVWrVrVLL73UZVadppnjcHyqeAWlzKx4MQJSAAAAAAAg9gqdK8g0atQot2zYsMF+++0327Jli7uvTJkyVq9ePatUqVJmHWtsWhdUk2vXbrO1awlMAQAAAACA2Jx9TxR8IgCVyRSAOv10szOP3F60yKxuXbMVKwhMAQAAAACA3F/oHNlk82az/QeSrktI8K8HAAAAAACIxUwpZJFEM/sx6GcAAAAAAIBcgKBUTrA9uw8AAAAAAAAgshi+F83i480KFky6rlAh/3oAAAAAAIAcjKBUNKtWzeynJWaVzb80bUKRcwAAAAAAkCswfC/qJZqddOTH3dl8KAAAAAAAANkdlNq2bZtNmjTJ/vjjD/ezz+dLcn9cXJy9+eabkTjG2LV2rdnpp5udeeT2okVmdeuSLQUAAAAAAGIzKDVjxgy74oorbM+ePVaiRAkrXbp0sm0UlMJx2rzZbP+BpOsSEvzrNbQPAAAAAAAgloJSAwcOtAoVKtiHH35oDRs2jPxRAQAAAAAAIFfLUKHzlStXWv/+/QlIAQAAAAAAIOuCUieeeKLt2rUrY8+ItIuPNytYIOm6QoX86wEAAAAAAGItKDVixAh7+eWXbc2aNZE/IhylulE//nj0dpMmFDkHAAAAAACxW1Pqiy++sLJly1r9+vXt3HPPtapVq1revHmTFTofNWpUpI4zdlWtbrb0yM+NilPgHAAAAAAAxG6m1Isvvmg//fST7d+/3z755BMbPXq0Wxe6IALWrTfbYv5l126ztWs5rQAA5HIqk3DnnXda9erVrXDhwtayZUtbsGBB2G1vvvlmdzHwueeeS7J+69atds0117iZkkuVKmW9e/e23bt3p+n5fT6fnX/++W6/H330UUTaBAAAEJGgVGJi4jGXw4cPZ2TXCKYAVKNGR28vXGhWty6BKQAAcrk+ffrYzJkzbdy4cbZs2TLr2LGjdejQwdavX59kuylTptj8+fOtUqVKyfahgNQvv/zi9qOLiN98843deOONaXp+BbgUkAIAAIi6oBSyyObNZgf2m1Uw/6K+YUKCfz0AAMiV9u3bZ5MnT7YnnnjCWrdubXXq1LEhQ4a4/5Wd7lGA6vbbb7cJEyZY/vz5k+zj119/tenTp9sbb7xhzZs3t1atWtkLL7xg77zzjm3YsCHV51+yZIk9/fTT9tZbb2VaGwEAADJcU8qzevVq++yzz+zPP/90t5VirlTvmjVrcnYjRYGo+kd+3qh8ek4tAAC52aFDh1zGeSHNuBtEw/jmzp3rflZW+nXXXWeDBg2yBg0aJNvHvHnz3JC9pk2bBtYp0ypPnjz2/fff22WXXRb2uffu3Wvdu3e3l156ySpU0BWxY1M5By2enTt3Bo5RSyRpfxpaGOn95nacN85b1juaacnva9rxu5oxnLfoO2/p2WeGg1IDBw50hcxDn0ydHdVAeOqppzJcQ+Ghhx5y6egbN260008/3T3PGWec4e6/4YYb7O23307ymE6dOrmrgcE1FHTlcNq0ae54unTp4vZRrFixFJ83ISHBtUlXENWx0j41w2D58uUz1A4AAICMKF68uLVo0cKGDx/uJpVRX2TSpEku0KRsKRk5cqTly5fP+vfvH3Yf//zzj5UrVy7JOm1/wgknuPtSctddd7n6VZdcckmaj/exxx6zoUOHJlu/adMm17+KJPU7d+zY4TrR6uOB85aZeL9l3OHDZc0srx0+nGgbN26K4KuSu/Ge47zllveb4jqZGpRSSvezzz5rV1xxhQvkqMPkpYprvZbKlSu7jk1Gaij8/PPProaC6iOMHz/eXdlbvny526ecd955NmbMmMBjChYsmKyGwt9//+1qKBw8eNB69uzpaihMnDgxxefVsX766af2/vvvW8mSJe22226zyy+/3L799lvLNvHxZgULmNmBo+t01VTrAQBArqV+UK9evVzfRzMcN27c2Lp162aLFi1yiy62LV68OKJ1nz7++GP78ssv7ccff0zX4wYPHmwDBgxIkimlmZk1U7OKrEe6A602a98EpThvmY33W8blzev/25Q3b55kAXLwnos0flej77yFZntHPCj1+uuv28UXX2zvvfdekvWqWaBMI10Ve/XVV9MdlPJqKEydOtXVUBDVUFDGk2oojBgxIhCESiml3KuhoBlqvJR11VDo3Lmzy94KVwhU0cE333zTBa3atWvn1inopWCbioeeeeaZli2qVTNTx/CWI2n5p59u9uFH/vUAACDXql27ts2ePdv27NnjgjwVK1a0q666ymrVqmVz5sxx2eTVgvoDGu6nC4UqUL5mzRrXT9I2ocMClU2eUh9KAalVq1a5YX/BlHF+9tln29dffx32ceqXhV4gFHVwMyNwpA50Zu07N+O8cd6y1tGaI/yupg+/qxnDeYuu85ae/WUoKKXOzh133JHi/aHD6SJZQ0HUKVLEvXTp0i6IpGBVmTJlMlxDQVcclVGl7Tz16tVznT3tL1xQKsvqJ1SpGqhG7yte3HxVquhJLCvF6hjdWG13LLc9Vtsdy22P1XbHctszu92R3m/RokXdsm3bNpsxY4Yrfq4gUXCfxet7qcaUssNFw/+2b9/u+jhNmjQJBJ10fLqIGM59993nMtaDNWzY0GXAX3TRRRFtFwAAQIaDUgoI/fTTTyner/uUApYZNRQ0dE/D6lRMXVfz7r//fldcXdsovT0jNRS0vkCBAsmuDOr5U3pMVtVPyLPqd/Nac2jrVtu2eLElKjCVhWJ1bHOstjuW2x6r7Y7ltsdqu2O57Znd7vTUUEiNAlA6xrp169rKlStdQXNdMFPQSTPteRfjPFqnDChtL+pHqc/Ut29fe+WVV9zFN5UmuPrqqwNZ45q9r3379jZ27Fhr1qyZe3y4LCpdpGMSGwAAEDVBqSuvvNLVMqhRo4YrKK4reKIU8xdffNFNP6xi55GuoSDqTAVfvWvUqJFLcVf2lDpWWSVL6iesXWtx555rdiRRK//PP1vZs88236+/ZukQvlgdoxur7Y7ltsdqu2O57bHa7lhue2a3Oz01FFKjwJn6GuvWrXMX1pQd9eijj7rgU1pNmDDBBaLUP/Imfnn++ecD9ytQtWLFCjfjHgAAQI4JSimTacmSJS5L6eGHHw5ccduwYYMbgte2bVsbNmxYxGsohKP18fHx7iqiOl0ZqaGg9QcOHHBp7sHZUv/++2+Kj8mS+glbt5olHDD7+chtn1lcQoLFaX2NGpaVYnWMbqy2O5bbHqvtjuW2x2q7Y7ntmdnuSO2za9eubklPaYVQCmalNsmLLi4qGys1x7ofAADgeGSo51SkSBH74osvbMqUKS6rSSniWvTzRx99ZLNmzXLbHA9lXykg5dVQSGlqYl1B3LJli9s2tIaC51g1FFRrQVce1SaPrhyuXbvW7S9bqS+46chCvxAAAAAAAMRyppRHgaKUgkWZUUNh9+7dro6T0s+VwaSaUvfcc4+rN6UCnxmtoVCyZEnr3bu3G46nq4oafqdhiQpIZdvMewAAAAAAALnYcQWlMkNqNRQ0DG/p0qX29ttvu2woBZk6duzohhMGD6XLSA0FzSzjbatZ9RTkevnlly1bxcebFSpgVvyA//ZmjRss5F8PAAAAAACQ24NSmnFFAZvffvvNBYd0W/UYUqP7lckUyRoKhQsXdplUx5KRGgoqTPrSSy+5JWqomPnSn8xuqu+/veM0sylTs7TIOQAAAAAAQLYFpc4555xAUdDg28gCnGcAAAAAABCrQan//ve/qd5GJlm71uzUU828+uxLlpjVrasq7GRLAQAAAACA2Jt9TwXCw0097Pnzzz/dNjhOmzebJexPui4hwb8eAAAAAAAg1oJSmgnvu+++S/H++fPnu20AAAAAAACAiAWlQouEh9qzZ4/lyxd1E/sBAAAAAAAgSqQ5crR06VJboppGR8yZM8cOHTqUbLvt27fbK6+8YieddFLkjjJWxcebFSpoZkFD+AoV8q8HAAAAAACIhaDUlClTbOjQoe5nzbz36quvuiWcUqVKUVMqEqpVM1v2i9lZdfy3GzYy+3gaRc4BAAAAAEDsBKVuvPFGu/DCC93QvWbNmtmwYcPs/PPPT7KNglVFixa12rVrM3wvUqrXMPvnyM+1ihGQAgAAAAAAsRWUqlixolvkq6++svr161u5cuUy89ggf/119Dzs3m22di2BKQAAAAAAkONlqBr5OeecE/kjQXIKQJ1cz6zMkdvLlprVrWu2YgWBKQAAAAAAkKNleIq8f/75x958801bvHix7dixwxITE5MN5fviiy8icYyxa/Nms/37zc48cnu2mSUk+Ner3hQAAAAAAEAsBaU0E1+bNm1s3759VrduXVu2bJmdfPLJbua99evXu5pSVatWjfzRAgAAAAAAIFfIk5EH3XfffVasWDFbsWKFzZo1yxU/HzVqlP3111/27rvv2rZt2+zxxx+P/NECAAAAAAAgdoNS3377rd10001WrVo1y5PHvwtv+N6VV15p11xzjQ0aNCiyRxqL4uPNChVMuq5QIf96AAAAAACAWAtKKQBVvnx593OpUqUsb968tnXr1sD9DRs2tEWLFkXuKGOV6kYtX370dv36FDkHAAAAAACxG5SqWbOmrV692r+DPHncbQ3j83z33XcuWIUIqFrNLE+c/+eiRSlwDgAAAAAAYjco1bFjR3v//fcDt2+55RZ74403rEOHDta+fXt7++23rXv37pE8ztj111ozn8//8+7dZmvXZvcRAQAAAEBYH35o9u+//p/1v24DQERn33vggQesW7dudvDgQcufP7/deeedtmfPHps8ebIbyvfQQw/Z/fffn5FdI5gCUPVPNjvhyO0Nv5nVrcsQPgAAAABRRwGoLl2O3j50yH978mSzyy/PziMDkKuCUqVLl7YmTZoEbsfFxdmDDz7oFkTQ5s1m+/abrQ9al5DgX696UwAAAAAQJYYO1XdDDfQ4Un7E4tztYcMISgGI4PC9l19+2TZt2pSRhwIAAAAAcqHffz9aecSj2ytWZNcRAciVQanbbrvNKleubOeee669+eabSWbeQyZQzXjqxgMAAACIYied5M+UCqbbqkACABELSv32229uqN7ff/9tffv2tYoVK1rnzp1t3LhxtnPnzozsEuHEx5sVKWh2uvkXvVqFCvnXAwAAAEAUeeQRL1PKS5fyudtaDwARC0qddNJJ9vDDD9vPP/9sy5Yts3vuucf++OMPu/766618+fJ26aWX2jvvvJORXSOY6kYtX26W/0jprzq1KXIOAAAAICqpmLmKmuc78vVF/6v4+WWXZfeRAchVQalgDRo0sOHDh7vsqR9//NHNxPfVV1/ZtddeG5kjxFGhA7QBAAAAIMoCU+XL+3/W/wSkAGRqUMqzdOlSe++99+yDDz6wXbt2WcGCBSO169i1dq3ZySebHTzkv73qD/+AbK0HAAAAAACI1aDU8uXL7ZFHHrH69evb6aefbk8//bSdfPLJNn78ePv3338jd5SxavNms4T9SdclJPjXAwAAAAAA5GBHRvumj4brKStKQam8efNa+/bt7b777nO1pEqWLBn5owQAAAAAAECukqFMqWHDhrmC5q+88oqbge+zzz5zRc4jEZDS0D/VpapevboVLlzYWrZsaQsWLAi77c0332xxcXH23HPPBdZ9/fXXbl24JaX9SJs2bZJtr/0DAAAAAAAgSjKl1q9fb+XKlYv80ZhZnz593Kx+48aNs0qVKrmhgB06dHBZWZUrVw5sN2XKFJs/f77bJpiCWAqUBXvooYfsiy++sKZNm6b63H379nUBN0+RIkUsW8XHm6k216ojQ/hU57xQIf96AAAAAACAWMuU8gJS+/fvt3nz5tnUqVNtcwTqHO3bt88mT55sTzzxhLVu3drq1KljQ4YMcf+PHj06SVDs9ttvtwkTJlj+/PmT7KNAgQJWoUKFwFKmTBl3fD179nTZT6lRECr4sSVKlLBsVa2a2W+/m+0sZaba5pUqm61Y4V8PAAAAAAAQi4XOn3/+eatYsaK1atXKLr/8cjf7nig4FR8fb2+99Va693no0CE7fPiwFVI2UBAN45s7d677OTEx0a677jobNGiQNWjQ4Jj7/Pjjj23Lli0uKHUsCnLp2E855RQbPHiw7d2717KdAlDeTIb58hGQAgAAAAAAsTt8b8yYMa7u09VXX20dO3a0Xr16Be5TUKddu3b2zjvvJFmfFsWLF7cWLVq4Quqa0U91qyZNmuSysZQtJSNHjrR8+fJZ//7907TPN9980zp16mRVqlRJdbvu3bu7OlYaDqgA27333msrVqywDz/8MOz2yhLT4tm5c2cgaKYlYnw+iyty2OKKm/kS9plv4UL/8L0szJZSe3w+X2TblQPEartjue2x2u5YbnustjuW257Z7Y618wkAAJDlQamnn37aLrnkEps4caLLQgrVpEkTl0mVEaolpWCW6kdpZr/GjRtbt27dbNGiRW4ZNWqULV68+JhD8WTdunU2Y8YMN1Pgsdx4442Bnxs2bOiywDSr4KpVq6x27drJtn/sscds6NChydZv2rTJEhISLFLy/LXGytbYbFbDLG72Ros74wzzFSxom+bOtcRjBNoi2cHesWOH68TnyZPh5LocJ1bbHcttj9V2x3LbY7Xdsdz2zG63JmwBAABAJgalVq5cmWqm0gknnBA2WJUWCgDNnj3b9uzZ47KPFBy66qqrrFatWjZnzhzbuHGjVQvKEtJwv4EDB7oZ+NasWZMso0s1pS6++OJ0H0fz5s0DbQ0XlNLwvgEDBgRu61irVq1qZcuWjWwtqr/WWGj4LW7/fnOlzjOp2Hy4DryCgGpbrH1xicV2x3LbY7Xdsdz2WG13LLc9s9sdWoIAAAAAEQ5KlSpVKtXC5popT4XCj0fRokXdsm3bNpftpOLnXbp0cTPxBdPQPNWYCq0ZpSugCkr16NEjWTH0tFiyZIn7X0GxcAoWLOiWUOrgRrSTm8K+3HNk4ZcIdeAj3rYcIFbbHcttj9V2x3LbY7Xdsdz2zGx3rJ1LAACALA9Kde7c2V577TW79dZbk933yy+/2Ouvv57uelIeBaAUUKpbt67LUlJB83r16rmgk4JLynwKpnUKgGn7YF9++aWtXr3a+vTpk+w5NHufhuaNHTvWmjVr5oboaSii2qX9q6bUXXfd5WYAbNSoUYbaAQAAAAAAgJRl6HLeiBEj3LA5zVL34IMPuiuOb7/9tl177bXWtGlTK1eunD388MMZ2bWr89CvXz8XiFKWk2b3U6AqvdlOKnDesmVLt59QBw8edEXMvdn1ChQoYLNmzXJF27W9hgMqK2vatGmW7VTUPHT8noYGaD0AAAAAAEAsZUpphjoVHb///vvt3XffdZlNKlCu2fNUlPzxxx93s/BlRNeuXd2SVqF1pDzKfEpJjRo13DF7VAtKdayiUtVq/tpR/240K1TQbM53WT77HgAAAAAAQFQEpUTZUG+88YZbNOOcCofGWrHULFOggP9/BdIaN87uowEAAAAAAMi+oFQwBaOQSeLymG0oZLZa4w4PmS1eTKYUAAAAAACIjaDUsGHD0r1j1Zl66KGHMnJMCPbXOrMvVpm50YaJZk2a+GtKrVjBED4AAAAAAJC7g1JDhgxJ944JSkXI5s3+YXvBEhL866krBQAAAAAAcnNQSvWikE0UkCpy5Gf/ZIEAAAAAAAA5HlXJo95hs+bmX3i1AAAAAABALpHmMMcPP/xgW7duTdO2q1evtrFjxx7PccETH2+WJy7p+VBNKa0HAAAAAADI7UGpFi1a2PTp0wO3FaAqUqSIzZ49O9m23333nfXs2TNyRxnLqlYzO/nko7c/+4wi5wAAAAAAIHaCUr6QYtu6nZCQYIcPH86M40KwvHmP/nzwIOcGAAAAAADkeFQpinZ/rTVbtuzo7YsvNqtb12zt2uw8KgAAAAAAgONCUCrabd5slpg0S80SEvzrAQAAAAAAciiCUgAAAAAAAMhy+dKz8Zo1a2zx4sXu5x07drj//+///s9KlSqVbPY9REoes7+O/BiSMAUAAAAAABATQamHHnrILcFuvfXWZNupCHpcXNzxHx3MypYzW5PP7NCho2ejUCGz+HjODgAAAAAAyP1BqTFjxmTukSC8atXM7r7b7PHH/beffNKsa1f/egAAAAAAgNwelLr++usz90gQns9nVukEs0IqcG5mFSsSkAIAIJfbtWuXy06fMmWKbdy40U4//XQbNWqUnXHGGcm2vfnmm+3VV1+1Z5991u68887A+q1bt9rtt99u06ZNszx58liXLl3cPooVK5bi89500002a9Ys27Bhg9uuZcuWNnLkSKtXr16mtRUAAMQuCp1HO99hszzzzVocebV+/dVs7drsPioAAJCJ+vTpYzNnzrRx48bZsmXLrGPHjtahQwdbv359ku0UtJo/f75VqlQp2T6uueYa++WXX9x+PvnkE/vmm2/sxhtvTPV5mzRp4rLjf/31V5sxY4YryaDnPnz4cMTbCAAAQFAq2v211uyjqUdvP/qoWd26BKYAAMil9u3bZ5MnT7YnnnjCWrdubXXq1LEhQ4a4/0ePHh3YTgEqZUJNmDDB8ufPn2QfCipNnz7d3njjDWvevLm1atXKXnjhBXvnnXdcFlRKFLTSc9aoUcMaN25sI0aMsL/++stNdgMAABBpBKWi3ebNZqFXJxMS/OsBAECuc+jQIZeZVEgTmwQpXLiwzZ071/2cmJho1113nQ0aNMgaNGiQbB/z5s1zsyM3bdo0sE6ZVhrG9/3336fpOPbs2eOypmrWrGlVq1Y97nYBAAAc1+x7AAAAyFzFixe3Fi1a2PDhw61+/fpWvnx5mzRpkgs0KVtKVOcpX7581r9//7D7+Oeff6xcuXJJ1mn7E044wd2XmpdfftnuueceF5SqW7euG/5XoECBFLffv3+/Wzw7d+4MBM60RJL2pyGFkd5vbsd547xlvaMzsfP7mnb8rmYM5y36zlt69klQCgAAIMqollSvXr2scuXKljdvXjeUrlu3brZo0SK3qGD54sWLLS7u6Be/SFEtqnPPPdf+/vtve+qpp6xr16727bffJsvc8jz22GM2dOjQZOs3bdpkCcrujnAnd8eOHa4TrawvcN4yE++3jDt8uKyZ5bXDhxNt48ZNEXxVcjfec5y33PJ+04QtaUVQKtrFx5vlz2d28NDRdeoUaj0AAMiVateubbNnz3bZSso8qlixol111VVWq1YtmzNnjpuRr1q1aoHtNdxv4MCB9txzz7n6TxUqVHDbhA4L1Ix8ui81JUuWdMuJJ55oZ555ppUuXdoVVFdQLJzBgwfbgAEDArd1vBruV7ZsWStRooRFugOtQJz2TVCK85bZeL9lXN68/oB53rx5kmVtgvdcpPG7Gn3nLaULWeEQlIp2VauZ3Xef2fAR/tstWpi9845ZUEcUAADkTkWLFnXLtm3b3Gx4Kn7epUsXVx8qWKdOnVyNqZ49e7rbGv63fft2l1WlGfXkyy+/dB1QFT5PK1091RI8PC9UwYIF3RJKHdzMCBypA51Z+87NOG+ct6zlC/zE72r68LuaMZy36Dpv6dkfQamoF2dWr73Z+hH+v+0+HwEpAAByOQWgFAxSTaeVK1e6gub16tVzQSfNtFemTJkk22udMqC0vagW1XnnnWd9+/a1V155xQ4ePGi33XabXX311VapUqXA7H3t27e3sWPHWrNmzeyPP/6wd9991zp27Oiumq5bt84ef/xxV2C9c+fO2XIeAABA7sYlpmiXJ69ZxTZm64v6g1IqTrp4sdnatdl9ZAAAIJOoxkO/fv1cIKpHjx7WqlUrF6hS8CmtJkyY4B6vwJOCStrHa6+9FrhfgaoVK1bY3r17A6n2GhqobVVQXcMFVXT9u+++Y/gNAADIFGRK5QQKQO3Z4/95zRozpeFrjOaKFWRNAQCQC6m4uJa0Uh2pUJppb+LEiSk+pkaNGi4by6MMqv/9738ZOFoAAICMIVMqJ9i43iz0wqhms9m8OZsOCAAAAAAA4PgQlIp2iYfMdn5q1opXCwAAAAAA5B5RF5TatWuX3XnnnVa9enVXWLNly5a2YMGCsNvefPPNrlq8pj8OTUfX+uBFhTpTk5CQ4Go3qHBosWLF3Mw2//77b0TbBgAAAAAAgCgNSvXp08dmzpxp48aNs2XLlrkZYDTtsWaICTZlyhSbP39+YAaZUMOGDbO///47sNx+++2pPu9dd91l06ZNs/fff99mz55tGzZssMsvv9yiQrFiZnnikq5TTan4+Ow6IgAAAAAAgNwTlNq3b59NnjzZnnjiCWvdurWb+WXIkCHu/9GjRwe2U4BKQSbNKpPSLDSaLUZTI3tL0aJFU53h5s0337RnnnnG2rVrZ02aNLExY8a42WYU+Mp2J5xgdtFFR28/8ghFzgEAAAAAQI4WVbPvHTp0yA4fPuymJA6mYXxz5851PycmJtp1111ngwYNsgYNGqS4Lw3XGz58uFWrVs26d+/uMqHy5Qvf3EWLFrlpkZWR5dEUynrsvHnz7Mwzz0z2mP3797vFs3PnzsDxaYkY7UtLpUqBCGJi3rxmVar412cBtUez80S0XTlArLY7ltseq+2O5bbHartjue2Z3e5YO58AAAC5Jiil7KYWLVq4YFL9+vWtfPnyNmnSJBcYUraUjBw50gWX+vfvn+J+dF/jxo3dVMjKdho8eLAbwqdMqHD++ecfK1CggJUqVSrJej2/7gvnscces6FDhyZbv2nTJlefKmISD1nhXbssX0KCeble+7//3nYtXmyJCkxlAXWwlU2mTnyePFGVXJepYrXdsdz2WG13LLc9Vtsdy23P7HarNiYAAAByYFBKVEuqV69eVrlyZcubN68LLnXr1s1lM2kZNWqULV682BUvT8mAAQMCPzdq1MgFnG666SYXSCpYsGBEjlOBruDnUaZU1apVrWzZslaiRAmL6Ox7aw9a3PjxgVWFP/3UCn3xhfl+/dWsWrXIPVdKh5CY6M632hZrX1xisd2x3PZYbXcstz1W2x3Lbc/sdodmewMAACAHBaVq167tCo3v2bPHBXoqVqxoV111ldWqVcvmzJljGzdudMPqPBruN3DgQDcD35o1a8Lus3nz5m5ooO6vW7dusvtVc+rAgQO2ffv2JNlSmn1P94Wj4Fa4AJc6uJHt5OY1Oxhv9tchM9/RtXEJCRa3daumGrSsoA585NsW/WK13bHc9lhtdyy3PVbbHcttz8x2x9q5BAAAOB5R23NSYXIFpLZt22YzZsywSy65xNWSWrp0qS1ZsiSwaPY91ZfSNinRduoklitXLuz9KmyugulffPFFYN2KFSts7dq1bjhhtsqT16xoU7NfLUlQCgAAAAAAICeLukwpBZdU50EZTStXrnQBJxUd79mzpwsclSlTJsn2WqdsJi8DSvWnvv/+e2vbtq2rUaXbKnJ+7bXXWunSpQOz97Vv397Gjh1rzZo1s5IlS1rv3r3dcDzVodLwO83up4BUuCLnAAAAAAAAyGVBKRUfVb2mdevWuQBRly5d7NFHH3XBp7TQkLp33nnHhgwZ4mbHq1mzpgtKBdd/0kx7yoTau3dvYN2zzz7rsqn0fHpcp06d7OWXX7aoUKaUWZGCZnuPzvZnOh/x8dl5VAAAAAAAALknKNW1a1e3pFVoHSkVRp8/f36qj6lRo4bLxgotTPrSSy+5Jaqo0PnBWWZfDTGbk8fs7nv962+5JUuKnAMAAAAAAMRUTSmEOOEEs4svPnp72TKzxYvN1q7lVAEAAAAAgByHoFROki8ose2rr1Sh3Uy1tAhMAQAAAACAHIagVE6ydWvydQkJZps3Z8fRAAAAAAAAZBhBKQAAAAAAAGQ5glIAAAAAAADIcgSlcpL4eLOCBZOuK1TIvx4AAAAAACAHISgV9eLMitXyL1Wrm/3+u9mppx69e+ZMs2rVsvMAAQAAAAAA0o2gVLTLk9esQgf/op8VgOra9ej9S5dm59EBAAAAAABkCEGpnOj884/+PGmS2eLFZmvXZucRAQAAAAAApAtBqZzohBOO/jx3rlmTJmZ16xKYAgAAAAAAOQZBqWiXeMhs5Wv+RT/Lli3Jt0tIMNu8OcsPDwAAAAAAICMISgEAAAAAACDLEZQCAAAAAABAliMolRPFx5sVKpR0XZ48/vUAAAAAAAA5AEGpnKhaNbMVK8y+/96sQgX/usREs23bsvvIAAAAAAAA0oSgVE4OTDVrZvbAA0fXPf54dh4RAAAAAABAmhGUyul69TIrW9b/87vvmk2darZ4sdnatdl9ZAAAAAAAACkiKBX14syKVPMv+jlUkSJmN9zg/9nnM7v0UrMmTczq1iUwBQAAAAAAohZBqWiXJ69ZpfP8i34O54ILkq9LSDDbvDnTDw8AAAAAACAjCErlBsWLZ/cRAAAAAAAApAtBqdxs//7sPgIAAAAAAICwCEpFu8RDZqve8i/6OZz4eLNChZKvf/HFTD88AAAAAACAjCAolRP4DvmXlFSrZrZihdmiRWYTJ5oVKOBfr5/HjMmywwQAAAAAAEirfGneEtFNgSktjRubHTxodv31/vW33GJWsKBZvXpHs6q0HQAAAAAAQDYiKJUb9ehhNm+e2Suv+OtKXXPN0fs0zE9ZVQSmAAAAAABANmL4Xm713HNmDRokX5+QYLZ5c3YcEQAAAAAAQABBqdxKQ/ZGjszuowAAAAAAAMgZQaldu3bZnXfeadWrV7fChQtby5YtbcGCBWG3vfnmmy0uLs6eU1bQEWvWrLHevXtbzZo13eNr165tjzzyiB04cCDV523Tpo3bV/Ci/edoFSuGX//BB2Y+X1YfDQAAAAAAQPTWlOrTp4/9/PPPNm7cOKtUqZKNHz/eOnToYMuXL7fKlSsHtpsyZYrNnz/fbRPst99+s8TERHv11VetTp06bl99+/a1PXv22FNPPZXqc2u7YcOGBW4XKVLEokKhFIJLx6Ki5qohpSF7wR57zGz9erPRo9XIiBwiAAAAAABAjg1K7du3zyZPnmxTp0611q1bu3VDhgyxadOm2ejRo23EiBFu3fr16+3222+3GTNm2AUXXJBkH+edd55bPLVq1bIVK1a4xx8rKKUgVIUKFSyq5MlnVuWijD1WxcxV1Fw1pA4dMhs1ymziRP99Y8ea/fST2eTJZrVrR/SQAQAAAAAActTwvUOHDtnhw4etkLJ7gmgY3ty5c93PyoK67rrrbNCgQdYgXCHvMHbs2GEnnHDCMbebMGGCxcfH2ymnnGKDBw+2vXv3Wo6nwFTjxmbNmqmBZu+8Y1a0qP8+BaWaNDH75JPsPkoAAAAAABBjoipTqnjx4taiRQsbPny41a9f38qXL2+TJk2yefPmuaF4MnLkSMuXL5/1798/TftcuXKlvfDCC8fMkurevburY6XhgEuXLrV7773XZVh9+OGHYbffv3+/Wzw7d+4MBM20RK0rr3Sz8sVdcYXFKYtqxw6ziy4yX69e5rvpJrM8efzD/hTMOkLt8fl80d2uTBCr7Y7ltsdqu2O57bHa7lhue2a3O9bOJwAAQK4JSolqSfXq1cvVj8qbN681btzYunXrZosWLXLLqFGjbPHixa4Q+bFomJ+G8l155ZWuXlRqbrzxxsDPDRs2tIoVK1r79u1t1apVrlh6qMcee8yGDh2abP2mTZssIbSG0/FIPGSF/vUHxhLKX+4fzne84uMtbto0K3nXXVbo00/dqri33nKL+AoWtE1z51pilSr+Q0hMdNlm6sTnUdAqRsRqu2O57bHa7lhue6y2O5bbntnt1oQtAAAAyKFBKQWAZs+e7QqTK/tIwaGrrrrK1YaaM2eObdy40aoFZfFouN/AgQPdDHyaec+zYcMGa9u2rZu977XXXkv3cTRv3jyQaRUuKKXhfQMGDAjc1rFWrVrVypYtayVKlLCISTxktruA+7FEuXKRCUqJ9jV1qiUOGGB5nn8+yV1x+/db/IYN/mF/RzrwCgKqbbH2xSUW2x3LbY/Vdsdy22O13bHc9sxud2gJAgAAAOSgoJSnaNGibtm2bZsraP7EE09Yly5d3Ex8wTp16uRqTPXs2TNJhpQCUk2aNLExY8ZkqNO5ZMkS97+CYuEULFjQLaH0XJHt5ObxD6nz7/zoz5Fy/fVmIUEp91SXXaYxjWb33WdWv77rwEe+bdEvVtsdy22P1XbHcttjtd2x3PbMbHesnUsAAIBcFZRSAEop9XXr1nVZSipoXq9ePRd0yp8/v5UpUybJ9lqnGfO0vReQatOmjasPpTpSGk7n8WbW0zYamjd27Fhr1qyZG6I3ceJE69y5s9u/akrdddddbgbARo0aWUxSTYzx490Sd9FFll/1ps4/P7uPCgAAAAAA5BJRF5RSnQcNjVu3bp2bMU/ZUY8++qgLPqXFzJkzXTBLS5UjNZE8CnbJwYMHXRFzb3a9AgUK2KxZs9wQQA0b1DA8Pe+DDz5ouZ6KmmuoQXAdrHz5zIoVM9u+3d1U/aky06aZr00bjVs0O/dcXWbOvmMGAAAAAAA5XtQFpbp27eqWtAquIyU33HCDW1JTo0aNQIBKFIRSHauYpPpcmoVv8+akgSplpL3+utnTT5utW+dWx339tZkW1ZrSsL7LLzfLmzf7jh0AAAAAAORYFD6APzClQJO36HbRomZ33mm2apUlvv66HQou9r54saKHZiefbPbmm2YHDnAWAQAAAABAuhCUygkKlvUv2aFAAbNevWzz7NmW+O67gRn5nN9/N+vTx6xWLbOHHzabO9cfsNKydm32HC8AAAAAAMgRCEpFuzz5zKpe5l/0c3bRML0rrjBbuNDs88/N2rY9et/69WbDh5udfbZZkyb+5aSTCEwBAAAAAIAUEZRC+qjAuQqdf/ml2bx5ZpdcEn67/fvNrrvO7NVXCU4BAAAAAIBkCEoh48480+yjj8zeey/8/d98Y3bzzWbVq5s1aGA2aJA/mEUNKgAAAAAAYl7Uzb6HEImHzNYeCfpU65q9Q/hSElwEPSXLl/uXp54yK1bMrH17s86dzc4/X9MfZsVRAgAAAACAKBKFEQ4kc2h3dJ+U+HizQoXMEhKOrtPt9983+/FHs88+M5s/38zn89+3e7fZ1Kn+RZRF5QWozjrLX1wdAAAAAADkagzfw/GrVs1sxQqzRYuOLrp94YVmDz1k9t13Zps2mU2c6K8zVTZkJsFffjF78kmzdu38Aa7LLzd7/XWzdet4dQAAMWnXrl125513WvXq1a1w4cLWsmVLW7BgQdhtb775ZouLi7PnnnsuyfqtW7faNddcYyVKlLBSpUpZ7969bbcuDKVA299+++1Wt25d95zVqlWz/v37244dOyLePgAAACFTCpELTGlJSZkyZt26+ZfERH/gShlU//uf2Q8/HM2i2rXLbMoU/yING/ozqLwsqvz5/YXTN28+um8FslJ7bgAAcpg+ffrYzz//bOPGjbNKlSrZ+PHjrUOHDrZ8+XKrXLlyYLspU6bY/Pnz3TahFJD6+++/bebMmXbw4EHr2bOn3XjjjTZRF4nC2LBhg1ueeuopO/nkk+3PP/90AS+t++CDDzK1vQAAIDYRlELWy5PH7Iwz/MvDD/sDTJ9/7g9QzZiRNOC0bJl/eeIJs+LF/YGpWbPMDh1KOlRQmVkEpgAAucC+ffts8uTJNnXqVGvdurVbN2TIEJs2bZqNHj3aRowY4datX7/eZTbNmDHDLrjggiT7+PXXX2369Okuu6pp06Zu3QsvvGCdO3d2QadwQaxTTjnFPa+ndu3a9uijj9q1115rhw4dsnz56DYCAIDIoneB7KdMp+7d/cvhw/4sKgWolEmloQrBWVTTpyd/vGpZ/fe/ZhddZFa/vj9IBQBADqUA0OHDh61QyOeZhtTNnTvX/ZyYmGjXXXedDRo0yBqoNmOIefPmuSF7XkBKlGmVJ08e+/777+2yyy5L07Fo6J6G/6UWkNq/f79bPDt37gwco5ZI0v58Pl/E95vbcd44b1kvLsn7D2nD72rGcN6i77ylZ58EpRBd8uY1a9bMvwwZ4q9FFZxFtWVL+Mc98oh/URbWiSfqcq9/6J/3v2YI1L4BAIhyxYsXtxYtWtjw4cOtfv36Vr58eZs0aZILNNWpU8dtM3LkSBcoUs2ncP755x8rV65cknXa/oQTTnD3pcXmzZvdMWjIX2oee+wxGzp0aLL1mzZtsoTgSVAi1MlVoEydaAXYwHnLTLzfMu7wYdWQzWuHDyfaxo2bIviq5G685zhvueX9ptqYaUVQKicoUNpiloqiX3ONf1EW1fjxZjfckPL2ishqKJ+WoCEILnvq5JOTB6s0fCHu6JUcAACigWpJ9erVy9WPyps3rzVu3Ni6detmixYtcsuoUaNs8eLFrsB5ZlC2k4YEqraUhg6mZvDgwTZgwIAkj61ataqVLVvWZVlFugOtNmvfBKU4b5mN91vG5c3r/9uUN2+eZAFy8J6LNH5Xo++8hWZ7p4agVLTLk8+s2pXZfRTRQZlObdv6A0zBV15V/Pzuu/2z9f38s9ny5RpLkPSx2n7xYv8SrHRpf4AqOFilResBAMgmquc0e/Zs27NnjwvyVKxY0a666iqrVauWzZkzxzZu3Ohmx/NouN/AgQPdDHxr1qyxChUquG1ChwVqhj3dd6yrm+edd57L2FIh9fz6nE1FwYIF3RJKHdzMCBypA51Z+87NOG+ct6zlS/K3AGnH72rGcN6i67ylZ38EpZCzqAOuLKjUZt9TEfRVq/wF0hWk8v5fudKfSRVs2zazOXP8S7DKlS3ulFOseK1a/qGEjRr561UVLpzJDQQA4KiiRYu6Zdu2ba6g+RNPPGFdunRx9aGCderUydWY0gx7ouF/27dvd1lVTZo0ceu+/PJLd1W0efPmKZ5iBcC0LwWZPv7443Rd6QQAAEgvglLIeRSASm2mPRVjrVvXv1xxxdH1+/ZpOqKjQSovYLV+ffJ9rF9vcevXW1H9PHq0f52ivarlETz8T/9rHfWqAAARpACUajzUrVvXVq5c6Qqa16tXzwWdlLlUpkyZJNtrnTKgtL2oFpWynfr27WuvvPKKHTx40G677Ta7+uqrAzPvafa+9u3b29ixY61Zs2YuINWxY0fbu3evjR8/3t32ipYrtV/DCAEAACKJoFS0Szxktm6K/+cql/mH8yFjlOXUuLF/Cc2WCg5Sef9v3x7yWiSa/f67fwmtV6UsqtBgVeXK/npVa9emntkFAEAIFR5VraZ169a54uTKjnr00UePOZQu2IQJE1wgSoEnpdFrH88//3zgfgWqVqxY4YJQohpVmplPvILqntWrV1uNGjV4nQAAQEQR4cgJDmzL7iPI3VQ/6uyz/YtHU2OuW2fb58yxUuvXWx4vaKV6VaEzCen2jz/6l2ClSvmzqLReRdo9+kLx9ttmVaqYFSjgvx3u/+Cflf1FQXYAiBldu3Z1S1qpjlQoBbMmTpyY4mMUZFI2lqdNmzZJbgMAAGQ2glJAOAoAVa5sB9q1M9OMIV6hNgWXgutVeVlV//d/yetVKdNq4cLk+z540Kx79/SfdwWoUgpgpfX/tG6bL58VVrBNw0NUvPZ49k1xSwAAAABAGASlgPRQPY2TTvIvXbocXa8AjupVhQ4B1IyAkaJglpYjwywyk0JwJSN5zjI7iBapfetYVXtMxfK1juw0AAAAAMg0BKWASFBdqdNP9y/BZs/WeIjk2/fqpXEV/iDTgQPH/j8t23j/Rxtll2kJHfYYhRSMC0yUroBUTgmmBf9PMA0AAABADkFQCshMNWv6A1bBARndfuSRzCl2rlogCgAdZ6Arcf9+27VlixUvXNj+v737AI+qSh8//k4SCISE3qRIL0oTUJooCihtUSELimURFURFLKz/1dX9gb2xKlKsLC66WFDEAooIioCASAkiEIgYMfQWiAQIydz/857kjpMwQBIm0+738zwhzJ0zd+Y9987NmXdOibJ7aPk7eVbwd8Hhj8GmdWnHFG50DrIiJrpcMTFS0bLEFR+fO2QzUEk0798M9QQAAAAchaQUUJI08ZScHLjV97R3jyYk9OdsuN1ydM8eSfCeT6ukaTLNVwLsbBJdRUyeWcePS1ZmppTWqizsvnSoX6jR11TE1+XSfKkEmZ5rge6RFh0tZez50zRhXMx9MNQTAAAAKDqSUuEgJj7YrwBnQxNQJZWEiiT6wV5/NDEQJJbbLQf37JHq1auLq7DJOO1R5Z1MC2AS7az3GWq0t5wmiAI41FOPckV/7CjUh3WeKpkGAAAABBFJqVAXFSNSvxgrtQEIDO2dZicFypULn1ovMNTTfeyY7Nu5U6qWLy9RhR0CGqxebaE21FPZr/XIEQkXmpCrob0qwyWJ5v27mAm1STcsk5UfbJUTupZBjMhFgxvKqP919nvdAgAAoHBISvlZTk6OWDovS96qXW6323M7yqvnhZZTuq2ky2o5La+ivRryRS2rP1rOn/v1FUeolLVj1v8Xdr+BOJ6BOE/sbcU5T0qibDCOvf4uyn5D7XgWqmzeUE8Tc1ycnNAhf+ec4xmyGbLHPjvbzHumSapoe9hn3lxoOgTTlZPjmQtNb7vzEkambN7/dZuV95N54IDElykjLt2udaBlvRJhpuyJE+Z+s9+82+6854jS57TL6nNmZ4vr+HGJynsuU1b3q69Lr6N2bC6XWFoHliVRXom2nLz4/V5W60/r0e0295m6tP9m6es9U1mXS9y6Xd8bwS7rcuWeJ3lJKndsrFg6N1qpUhKVN+G/3nbnJcCiY2Lk1w1H5K4dy0zdWNEuceW4xTXDkknyvdz1Tie/XU/s+wAAAHBmJKX87Pvvv5crrrhCSmtDWER+//13+fXXX+Wcc86RZs2aecotXbrUNFw7deokZfKGK+3YsUNSUlLM0KHzzz/fU3b58uVy4sQJueiii6RcXk+MXbt2yebNm6Vq1arSsmVLT9mVK1fKsWPHpF27dlK+fHmzbc+ePbJx40apVKmStGnTxlN21apVkpmZKRdccIFUrJg7gGX//v2yfv1681jdhy05Odk8X+vWraWKzr0iIgcPHpR169ZJfHy8XHjhhZ6yP/30k6Snp5sYNBZ1+PBhWbNmjZQtW1Y6duzoKavPdeDAAWnevLnUrJm77tmRI0fkxx9/NHXYpUsXT1mNYe/evdKkSROpXbu22Xb06FH54YcfJCYmRrp27eopq69V66hhw4Zybt7QuaysLFm2bJn5cNGtWzdPWa1zrfv69eubH/tD85IlS8xr6d27t6esHks9pnXr1pVGjRqZbfohZPHixeb/+hr0taht27ZJamqq1KpVS5o2berZh+5XH9O5c2eJ1QmlRSQtLU22bt1q6kDrwqavNzs7Wzp06CBxcXFm286dO2XLli1SrVo1adGihafsihUrTIx6LPSY2Md+06ZNUrlyZXPsbFq/Wndt27aVChUqmG1atxs2bDDngndZPW5//PGH2ab7UXrM9DgnJCRI+/btPWWTkpLMsdZzUs9NdejQIVm7dq15/RqH97HXc+i8886TGjVqmG0ZGRmyevVq857Q94ZNX9e+fftMPWp9Kj139XwvVaqUXHzxxZ6yGq/G3bhxY6lTp47Zdvz4cfM+0g+Vl156qaes1qPWZ4MGDaRevXpmm9a3HiM9Ty7zWjlRj48eJz2f9LxS+h62j/0ll1zi+YCqx12Pvz6/vg6bXVbP61C7Rmgd6+vX11Gca4QeYz1+rVq1KvlrxLFjvq8RP/8se/fty3+NyMzMvUbExeW/RmzaZOpIj72+D+OrV5esEyd8XyM2bz75GpF3nig9p+zhnr/+8svJ1wg9T777ziRdunbsKDF5k+hvS02V1N9/l1qVKklTrYe8hNeSjRtNYqvzOedIrCY4srIkLT1dth46JDVjYqS5Jl3yyi47ckSyc3Kkg9stcXmJsZ05ObIlOlqqHTsmLQ4f9iTXVlSsKDpo88K0NIk/csQky3bExMiWWrWkSnq6tE5J8ZT98bzz5Gjp0tJ29WqpkDcn3t6qVWVDixZSMT1dLli71lM/a9q1kz/i46V1UpJUPnjQbDtQubL81KqVJGRkSPtVqzxlk9q0kcMVKkjL9eulat5+D1WoIGsvuEDijhyRDitX/nnsW7WSg5UqyXkbN0qN3bvNtoz4eFndvr2ZB6zT8uX65jbbN7RsKfuqVpWmyclSa+dOsy2zXDlZedFFUurECbn422+lgX2eNGsme2rUkMYpKVInLc30nDo+tW2hrxH6XtO/9crXNUL/1gIAAKBwSEqFOne2VM5cJDnZOSLutsF+NQCAsx3qqYlrTR4eOpT7o0lZr8S1ZGTkDq/s3Dl3JUS1bZtmPUQ0MeeVuBZNjGkvLE345iWuZft2zaaIVKsm4pW4Fk2kaNJJE4Tx8SZZlr5hg2akcyd690pGy4oVmvUXadtWRJOX2stMkz0//5z72jXhZvcm27Qpd9iixqHx6TZNhmkiSZN1CQl/ltV49Xffvn8ubqC3NV6NQxOS9lBNjV0frzHr/nSb0ts675i+Prusvn5NxmuSXV+Lbi/kvHA6lA8AAADB4bK8xyaFAP2m/V//+pd8/PHH5tt77ckxYcIE0wOgoJEjR8prr70mL774otx7772e7fqt+t133y2fffaZ+dYzMTHR7MPuPeKL9hwYM2aMvPfee6ZXRa9evWTKlCmeHhxnot/ya48TfW7tUeC34TbubHGnvGn+62p0q7iiSxV5v2c7hEZv6zfF2qNBewGF87CsopTVHjN6DmrvDO+6cMrwPY1dj7l9iQi5IVwlUFZv79692/Qu0tsRP3zPq97t8117SkWF+vA9P5bVH+2FZya316Fhxdjvmeo9VM8TLae9xbTXpcYbqKHgAT1PNNGVN8zzrsozZHL2SDP8T4cButxuibIsGRrzjryVdb3fziltx2hvKe0lavdGdBq7TVQSdaD1bP998j5nQb2VBM634qtTx5Lt211Su7YlaWl/TgsBzrmSwHs19OqtKG2BkOspddttt5nhGm+//bYZpvPOO+9Iz549zdASeziG0qSVdrW3h/J4u+GGG0wSZf78+aab/bBhw2TEiBEyY8aMUz7vfffdJ3PmzJGZM2eayhs1apQMHDjQDKEpCm2ges/Hc6qD692QPVNZz/Zi7ldfj6/tRS1bMDZ/7NdXHKFUtjDHsyj7VaFa1jsO7zlRSvKcCuVjX/A+Jxz7gvc54dh7n+uhcP6pQJf1db6HwrH3y3mSN7+UOm9wa7FmSL65szTl3uHahn49niRKAAAACi+kklI6x81HH30kn3zyiWdOh3HjxpkeT6+88oo88cQTZtv27dtNT6h58+ZJv3798u1D5x368ssvzbwp9hwmEydOlL59+8r48eN9JrE0ezd16lSTtOrevbvZNm3aNDPXjSa+vOe2AQAA4UdX2ft/276XtCVbPdvqXtJQnn2H1fcAAACCJaSSUjp8RLvr25P62nTiW3tCWf1W+6abbpIHHngg3yTPNp2kVofPeU+qqz2t9JtLnQh6wIABJz1GJ/PVHlVazqaT6uqExro/X0kpHeKnP97d0+zX59eVd3Rf9v7M78Cv6uPUFYWcGreTY3dq3E6O3alxOzH2WbNEnl+iCSj9m649YC2RxS656EO3DBzov+dxSn0CAABEXFJKV/LSFckef/xxz4pc7777rkkM2StYPfvss2Zeo9GjR/vch86PYa/mZNPyumqY3neqx+gqTvbqUjZ9/lM95umnn5ZHH330pO26gpnOT+U37mwpq5Peak+yPXtEogJ/yLSBrb3J9MOLk4YlODVuJ8fu1LidHLtT43Zi7P/3f1XM0DvLsodku8TlsmTs2Bzp2nW/355H55QCAABAGCallM4ldcstt5j5o3TOBl1yfMiQIaY3k/7ohOW6ZLz3PD/B8NBDD8n999+fr6eULgGuE8b6dVJPd7bIHwnmvwmabAtSUkrrW2NzwgcXp8ft5NidGreTY3dq3E6MfetW74RULr29dWvMSV9mnY2Cvb0BAAAQRkmpRo0ayaJFi+TIkSMm0aMrQV177bXSsGFDWbx4sZkdXofV2XS4n66a99JLL0lqaqpZKU3LFBwWqKvi6X2+6PasrCxJT0/P11tKV+E61WNiY2PNT0HasPdv4z5KJCZvmW/db5A+ONgrDznhg4s3p8bt5NidGreTY3dq3E6LXb8v2rv35O0JCVoH/vuiywl1CQAA4C8h23IqV66cSUgdPHjQTGh+9dVXm7mk1q1bJ2vXrvX86MTlOr+UllE6/E+TS9qryrZw4ULzjXDHjh19Plf79u2lVKlSsmDBAs+25ORk2bZtm9lfUGnPqIZ/y/0JQi8pAAAiQXp60bYDAACg5IVclkOTSzq/RbNmzSQlJcUknHTS8WHDhpnEUZUqVfKV123am0nLK52Lqnfv3jJ8+HB59dVXzQTmo0aNkuuuu86z8p6u3tejRw+ZPn26dOjQQSpUqCC33nqrGY6nc0/p8Dtd3U8TUqy8BwBA+DtxomjbAQAA4MCklE66qvM1paWlmQRRYmKiPPnkkyb5VFj/+9//TCJKE0/ajV738fLLL3vu10SV9oTKzMz0bHvxxRc9ZXVVvV69esmUKVP8Hh8AAAg8nYrSsnxvBwAAQHCEXFJq8ODB5qewdB6pgjSZNWPGjFM+pn79+qY3VsGJSSdPnmx+QopOdL7ji9z/1+rDED4AAIpBp3rKyfG9HQDgP7Nm6dy8uf/X33p74EBqGIBvNMXCwbGduT8AAKBY6tTxvb1uXSoUAPxFE1CJibrQVO5t/a23dTsA+EJSCgAAAABw1h591B4WbY+Ndpnbjz1G5QLwjaQUAACIePZQkoJ27Qr0KwGAyLV588nz9+nt5ORgvSIAoY6kFAAAiHhNm548qbnezlu8FwDAtRZAEJCUAgAAEW/s2Nxv612u3K/w9bfe1u0AAK61AIKDpBQAAIh4uvLTRx+JtGolEhtrmd868e6AAcF+ZQAQObjWAiiqmCI/AoHn4jABAOCPD0vXXGPJnj17pHr16hIVVWA8HwCAay2AgCLbEeqiYkQa3RLsVwEAAAAAAOBXDN8DAAAAAABAwJGUAgAAAAAAQMAxfC/UuXNEds3P/X/NK0SiooP9igAAAAAAAM4aSamQZ4lkbvvz/wAAAAAAABGA4XsAAAAAAAAIOJJSAAAAAAAACDiSUgAAAAAAAAg4klIAAAAAAAAIOJJSAAAAAAAACDhW3/MTy8pdGe/w4cPiV+5skYyjuf/XfUcF/pC53W7JyMiQMmXKSFSUc/KYTo3bybE7NW4nx+7UuJ0ce0nHbbcD7HaBE5VYm8jB5+3Zot6oN8658MB7lXqLlPOtKO0hklJ+ogdT1a1bV0rOvSW4bwAA4M92QYUKFRxZoYFpEwEAgEhoD7ksJ3+V5+cs444dOyQhIUFcLpdEEs1yasPy999/l/Lly4tTODVuJ8fu1LidHLtT43Zy7CUdtzartAFWq1Ytx/bkKck2kVPP27NFvVFvnHPhgfcq9RYp51tR2kP0lPITreg6depIJNMT1YkNQKfG7eTYnRq3k2N3atxOjr0k43ZqD6lAtomcet6eLeqNeuOcCw+8V6m3SDjfCtsecuZXeAAAAAAAAAgqklIAAAAAAAAIOJJSOKPY2FgZO3as+e0kTo3bybE7NW4nx+7UuJ0cu1PjjhQcP+qN8y088F6l3jjfQl9siLSJmOgcAAAAAAAAAUdPKQAAAAAAAAQcSSkAAAAAAAAEHEkpAAAAAAAABBxJKQeYPHmy1K9fX8qUKSMdO3aUH3744bTlZ86cKc2bNzflW7VqJXPnzj1l2ZEjR4rL5ZKXXnrppPvmzJljnq9s2bJSqVIlueaaayTS4968ebNcffXVUrVqVSlfvrx07dpVvvnmGwk0f8d+8803m3i9f3r37p2vzIEDB+SGG24wcVesWFFuvfVW+eOPPySS405NTTVxNmjQwJznjRo1MpMFZmVliROOue348eNywQUXmDJr1671a1yhGnewr2/Bij0UrnElcW3fuHGjXHXVVVKhQgUpV66cXHTRRbJt2zbP/ceOHZO77rpLqlSpIvHx8ZKYmCi7d+8ukfgiXaDP22+//fak++2flStXSrhw6vs9XOtu9erVcsUVV5j2kF43RowYEfA20dniWhs+9fb666/LZZddZt6nej6mp6dLuAl0vennlrvvvluaNWtm2nLnnnuujB49Wg4dOiThZHIQzrfbb7/dfObReqtWrZr5O7Fp06azC8RCRHvvvfes0qVLW//5z3+sn3/+2Ro+fLhVsWJFa/fu3T7LL1261IqOjraee+45a8OGDdYjjzxilSpVyvrpp59OKjtr1iyrTZs2Vq1atawXX3wx330ffvihValSJeuVV16xkpOTzXO///77VqTH3aRJE6tv375WUlKStXnzZuvOO++04uLirJ07d1rhHPvQoUOt3r17mzjsnwMHDuTbj96v9bJ8+XJr8eLFVuPGja0hQ4ZYkRz3F198Yd18883WvHnzrF9++cX65JNPrOrVq1tjxoyxAilYx9w2evRoq0+fPpb+SVmzZo0V6XEH+/oWzNiDfY0ribhTUlKsypUrWw888IC1evVqc1vfy977HDlypFW3bl1rwYIF1o8//mh16tTJ6tKlS0BijiTBOG+PHz+e7z79ue2226wGDRpYbrfbCgdOfb+Ha91t377d/I3Q68amTZusH374wVwvEhMTrXDBtTa86k0/jzz99NPmR9tiBw8etMJJMOpNyw4cOND69NNPzX36912vebxPU854vr322mvWokWLrF9//dVatWqV1b9/f9NGys7OLvY5QFIqwnXo0MG66667PLdzcnJMMkUvWr4MHjzY6tevX75tHTt2tG6//fZ829LS0qzatWtb69evt+rVq5cvOXPixAlz35tvvmk5Ke69e/eaPwTfffedZ9vhw4fNtvnz51vhHLs2wK6++upTPqf+QdA4V65cmS9h43K5TOMsUuP2Rf9A6oedQApm7HPnzrWaN29uGhGBTkoFI+5QuL4FK/ZQuMaVRNzXXnutdeONN57yOdPT001jd+bMmZ5tGzduNHEvW7bsLCNyllC4TmdlZVnVqlWzHnvsMStcOPX9Hq51px/Y9AsqfS7bunXrTN1t2bLFCgdca8On3rx98803YZmUCna92T744AOTHNO2XjjoECL1pl9c6HmnCaziYvheBNMhRKtWrZKePXt6tkVFRZnby5Yt8/kY3e5dXvXq1StfebfbLTfddJM88MAD0qJFi5P2oV2Wt2/fbp6rbdu2cs4550ifPn1k/fr1Eslxa/ds7QI6ffp0OXLkiGRnZ8trr70m1atXl/bt20s4x24PgdBYNMY77rhD9u/fn28f2kX9wgsv9GzTfepzr1ixQiI1bl+022/lypUlUIIZuw5fGj58uLz99tsSFxcngRSsuIN9fQtm7MG+xpVE3Hpd16GYTZs2Nds1Fu3+Pnv2bE95fc4TJ07k2492fdeu/qd6XgTm+BXnOv3pp5+a+4cNGxYWh8mp7/dwrjsd0l66dGnzXDYd5qKWLFkioY5rbXjVW7gLpXrTNrwOgYyJiZFQlxUi9aZ/H6ZNm2amMqlbt26x4yEpFcH27dsnOTk5UqNGjXzb9fauXbt8Pka3n6n8s88+a96sOu7Wl61bt5rf48aNk0ceeUQ+//xzM+eKjnXW8buRGreO4f76669lzZo1kpCQYMbqvvDCC/Lll1+a+AOhpGLXuRK0YbpgwQJTD4sWLTIfxPW57H3ohcub1pUmZ071vJEQd0EpKSkyceJEM9Y6UIIVu/a01Xk1dH4172RkpMcd7OtbMGMP9jWuJOLes2ePmeflmWeeMfF/9dVXMmDAABk4cKCJ396HfsDUxHthnxeBOX7FuU5PnTrVNLbr1KkTFofJqe/3cK677t27m/LPP/+8+eB48OBBefDBB819O3fulFDHtTa86i3chUq96et4/PHHzfxv4WBfkOttypQpZo5N/fniiy9k/vz5pq1UXKGfBkRI0YzshAkTTG8BbbD4ollW9fDDD5vJYJVmULUBqJOrBfIDeyDj1g/pOhGuJmcWL15svhV78803pX///mYyVe1REa6uu+46z/91UrzWrVubCe70m8IePXpIpCpK3Np7Ri/ggwYNMr2HIj12Tb5lZGTIQw89JJHkTHFH4vWtsLFH4jXOPp46Sed9991n/q+T9n///ffy6quvSrdu3YL8CuHP63RaWprMmzdPPvjgA8dXrBPf74GqO+1N/9///lfuv/9+8zcyOjrafKGpH/68e085Cdda6i2Uz7fDhw9Lv3795PzzzzdfOjqVuwj1potb6WIOmmgfP368DB48WJYuXWq+wCgOZ14ZHUJXS9E/hAVXCNLbNWvW9PkY3X668tow0SyqDlvQnjD689tvv8mYMWPMzP/KbqjoG9sWGxsrDRs2zDdzf6TFvXDhQtNr4r333pOLL75Y2rVrZ7LI2pDTxkkglETsvuix1OfSnkH2PrR+vGlXf+05crr9hHvcth07dsjll18uXbp0MSugBFKwYtfzXbv76ntb3w+NGzc227XX1NChQyVS4w729S3YxzyY17iSiFv3qeev9/FU5513nud4alnt7VBwNaMz1R9K/vgV5TptJ5B1WJquKhQunPp+D/dz7vrrrze9D/QLKx3apx909+7da8qGOq614VVv4S7Y9aZfsOqXytoj9OOPP5ZSpUpJOKga5HrTlfmaNGkil156qXz44Ydm9T2tv+IiKRXBtAudjvvX7sXeGVC93blzZ5+P0e3e5ZV2x7PL65xK69atM8u+2z+1atUy8yzpt49Kn1M/pCUnJ3v2ofNxpKamSr169SRS487MzDS/C34LprftzHM4xu6LftusjSz7A7qW1Q9s2qPMpg1afW4di1zSghW30ganDt3S59cPPIH+FjRYsb/88suSlJTkeT/YS8q+//778uSTT0qkxh3s61swYw/2Na4k4tZ96lLH3sdTbd682XM89Tm1keq9Hy2vDbTT1R9K/vgV9jqttOePXqP/9re/hc2HDie/3yPhnFPaO0qHt+jfRu1BoD0LQh3X2vCqt3AXzHrTHlJXXnmlKa/zDRa3l4/Tzzcrd/E8M59esRV7inSEzRKbsbGx1ltvvWVWSBsxYoRZYnPXrl3m/ptuusl68MEH8y2xGRMTY40fP96sLjR27NiTltgsqOAqdOqee+4xK1TNmzfPLId76623mpVITrWkfCTErSvVVKlSxSwvunbtWrNU/N///nezH70dKP6OPSMjw8Shq0zp0p9ff/211a5dO7Ns6rFjxzz70eWR27Zta61YscJasmSJuX/IkCERHbeuxti4cWOrR48e5v/ey0MHUrCOuTctF+jV94IVd7Cvb8GKPRSucSVxbZ81a5bZ9vrrr5uVsSZOnGiWml68eLGnjC7tfu6551oLFy60fvzxR6tz587mB+FzrdL79Bql+wk3Tn2/h/M5p9cRXSpd623SpElW2bJlrQkTJljhgmtteNWbtju1/fXGG294Vs3U2/v377fCQTDq7dChQ2bluVatWplV47zb8NnZ2VY4eC8I9fbLL79YTz31lGkL/fbbb2af/fv3typXrmzt3r272LGQlHIAPZm0Ma1LXOrSkcuXL/fc161bN7O0bcHlMJs2bWrKt2jRwpozZ85p9+8rKaVLLo8ZM8Z8UEtISLB69uxprV+/3or0uFeuXGldeeWV5o2pcXfq1MmaO3euFWj+jD0zM9PEpEto60VK4x4+fLjngmfTP3yahIqPj7fKly9vDRs2zDTeIjnuadOmmT/+vn6ccMyDnZQKVtyhcH0LVuyhcI0riWv71KlTTYK5TJkyVps2bazZs2fnu//o0aPWnXfeaVWqVMmKi4uzBgwYEPDkc6QI1rVK/z516dLFCldOfb+Ha93ph0GtN91H69atrenTp1vhhmtt+NSbJhd8tUW1nRouAl1v33zzzSnb8NqmDRcTA1xv27dvt/r06WPawHoNrFOnjnX99debL2nPhkv/KX4/KwAAAAAAAKDomFMKAAAAAAAAAUdSCgAAAAAAAAFHUgoAAAAAAAABR1IKAAAAAAAAAUdSCgAAAAAAAAFHUgoAAAAAAAABR1IKAAAAAAAAAUdSCgAAAAAAAAFHUgoAzlL9+vXl5ptvph4BAIBj0R4CUBwkpQCEjLfeektcLpf5WbJkyUn3W5YldevWNff/5S9/ESf59ttvTdypqanBfikAAKAE0R46NdpDQOSJCfYLAICCypQpIzNmzJCuXbvm275o0SJJS0uT2NjYkKq05ORkiYoixw8AAPyH9hAAJ+BTFICQ07dvX5k5c6ZkZ2fn266Jqvbt20vNmjUllGiSrFSpUsF+GQAAIILQHgLgBCSlAIScIUOGyP79+2X+/PmebVlZWfLhhx/K9ddf7/Mx48ePly5dukiVKlWkbNmyJnml5QvSIXCjRo2S2bNnS8uWLU1CqUWLFvLll1/mKzdu3DhTNiUlxcwXVbFiRalQoYIMGzZMMjMzTzuHgt3tfunSpXL//fdLtWrVpFy5cjJgwADZu3dvvse63W7zXLVq1ZK4uDi5/PLLZcOGDYWal2HLli2SmJhoknT6bWqdOnXkuuuuk0OHDp32cZdddpmJXZ9Hn0+ft3bt2vLcc8+d9nEAACBwaA/RHgKcgKQUgJCjCZnOnTvLu+++69n2xRdfmGSLJl18mTBhgrRt21Yee+wxeeqppyQmJkYGDRokc+bMOamszld15513mn1pIubYsWMmuaOJsIIGDx4sGRkZ8vTTT5v/a8Lp0UcfLVQcd999tyQlJcnYsWPljjvukM8++8wkxLw99NBDZn8XXnihPP/889KkSRPp1auXHDly5LT71iSdllu+fLl5nsmTJ8uIESNk69atkp6efsbXdvDgQendu7e0adNG/v3vf0vz5s3lH//4h6lnAAAQfLSHaA8BjmABQIiYNm2apZellStXWpMmTbISEhKszMxMc9+gQYOsyy+/3Py/Xr16Vr9+/fI91i5ny8rKslq2bGl1794933bdf+nSpa2UlBTPtqSkJLN94sSJnm1jx44122655ZZ8jx8wYIBVpUqVfNv09QwdOvSkOHr27Gm53W7P9vvuu8+Kjo620tPTze1du3ZZMTEx1jXXXJNvf+PGjTOP995nQWvWrDFlZs6caRVVt27dzGOnT5/u2Xb8+HGrZs2aVmJiYpH3BwAA/If2UC7aQ4Az0FMKQEjSXklHjx6Vzz//3PRU0t+nGrqndMiedy8g7VV1ySWXyOrVq08q27NnT2nUqJHnduvWraV8+fKml1FBI0eOzHdb96k9qg4fPnzGGLTnkg7j835sTk6O/Pbbb+b2ggULzLxZ2mvLm/Z8OhMdSqjmzZt30nDCwoiPj5cbb7zRc7t06dLSoUMHn3UAAACCg/bQ6dEeAsIfSSkAIUnnYdLkkU5uPmvWLJPM+etf/3rK8pq06tSpk5lbqXLlyubxr7zyis/5lc4999yTtlWqVMkks85UVsspX2WL+lg7OdW4ceN85fT122VPpUGDBma+qjfffFOqVq1qhvLpEL4zzSdl0/mnvBNm9usrTFwAACAwaA/RHgIiHUkpACFLe0bpHEevvvqq9OnTx0w27svixYvlqquuMgmpKVOmyNy5c80k6fr43BF7+UVHR/vcz9mW9edjC0Pnglq3bp3885//NL3KRo8ebSZtT0tLC/prAwAA/kF76PRoDwHhjaQUgJClq9VFRUWZybxPN3Tvo48+MgkpHcp2yy23mASW9rIKdfXq1TO/dYU/bzo8sLA9llq1aiWPPPKIfPfddyY5t337dpPEAwAAkYH20JnRHgLCV0ywXwAAnG7eIx2Cl5qaKv379z9trx8diqZD/Gz6mNmzZ4d05fbo0cOsEqgxXnHFFZ7tkyZNOuNjdU6ruLg483jvBpkm8Y4fP15irxkAAAQW7aFToz0EhD+SUgBC2tChQ89Ypl+/fvLCCy9I7969TY+qPXv2mPmVdK4mHd4WqmrUqCH33HOP6Xauww/19SclJZkhizpPVME5n7wtXLhQRo0aJYMGDZKmTZuaCdPffvttk6BLTEwMaBwAAKBk0R7yjfYQEP5ISgEIe927d5epU6fKM888I/fee6+ZBPzZZ581vaVCOSml9HVqj6c33nhDvv76a+ncubN89dVX0rVrVzMk8VTatGljJjf/7LPPzJA93Ydu04SWTvgOAACchfYQ7SEgHLksZrUFgJCSnp5uVsJ74okn5OGHHw72ywEAAAg42kOAMzDROQAEka6aV9BLL71kfl922WVBeEUAAACBRXsIcC6G7wFAEL3//vvy1ltvSd++fc1EpkuWLJF3331XrrzySrn44os5NgAAIOLRHgKci6QUAARR69atzQp6zz33nFlBxp78XIfuAQAAOAHtIcC5mFMKAAAAAAAAAcecUgAAAAAAAAg4klIAAAAAAAAIOJJSAAAAAAAACDiSUgAAAAAAAAg4klIAAAAAAAAIOJJSAAAAAAAACDiSUgAAAAAAAAg4klIAAAAAAAAIOJJSAAAAAAAAkED7/44ak3iZjANTAAAAAElFTkSuQmCC",
+      "text/plain": [
+       "<Figure size 1200x500 with 2 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# --- Figure: Channel face (extended) vs Overbank face (unchanged) ---\n",
+    "if channel_face_ids and overbank_face_example:\n",
+    "    fig, axes = plt.subplots(1, 2, figsize=(12, 5), sharey=False)\n",
+    "\n",
+    "    # Channel face: extended with depth-varying n\n",
+    "    ax = axes[0]\n",
+    "    ch_orig_max = ch_before['Elevation'].max()\n",
+    "    ch_orig = ch_after[ch_after['Elevation'] <= ch_orig_max + 0.01]\n",
+    "    ch_ext = ch_after[ch_after['Elevation'] > ch_orig_max - 0.01]\n",
+    "\n",
+    "    ax.plot(ch_orig[n_col], ch_orig['Elevation'], 'b-o', markersize=4,\n",
+    "            label='Preprocessed', linewidth=2)\n",
+    "    ax.plot(ch_ext[n_col], ch_ext['Elevation'], 'r-s', markersize=3,\n",
+    "            label='Extended (depth-varying)', linewidth=2)\n",
+    "    ax.axhline(y=ch_orig_max, color='gray', linestyle=':', alpha=0.5)\n",
+    "    ax.axvline(x=N_ASYMPTOTE, color='orange', linestyle='--', alpha=0.4)\n",
+    "    ax.set_xlabel(\"Manning's n\", fontsize=12)\n",
+    "    ax.set_ylabel('Elevation (ft)', fontsize=12)\n",
+    "    ax.set_title(f'Channel Face {channel_face_example}\\n(Extended)', fontsize=12)\n",
+    "    ax.legend(fontsize=9)\n",
+    "    ax.grid(True, alpha=0.3)\n",
+    "\n",
+    "    # Overbank face: unchanged\n",
+    "    ax = axes[1]\n",
+    "    ob_data = ob_after\n",
+    "    ax.plot(ob_data[n_col], ob_data['Elevation'], 'b-o', markersize=4,\n",
+    "            label='Original (unchanged)', linewidth=2)\n",
+    "    ax.set_xlabel(\"Manning's n\", fontsize=12)\n",
+    "    ax.set_title(f'Overbank Face {overbank_face_example}\\n(Not Modified)', fontsize=12)\n",
+    "    ax.legend(fontsize=9)\n",
+    "    ax.grid(True, alpha=0.3)\n",
+    "\n",
+    "    fig.suptitle('Selective Application: Channel vs Overbank', fontsize=14, y=1.02)\n",
+    "    fig.tight_layout()\n",
+    "    plt.show()\n",
+    "else:\n",
+    "    print(\"Skipping figure — no polygon-based face selection available\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "eec0a323",
+   "metadata": {
+    "papermill": {
+     "duration": 0.016894,
+     "end_time": "2026-05-12T12:24:38.084905+00:00",
+     "exception": false,
+     "start_time": "2026-05-12T12:24:38.068011+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## Summary\n",
     "\n",
-    "This notebook demonstrated a complete **edit-run-read** loop for 2D Manning's n:\n",
+    "This notebook demonstrated a complete workflow for depth-varying Manning's n\n",
+    "in HEC-RAS 2D models:\n",
     "\n",
-    "1. **Read** the 2D flow area settings with `GeomStorage.get_2d_flow_area_settings()`\n",
-    "2. **Modify** the uniform n (2x multiplier) with `GeomStorage.set_2d_flow_area_settings()`\n",
-    "3. **Run** both models with `force_geompre=True` to regenerate face property tables\n",
-    "4. **Verify** that face property tables in the geometry HDF have different n values\n",
-    "5. **Compare** simulation results — higher roughness produced measurably higher WSE\n",
+    "### What We Showed\n",
+    "\n",
+    "1. **Literature basis**: Manning's n decreases with flow depth — established by\n",
+    "   HEC-15, Limerinos (1970), Jarrett (1984), and Chow (1959)\n",
+    "2. **Edit-run-read loop**: Modified uniform n in the plain-text geometry file,\n",
+    "   ran with `force_geompre=True`, verified face property tables updated\n",
+    "3. **Depth-varying n**: Applied an exponential decay formula to the face property\n",
+    "   tables using `HdfMesh.set_face_mannings_n_values()`\n",
+    "4. **Table extension**: Extended face tables above terrain elevation using\n",
+    "   `HdfMesh.extend_face_property_tables()` with depth-varying Manning's n\n",
+    "5. **Selective application**: Used `polygon` parameter to modify only channel\n",
+    "   faces — overbank faces retained original roughness\n",
+    "6. **Channel delineation**: Demonstrated fluvial/pluvial classification and\n",
+    "   bank line extraction as channel polygon sources\n",
     "\n",
     "### Key Architecture Points\n",
     "\n",
-    "- **Uniform vs Spatially Varied**: Models use either a single uniform n or land cover-based\n",
-    "  spatially varying n. Check `spatially_varied_mann_on_faces` in `get_2d_flow_area_settings()`\n",
-    "- **To persist Manning's n changes through compute**: Modify the plain-text geometry\n",
-    "  file (`.g##`) via `GeomStorage` or `GeomLandCover`, then run with `force_geompre=True`\n",
-    "- **Direct HDF modification** (`HdfMesh.set_face_mannings_n_values()`) is useful for\n",
-    "  analysis and post-processing, but HEC-RAS geometry preprocessing regenerates these\n",
-    "  tables from the plain-text settings\n",
-    "- The `Pinned` attribute protects tables from RASMapper overwrite but NOT from the\n",
-    "  geometry preprocessor during compute\n",
+    "| Workflow | Method |\n",
+    "|----------|--------|\n",
+    "| Persist n through compute | Modify `.g##` via `GeomStorage` + `force_geompre=True` |\n",
+    "| Direct HDF modification | `HdfMesh.set_face_mannings_n_values()` (analysis only) |\n",
+    "| Extend tables higher | `HdfMesh.extend_face_property_tables()` |\n",
+    "| Protect from RASMapper | `HdfMesh.pin_property_tables()` (but NOT from preprocessor) |\n",
+    "| Spatial filtering | `polygon=`, `region_name=`, or `face_ids=` parameters |\n",
+    "| Channel identification | Calibration regions, fluvial/pluvial, bank lines |\n",
     "\n",
-    "### API Reference\n",
+    "### Adapting for Your Project\n",
     "\n",
-    "| Method | Purpose |\n",
-    "|--------|---------|\n",
-    "| `GeomStorage.get_2d_flow_area_settings()` | Read 2D flow area config (including uniform n) |\n",
-    "| `GeomStorage.set_2d_flow_area_settings()` | Modify uniform n in `.g##` |\n",
-    "| `GeomLandCover.get_base_mannings_n()` | Read land cover n table from `.g##` |\n",
-    "| `GeomLandCover.set_base_mannings_n()` | Write modified n table to `.g##` |\n",
-    "| `HdfMesh.get_mesh_face_property_tables()` | Read per-face n from geometry HDF |\n",
-    "| `HdfMesh.set_face_mannings_n_values()` | Replace n column with custom function |\n",
-    "| `HdfMesh.extend_face_property_tables()` | Extend tables to higher elevations |\n",
-    "| `HdfMesh.pin_property_tables()` | Set Pinned attribute on mesh group |"
+    "```python\n",
+    "# 1. Extract your project (or point to your local copy)\n",
+    "ras = init_ras_project(\"/path/to/your/project\", \"7.0\")\n",
+    "\n",
+    "# 2. Run with force_geompre to generate face tables\n",
+    "RasCmdr.compute_plan(\"01\", ras_object=ras, force_geompre=True)\n",
+    "ras = init_ras_project(\"/path/to/your/project\", \"7.0\", ras_object=\"new\")\n",
+    "\n",
+    "# 3. Define your depth-varying n function\n",
+    "def my_n_func(depth, base_n):\n",
+    "    if depth <= 0: return base_n\n",
+    "    return 0.035 + (base_n - 0.035) * np.exp(-depth / 1.5)\n",
+    "\n",
+    "# 4. Extend channel faces only (using calibration region)\n",
+    "geom_hdf = Path(ras.geom_df.iloc[0]['file_path']).with_suffix('.hdf')\n",
+    "HdfMesh.extend_face_property_tables(\n",
+    "    hdf_path=geom_hdf,\n",
+    "    mesh_name=\"Your 2D Area\",\n",
+    "    extension_elevation=960.0,  # target elevation\n",
+    "    mannings_n_func=my_n_func,\n",
+    "    region_name=\"Channel\",      # drawn in RASMapper\n",
+    "    pin_tables=True,\n",
+    ")\n",
+    "```\n",
+    "\n",
+    "### References\n",
+    "\n",
+    "- Chow, V.T., 1959. *Open-Channel Hydraulics*. McGraw-Hill.\n",
+    "- FHWA, 2005. *Design of Roadside Channels with Flexible Linings* (HEC-15). FHWA-NHI-05-114.\n",
+    "- Limerinos, J.T., 1970. USGS Water-Supply Paper 1898-B.\n",
+    "- Jarrett, R.D., 1984. *J. Hydraulic Engineering*, ASCE, 110(11): 1519-1539.\n",
+    "- [HEC-RAS Technical Reference — Energy Loss Coefficients](https://www.hec.usace.army.mil/confluence/rasdocs/ras1dtechref/6.6/basic-data-requirements/geometric-data/energy-loss-coefficients)\n",
+    "- [HEC-RAS 2D — Face Property Tables](https://www.hec.usace.army.mil/confluence/rasdocs/r2dum/latest/development-of-a-2d-or-combined-1d-2d-model/creating-hydraulic-property-tables-for-2d-flow-areas)"
    ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -2640,9 +5042,21 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.13"
+   "version": "3.14.3"
+  },
+  "papermill": {
+   "default_parameters": {},
+   "duration": 119.438422,
+   "end_time": "2026-05-12T12:24:38.661455+00:00",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "examples/414_depth_varying_mannings_n.ipynb",
+   "output_path": "examples/414_depth_varying_mannings_n_executed.ipynb",
+   "parameters": {},
+   "start_time": "2026-05-12T12:22:39.223033+00:00",
+   "version": "2.7.0"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 4
+ "nbformat_minor": 5
 }

--- a/ras_commander/hdf/AGENTS.md
+++ b/ras_commander/hdf/AGENTS.md
@@ -39,6 +39,8 @@ This file is the canonical local instruction file for `ras_commander/hdf/`.
 - Plan metadata and compute messages: `HdfResultsPlan`
 - 2D cell geometry and face geometry: `HdfMesh`
 - 2D face property table write (Manning's n vs Elevation): `HdfMesh.set_mesh_face_property_tables()`, `extend_face_property_tables()`, `set_face_mannings_n_values()`, `pin_property_tables()`
+- 2D face spatial filtering (polygon mask): `HdfMesh.get_face_ids_in_polygon()`, `get_face_ids_in_calibration_region()`
+- Both `extend_face_property_tables()` and `set_face_mannings_n_values()` accept optional `polygon` and `region_name` parameters for selective face application (precedence: `face_ids` > `region_name` > `polygon` > all faces)
 - 2D results extraction: `HdfResultsMesh`
 - 1D cross section geometry and results: `HdfXsec`, `HdfResultsXsec`
 - Land cover and infiltration preprocessing: `HdfLandCover`, `HdfInfiltration`

--- a/ras_commander/hdf/HdfMesh.py
+++ b/ras_commander/hdf/HdfMesh.py
@@ -44,6 +44,13 @@ set_face_mannings_n_values()
 pin_property_tables()
     Set or clear the Pinned attribute to prevent RASMapper overwrite
 
+Spatial Filtering (Polygon Mask):
+---------------------------------
+get_face_ids_in_polygon()
+    Filter mesh faces by polygon boundary (midpoint or any-vertex method)
+get_face_ids_in_calibration_region()
+    Filter mesh faces by named Manning's n calibration region from geometry HDF
+
 Spatial Query Utilities:
 -----------------------
 find_nearest_face()
@@ -1749,6 +1756,8 @@ class HdfMesh:
         mannings_n_func: Callable[[float, float], float],
         elevation_step: float = 0.5,
         face_ids: Optional[List[int]] = None,
+        polygon=None,
+        region_name: Optional[str] = None,
         pin_tables: bool = True,
     ) -> Dict[int, int]:
         """
@@ -1777,6 +1786,13 @@ class HdfMesh:
         face_ids : Optional[List[int]]
             List of face IDs to extend. ``None`` extends all faces whose
             current maximum is below ``extension_elevation``.
+        polygon : shapely Polygon/MultiPolygon or GeoDataFrame, optional
+            If provided and ``face_ids`` is None, only extend faces whose
+            midpoint falls within this polygon.
+        region_name : str, optional
+            If provided and ``face_ids`` is None, only extend faces within
+            the named Manning's n calibration region from the geometry HDF.
+            Precedence: ``face_ids`` > ``region_name`` > ``polygon``.
         pin_tables : bool, default True
             Pin tables after modification.
 
@@ -1790,6 +1806,10 @@ class HdfMesh:
         info_path = f"{base_path}/Faces Area Elevation Info"
         values_path = f"{base_path}/Faces Area Elevation Values"
 
+        resolved = HdfMesh._resolve_face_ids(
+            hdf_path, mesh_name, face_ids, polygon, region_name
+        )
+
         with h5py.File(str(hdf_path), 'r') as hdf_file:
             if info_path not in hdf_file or values_path not in hdf_file:
                 raise KeyError(f"Face property tables not found for mesh '{mesh_name}'")
@@ -1797,10 +1817,10 @@ class HdfMesh:
             old_values = hdf_file[values_path][()]
 
         num_faces = old_info.shape[0]
-        if face_ids is None:
+        if resolved is None:
             face_ids_to_extend = list(range(num_faces))
         else:
-            face_ids_to_extend = list(face_ids)
+            face_ids_to_extend = list(resolved)
 
         modified_tables: Dict[int, pd.DataFrame] = {}
         rows_added: Dict[int, int] = {}
@@ -1860,6 +1880,8 @@ class HdfMesh:
         mesh_name: str,
         mannings_n_func: Callable[[float, float, float], float],
         face_ids: Optional[List[int]] = None,
+        polygon=None,
+        region_name: Optional[str] = None,
         pin_tables: bool = True,
     ) -> int:
         """
@@ -1881,6 +1903,13 @@ class HdfMesh:
             Manning's n value.
         face_ids : Optional[List[int]]
             Faces to modify. ``None`` modifies all faces.
+        polygon : shapely Polygon/MultiPolygon or GeoDataFrame, optional
+            If provided and ``face_ids`` is None, only modify faces whose
+            midpoint falls within this polygon.
+        region_name : str, optional
+            If provided and ``face_ids`` is None, only modify faces within
+            the named Manning's n calibration region from the geometry HDF.
+            Precedence: ``face_ids`` > ``region_name`` > ``polygon``.
         pin_tables : bool, default True
             Pin tables after modification.
 
@@ -1894,6 +1923,10 @@ class HdfMesh:
         info_path = f"{base_path}/Faces Area Elevation Info"
         values_path = f"{base_path}/Faces Area Elevation Values"
 
+        resolved = HdfMesh._resolve_face_ids(
+            hdf_path, mesh_name, face_ids, polygon, region_name
+        )
+
         with h5py.File(str(hdf_path), 'r') as hdf_file:
             if info_path not in hdf_file or values_path not in hdf_file:
                 raise KeyError(f"Face property tables not found for mesh '{mesh_name}'")
@@ -1901,10 +1934,10 @@ class HdfMesh:
             old_values = hdf_file[values_path][()]
 
         num_faces = old_info.shape[0]
-        if face_ids is None:
+        if resolved is None:
             target_ids = list(range(num_faces))
         else:
-            target_ids = list(face_ids)
+            target_ids = list(resolved)
 
         modified_tables: Dict[int, pd.DataFrame] = {}
 
@@ -1971,3 +2004,161 @@ class HdfMesh:
 
         action = "Pinned" if pinned else "Unpinned"
         logger.info(f"{action} property tables for mesh '{mesh_name}'")
+
+    # -------------------------------------------------------------------------
+    # Spatial Filtering: Polygon Mask for Selective Face Application
+    # -------------------------------------------------------------------------
+
+    @staticmethod
+    @log_call
+    def get_face_ids_in_polygon(
+        hdf_path: Union[str, Path],
+        mesh_name: str,
+        polygon,
+        method: str = 'midpoint',
+    ) -> List[int]:
+        """
+        Return face IDs whose geometry falls within a polygon boundary.
+
+        Parameters
+        ----------
+        hdf_path : Union[str, Path]
+            Path to the HEC-RAS geometry HDF file (.g##.hdf).
+        mesh_name : str
+            Name of the 2D flow area / mesh.
+        polygon : shapely.geometry.Polygon, shapely.geometry.MultiPolygon, or GeoDataFrame
+            The masking polygon. If a GeoDataFrame is provided, all
+            geometries are unioned into a single polygon.
+        method : str, default 'midpoint'
+            How to test each face against the polygon:
+            - ``'midpoint'``: face midpoint must be within the polygon
+            - ``'any_vertex'``: at least one face vertex must be within
+
+        Returns
+        -------
+        List[int]
+            Sorted list of face IDs (0-indexed) that satisfy the spatial filter.
+        """
+        from shapely.geometry import Point, MultiPolygon
+        from shapely.ops import unary_union
+        from shapely import prepare
+        from geopandas import GeoDataFrame
+
+        if isinstance(polygon, GeoDataFrame):
+            polygon = unary_union(polygon.geometry)
+        if isinstance(polygon, MultiPolygon):
+            pass
+        prepare(polygon)
+
+        faces_gdf = HdfMesh.get_mesh_cell_faces(hdf_path)
+        if faces_gdf.empty:
+            return []
+
+        faces_gdf = faces_gdf[faces_gdf['mesh_name'] == mesh_name]
+        if faces_gdf.empty:
+            return []
+
+        matching_ids = []
+
+        if method == 'midpoint':
+            for _, row in faces_gdf.iterrows():
+                mid = row.geometry.interpolate(0.5, normalized=True)
+                if polygon.contains(mid):
+                    matching_ids.append(int(row['face_id']))
+        elif method == 'any_vertex':
+            for _, row in faces_gdf.iterrows():
+                coords = list(row.geometry.coords)
+                if any(polygon.contains(Point(c)) for c in coords):
+                    matching_ids.append(int(row['face_id']))
+        else:
+            raise ValueError(f"method must be 'midpoint' or 'any_vertex', got '{method}'")
+
+        logger.info(
+            f"Found {len(matching_ids)} faces in polygon "
+            f"(mesh '{mesh_name}', method='{method}')"
+        )
+        return sorted(matching_ids)
+
+    @staticmethod
+    @log_call
+    def get_face_ids_in_calibration_region(
+        hdf_path: Union[str, Path],
+        mesh_name: str,
+        region_name: str,
+        method: str = 'midpoint',
+    ) -> List[int]:
+        """
+        Return face IDs within a named Manning's n calibration region.
+
+        Reads the calibration region polygon from the geometry HDF via
+        ``HdfLandCover.get_mannings_region_polygons()`` and delegates
+        to ``get_face_ids_in_polygon()``.
+
+        Parameters
+        ----------
+        hdf_path : Union[str, Path]
+            Path to the HEC-RAS geometry HDF file (.g##.hdf).
+        mesh_name : str
+            Name of the 2D flow area / mesh.
+        region_name : str
+            Name of the calibration region as defined in RASMapper GUI.
+        method : str, default 'midpoint'
+            Spatial test method (see ``get_face_ids_in_polygon``).
+
+        Returns
+        -------
+        List[int]
+            Sorted list of face IDs within the named calibration region.
+
+        Raises
+        ------
+        ValueError
+            If the named region is not found in the geometry HDF.
+        """
+        from .HdfLandCover import HdfLandCover
+
+        regions_gdf = HdfLandCover.get_mannings_region_polygons(hdf_path)
+        if regions_gdf.empty:
+            raise ValueError(
+                f"No Manning's n calibration regions found in '{hdf_path}'"
+            )
+
+        match = regions_gdf[regions_gdf['Name'] == region_name]
+        if match.empty:
+            available = regions_gdf['Name'].tolist()
+            raise ValueError(
+                f"Calibration region '{region_name}' not found. "
+                f"Available regions: {available}"
+            )
+
+        region_polygon = match.geometry.iloc[0]
+
+        return HdfMesh.get_face_ids_in_polygon(
+            hdf_path, mesh_name, region_polygon, method=method
+        )
+
+    @staticmethod
+    def _resolve_face_ids(
+        hdf_path: Union[str, Path],
+        mesh_name: str,
+        face_ids: Optional[List[int]],
+        polygon=None,
+        region_name: Optional[str] = None,
+        method: str = 'midpoint',
+    ) -> Optional[List[int]]:
+        """
+        Resolve face_ids from explicit list, region_name, or polygon.
+
+        Precedence: face_ids > region_name > polygon > None (all faces).
+        """
+        if face_ids is not None:
+            return face_ids
+        if region_name is not None:
+            return HdfMesh.get_face_ids_in_calibration_region(
+                hdf_path, mesh_name, region_name, method=method
+            )
+        if polygon is not None:
+            return HdfMesh.get_face_ids_in_polygon(
+                hdf_path, mesh_name, polygon, method=method
+            )
+        return None


### PR DESCRIPTION
## Summary
- Adds `HdfMesh.get_face_ids_in_polygon()` for spatial filtering of mesh faces by polygon boundary
- Adds `HdfMesh.get_face_ids_in_calibration_region()` to filter by named Manning's n calibration region
- Extends `extend_face_property_tables()` and `set_face_mannings_n_values()` with optional `polygon=` and `region_name=` parameters (precedence: face_ids > region_name > polygon > all faces)
- Complete rewrite of notebook 414 with 7 professional figures covering HEC-15/Limerinos/Jarrett literature, face property tables, WSE comparison, depth-varying n, table extension, channel polygon map, and channel vs overbank comparison
- Demonstrates 3 channel polygon strategies: fluvial/pluvial classification, bank lines from 1D geometry, and calibration regions

## Test plan
- [x] Notebook 414 executes end-to-end without errors (17 code cells, 0 errors)
- [x] All 7 figures render correctly (verified via papermill execution)
- [x] Fluvial polygon: 286 acres, 9832 channel faces identified (88.1%)
- [x] Selective application: channel faces extended (7→46 rows), overbank unchanged (3 rows)
- [x] Bank lines: 2 lines found (~15,500 ft each)
- [x] WSE comparison: mean delta +0.111 ft, max +0.865 ft from doubling Manning's n
- [x] File size: 632 KB (within 5 MB limit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)