### PR TITLE
feat(unsteady): enhance IC table API — DataFrame support, auto_set_method, station validation (CLB-731)

### DIFF
--- a/examples/312_boundary_df_qmult_dss_paths.ipynb
+++ b/examples/312_boundary_df_qmult_dss_paths.ipynb
@@ -44,9 +44,9 @@
     "    local_path = str(Path.cwd().parent)\n",
     "    if local_path not in sys.path:\n",
     "        sys.path.insert(0, local_path)\n",
-    "    print(f\"📁 LOCAL SOURCE MODE: Loading from {local_path}/ras_commander\")\n",
+    "    print(f\"\ud83d\udcc1 LOCAL SOURCE MODE: Loading from {local_path}/ras_commander\")\n",
     "else:\n",
-    "    print(\"📦 PIP PACKAGE MODE: Loading installed ras-commander\")\n",
+    "    print(\"\ud83d\udce6 PIP PACKAGE MODE: Loading installed ras-commander\")\n",
     "\n",
     "# Import ras-commander\n",
     "from ras_commander import init_ras_project, RasExamples, RasUnsteady\n",
@@ -58,7 +58,7 @@
     "\n",
     "# Verify which version loaded\n",
     "import ras_commander\n",
-    "print(f\"✓ Loaded: {ras_commander.__file__}\")"
+    "print(f\"\u2713 Loaded: {ras_commander.__file__}\")"
    ],
    "id": "b49f8ff4"
   },
@@ -336,7 +336,7 @@
     "        old_a_part=original_a_part  # Optional: only update if this matches\n",
     "    )\n",
     "    \n",
-    "    print(f\"\\n✓ Updated {count} DSS path(s)\")"
+    "    print(f\"\\n\u2713 Updated {count} DSS path(s)\")"
    ],
    "id": "889a395e"
   },
@@ -402,9 +402,9 @@
     "    )\n",
     "    \n",
     "    if success:\n",
-    "        print(f\"\\n✓ Flow multiplier updated/inserted successfully\")\n",
+    "        print(f\"\\n\u2713 Flow multiplier updated/inserted successfully\")\n",
     "    else:\n",
-    "        print(f\"\\n✗ Failed to update flow multiplier\")"
+    "        print(f\"\\n\u2717 Failed to update flow multiplier\")"
    ],
    "id": "ba32af22"
   },
@@ -440,7 +440,7 @@
   },
   {
    "cell_type": "code",
-   "source": "# Demonstrate set_stage_hydrograph_tw_check() on BaldEagle 2D project\n# The project was already extracted in Step 1 — re-initialize to get fresh state\nras = init_ras_project(project_path, RAS_VERSION)\n\n# Find a Flow Hydrograph boundary with 2D selectors (area_2d, bc_line)\nflow_hydro_2d = ras.boundaries_df[\n    (ras.boundaries_df['bc_type'] == 'Flow Hydrograph') &\n    (ras.boundaries_df['area_2d'].notna())\n].head(1)\n\nif len(flow_hydro_2d) > 0:\n    row = flow_hydro_2d.iloc[0]\n    area_2d = row['area_2d']\n    bc_line = row['bc_line']\n    unsteady_num = row['unsteady_number']\n    \n    # Resolve unsteady file path\n    u_row = ras.unsteady_df[ras.unsteady_df['unsteady_number'] == unsteady_num].iloc[0]\n    u_file = u_row['full_path']\n    \n    print(f\"Target boundary:\")\n    print(f\"  BC Type:       {row['bc_type']}\")\n    print(f\"  2D Area:       {area_2d}\")\n    print(f\"  BC Line:       {bc_line}\")\n    print(f\"  Unsteady File: {Path(u_file).name}\")\n    \n    # Check current TW Check value (may be absent)\n    tw_col = 'Stage Hydrograph TW Check'\n    current_val = row.get(tw_col, None)\n    print(f\"  Current TW Check: {current_val if pd.notna(current_val) else '(not set)'}\")\n    \n    # Set TW Check = 1 (enable)\n    print(f\"\\nSetting TW Check = 1 (enabled)...\")\n    result = RasUnsteady.set_stage_hydrograph_tw_check(\n        unsteady_file=u_file,\n        tw_check=1,\n        area_2d=area_2d,\n        bc_line=bc_line,\n        ras_object=ras,\n    )\n    \n    print(f\"\\nResult:\")\n    print(f\"  Matched Location: {result['matched_location']}\")\n    print(f\"  BC Type:          {result['bc_type']}\")\n    print(f\"  Previous Value:   {result['previous_tw_check']}\")\n    print(f\"  New Value:        {result['new_tw_check']}\")\n    print(f\"  Updated In Place: {result['updated_in_place']}\")\n    if not result['updated_in_place']:\n        print(f\"  Insert Anchor:    {result['insert_anchor']}\")\nelse:\n    print(\"No 2D Flow Hydrograph boundaries found in BaldEagle project.\")\n    print(\"Trying 1D selectors instead...\")\n    flow_hydro_1d = ras.boundaries_df[\n        (ras.boundaries_df['bc_type'] == 'Flow Hydrograph') &\n        (ras.boundaries_df['river'].notna())\n    ].head(1)\n    if len(flow_hydro_1d) > 0:\n        row = flow_hydro_1d.iloc[0]\n        u_row = ras.unsteady_df[ras.unsteady_df['unsteady_number'] == row['unsteady_number']].iloc[0]\n        u_file = u_row['full_path']\n        result = RasUnsteady.set_stage_hydrograph_tw_check(\n            unsteady_file=u_file,\n            tw_check=1,\n            river=row['river'],\n            reach=row['reach'],\n            station=row['river_station'],\n            ras_object=ras,\n        )\n        print(f\"Set TW Check=1 on 1D boundary: {result['matched_location']}\")\n        print(f\"  Previous: {result['previous_tw_check']} -> New: {result['new_tw_check']}\")",
+   "source": "# Demonstrate set_stage_hydrograph_tw_check() on BaldEagle 2D project\n# The project was already extracted in Step 1 \u2014 re-initialize to get fresh state\nras = init_ras_project(project_path, RAS_VERSION)\n\n# Find a Flow Hydrograph boundary with 2D selectors (area_2d, bc_line)\nflow_hydro_2d = ras.boundaries_df[\n    (ras.boundaries_df['bc_type'] == 'Flow Hydrograph') &\n    (ras.boundaries_df['area_2d'].notna())\n].head(1)\n\nif len(flow_hydro_2d) > 0:\n    row = flow_hydro_2d.iloc[0]\n    area_2d = row['area_2d']\n    bc_line = row['bc_line']\n    unsteady_num = row['unsteady_number']\n    \n    # Resolve unsteady file path\n    u_row = ras.unsteady_df[ras.unsteady_df['unsteady_number'] == unsteady_num].iloc[0]\n    u_file = u_row['full_path']\n    \n    print(f\"Target boundary:\")\n    print(f\"  BC Type:       {row['bc_type']}\")\n    print(f\"  2D Area:       {area_2d}\")\n    print(f\"  BC Line:       {bc_line}\")\n    print(f\"  Unsteady File: {Path(u_file).name}\")\n    \n    # Check current TW Check value (may be absent)\n    tw_col = 'Stage Hydrograph TW Check'\n    current_val = row.get(tw_col, None)\n    print(f\"  Current TW Check: {current_val if pd.notna(current_val) else '(not set)'}\")\n    \n    # Set TW Check = 1 (enable)\n    print(f\"\\nSetting TW Check = 1 (enabled)...\")\n    result = RasUnsteady.set_stage_hydrograph_tw_check(\n        unsteady_file=u_file,\n        tw_check=1,\n        area_2d=area_2d,\n        bc_line=bc_line,\n        ras_object=ras,\n    )\n    \n    print(f\"\\nResult:\")\n    print(f\"  Matched Location: {result['matched_location']}\")\n    print(f\"  BC Type:          {result['bc_type']}\")\n    print(f\"  Previous Value:   {result['previous_tw_check']}\")\n    print(f\"  New Value:        {result['new_tw_check']}\")\n    print(f\"  Updated In Place: {result['updated_in_place']}\")\n    if not result['updated_in_place']:\n        print(f\"  Insert Anchor:    {result['insert_anchor']}\")\nelse:\n    print(\"No 2D Flow Hydrograph boundaries found in BaldEagle project.\")\n    print(\"Trying 1D selectors instead...\")\n    flow_hydro_1d = ras.boundaries_df[\n        (ras.boundaries_df['bc_type'] == 'Flow Hydrograph') &\n        (ras.boundaries_df['river'].notna())\n    ].head(1)\n    if len(flow_hydro_1d) > 0:\n        row = flow_hydro_1d.iloc[0]\n        u_row = ras.unsteady_df[ras.unsteady_df['unsteady_number'] == row['unsteady_number']].iloc[0]\n        u_file = u_row['full_path']\n        result = RasUnsteady.set_stage_hydrograph_tw_check(\n            unsteady_file=u_file,\n            tw_check=1,\n            river=row['river'],\n            reach=row['reach'],\n            station=row['river_station'],\n            ras_object=ras,\n        )\n        print(f\"Set TW Check=1 on 1D boundary: {result['matched_location']}\")\n        print(f\"  Previous: {result['previous_tw_check']} -> New: {result['new_tw_check']}\")",
    "metadata": {},
    "execution_count": null,
    "outputs": [],
@@ -508,7 +508,7 @@
     "        updates=updates\n",
     "    )\n",
     "    \n",
-    "    print(f\"\\n✓ Batch update complete: {count} operations performed\")"
+    "    print(f\"\\n\u2713 Batch update complete: {count} operations performed\")"
    ],
    "id": "c90dfc13"
   },
