### PR TITLE
feat(unsteady): add yield/viscosity shear API (CLB-745)

### DIFF
--- a/examples/312_boundary_df_qmult_dss_paths.ipynb
+++ b/examples/312_boundary_df_qmult_dss_paths.ipynb
@@ -1327,6 +1327,77 @@
   {
    "cell_type": "markdown",
    "metadata": {},
+   "source": [
+    "## Step 18: Non-Newtonian Shear Components (Yield Stress & Viscosity)\n",
+    "\n",
+    "Beyond the method selector and concentration, Non-Newtonian models require\n",
+    "**yield stress** and **viscosity** parameters. These are stored as separate\n",
+    "keys in the  file:\n",
+    "\n",
+    "| Key | Type | Description |\n",
+    "|-----|------|-------------|\n",
+    "|  | int | 0=Exponential, 1=User Yield |\n",
+    "|  | float, float | Exponential coefficients (a, b) for τ_y = a·e^(b·Cv) |\n",
+    "|  | float | Constant user yield stress (Pa) — note canonical typo |\n",
+    "|  | int | 0=Use Coulomb, 1=Maron & Pierce, 2=User Viscosity, 3=User Visc Ratio |\n",
+    "|  | float | O’Brien exponential viscosity B coefficient |\n",
+    "|  | float | User-defined dynamic viscosity (Pa·s) |\n",
+    "|  | float | Viscosity ratio multiplier |\n",
+    "\n",
+    "The  /  API provides\n",
+    "unified read/write access to all seven parameters in a single call."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "# --- Step 18a: Read shear parameters from .u02 ---\n",
+    "shear = RasUnsteady.get_non_newtonian_shear(u02_orig)\n",
+    "print(\"Shear parameters (yield stress + viscosity):\")\n",
+    "for k, v in shear.items():\n",
+    "    print(f\"  {k}: {v}\")\n",
+    "\n",
+    "print(f\"\nYield methods:  {RasUnsteady.YIELD_METHODS}\")\n",
+    "print(f\"Viscosity methods: {RasUnsteady.VISCOSITY_METHODS}\")"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "# --- Step 18b: Round-trip set_non_newtonian_shear() ---\n",
+    "shutil.copy2(u02_orig, u02_copy)\n",
+    "\n",
+    "# Set yield and viscosity parameters for a Bingham model\n",
+    "RasUnsteady.set_non_newtonian_shear(\n",
+    "    u02_copy,\n",
+    "    yield_method=0,            # Exponential\n",
+    "    yield_coef=(0.0765, 16.9), # Typical O’Brien coefficients\n",
+    "    visc_method=2,             # User Defined Viscosity\n",
+    "    user_viscosity=0.15,       # 0.15 Pa·s\n",
+    ")\n",
+    "\n",
+    "# Verify round-trip\n",
+    "after = RasUnsteady.get_non_newtonian_shear(u02_copy)\n",
+    "print(\"After set_non_newtonian_shear():\")\n",
+    "print(f\"  yield_method:  {after[\"yield_method\"]} ({after[\"yield_method_name\"]})\")\n",
+    "print(f\"  yield_coef:    {after[\"yield_coef\"]}\")\n",
+    "print(f\"  visc_method:   {after[\"visc_method\"]} ({after[\"visc_method_name\"]})\")\n",
+    "print(f\"  user_viscosity: {after[\"user_viscosity\"]}\")\n",
+    "\n",
+    "# Clean up copy\n",
+    "u02_copy.unlink(missing_ok=True)\n",
+    "print(\"\nRound-trip verified.\")"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
    "source": "## Summary\n\nThis notebook demonstrated the enhanced `boundaries_df` features:\n\n### New DataFrame Columns\n\n| Column | Description | Use Case |\n|--------|-------------|----------|\n| `Flow Hydrograph QMult` | Flow multiplier value | Sensitivity analysis |\n| `Flow Hydrograph QMin` | Minimum flow threshold | Low flow conditions |\n| `Stage Hydrograph TW Check` | Tailwater check flag (0/1) | Flow Hydrograph TW control |\n| `dss_part_a` | HMS subbasin/location | HMS-RAS linking |\n| `dss_part_b` | Parameter (FLOW/STAGE) | Data type identification |\n| `dss_part_c` | Date reference | Time synchronization |\n| `dss_part_d` | Time interval | Timestep verification |\n| `dss_part_e` | Run identifier | Scenario tracking |\n| `dss_part_f` | Additional ID | Optional metadata |\n\n### Update Methods\n\n| Method | Purpose |\n|--------|---------|\n| `RasUnsteady.update_dss_path_by_station()` | Update DSS A-part by river station |\n| `RasUnsteady.update_flow_multiplier_by_station()` | Update/insert QMult value |\n| `RasUnsteady.update_boundary_dss_paths()` | Batch update multiple boundaries |\n| `RasUnsteady.set_stage_hydrograph_tw_check()` | Set TW Check flag (0 or 1) on Flow Hydrograph BC |\n\n### State Transition Methods\n\n| Method | Direction | Purpose |\n|--------|-----------|---------|\n| `RasUnsteady.set_boundary_dss_link()` | Inline to DSS | Remove inline data, set DSS File/Path, Use DSS=True |\n| `RasUnsteady.set_boundary_inline_hydrograph()` | DSS to Inline | Write inline data, clear DSS fields, Use DSS=False |\n| `RasUnsteady.get_inline_hydrograph_boundaries()` | Read | Extract all inline hydrograph boundaries with values |\n\n### Stage/Flow Hydrograph Methods (Internal Boundaries)\n\n| Method | Purpose |\n|--------|---------|\n| `RasUnsteady.get_stage_flow_hydrograph()` | Read interleaved stage/flow pairs from `.u##` file |\n| `RasUnsteady.set_stage_flow_hydrograph()` | Write or replace stage/flow pairs in `.u##` file |\n\n### Lateral Inflow Hydrograph Methods (Step 11)\n\n| Method | Purpose |\n|--------|---------|\n| `RasUnsteady.get_lateral_inflow_hydrograph()` | Read lateral inflow values + metadata (interval, slope) from `.u##` file |\n| `RasUnsteady.set_lateral_inflow_hydrograph()` | Write/replace lateral inflow values, optionally update `Flow Hydrograph Slope=` |\n\n### Uniform Lateral Inflow Hydrograph Methods (Step 12)\n\n| Method | Purpose |\n|--------|---------|\n| `RasUnsteady.get_uniform_lateral_inflow_hydrograph()` | Read uniform lateral inflow values + metadata from `.u##` file |\n| `RasUnsteady.set_uniform_lateral_inflow_hydrograph()` | Write/replace uniform lateral inflow values, optionally update slope |\n\n### Initial Conditions Method Selection (Steps 13-14)\n\n| Method | Purpose |\n|--------|---------|\n| `RasUnsteady.get_initial_flow_method()` | Determine which IC method is active (restart_file, prior_ws, initial_flow_distribution, or none) |\n| `RasUnsteady.set_initial_flow_method()` | Set the IC method selection and manage `Use Restart` / `Restart Filename` / `Prior WS Filename` keys |\n| `RasUnsteady.get_prior_ws_filename()` | Read Prior WS Filename and Profile from `.u##` file |\n| `RasUnsteady.set_prior_ws_filename()` | Write Prior WS Filename and Profile (convenience wrapper for `set_initial_flow_method(method=\"prior_ws\")`) |\n\n### Computational Verification (Step 9)\n\nThree independent HEC-RAS computations verified the implementation:\n\n**Step 9a: Round-Trip Fidelity Test**\n1. Computed **baseline** plan with original inline boundary conditions\n2. Performed inline -> DSS -> inline **round-trip** on a second copy\n3. Computed the **round-trip** plan\n4. Compared cross section results via `HdfResultsXsec.get_xsec_timeseries()`\n5. **Result**: All Water Surface, Flow, and Velocity matched exactly (max diff = 0.000000)\n\n**Step 9b: QMult Sensitivity Test**\n1. Inserted `Flow Hydrograph QMult=0.50` on a third copy\n2. Computed the **QMult** plan with 50% of baseline flow\n3. Compared cross section results against baseline\n4. **Result**: All cross sections showed lower WSE with reduced flow (QMult correctly applied)\n\n### Stage/Flow Hydrograph Verification (Step 10)\n\n1. Extracted **Internal Stage and Flow Boundary Condition** fixture project\n2. Read observed stage/flow hydrograph at internal BC station with `get_stage_flow_hydrograph()`\n3. Scaled flows by 1.25x and wrote back with `set_stage_flow_hydrograph()`\n4. Re-read and verified round-trip: stage values unchanged, flow values match scaled values\n5. **Result**: Round-trip verification PASSED\n\n### Lateral Inflow Hydrograph Verification (Step 11)\n\n1. Read lateral inflow hydrograph from BaldEagleCrkMulti2D with `get_lateral_inflow_hydrograph()`\n2. Verified metadata extraction: interval, slope, matched_location via `df.attrs`\n3. Scaled flows by 1.5x and wrote back with new slope using `set_lateral_inflow_hydrograph()`\n4. Re-read and verified round-trip: flow values match, slope updated\n5. **Result**: Round-trip verification PASSED\n\n### Uniform Lateral Inflow Hydrograph Verification (Step 12)\n\n1. Found Uniform Lateral Inflow Hydrograph BCs in BaldEagleCrkMulti2D (DSS-linked, count=0)\n2. Attempted read with `get_uniform_lateral_inflow_hydrograph()` -- returns None (expected for DSS-linked)\n3. Wrote synthetic triangular hydrograph (25 values, peak 500 cfs) with `set_uniform_lateral_inflow_hydrograph()`\n4. Re-read and verified round-trip: flow values match, slope updated\n5. **Result**: Round-trip verification PASSED -- reach-based uniform lateral inflow API works correctly\n\n### Initial Conditions Method Selection Verification (Step 13)\n\n1. Read IC method from 3 BaldEagle unsteady files: `.u08` (initial_flow_distribution, 8 IC lines), `.u03` (none), `.u01` (initial_flow_distribution, 1 IC line)\n2. Verified `get_initial_flow_method()` correctly infers the implicit state machine\n3. Round-trip tested `set_initial_flow_method()`: initial_flow_distribution -> restart_file -> none -> initial_flow_distribution\n4. **Result**: All state transitions verified correctly\n\n### Prior Water Surface Filename Verification (Step 14)\n\n1. Started from `.u03` (method=none, no Prior WS) as clean baseline\n2. Verified `get_prior_ws_filename()` returns None before setting\n3. Set Prior WS via `set_prior_ws_filename()` with plan file and profile name\n4. Read back and verified: filename and profile match, `get_initial_flow_method()` detects `prior_ws`\n5. Round-trip tested state transitions: none -> prior_ws -> none -> prior_ws -> restart_file\n6. Verified Prior WS keys are properly stripped when switching away from `prior_ws` method\n7. **Result**: All Prior WS state transitions verified correctly\n\n### Key Features\n\n- **QMult insertion**: Automatically inserts line if not present\n- **TW Check setter**: Set/toggle tailwater check flag with `set_stage_hydrograph_tw_check()`\n- **Stage/Flow Hydrograph**: Read/write interleaved (stage, flow) pairs for internal BCs\n- **Lateral Inflow Hydrograph**: Dedicated read/write with slope integration and metadata via `df.attrs`\n- **Uniform Lateral Inflow Hydrograph**: Reach-based BC read/write with slope and metadata support\n- **IC Method Selection**: Detect and set the implicit Initial Conditions state machine (restart_file / prior_ws / initial_flow_distribution / none)\n- **Prior WS Filename**: Read/write Prior WS Filename and Profile for using steady-state results as IC\n- **Partial station matching**: Matches stations even with coordinates appended\n- **Batch efficiency**: Single file read/write for multiple updates\n- **Safe updates**: Optional `old_a_part` validation prevents accidental overwrites\n- **Complete state transitions**: Inline to DSS and DSS to Inline with round-trip fidelity\n- **Inline data cleanup**: `set_boundary_dss_link()` removes inline table data when switching to DSS\n- **Verified correctness**: Computational tests prove state transitions are lossless and QMult affects results\n\n### Initial Conditions Table API (Step 15)\n\n| Method | Purpose |\n|--------|--------|\n|  | Read IC entries from .u## as list of dicts |\n|  | Write IC entries (DataFrame or list of dicts) |\n|  | Check IC stations match geometry XS |\n\n accepts  in addition to , and automatically sets the IC method to Initial Flow Distribution when  (default).\n\n### Non-Newtonian Parameters (Steps 16-17)\n\n| Method | Description |\n|--------|-------------|\n| `get_non_newtonian_method()` | Read method ID and name from .u## |\n| `set_non_newtonian_method()` | Set method by int (0-4) or name string |\n| `get_non_newtonian_concentration()` | Read Cv, bulking method, max Cv |\n| `set_non_newtonian_concentration()` | Set Cv, bulking method, max Cv |\n\nMethod enum verified via binary analysis of Ras.exe (0=Newtonian, 1=Bingham, 2=O'Brien, 3=Clastic, 4=Herschel-Bulkley).",
    "id": "19a2ae8a"
   },

--- a/ras_commander/AGENTS.md
+++ b/ras_commander/AGENTS.md
@@ -12,7 +12,7 @@ This file is the canonical local instruction file for the `ras_commander/` packa
 
 - Project management: `RasPrj`, `init_ras_project()`
 - Plan execution: `RasCmdr`
-- Plan and model files: `RasPlan`, `RasMap`, `RasControl`, `RasUnsteady` (includes IC method selection: `get_initial_flow_method()`, `set_initial_flow_method()`, `get_prior_ws_filename()`, `set_prior_ws_filename()`; IC table: `get_initial_conditions()`, `set_initial_conditions()`, `validate_initial_flow_stations()`; Non-Newtonian: `get_non_newtonian_method()`, `set_non_newtonian_method()`, `get_non_newtonian_concentration()`, `set_non_newtonian_concentration()`)
+- Plan and model files: `RasPlan`, `RasMap`, `RasControl`, `RasUnsteady` (includes IC method selection: `get_initial_flow_method()`, `set_initial_flow_method()`, `get_prior_ws_filename()`, `set_prior_ws_filename()`; IC table: `get_initial_conditions()`, `set_initial_conditions()`, `validate_initial_flow_stations()`; Non-Newtonian: `get_non_newtonian_method()`, `set_non_newtonian_method()`, `get_non_newtonian_concentration()`, `set_non_newtonian_concentration()`, `get_non_newtonian_shear()`, `set_non_newtonian_shear()`)
 - Validation framework: `RasValidation`
 - HDF access: `Hdf*` classes and `ras_commander/hdf/`
 - Domain subpackages: `geom/`, `remote/`, `usgs/`, `check/`, `dss/`, `fixit/`, `precip/`, `gui/`, `terrain/`

--- a/ras_commander/RasUnsteady.py
+++ b/ras_commander/RasUnsteady.py
@@ -479,6 +479,18 @@ class RasUnsteady:
         1: "Bulk Fluid Volume",
     }
 
