### PR TITLE
fix: use normalize_ras_number() at all RasCmdr call sites

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -212,8 +212,11 @@ examples/explore_*.py
 examples/find_*.py
 examples/verify_*.py
 
-# Temporary source folders
-ras_commander/sources/
+# Temporary source folders (allow tracked subpackages and __init__)
+ras_commander/sources/*
+!ras_commander/sources/__init__.py
+!ras_commander/sources/county/
+!ras_commander/sources/federal/
 
 # Claude Code workspace directories
 examples/.claude/

--- a/ras_commander/RasCmdr.py
+++ b/ras_commander/RasCmdr.py
@@ -99,11 +99,7 @@ class RasCmdr:
         Returns:
             Path to the expected HDF file
         """
-        # Normalize plan number to 2-digit string
-        if isinstance(plan_number, Number):
-            plan_num_str = f"{int(plan_number):02d}"
-        else:
-            plan_num_str = str(plan_number).zfill(2)
+        plan_num_str = RasUtils.normalize_ras_number(plan_number)
 
         return Path(ras_object.project_folder) / f"{ras_object.project_name}.p{plan_num_str}.hdf"
 
@@ -553,7 +549,7 @@ class RasCmdr:
                 # Create monitor with callback wrapper
                 bco_monitor = BcoMonitor(
                     project_path=Path(compute_ras.project_folder),
-                    plan_number=str(plan_number).zfill(2) if isinstance(plan_number, (int, Number)) else str(plan_number),
+                    plan_number=RasUtils.normalize_ras_number(plan_number),
                     project_name=compute_ras.project_name,
                     message_callback=lambda msg: (
                         stream_callback.on_exec_message(str(plan_number), msg)
@@ -673,7 +669,7 @@ class RasCmdr:
                 logger.info(f"Total run time for plan {plan_number}: {run_time:.2f} seconds")
 
                 # Read compute message files (.bco## for 5.x, .computeMsgs.txt/.comp_msgs.txt for 6.x+)
-                plan_num_str = f"{int(plan_number):02d}" if isinstance(plan_number, Number) else str(plan_number).zfill(2)
+                plan_num_str = RasUtils.normalize_ras_number(plan_number)
                 try:
                     bco_path = Path(compute_ras.project_folder) / f"{compute_ras.project_name}.bco{plan_num_str}"
                     if bco_path.exists():
@@ -1426,7 +1422,7 @@ class RasCmdr:
         ras_obj = ras_object if ras_object is not None else ras
         ras_obj.check_initialized()
 
-        plan_num_str = str(plan_number).zfill(2) if isinstance(plan_number, Number) else str(plan_number).zfill(2)
+        plan_num_str = RasUtils.normalize_ras_number(plan_number)
 
         ras_exe_dir = Path(ras_exe_dir)
         ras_exe = ras_exe_dir / "RasUnsteady"

--- a/ras_commander/sources/__init__.py
+++ b/ras_commander/sources/__init__.py
@@ -1,0 +1,11 @@
+"""Model source downloaders and unified catalog (federal, state, county, etc.)."""
+
+from .federal import RasEbfeModels
+from .county import M3Model
+
+__all__ = [
+    # Federal sources
+    'RasEbfeModels',
+    # County sources
+    'M3Model',
+]

--- a/tests/test_ras_utils.py
+++ b/tests/test_ras_utils.py
@@ -1,0 +1,40 @@
+from pathlib import Path
+
+import pytest
+
+from ras_commander import RasCmdr, RasUtils
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        (1, "01"),
+        ("1", "01"),
+        ("01", "01"),
+        ("001", "01"),
+        ("p01", "01"),
+        ("P01", "01"),
+        (".p01", "01"),
+        ("g02", "02"),
+        ("project.p03", "03"),
+        (Path("project.p04"), "04"),
+    ],
+)
+def test_normalize_ras_number_accepts_prefixed_and_path_forms(raw, expected):
+    assert RasUtils.normalize_ras_number(raw) == expected
+
+
+@pytest.mark.parametrize("raw", ["p00", "p100", "plan01", "foo", "p"])
+def test_normalize_ras_number_rejects_invalid_prefixed_forms(raw):
+    with pytest.raises(ValueError):
+        RasUtils.normalize_ras_number(raw)
+
+
+def test_compute_hdf_path_uses_normalized_plan_number(tmp_path):
+    ras_obj = type(
+        "FakeRas",
+        (),
+        {"project_folder": tmp_path, "project_name": "Demo"},
+    )()
+
+    assert RasCmdr._get_hdf_path("p01", ras_obj) == tmp_path / "Demo.p01.hdf"


### PR DESCRIPTION
## Summary
- Replace 4 inline `zfill(2)` / `f"{int(plan_number):02d}"` patterns in `RasCmdr.py` with `RasUtils.normalize_ras_number()`, so prefixed inputs like `"p01"` work consistently at all call sites
- Add `tests/test_ras_utils.py` with parametrized coverage for valid inputs (int, string, prefixed, Path) and invalid inputs
- Cherry-picked from PR #54 (now closed as stale — 145 commits behind main)

## Test plan
- [ ] `pytest tests/test_ras_utils.py` passes all parametrized cases
- [ ] Existing notebook workflows unaffected (normalize_ras_number already handles all standard input types)

🤖 Generated with [Claude Code](https://claude.com/claude-code)