@@ -550,23 +550,23 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Step 9: Boundary Condition State Transitions — Compute and Verify\n",
+    "## Step 9: Boundary Condition State Transitions \u2014 Compute and Verify\n",
     "\n",
     "ras-commander provides complete state management for converting boundary conditions between inline hydrograph tables and DSS file references.\n",
     "\n",
     "| Method | Direction | What It Does |\n",
     "|--------|-----------|--------------|\n",
-    "| `set_boundary_dss_link()` | Inline → DSS | Sets Use DSS=True, adds DSS File/Path, **removes inline data**, sets count to 0 |\n",
-    "| `set_boundary_inline_hydrograph()` | DSS → Inline | Sets Use DSS=False, clears DSS File/Path, **writes inline data** |\n",
+    "| `set_boundary_dss_link()` | Inline \u2192 DSS | Sets Use DSS=True, adds DSS File/Path, **removes inline data**, sets count to 0 |\n",
+    "| `set_boundary_inline_hydrograph()` | DSS \u2192 Inline | Sets Use DSS=False, clears DSS File/Path, **writes inline data** |\n",
     "\n",
     "### Verification Strategy\n",
     "\n",
     "This section demonstrates THREE computational verifications using independent Muncie project copies:\n",
     "\n",
-    "1. **Step 9a: Round-Trip Fidelity** — Inline → DSS → Inline preserves data exactly\n",
+    "1. **Step 9a: Round-Trip Fidelity** \u2014 Inline \u2192 DSS \u2192 Inline preserves data exactly\n",
     "   - Expected: Identical results (max diff = 0.000000)\n",
     "   \n",
-    "2. **Step 9b: QMult Sensitivity** — Flow multiplier affects results correctly\n",
+    "2. **Step 9b: QMult Sensitivity** \u2014 Flow multiplier affects results correctly\n",
     "   - Expected: Lower WSE with QMult=0.50 (50% flow reduction)"
    ],
    "id": "371777a8"
@@ -724,7 +724,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Note: The HDF comparisons assume the same geometry between baseline and round-trip copies; this is intentional for validating inline↔DSS boundary conversions on identical geometry."
+    "Note: The HDF comparisons assume the same geometry between baseline and round-trip copies; this is intentional for validating inline\u2194DSS boundary conversions on identical geometry."
    ],
    "id": "97696299"
   },
@@ -899,7 +899,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Step 9b: QMult Sensitivity — Compute with Flow Multiplier\n",
+    "### Step 9b: QMult Sensitivity \u2014 Compute with Flow Multiplier\n",
     "\n",
     "To confirm that `update_flow_multiplier_by_station()` actually changes simulation results, we extract a **third** copy of Muncie, insert `Flow Hydrograph QMult=0.50` (50% of base flow), compute, and compare against the baseline.\n",
     "\n",
