### PR TITLE
feat(unsteady): add concentration/bulking API + fix NN method enum (CLB-744)

### DIFF
--- a/examples/312_boundary_df_qmult_dss_paths.ipynb
+++ b/examples/312_boundary_df_qmult_dss_paths.ipynb
@@ -44,9 +44,9 @@
     "    local_path = str(Path.cwd().parent)\n",
     "    if local_path not in sys.path:\n",
     "        sys.path.insert(0, local_path)\n",
-    "    print(f\"\ud83d\udcc1 LOCAL SOURCE MODE: Loading from {local_path}/ras_commander\")\n",
+    "    print(f\"📁 LOCAL SOURCE MODE: Loading from {local_path}/ras_commander\")\n",
     "else:\n",
-    "    print(\"\ud83d\udce6 PIP PACKAGE MODE: Loading installed ras-commander\")\n",
+    "    print(\"📦 PIP PACKAGE MODE: Loading installed ras-commander\")\n",
     "\n",
     "# Import ras-commander\n",
     "from ras_commander import init_ras_project, RasExamples, RasUnsteady\n",
@@ -58,7 +58,7 @@
     "\n",
     "# Verify which version loaded\n",
     "import ras_commander\n",
-    "print(f\"\u2713 Loaded: {ras_commander.__file__}\")"
+    "print(f\"✓ Loaded: {ras_commander.__file__}\")"
    ],
    "id": "b49f8ff4"
   },
@@ -336,7 +336,7 @@
     "        old_a_part=original_a_part  # Optional: only update if this matches\n",
     "    )\n",
     "    \n",
-    "    print(f\"\\n\u2713 Updated {count} DSS path(s)\")"
+    "    print(f\"\\n✓ Updated {count} DSS path(s)\")"
    ],
    "id": "889a395e"
   },
@@ -402,9 +402,9 @@
     "    )\n",
     "    \n",
     "    if success:\n",
-    "        print(f\"\\n\u2713 Flow multiplier updated/inserted successfully\")\n",
+    "        print(f\"\\n✓ Flow multiplier updated/inserted successfully\")\n",
     "    else:\n",
-    "        print(f\"\\n\u2717 Failed to update flow multiplier\")"
+    "        print(f\"\\n✗ Failed to update flow multiplier\")"
    ],
    "id": "ba32af22"
   },
@@ -440,7 +440,7 @@
   },
   {
    "cell_type": "code",
-   "source": "# Demonstrate set_stage_hydrograph_tw_check() on BaldEagle 2D project\n# The project was already extracted in Step 1 \u2014 re-initialize to get fresh state\nras = init_ras_project(project_path, RAS_VERSION)\n\n# Find a Flow Hydrograph boundary with 2D selectors (area_2d, bc_line)\nflow_hydro_2d = ras.boundaries_df[\n    (ras.boundaries_df['bc_type'] == 'Flow Hydrograph') &\n    (ras.boundaries_df['area_2d'].notna())\n].head(1)\n\nif len(flow_hydro_2d) > 0:\n    row = flow_hydro_2d.iloc[0]\n    area_2d = row['area_2d']\n    bc_line = row['bc_line']\n    unsteady_num = row['unsteady_number']\n    \n    # Resolve unsteady file path\n    u_row = ras.unsteady_df[ras.unsteady_df['unsteady_number'] == unsteady_num].iloc[0]\n    u_file = u_row['full_path']\n    \n    print(f\"Target boundary:\")\n    print(f\"  BC Type:       {row['bc_type']}\")\n    print(f\"  2D Area:       {area_2d}\")\n    print(f\"  BC Line:       {bc_line}\")\n    print(f\"  Unsteady File: {Path(u_file).name}\")\n    \n    # Check current TW Check value (may be absent)\n    tw_col = 'Stage Hydrograph TW Check'\n    current_val = row.get(tw_col, None)\n    print(f\"  Current TW Check: {current_val if pd.notna(current_val) else '(not set)'}\")\n    \n    # Set TW Check = 1 (enable)\n    print(f\"\\nSetting TW Check = 1 (enabled)...\")\n    result = RasUnsteady.set_stage_hydrograph_tw_check(\n        unsteady_file=u_file,\n        tw_check=1,\n        area_2d=area_2d,\n        bc_line=bc_line,\n        ras_object=ras,\n    )\n    \n    print(f\"\\nResult:\")\n    print(f\"  Matched Location: {result['matched_location']}\")\n    print(f\"  BC Type:          {result['bc_type']}\")\n    print(f\"  Previous Value:   {result['previous_tw_check']}\")\n    print(f\"  New Value:        {result['new_tw_check']}\")\n    print(f\"  Updated In Place: {result['updated_in_place']}\")\n    if not result['updated_in_place']:\n        print(f\"  Insert Anchor:    {result['insert_anchor']}\")\nelse:\n    print(\"No 2D Flow Hydrograph boundaries found in BaldEagle project.\")\n    print(\"Trying 1D selectors instead...\")\n    flow_hydro_1d = ras.boundaries_df[\n        (ras.boundaries_df['bc_type'] == 'Flow Hydrograph') &\n        (ras.boundaries_df['river'].notna())\n    ].head(1)\n    if len(flow_hydro_1d) > 0:\n        row = flow_hydro_1d.iloc[0]\n        u_row = ras.unsteady_df[ras.unsteady_df['unsteady_number'] == row['unsteady_number']].iloc[0]\n        u_file = u_row['full_path']\n        result = RasUnsteady.set_stage_hydrograph_tw_check(\n            unsteady_file=u_file,\n            tw_check=1,\n            river=row['river'],\n            reach=row['reach'],\n            station=row['river_station'],\n            ras_object=ras,\n        )\n        print(f\"Set TW Check=1 on 1D boundary: {result['matched_location']}\")\n        print(f\"  Previous: {result['previous_tw_check']} -> New: {result['new_tw_check']}\")",
+   "source": "# Demonstrate set_stage_hydrograph_tw_check() on BaldEagle 2D project\n# The project was already extracted in Step 1 — re-initialize to get fresh state\nras = init_ras_project(project_path, RAS_VERSION)\n\n# Find a Flow Hydrograph boundary with 2D selectors (area_2d, bc_line)\nflow_hydro_2d = ras.boundaries_df[\n    (ras.boundaries_df['bc_type'] == 'Flow Hydrograph') &\n    (ras.boundaries_df['area_2d'].notna())\n].head(1)\n\nif len(flow_hydro_2d) > 0:\n    row = flow_hydro_2d.iloc[0]\n    area_2d = row['area_2d']\n    bc_line = row['bc_line']\n    unsteady_num = row['unsteady_number']\n    \n    # Resolve unsteady file path\n    u_row = ras.unsteady_df[ras.unsteady_df['unsteady_number'] == unsteady_num].iloc[0]\n    u_file = u_row['full_path']\n    \n    print(f\"Target boundary:\")\n    print(f\"  BC Type:       {row['bc_type']}\")\n    print(f\"  2D Area:       {area_2d}\")\n    print(f\"  BC Line:       {bc_line}\")\n    print(f\"  Unsteady File: {Path(u_file).name}\")\n    \n    # Check current TW Check value (may be absent)\n    tw_col = 'Stage Hydrograph TW Check'\n    current_val = row.get(tw_col, None)\n    print(f\"  Current TW Check: {current_val if pd.notna(current_val) else '(not set)'}\")\n    \n    # Set TW Check = 1 (enable)\n    print(f\"\\nSetting TW Check = 1 (enabled)...\")\n    result = RasUnsteady.set_stage_hydrograph_tw_check(\n        unsteady_file=u_file,\n        tw_check=1,\n        area_2d=area_2d,\n        bc_line=bc_line,\n        ras_object=ras,\n    )\n    \n    print(f\"\\nResult:\")\n    print(f\"  Matched Location: {result['matched_location']}\")\n    print(f\"  BC Type:          {result['bc_type']}\")\n    print(f\"  Previous Value:   {result['previous_tw_check']}\")\n    print(f\"  New Value:        {result['new_tw_check']}\")\n    print(f\"  Updated In Place: {result['updated_in_place']}\")\n    if not result['updated_in_place']:\n        print(f\"  Insert Anchor:    {result['insert_anchor']}\")\nelse:\n    print(\"No 2D Flow Hydrograph boundaries found in BaldEagle project.\")\n    print(\"Trying 1D selectors instead...\")\n    flow_hydro_1d = ras.boundaries_df[\n        (ras.boundaries_df['bc_type'] == 'Flow Hydrograph') &\n        (ras.boundaries_df['river'].notna())\n    ].head(1)\n    if len(flow_hydro_1d) > 0:\n        row = flow_hydro_1d.iloc[0]\n        u_row = ras.unsteady_df[ras.unsteady_df['unsteady_number'] == row['unsteady_number']].iloc[0]\n        u_file = u_row['full_path']\n        result = RasUnsteady.set_stage_hydrograph_tw_check(\n            unsteady_file=u_file,\n            tw_check=1,\n            river=row['river'],\n            reach=row['reach'],\n            station=row['river_station'],\n            ras_object=ras,\n        )\n        print(f\"Set TW Check=1 on 1D boundary: {result['matched_location']}\")\n        print(f\"  Previous: {result['previous_tw_check']} -> New: {result['new_tw_check']}\")",
    "metadata": {},
    "execution_count": null,
    "outputs": [],
@@ -508,7 +508,7 @@
     "        updates=updates\n",
     "    )\n",
     "    \n",
-    "    print(f\"\\n\u2713 Batch update complete: {count} operations performed\")"
+    "    print(f\"\\n✓ Batch update complete: {count} operations performed\")"
    ],
    "id": "c90dfc13"
   },