+    YIELD_METHODS = {
+        0: "Exponential",
+        1: "User Yield",
+    }
+
+    VISCOSITY_METHODS = {
+        0: "Use Coulomb",
+        1: "Maron and Pierce",
+        2: "User Defined Viscosity",
+        3: "User Visc Ratio",
+    }
+
     @staticmethod
     @log_call
     def get_non_newtonian_method(
@@ -719,6 +731,224 @@ class RasUnsteady:
         if max_cv is not None:
             changes.append(f"max_cv={max_cv}%")
         logger.info(f"Set NN concentration params ({', '.join(changes)}) in {unsteady_file.name}")
+
+    @staticmethod
+    @log_call
+    def get_non_newtonian_shear(
+        unsteady_number_or_path: Union[str, Path],
+        ras_object: Optional[Any] = None,
+    ) -> Dict[str, Any]:
+        """
+        Read Non-Newtonian yield stress and viscosity parameters from a .u## file.
+
+        Parameters
+        ----------
+        unsteady_number_or_path : str or Path
+            Unsteady flow number (e.g. ``"02"``) or path to a ``.u##`` file.
+        ras_object : RasPrj, optional
+            RAS project object. If None, uses the global ``ras`` object.
+
+        Returns
+        -------
+        dict
+            ``yield_method`` (int): 0=Exponential, 1=User Yield.
+            ``yield_method_name`` (str): Human-readable yield method name.
+            ``yield_coef`` (tuple[float, float]): Exponential yield coefficients (a, b).
+            ``user_yield`` (float): User-specified yield stress in Pa.
+            ``visc_method`` (int): 0=Use Coulomb, 1=Maron and Pierce, 2=User Defined Viscosity, 3=User Visc Ratio.
+            ``visc_method_name`` (str): Human-readable viscosity method name.
+            ``obrien_b`` (float): O'Brien exponential viscosity B coefficient.
+            ``user_viscosity`` (float): User-defined dynamic viscosity in Pa·s.
+            ``user_visc_ratio`` (float): Viscosity ratio multiplier.
+        """
+        unsteady_file = RasUnsteady._resolve_unsteady_file_path(
+            unsteady_number_or_path, ras_object=ras_object,
+        )
+        result = {
+            'yield_method': 0, 'yield_method_name': 'Exponential',
+            'yield_coef': (0.0, 0.0), 'user_yield': 0.0,
+            'visc_method': 0, 'visc_method_name': 'Use Coulomb',
+            'obrien_b': 0.0, 'user_viscosity': 0.0, 'user_visc_ratio': 0.0,
+        }
+        with open(unsteady_file, 'r') as f:
+            for line in f:
+                if line.startswith('Non-Newtonian Yield Method='):
+                    val_str = line.split('=', 1)[1].strip()
+                    try:
+                        ym = int(val_str)
+                        result['yield_method'] = ym
+                        result['yield_method_name'] = RasUnsteady.YIELD_METHODS.get(
+                            ym, f"Unknown ({ym})"
+                        )
+                    except ValueError:
+                        pass
+                elif line.startswith('Non-Newtonian Yield Coef='):
+                    val_str = line.split('=', 1)[1].strip()
+                    parts = [p.strip() for p in val_str.split(',')]
+                    try:
+                        result['yield_coef'] = (float(parts[0]), float(parts[1]))
+                    except (ValueError, IndexError):
+                        pass
+                elif line.startswith('User Yeild='):
+                    val_str = line.split('=', 1)[1].strip()
+                    try:
+                        result['user_yield'] = float(val_str)
+                    except ValueError:
+                        pass
+                elif line.startswith('Non-Newtonian Sed Visc='):
+                    val_str = line.split('=', 1)[1].strip()
+                    try:
+                        vm = int(val_str)
+                        result['visc_method'] = vm
+                        result['visc_method_name'] = RasUnsteady.VISCOSITY_METHODS.get(
+                            vm, f"Unknown ({vm})"
+                        )
+                    except ValueError:
+                        pass
+                elif line.startswith('Non-Newtonian Obrian B='):
+                    val_str = line.split('=', 1)[1].strip()
+                    try:
+                        result['obrien_b'] = float(val_str)
+                    except ValueError:
+                        pass
+                elif line.startswith('User Viscosity Ratio='):
+                    val_str = line.split('=', 1)[1].strip()
+                    try:
+                        result['user_visc_ratio'] = float(val_str)
+                    except ValueError:
+                        pass
+                elif line.startswith('User Viscosity='):
+                    val_str = line.split('=', 1)[1].strip()
+                    try:
+                        result['user_viscosity'] = float(val_str)
+                    except ValueError:
+                        pass
+        return result
+
+    @staticmethod
+    @log_call
+    def set_non_newtonian_shear(
+        unsteady_number_or_path: Union[str, Path],
+        yield_method: Optional[Union[int, str]] = None,
+        yield_coef: Optional[tuple] = None,
+        user_yield: Optional[float] = None,
+        visc_method: Optional[Union[int, str]] = None,
+        obrien_b: Optional[float] = None,
+        user_viscosity: Optional[float] = None,
+        user_visc_ratio: Optional[float] = None,
+        ras_object: Optional[Any] = None,
+    ) -> None:
+        """
+        Set Non-Newtonian yield stress and viscosity parameters in a .u## file.
+
+        Parameters
+        ----------
+        unsteady_number_or_path : str or Path
+            Unsteady flow number (e.g. ``"02"``) or path to a ``.u##`` file.
+        yield_method : int or str, optional
+            ``0``/``"Exponential"`` or ``1``/``"User Yield"``.
+        yield_coef : tuple of (float, float), optional
+            Exponential yield coefficients (a, b) for tau_y = a * exp(b * Cv).
+        user_yield : float, optional
+            User-specified constant yield stress in Pa.
+        visc_method : int or str, optional
+            ``0``/``"Use Coulomb"``, ``1``/``"Maron and Pierce"``,
+            ``2``/``"User Defined Viscosity"``, ``3``/``"User Visc Ratio"``.
+        obrien_b : float, optional
+            O'Brien exponential viscosity B coefficient.
+        user_viscosity : float, optional
+            User-defined dynamic viscosity in Pa·s.
+        user_visc_ratio : float, optional
+            Viscosity ratio multiplier.
+        ras_object : RasPrj, optional
+            RAS project object. If None, uses the global ``ras`` object.
+        """
+        all_none = all(v is None for v in [
+            yield_method, yield_coef, user_yield, visc_method,
+            obrien_b, user_viscosity, user_visc_ratio,
+        ])
+        if all_none:
+            return
+
+        if yield_method is not None:
+            if isinstance(yield_method, str):
+                name_to_id = {v.lower(): k for k, v in RasUnsteady.YIELD_METHODS.items()}
+                ym_lower = yield_method.lower().strip()
+                if ym_lower in name_to_id:
+                    yield_method = name_to_id[ym_lower]
+                elif yield_method.strip().isdigit():
+                    yield_method = int(yield_method.strip())
+                else:
+                    raise ValueError(
+                        f"Unknown yield method: '{yield_method}'. "
+                        f"Valid: {list(RasUnsteady.YIELD_METHODS.values())}"
+                    )
+            if yield_method not in RasUnsteady.YIELD_METHODS:
+                raise ValueError(
+                    f"Invalid yield_method {yield_method}. Must be 0-1: "
+                    f"{RasUnsteady.YIELD_METHODS}"
+                )
+
+        if visc_method is not None:
+            if isinstance(visc_method, str):
+                name_to_id = {v.lower(): k for k, v in RasUnsteady.VISCOSITY_METHODS.items()}
+                vm_lower = visc_method.lower().strip()
+                if vm_lower in name_to_id:
+                    visc_method = name_to_id[vm_lower]
+                elif visc_method.strip().isdigit():
+                    visc_method = int(visc_method.strip())
+                else:
+                    raise ValueError(
+                        f"Unknown viscosity method: '{visc_method}'. "
+                        f"Valid: {list(RasUnsteady.VISCOSITY_METHODS.values())}"
+                    )
+            if visc_method not in RasUnsteady.VISCOSITY_METHODS:
+                raise ValueError(
+                    f"Invalid visc_method {visc_method}. Must be 0-3: "
+                    f"{RasUnsteady.VISCOSITY_METHODS}"
+                )
+
+        unsteady_file = RasUnsteady._resolve_unsteady_file_path(
+            unsteady_number_or_path, ras_object=ras_object,
+        )
+        with open(unsteady_file, 'r') as f:
+            lines = f.readlines()
+
+        for i, line in enumerate(lines):
+            if yield_method is not None and line.startswith('Non-Newtonian Yield Method='):
+                lines[i] = f"Non-Newtonian Yield Method= {yield_method} \n"
+            elif yield_coef is not None and line.startswith('Non-Newtonian Yield Coef='):
+                lines[i] = f"Non-Newtonian Yield Coef={yield_coef[0]}, {yield_coef[1]}\n"
+            elif user_yield is not None and line.startswith('User Yeild='):
+                lines[i] = f"User Yeild={user_yield}\n"
+            elif visc_method is not None and line.startswith('Non-Newtonian Sed Visc='):
+                lines[i] = f"Non-Newtonian Sed Visc= {visc_method} \n"
+            elif obrien_b is not None and line.startswith('Non-Newtonian Obrian B='):
+                lines[i] = f"Non-Newtonian Obrian B={obrien_b}\n"
+            elif user_visc_ratio is not None and line.startswith('User Viscosity Ratio='):
+                lines[i] = f"User Viscosity Ratio={user_visc_ratio}\n"
+            elif user_viscosity is not None and line.startswith('User Viscosity='):
+                lines[i] = f"User Viscosity={user_viscosity}\n"
+
+        with open(unsteady_file, 'w') as f:
+            f.writelines(lines)
+
+        changes = []
+        if yield_method is not None:
+            changes.append(f"yield_method={RasUnsteady.YIELD_METHODS[yield_method]}")
+        if yield_coef is not None:
+            changes.append(f"yield_coef=({yield_coef[0]}, {yield_coef[1]})")
+        if user_yield is not None:
+            changes.append(f"user_yield={user_yield} Pa")
+        if visc_method is not None:
+            changes.append(f"visc_method={RasUnsteady.VISCOSITY_METHODS[visc_method]}")
+        if obrien_b is not None:
+            changes.append(f"obrien_b={obrien_b}")
+        if user_viscosity is not None:
+            changes.append(f"user_viscosity={user_viscosity} Pa·s")
+        if user_visc_ratio is not None:
+            changes.append(f"user_visc_ratio={user_visc_ratio}")
+        logger.info(f"Set NN shear params ({', '.join(changes)}) in {unsteady_file.name}")
 
     @staticmethod
     @log_call


### PR DESCRIPTION
## Summary
- Add `YIELD_METHODS` (0-1) and `VISCOSITY_METHODS` (0-3) enum dicts to `RasUnsteady`
- Add `get_non_newtonian_shear()` — reads all 7 yield/viscosity keys from `.u##` files
- Add `set_non_newtonian_shear()` — writes any subset of yield/viscosity parameters
- Fix `User Viscosity` / `User Viscosity Ratio` prefix ambiguity in both getter and setter
- Notebook Step 18 demonstrates round-trip with O'Brien coefficients

## Test plan
- [x] Notebook cells 65-66 exercise read and round-trip write
- [x] AGENTS.md updated with new method names
- [x] Selective staging excludes unrelated RasMap.py and federal/__init__.py changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)