@@ -1040,7 +1040,7 @@
   },
   {
    "cell_type": "code",
-   "source": "# --- Step 10a: Extract the Internal Stage and Flow Boundary Condition project ---\nimport shutil\nfrom pathlib import Path\n\n# The fixture lives under example_projects/ (committed with the repo)\nfixture_src = Path(\"../example_projects/Internal Stage and Flow Boundary Condition\")\nib_project_path = Path(\"example_projects\") / \"IBStageFlowTest_312\"\nif ib_project_path.exists():\n    shutil.rmtree(ib_project_path)\nshutil.copytree(fixture_src, ib_project_path)\n\nras_ib = init_ras_project(ib_project_path, RAS_VERSION)\nprint(f\"Project: {ras_ib.project_name}\")\nprint(f\"Boundaries ({len(ras_ib.boundaries_df)}):\")\ndisplay(ras_ib.boundaries_df[['river', 'reach', 'river_station', 'bc_type']].head(10))\n\n# Read observed stage/flow data from the internal BC at station 41.76\nib_u01 = ras_ib.unsteady_df.iloc[0]['full_path']\nsf_df = RasUnsteady.get_stage_flow_hydrograph(\n    unsteady_file=ib_u01,\n    river=\"Nittany River\",\n    reach=\"Weir Reach\",\n    station=\"41.76\",\n    ras_object=ras_ib,\n)\n\nprint(f\"\\nObserved Stage and Flow Hydrograph at Nittany River / Weir Reach / 41.76:\")\nprint(f\"  Pairs: {len(sf_df)}\")\nprint(f\"  Stage range: {sf_df['stage'].min():.2f} – {sf_df['stage'].max():.2f}\")\nprint(f\"  Flow  range: {sf_df['flow'].min():.0f} – {sf_df['flow'].max():.0f}\")\ndisplay(sf_df.head(10))",
+   "source": "# --- Step 10a: Extract the Internal Stage and Flow Boundary Condition project ---\nimport shutil\nfrom pathlib import Path\n\n# The fixture lives under example_projects/ (committed with the repo)\nfixture_src = Path(\"../example_projects/Internal Stage and Flow Boundary Condition\")\nib_project_path = Path(\"example_projects\") / \"IBStageFlowTest_312\"\nif ib_project_path.exists():\n    shutil.rmtree(ib_project_path)\nshutil.copytree(fixture_src, ib_project_path)\n\nras_ib = init_ras_project(ib_project_path, RAS_VERSION)\nprint(f\"Project: {ras_ib.project_name}\")\nprint(f\"Boundaries ({len(ras_ib.boundaries_df)}):\")\ndisplay(ras_ib.boundaries_df[['river', 'reach', 'river_station', 'bc_type']].head(10))\n\n# Read observed stage/flow data from the internal BC at station 41.76\nib_u01 = ras_ib.unsteady_df.iloc[0]['full_path']\nsf_df = RasUnsteady.get_stage_flow_hydrograph(\n    unsteady_file=ib_u01,\n    river=\"Nittany River\",\n    reach=\"Weir Reach\",\n    station=\"41.76\",\n    ras_object=ras_ib,\n)\n\nprint(f\"\\nObserved Stage and Flow Hydrograph at Nittany River / Weir Reach / 41.76:\")\nprint(f\"  Pairs: {len(sf_df)}\")\nprint(f\"  Stage range: {sf_df['stage'].min():.2f} \u2013 {sf_df['stage'].max():.2f}\")\nprint(f\"  Flow  range: {sf_df['flow'].min():.0f} \u2013 {sf_df['flow'].max():.0f}\")\ndisplay(sf_df.head(10))",
    "metadata": {},
    "execution_count": null,
    "outputs": [],
@@ -1056,7 +1056,7 @@
   },
   {
    "cell_type": "code",
-   "source": "# --- Step 10c: Round-trip verification — re-read and compare ---\n\nsf_reread = RasUnsteady.get_stage_flow_hydrograph(\n    unsteady_file=ib_u01,\n    river=\"Nittany River\", reach=\"Weir Reach\", station=\"41.76\",\n    ras_object=ras_ib,\n)\nprint(f\"Re-read {len(sf_reread)} stage/flow pairs after write\")\ndisplay(sf_reread.head(10))\n\n# Verify round-trip: written values match what we read back\nassert len(sf_reread) == len(sf_modified), (\n    f\"Row count mismatch: wrote {len(sf_modified)}, read {len(sf_reread)}\"\n)\nassert np.allclose(sf_reread['stage'].values, sf_modified['stage'].values, atol=0.01), \\\n    \"Stage values changed during round-trip!\"\nassert np.allclose(sf_reread['flow'].values, sf_modified['flow'].values, atol=0.1), \\\n    \"Flow values changed during round-trip!\"\n\nprint(\"\\nRound-trip verification PASSED — written values match read-back\")",
+   "source": "# --- Step 10c: Round-trip verification \u2014 re-read and compare ---\n\nsf_reread = RasUnsteady.get_stage_flow_hydrograph(\n    unsteady_file=ib_u01,\n    river=\"Nittany River\", reach=\"Weir Reach\", station=\"41.76\",\n    ras_object=ras_ib,\n)\nprint(f\"Re-read {len(sf_reread)} stage/flow pairs after write\")\ndisplay(sf_reread.head(10))\n\n# Verify round-trip: written values match what we read back\nassert len(sf_reread) == len(sf_modified), (\n    f\"Row count mismatch: wrote {len(sf_modified)}, read {len(sf_reread)}\"\n)\nassert np.allclose(sf_reread['stage'].values, sf_modified['stage'].values, atol=0.01), \\\n    \"Stage values changed during round-trip!\"\nassert np.allclose(sf_reread['flow'].values, sf_modified['flow'].values, atol=0.1), \\\n    \"Flow values changed during round-trip!\"\n\nprint(\"\\nRound-trip verification PASSED \u2014 written values match read-back\")",
    "metadata": {},
    "execution_count": null,
    "outputs": []
@@ -1085,12 +1085,12 @@
   },
   {
    "cell_type": "markdown",
-   "source": "## Step 12: Uniform Lateral Inflow Hydrograph Read/Write\n\nHEC-RAS supports **Uniform Lateral Inflow Hydrograph** boundary conditions for distributing flow uniformly along a reach between two river stations. Unlike point-based Lateral Inflow (Step 11), this BC type is **reach-based** — applied between two stations listed in the Boundary Location field.\n\n| Method | Purpose |\n|--------|---------|\n| `RasUnsteady.get_uniform_lateral_inflow_hydrograph()` | Read uniform lateral inflow values and metadata from a `.u##` file |\n| `RasUnsteady.set_uniform_lateral_inflow_hydrograph()` | Write or replace uniform lateral inflow values, optionally update slope |\n\nThe inline data format is identical to other hydrograph types (8-character fixed-width, 10 values per line). Metadata includes `interval`, `slope`, `matched_location`, and `value_count` via `df.attrs`.",
+   "source": "## Step 12: Uniform Lateral Inflow Hydrograph Read/Write\n\nHEC-RAS supports **Uniform Lateral Inflow Hydrograph** boundary conditions for distributing flow uniformly along a reach between two river stations. Unlike point-based Lateral Inflow (Step 11), this BC type is **reach-based** \u2014 applied between two stations listed in the Boundary Location field.\n\n| Method | Purpose |\n|--------|---------|\n| `RasUnsteady.get_uniform_lateral_inflow_hydrograph()` | Read uniform lateral inflow values and metadata from a `.u##` file |\n| `RasUnsteady.set_uniform_lateral_inflow_hydrograph()` | Write or replace uniform lateral inflow values, optionally update slope |\n\nThe inline data format is identical to other hydrograph types (8-character fixed-width, 10 values per line). Metadata includes `interval`, `slope`, `matched_location`, and `value_count` via `df.attrs`.",
    "metadata": {}
   },
   {
    "cell_type": "code",
-   "source": "# --- Step 12a: Read uniform lateral inflow hydrograph from BaldEagleCrkMulti2D ---\n# Re-initialize BaldEagle project (extracted in Step 1)\nras = init_ras_project(project_path, RAS_VERSION)\n\n# Find Uniform Lateral Inflow Hydrograph boundaries in boundaries_df\nulat_bcs = ras.boundaries_df[ras.boundaries_df['bc_type'] == 'Uniform Lateral Inflow Hydrograph']\nprint(f\"Uniform Lateral Inflow Hydrograph boundaries: {len(ulat_bcs)}\")\nif len(ulat_bcs) > 0:\n    display(ulat_bcs[['river', 'reach', 'river_station', 'bc_type', 'area_2d', 'bc_line']].head())\n\n# Pick the first unsteady file that has uniform lateral inflow BCs\nulat_u_file = None\nfor _, urow in ras.unsteady_df.iterrows():\n    unum = urow['unsteady_number']\n    match = ras.boundaries_df[\n        (ras.boundaries_df['unsteady_number'] == unum) &\n        (ras.boundaries_df['bc_type'] == 'Uniform Lateral Inflow Hydrograph')\n    ]\n    if len(match) > 0:\n        ulat_u_file = urow['full_path']\n        ulat_sample = match.iloc[0]\n        break\n\nif ulat_u_file:\n    print(f\"\\nUsing unsteady file: {Path(ulat_u_file).name}\")\n    print(f\"  River:   {ulat_sample.get('river', 'N/A')}\")\n    print(f\"  Reach:   {ulat_sample.get('reach', 'N/A')}\")\n    print(f\"  Station: {ulat_sample.get('river_station', 'N/A')}\")\n\n    # Attempt to read inline data (BaldEagle BCs are DSS-linked, so expect None)\n    ulat_df = RasUnsteady.get_uniform_lateral_inflow_hydrograph(\n        unsteady_file=ulat_u_file,\n        river=ulat_sample.get('river'),\n        reach=ulat_sample.get('reach'),\n        station=ulat_sample.get('river_station'),\n        ras_object=ras,\n    )\n\n    if ulat_df is not None:\n        print(f\"\\nUniform Lateral Inflow Hydrograph:\")\n        print(f\"  Values:   {len(ulat_df)}\")\n        print(f\"  Flow range: {ulat_df['flow'].min():.1f} - {ulat_df['flow'].max():.1f}\")\n        print(f\"  Interval: {ulat_df.attrs.get('interval', 'N/A')}\")\n        print(f\"  Slope:    {ulat_df.attrs.get('slope', 'N/A')}\")\n        print(f\"  Location: {ulat_df.attrs.get('matched_location', 'N/A')}\")\n        display(ulat_df.head(10))\n    else:\n        print(\"\\nNo inline uniform lateral inflow found (DSS-linked with count=0)\")\n        print(\"  This is expected for BaldEagle — will use setter to write inline data in Step 12b\")\nelse:\n    print(\"No Uniform Lateral Inflow Hydrograph boundaries found in this project\")",
+   "source": "# --- Step 12a: Read uniform lateral inflow hydrograph from BaldEagleCrkMulti2D ---\n# Re-initialize BaldEagle project (extracted in Step 1)\nras = init_ras_project(project_path, RAS_VERSION)\n\n# Find Uniform Lateral Inflow Hydrograph boundaries in boundaries_df\nulat_bcs = ras.boundaries_df[ras.boundaries_df['bc_type'] == 'Uniform Lateral Inflow Hydrograph']\nprint(f\"Uniform Lateral Inflow Hydrograph boundaries: {len(ulat_bcs)}\")\nif len(ulat_bcs) > 0:\n    display(ulat_bcs[['river', 'reach', 'river_station', 'bc_type', 'area_2d', 'bc_line']].head())\n\n# Pick the first unsteady file that has uniform lateral inflow BCs\nulat_u_file = None\nfor _, urow in ras.unsteady_df.iterrows():\n    unum = urow['unsteady_number']\n    match = ras.boundaries_df[\n        (ras.boundaries_df['unsteady_number'] == unum) &\n        (ras.boundaries_df['bc_type'] == 'Uniform Lateral Inflow Hydrograph')\n    ]\n    if len(match) > 0:\n        ulat_u_file = urow['full_path']\n        ulat_sample = match.iloc[0]\n        break\n\nif ulat_u_file:\n    print(f\"\\nUsing unsteady file: {Path(ulat_u_file).name}\")\n    print(f\"  River:   {ulat_sample.get('river', 'N/A')}\")\n    print(f\"  Reach:   {ulat_sample.get('reach', 'N/A')}\")\n    print(f\"  Station: {ulat_sample.get('river_station', 'N/A')}\")\n\n    # Attempt to read inline data (BaldEagle BCs are DSS-linked, so expect None)\n    ulat_df = RasUnsteady.get_uniform_lateral_inflow_hydrograph(\n        unsteady_file=ulat_u_file,\n        river=ulat_sample.get('river'),\n        reach=ulat_sample.get('reach'),\n        station=ulat_sample.get('river_station'),\n        ras_object=ras,\n    )\n\n    if ulat_df is not None:\n        print(f\"\\nUniform Lateral Inflow Hydrograph:\")\n        print(f\"  Values:   {len(ulat_df)}\")\n        print(f\"  Flow range: {ulat_df['flow'].min():.1f} - {ulat_df['flow'].max():.1f}\")\n        print(f\"  Interval: {ulat_df.attrs.get('interval', 'N/A')}\")\n        print(f\"  Slope:    {ulat_df.attrs.get('slope', 'N/A')}\")\n        print(f\"  Location: {ulat_df.attrs.get('matched_location', 'N/A')}\")\n        display(ulat_df.head(10))\n    else:\n        print(\"\\nNo inline uniform lateral inflow found (DSS-linked with count=0)\")\n        print(\"  This is expected for BaldEagle \u2014 will use setter to write inline data in Step 12b\")\nelse:\n    print(\"No Uniform Lateral Inflow Hydrograph boundaries found in this project\")",
    "metadata": {},
    "execution_count": null,
    "outputs": []
@@ -1104,7 +1104,7 @@
   },
   {
    "cell_type": "markdown",
-   "source": "## Step 13: Initial Conditions Method Selection\n\nHEC-RAS unsteady flow files use an **implicit** state machine for Initial Conditions:\n\n| File State | IC Method | Description |\n|-----------|-----------|-------------|\n| `Use Restart= -1` (or `1`) | **Restart File** | Resume from a previously saved `.rst` file |\n| `Use Restart= 0` + `Initial Flow Loc=` lines | **Enter Initial Flow Distribution** | User-specified flows, storage elevations, and RRR elevations |\n| `Use Restart= 0` with no IC lines | **None** | HEC-RAS uses zero initial flow |\n\nThere is no single explicit \"method selector\" key — the method is determined by the combination of `Use Restart` and the presence of `Initial Flow Loc=` / `Initial Storage Elev=` / `Initial RRR Elev=` lines.\n\n| Method | Purpose |\n|--------|---------|\n| `RasUnsteady.get_initial_flow_method()` | Determine which IC method is active |\n| `RasUnsteady.set_initial_flow_method()` | Set the IC method (`restart_file`, `initial_flow_distribution`, or `none`) |",
+   "source": "## Step 13: Initial Conditions Method Selection\n\nHEC-RAS unsteady flow files use an **implicit** state machine for Initial Conditions:\n\n| File State | IC Method | Description |\n|-----------|-----------|-------------|\n| `Use Restart= -1` (or `1`) | **Restart File** | Resume from a previously saved `.rst` file |\n| `Use Restart= 0` + `Initial Flow Loc=` lines | **Enter Initial Flow Distribution** | User-specified flows, storage elevations, and RRR elevations |\n| `Use Restart= 0` with no IC lines | **None** | HEC-RAS uses zero initial flow |\n\nThere is no single explicit \"method selector\" key \u2014 the method is determined by the combination of `Use Restart` and the presence of `Initial Flow Loc=` / `Initial Storage Elev=` / `Initial RRR Elev=` lines.\n\n| Method | Purpose |\n|--------|---------|\n| `RasUnsteady.get_initial_flow_method()` | Determine which IC method is active |\n| `RasUnsteady.set_initial_flow_method()` | Set the IC method (`restart_file`, `initial_flow_distribution`, or `none`) |",
    "metadata": {},
    "id": "cell-step13-intro"
   },
