### PR TITLE
feat(unsteady): add Herschel-Bulkley parameter API (CLB-746)

### DIFF
--- a/examples/312_boundary_df_qmult_dss_paths.ipynb
+++ b/examples/312_boundary_df_qmult_dss_paths.ipynb
@@ -1398,6 +1398,62 @@
   {
    "cell_type": "markdown",
    "metadata": {},
+   "source": [
+    "## Step 19: Generalized Herschel-Bulkley Parameters\n",
+    "\n",
+    "The Generalized Herschel-Bulkley model (`Non-Newtonian Method= 4`) uses two\n",
+    "parameters stored as a comma-separated pair:\n",
+    "\n",
+    "\n",
+    "\n",
+    "Where the constitutive equation is: **τ = τ_y + K · (ḋγ)^n**\n",
+    "\n",
+    "- **K** = consistency factor (Pa·s^n)\n",
+    "- **n** = power index (n=1 reduces to Bingham plastic)\n",
+    "\n",
+    "The `get_non_newtonian_herschel_bulkley()` / `set_non_newtonian_herschel_bulkley()`\n",
+    "API reads and writes these two values individually or together."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "# --- Step 19a: Read Herschel-Bulkley parameters from .u02 ---\n",
+    "hb = RasUnsteady.get_non_newtonian_herschel_bulkley(u02_orig)\n",
+    "print(f\"Herschel-Bulkley params:  K={hb['k']}, n={hb['n']}\")\n",
+    "print(f\"  (n=1 is Bingham plastic, n<1 is shear-thinning, n>1 is shear-thickening)\")"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "# --- Step 19b: Round-trip set_non_newtonian_herschel_bulkley() ---\n",
+    "shutil.copy2(u02_orig, u02_copy)\n",
+    "\n",
+    "# Set HB model parameters (typical debris-flow values)\n",
+    "RasUnsteady.set_non_newtonian_herschel_bulkley(\n",
+    "    u02_copy, k=150.0, n=0.35,\n",
+    ")\n",
+    "\n",
+    "# Verify round-trip\n",
+    "after = RasUnsteady.get_non_newtonian_herschel_bulkley(u02_copy)\n",
+    "print(f\"After set: K={after['k']}, n={after['n']}\")\n",
+    "assert after[\"k\"] == 150.0 and after[\"n\"] == 0.35, \"Round-trip failed\"\n",
+    "print(\"Round-trip verified.\")\n",
+    "\n",
+    "# Clean up copy\n",
+    "u02_copy.unlink(missing_ok=True)"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
    "source": "## Summary\n\nThis notebook demonstrated the enhanced `boundaries_df` features:\n\n### New DataFrame Columns\n\n| Column | Description | Use Case |\n|--------|-------------|----------|\n| `Flow Hydrograph QMult` | Flow multiplier value | Sensitivity analysis |\n| `Flow Hydrograph QMin` | Minimum flow threshold | Low flow conditions |\n| `Stage Hydrograph TW Check` | Tailwater check flag (0/1) | Flow Hydrograph TW control |\n| `dss_part_a` | HMS subbasin/location | HMS-RAS linking |\n| `dss_part_b` | Parameter (FLOW/STAGE) | Data type identification |\n| `dss_part_c` | Date reference | Time synchronization |\n| `dss_part_d` | Time interval | Timestep verification |\n| `dss_part_e` | Run identifier | Scenario tracking |\n| `dss_part_f` | Additional ID | Optional metadata |\n\n### Update Methods\n\n| Method | Purpose |\n|--------|---------|\n| `RasUnsteady.update_dss_path_by_station()` | Update DSS A-part by river station |\n| `RasUnsteady.update_flow_multiplier_by_station()` | Update/insert QMult value |\n| `RasUnsteady.update_boundary_dss_paths()` | Batch update multiple boundaries |\n| `RasUnsteady.set_stage_hydrograph_tw_check()` | Set TW Check flag (0 or 1) on Flow Hydrograph BC |\n\n### State Transition Methods\n\n| Method | Direction | Purpose |\n|--------|-----------|---------|\n| `RasUnsteady.set_boundary_dss_link()` | Inline to DSS | Remove inline data, set DSS File/Path, Use DSS=True |\n| `RasUnsteady.set_boundary_inline_hydrograph()` | DSS to Inline | Write inline data, clear DSS fields, Use DSS=False |\n| `RasUnsteady.get_inline_hydrograph_boundaries()` | Read | Extract all inline hydrograph boundaries with values |\n\n### Stage/Flow Hydrograph Methods (Internal Boundaries)\n\n| Method | Purpose |\n|--------|---------|\n| `RasUnsteady.get_stage_flow_hydrograph()` | Read interleaved stage/flow pairs from `.u##` file |\n| `RasUnsteady.set_stage_flow_hydrograph()` | Write or replace stage/flow pairs in `.u##` file |\n\n### Lateral Inflow Hydrograph Methods (Step 11)\n\n| Method | Purpose |\n|--------|---------|\n| `RasUnsteady.get_lateral_inflow_hydrograph()` | Read lateral inflow values + metadata (interval, slope) from `.u##` file |\n| `RasUnsteady.set_lateral_inflow_hydrograph()` | Write/replace lateral inflow values, optionally update `Flow Hydrograph Slope=` |\n\n### Uniform Lateral Inflow Hydrograph Methods (Step 12)\n\n| Method | Purpose |\n|--------|---------|\n| `RasUnsteady.get_uniform_lateral_inflow_hydrograph()` | Read uniform lateral inflow values + metadata from `.u##` file |\n| `RasUnsteady.set_uniform_lateral_inflow_hydrograph()` | Write/replace uniform lateral inflow values, optionally update slope |\n\n### Initial Conditions Method Selection (Steps 13-14)\n\n| Method | Purpose |\n|--------|---------|\n| `RasUnsteady.get_initial_flow_method()` | Determine which IC method is active (restart_file, prior_ws, initial_flow_distribution, or none) |\n| `RasUnsteady.set_initial_flow_method()` | Set the IC method selection and manage `Use Restart` / `Restart Filename` / `Prior WS Filename` keys |\n| `RasUnsteady.get_prior_ws_filename()` | Read Prior WS Filename and Profile from `.u##` file |\n| `RasUnsteady.set_prior_ws_filename()` | Write Prior WS Filename and Profile (convenience wrapper for `set_initial_flow_method(method=\"prior_ws\")`) |\n\n### Computational Verification (Step 9)\n\nThree independent HEC-RAS computations verified the implementation:\n\n**Step 9a: Round-Trip Fidelity Test**\n1. Computed **baseline** plan with original inline boundary conditions\n2. Performed inline -> DSS -> inline **round-trip** on a second copy\n3. Computed the **round-trip** plan\n4. Compared cross section results via `HdfResultsXsec.get_xsec_timeseries()`\n5. **Result**: All Water Surface, Flow, and Velocity matched exactly (max diff = 0.000000)\n\n**Step 9b: QMult Sensitivity Test**\n1. Inserted `Flow Hydrograph QMult=0.50` on a third copy\n2. Computed the **QMult** plan with 50% of baseline flow\n3. Compared cross section results against baseline\n4. **Result**: All cross sections showed lower WSE with reduced flow (QMult correctly applied)\n\n### Stage/Flow Hydrograph Verification (Step 10)\n\n1. Extracted **Internal Stage and Flow Boundary Condition** fixture project\n2. Read observed stage/flow hydrograph at internal BC station with `get_stage_flow_hydrograph()`\n3. Scaled flows by 1.25x and wrote back with `set_stage_flow_hydrograph()`\n4. Re-read and verified round-trip: stage values unchanged, flow values match scaled values\n5. **Result**: Round-trip verification PASSED\n\n### Lateral Inflow Hydrograph Verification (Step 11)\n\n1. Read lateral inflow hydrograph from BaldEagleCrkMulti2D with `get_lateral_inflow_hydrograph()`\n2. Verified metadata extraction: interval, slope, matched_location via `df.attrs`\n3. Scaled flows by 1.5x and wrote back with new slope using `set_lateral_inflow_hydrograph()`\n4. Re-read and verified round-trip: flow values match, slope updated\n5. **Result**: Round-trip verification PASSED\n\n### Uniform Lateral Inflow Hydrograph Verification (Step 12)\n\n1. Found Uniform Lateral Inflow Hydrograph BCs in BaldEagleCrkMulti2D (DSS-linked, count=0)\n2. Attempted read with `get_uniform_lateral_inflow_hydrograph()` -- returns None (expected for DSS-linked)\n3. Wrote synthetic triangular hydrograph (25 values, peak 500 cfs) with `set_uniform_lateral_inflow_hydrograph()`\n4. Re-read and verified round-trip: flow values match, slope updated\n5. **Result**: Round-trip verification PASSED -- reach-based uniform lateral inflow API works correctly\n\n### Initial Conditions Method Selection Verification (Step 13)\n\n1. Read IC method from 3 BaldEagle unsteady files: `.u08` (initial_flow_distribution, 8 IC lines), `.u03` (none), `.u01` (initial_flow_distribution, 1 IC line)\n2. Verified `get_initial_flow_method()` correctly infers the implicit state machine\n3. Round-trip tested `set_initial_flow_method()`: initial_flow_distribution -> restart_file -> none -> initial_flow_distribution\n4. **Result**: All state transitions verified correctly\n\n### Prior Water Surface Filename Verification (Step 14)\n\n1. Started from `.u03` (method=none, no Prior WS) as clean baseline\n2. Verified `get_prior_ws_filename()` returns None before setting\n3. Set Prior WS via `set_prior_ws_filename()` with plan file and profile name\n4. Read back and verified: filename and profile match, `get_initial_flow_method()` detects `prior_ws`\n5. Round-trip tested state transitions: none -> prior_ws -> none -> prior_ws -> restart_file\n6. Verified Prior WS keys are properly stripped when switching away from `prior_ws` method\n7. **Result**: All Prior WS state transitions verified correctly\n\n### Key Features\n\n- **QMult insertion**: Automatically inserts line if not present\n- **TW Check setter**: Set/toggle tailwater check flag with `set_stage_hydrograph_tw_check()`\n- **Stage/Flow Hydrograph**: Read/write interleaved (stage, flow) pairs for internal BCs\n- **Lateral Inflow Hydrograph**: Dedicated read/write with slope integration and metadata via `df.attrs`\n- **Uniform Lateral Inflow Hydrograph**: Reach-based BC read/write with slope and metadata support\n- **IC Method Selection**: Detect and set the implicit Initial Conditions state machine (restart_file / prior_ws / initial_flow_distribution / none)\n- **Prior WS Filename**: Read/write Prior WS Filename and Profile for using steady-state results as IC\n- **Partial station matching**: Matches stations even with coordinates appended\n- **Batch efficiency**: Single file read/write for multiple updates\n- **Safe updates**: Optional `old_a_part` validation prevents accidental overwrites\n- **Complete state transitions**: Inline to DSS and DSS to Inline with round-trip fidelity\n- **Inline data cleanup**: `set_boundary_dss_link()` removes inline table data when switching to DSS\n- **Verified correctness**: Computational tests prove state transitions are lossless and QMult affects results\n\n### Initial Conditions Table API (Step 15)\n\n| Method | Purpose |\n|--------|--------|\n|  | Read IC entries from .u## as list of dicts |\n|  | Write IC entries (DataFrame or list of dicts) |\n|  | Check IC stations match geometry XS |\n\n accepts  in addition to , and automatically sets the IC method to Initial Flow Distribution when  (default).\n\n### Non-Newtonian Parameters (Steps 16-17)\n\n| Method | Description |\n|--------|-------------|\n| `get_non_newtonian_method()` | Read method ID and name from .u## |\n| `set_non_newtonian_method()` | Set method by int (0-4) or name string |\n| `get_non_newtonian_concentration()` | Read Cv, bulking method, max Cv |\n| `set_non_newtonian_concentration()` | Set Cv, bulking method, max Cv |\n\nMethod enum verified via binary analysis of Ras.exe (0=Newtonian, 1=Bingham, 2=O'Brien, 3=Clastic, 4=Herschel-Bulkley).",
    "id": "19a2ae8a"
   },

--- a/ras_commander/AGENTS.md
+++ b/ras_commander/AGENTS.md
@@ -12,7 +12,7 @@ This file is the canonical local instruction file for the `ras_commander/` packa
 
 - Project management: `RasPrj`, `init_ras_project()`
 - Plan execution: `RasCmdr`
-- Plan and model files: `RasPlan`, `RasMap`, `RasControl`, `RasUnsteady` (includes IC method selection: `get_initial_flow_method()`, `set_initial_flow_method()`, `get_prior_ws_filename()`, `set_prior_ws_filename()`; IC table: `get_initial_conditions()`, `set_initial_conditions()`, `validate_initial_flow_stations()`; Non-Newtonian: `get_non_newtonian_method()`, `set_non_newtonian_method()`, `get_non_newtonian_concentration()`, `set_non_newtonian_concentration()`, `get_non_newtonian_shear()`, `set_non_newtonian_shear()`)
+- Plan and model files: `RasPlan`, `RasMap`, `RasControl`, `RasUnsteady` (includes IC method selection: `get_initial_flow_method()`, `set_initial_flow_method()`, `get_prior_ws_filename()`, `set_prior_ws_filename()`; IC table: `get_initial_conditions()`, `set_initial_conditions()`, `validate_initial_flow_stations()`; Non-Newtonian: `get_non_newtonian_method()`, `set_non_newtonian_method()`, `get_non_newtonian_concentration()`, `set_non_newtonian_concentration()`, `get_non_newtonian_shear()`, `set_non_newtonian_shear()`, `get_non_newtonian_herschel_bulkley()`, `set_non_newtonian_herschel_bulkley()`)
 - Validation framework: `RasValidation`
 - HDF access: `Hdf*` classes and `ras_commander/hdf/`
 - Domain subpackages: `geom/`, `remote/`, `usgs/`, `check/`, `dss/`, `fixit/`, `precip/`, `gui/`, `terrain/`

--- a/ras_commander/RasUnsteady.py
+++ b/ras_commander/RasUnsteady.py
@@ -952,6 +952,106 @@ class RasUnsteady:
 
     @staticmethod
     @log_call
+    def get_non_newtonian_herschel_bulkley(
+        unsteady_number_or_path: Union[str, Path],
+        ras_object: Optional[Any] = None,
+    ) -> Dict[str, Any]:
+        """
+        Read Generalized Herschel-Bulkley parameters from a .u## file.
+
+        The HB model is: tau = tau_y + K * (du/dy)^n.
+        When n=1 the model reduces to Bingham plastic.
+
+        Parameters
+        ----------
+        unsteady_number_or_path : str or Path
+            Unsteady flow number (e.g. ``"02"``) or path to a ``.u##`` file.
+        ras_object : RasPrj, optional
+            RAS project object. If None, uses the global ``ras`` object.
+
+        Returns
+        -------
+        dict
+            ``k`` (float): Consistency factor K.
+            ``n`` (float): Power index n.
+        """
+        unsteady_file = RasUnsteady._resolve_unsteady_file_path(
+            unsteady_number_or_path, ras_object=ras_object,
+        )
+        result = {'k': 0.0, 'n': 0.0}
+        with open(unsteady_file, 'r') as f:
+            for line in f:
+                if line.startswith('Herschel-Bulkley Coef='):
+                    val_str = line.split('=', 1)[1].strip()
+                    parts = [p.strip() for p in val_str.split(',')]
+                    try:
+                        result['k'] = float(parts[0])
+                        result['n'] = float(parts[1])
+                    except (ValueError, IndexError):
+                        pass
+                    break
+        return result
+
+    @staticmethod
+    @log_call
+    def set_non_newtonian_herschel_bulkley(
+        unsteady_number_or_path: Union[str, Path],
+        k: Optional[float] = None,
+        n: Optional[float] = None,
+        ras_object: Optional[Any] = None,
+    ) -> None:
+        """
+        Set Generalized Herschel-Bulkley parameters in a .u## file.
+
+        The HB model is: tau = tau_y + K * (du/dy)^n.
+        When n=1 the model reduces to Bingham plastic.
+
+        Parameters
+        ----------
+        unsteady_number_or_path : str or Path
+            Unsteady flow number (e.g. ``"02"``) or path to a ``.u##`` file.
+        k : float, optional
+            Consistency factor K.
+        n : float, optional
+            Power index n (n=1 is Bingham plastic).
+        ras_object : RasPrj, optional
+            RAS project object. If None, uses the global ``ras`` object.
+        """
+        if k is None and n is None:
+            return
+
+        unsteady_file = RasUnsteady._resolve_unsteady_file_path(
+            unsteady_number_or_path, ras_object=ras_object,
+        )
+        with open(unsteady_file, 'r') as f:
+            lines = f.readlines()
+
+        for i, line in enumerate(lines):
+            if line.startswith('Herschel-Bulkley Coef='):
+                current = line.split('=', 1)[1].strip()
+                parts = [p.strip() for p in current.split(',')]
+                try:
+                    cur_k = float(parts[0])
+                    cur_n = float(parts[1])
+                except (ValueError, IndexError):
+                    cur_k, cur_n = 0.0, 0.0
+                new_k = k if k is not None else cur_k
+                new_n = n if n is not None else cur_n
+                lines[i] = f"Herschel-Bulkley Coef={new_k}, {new_n}\n"
+                break
+
+        with open(unsteady_file, 'w') as f:
+            f.writelines(lines)
+
+        changes = []
+        if k is not None:
+            changes.append(f"K={k}")
+        if n is not None:
+            changes.append(f"n={n}")
+        logger.info(f"Set HB params ({', '.join(changes)}) in {unsteady_file.name}")
+
+    @staticmethod
+    @log_call
     def update_restart_settings(unsteady_file: str, use_restart: bool, restart_filename: Optional[str] = None, ras_object: Optional[Any] = None) -> None:
         """
         Update the restart file settings in an unsteady flow file.


### PR DESCRIPTION
## Summary
- Add `get_non_newtonian_herschel_bulkley()` / `set_non_newtonian_herschel_bulkley()` for the `Herschel-Bulkley Coef=K, n` key
- Setter supports partial updates (K alone, n alone, or both)
- Notebook Step 19 demonstrates round-trip with typical debris-flow values (K=150, n=0.35)
- AGENTS.md updated

## Test plan
- [x] Notebook cells 68-69 exercise read and round-trip write with assertion
- [x] AGENTS.md updated with new method names

🤖 Generated with [Claude Code](https://claude.com/claude-code)