@@ -550,23 +550,23 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Step 9: Boundary Condition State Transitions \u2014 Compute and Verify\n",
+    "## Step 9: Boundary Condition State Transitions — Compute and Verify\n",
     "\n",
     "ras-commander provides complete state management for converting boundary conditions between inline hydrograph tables and DSS file references.\n",
     "\n",
     "| Method | Direction | What It Does |\n",
     "|--------|-----------|--------------|\n",
-    "| `set_boundary_dss_link()` | Inline \u2192 DSS | Sets Use DSS=True, adds DSS File/Path, **removes inline data**, sets count to 0 |\n",
-    "| `set_boundary_inline_hydrograph()` | DSS \u2192 Inline | Sets Use DSS=False, clears DSS File/Path, **writes inline data** |\n",
+    "| `set_boundary_dss_link()` | Inline → DSS | Sets Use DSS=True, adds DSS File/Path, **removes inline data**, sets count to 0 |\n",
+    "| `set_boundary_inline_hydrograph()` | DSS → Inline | Sets Use DSS=False, clears DSS File/Path, **writes inline data** |\n",
     "\n",
     "### Verification Strategy\n",
     "\n",
     "This section demonstrates THREE computational verifications using independent Muncie project copies:\n",
     "\n",
-    "1. **Step 9a: Round-Trip Fidelity** \u2014 Inline \u2192 DSS \u2192 Inline preserves data exactly\n",
+    "1. **Step 9a: Round-Trip Fidelity** — Inline → DSS → Inline preserves data exactly\n",
     "   - Expected: Identical results (max diff = 0.000000)\n",
     "   \n",
-    "2. **Step 9b: QMult Sensitivity** \u2014 Flow multiplier affects results correctly\n",
+    "2. **Step 9b: QMult Sensitivity** — Flow multiplier affects results correctly\n",
     "   - Expected: Lower WSE with QMult=0.50 (50% flow reduction)"
    ],
    "id": "371777a8"
@@ -724,7 +724,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Note: The HDF comparisons assume the same geometry between baseline and round-trip copies; this is intentional for validating inline\u2194DSS boundary conversions on identical geometry."
+    "Note: The HDF comparisons assume the same geometry between baseline and round-trip copies; this is intentional for validating inline↔DSS boundary conversions on identical geometry."
    ],
    "id": "97696299"
   },
@@ -899,7 +899,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Step 9b: QMult Sensitivity \u2014 Compute with Flow Multiplier\n",
+    "### Step 9b: QMult Sensitivity — Compute with Flow Multiplier\n",
     "\n",
     "To confirm that `update_flow_multiplier_by_station()` actually changes simulation results, we extract a **third** copy of Muncie, insert `Flow Hydrograph QMult=0.50` (50% of base flow), compute, and compare against the baseline.\n",
     "\n",