@@ -1118,7 +1118,7 @@
   },
   {
    "cell_type": "code",
-   "source": "# --- Step 13b: Round-trip set_initial_flow_method() ---\nimport shutil\n\n# Work on a copy of .u08 so we don't alter the original fixture\nu08_copy = project_path / \"BaldEagleDamBrk_IC_test.u08\"\nshutil.copy2(u08_path, u08_copy)\n\n# Verify starting state: initial_flow_distribution with 8 IC lines\nic_before = RasUnsteady.get_initial_flow_method(u08_copy, ras_object=ras)\nprint(f\"Before: method={ic_before['method']}, ic_count={ic_before['ic_count']}\")\nassert ic_before['method'] == 'initial_flow_distribution'\n\n# Switch to restart_file mode\nRasUnsteady.set_initial_flow_method(\n    u08_copy, method=\"restart_file\",\n    restart_filename=\"BaldEagleDamBrk.p08.01JAN2000 2400.rst\",\n    ras_object=ras,\n)\nic_restart = RasUnsteady.get_initial_flow_method(u08_copy, ras_object=ras)\nprint(f\"After set restart_file: method={ic_restart['method']}, \"\n      f\"restart_filename={ic_restart['restart_filename']}\")\nassert ic_restart['method'] == 'restart_file'\nassert ic_restart['restart_filename'] == \"BaldEagleDamBrk.p08.01JAN2000 2400.rst\"\n\n# Switch to none (strips all IC lines)\nRasUnsteady.set_initial_flow_method(u08_copy, method=\"none\", ras_object=ras)\nic_none = RasUnsteady.get_initial_flow_method(u08_copy, ras_object=ras)\nprint(f\"After set none: method={ic_none['method']}, ic_count={ic_none['ic_count']}\")\nassert ic_none['method'] == 'none'\nassert ic_none['ic_count'] == 0\n\n# Switch back to initial_flow_distribution (preserves Use Restart=0, IC lines were stripped)\nRasUnsteady.set_initial_flow_method(u08_copy, method=\"initial_flow_distribution\", ras_object=ras)\nic_ifd = RasUnsteady.get_initial_flow_method(u08_copy, ras_object=ras)\nprint(f\"After set initial_flow_distribution: method={ic_ifd['method']}, ic_count={ic_ifd['ic_count']}\")\n# Note: IC lines were stripped when we set 'none', so ic_count=0 but method is\n# technically 'none' since there are no IC lines. The setter only controls\n# the Use Restart flag — IC line content is managed by usgs/initial_conditions.py.\nprint(f\"  (IC lines were stripped by 'none' — Use Restart=0 is set correctly)\")\n\n# Cleanup temp file\nu08_copy.unlink()\nprint(f\"\\n[OK] Round-trip state transitions verified: \"\n      f\"initial_flow_distribution -> restart_file -> none -> initial_flow_distribution\")",
+   "source": "# --- Step 13b: Round-trip set_initial_flow_method() ---\nimport shutil\n\n# Work on a copy of .u08 so we don't alter the original fixture\nu08_copy = project_path / \"BaldEagleDamBrk_IC_test.u08\"\nshutil.copy2(u08_path, u08_copy)\n\n# Verify starting state: initial_flow_distribution with 8 IC lines\nic_before = RasUnsteady.get_initial_flow_method(u08_copy, ras_object=ras)\nprint(f\"Before: method={ic_before['method']}, ic_count={ic_before['ic_count']}\")\nassert ic_before['method'] == 'initial_flow_distribution'\n\n# Switch to restart_file mode\nRasUnsteady.set_initial_flow_method(\n    u08_copy, method=\"restart_file\",\n    restart_filename=\"BaldEagleDamBrk.p08.01JAN2000 2400.rst\",\n    ras_object=ras,\n)\nic_restart = RasUnsteady.get_initial_flow_method(u08_copy, ras_object=ras)\nprint(f\"After set restart_file: method={ic_restart['method']}, \"\n      f\"restart_filename={ic_restart['restart_filename']}\")\nassert ic_restart['method'] == 'restart_file'\nassert ic_restart['restart_filename'] == \"BaldEagleDamBrk.p08.01JAN2000 2400.rst\"\n\n# Switch to none (strips all IC lines)\nRasUnsteady.set_initial_flow_method(u08_copy, method=\"none\", ras_object=ras)\nic_none = RasUnsteady.get_initial_flow_method(u08_copy, ras_object=ras)\nprint(f\"After set none: method={ic_none['method']}, ic_count={ic_none['ic_count']}\")\nassert ic_none['method'] == 'none'\nassert ic_none['ic_count'] == 0\n\n# Switch back to initial_flow_distribution (preserves Use Restart=0, IC lines were stripped)\nRasUnsteady.set_initial_flow_method(u08_copy, method=\"initial_flow_distribution\", ras_object=ras)\nic_ifd = RasUnsteady.get_initial_flow_method(u08_copy, ras_object=ras)\nprint(f\"After set initial_flow_distribution: method={ic_ifd['method']}, ic_count={ic_ifd['ic_count']}\")\n# Note: IC lines were stripped when we set 'none', so ic_count=0 but method is\n# technically 'none' since there are no IC lines. The setter only controls\n# the Use Restart flag \u2014 IC line content is managed by usgs/initial_conditions.py.\nprint(f\"  (IC lines were stripped by 'none' \u2014 Use Restart=0 is set correctly)\")\n\n# Cleanup temp file\nu08_copy.unlink()\nprint(f\"\\n[OK] Round-trip state transitions verified: \"\n      f\"initial_flow_distribution -> restart_file -> none -> initial_flow_distribution\")",
    "metadata": {},
    "execution_count": null,
    "outputs": [],
@@ -1148,7 +1148,145 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "## Summary\n\nThis notebook demonstrated the enhanced `boundaries_df` features:\n\n### New DataFrame Columns\n\n| Column | Description | Use Case |\n|--------|-------------|----------|\n| `Flow Hydrograph QMult` | Flow multiplier value | Sensitivity analysis |\n| `Flow Hydrograph QMin` | Minimum flow threshold | Low flow conditions |\n| `Stage Hydrograph TW Check` | Tailwater check flag (0/1) | Flow Hydrograph TW control |\n| `dss_part_a` | HMS subbasin/location | HMS-RAS linking |\n| `dss_part_b` | Parameter (FLOW/STAGE) | Data type identification |\n| `dss_part_c` | Date reference | Time synchronization |\n| `dss_part_d` | Time interval | Timestep verification |\n| `dss_part_e` | Run identifier | Scenario tracking |\n| `dss_part_f` | Additional ID | Optional metadata |\n\n### Update Methods\n\n| Method | Purpose |\n|--------|---------|\n| `RasUnsteady.update_dss_path_by_station()` | Update DSS A-part by river station |\n| `RasUnsteady.update_flow_multiplier_by_station()` | Update/insert QMult value |\n| `RasUnsteady.update_boundary_dss_paths()` | Batch update multiple boundaries |\n| `RasUnsteady.set_stage_hydrograph_tw_check()` | Set TW Check flag (0 or 1) on Flow Hydrograph BC |\n\n### State Transition Methods\n\n| Method | Direction | Purpose |\n|--------|-----------|---------|\n| `RasUnsteady.set_boundary_dss_link()` | Inline to DSS | Remove inline data, set DSS File/Path, Use DSS=True |\n| `RasUnsteady.set_boundary_inline_hydrograph()` | DSS to Inline | Write inline data, clear DSS fields, Use DSS=False |\n| `RasUnsteady.get_inline_hydrograph_boundaries()` | Read | Extract all inline hydrograph boundaries with values |\n\n### Stage/Flow Hydrograph Methods (Internal Boundaries)\n\n| Method | Purpose |\n|--------|---------|\n| `RasUnsteady.get_stage_flow_hydrograph()` | Read interleaved stage/flow pairs from `.u##` file |\n| `RasUnsteady.set_stage_flow_hydrograph()` | Write or replace stage/flow pairs in `.u##` file |\n\n### Lateral Inflow Hydrograph Methods (Step 11)\n\n| Method | Purpose |\n|--------|---------|\n| `RasUnsteady.get_lateral_inflow_hydrograph()` | Read lateral inflow values + metadata (interval, slope) from `.u##` file |\n| `RasUnsteady.set_lateral_inflow_hydrograph()` | Write/replace lateral inflow values, optionally update `Flow Hydrograph Slope=` |\n\n### Uniform Lateral Inflow Hydrograph Methods (Step 12)\n\n| Method | Purpose |\n|--------|---------|\n| `RasUnsteady.get_uniform_lateral_inflow_hydrograph()` | Read uniform lateral inflow values + metadata from `.u##` file |\n| `RasUnsteady.set_uniform_lateral_inflow_hydrograph()` | Write/replace uniform lateral inflow values, optionally update slope |\n\n### Initial Conditions Method Selection (Steps 13-14)\n\n| Method | Purpose |\n|--------|---------|\n| `RasUnsteady.get_initial_flow_method()` | Determine which IC method is active (restart_file, prior_ws, initial_flow_distribution, or none) |\n| `RasUnsteady.set_initial_flow_method()` | Set the IC method selection and manage `Use Restart` / `Restart Filename` / `Prior WS Filename` keys |\n| `RasUnsteady.get_prior_ws_filename()` | Read Prior WS Filename and Profile from `.u##` file |\n| `RasUnsteady.set_prior_ws_filename()` | Write Prior WS Filename and Profile (convenience wrapper for `set_initial_flow_method(method=\"prior_ws\")`) |\n\n### Computational Verification (Step 9)\n\nThree independent HEC-RAS computations verified the implementation:\n\n**Step 9a: Round-Trip Fidelity Test**\n1. Computed **baseline** plan with original inline boundary conditions\n2. Performed inline -> DSS -> inline **round-trip** on a second copy\n3. Computed the **round-trip** plan\n4. Compared cross section results via `HdfResultsXsec.get_xsec_timeseries()`\n5. **Result**: All Water Surface, Flow, and Velocity matched exactly (max diff = 0.000000)\n\n**Step 9b: QMult Sensitivity Test**\n1. Inserted `Flow Hydrograph QMult=0.50` on a third copy\n2. Computed the **QMult** plan with 50% of baseline flow\n3. Compared cross section results against baseline\n4. **Result**: All cross sections showed lower WSE with reduced flow (QMult correctly applied)\n\n### Stage/Flow Hydrograph Verification (Step 10)\n\n1. Extracted **Internal Stage and Flow Boundary Condition** fixture project\n2. Read observed stage/flow hydrograph at internal BC station with `get_stage_flow_hydrograph()`\n3. Scaled flows by 1.25x and wrote back with `set_stage_flow_hydrograph()`\n4. Re-read and verified round-trip: stage values unchanged, flow values match scaled values\n5. **Result**: Round-trip verification PASSED\n\n### Lateral Inflow Hydrograph Verification (Step 11)\n\n1. Read lateral inflow hydrograph from BaldEagleCrkMulti2D with `get_lateral_inflow_hydrograph()`\n2. Verified metadata extraction: interval, slope, matched_location via `df.attrs`\n3. Scaled flows by 1.5x and wrote back with new slope using `set_lateral_inflow_hydrograph()`\n4. Re-read and verified round-trip: flow values match, slope updated\n5. **Result**: Round-trip verification PASSED\n\n### Uniform Lateral Inflow Hydrograph Verification (Step 12)\n\n1. Found Uniform Lateral Inflow Hydrograph BCs in BaldEagleCrkMulti2D (DSS-linked, count=0)\n2. Attempted read with `get_uniform_lateral_inflow_hydrograph()` -- returns None (expected for DSS-linked)\n3. Wrote synthetic triangular hydrograph (25 values, peak 500 cfs) with `set_uniform_lateral_inflow_hydrograph()`\n4. Re-read and verified round-trip: flow values match, slope updated\n5. **Result**: Round-trip verification PASSED -- reach-based uniform lateral inflow API works correctly\n\n### Initial Conditions Method Selection Verification (Step 13)\n\n1. Read IC method from 3 BaldEagle unsteady files: `.u08` (initial_flow_distribution, 8 IC lines), `.u03` (none), `.u01` (initial_flow_distribution, 1 IC line)\n2. Verified `get_initial_flow_method()` correctly infers the implicit state machine\n3. Round-trip tested `set_initial_flow_method()`: initial_flow_distribution -> restart_file -> none -> initial_flow_distribution\n4. **Result**: All state transitions verified correctly\n\n### Prior Water Surface Filename Verification (Step 14)\n\n1. Started from `.u03` (method=none, no Prior WS) as clean baseline\n2. Verified `get_prior_ws_filename()` returns None before setting\n3. Set Prior WS via `set_prior_ws_filename()` with plan file and profile name\n4. Read back and verified: filename and profile match, `get_initial_flow_method()` detects `prior_ws`\n5. Round-trip tested state transitions: none -> prior_ws -> none -> prior_ws -> restart_file\n6. Verified Prior WS keys are properly stripped when switching away from `prior_ws` method\n7. **Result**: All Prior WS state transitions verified correctly\n\n### Key Features\n\n- **QMult insertion**: Automatically inserts line if not present\n- **TW Check setter**: Set/toggle tailwater check flag with `set_stage_hydrograph_tw_check()`\n- **Stage/Flow Hydrograph**: Read/write interleaved (stage, flow) pairs for internal BCs\n- **Lateral Inflow Hydrograph**: Dedicated read/write with slope integration and metadata via `df.attrs`\n- **Uniform Lateral Inflow Hydrograph**: Reach-based BC read/write with slope and metadata support\n- **IC Method Selection**: Detect and set the implicit Initial Conditions state machine (restart_file / prior_ws / initial_flow_distribution / none)\n- **Prior WS Filename**: Read/write Prior WS Filename and Profile for using steady-state results as IC\n- **Partial station matching**: Matches stations even with coordinates appended\n- **Batch efficiency**: Single file read/write for multiple updates\n- **Safe updates**: Optional `old_a_part` validation prevents accidental overwrites\n- **Complete state transitions**: Inline to DSS and DSS to Inline with round-trip fidelity\n- **Inline data cleanup**: `set_boundary_dss_link()` removes inline table data when switching to DSS\n- **Verified correctness**: Computational tests prove state transitions are lossless and QMult affects results",
+   "id": "cell-step15-intro",
+   "source": [
+    "## Step 15: Initial Conditions Table \u2014 Get / Set / Validate\n",
+    "\n",
+    "HEC-RAS stores **initial flow conditions** as `Initial Flow Loc=` lines in the `.u##` file.\n",
+    "These define the starting flow at each cross section for an unsteady simulation.\n",
+    "\n",
+    "`RasUnsteady` provides three methods for working with this table:\n",
+    "\n",
+    "| Method | Returns | Purpose |\n",
+    "|--------|---------|--------|\n",
+    "| `get_initial_conditions()` | DataFrame | Read IC entries (columns: type, river, reach, station, value, area_name) |\n",
+    "| `set_initial_conditions()` | None | Write IC entries (accepts DataFrame or list of dicts) |\n",
+    "| `validate_initial_flow_stations()` | dict | Check IC stations against geometry XS |\n",
+    "\n",
+    "`set_initial_conditions()` accepts both `pd.DataFrame` and `list[dict]` inputs,\n",
+    "and by default automatically sets the IC method to \"Initial Flow Distribution\" via `auto_set_method=True`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "id": "cell-step15a",
+   "source": [
+    "# --- Step 15a: Read initial conditions from .u12 ---\n",
+    "from ras_commander import RasUnsteady, RasExamples, init_ras_project\n",
+    "import pandas as pd\n",
+    "\n",
+    "# Use BaldEagleCrkMulti2D which has IC entries in .u12\n",
+    "project_folder = RasExamples.extract_project(\"BaldEagleCrkMulti2D\", suffix=\"312_ic\")\n",
+    "ras = init_ras_project(project_folder, \"6.6\")\n",
+    "\n",
+    "# Read IC entries from unsteady file 12\n",
+    "ic_df = RasUnsteady.get_initial_conditions(\"12\", ras_object=ras)\n",
+    "print(f\"Found {len(ic_df)} IC entries in .u12\")\n",
+    "print(f\"Columns: {list(ic_df.columns)}\")\n",
+    "print()\n",
+    "\n",
+    "# Show flow-type entries\n",
+    "flow_ics = ic_df[ic_df[\"type\"] == \"flow\"]\n",
+    "print(f\"Flow IC entries ({len(flow_ics)}):\")\n",
+    "for _, row in flow_ics.head(5).iterrows():\n",
+    "    print(f\"  {row[\"river\"]:>16s} | {row[\"reach\"]:>16s} | RS {row[\"station\"]:>10.2f} | Value={row[\"value\"]:>10.1f}\")\n",
+    "if len(flow_ics) > 5:\n",
+    "    print(f\"  ... and {len(flow_ics) - 5} more\")\n",
+    "\n",
+    "# Show storage/2D entries if any\n",
+    "storage_ics = ic_df[ic_df[\"type\"] == \"storage\"]\n",
+    "if len(storage_ics) > 0:\n",
+    "    print(f\"\nStorage/2D IC entries ({len(storage_ics)}):\")\n",
+    "    for _, row in storage_ics.head(3).iterrows():\n",
+    "        print(f\"  Area: {row[\"area_name\"]} | Elevation={row[\"value\"]:>10.2f}\")"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "id": "cell-step15b",
+   "source": [
+    "# --- Step 15b: Round-trip set_initial_conditions() with DataFrame ---\n",
+    "import shutil\n",
+    "from pathlib import Path\n",
+    "\n",
+    "# Work on a copy of .u12 to avoid altering the original\n",
+    "u12_original = list(project_folder.glob(\"*.u12\"))[0]\n",
+    "u12_copy = u12_original.with_suffix(\".u99\")\n",
+    "shutil.copy2(u12_original, u12_copy)\n",
+    "\n",
+    "# Show original flow IC values\n",
+    "flow_ics = ic_df[ic_df[\"type\"] == \"flow\"].copy()\n",
+    "print(\"Original flow IC values:\")\n",
+    "print(flow_ics[[\"river\", \"reach\", \"station\", \"value\"]].to_string(index=False))\n",
+    "\n",
+    "# Increase all flow values by 10%\n",
+    "modified_df = ic_df.copy()\n",
+    "flow_mask = modified_df[\"type\"] == \"flow\"\n",
+    "modified_df.loc[flow_mask, \"value\"] = modified_df.loc[flow_mask, \"value\"] * 1.10\n",
+    "print(f\"\nModified flow values (10% increase):\")\n",
+    "print(modified_df.loc[flow_mask, [\"station\", \"value\"]].to_string(index=False))\n",
+    "\n",
+    "# Write modified DataFrame back to the copy\n",
+    "RasUnsteady.set_initial_conditions(u12_copy, modified_df)\n",
+    "\n",
+    "# Read back and verify round-trip\n",
+    "ic_readback = RasUnsteady.get_initial_conditions(u12_copy)\n",
+    "readback_flows = ic_readback[ic_readback[\"type\"] == \"flow\"]\n",
+    "modified_flows = modified_df[modified_df[\"type\"] == \"flow\"]\n",
+    "\n",
+    "print(f\"\nRound-trip verification ({len(readback_flows)} flow entries read back):\")\n",
+    "for (_, orig), (_, read) in zip(modified_flows.iterrows(), readback_flows.iterrows()):\n",
+    "    match = abs(orig[\"value\"] - read[\"value\"]) < 0.1\n",
+    "    status = \"MATCH\" if match else \"MISMATCH\"\n",
+    "    print(f\"  RS {orig[\"station\"]:>10.2f}: wrote {orig[\"value\"]:>10.1f}, read {read[\"value\"]:>10.1f} [{status}]\")\n",
+    "\n",
+    "# Clean up copy\n",
+    "u12_copy.unlink(missing_ok=True)\n",
+    "print(\"\nRound-trip complete.\")"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "id": "cell-step15c",
+   "source": [
+    "# --- Step 15c: Validate IC stations against geometry ---\n",
+    "\n",
+    "# validate_initial_flow_stations() checks that every IC station\n",
+    "# matches a real cross section in the geometry file.\n",
+    "validation = RasUnsteady.validate_initial_flow_stations(\"12\", ras_object=ras)\n",
+    "\n",
+    "print(f\"Validation result: {\"PASS\" if validation[\"valid\"] else \"FAIL\"}\")\n",
+    "print(f\"  IC flow entries: {validation[\"ic_count\"]}\")\n",
+    "print(f\"  Geometry XS:     {validation[\"geom_xs_count\"]}\")\n",
+    "print(f\"  Matched:         {len(validation[\"matched\"])}\")\n",
+    "print(f\"  Unmatched:       {len(validation[\"unmatched\"])}\")\n",
+    "\n",
+    "if validation[\"unmatched\"]:\n",
+    "    print(\"\nUnmatched IC stations (not found in geometry):\")\n",
+    "    for um in validation[\"unmatched\"]:\n",
+    "        print(f\"  {um[\"river\"]} / {um[\"reach\"]} / RS {um[\"station\"]}\")\n",
+    "else:\n",
+    "    print(\"\nAll IC stations match geometry cross sections.\")\n",
+    "\n",
+    "# Clean up extracted project\n",
+    "import shutil\n",
+    "shutil.rmtree(project_folder, ignore_errors=True)\n",
+    "print(f\"Cleaned up {project_folder.name}\")"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Summary\n\nThis notebook demonstrated the enhanced `boundaries_df` features:\n\n### New DataFrame Columns\n\n| Column | Description | Use Case |\n|--------|-------------|----------|\n| `Flow Hydrograph QMult` | Flow multiplier value | Sensitivity analysis |\n| `Flow Hydrograph QMin` | Minimum flow threshold | Low flow conditions |\n| `Stage Hydrograph TW Check` | Tailwater check flag (0/1) | Flow Hydrograph TW control |\n| `dss_part_a` | HMS subbasin/location | HMS-RAS linking |\n| `dss_part_b` | Parameter (FLOW/STAGE) | Data type identification |\n| `dss_part_c` | Date reference | Time synchronization |\n| `dss_part_d` | Time interval | Timestep verification |\n| `dss_part_e` | Run identifier | Scenario tracking |\n| `dss_part_f` | Additional ID | Optional metadata |\n\n### Update Methods\n\n| Method | Purpose |\n|--------|---------|\n| `RasUnsteady.update_dss_path_by_station()` | Update DSS A-part by river station |\n| `RasUnsteady.update_flow_multiplier_by_station()` | Update/insert QMult value |\n| `RasUnsteady.update_boundary_dss_paths()` | Batch update multiple boundaries |\n| `RasUnsteady.set_stage_hydrograph_tw_check()` | Set TW Check flag (0 or 1) on Flow Hydrograph BC |\n\n### State Transition Methods\n\n| Method | Direction | Purpose |\n|--------|-----------|---------|\n| `RasUnsteady.set_boundary_dss_link()` | Inline to DSS | Remove inline data, set DSS File/Path, Use DSS=True |\n| `RasUnsteady.set_boundary_inline_hydrograph()` | DSS to Inline | Write inline data, clear DSS fields, Use DSS=False |\n| `RasUnsteady.get_inline_hydrograph_boundaries()` | Read | Extract all inline hydrograph boundaries with values |\n\n### Stage/Flow Hydrograph Methods (Internal Boundaries)\n\n| Method | Purpose |\n|--------|---------|\n| `RasUnsteady.get_stage_flow_hydrograph()` | Read interleaved stage/flow pairs from `.u##` file |\n| `RasUnsteady.set_stage_flow_hydrograph()` | Write or replace stage/flow pairs in `.u##` file |\n\n### Lateral Inflow Hydrograph Methods (Step 11)\n\n| Method | Purpose |\n|--------|---------|\n| `RasUnsteady.get_lateral_inflow_hydrograph()` | Read lateral inflow values + metadata (interval, slope) from `.u##` file |\n| `RasUnsteady.set_lateral_inflow_hydrograph()` | Write/replace lateral inflow values, optionally update `Flow Hydrograph Slope=` |\n\n### Uniform Lateral Inflow Hydrograph Methods (Step 12)\n\n| Method | Purpose |\n|--------|---------|\n| `RasUnsteady.get_uniform_lateral_inflow_hydrograph()` | Read uniform lateral inflow values + metadata from `.u##` file |\n| `RasUnsteady.set_uniform_lateral_inflow_hydrograph()` | Write/replace uniform lateral inflow values, optionally update slope |\n\n### Initial Conditions Method Selection (Steps 13-14)\n\n| Method | Purpose |\n|--------|---------|\n| `RasUnsteady.get_initial_flow_method()` | Determine which IC method is active (restart_file, prior_ws, initial_flow_distribution, or none) |\n| `RasUnsteady.set_initial_flow_method()` | Set the IC method selection and manage `Use Restart` / `Restart Filename` / `Prior WS Filename` keys |\n| `RasUnsteady.get_prior_ws_filename()` | Read Prior WS Filename and Profile from `.u##` file |\n| `RasUnsteady.set_prior_ws_filename()` | Write Prior WS Filename and Profile (convenience wrapper for `set_initial_flow_method(method=\"prior_ws\")`) |\n\n### Computational Verification (Step 9)\n\nThree independent HEC-RAS computations verified the implementation:\n\n**Step 9a: Round-Trip Fidelity Test**\n1. Computed **baseline** plan with original inline boundary conditions\n2. Performed inline -> DSS -> inline **round-trip** on a second copy\n3. Computed the **round-trip** plan\n4. Compared cross section results via `HdfResultsXsec.get_xsec_timeseries()`\n5. **Result**: All Water Surface, Flow, and Velocity matched exactly (max diff = 0.000000)\n\n**Step 9b: QMult Sensitivity Test**\n1. Inserted `Flow Hydrograph QMult=0.50` on a third copy\n2. Computed the **QMult** plan with 50% of baseline flow\n3. Compared cross section results against baseline\n4. **Result**: All cross sections showed lower WSE with reduced flow (QMult correctly applied)\n\n### Stage/Flow Hydrograph Verification (Step 10)\n\n1. Extracted **Internal Stage and Flow Boundary Condition** fixture project\n2. Read observed stage/flow hydrograph at internal BC station with `get_stage_flow_hydrograph()`\n3. Scaled flows by 1.25x and wrote back with `set_stage_flow_hydrograph()`\n4. Re-read and verified round-trip: stage values unchanged, flow values match scaled values\n5. **Result**: Round-trip verification PASSED\n\n### Lateral Inflow Hydrograph Verification (Step 11)\n\n1. Read lateral inflow hydrograph from BaldEagleCrkMulti2D with `get_lateral_inflow_hydrograph()`\n2. Verified metadata extraction: interval, slope, matched_location via `df.attrs`\n3. Scaled flows by 1.5x and wrote back with new slope using `set_lateral_inflow_hydrograph()`\n4. Re-read and verified round-trip: flow values match, slope updated\n5. **Result**: Round-trip verification PASSED\n\n### Uniform Lateral Inflow Hydrograph Verification (Step 12)\n\n1. Found Uniform Lateral Inflow Hydrograph BCs in BaldEagleCrkMulti2D (DSS-linked, count=0)\n2. Attempted read with `get_uniform_lateral_inflow_hydrograph()` -- returns None (expected for DSS-linked)\n3. Wrote synthetic triangular hydrograph (25 values, peak 500 cfs) with `set_uniform_lateral_inflow_hydrograph()`\n4. Re-read and verified round-trip: flow values match, slope updated\n5. **Result**: Round-trip verification PASSED -- reach-based uniform lateral inflow API works correctly\n\n### Initial Conditions Method Selection Verification (Step 13)\n\n1. Read IC method from 3 BaldEagle unsteady files: `.u08` (initial_flow_distribution, 8 IC lines), `.u03` (none), `.u01` (initial_flow_distribution, 1 IC line)\n2. Verified `get_initial_flow_method()` correctly infers the implicit state machine\n3. Round-trip tested `set_initial_flow_method()`: initial_flow_distribution -> restart_file -> none -> initial_flow_distribution\n4. **Result**: All state transitions verified correctly\n\n### Prior Water Surface Filename Verification (Step 14)\n\n1. Started from `.u03` (method=none, no Prior WS) as clean baseline\n2. Verified `get_prior_ws_filename()` returns None before setting\n3. Set Prior WS via `set_prior_ws_filename()` with plan file and profile name\n4. Read back and verified: filename and profile match, `get_initial_flow_method()` detects `prior_ws`\n5. Round-trip tested state transitions: none -> prior_ws -> none -> prior_ws -> restart_file\n6. Verified Prior WS keys are properly stripped when switching away from `prior_ws` method\n7. **Result**: All Prior WS state transitions verified correctly\n\n### Key Features\n\n- **QMult insertion**: Automatically inserts line if not present\n- **TW Check setter**: Set/toggle tailwater check flag with `set_stage_hydrograph_tw_check()`\n- **Stage/Flow Hydrograph**: Read/write interleaved (stage, flow) pairs for internal BCs\n- **Lateral Inflow Hydrograph**: Dedicated read/write with slope integration and metadata via `df.attrs`\n- **Uniform Lateral Inflow Hydrograph**: Reach-based BC read/write with slope and metadata support\n- **IC Method Selection**: Detect and set the implicit Initial Conditions state machine (restart_file / prior_ws / initial_flow_distribution / none)\n- **Prior WS Filename**: Read/write Prior WS Filename and Profile for using steady-state results as IC\n- **Partial station matching**: Matches stations even with coordinates appended\n- **Batch efficiency**: Single file read/write for multiple updates\n- **Safe updates**: Optional `old_a_part` validation prevents accidental overwrites\n- **Complete state transitions**: Inline to DSS and DSS to Inline with round-trip fidelity\n- **Inline data cleanup**: `set_boundary_dss_link()` removes inline table data when switching to DSS\n- **Verified correctness**: Computational tests prove state transitions are lossless and QMult affects results\n\n### Initial Conditions Table API (Step 15)\n\n| Method | Purpose |\n|--------|--------|\n|  | Read IC entries from .u## as list of dicts |\n|  | Write IC entries (DataFrame or list of dicts) |\n|  | Check IC stations match geometry XS |\n\n accepts  in addition to , and automatically sets the IC method to Initial Flow Distribution when  (default).",
    "id": "19a2ae8a"
   },
   {

--- a/ras_commander/AGENTS.md
+++ b/ras_commander/AGENTS.md
@@ -12,7 +12,7 @@ This file is the canonical local instruction file for the `ras_commander/` packa
 
 - Project management: `RasPrj`, `init_ras_project()`
 - Plan execution: `RasCmdr`
-- Plan and model files: `RasPlan`, `RasMap`, `RasControl`, `RasUnsteady` (includes IC method selection: `get_initial_flow_method()`, `set_initial_flow_method()`, `get_prior_ws_filename()`, `set_prior_ws_filename()`)
+- Plan and model files: `RasPlan`, `RasMap`, `RasControl`, `RasUnsteady` (includes IC method selection: `get_initial_flow_method()`, `set_initial_flow_method()`, `get_prior_ws_filename()`, `set_prior_ws_filename()`; IC table: `get_initial_conditions()`, `set_initial_conditions()`, `validate_initial_flow_stations()`)
 - Validation framework: `RasValidation`
 - HDF access: `Hdf*` classes and `ras_commander/hdf/`
 - Domain subpackages: `geom/`, `remote/`, `usgs/`, `check/`, `dss/`, `fixit/`, `precip/`, `gui/`, `terrain/`

--- a/ras_commander/RasUnsteady.py
+++ b/ras_commander/RasUnsteady.py
@@ -84,6 +84,11 @@ Initial Conditions Method Selection:
 - get_prior_ws_filename() - Read Prior WS Filename and Profile from unsteady file
 - set_prior_ws_filename() - Write Prior WS Filename and Profile to unsteady file
 
+Initial Flow Distribution Table:
+- get_initial_conditions() - Read all IC entries (flow, storage, rrr) as DataFrame
+- set_initial_conditions() - Write IC entries from list of dicts or DataFrame (auto-sets IC method)
+- validate_initial_flow_stations() - Check IC flow stations match geometry cross sections
+
 """
 import os
 import numbers
@@ -283,25 +288,179 @@ class RasUnsteady:
     @log_call
     def set_initial_conditions(
         unsteady_number_or_path: Union[str, Path],
-        ic_entries: List[Dict[str, Any]],
-        ras_object: Optional[Any] = None
+        ic_entries,
+        ras_object: Optional[Any] = None,
+        auto_set_method: bool = True,
     ) -> None:
         """
         Write initial condition entries to a HEC-RAS unsteady flow file.
 
-        Args:
-            unsteady_number_or_path: Unsteady flow number or path to a .u## file.
-            ic_entries: List of initial condition dictionaries with keys accepted
-                by ``InitialConditions.write_initial_conditions()``.
-            ras_object: Optional RAS project object. If None, uses global ``ras``.
+        Replaces all existing ``Initial Flow Loc=``, ``Initial Storage Elev=``,
+        and ``Initial RRR Elev=`` lines with the provided entries.
+
+        Parameters
+        ----------
+        unsteady_number_or_path : str or Path
+            Unsteady flow number (e.g. ``"03"``) or path to a ``.u##`` file.
+        ic_entries : list[dict] or pd.DataFrame
+            IC entries. Each row/dict must have:
+
+            * ``type`` — ``'flow'``, ``'storage'``, or ``'rrr'``
+            * ``river``, ``reach``, ``station``, ``value`` (for flow/rrr)
+            * ``area_name``, ``value`` (for storage)
+        ras_object : RasPrj, optional
+            RAS project object. If None, uses global ``ras``.
+        auto_set_method : bool, default True
+            When True and entries are non-empty, automatically sets the IC
+            method to ``initial_flow_distribution`` via
+            ``set_initial_flow_method()``.
+
+        Examples
+        --------
+        >>> import pandas as pd
+        >>> ic_df = pd.DataFrame([
+        ...     {'type': 'flow', 'river': 'White', 'reach': 'Muncie',
+        ...      'station': 15696.24, 'value': 1500},
+        ... ])
+        >>> RasUnsteady.set_initial_conditions("01", ic_df, ras_object=ras)
         """
         from .usgs.initial_conditions import InitialConditions
+
+        if isinstance(ic_entries, pd.DataFrame):
+            entries = ic_entries.to_dict('records')
+        else:
+            entries = list(ic_entries)
 
         unsteady_file_path = RasUnsteady._resolve_unsteady_file_path(
             unsteady_number_or_path,
             ras_object=ras_object,
         )
-        InitialConditions.write_initial_conditions(unsteady_file_path, ic_entries)
+        InitialConditions.write_initial_conditions(unsteady_file_path, entries)
+
+        if auto_set_method and entries:
+            RasUnsteady.set_initial_flow_method(
+                unsteady_number_or_path,
+                method="initial_flow_distribution",
+                ras_object=ras_object,
+            )
+
+    @staticmethod
+    @log_call
+    def validate_initial_flow_stations(
+        unsteady_number_or_path: Union[str, Path],
+        geom_number_or_path: Optional[Union[str, Path]] = None,
+        ras_object: Optional[Any] = None,
+    ) -> Dict[str, Any]:
+        """
+        Validate that Initial Flow Loc stations match cross sections in geometry.
+
+        Reads the IC table from the unsteady file and checks each ``flow`` entry
+        against cross sections parsed from the geometry file. Reports matched,
+        unmatched, and summary statistics.
+
+        Parameters
+        ----------
+        unsteady_number_or_path : str or Path
+            Unsteady flow number or path to a ``.u##`` file.
+        geom_number_or_path : str or Path, optional
+            Geometry file number or path. If None, resolves via the plan that
+            references this unsteady file.
+        ras_object : RasPrj, optional
+            RAS project object. If None, uses the global ``ras`` object.
+
+        Returns
+        -------
+        dict
+            ``valid`` (bool): True if all flow stations have matching XS.
+            ``matched`` (list[dict]): Entries with matching geometry XS.
+            ``unmatched`` (list[dict]): Entries with no matching geometry XS.
+            ``ic_count`` (int): Total flow IC entries checked.
+            ``geom_xs_count`` (int): Total XS in geometry.
+        """
+        from ras_commander import ras as global_ras
+        _ras = ras_object if ras_object is not None else global_ras
+
+        ic_df = RasUnsteady.get_initial_conditions(
+            unsteady_number_or_path, ras_object=ras_object,
+        )
+        flow_ics = ic_df[ic_df['type'] == 'flow'] if len(ic_df) > 0 else ic_df
+
+        if geom_number_or_path is None:
+            geom_path = None
+            if hasattr(_ras, 'plan_df') and hasattr(_ras, 'unsteady_df'):
+                try:
+                    unsteady_path = RasUnsteady._resolve_unsteady_file_path(
+                        unsteady_number_or_path, ras_object=ras_object,
+                    )
+                    u_name = unsteady_path.name
+                    for _, plan_row in _ras.plan_df.iterrows():
+                        u_num = plan_row.get('unsteady_number')
+                        if u_num is not None and f".u{str(u_num).zfill(2)}" in u_name:
+                            g_num = plan_row.get('Geom File')
+                            if g_num is not None:
+                                g_match = _ras.geom_df[
+                                    _ras.geom_df['geom_number'] == str(g_num)
+                                ]
+                                if len(g_match) > 0:
+                                    geom_path = Path(g_match.iloc[0]['full_path'])
+                                break
+                except Exception:
+                    pass
+        else:
+            geom_path = Path(geom_number_or_path)
+            if not geom_path.is_file() and hasattr(_ras, 'geom_df'):
+                g_match = _ras.geom_df[
+                    _ras.geom_df['geom_number'] == str(geom_number_or_path)
+                ]
+                if len(g_match) > 0:
+                    geom_path = Path(g_match.iloc[0]['full_path'])
+
+        geom_stations = set()
+        if geom_path is not None and geom_path.is_file():
+            try:
+                from ras_commander.geom import GeomCrossSection
+                xs_df = GeomCrossSection.get_cross_sections(geom_path)
+                if xs_df is not None and len(xs_df) > 0:
+                    for _, xs_row in xs_df.iterrows():
+                        river = str(xs_row.get('river', '')).strip()
+                        reach = str(xs_row.get('reach', '')).strip()
+                        station = xs_row.get('station')
+                        if station is not None:
+                            geom_stations.add((river, reach, float(station)))
+            except Exception as e:
+                logger.warning(f"Could not parse geometry for validation: {e}")
+
+        matched = []
+        unmatched = []
+        for _, ic_row in flow_ics.iterrows():
+            river = str(ic_row.get('river', '')).strip()
+            reach = str(ic_row.get('reach', '')).strip()
+            station = ic_row.get('station')
+            entry = {
+                'river': river, 'reach': reach,
+                'station': station, 'value': ic_row.get('value'),
+            }
+            if (river, reach, float(station)) in geom_stations:
+                matched.append(entry)
+            else:
+                unmatched.append(entry)
+
+        valid = len(unmatched) == 0 and len(flow_ics) > 0
+        if not geom_stations:
+            valid = True
+            logger.info("No geometry XS available for validation; skipping station check")
+
+        logger.info(
+            f"IC validation: {len(matched)} matched, {len(unmatched)} unmatched "
+            f"out of {len(flow_ics)} flow ICs ({len(geom_stations)} XS in geometry)"
+        )
+        return {
+            'valid': valid,
+            'matched': matched,
+            'unmatched': unmatched,
+            'ic_count': len(flow_ics),
+            'geom_xs_count': len(geom_stations),
+        }
 
     @staticmethod
     @log_call


### PR DESCRIPTION
## Summary
- `set_initial_conditions()` now accepts `pd.DataFrame` in addition to `list[dict]`
- Added `auto_set_method` parameter (default `True`) to auto-set IC method to "Initial Flow Distribution"
- Added `validate_initial_flow_stations()` that checks IC flow stations against geometry cross sections
- Notebook 312 Step 15 demonstrates get/set/validate round-trip with BaldEagle `.u12`

## Test plan
- [ ] Notebook 312 executes through Step 15 without errors
- [ ] Round-trip: modify IC flows → write → read back → values match
- [ ] Validation correctly reports matched/unmatched stations

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes CLB-731