### PR TITLE
CLB-720: verify Normal Depth BC, parse typed boundary columns

### DIFF
--- a/ras_commander/RasPrj.py
+++ b/ras_commander/RasPrj.py
@@ -1583,7 +1583,9 @@ class RasPrj:
             'river_reach_name': fields[0] if len(fields) > 0 else '',
             'river_station': fields[1] if len(fields) > 1 else '',
             'storage_area_name': fields[2] if len(fields) > 2 else '',
-            'pump_station_name': fields[3] if len(fields) > 3 else ''
+            'pump_station_name': fields[3] if len(fields) > 3 else '',
+            'area_2d': fields[5] if len(fields) > 5 else '',
+            'bc_line_name': fields[7] if len(fields) > 7 else ''
         })
         parsed_lines.add(0)
         
@@ -1623,6 +1625,22 @@ class RasPrj:
                 if key in known_fields:
                     bc_info[key] = value.strip()
                     parsed_lines.add(i)
+
+        # Parse Friction Slope into typed columns
+        if 'Friction Slope' in bc_info:
+            fs_raw = bc_info['Friction Slope']
+            fs_parts = [p.strip() for p in fs_raw.split(',')]
+            try:
+                bc_info['friction_slope_value'] = float(fs_parts[0])
+            except (ValueError, IndexError):
+                bc_info['friction_slope_value'] = None
+            if len(fs_parts) > 1:
+                try:
+                    bc_info['critical_fallback_flag'] = int(fs_parts[1])
+                except ValueError:
+                    bc_info['critical_fallback_flag'] = None
+            else:
+                bc_info['critical_fallback_flag'] = None
 
         # Parse DSS Path components if available
         if 'DSS Path' in bc_info and bc_info['DSS Path']:

--- a/ras_commander/RasUnsteady.py
+++ b/ras_commander/RasUnsteady.py
@@ -3728,6 +3728,12 @@ class RasUnsteady:
 
         Notes
         -----
+        **1D applicability**: Normal Depth is a downstream-only boundary
+        condition for 1D reaches. HEC-RAS uses the Manning equation with
+        the specified friction slope to compute the stage at the most
+        downstream cross section. Do not apply this to upstream 1D
+        boundaries — use Flow Hydrograph or Stage Hydrograph instead.
+
         **Follow-up scope (out of this function)**: validation that the
         selected boundary actually exists in the geometry file, and creating
         a brand-new ``Boundary Location=`` block when the boundary exists in


### PR DESCRIPTION
## Summary
- Parse `area_2d` (field[5]) and `bc_line_name` (field[7]) from `Boundary Location=` lines in `_parse_boundary_condition()`
- Post-process `Friction Slope` raw string into `friction_slope_value` (float) and `critical_fallback_flag` (int) typed columns
- Add downstream-only applicability note to `set_normal_depth_boundary()` docstring

## Verification
- Round-trip verified with Muncie (1D: `Friction Slope=0.00064,0`) and BaldEagleCrkMulti2D (2D: `Friction Slope=0.0003`)
- New columns correctly populate in `boundaries_df`: `area_2d`, `bc_line_name`, `friction_slope_value`, `critical_fallback_flag`

## Test plan
- [x] Muncie 1D: friction_slope_value=0.00064, critical_fallback_flag=0
- [x] BaldEagle 2D: area_2d=BaldEagleCr, bc_line_name=DSNormalDepth
- [x] Round-trip: write 0.001 → re-parse → friction_slope_value=0.001

🤖 Generated with [Claude Code](https://claude.com/claude-code)