@@ -1040,7 +1040,7 @@
   },
   {
    "cell_type": "code",
-   "source": "# --- Step 10a: Extract the Internal Stage and Flow Boundary Condition project ---\nimport shutil\nfrom pathlib import Path\n\n# The fixture lives under example_projects/ (committed with the repo)\nfixture_src = Path(\"../example_projects/Internal Stage and Flow Boundary Condition\")\nib_project_path = Path(\"example_projects\") / \"IBStageFlowTest_312\"\nif ib_project_path.exists():\n    shutil.rmtree(ib_project_path)\nshutil.copytree(fixture_src, ib_project_path)\n\nras_ib = init_ras_project(ib_project_path, RAS_VERSION)\nprint(f\"Project: {ras_ib.project_name}\")\nprint(f\"Boundaries ({len(ras_ib.boundaries_df)}):\")\ndisplay(ras_ib.boundaries_df[['river', 'reach', 'river_station', 'bc_type']].head(10))\n\n# Read observed stage/flow data from the internal BC at station 41.76\nib_u01 = ras_ib.unsteady_df.iloc[0]['full_path']\nsf_df = RasUnsteady.get_stage_flow_hydrograph(\n    unsteady_file=ib_u01,\n    river=\"Nittany River\",\n    reach=\"Weir Reach\",\n    station=\"41.76\",\n    ras_object=ras_ib,\n)\n\nprint(f\"\\nObserved Stage and Flow Hydrograph at Nittany River / Weir Reach / 41.76:\")\nprint(f\"  Pairs: {len(sf_df)}\")\nprint(f\"  Stage range: {sf_df['stage'].min():.2f} \u2013 {sf_df['stage'].max():.2f}\")\nprint(f\"  Flow  range: {sf_df['flow'].min():.0f} \u2013 {sf_df['flow'].max():.0f}\")\ndisplay(sf_df.head(10))",
+   "source": "# --- Step 10a: Extract the Internal Stage and Flow Boundary Condition project ---\nimport shutil\nfrom pathlib import Path\n\n# The fixture lives under example_projects/ (committed with the repo)\nfixture_src = Path(\"../example_projects/Internal Stage and Flow Boundary Condition\")\nib_project_path = Path(\"example_projects\") / \"IBStageFlowTest_312\"\nif ib_project_path.exists():\n    shutil.rmtree(ib_project_path)\nshutil.copytree(fixture_src, ib_project_path)\n\nras_ib = init_ras_project(ib_project_path, RAS_VERSION)\nprint(f\"Project: {ras_ib.project_name}\")\nprint(f\"Boundaries ({len(ras_ib.boundaries_df)}):\")\ndisplay(ras_ib.boundaries_df[['river', 'reach', 'river_station', 'bc_type']].head(10))\n\n# Read observed stage/flow data from the internal BC at station 41.76\nib_u01 = ras_ib.unsteady_df.iloc[0]['full_path']\nsf_df = RasUnsteady.get_stage_flow_hydrograph(\n    unsteady_file=ib_u01,\n    river=\"Nittany River\",\n    reach=\"Weir Reach\",\n    station=\"41.76\",\n    ras_object=ras_ib,\n)\n\nprint(f\"\\nObserved Stage and Flow Hydrograph at Nittany River / Weir Reach / 41.76:\")\nprint(f\"  Pairs: {len(sf_df)}\")\nprint(f\"  Stage range: {sf_df['stage'].min():.2f} – {sf_df['stage'].max():.2f}\")\nprint(f\"  Flow  range: {sf_df['flow'].min():.0f} – {sf_df['flow'].max():.0f}\")\ndisplay(sf_df.head(10))",
    "metadata": {},
    "execution_count": null,
    "outputs": [],
@@ -1056,7 +1056,7 @@
   },
   {
    "cell_type": "code",
-   "source": "# --- Step 10c: Round-trip verification \u2014 re-read and compare ---\n\nsf_reread = RasUnsteady.get_stage_flow_hydrograph(\n    unsteady_file=ib_u01,\n    river=\"Nittany River\", reach=\"Weir Reach\", station=\"41.76\",\n    ras_object=ras_ib,\n)\nprint(f\"Re-read {len(sf_reread)} stage/flow pairs after write\")\ndisplay(sf_reread.head(10))\n\n# Verify round-trip: written values match what we read back\nassert len(sf_reread) == len(sf_modified), (\n    f\"Row count mismatch: wrote {len(sf_modified)}, read {len(sf_reread)}\"\n)\nassert np.allclose(sf_reread['stage'].values, sf_modified['stage'].values, atol=0.01), \\\n    \"Stage values changed during round-trip!\"\nassert np.allclose(sf_reread['flow'].values, sf_modified['flow'].values, atol=0.1), \\\n    \"Flow values changed during round-trip!\"\n\nprint(\"\\nRound-trip verification PASSED \u2014 written values match read-back\")",
+   "source": "# --- Step 10c: Round-trip verification — re-read and compare ---\n\nsf_reread = RasUnsteady.get_stage_flow_hydrograph(\n    unsteady_file=ib_u01,\n    river=\"Nittany River\", reach=\"Weir Reach\", station=\"41.76\",\n    ras_object=ras_ib,\n)\nprint(f\"Re-read {len(sf_reread)} stage/flow pairs after write\")\ndisplay(sf_reread.head(10))\n\n# Verify round-trip: written values match what we read back\nassert len(sf_reread) == len(sf_modified), (\n    f\"Row count mismatch: wrote {len(sf_modified)}, read {len(sf_reread)}\"\n)\nassert np.allclose(sf_reread['stage'].values, sf_modified['stage'].values, atol=0.01), \\\n    \"Stage values changed during round-trip!\"\nassert np.allclose(sf_reread['flow'].values, sf_modified['flow'].values, atol=0.1), \\\n    \"Flow values changed during round-trip!\"\n\nprint(\"\\nRound-trip verification PASSED — written values match read-back\")",
    "metadata": {},
    "execution_count": null,
    "outputs": []
@@ -1085,12 +1085,12 @@
   },
   {
    "cell_type": "markdown",
-   "source": "## Step 12: Uniform Lateral Inflow Hydrograph Read/Write\n\nHEC-RAS supports **Uniform Lateral Inflow Hydrograph** boundary conditions for distributing flow uniformly along a reach between two river stations. Unlike point-based Lateral Inflow (Step 11), this BC type is **reach-based** \u2014 applied between two stations listed in the Boundary Location field.\n\n| Method | Purpose |\n|--------|---------|\n| `RasUnsteady.get_uniform_lateral_inflow_hydrograph()` | Read uniform lateral inflow values and metadata from a `.u##` file |\n| `RasUnsteady.set_uniform_lateral_inflow_hydrograph()` | Write or replace uniform lateral inflow values, optionally update slope |\n\nThe inline data format is identical to other hydrograph types (8-character fixed-width, 10 values per line). Metadata includes `interval`, `slope`, `matched_location`, and `value_count` via `df.attrs`.",
+   "source": "## Step 12: Uniform Lateral Inflow Hydrograph Read/Write\n\nHEC-RAS supports **Uniform Lateral Inflow Hydrograph** boundary conditions for distributing flow uniformly along a reach between two river stations. Unlike point-based Lateral Inflow (Step 11), this BC type is **reach-based** — applied between two stations listed in the Boundary Location field.\n\n| Method | Purpose |\n|--------|---------|\n| `RasUnsteady.get_uniform_lateral_inflow_hydrograph()` | Read uniform lateral inflow values and metadata from a `.u##` file |\n| `RasUnsteady.set_uniform_lateral_inflow_hydrograph()` | Write or replace uniform lateral inflow values, optionally update slope |\n\nThe inline data format is identical to other hydrograph types (8-character fixed-width, 10 values per line). Metadata includes `interval`, `slope`, `matched_location`, and `value_count` via `df.attrs`.",
    "metadata": {}
   },
   {
    "cell_type": "code",
-   "source": "# --- Step 12a: Read uniform lateral inflow hydrograph from BaldEagleCrkMulti2D ---\n# Re-initialize BaldEagle project (extracted in Step 1)\nras = init_ras_project(project_path, RAS_VERSION)\n\n# Find Uniform Lateral Inflow Hydrograph boundaries in boundaries_df\nulat_bcs = ras.boundaries_df[ras.boundaries_df['bc_type'] == 'Uniform Lateral Inflow Hydrograph']\nprint(f\"Uniform Lateral Inflow Hydrograph boundaries: {len(ulat_bcs)}\")\nif len(ulat_bcs) > 0:\n    display(ulat_bcs[['river', 'reach', 'river_station', 'bc_type', 'area_2d', 'bc_line']].head())\n\n# Pick the first unsteady file that has uniform lateral inflow BCs\nulat_u_file = None\nfor _, urow in ras.unsteady_df.iterrows():\n    unum = urow['unsteady_number']\n    match = ras.boundaries_df[\n        (ras.boundaries_df['unsteady_number'] == unum) &\n        (ras.boundaries_df['bc_type'] == 'Uniform Lateral Inflow Hydrograph')\n    ]\n    if len(match) > 0:\n        ulat_u_file = urow['full_path']\n        ulat_sample = match.iloc[0]\n        break\n\nif ulat_u_file:\n    print(f\"\\nUsing unsteady file: {Path(ulat_u_file).name}\")\n    print(f\"  River:   {ulat_sample.get('river', 'N/A')}\")\n    print(f\"  Reach:   {ulat_sample.get('reach', 'N/A')}\")\n    print(f\"  Station: {ulat_sample.get('river_station', 'N/A')}\")\n\n    # Attempt to read inline data (BaldEagle BCs are DSS-linked, so expect None)\n    ulat_df = RasUnsteady.get_uniform_lateral_inflow_hydrograph(\n        unsteady_file=ulat_u_file,\n        river=ulat_sample.get('river'),\n        reach=ulat_sample.get('reach'),\n        station=ulat_sample.get('river_station'),\n        ras_object=ras,\n    )\n\n    if ulat_df is not None:\n        print(f\"\\nUniform Lateral Inflow Hydrograph:\")\n        print(f\"  Values:   {len(ulat_df)}\")\n        print(f\"  Flow range: {ulat_df['flow'].min():.1f} - {ulat_df['flow'].max():.1f}\")\n        print(f\"  Interval: {ulat_df.attrs.get('interval', 'N/A')}\")\n        print(f\"  Slope:    {ulat_df.attrs.get('slope', 'N/A')}\")\n        print(f\"  Location: {ulat_df.attrs.get('matched_location', 'N/A')}\")\n        display(ulat_df.head(10))\n    else:\n        print(\"\\nNo inline uniform lateral inflow found (DSS-linked with count=0)\")\n        print(\"  This is expected for BaldEagle \u2014 will use setter to write inline data in Step 12b\")\nelse:\n    print(\"No Uniform Lateral Inflow Hydrograph boundaries found in this project\")",
+   "source": "# --- Step 12a: Read uniform lateral inflow hydrograph from BaldEagleCrkMulti2D ---\n# Re-initialize BaldEagle project (extracted in Step 1)\nras = init_ras_project(project_path, RAS_VERSION)\n\n# Find Uniform Lateral Inflow Hydrograph boundaries in boundaries_df\nulat_bcs = ras.boundaries_df[ras.boundaries_df['bc_type'] == 'Uniform Lateral Inflow Hydrograph']\nprint(f\"Uniform Lateral Inflow Hydrograph boundaries: {len(ulat_bcs)}\")\nif len(ulat_bcs) > 0:\n    display(ulat_bcs[['river', 'reach', 'river_station', 'bc_type', 'area_2d', 'bc_line']].head())\n\n# Pick the first unsteady file that has uniform lateral inflow BCs\nulat_u_file = None\nfor _, urow in ras.unsteady_df.iterrows():\n    unum = urow['unsteady_number']\n    match = ras.boundaries_df[\n        (ras.boundaries_df['unsteady_number'] == unum) &\n        (ras.boundaries_df['bc_type'] == 'Uniform Lateral Inflow Hydrograph')\n    ]\n    if len(match) > 0:\n        ulat_u_file = urow['full_path']\n        ulat_sample = match.iloc[0]\n        break\n\nif ulat_u_file:\n    print(f\"\\nUsing unsteady file: {Path(ulat_u_file).name}\")\n    print(f\"  River:   {ulat_sample.get('river', 'N/A')}\")\n    print(f\"  Reach:   {ulat_sample.get('reach', 'N/A')}\")\n    print(f\"  Station: {ulat_sample.get('river_station', 'N/A')}\")\n\n    # Attempt to read inline data (BaldEagle BCs are DSS-linked, so expect None)\n    ulat_df = RasUnsteady.get_uniform_lateral_inflow_hydrograph(\n        unsteady_file=ulat_u_file,\n        river=ulat_sample.get('river'),\n        reach=ulat_sample.get('reach'),\n        station=ulat_sample.get('river_station'),\n        ras_object=ras,\n    )\n\n    if ulat_df is not None:\n        print(f\"\\nUniform Lateral Inflow Hydrograph:\")\n        print(f\"  Values:   {len(ulat_df)}\")\n        print(f\"  Flow range: {ulat_df['flow'].min():.1f} - {ulat_df['flow'].max():.1f}\")\n        print(f\"  Interval: {ulat_df.attrs.get('interval', 'N/A')}\")\n        print(f\"  Slope:    {ulat_df.attrs.get('slope', 'N/A')}\")\n        print(f\"  Location: {ulat_df.attrs.get('matched_location', 'N/A')}\")\n        display(ulat_df.head(10))\n    else:\n        print(\"\\nNo inline uniform lateral inflow found (DSS-linked with count=0)\")\n        print(\"  This is expected for BaldEagle — will use setter to write inline data in Step 12b\")\nelse:\n    print(\"No Uniform Lateral Inflow Hydrograph boundaries found in this project\")",
    "metadata": {},
    "execution_count": null,
    "outputs": []
@@ -1104,7 +1104,7 @@
   },
   {
    "cell_type": "markdown",
-   "source": "## Step 13: Initial Conditions Method Selection\n\nHEC-RAS unsteady flow files use an **implicit** state machine for Initial Conditions:\n\n| File State | IC Method | Description |\n|-----------|-----------|-------------|\n| `Use Restart= -1` (or `1`) | **Restart File** | Resume from a previously saved `.rst` file |\n| `Use Restart= 0` + `Initial Flow Loc=` lines | **Enter Initial Flow Distribution** | User-specified flows, storage elevations, and RRR elevations |\n| `Use Restart= 0` with no IC lines | **None** | HEC-RAS uses zero initial flow |\n\nThere is no single explicit \"method selector\" key \u2014 the method is determined by the combination of `Use Restart` and the presence of `Initial Flow Loc=` / `Initial Storage Elev=` / `Initial RRR Elev=` lines.\n\n| Method | Purpose |\n|--------|---------|\n| `RasUnsteady.get_initial_flow_method()` | Determine which IC method is active |\n| `RasUnsteady.set_initial_flow_method()` | Set the IC method (`restart_file`, `initial_flow_distribution`, or `none`) |",
+   "source": "## Step 13: Initial Conditions Method Selection\n\nHEC-RAS unsteady flow files use an **implicit** state machine for Initial Conditions:\n\n| File State | IC Method | Description |\n|-----------|-----------|-------------|\n| `Use Restart= -1` (or `1`) | **Restart File** | Resume from a previously saved `.rst` file |\n| `Use Restart= 0` + `Initial Flow Loc=` lines | **Enter Initial Flow Distribution** | User-specified flows, storage elevations, and RRR elevations |\n| `Use Restart= 0` with no IC lines | **None** | HEC-RAS uses zero initial flow |\n\nThere is no single explicit \"method selector\" key — the method is determined by the combination of `Use Restart` and the presence of `Initial Flow Loc=` / `Initial Storage Elev=` / `Initial RRR Elev=` lines.\n\n| Method | Purpose |\n|--------|---------|\n| `RasUnsteady.get_initial_flow_method()` | Determine which IC method is active |\n| `RasUnsteady.set_initial_flow_method()` | Set the IC method (`restart_file`, `initial_flow_distribution`, or `none`) |",
    "metadata": {},
    "id": "cell-step13-intro"
   },
@@ -1118,7 +1118,7 @@
   },
   {
    "cell_type": "code",
-   "source": "# --- Step 13b: Round-trip set_initial_flow_method() ---\nimport shutil\n\n# Work on a copy of .u08 so we don't alter the original fixture\nu08_copy = project_path / \"BaldEagleDamBrk_IC_test.u08\"\nshutil.copy2(u08_path, u08_copy)\n\n# Verify starting state: initial_flow_distribution with 8 IC lines\nic_before = RasUnsteady.get_initial_flow_method(u08_copy, ras_object=ras)\nprint(f\"Before: method={ic_before['method']}, ic_count={ic_before['ic_count']}\")\nassert ic_before['method'] == 'initial_flow_distribution'\n\n# Switch to restart_file mode\nRasUnsteady.set_initial_flow_method(\n    u08_copy, method=\"restart_file\",\n    restart_filename=\"BaldEagleDamBrk.p08.01JAN2000 2400.rst\",\n    ras_object=ras,\n)\nic_restart = RasUnsteady.get_initial_flow_method(u08_copy, ras_object=ras)\nprint(f\"After set restart_file: method={ic_restart['method']}, \"\n      f\"restart_filename={ic_restart['restart_filename']}\")\nassert ic_restart['method'] == 'restart_file'\nassert ic_restart['restart_filename'] == \"BaldEagleDamBrk.p08.01JAN2000 2400.rst\"\n\n# Switch to none (strips all IC lines)\nRasUnsteady.set_initial_flow_method(u08_copy, method=\"none\", ras_object=ras)\nic_none = RasUnsteady.get_initial_flow_method(u08_copy, ras_object=ras)\nprint(f\"After set none: method={ic_none['method']}, ic_count={ic_none['ic_count']}\")\nassert ic_none['method'] == 'none'\nassert ic_none['ic_count'] == 0\n\n# Switch back to initial_flow_distribution (preserves Use Restart=0, IC lines were stripped)\nRasUnsteady.set_initial_flow_method(u08_copy, method=\"initial_flow_distribution\", ras_object=ras)\nic_ifd = RasUnsteady.get_initial_flow_method(u08_copy, ras_object=ras)\nprint(f\"After set initial_flow_distribution: method={ic_ifd['method']}, ic_count={ic_ifd['ic_count']}\")\n# Note: IC lines were stripped when we set 'none', so ic_count=0 but method is\n# technically 'none' since there are no IC lines. The setter only controls\n# the Use Restart flag \u2014 IC line content is managed by usgs/initial_conditions.py.\nprint(f\"  (IC lines were stripped by 'none' \u2014 Use Restart=0 is set correctly)\")\n\n# Cleanup temp file\nu08_copy.unlink()\nprint(f\"\\n[OK] Round-trip state transitions verified: \"\n      f\"initial_flow_distribution -> restart_file -> none -> initial_flow_distribution\")",
+   "source": "# --- Step 13b: Round-trip set_initial_flow_method() ---\nimport shutil\n\n# Work on a copy of .u08 so we don't alter the original fixture\nu08_copy = project_path / \"BaldEagleDamBrk_IC_test.u08\"\nshutil.copy2(u08_path, u08_copy)\n\n# Verify starting state: initial_flow_distribution with 8 IC lines\nic_before = RasUnsteady.get_initial_flow_method(u08_copy, ras_object=ras)\nprint(f\"Before: method={ic_before['method']}, ic_count={ic_before['ic_count']}\")\nassert ic_before['method'] == 'initial_flow_distribution'\n\n# Switch to restart_file mode\nRasUnsteady.set_initial_flow_method(\n    u08_copy, method=\"restart_file\",\n    restart_filename=\"BaldEagleDamBrk.p08.01JAN2000 2400.rst\",\n    ras_object=ras,\n)\nic_restart = RasUnsteady.get_initial_flow_method(u08_copy, ras_object=ras)\nprint(f\"After set restart_file: method={ic_restart['method']}, \"\n      f\"restart_filename={ic_restart['restart_filename']}\")\nassert ic_restart['method'] == 'restart_file'\nassert ic_restart['restart_filename'] == \"BaldEagleDamBrk.p08.01JAN2000 2400.rst\"\n\n# Switch to none (strips all IC lines)\nRasUnsteady.set_initial_flow_method(u08_copy, method=\"none\", ras_object=ras)\nic_none = RasUnsteady.get_initial_flow_method(u08_copy, ras_object=ras)\nprint(f\"After set none: method={ic_none['method']}, ic_count={ic_none['ic_count']}\")\nassert ic_none['method'] == 'none'\nassert ic_none['ic_count'] == 0\n\n# Switch back to initial_flow_distribution (preserves Use Restart=0, IC lines were stripped)\nRasUnsteady.set_initial_flow_method(u08_copy, method=\"initial_flow_distribution\", ras_object=ras)\nic_ifd = RasUnsteady.get_initial_flow_method(u08_copy, ras_object=ras)\nprint(f\"After set initial_flow_distribution: method={ic_ifd['method']}, ic_count={ic_ifd['ic_count']}\")\n# Note: IC lines were stripped when we set 'none', so ic_count=0 but method is\n# technically 'none' since there are no IC lines. The setter only controls\n# the Use Restart flag — IC line content is managed by usgs/initial_conditions.py.\nprint(f\"  (IC lines were stripped by 'none' — Use Restart=0 is set correctly)\")\n\n# Cleanup temp file\nu08_copy.unlink()\nprint(f\"\\n[OK] Round-trip state transitions verified: \"\n      f\"initial_flow_distribution -> restart_file -> none -> initial_flow_distribution\")",
    "metadata": {},
    "execution_count": null,
    "outputs": [],
@@ -1150,7 +1150,7 @@
    "metadata": {},
    "id": "cell-step15-intro",
    "source": [
-    "## Step 15: Initial Conditions Table \u2014 Get / Set / Validate\n",
+    "## Step 15: Initial Conditions Table — Get / Set / Validate\n",
     "\n",
     "HEC-RAS stores **initial flow conditions** as `Initial Flow Loc=` lines in the `.u##` file.\n",
     "These define the starting flow at each cross section for an unsteady simulation.\n",
@@ -1287,50 +1287,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "id": "cell-step16-intro",
-   "source": [
-    "## Step 16: Non-Newtonian Method Selection\n",
-    "\n",
-    "HEC-RAS supports **Non-Newtonian mud and debris flow** simulation through the\n",
-    "Unsteady Flow Editor. The method is stored in the `.u##` file as:\n",
-    "```\n",
-    "Non-Newtonian Method= 0 ,\n",
-    "```\n",
-    "\n",
-    "| Integer | Method |\n",
-    "|---------|--------|\n",
-    "| 0 | Newtonian Assumptions (default) |\n",
-    "| 1 | Bulking Only |\n",
-    "| 2 | Bingham |\n",
-    "| 3 | O'Brien (Quadratic) |\n",
-    "| 4 | Herschel-Bulkley |\n",
-    "| 5 | Voellmy |\n",
-    "\n",
-    "`get_non_newtonian_method()` reads this integer and returns both the ID and human-readable name.\n",
-    "`set_non_newtonian_method()` accepts either an integer or the method name string."
-   ]
+   "source": "## Step 16: Non-Newtonian Method Selection\n\nHEC-RAS supports **Non-Newtonian mud and debris flow** simulation through the\nUnsteady Flow Editor. The method is stored in the `.u##` file as:\n```\nNon-Newtonian Method= 0 \n```\n\n| Integer | Method |\n|---------|--------|\n| 0 | Newtonian Assumptions (default) |\n| 1 | Bingham |\n| 2 | O'Brien (Quadratic) |\n| 3 | Clastic Grain-Flow |\n| 4 | Generalized Herschel-Bulkley |\n\nMethod mapping verified via binary analysis of `Ras.exe` (HEC-RAS 6.6/7.0).\n\n`get_non_newtonian_method()` reads this integer and returns both the ID and human-readable name.\n`set_non_newtonian_method()` accepts either an integer or the method name string."
   },
   {
    "cell_type": "code",
    "metadata": {},
    "id": "cell-step16a",
-   "source": [
-    "# --- Step 16a: Read Non-Newtonian method from .u02 ---\n",
-    "from ras_commander import RasUnsteady, RasExamples, init_ras_project\n",
-    "\n",
-    "# BaldEagle .u02 and .u03 have NN blocks\n",
-    "project_folder = RasExamples.extract_project(\"BaldEagleCrkMulti2D\", suffix=\"312_nn\")\n",
-    "ras = init_ras_project(project_folder, \"6.6\")\n",
-    "\n",
-    "# Read NN method from .u02\n",
-    "nn = RasUnsteady.get_non_newtonian_method(\"02\", ras_object=ras)\n",
-    "print(f\"Method ID: {nn['method_id']}  Name: {nn['method_name']}\")\n",
-    "\n",
-    "# Show the full method dictionary\n",
-    "print(\"\nAvailable Non-Newtonian methods:\")\n",
-    "for mid, mname in RasUnsteady.NON_NEWTONIAN_METHODS.items():\n",
-    "    marker = \" <-- current\" if mid == nn['method_id'] else \"\"\n",
-    "    print(f\"  {mid}: {mname}{marker}\")"
-   ],
+   "source": "# --- Step 16a: Read Non-Newtonian method from .u02 ---\nfrom ras_commander import RasUnsteady, RasExamples, init_ras_project\n\nproject_folder = RasExamples.extract_project(\"BaldEagleCrkMulti2D\")\nras = init_ras_project(project_folder, \"6.6\")\n\nu02_path = ras.project_folder / f\"{ras.project_name}.u02\"\nresult = RasUnsteady.get_non_newtonian_method(u02_path)\nprint(f\"Method ID: {result['method_id']}\")\nprint(f\"Method Name: {result['method_name']}\")\nprint(f\"\nAll methods: {RasUnsteady.NON_NEWTONIAN_METHODS}\")",
    "outputs": [],
    "execution_count": null
   },
@@ -1338,43 +1301,33 @@
    "cell_type": "code",
    "metadata": {},
    "id": "cell-step16b",
-   "source": [
-    "# --- Step 16b: Round-trip set_non_newtonian_method() ---\n",
-    "import shutil\n",
-    "from pathlib import Path\n",
-    "\n",
-    "# Work on a copy\n",
-    "u02_original = list(project_folder.glob(\"*.u02\"))[0]\n",
-    "u02_copy = u02_original.with_suffix(\".u98\")\n",
-    "shutil.copy2(u02_original, u02_copy)\n",
-    "\n",
-    "# Set by integer\n",
-    "RasUnsteady.set_non_newtonian_method(u02_copy, 4)  # Herschel-Bulkley\n",
-    "result = RasUnsteady.get_non_newtonian_method(u02_copy)\n",
-    "print(f\"After set(4): {result['method_id']} = {result['method_name']}\")\n",
-    "\n",
-    "# Set by name string\n",
-    "RasUnsteady.set_non_newtonian_method(u02_copy, \"Voellmy\")\n",
-    "result = RasUnsteady.get_non_newtonian_method(u02_copy)\n",
-    "print(f\"After set('Voellmy'): {result['method_id']} = {result['method_name']}\")\n",
-    "\n",
-    "# Reset to default\n",
-    "RasUnsteady.set_non_newtonian_method(u02_copy, 0)\n",
-    "result = RasUnsteady.get_non_newtonian_method(u02_copy)\n",
-    "print(f\"After set(0): {result['method_id']} = {result['method_name']}\")\n",
-    "\n",
-    "# Clean up\n",
-    "u02_copy.unlink(missing_ok=True)\n",
-    "shutil.rmtree(project_folder, ignore_errors=True)\n",
-    "print(\"\nRound-trip complete.\")"
-   ],
+   "source": "# --- Step 16b: Round-trip set_non_newtonian_method() ---\nimport shutil\nfrom pathlib import Path\n\n# Work on a copy\nu02_orig = ras.project_folder / f\"{ras.project_name}.u02\"\nu02_copy = ras.project_folder / f\"{ras.project_name}.u02.bak\"\nshutil.copy2(u02_orig, u02_copy)\n\n# Set by integer\nRasUnsteady.set_non_newtonian_method(u02_orig, method=1)\ncheck = RasUnsteady.get_non_newtonian_method(u02_orig)\nprint(f\"After set(1): {check['method_id']} = {check['method_name']}\")\n\n# Set by name\nRasUnsteady.set_non_newtonian_method(u02_orig, method=\"O'Brien (Quadratic)\")\ncheck = RasUnsteady.get_non_newtonian_method(u02_orig)\nprint(f\"After set('O'Brien (Quadratic)'): {check['method_id']} = {check['method_name']}\")\n\n# Restore original\nshutil.copy2(u02_copy, u02_orig)\nu02_copy.unlink()\nprint(\"\nRestored original .u02\")",
    "outputs": [],
    "execution_count": null
   },
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "## Summary\n\nThis notebook demonstrated the enhanced `boundaries_df` features:\n\n### New DataFrame Columns\n\n| Column | Description | Use Case |\n|--------|-------------|----------|\n| `Flow Hydrograph QMult` | Flow multiplier value | Sensitivity analysis |\n| `Flow Hydrograph QMin` | Minimum flow threshold | Low flow conditions |\n| `Stage Hydrograph TW Check` | Tailwater check flag (0/1) | Flow Hydrograph TW control |\n| `dss_part_a` | HMS subbasin/location | HMS-RAS linking |\n| `dss_part_b` | Parameter (FLOW/STAGE) | Data type identification |\n| `dss_part_c` | Date reference | Time synchronization |\n| `dss_part_d` | Time interval | Timestep verification |\n| `dss_part_e` | Run identifier | Scenario tracking |\n| `dss_part_f` | Additional ID | Optional metadata |\n\n### Update Methods\n\n| Method | Purpose |\n|--------|---------|\n| `RasUnsteady.update_dss_path_by_station()` | Update DSS A-part by river station |\n| `RasUnsteady.update_flow_multiplier_by_station()` | Update/insert QMult value |\n| `RasUnsteady.update_boundary_dss_paths()` | Batch update multiple boundaries |\n| `RasUnsteady.set_stage_hydrograph_tw_check()` | Set TW Check flag (0 or 1) on Flow Hydrograph BC |\n\n### State Transition Methods\n\n| Method | Direction | Purpose |\n|--------|-----------|---------|\n| `RasUnsteady.set_boundary_dss_link()` | Inline to DSS | Remove inline data, set DSS File/Path, Use DSS=True |\n| `RasUnsteady.set_boundary_inline_hydrograph()` | DSS to Inline | Write inline data, clear DSS fields, Use DSS=False |\n| `RasUnsteady.get_inline_hydrograph_boundaries()` | Read | Extract all inline hydrograph boundaries with values |\n\n### Stage/Flow Hydrograph Methods (Internal Boundaries)\n\n| Method | Purpose |\n|--------|---------|\n| `RasUnsteady.get_stage_flow_hydrograph()` | Read interleaved stage/flow pairs from `.u##` file |\n| `RasUnsteady.set_stage_flow_hydrograph()` | Write or replace stage/flow pairs in `.u##` file |\n\n### Lateral Inflow Hydrograph Methods (Step 11)\n\n| Method | Purpose |\n|--------|---------|\n| `RasUnsteady.get_lateral_inflow_hydrograph()` | Read lateral inflow values + metadata (interval, slope) from `.u##` file |\n| `RasUnsteady.set_lateral_inflow_hydrograph()` | Write/replace lateral inflow values, optionally update `Flow Hydrograph Slope=` |\n\n### Uniform Lateral Inflow Hydrograph Methods (Step 12)\n\n| Method | Purpose |\n|--------|---------|\n| `RasUnsteady.get_uniform_lateral_inflow_hydrograph()` | Read uniform lateral inflow values + metadata from `.u##` file |\n| `RasUnsteady.set_uniform_lateral_inflow_hydrograph()` | Write/replace uniform lateral inflow values, optionally update slope |\n\n### Initial Conditions Method Selection (Steps 13-14)\n\n| Method | Purpose |\n|--------|---------|\n| `RasUnsteady.get_initial_flow_method()` | Determine which IC method is active (restart_file, prior_ws, initial_flow_distribution, or none) |\n| `RasUnsteady.set_initial_flow_method()` | Set the IC method selection and manage `Use Restart` / `Restart Filename` / `Prior WS Filename` keys |\n| `RasUnsteady.get_prior_ws_filename()` | Read Prior WS Filename and Profile from `.u##` file |\n| `RasUnsteady.set_prior_ws_filename()` | Write Prior WS Filename and Profile (convenience wrapper for `set_initial_flow_method(method=\"prior_ws\")`) |\n\n### Computational Verification (Step 9)\n\nThree independent HEC-RAS computations verified the implementation:\n\n**Step 9a: Round-Trip Fidelity Test**\n1. Computed **baseline** plan with original inline boundary conditions\n2. Performed inline -> DSS -> inline **round-trip** on a second copy\n3. Computed the **round-trip** plan\n4. Compared cross section results via `HdfResultsXsec.get_xsec_timeseries()`\n5. **Result**: All Water Surface, Flow, and Velocity matched exactly (max diff = 0.000000)\n\n**Step 9b: QMult Sensitivity Test**\n1. Inserted `Flow Hydrograph QMult=0.50` on a third copy\n2. Computed the **QMult** plan with 50% of baseline flow\n3. Compared cross section results against baseline\n4. **Result**: All cross sections showed lower WSE with reduced flow (QMult correctly applied)\n\n### Stage/Flow Hydrograph Verification (Step 10)\n\n1. Extracted **Internal Stage and Flow Boundary Condition** fixture project\n2. Read observed stage/flow hydrograph at internal BC station with `get_stage_flow_hydrograph()`\n3. Scaled flows by 1.25x and wrote back with `set_stage_flow_hydrograph()`\n4. Re-read and verified round-trip: stage values unchanged, flow values match scaled values\n5. **Result**: Round-trip verification PASSED\n\n### Lateral Inflow Hydrograph Verification (Step 11)\n\n1. Read lateral inflow hydrograph from BaldEagleCrkMulti2D with `get_lateral_inflow_hydrograph()`\n2. Verified metadata extraction: interval, slope, matched_location via `df.attrs`\n3. Scaled flows by 1.5x and wrote back with new slope using `set_lateral_inflow_hydrograph()`\n4. Re-read and verified round-trip: flow values match, slope updated\n5. **Result**: Round-trip verification PASSED\n\n### Uniform Lateral Inflow Hydrograph Verification (Step 12)\n\n1. Found Uniform Lateral Inflow Hydrograph BCs in BaldEagleCrkMulti2D (DSS-linked, count=0)\n2. Attempted read with `get_uniform_lateral_inflow_hydrograph()` -- returns None (expected for DSS-linked)\n3. Wrote synthetic triangular hydrograph (25 values, peak 500 cfs) with `set_uniform_lateral_inflow_hydrograph()`\n4. Re-read and verified round-trip: flow values match, slope updated\n5. **Result**: Round-trip verification PASSED -- reach-based uniform lateral inflow API works correctly\n\n### Initial Conditions Method Selection Verification (Step 13)\n\n1. Read IC method from 3 BaldEagle unsteady files: `.u08` (initial_flow_distribution, 8 IC lines), `.u03` (none), `.u01` (initial_flow_distribution, 1 IC line)\n2. Verified `get_initial_flow_method()` correctly infers the implicit state machine\n3. Round-trip tested `set_initial_flow_method()`: initial_flow_distribution -> restart_file -> none -> initial_flow_distribution\n4. **Result**: All state transitions verified correctly\n\n### Prior Water Surface Filename Verification (Step 14)\n\n1. Started from `.u03` (method=none, no Prior WS) as clean baseline\n2. Verified `get_prior_ws_filename()` returns None before setting\n3. Set Prior WS via `set_prior_ws_filename()` with plan file and profile name\n4. Read back and verified: filename and profile match, `get_initial_flow_method()` detects `prior_ws`\n5. Round-trip tested state transitions: none -> prior_ws -> none -> prior_ws -> restart_file\n6. Verified Prior WS keys are properly stripped when switching away from `prior_ws` method\n7. **Result**: All Prior WS state transitions verified correctly\n\n### Key Features\n\n- **QMult insertion**: Automatically inserts line if not present\n- **TW Check setter**: Set/toggle tailwater check flag with `set_stage_hydrograph_tw_check()`\n- **Stage/Flow Hydrograph**: Read/write interleaved (stage, flow) pairs for internal BCs\n- **Lateral Inflow Hydrograph**: Dedicated read/write with slope integration and metadata via `df.attrs`\n- **Uniform Lateral Inflow Hydrograph**: Reach-based BC read/write with slope and metadata support\n- **IC Method Selection**: Detect and set the implicit Initial Conditions state machine (restart_file / prior_ws / initial_flow_distribution / none)\n- **Prior WS Filename**: Read/write Prior WS Filename and Profile for using steady-state results as IC\n- **Partial station matching**: Matches stations even with coordinates appended\n- **Batch efficiency**: Single file read/write for multiple updates\n- **Safe updates**: Optional `old_a_part` validation prevents accidental overwrites\n- **Complete state transitions**: Inline to DSS and DSS to Inline with round-trip fidelity\n- **Inline data cleanup**: `set_boundary_dss_link()` removes inline table data when switching to DSS\n- **Verified correctness**: Computational tests prove state transitions are lossless and QMult affects results\n\n### Initial Conditions Table API (Step 15)\n\n| Method | Purpose |\n|--------|--------|\n|  | Read IC entries from .u## as list of dicts |\n|  | Write IC entries (DataFrame or list of dicts) |\n|  | Check IC stations match geometry XS |\n\n accepts  in addition to , and automatically sets the IC method to Initial Flow Distribution when  (default).\n\n### Non-Newtonian Method Selection (Step 16)\n\n| Method | Purpose |\n|--------|--------|\n| `get_non_newtonian_method()` | Read NN method integer and name from .u## |\n| `set_non_newtonian_method()` | Set NN method by integer (0-5) or name string |\n\nSupports all 6 HEC-RAS Non-Newtonian methods: Newtonian (0), Bulking Only (1), Bingham (2), O'Brien Quadratic (3), Herschel-Bulkley (4), Voellmy (5).",
+   "source": "## Step 17: Non-Newtonian Concentration and Bulking Parameters\n\nThe `.u##` file stores concentration and bulking settings for Non-Newtonian analyses:\n\n| Key | Description |\n|-----|-------------|\n| `Non-Newtonian Constant Vol Conc` | Volumetric concentration Cv (%) |\n| `Non-Newtonian Bulking Method` | 0=Do Not Bulk, 1=Bulk Fluid Volume |\n| `Non-Newtonian Max Cv` | Maximum volumetric concentration (%) |\n\n**Important**: Cv is entered as a *percentage* (e.g., 30 for 30%), not as a decimal."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# --- Step 17a: Read concentration and bulking parameters ---\nconc = RasUnsteady.get_non_newtonian_concentration(u02_orig)\nprint(\"Concentration parameters:\")\nfor k, v in conc.items():\n    print(f\"  {k}: {v}\")"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# --- Step 17b: Round-trip set_non_newtonian_concentration() ---\nshutil.copy2(u02_orig, u02_copy)\n\n# Set concentration parameters\nRasUnsteady.set_non_newtonian_concentration(\n    u02_orig, cv=25.0, bulking_method=1, max_cv=61.5\n)\ncheck = RasUnsteady.get_non_newtonian_concentration(u02_orig)\nprint(f\"After set: cv={check['cv']}%, bulking={check['bulking_method_name']}, max_cv={check['max_cv']}%\")\n\n# Set bulking by name\nRasUnsteady.set_non_newtonian_concentration(u02_orig, bulking_method=\"Do Not Bulk\")\ncheck = RasUnsteady.get_non_newtonian_concentration(u02_orig)\nprint(f\"After set bulking by name: {check['bulking_method_name']}\")\n\n# Restore original\nshutil.copy2(u02_copy, u02_orig)\nu02_copy.unlink()\nprint(\"\nRestored original .u02\")"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Summary\n\nThis notebook demonstrated the enhanced `boundaries_df` features:\n\n### New DataFrame Columns\n\n| Column | Description | Use Case |\n|--------|-------------|----------|\n| `Flow Hydrograph QMult` | Flow multiplier value | Sensitivity analysis |\n| `Flow Hydrograph QMin` | Minimum flow threshold | Low flow conditions |\n| `Stage Hydrograph TW Check` | Tailwater check flag (0/1) | Flow Hydrograph TW control |\n| `dss_part_a` | HMS subbasin/location | HMS-RAS linking |\n| `dss_part_b` | Parameter (FLOW/STAGE) | Data type identification |\n| `dss_part_c` | Date reference | Time synchronization |\n| `dss_part_d` | Time interval | Timestep verification |\n| `dss_part_e` | Run identifier | Scenario tracking |\n| `dss_part_f` | Additional ID | Optional metadata |\n\n### Update Methods\n\n| Method | Purpose |\n|--------|---------|\n| `RasUnsteady.update_dss_path_by_station()` | Update DSS A-part by river station |\n| `RasUnsteady.update_flow_multiplier_by_station()` | Update/insert QMult value |\n| `RasUnsteady.update_boundary_dss_paths()` | Batch update multiple boundaries |\n| `RasUnsteady.set_stage_hydrograph_tw_check()` | Set TW Check flag (0 or 1) on Flow Hydrograph BC |\n\n### State Transition Methods\n\n| Method | Direction | Purpose |\n|--------|-----------|---------|\n| `RasUnsteady.set_boundary_dss_link()` | Inline to DSS | Remove inline data, set DSS File/Path, Use DSS=True |\n| `RasUnsteady.set_boundary_inline_hydrograph()` | DSS to Inline | Write inline data, clear DSS fields, Use DSS=False |\n| `RasUnsteady.get_inline_hydrograph_boundaries()` | Read | Extract all inline hydrograph boundaries with values |\n\n### Stage/Flow Hydrograph Methods (Internal Boundaries)\n\n| Method | Purpose |\n|--------|---------|\n| `RasUnsteady.get_stage_flow_hydrograph()` | Read interleaved stage/flow pairs from `.u##` file |\n| `RasUnsteady.set_stage_flow_hydrograph()` | Write or replace stage/flow pairs in `.u##` file |\n\n### Lateral Inflow Hydrograph Methods (Step 11)\n\n| Method | Purpose |\n|--------|---------|\n| `RasUnsteady.get_lateral_inflow_hydrograph()` | Read lateral inflow values + metadata (interval, slope) from `.u##` file |\n| `RasUnsteady.set_lateral_inflow_hydrograph()` | Write/replace lateral inflow values, optionally update `Flow Hydrograph Slope=` |\n\n### Uniform Lateral Inflow Hydrograph Methods (Step 12)\n\n| Method | Purpose |\n|--------|---------|\n| `RasUnsteady.get_uniform_lateral_inflow_hydrograph()` | Read uniform lateral inflow values + metadata from `.u##` file |\n| `RasUnsteady.set_uniform_lateral_inflow_hydrograph()` | Write/replace uniform lateral inflow values, optionally update slope |\n\n### Initial Conditions Method Selection (Steps 13-14)\n\n| Method | Purpose |\n|--------|---------|\n| `RasUnsteady.get_initial_flow_method()` | Determine which IC method is active (restart_file, prior_ws, initial_flow_distribution, or none) |\n| `RasUnsteady.set_initial_flow_method()` | Set the IC method selection and manage `Use Restart` / `Restart Filename` / `Prior WS Filename` keys |\n| `RasUnsteady.get_prior_ws_filename()` | Read Prior WS Filename and Profile from `.u##` file |\n| `RasUnsteady.set_prior_ws_filename()` | Write Prior WS Filename and Profile (convenience wrapper for `set_initial_flow_method(method=\"prior_ws\")`) |\n\n### Computational Verification (Step 9)\n\nThree independent HEC-RAS computations verified the implementation:\n\n**Step 9a: Round-Trip Fidelity Test**\n1. Computed **baseline** plan with original inline boundary conditions\n2. Performed inline -> DSS -> inline **round-trip** on a second copy\n3. Computed the **round-trip** plan\n4. Compared cross section results via `HdfResultsXsec.get_xsec_timeseries()`\n5. **Result**: All Water Surface, Flow, and Velocity matched exactly (max diff = 0.000000)\n\n**Step 9b: QMult Sensitivity Test**\n1. Inserted `Flow Hydrograph QMult=0.50` on a third copy\n2. Computed the **QMult** plan with 50% of baseline flow\n3. Compared cross section results against baseline\n4. **Result**: All cross sections showed lower WSE with reduced flow (QMult correctly applied)\n\n### Stage/Flow Hydrograph Verification (Step 10)\n\n1. Extracted **Internal Stage and Flow Boundary Condition** fixture project\n2. Read observed stage/flow hydrograph at internal BC station with `get_stage_flow_hydrograph()`\n3. Scaled flows by 1.25x and wrote back with `set_stage_flow_hydrograph()`\n4. Re-read and verified round-trip: stage values unchanged, flow values match scaled values\n5. **Result**: Round-trip verification PASSED\n\n### Lateral Inflow Hydrograph Verification (Step 11)\n\n1. Read lateral inflow hydrograph from BaldEagleCrkMulti2D with `get_lateral_inflow_hydrograph()`\n2. Verified metadata extraction: interval, slope, matched_location via `df.attrs`\n3. Scaled flows by 1.5x and wrote back with new slope using `set_lateral_inflow_hydrograph()`\n4. Re-read and verified round-trip: flow values match, slope updated\n5. **Result**: Round-trip verification PASSED\n\n### Uniform Lateral Inflow Hydrograph Verification (Step 12)\n\n1. Found Uniform Lateral Inflow Hydrograph BCs in BaldEagleCrkMulti2D (DSS-linked, count=0)\n2. Attempted read with `get_uniform_lateral_inflow_hydrograph()` -- returns None (expected for DSS-linked)\n3. Wrote synthetic triangular hydrograph (25 values, peak 500 cfs) with `set_uniform_lateral_inflow_hydrograph()`\n4. Re-read and verified round-trip: flow values match, slope updated\n5. **Result**: Round-trip verification PASSED -- reach-based uniform lateral inflow API works correctly\n\n### Initial Conditions Method Selection Verification (Step 13)\n\n1. Read IC method from 3 BaldEagle unsteady files: `.u08` (initial_flow_distribution, 8 IC lines), `.u03` (none), `.u01` (initial_flow_distribution, 1 IC line)\n2. Verified `get_initial_flow_method()` correctly infers the implicit state machine\n3. Round-trip tested `set_initial_flow_method()`: initial_flow_distribution -> restart_file -> none -> initial_flow_distribution\n4. **Result**: All state transitions verified correctly\n\n### Prior Water Surface Filename Verification (Step 14)\n\n1. Started from `.u03` (method=none, no Prior WS) as clean baseline\n2. Verified `get_prior_ws_filename()` returns None before setting\n3. Set Prior WS via `set_prior_ws_filename()` with plan file and profile name\n4. Read back and verified: filename and profile match, `get_initial_flow_method()` detects `prior_ws`\n5. Round-trip tested state transitions: none -> prior_ws -> none -> prior_ws -> restart_file\n6. Verified Prior WS keys are properly stripped when switching away from `prior_ws` method\n7. **Result**: All Prior WS state transitions verified correctly\n\n### Key Features\n\n- **QMult insertion**: Automatically inserts line if not present\n- **TW Check setter**: Set/toggle tailwater check flag with `set_stage_hydrograph_tw_check()`\n- **Stage/Flow Hydrograph**: Read/write interleaved (stage, flow) pairs for internal BCs\n- **Lateral Inflow Hydrograph**: Dedicated read/write with slope integration and metadata via `df.attrs`\n- **Uniform Lateral Inflow Hydrograph**: Reach-based BC read/write with slope and metadata support\n- **IC Method Selection**: Detect and set the implicit Initial Conditions state machine (restart_file / prior_ws / initial_flow_distribution / none)\n- **Prior WS Filename**: Read/write Prior WS Filename and Profile for using steady-state results as IC\n- **Partial station matching**: Matches stations even with coordinates appended\n- **Batch efficiency**: Single file read/write for multiple updates\n- **Safe updates**: Optional `old_a_part` validation prevents accidental overwrites\n- **Complete state transitions**: Inline to DSS and DSS to Inline with round-trip fidelity\n- **Inline data cleanup**: `set_boundary_dss_link()` removes inline table data when switching to DSS\n- **Verified correctness**: Computational tests prove state transitions are lossless and QMult affects results\n\n### Initial Conditions Table API (Step 15)\n\n| Method | Purpose |\n|--------|--------|\n|  | Read IC entries from .u## as list of dicts |\n|  | Write IC entries (DataFrame or list of dicts) |\n|  | Check IC stations match geometry XS |\n\n accepts  in addition to , and automatically sets the IC method to Initial Flow Distribution when  (default).\n\n### Non-Newtonian Parameters (Steps 16-17)\n\n| Method | Description |\n|--------|-------------|\n| `get_non_newtonian_method()` | Read method ID and name from .u## |\n| `set_non_newtonian_method()` | Set method by int (0-4) or name string |\n| `get_non_newtonian_concentration()` | Read Cv, bulking method, max Cv |\n| `set_non_newtonian_concentration()` | Set Cv, bulking method, max Cv |\n\nMethod enum verified via binary analysis of Ras.exe (0=Newtonian, 1=Bingham, 2=O'Brien, 3=Clastic, 4=Herschel-Bulkley).",
    "id": "19a2ae8a"
   },
   {

--- a/ras_commander/AGENTS.md
+++ b/ras_commander/AGENTS.md
@@ -12,7 +12,7 @@ This file is the canonical local instruction file for the `ras_commander/` packa
 
 - Project management: `RasPrj`, `init_ras_project()`
 - Plan execution: `RasCmdr`
-- Plan and model files: `RasPlan`, `RasMap`, `RasControl`, `RasUnsteady` (includes IC method selection: `get_initial_flow_method()`, `set_initial_flow_method()`, `get_prior_ws_filename()`, `set_prior_ws_filename()`; IC table: `get_initial_conditions()`, `set_initial_conditions()`, `validate_initial_flow_stations()`; Non-Newtonian: `get_non_newtonian_method()`, `set_non_newtonian_method()`)
+- Plan and model files: `RasPlan`, `RasMap`, `RasControl`, `RasUnsteady` (includes IC method selection: `get_initial_flow_method()`, `set_initial_flow_method()`, `get_prior_ws_filename()`, `set_prior_ws_filename()`; IC table: `get_initial_conditions()`, `set_initial_conditions()`, `validate_initial_flow_stations()`; Non-Newtonian: `get_non_newtonian_method()`, `set_non_newtonian_method()`, `get_non_newtonian_concentration()`, `set_non_newtonian_concentration()`)
 - Validation framework: `RasValidation`
 - HDF access: `Hdf*` classes and `ras_commander/hdf/`
 - Domain subpackages: `geom/`, `remote/`, `usgs/`, `check/`, `dss/`, `fixit/`, `precip/`, `gui/`, `terrain/`

--- a/ras_commander/RasUnsteady.py
+++ b/ras_commander/RasUnsteady.py
@@ -468,11 +468,15 @@ class RasUnsteady:
 
     NON_NEWTONIAN_METHODS = {
         0: "Newtonian Assumptions",
-        1: "Bulking Only",
-        2: "Bingham",
-        3: "O'Brien (Quadratic)",
-        4: "Herschel-Bulkley",
-        5: "Voellmy",
+        1: "Bingham",
+        2: "O'Brien (Quadratic)",
+        3: "Clastic Grain-Flow",
+        4: "Generalized Herschel-Bulkley",
+    }
+
+    BULKING_METHODS = {
+        0: "Do Not Bulk",
+        1: "Bulk Fluid Volume",
     }
 
     @staticmethod
@@ -494,7 +498,7 @@ class RasUnsteady:
         Returns
         -------
         dict
-            ``method_id`` (int): Integer method code (0-5).
+            ``method_id`` (int): Integer method code (0-4).
             ``method_name`` (str): Human-readable method name.
         """
         unsteady_file = RasUnsteady._resolve_unsteady_file_path(
@@ -526,17 +530,17 @@ class RasUnsteady:
         unsteady_number_or_path : str or Path
             Unsteady flow number (e.g. ``"03"``) or path to a ``.u##`` file.
         method : int or str
-            Method to set. Accepts integer (0-5) or name string:
-            ``0``/``"Newtonian Assumptions"``, ``1``/``"Bulking Only"``,
-            ``2``/``"Bingham"``, ``3``/``"O'Brien (Quadratic)"``,
-            ``4``/``"Herschel-Bulkley"``, ``5``/``"Voellmy"``.
+            Method to set. Accepts integer (0-4) or name string:
+            ``0``/``"Newtonian Assumptions"``, ``1``/``"Bingham"``,
+            ``2``/``"O'Brien (Quadratic)"``, ``3``/``"Clastic Grain-Flow"``,
+            ``4``/``"Generalized Herschel-Bulkley"``.
         ras_object : RasPrj, optional
             RAS project object. If None, uses the global ``ras`` object.
 
         Raises
         ------
         ValueError
-            If the method is not a valid integer (0-5) or recognized name.
+            If the method is not a valid integer (0-4) or recognized name.
         """
         if isinstance(method, int):
             method_id = method
@@ -557,7 +561,7 @@ class RasUnsteady:
 
         if method_id not in RasUnsteady.NON_NEWTONIAN_METHODS:
             raise ValueError(
-                f"Invalid method_id {method_id}. Must be 0-5: "
+                f"Invalid method_id {method_id}. Must be 0-4: "
                 f"{RasUnsteady.NON_NEWTONIAN_METHODS}"
             )
 
@@ -570,7 +574,7 @@ class RasUnsteady:
         found = False
         for i, line in enumerate(lines):
             if line.startswith("Non-Newtonian Method="):
-                lines[i] = f"Non-Newtonian Method= {method_id} ,\n"
+                lines[i] = f"Non-Newtonian Method= {method_id} \n"
                 found = True
                 break
 
@@ -589,6 +593,132 @@ class RasUnsteady:
             f"({RasUnsteady.NON_NEWTONIAN_METHODS[method_id]}) "
             f"in {unsteady_file.name}"
         )
+
+    @staticmethod
+    @log_call
+    def get_non_newtonian_concentration(
+        unsteady_number_or_path: Union[str, Path],
+        ras_object: Optional[Any] = None,
+    ) -> Dict[str, Any]:
+        """
+        Read Non-Newtonian concentration and bulking parameters from a .u## file.
+
+        Parameters
+        ----------
+        unsteady_number_or_path : str or Path
+            Unsteady flow number (e.g. ``"02"``) or path to a ``.u##`` file.
+        ras_object : RasPrj, optional
+            RAS project object. If None, uses the global ``ras`` object.
+
+        Returns
+        -------
+        dict
+            ``cv`` (float): Volumetric concentration in percent.
+            ``bulking_method`` (int): 0=Do Not Bulk, 1=Bulk Fluid Volume.
+            ``bulking_method_name`` (str): Human-readable bulking method name.
+            ``max_cv`` (float): Maximum volumetric concentration in percent.
+        """
+        unsteady_file = RasUnsteady._resolve_unsteady_file_path(
+            unsteady_number_or_path, ras_object=ras_object,
+        )
+        result = {'cv': 0.0, 'bulking_method': 0, 'bulking_method_name': 'Do Not Bulk', 'max_cv': 0.0}
+        key_map = {
+            'Non-Newtonian Constant Vol Conc=': 'cv',
+            'Non-Newtonian Max Cv=': 'max_cv',
+        }
+        with open(unsteady_file, 'r') as f:
+            for line in f:
+                for key, field in key_map.items():
+                    if line.startswith(key):
+                        val_str = line.split('=', 1)[1].strip()
+                        try:
+                            result[field] = float(val_str)
+                        except ValueError:
+                            pass
+                if line.startswith('Non-Newtonian Bulking Method='):
+                    val_str = line.split('=', 1)[1].strip()
+                    try:
+                        bm = int(val_str)
+                        result['bulking_method'] = bm
+                        result['bulking_method_name'] = RasUnsteady.BULKING_METHODS.get(
+                            bm, f"Unknown ({bm})"
+                        )
+                    except ValueError:
+                        pass
+        return result
+
+    @staticmethod
+    @log_call
+    def set_non_newtonian_concentration(
+        unsteady_number_or_path: Union[str, Path],
+        cv: Optional[float] = None,
+        bulking_method: Optional[Union[int, str]] = None,
+        max_cv: Optional[float] = None,
+        ras_object: Optional[Any] = None,
+    ) -> None:
+        """
+        Set Non-Newtonian concentration and bulking parameters in a .u## file.
+
+        Parameters
+        ----------
+        unsteady_number_or_path : str or Path
+            Unsteady flow number (e.g. ``"02"``) or path to a ``.u##`` file.
+        cv : float, optional
+            Volumetric concentration in percent (e.g. 30.0 for 30%).
+        bulking_method : int or str, optional
+            ``0``/``"Do Not Bulk"`` or ``1``/``"Bulk Fluid Volume"``.
+        max_cv : float, optional
+            Maximum volumetric concentration in percent.
+        ras_object : RasPrj, optional
+            RAS project object. If None, uses the global ``ras`` object.
+        """
+        if cv is None and bulking_method is None and max_cv is None:
+            return
+
+        if bulking_method is not None:
+            if isinstance(bulking_method, str):
+                name_to_id = {v.lower(): k for k, v in RasUnsteady.BULKING_METHODS.items()}
+                bm_lower = bulking_method.lower().strip()
+                if bm_lower in name_to_id:
+                    bulking_method = name_to_id[bm_lower]
+                elif bulking_method.strip().isdigit():
+                    bulking_method = int(bulking_method.strip())
+                else:
+                    raise ValueError(
+                        f"Unknown bulking method: '{bulking_method}'. "
+                        f"Valid: {list(RasUnsteady.BULKING_METHODS.values())}"
+                    )
+            if bulking_method not in RasUnsteady.BULKING_METHODS:
+                raise ValueError(
+                    f"Invalid bulking_method {bulking_method}. Must be 0-1: "
+                    f"{RasUnsteady.BULKING_METHODS}"
+                )
+
+        unsteady_file = RasUnsteady._resolve_unsteady_file_path(
+            unsteady_number_or_path, ras_object=ras_object,
+        )
+        with open(unsteady_file, 'r') as f:
+            lines = f.readlines()
+
+        for i, line in enumerate(lines):
+            if cv is not None and line.startswith('Non-Newtonian Constant Vol Conc='):
+                lines[i] = f"Non-Newtonian Constant Vol Conc={cv}\n"
+            elif bulking_method is not None and line.startswith('Non-Newtonian Bulking Method='):
+                lines[i] = f"Non-Newtonian Bulking Method= {bulking_method} \n"
+            elif max_cv is not None and line.startswith('Non-Newtonian Max Cv='):
+                lines[i] = f"Non-Newtonian Max Cv={max_cv}\n"
+
+        with open(unsteady_file, 'w') as f:
+            f.writelines(lines)
+
+        changes = []
+        if cv is not None:
+            changes.append(f"cv={cv}%")
+        if bulking_method is not None:
+            changes.append(f"bulking={RasUnsteady.BULKING_METHODS[bulking_method]}")
+        if max_cv is not None:
+            changes.append(f"max_cv={max_cv}%")
+        logger.info(f"Set NN concentration params ({', '.join(changes)}) in {unsteady_file.name}")
 
     @staticmethod
     @log_call


### PR DESCRIPTION
## Summary
- **Breaking fix**: Corrects `NON_NEWTONIAN_METHODS` dict from documentation-inferred 6-method mapping to ground-truth 5-method mapping (0-4) verified via binary analysis of `Ras.exe` VB6 assembly
- Adds `BULKING_METHODS` dict, `get_non_newtonian_concentration()`, and `set_non_newtonian_concentration()` for Cv, bulking method, and max Cv parameters
- Notebook 312 Steps 16-17 updated with corrected enum table and concentration/bulking demo

## Method enum correction
| Old (docs-inferred) | New (binary ground-truth) |
|-----|-----|
| 0=Newtonian, 1=Bulking Only, 2=Bingham, 3=O'Brien, 4=HB, 5=Voellmy | 0=Newtonian, 1=Bingham, 2=O'Brien, 3=Clastic, 4=HB |

Voellmy is a sub-selector under Clastic (`Clastic Method= 1`), not a top-level method. "Bulking Only" is a parameter (`Non-Newtonian Bulking Method=`), not a method.

## Test plan
- [x] Notebook 312 Step 16: corrected method table and round-trip test
- [x] Notebook 312 Step 17: read/set concentration params with BaldEagle .u02
- [x] AGENTS.md updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)