### PR TITLE
feat(sources): model sources showcase notebook and library fixes

### DIFF
--- a/examples/958_model_sources_showcase.ipynb
+++ b/examples/958_model_sources_showcase.ipynb
@@ -3,22 +3,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "# Model Sources: Unified Discovery, Download & Visualization\n",
-    "\n",
-    "This notebook downloads a representative HEC-RAS model from each source, initializes it with ras-commander, and captures a RASMapper screenshot.\n",
-    "\n",
-    "| Source | Representative Model | HEC-RAS Version | Type |\n",
-    "|--------|---------------------|-----------------|------|\n",
-    "| USGS ScienceBase | Kalamazoo River, MI | 6.6 | 2D Unsteady |\n",
-    "| Minnesota DNR | Chester Creek | 5.0.3 | 1D Steady |\n",
-    "| Indiana DNR | Fall Creek Trail Bridge | 5.0.7 | 1D Steady |\n",
-    "| Colorado CHAMP | Henson Creek | 4.1.0 | 1D Steady |\n",
-    "| FEMA eBFE/BLE | Spring Creek | 5.0.7 | 2D Unsteady |\n",
-    "| Harris County M3 | Brays Bayou | 3.0.1 | 1D Steady |\n",
-    "\n",
-    "**Requirements**: HEC-RAS installed (for RASMapper screenshots), internet connection (for API queries)."
-   ]
+   "source": "# Model Sources: Unified Discovery, Download & Visualization\n\nThis notebook downloads a representative HEC-RAS model from each source, initializes it with ras-commander, and captures a RASMapper screenshot.\n\n| Source | Representative Model | HEC-RAS Version | Type |\n|--------|---------------------|-----------------|------|\n| USGS ScienceBase | Kalamazoo River, MI | 6.6 | 2D Unsteady |\n| Minnesota DNR | Chester Creek | 5.0.3 | 1D Steady |\n| Indiana DNR | Fall Creek Trail Bridge | 5.0.7 | 1D Steady |\n| Colorado CHAMP | Henson Creek | 4.1.0 | 1D Steady |\n| FEMA eBFE/BLE | Spring Creek | 5.0.7 | 2D Unsteady |\n| Harris County M3 | Brays Bayou | 3.0.1 | 1D Steady |\n\n**Requirements**: HEC-RAS installed (for RASMapper screenshots), internet connection (for API queries)."
   },
   {
    "cell_type": "code",
@@ -70,49 +55,7 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "def find_ras_prj(folder: Path) -> Path:\n",
-    "    \"\"\"Find the primary HEC-RAS .prj file in a folder (not CRS projection files).\"\"\"\n",
-    "    for prj in sorted(folder.rglob(\"*.prj\")):\n",
-    "        try:\n",
-    "            first_line = prj.read_text(encoding=\"utf-8\", errors=\"ignore\").split(\"\\n\")[0]\n",
-    "            if first_line.startswith(\"Proj Title=\"):\n",
-    "                return prj\n",
-    "        except Exception:\n",
-    "            continue\n",
-    "    return None\n",
-    "\n",
-    "\n",
-    "def screenshot_and_display(\n",
-    "    prj_path: Path,\n",
-    "    label: str,\n",
-    "    ras_version: str,\n",
-    "    delay: float = 8.0,\n",
-    ") -> Path:\n",
-    "    \"\"\"Take a RASMapper screenshot and display it inline.\"\"\"\n",
-    "    png_path = SCREENSHOT_DIR / f\"{label}.png\"\n",
-    "    print(f\"Capturing RASMapper screenshot for {label}...\")\n",
-    "    print(f\"  .prj: {prj_path}\")\n",
-    "    print(f\"  RAS version: {ras_version}\")\n",
-    "\n",
-    "    result = RasMap.screenshot_model(\n",
-    "        ras_project_path=prj_path,\n",
-    "        output_path=png_path,\n",
-    "        delay_seconds=delay,\n",
-    "        ras_version=ras_version,\n",
-    "    )\n",
-    "\n",
-    "    if result and result.exists() and result.stat().st_size > 0:\n",
-    "        print(f\"  Saved: {result} ({result.stat().st_size / 1024:.1f} KB)\")\n",
-    "        display(Image(filename=str(result), width=800))\n",
-    "        return result\n",
-    "    else:\n",
-    "        print(f\"  Screenshot capture failed.\")\n",
-    "        return None\n",
-    "\n",
-    "\n",
-    "print(\"Helper functions ready.\")"
-   ]
+   "source": "def find_ras_prj(folder: Path) -> Path:\n    \"\"\"Find the primary HEC-RAS .prj file in a folder (not CRS projection files).\"\"\"\n    for prj in sorted(folder.rglob(\"*.prj\")):\n        try:\n            first_line = prj.read_text(encoding=\"utf-8\", errors=\"ignore\").split(\"\\n\")[0]\n            if first_line.startswith(\"Proj Title=\"):\n                return prj\n        except Exception:\n            continue\n    return None\n\n\ndef screenshot_and_display(\n    prj_path: Path,\n    label: str,\n    ras_version: str,\n    delay: float = 8.0,\n) -> Path:\n    \"\"\"Take a RASMapper screenshot and display it inline.\"\"\"\n    png_path = SCREENSHOT_DIR / f\"{label}.png\"\n    print(f\"Capturing RASMapper screenshot for {label}...\")\n    print(f\"  .prj: {prj_path}\")\n    print(f\"  RAS version: {ras_version}\")\n\n    try:\n        result = RasMap.screenshot_model(\n            ras_project_path=prj_path,\n            output_path=png_path,\n            delay_seconds=delay,\n            ras_version=ras_version,\n        )\n    except FileNotFoundError as exc:\n        print(f\"  Skipped (no .rasmap file): {exc}\")\n        return None\n    except Exception as exc:\n        print(f\"  Screenshot failed: {exc}\")\n        return None\n\n    if result and result.exists() and result.stat().st_size > 0:\n        print(f\"  Saved: {result} ({result.stat().st_size / 1024:.1f} KB)\")\n        display(Image(filename=str(result), width=800))\n        return result\n    else:\n        print(f\"  Screenshot capture failed.\")\n        return None\n\n\nprint(\"Helper functions ready.\")"
   },
   {
    "cell_type": "markdown",
@@ -216,7 +159,7 @@
    "id": "",
    "metadata": {},
    "outputs": [],
-   "source": "# Download Chester Creek (MN DNR — St. Louis County)\nchester = [m for m in MinnesotaDnrModels.list_models(location=\"St. Louis\") if \"Chester\" in m.name]\nmn_model = chester[0] if chester else mn_models[0]\nmn_result = MinnesotaDnrModels.download_model(\n    mn_model.source_id,\n    output_folder=DOWNLOAD_ROOT / \"mn_dnr\",\n)\nmn_prj = find_ras_prj(mn_result.model_path) if mn_result and mn_result.success else None\nprint(f\"MN DNR prj: {mn_prj}\")"
+   "source": "# Download Chester Creek (MN DNR — St. Louis County)\n# Try specific search first; fall back to any available model if location query returns empty.\nchester = [m for m in MinnesotaDnrModels.list_models(location=\"St. Louis\") if \"Chester\" in m.name]\nmn_prj = None\nif chester:\n    mn_model = chester[0]\nelif mn_models:\n    mn_model = mn_models[0]\nelse:\n    _all_mn = MinnesotaDnrModels.list_models(limit=1)\n    mn_model = _all_mn[0] if _all_mn else None\n\nif mn_model:\n    mn_result = MinnesotaDnrModels.download_model(\n        mn_model.source_id,\n        output_folder=DOWNLOAD_ROOT / \"mn_dnr\",\n    )\n    mn_prj = find_ras_prj(mn_result.model_path) if mn_result and mn_result.success else None\n    print(f\"MN DNR model: {mn_model.name}\")\nelse:\n    print(\"MN DNR: no models available\")\nprint(f\"MN DNR prj: {mn_prj}\")"
   },
   {
    "cell_type": "code",
@@ -271,12 +214,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "---\n",
-    "## Source 4: Colorado CHAMP -- Henson Creek\n",
-    "\n",
-    "Small CWCB CHAMP catalog (~3 downloadable models). Henson Creek is a 1D steady model (HEC-RAS 4.1.0)."
-   ]
+   "source": "---\n## Source 4: Colorado CHAMP -- Henson Creek\n\nSmall CWCB CHAMP catalog (~3 downloadable models). Models in the catalog change over time; the download cell selects the first available entry."
   },
   {
    "cell_type": "code",
@@ -298,7 +236,7 @@
    "id": "",
    "metadata": {},
    "outputs": [],
-   "source": "# Download Henson Creek (Colorado CHAMP)\nhenson = [m for m in co_models if \"Henson\" in m.name]\nco_model = henson[0] if henson else co_models[0]\nco_result = ColoradoChampModels.download_model(\n    co_model.source_id,\n    output_folder=DOWNLOAD_ROOT / \"co_champ\",\n)\nco_prj = find_ras_prj(co_result.model_path) if co_result and co_result.success else None\nprint(f\"CO CHAMP prj: {co_prj}\")"
+   "source": "# Download first available Colorado CHAMP model\n# (catalog contents change over time; use whatever is currently listed)\nco_prj = None\nif co_models:\n    co_model = co_models[0]\n    print(f\"CO CHAMP model: {co_model.name}\")\n    co_result = ColoradoChampModels.download_model(\n        co_model.source_id,\n        output_folder=DOWNLOAD_ROOT / \"co_champ\",\n    )\n    co_prj = find_ras_prj(co_result.model_path) if co_result and co_result.success else None\nelse:\n    print(\"CO CHAMP: no models available\")\nprint(f\"CO CHAMP prj: {co_prj}\")"
   },
   {
    "cell_type": "code",
@@ -375,7 +313,7 @@
    "id": "",
    "metadata": {},
    "outputs": [],
-   "source": "# Download Brays Bayou (Harris County M3 — model D)\nm3_path = M3Model.extract_model(\"D\", output_path=DOWNLOAD_ROOT / \"m3\")\nm3_prj = find_ras_prj(m3_path) if m3_path else None\nprint(f\"M3 prj: {m3_prj}\")"
+   "source": "# Download Brays Bayou (Harris County M3 — model D)\n# M3 delivers sub-reach models as nested zips; extract inner archives after outer.\nimport zipfile as _zipfile\n\nm3_path = M3Model.extract_model(\"D\", output_path=DOWNLOAD_ROOT / \"m3\")\nm3_prj = None\nif m3_path:\n    for inner_zip in m3_path.rglob(\"*.zip\"):\n        dest = inner_zip.parent / inner_zip.stem\n        if not dest.exists():\n            try:\n                with _zipfile.ZipFile(inner_zip, \"r\") as zf:\n                    zf.extractall(dest)\n                print(f\"  Extracted: {inner_zip.name}\")\n            except _zipfile.BadZipFile:\n                pass\n    m3_prj = find_ras_prj(m3_path)\nprint(f\"M3 prj: {m3_prj}\")"
   },
   {
    "cell_type": "code",
@@ -446,22 +384,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "---\n",
-    "## Summary\n",
-    "\n",
-    "| Source | Model | Version | Type | Screenshot |\n",
-    "|--------|-------|---------|------|------------|\n",
-    "| USGS ScienceBase | Kalamazoo River, MI | 6.6 | 2D Unsteady | Yes |\n",
-    "| Minnesota DNR | Chester Creek | 5.0.3 | 1D Steady | Yes |\n",
-    "| Indiana DNR | Fall Creek Trail Bridge | 5.0.7 | 1D Steady | Yes |\n",
-    "| Colorado CHAMP | Henson Creek | 4.1.0 | 1D Steady | Yes |\n",
-    "| FEMA eBFE/BLE | Spring Creek | 5.0.7 | 2D Unsteady | Yes |\n",
-    "| Harris County M3 | Brays Bayou | 3.0.1 | 1D Steady | Yes |\n",
-    "| NOAA ras2fim | (catalog only) | -- | 1D Steady | No (S3) |\n",
-    "\n",
-    "Each model was downloaded using its source class, initialized with `init_ras_project()`, and visualized via `RasMap.screenshot_model()`."
-   ]
+   "source": "---\n## Summary\n\n| Source | Model | Version | Type | Screenshot |\n|--------|-------|---------|------|------------|\n| USGS ScienceBase | Kalamazoo River, MI | 6.6 | 2D Unsteady | Yes |\n| Minnesota DNR | Chester Creek | 5.0.3 | 1D Steady | Yes |\n| Indiana DNR | Fall Creek Trail Bridge | 5.0.7 | 1D Steady | Yes |\n| Colorado CHAMP | Henson Creek | 4.1.0 | 1D Steady | Yes |\n| FEMA eBFE/BLE | Spring Creek | 5.0.7 | 2D Unsteady | Yes |\n| Harris County M3 | Brays Bayou | 3.0.1 | 1D Steady | Yes |\n| NOAA ras2fim | (catalog only) | -- | 1D Steady | No (S3) |\n\nEach model was downloaded using its source class, initialized with `init_ras_project()`, and visualized via `RasMap.screenshot_model()`."
   }
  ],
  "metadata": {

--- a/examples/958_model_sources_showcase.ipynb
+++ b/examples/958_model_sources_showcase.ipynb
@@ -128,14 +128,8 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "---\n",
-    "## Source 2: Minnesota DNR -- Chester Creek\n",
-    "\n",
-    "~2,384 FEMA floodplain HEC-RAS models across 67 MN counties, all 1D steady-state.\n",
-    "\n",
-    "Chester Creek (St. Louis County) is a multi-geometry model built with HEC-RAS 5.0.3."
-   ]
+   "source": "---\n## Source 2: Minnesota DNR -- Chester Creek\n\n~2,384 FEMA floodplain HEC-RAS models across 67 MN counties, all 1D steady-state.\n\nChester Creek (St. Louis County) is a multi-geometry model built with HEC-RAS 5.0.3.\n\n> **Note**: MN DNR models are 1D steady-state (HEC-RAS 4.x/5.x), which predate the RASMapper `.rasmap` convention. Screenshots are not available for this source.",
+   "outputs": []
   },
   {
    "cell_type": "code",
@@ -159,7 +153,7 @@
    "id": "",
    "metadata": {},
    "outputs": [],
-   "source": "# Download Chester Creek (MN DNR — St. Louis County)\n# Try specific search first; fall back to any available model if location query returns empty.\nchester = [m for m in MinnesotaDnrModels.list_models(location=\"St. Louis\") if \"Chester\" in m.name]\nmn_prj = None\nif chester:\n    mn_model = chester[0]\nelif mn_models:\n    mn_model = mn_models[0]\nelse:\n    _all_mn = MinnesotaDnrModels.list_models(limit=1)\n    mn_model = _all_mn[0] if _all_mn else None\n\nif mn_model:\n    mn_result = MinnesotaDnrModels.download_model(\n        mn_model.source_id,\n        output_folder=DOWNLOAD_ROOT / \"mn_dnr\",\n    )\n    mn_prj = find_ras_prj(mn_result.model_path) if mn_result and mn_result.success else None\n    print(f\"MN DNR model: {mn_model.name}\")\nelse:\n    print(\"MN DNR: no models available\")\nprint(f\"MN DNR prj: {mn_prj}\")"
+   "source": "# Download Chester Creek (MN DNR)\n# Search the full catalog by name — location-based filtering is unreliable\n# when the API county name format changes.\nmn_all = MinnesotaDnrModels.list_models(limit=100)\nchester = [m for m in mn_all if \"Chester\" in m.name]\nmn_prj = None\nif chester:\n    mn_model = chester[0]\nelif mn_models:\n    mn_model = mn_models[0]\nelse:\n    mn_model = mn_all[0] if mn_all else None\n\nif mn_model:\n    mn_result = MinnesotaDnrModels.download_model(\n        mn_model.source_id,\n        output_folder=DOWNLOAD_ROOT / \"mn_dnr\",\n    )\n    mn_prj = find_ras_prj(mn_result.model_path) if mn_result and mn_result.success else None\n    print(f\"MN DNR model: {mn_model.name}\")\nelse:\n    print(\"MN DNR: no models available\")\nprint(f\"MN DNR prj: {mn_prj}\")"
   },
   {
    "cell_type": "code",
@@ -171,14 +165,8 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "---\n",
-    "## Source 3: Indiana DNR -- Fall Creek Trail Bridge\n",
-    "\n",
-    "~11,400 models across 92 IN counties (largest single state source).\n",
-    "\n",
-    "Fall Creek Trail Bridge (Hamilton County) is a 1D steady model with 4 plans, built with HEC-RAS 5.0.7."
-   ]
+   "source": "---\n## Source 3: Indiana DNR -- Fall Creek Trail Bridge\n\n~11,400 models across 92 IN counties (largest single state source).\n\nFall Creek Trail Bridge (Hamilton County) is a 1D steady model with 4 plans, built with HEC-RAS 5.0.7.\n\n> **Note**: IN DNR models are 1D steady-state (HEC-RAS 4.x/5.x), which predate the RASMapper `.rasmap` convention. Screenshots are not available for this source.",
+   "outputs": []
   },
   {
    "cell_type": "code",
@@ -214,7 +202,8 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "---\n## Source 4: Colorado CHAMP -- Henson Creek\n\nSmall CWCB CHAMP catalog (~3 downloadable models). Models in the catalog change over time; the download cell selects the first available entry."
+   "source": "---\n## Source 4: Colorado CHAMP\n\nSmall CWCB CHAMP catalog (~3 downloadable entries). Catalog contents change over time; some entries are non-HEC-RAS studies (HMS hydrology models, shapefiles only). The download cell iterates through available entries until one containing a valid HEC-RAS project is found.",
+   "outputs": []
   },
   {
    "cell_type": "code",
@@ -236,7 +225,7 @@
    "id": "",
    "metadata": {},
    "outputs": [],
-   "source": "# Download first available Colorado CHAMP model\n# (catalog contents change over time; use whatever is currently listed)\nco_prj = None\nif co_models:\n    co_model = co_models[0]\n    print(f\"CO CHAMP model: {co_model.name}\")\n    co_result = ColoradoChampModels.download_model(\n        co_model.source_id,\n        output_folder=DOWNLOAD_ROOT / \"co_champ\",\n    )\n    co_prj = find_ras_prj(co_result.model_path) if co_result and co_result.success else None\nelse:\n    print(\"CO CHAMP: no models available\")\nprint(f\"CO CHAMP prj: {co_prj}\")"
+   "source": "# Download first CO CHAMP entry that contains a HEC-RAS project.\n# Some catalog entries are non-HEC-RAS studies (HMS models, shapefiles only);\n# iterate until find_ras_prj() succeeds.\nco_prj = None\nfor co_model in co_models:\n    co_result = ColoradoChampModels.download_model(\n        co_model.source_id,\n        output_folder=DOWNLOAD_ROOT / \"co_champ\",\n    )\n    if co_result and co_result.success:\n        co_prj = find_ras_prj(co_result.model_path)\n        if co_prj:\n            print(f\"CO CHAMP model: {co_model.name}\")\n            break\n        print(f\"  {co_model.name}: no HEC-RAS project found, trying next\")\nif not co_prj:\n    print(\"CO CHAMP: no models with HEC-RAS content found in catalog\")\nprint(f\"CO CHAMP prj: {co_prj}\")"
   },
   {
    "cell_type": "code",
@@ -290,14 +279,8 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "---\n",
-    "## Source 6: Harris County M3 -- Brays Bayou\n",
-    "\n",
-    "20 FEMA-effective H&H models for Houston-area watersheds. All 1D steady (HEC-RAS 3.0.1).\n",
-    "\n",
-    "**Note**: HEC-RAS 3.0.1 predates RASMapper, so the screenshot uses the earliest available RASMapper version (4.1.0)."
-   ]
+   "source": "---\n## Source 6: Harris County M3 -- Brays Bayou\n\n20 FEMA-effective H&H models for Houston-area watersheds. All 1D steady (HEC-RAS 3.0.1).\n\n> **Note**: HEC-RAS 3.0.1 predates RASMapper -- no `.rasmap` file is included and screenshots are not available for this source.",
+   "outputs": []
   },
   {
    "cell_type": "code",
@@ -384,7 +367,8 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "---\n## Summary\n\n| Source | Model | Version | Type | Screenshot |\n|--------|-------|---------|------|------------|\n| USGS ScienceBase | Kalamazoo River, MI | 6.6 | 2D Unsteady | Yes |\n| Minnesota DNR | Chester Creek | 5.0.3 | 1D Steady | Yes |\n| Indiana DNR | Fall Creek Trail Bridge | 5.0.7 | 1D Steady | Yes |\n| Colorado CHAMP | Henson Creek | 4.1.0 | 1D Steady | Yes |\n| FEMA eBFE/BLE | Spring Creek | 5.0.7 | 2D Unsteady | Yes |\n| Harris County M3 | Brays Bayou | 3.0.1 | 1D Steady | Yes |\n| NOAA ras2fim | (catalog only) | -- | 1D Steady | No (S3) |\n\nEach model was downloaded using its source class, initialized with `init_ras_project()`, and visualized via `RasMap.screenshot_model()`."
+   "source": "---\n## Summary\n\n| Source | Model | Version | Type | Screenshot |\n|--------|-------|---------|------|------------|\n| USGS ScienceBase | Kalamazoo River, MI | 6.6 | 2D Unsteady | Yes |\n| Minnesota DNR | Chester Creek | 5.0.3 | 1D Steady | No (pre-RASMapper) |\n| Indiana DNR | Fall Creek Trail Bridge | 5.0.7 | 1D Steady | No (pre-RASMapper) |\n| Colorado CHAMP | First HEC-RAS entry | varies | 1D Steady | Yes (when found) |\n| FEMA eBFE/BLE | Spring Creek | 5.0.7 | 2D Unsteady | Yes |\n| Harris County M3 | Brays Bayou | 3.0.1 | 1D Steady | No (pre-RASMapper) |\n| NOAA ras2fim | (catalog only) | -- | 1D Steady | No (S3 only) |\n\nSources 1 and 5 (2D models with `.rasmap` files) produce terrain screenshots via `RasMap.screenshot_model()`. Sources 2, 3, and 6 are 1D steady-state models predating RASMapper; source 4 (CO CHAMP) screenshots when a HEC-RAS project is found in the catalog.",
+   "outputs": []
   }
  ],
  "metadata": {

--- a/examples/958_model_sources_showcase.ipynb
+++ b/examples/958_model_sources_showcase.ipynb
@@ -1,0 +1,487 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Model Sources: Unified Discovery, Download & Visualization\n",
+    "\n",
+    "This notebook downloads a representative HEC-RAS model from each source, initializes it with ras-commander, and captures a RASMapper screenshot.\n",
+    "\n",
+    "| Source | Representative Model | HEC-RAS Version | Type |\n",
+    "|--------|---------------------|-----------------|------|\n",
+    "| USGS ScienceBase | Kalamazoo River, MI | 6.6 | 2D Unsteady |\n",
+    "| Minnesota DNR | Chester Creek | 5.0.3 | 1D Steady |\n",
+    "| Indiana DNR | Fall Creek Trail Bridge | 5.0.7 | 1D Steady |\n",
+    "| Colorado CHAMP | Henson Creek | 4.1.0 | 1D Steady |\n",
+    "| FEMA eBFE/BLE | Spring Creek | 5.0.7 | 2D Unsteady |\n",
+    "| Harris County M3 | Brays Bayou | 3.0.1 | 1D Steady |\n",
+    "\n",
+    "**Requirements**: HEC-RAS installed (for RASMapper screenshots), internet connection (for API queries)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pathlib import Path\n",
+    "import os\n",
+    "import sys\n",
+    "import time\n",
+    "\n",
+    "try:\n",
+    "    from ras_commander import init_ras_project, RasMap\n",
+    "except ImportError:\n",
+    "    sys.path.insert(0, str(Path.cwd().parent))\n",
+    "    from ras_commander import init_ras_project, RasMap\n",
+    "\n",
+    "import pandas as pd\n",
+    "from IPython.display import Image, display\n",
+    "\n",
+    "from ras_commander.sources import (\n",
+    "    ModelCatalog, get_catalog, ModelMetadata, ModelType, ModelFilter,\n",
+    "    SourceStatus, DownloadResult,\n",
+    ")\n",
+    "from ras_commander.sources.federal.usgs_sciencebase import UsgsScienceBase\n",
+    "from ras_commander.sources.state.mn_dnr import MinnesotaDnrModels\n",
+    "from ras_commander.sources.state.in_dnr import IndianaDnrModels\n",
+    "from ras_commander.sources.state.co_champ import ColoradoChampModels\n",
+    "from ras_commander.sources.federal.noaa_ras2fim import NoaaRas2fimModels\n",
+    "from ras_commander.sources.federal import RasEbfeModels\n",
+    "from ras_commander.sources.county import M3Model\n",
+    "\n",
+    "# Shared workspace\n",
+    "DOWNLOAD_ROOT = Path(os.environ.get(\n",
+    "    \"RAS_COMMANDER_MODEL_SOURCES_ROOT\",\n",
+    "    r\"H:\\Testing\\Model_Sources_Showcase\"\n",
+    "))\n",
+    "SCREENSHOT_DIR = DOWNLOAD_ROOT / \"screenshots\"\n",
+    "DOWNLOAD_ROOT.mkdir(parents=True, exist_ok=True)\n",
+    "SCREENSHOT_DIR.mkdir(parents=True, exist_ok=True)\n",
+    "\n",
+    "print(f\"Download root: {DOWNLOAD_ROOT}\")\n",
+    "print(f\"Screenshots:   {SCREENSHOT_DIR}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def find_ras_prj(folder: Path) -> Path:\n",
+    "    \"\"\"Find the primary HEC-RAS .prj file in a folder (not CRS projection files).\"\"\"\n",
+    "    for prj in sorted(folder.rglob(\"*.prj\")):\n",
+    "        try:\n",
+    "            first_line = prj.read_text(encoding=\"utf-8\", errors=\"ignore\").split(\"\\n\")[0]\n",
+    "            if first_line.startswith(\"Proj Title=\"):\n",
+    "                return prj\n",
+    "        except Exception:\n",
+    "            continue\n",
+    "    return None\n",
+    "\n",
+    "\n",
+    "def screenshot_and_display(\n",
+    "    prj_path: Path,\n",
+    "    label: str,\n",
+    "    ras_version: str,\n",
+    "    delay: float = 8.0,\n",
+    ") -> Path:\n",
+    "    \"\"\"Take a RASMapper screenshot and display it inline.\"\"\"\n",
+    "    png_path = SCREENSHOT_DIR / f\"{label}.png\"\n",
+    "    print(f\"Capturing RASMapper screenshot for {label}...\")\n",
+    "    print(f\"  .prj: {prj_path}\")\n",
+    "    print(f\"  RAS version: {ras_version}\")\n",
+    "\n",
+    "    result = RasMap.screenshot_model(\n",
+    "        ras_project_path=prj_path,\n",
+    "        output_path=png_path,\n",
+    "        delay_seconds=delay,\n",
+    "        ras_version=ras_version,\n",
+    "    )\n",
+    "\n",
+    "    if result and result.exists() and result.stat().st_size > 0:\n",
+    "        print(f\"  Saved: {result} ({result.stat().st_size / 1024:.1f} KB)\")\n",
+    "        display(Image(filename=str(result), width=800))\n",
+    "        return result\n",
+    "    else:\n",
+    "        print(f\"  Screenshot capture failed.\")\n",
+    "        return None\n",
+    "\n",
+    "\n",
+    "print(\"Helper functions ready.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Unified Catalog\n",
+    "\n",
+    "The `ModelCatalog` auto-registers all available sources. Cross-source search with a single call."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "catalog = get_catalog()\n",
+    "\n",
+    "print(\"Registered sources:\")\n",
+    "for name in catalog.list_sources(include_unavailable=True):\n",
+    "    status = catalog._source_status.get(name, SourceStatus.UNAVAILABLE)\n",
+    "    print(f\"  {name}: {status.value}\")\n",
+    "\n",
+    "print(\"\\nCross-source search: 'Creek' (limit 3 per source)\")\n",
+    "creek_models = catalog.search_models(location=\"Creek\", limit_per_source=3)\n",
+    "print(f\"Found {len(creek_models)} models:\\n\")\n",
+    "for m in creek_models:\n",
+    "    print(f\"  [{m.source_name}] {m.name} -- {m.model_type.value}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## Source 1: USGS ScienceBase -- Kalamazoo River, MI\n",
+    "\n",
+    "Peer-reviewed 2D unsteady model (HEC-RAS 6.6, ~3 GB). DOI: 10.5066/P13CPA5B.\n",
+    "\n",
+    "21 plans with HDF outputs, ADCP velocity and WSE calibration data."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# List ScienceBase catalog\n",
+    "sb_models = UsgsScienceBase.list_catalog_models()\n",
+    "for m in sb_models:\n",
+    "    print(f\"{m.name} -- {m.model_type.value}, v{m.hecras_version}, DOI: {m.doi}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "",
+   "metadata": {},
+   "outputs": [],
+   "source": "# Download Kalamazoo River (USGS ScienceBase) — ~3 GB, may take several minutes\nsb_result = UsgsScienceBase.download_model(\n    \"kalamazoo\",\n    output_dir=DOWNLOAD_ROOT / \"usgs\",\n)\nsb_prj = find_ras_prj(sb_result) if sb_result else None\nprint(f\"USGS prj: {sb_prj}\")"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "if sb_prj:\n    screenshot_and_display(sb_prj, \"01_USGS_ScienceBase_Kalamazoo\", ras_version=\"7.0\")"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## Source 2: Minnesota DNR -- Chester Creek\n",
+    "\n",
+    "~2,384 FEMA floodplain HEC-RAS models across 67 MN counties, all 1D steady-state.\n",
+    "\n",
+    "Chester Creek (St. Louis County) is a multi-geometry model built with HEC-RAS 5.0.3."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Query MN DNR catalog\n",
+    "mn_counties = MinnesotaDnrModels.list_counties()\n",
+    "print(f\"MN DNR: {len(mn_counties)} counties\")\n",
+    "\n",
+    "mn_models = MinnesotaDnrModels.list_models(location=\"St. Louis\", limit=5)\n",
+    "print(f\"St. Louis County models (up to 5): {len(mn_models)}\")\n",
+    "for m in mn_models:\n",
+    "    print(f\"  {m.name} -- {m.source_id}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "",
+   "metadata": {},
+   "outputs": [],
+   "source": "# Download Chester Creek (MN DNR — St. Louis County)\nchester = [m for m in MinnesotaDnrModels.list_models(location=\"St. Louis\") if \"Chester\" in m.name]\nmn_model = chester[0] if chester else mn_models[0]\nmn_result = MinnesotaDnrModels.download_model(\n    mn_model.source_id,\n    output_folder=DOWNLOAD_ROOT / \"mn_dnr\",\n)\nmn_prj = find_ras_prj(mn_result.model_path) if mn_result and mn_result.success else None\nprint(f\"MN DNR prj: {mn_prj}\")"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "if mn_prj:\n    screenshot_and_display(mn_prj, \"02_MN_DNR_Chester_Creek\", ras_version=\"7.0\")"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## Source 3: Indiana DNR -- Fall Creek Trail Bridge\n",
+    "\n",
+    "~11,400 models across 92 IN counties (largest single state source).\n",
+    "\n",
+    "Fall Creek Trail Bridge (Hamilton County) is a 1D steady model with 4 plans, built with HEC-RAS 5.0.7."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Query IN DNR catalog\n",
+    "in_counties = IndianaDnrModels.list_counties()\n",
+    "print(f\"IN DNR: {len(in_counties)} counties\")\n",
+    "\n",
+    "in_models = IndianaDnrModels.list_models(location=\"Hamilton\", limit=5)\n",
+    "print(f\"Hamilton County models (up to 5): {len(in_models)}\")\n",
+    "for m in in_models:\n",
+    "    print(f\"  {m.name} -- ID: {m.source_id}, {m.model_type.value}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "",
+   "metadata": {},
+   "outputs": [],
+   "source": "# Download Fall Creek Trail Bridge (IN DNR — Hamilton County)\nfall_creek = [m for m in IndianaDnrModels.list_models(location=\"Hamilton\") if \"Fall Creek\" in m.name]\nin_model = fall_creek[0] if fall_creek else in_models[0]\nin_result = IndianaDnrModels.download_model(\n    in_model.source_id,\n    output_folder=DOWNLOAD_ROOT / \"in_dnr\",\n)\nin_prj = find_ras_prj(in_result.model_path) if in_result and in_result.success else None\nprint(f\"IN DNR prj: {in_prj}\")"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "if in_prj:\n    screenshot_and_display(in_prj, \"03_IN_DNR_Fall_Creek\", ras_version=\"7.0\")"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## Source 4: Colorado CHAMP -- Henson Creek\n",
+    "\n",
+    "Small CWCB CHAMP catalog (~3 downloadable models). Henson Creek is a 1D steady model (HEC-RAS 4.1.0)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Query CHAMP catalog\n",
+    "co_models = ColoradoChampModels.list_models()\n",
+    "print(f\"Colorado CHAMP models: {len(co_models)}\")\n",
+    "for m in co_models:\n",
+    "    size = f\"{m.file_size_mb:.1f} MB\" if m.file_size_mb else \"unknown\"\n",
+    "    print(f\"  {m.name} -- {m.model_type.value} ({size})\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "",
+   "metadata": {},
+   "outputs": [],
+   "source": "# Download Henson Creek (Colorado CHAMP)\nhenson = [m for m in co_models if \"Henson\" in m.name]\nco_model = henson[0] if henson else co_models[0]\nco_result = ColoradoChampModels.download_model(\n    co_model.source_id,\n    output_folder=DOWNLOAD_ROOT / \"co_champ\",\n)\nco_prj = find_ras_prj(co_result.model_path) if co_result and co_result.success else None\nprint(f\"CO CHAMP prj: {co_prj}\")"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "if co_prj:\n    screenshot_and_display(co_prj, \"04_CO_CHAMP_Henson_Creek\", ras_version=\"7.0\")"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## Source 5: FEMA eBFE/BLE -- Spring Creek\n",
+    "\n",
+    "Large 2D unsteady models from FEMA's BLE program. Spring Creek (HUC 12040102) is organized via `RasEbfeModels.organize_model()` into the standard delivery format.\n",
+    "\n",
+    "See notebooks 950-957 for detailed eBFE workflows."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# List available eBFE models\n",
+    "seen = set()\n",
+    "for alias, canonical in sorted(RasEbfeModels._MODEL_ALIASES.items()):\n",
+    "    if canonical not in seen:\n",
+    "        seen.add(canonical)\n",
+    "        print(f\"  {canonical}\")\n",
+    "print(f\"\\nTotal eBFE models: {len(seen)}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "",
+   "metadata": {},
+   "outputs": [],
+   "source": "# Organize Spring Creek eBFE model (downloads + fixes broken paths automatically)\nebfe_result = RasEbfeModels.download_model(\n    \"spring-creek\",\n    output_folder=DOWNLOAD_ROOT / \"ebfe\",\n)\nif ebfe_result.success and ebfe_result.model_path:\n    ebfe_ras_dir = ebfe_result.model_path / \"RAS Model\"\n    ebfe_prj = find_ras_prj(ebfe_ras_dir) or find_ras_prj(ebfe_result.model_path)\nelse:\n    ebfe_prj = None\nprint(f\"eBFE prj: {ebfe_prj}\")"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "if ebfe_prj:\n    screenshot_and_display(ebfe_prj, \"05_eBFE_Spring_Creek\", ras_version=\"7.0\")"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## Source 6: Harris County M3 -- Brays Bayou\n",
+    "\n",
+    "20 FEMA-effective H&H models for Houston-area watersheds. All 1D steady (HEC-RAS 3.0.1).\n",
+    "\n",
+    "**Note**: HEC-RAS 3.0.1 predates RASMapper, so the screenshot uses the earliest available RASMapper version (4.1.0)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "",
+   "metadata": {},
+   "outputs": [],
+   "source": "# List M3 models\nm3_df = M3Model.list_models(as_dataframe=True)\nprint(f\"Harris County M3 Models: {len(m3_df)}\\n\")\nprint(m3_df[['name', 'description', 'effective_date', 'size_gb']].to_string(index=True))"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "",
+   "metadata": {},
+   "outputs": [],
+   "source": "# Download Brays Bayou (Harris County M3 — model D)\nm3_path = M3Model.extract_model(\"D\", output_path=DOWNLOAD_ROOT / \"m3\")\nm3_prj = find_ras_prj(m3_path) if m3_path else None\nprint(f\"M3 prj: {m3_prj}\")"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "if m3_prj:\n    screenshot_and_display(m3_prj, \"06_M3_Brays_Bayou\", ras_version=\"7.0\")"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## Source 7: NOAA ras2fim (Catalog Only)\n",
+    "\n",
+    "NWM-aligned 1D models on S3 (`noaa-nws-owp-fim`). Full access requires `boto3` with AWS credentials; without it, a hardcoded registry is returned."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "noaa_status = NoaaRas2fimModels.get_source_status()\n",
+    "print(f\"NOAA ras2fim status: {noaa_status.value}\")\n",
+    "\n",
+    "try:\n",
+    "    import boto3\n",
+    "    print(\"boto3: available\")\n",
+    "except ImportError:\n",
+    "    print(\"boto3: not installed (using hardcoded registry)\")\n",
+    "\n",
+    "noaa_models = NoaaRas2fimModels.list_models(limit=5)\n",
+    "print(f\"\\nNOAA ras2fim models (up to 5): {len(noaa_models)}\")\n",
+    "for m in noaa_models:\n",
+    "    print(f\"  {m.name} -- HUC8: {m.location}, {m.model_type.value}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## Screenshot Gallery\n",
+    "\n",
+    "Collect all captured screenshots into a summary gallery."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Display all captured screenshots\n",
+    "screenshots = sorted(SCREENSHOT_DIR.glob(\"*.png\"))\n",
+    "print(f\"Screenshots captured: {len(screenshots)}\\n\")\n",
+    "\n",
+    "for png in screenshots:\n",
+    "    label = png.stem.replace(\"_\", \" \")\n",
+    "    size_kb = png.stat().st_size / 1024\n",
+    "    print(f\"--- {label} ({size_kb:.0f} KB) ---\")\n",
+    "    display(Image(filename=str(png), width=700))\n",
+    "    print()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## Summary\n",
+    "\n",
+    "| Source | Model | Version | Type | Screenshot |\n",
+    "|--------|-------|---------|------|------------|\n",
+    "| USGS ScienceBase | Kalamazoo River, MI | 6.6 | 2D Unsteady | Yes |\n",
+    "| Minnesota DNR | Chester Creek | 5.0.3 | 1D Steady | Yes |\n",
+    "| Indiana DNR | Fall Creek Trail Bridge | 5.0.7 | 1D Steady | Yes |\n",
+    "| Colorado CHAMP | Henson Creek | 4.1.0 | 1D Steady | Yes |\n",
+    "| FEMA eBFE/BLE | Spring Creek | 5.0.7 | 2D Unsteady | Yes |\n",
+    "| Harris County M3 | Brays Bayou | 3.0.1 | 1D Steady | Yes |\n",
+    "| NOAA ras2fim | (catalog only) | -- | 1D Steady | No (S3) |\n",
+    "\n",
+    "Each model was downloaded using its source class, initialized with `init_ras_project()`, and visualized via `RasMap.screenshot_model()`."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbformat_minor": 4,
+   "version": "3.12.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/ras_commander/RasMap.py
+++ b/ras_commander/RasMap.py
@@ -2232,6 +2232,7 @@ class RasMap:
         delay_seconds: float = 5.0,
         timeout_seconds: float = 1800.0,
         ras_version: Optional[str] = None,
+        configure_layers: bool = True,
     ) -> Optional[Path]:
         """
         One-call screenshot: backup rasmap, open RASMapper, capture, close, restore.
@@ -2247,6 +2248,9 @@ class RasMap:
             delay_seconds: Wait time for RASMapper to render before capture.
             timeout_seconds: Max time to wait for RASMapper window.
             ras_version: HEC-RAS version for finding RASMapper.exe.
+            configure_layers: If True (default), enable terrain and geometry layers
+                in the .rasmap before opening RASMapper so the screenshot shows
+                model content. The original .rasmap is restored afterward.
 
         Returns:
             Path to the saved PNG, or None if capture failed.
@@ -2264,6 +2268,18 @@ class RasMap:
         if rasmap_path.exists():
             rasmap_backup = rasmap_path.with_suffix(".rasmap.screenshot_bak")
             shutil.copy2(rasmap_path, rasmap_backup)
+
+        # Enable terrain and geometry layers so the screenshot is not blank.
+        # Errors are suppressed — the original .rasmap is restored in the finally block.
+        if configure_layers and rasmap_path.exists():
+            try:
+                _rch.set_terrain_layer_visibility(rasmap_path, checked=True)
+            except Exception:
+                pass
+            try:
+                _rch.set_geometry_layer_visibility(rasmap_path, checked=True)
+            except Exception:
+                pass
 
         # Default output path
         if output_path is None:

--- a/ras_commander/RasMap.py
+++ b/ras_commander/RasMap.py
@@ -2269,8 +2269,9 @@ class RasMap:
             rasmap_backup = rasmap_path.with_suffix(".rasmap.screenshot_bak")
             shutil.copy2(rasmap_path, rasmap_backup)
 
-        # Enable terrain and geometry layers so the screenshot is not blank.
-        # Errors are suppressed — the original .rasmap is restored in the finally block.
+        # Enable terrain and geometry layers and zoom view to the model extent so
+        # the screenshot is not blank.  Errors are suppressed — the original .rasmap
+        # is restored in the finally block regardless.
         if configure_layers and rasmap_path.exists():
             try:
                 _rch.set_terrain_layer_visibility(rasmap_path, checked=True)
@@ -2278,6 +2279,10 @@ class RasMap:
                 pass
             try:
                 _rch.set_geometry_layer_visibility(rasmap_path, checked=True)
+            except Exception:
+                pass
+            try:
+                _rch.zoom_to_geometry_layer(rasmap_path)
             except Exception:
                 pass
 

--- a/ras_commander/_rasmap_control_helper.py
+++ b/ras_commander/_rasmap_control_helper.py
@@ -967,10 +967,13 @@ def capture_rasmapper_snapshot(
     timeout_seconds: float = 1800.0,
     poll_interval_seconds: float = 0.5,
 ) -> Optional[Path]:
-    """Capture a visible RASMapper window using the existing Win32 screenshot helper."""
-    if delay_seconds > 0:
-        time.sleep(delay_seconds)
+    """Capture a visible RASMapper window using the existing Win32 screenshot helper.
 
+    ``delay_seconds`` is the render-wait applied *after* the RASMapper window
+    appears, giving the map canvas time to draw terrain and geometry.  Previously
+    the sleep preceded the window search, which consumed the entire delay on
+    process startup for large models and left zero time for map rendering.
+    """
     hwnd = wait_for_rasmapper_window(
         pid=pid,
         timeout_seconds=timeout_seconds,
@@ -979,6 +982,11 @@ def capture_rasmapper_snapshot(
     if hwnd is None:
         logger.warning("No visible RASMapper window found for screenshot capture")
         return None
+
+    # Sleep *after* the window appears so the delay is spent on map rendering,
+    # not on waiting for the process to start.
+    if delay_seconds > 0:
+        time.sleep(delay_seconds)
 
     from .RasScreenshot import RasScreenshot
 

--- a/ras_commander/sources/catalog.py
+++ b/ras_commander/sources/catalog.py
@@ -1,0 +1,215 @@
+"""
+Unified catalog for discovering HEC-RAS models across all sources.
+
+The ModelCatalog provides a single interface for searching and downloading
+models from federal, state, county, and academic sources.
+"""
+
+import logging
+from pathlib import Path
+from typing import Dict, List, Optional, Union
+
+from ras_commander.LoggingConfig import log_call
+from ras_commander.sources.base import (
+    DownloadResult,
+    ModelFilter,
+    ModelMetadata,
+    ModelSource,
+    ModelType,
+    SourceStatus,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class ModelCatalog:
+    """
+    Unified catalog for discovering HEC-RAS models across all sources.
+
+    Example:
+        >>> catalog = get_catalog()
+        >>> models = catalog.search_models(location="Minnesota")
+        >>> result = catalog.download_model(models[0], output_folder="models")
+    """
+
+    def __init__(self):
+        self._sources: Dict[str, ModelSource] = {}
+        self._source_status: Dict[str, SourceStatus] = {}
+
+    @log_call
+    def register_source(self, source: ModelSource) -> None:
+        """Register a model source with the catalog."""
+        name = source.source_name
+        self._sources[name] = source
+        try:
+            status = source.get_source_status()
+            self._source_status[name] = status
+            logger.debug(f"Registered source '{name}' with status: {status.value}")
+        except Exception as e:
+            logger.warning(f"Could not check status for '{name}': {e}")
+            self._source_status[name] = SourceStatus.UNAVAILABLE
+
+    @log_call
+    def list_sources(self, include_unavailable: bool = False) -> List[str]:
+        """List all registered source names."""
+        if include_unavailable:
+            return list(self._sources.keys())
+        return [
+            name for name, status in self._source_status.items()
+            if status not in (SourceStatus.UNAVAILABLE, SourceStatus.DEPRECATED)
+        ]
+
+    def get_source(self, source_name: str) -> Optional[ModelSource]:
+        """Get a registered source by name."""
+        return self._sources.get(source_name)
+
+    @log_call
+    def search_models(
+        self,
+        location: Optional[str] = None,
+        model_type: Optional[ModelType] = None,
+        hecras_version: Optional[str] = None,
+        tags: Optional[List[str]] = None,
+        sources: Optional[List[str]] = None,
+        limit_per_source: Optional[int] = None,
+        model_filter: Optional[ModelFilter] = None,
+    ) -> List[ModelMetadata]:
+        """Search for models across all registered sources."""
+        if sources:
+            source_names = [s for s in sources if s in self._sources]
+        else:
+            source_names = self.list_sources(include_unavailable=False)
+
+        if not source_names:
+            logger.warning("No available sources to search")
+            return []
+
+        all_results = []
+        for source_name in source_names:
+            source = self._sources[source_name]
+            try:
+                # Prefer list_catalog_models (returns ModelMetadata) over
+                # legacy list_models (may return slugs for older sources)
+                list_fn = getattr(source, "list_catalog_models", None)
+                if list_fn and callable(list_fn):
+                    results = list_fn(
+                        location=location,
+                        model_type=model_type,
+                        hecras_version=hecras_version,
+                        tags=tags,
+                        limit=limit_per_source,
+                    )
+                else:
+                    results = source.list_models(
+                        location=location,
+                        model_type=model_type,
+                        hecras_version=hecras_version,
+                        tags=tags,
+                        limit=limit_per_source,
+                    )
+                if model_filter:
+                    results = [m for m in results if model_filter.matches(m)]
+                logger.info(f"Found {len(results)} models from {source_name}")
+                all_results.extend(results)
+            except Exception as e:
+                logger.error(f"Error querying {source_name}: {e}")
+                continue
+
+        return all_results
+
+    @log_call
+    def download_model(
+        self,
+        metadata: ModelMetadata,
+        output_folder: Union[str, Path],
+        extract: bool = True,
+        overwrite: bool = False,
+        credentials: Optional[dict] = None,
+    ) -> DownloadResult:
+        """Download a model using its metadata."""
+        source = self._sources.get(metadata.source_name)
+        if source is None:
+            return DownloadResult(
+                success=False,
+                model_path=None,
+                message=f"Source not registered: {metadata.source_name}",
+                metadata=metadata,
+            )
+
+        try:
+            return source.download_model(
+                model_id=metadata.source_id,
+                output_folder=output_folder,
+                extract=extract,
+                overwrite=overwrite,
+                credentials=credentials,
+            )
+        except Exception as e:
+            logger.error(f"Error downloading model {metadata.name}: {e}")
+            return DownloadResult(
+                success=False,
+                model_path=None,
+                message=f"Download failed: {e}",
+                metadata=metadata,
+            )
+
+    @log_call
+    def refresh_source_status(self) -> None:
+        """Refresh availability status for all registered sources."""
+        for name, source in self._sources.items():
+            try:
+                status = source.get_source_status()
+                self._source_status[name] = status
+            except Exception as e:
+                logger.warning(f"Could not check status for '{name}': {e}")
+                self._source_status[name] = SourceStatus.UNAVAILABLE
+
+
+_catalog: Optional[ModelCatalog] = None
+
+
+def get_catalog(auto_register: bool = True) -> ModelCatalog:
+    """Get the global model catalog instance (singleton)."""
+    global _catalog
+
+    if _catalog is None:
+        _catalog = ModelCatalog()
+
+        if auto_register:
+            try:
+                from ras_commander.sources.federal.usgs_sciencebase import UsgsScienceBase
+                _catalog.register_source(UsgsScienceBase())
+            except (ImportError, Exception):
+                logger.debug("UsgsScienceBase not available")
+
+            try:
+                from ras_commander.sources.state.mn_dnr import MinnesotaDnrModels
+                _catalog.register_source(MinnesotaDnrModels())
+            except (ImportError, Exception):
+                logger.debug("MinnesotaDnrModels not available")
+
+            try:
+                from ras_commander.sources.state.in_dnr import IndianaDnrModels
+                _catalog.register_source(IndianaDnrModels())
+            except (ImportError, Exception):
+                logger.debug("IndianaDnrModels not available")
+
+            try:
+                from ras_commander.sources.state.co_champ import ColoradoChampModels
+                _catalog.register_source(ColoradoChampModels())
+            except (ImportError, Exception):
+                logger.debug("ColoradoChampModels not available")
+
+            try:
+                from ras_commander.sources.federal.noaa_ras2fim import NoaaRas2fimModels
+                _catalog.register_source(NoaaRas2fimModels())
+            except (ImportError, Exception):
+                logger.debug("NoaaRas2fimModels not available")
+
+            try:
+                from ras_commander.sources.federal.ebfe_models import RasEbfeModels
+                _catalog.register_source(RasEbfeModels())
+            except (ImportError, Exception):
+                logger.debug("RasEbfeModels not available")
+
+    return _catalog

--- a/ras_commander/sources/county/m3_model.py
+++ b/ras_commander/sources/county/m3_model.py
@@ -51,7 +51,7 @@ import shutil
 from typing import Union, List, Dict, Optional
 from datetime import datetime
 import logging
-from tqdm import tqdm
+from tqdm.auto import tqdm
 from ras_commander import get_logger
 from ras_commander.LoggingConfig import log_call
 
@@ -453,6 +453,7 @@ class M3Model:
                         unit='iB',
                         unit_scale=True,
                         unit_divisor=1024,
+                        mininterval=2.0,
                     ) as progress_bar:
                         for chunk in response.iter_content(chunk_size=8192):
                             size = file.write(chunk)

--- a/ras_commander/sources/federal/ebfe_models.py
+++ b/ras_commander/sources/federal/ebfe_models.py
@@ -33,7 +33,7 @@ import sys
 import zipfile
 from datetime import datetime
 import requests
-from tqdm import tqdm
+from tqdm.auto import tqdm
 
 from ras_commander.Decorators import log_call
 from ras_commander.sources.base import (
@@ -2594,7 +2594,8 @@ HEC-RAS version: 5.0.1 / 5.0.3
                     initial=resume_from,
                     unit='B',
                     unit_scale=True,
-                    desc=f"    {dest.name}"
+                    desc=f"    {dest.name}",
+                    mininterval=2.0,
                 ) as pbar:
                     for chunk in response.iter_content(chunk_size=8192):
                         if not chunk:
@@ -2632,7 +2633,7 @@ HEC-RAS version: 5.0.1 / 5.0.3
         print(f"  Extracting {description or zip_path.name}...")
         with zipfile.ZipFile(zip_path, 'r') as zf:
             total = sum(info.file_size for info in zf.filelist)
-            with tqdm(total=total, unit='B', unit_scale=True, desc=f"    {zip_path.name}") as pbar:
+            with tqdm(total=total, unit='B', unit_scale=True, desc=f"    {zip_path.name}", mininterval=2.0) as pbar:
                 for member in zf.filelist:
                     zf.extract(member, dest)
                     pbar.update(member.file_size)
@@ -2707,7 +2708,7 @@ HEC-RAS version: 5.0.1 / 5.0.3
                 # Get total uncompressed size for progress bar
                 total_size = sum(info.file_size for info in zip_ref.filelist)
 
-                with tqdm(total=total_size, unit='B', unit_scale=True, desc=f"  Extracting") as pbar:
+                with tqdm(total=total_size, unit='B', unit_scale=True, desc=f"  Extracting", mininterval=2.0) as pbar:
                     for member in zip_ref.filelist:
                         zip_ref.extract(member, extracted_folder)
                         pbar.update(member.file_size)

--- a/ras_commander/sources/federal/ebfe_models.py
+++ b/ras_commander/sources/federal/ebfe_models.py
@@ -24,7 +24,7 @@ Last Updated: 2026-04-24
 """
 
 from pathlib import Path
-from typing import Optional, Dict, List, Any
+from typing import Optional, Dict, List, Any, Union
 import os
 import re
 import shutil
@@ -36,6 +36,9 @@ import requests
 from tqdm import tqdm
 
 from ras_commander.Decorators import log_call
+from ras_commander.sources.base import (
+    DownloadResult, ModelMetadata, ModelSource, ModelType, SourceStatus,
+)
 
 
 class RasEbfeModels:
@@ -228,6 +231,95 @@ class RasEbfeModels:
                 "notes": str(metadata["notes"]),
             }
         return models
+
+    # ── ModelSource protocol ──────────────────────────────────────────────────
+
+    @property
+    def source_name(self) -> str:
+        return "FEMA eBFE/BLE"
+
+    @property
+    def source_type(self) -> str:
+        return "federal"
+
+    @staticmethod
+    def get_source_status() -> SourceStatus:
+        """Always available — registry is built-in, no network required."""
+        return SourceStatus.AVAILABLE
+
+    @staticmethod
+    def list_models(
+        location: Optional[str] = None,
+        model_type: Optional[ModelType] = None,
+        hecras_version: Optional[str] = None,
+        tags: Optional[List[str]] = None,
+        limit: Optional[int] = None,
+        **kwargs,
+    ) -> List[ModelMetadata]:
+        """Return ModelMetadata for all registered eBFE models, with optional filtering."""
+        results: List[ModelMetadata] = []
+        for key, meta in RasEbfeModels._MODEL_REGISTRY.items():
+            if location and location.lower() not in meta["study_area"].lower():
+                continue
+            if hecras_version and meta["ras_version"] != hecras_version:
+                continue
+            results.append(
+                ModelMetadata(
+                    source_name="FEMA eBFE/BLE",
+                    source_id=key,
+                    name=meta["study_area"],
+                    description=meta["notes"],
+                    location=meta["huc8"],
+                    model_type=ModelType.UNSTEADY_2D,
+                    hecras_version=meta["ras_version"],
+                    tags=["ebfe", "ble", "fema", meta["huc8"]],
+                )
+            )
+            if limit and len(results) >= limit:
+                break
+        return results
+
+    @staticmethod
+    @log_call
+    def download_model(
+        model_id: str,
+        output_folder: Union[str, Path],
+        extract: bool = True,
+        overwrite: bool = False,
+        credentials: Optional[dict] = None,
+        **kwargs,
+    ) -> DownloadResult:
+        """Thin ModelSource-compatible wrapper around organize_model()."""
+        try:
+            organized_path = RasEbfeModels.organize_model(
+                model_key=model_id,
+                output_root=Path(output_folder),
+                **kwargs,
+            )
+            meta = RasEbfeModels._MODEL_REGISTRY.get(
+                RasEbfeModels.normalize_model_key(model_id), {}
+            )
+            return DownloadResult(
+                success=True,
+                model_path=organized_path,
+                message=f"Organized {model_id} to {organized_path}",
+                metadata=ModelMetadata(
+                    source_name="FEMA eBFE/BLE",
+                    source_id=model_id,
+                    name=meta.get("study_area", model_id),
+                    description=meta.get("notes", ""),
+                    location=meta.get("huc8", ""),
+                    model_type=ModelType.UNSTEADY_2D,
+                    hecras_version=meta.get("ras_version"),
+                ),
+                extracted=True,
+            )
+        except Exception as exc:
+            return DownloadResult(
+                success=False,
+                model_path=None,
+                message=str(exc),
+            )
 
     @staticmethod
     @log_call

--- a/ras_commander/sources/federal/usgs_sciencebase.py
+++ b/ras_commander/sources/federal/usgs_sciencebase.py
@@ -1,0 +1,1004 @@
+"""
+USGS ScienceBase Calibrated HEC-RAS Models
+
+Download and organize publicly available calibrated HEC-RAS models from
+USGS ScienceBase for use as example datasets in ras-commander calibration
+workflows, validation notebooks, and the USGS metrics module.
+
+Models:
+- Kalamazoo River, MI (2D, HEC-RAS 6.6, CC0-1.0) - DOI: 10.5066/P13CPA5B
+- St. Joseph River, IN (1D steady, HEC-RAS 4.10) - DOI: 10.5066/F7QZ2836
+
+Generated: 2025-05-05
+"""
+
+from pathlib import Path
+from typing import Optional, Dict, List, Set, Any
+import hashlib
+import json
+import logging
+import re
+import shutil
+import time
+import zipfile
+from datetime import datetime, timezone
+
+import requests
+from tqdm.auto import tqdm
+
+from ras_commander.Decorators import log_call
+
+logger = logging.getLogger(__name__)
+
+SCIENCEBASE_CATALOG_URL = "https://www.sciencebase.gov/catalog"
+
+_SB_MAX_PER_PAGE = 100
+_SB_DEFAULT_FIELDS = (
+    "title,id,hasChildren,files,parentId,tags,summary,"
+    "identifiers,spatial,dates,contacts,provenance"
+)
+_SB_REQUEST_DELAY = 0.6
+_FIM_SITES_URL = (
+    "https://fim.wim.usgs.gov/server/rest/services/"
+    "FIMMapper/sites/MapServer/0/query"
+)
+
+_RAS_EXTENSIONS = frozenset({
+    ".prj", ".g01", ".g02", ".g03", ".g04", ".g05",
+    ".p01", ".p02", ".p03", ".p04", ".p05",
+    ".f01", ".f02", ".u01", ".u02", ".hdf",
+    ".rasmap", ".dss",
+})
+_HMS_EXTENSIONS = frozenset({
+    ".hms", ".basin", ".met", ".gage", ".grid", ".dss",
+})
+_MODEL_ARCHIVE_EXTENSIONS = frozenset({".zip", ".7z", ".tar.gz"})
+
+
+class UsgsScienceBase:
+    """
+    Download and organize USGS ScienceBase calibrated HEC-RAS models.
+
+    Implements the ModelSource protocol for catalog integration while
+    maintaining backward compatibility with the original slug-based API.
+
+    Example:
+        >>> from ras_commander.sources.federal.usgs_sciencebase import UsgsScienceBase
+        >>> from pathlib import Path
+        >>>
+        >>> # Download Kalamazoo River model
+        >>> model_dir = UsgsScienceBase.download_kalamazoo(Path("H:/Testing/USGS Sciencebase Models"))
+        >>>
+        >>> # Use with ras-commander
+        >>> from ras_commander import init_ras_project
+        >>> ras = init_ras_project(model_dir / "hec_ras_model", ras_version="6.6")
+    """
+
+    SOURCE_NAME = "USGS ScienceBase"
+
+    @property
+    def source_name(self) -> str:
+        return self.SOURCE_NAME
+
+    @property
+    def source_type(self) -> str:
+        return "federal"
+
+    @staticmethod
+    def get_source_status():
+        """Check if ScienceBase API is reachable."""
+        from ras_commander.sources.base import SourceStatus
+        try:
+            resp = requests.get(
+                f"{SCIENCEBASE_CATALOG_URL}/item/4f4e4760e4b07f02db47df9c",
+                params={"format": "json", "fields": "title"},
+                timeout=15,
+            )
+            resp.raise_for_status()
+            return SourceStatus.AVAILABLE
+        except Exception:
+            return SourceStatus.UNAVAILABLE
+
+    @staticmethod
+    def list_catalog_models(**kwargs):
+        """Return ModelMetadata list for catalog integration."""
+        from ras_commander.sources.base import ModelMetadata, ModelType
+        results = []
+        _type_map = {
+            "2D unsteady": ModelType.UNSTEADY_2D,
+            "1D steady": ModelType.STEADY_1D,
+            "1D unsteady": ModelType.UNSTEADY_1D,
+        }
+        for slug, info in UsgsScienceBase._MODEL_REGISTRY.items():
+            mt = _type_map.get(info.get("model_type", ""), ModelType.UNKNOWN)
+            results.append(ModelMetadata(
+                source_name="USGS ScienceBase",
+                source_id=slug,
+                name=info["name"],
+                description=info.get("notes", ""),
+                location=info["name"],
+                model_type=mt,
+                hecras_version=info.get("ras_version"),
+                doi=info.get("doi"),
+                url=f"{SCIENCEBASE_CATALOG_URL}/item/{info['sciencebase_id']}",
+                tags=["USGS", "ScienceBase", "calibrated"],
+            ))
+        return results
+
+    _MODEL_REGISTRY = {
+        "kalamazoo": {
+            "name": "Kalamazoo River, MI",
+            "sciencebase_id": "67a38201d34ee33d441d2f22",
+            "doi": "10.5066/P13CPA5B",
+            "ras_version": "6.6",
+            "model_type": "2D unsteady",
+            "license": "CC0-1.0",
+            "crs": "EPSG:6499",
+            "calibration_data": True,
+            "hdf_results": True,
+            "dss_file": True,
+            "files": {
+                "hec_ras_model.zip": {"size_mb": 2977, "required": True},
+                "calibration_data.zip": {"size_mb": 38, "required": True},
+                "quasi_steady_raster_outputs.zip": {"size_mb": 317, "required": False},
+                "miscellaneous.zip": {"size_mb": 27, "required": False},
+                "substrate.zip": {"size_mb": 0.02, "required": False},
+                "readme.md": {"size_mb": 0.01, "required": True},
+            },
+            "project_file": "hec_ras_model/kalamazoo_trowbridg.prj",
+            "notes": (
+                "2D hydraulic model of Kalamazoo River between Trowbridge Dam "
+                "and Allegan City Dam. 21 plans with HDF outputs, dedicated "
+                "calibration_data/ with ADCP velocity and WSE measurements from "
+                "June 2024 and April 2025 campaigns. 602 MB DSS file included."
+            ),
+        },
+        "st-joseph": {
+            "name": "St. Joseph River, Elkhart, IN",
+            "sciencebase_id": "584197dfe4b04fc80e518b6b",
+            "doi": "10.5066/F7QZ2836",
+            "ras_version": "4.10",
+            "model_type": "1D steady",
+            "license": "USGS federal data release",
+            "crs": None,
+            "calibration_data": True,
+            "hdf_results": False,
+            "dss_file": False,
+            "files": {
+                "model.zip": {"size_mb": 5, "required": True},
+                "calibration_table_4_from_report.xlsx": {"size_mb": 0.04, "required": True},
+                "model_output_table.csv": {"size_mb": 0.05, "required": True},
+                "field_data.zip": {"size_mb": 129, "required": False},
+                "dem_clip.zip": {"size_mb": 26, "required": False},
+                "modelversion.docx": {"size_mb": 0.14, "required": False},
+                "README_Contents_Directory.docx": {"size_mb": 0.01, "required": False},
+            },
+            "project_file": "model/model/St_Joe_Elkhart_FIM.prj",
+            "notes": (
+                "1D steady-state flood inundation model for 6.6-mile reach. "
+                "24 plans (only p24 in archive), calibrated to USGS 04101000. "
+                "Excel calibration table + CSV model output for easy comparison."
+            ),
+        },
+    }
+
+    _MODEL_ALIASES = {
+        "kalamazoo": "kalamazoo",
+        "kalamazoo-river": "kalamazoo",
+        "kzoo": "kalamazoo",
+        "trowbridge": "kalamazoo",
+        "P13CPA5B": "kalamazoo",
+        "st-joseph": "st-joseph",
+        "st-joseph-river": "st-joseph",
+        "stjoseph": "st-joseph",
+        "elkhart": "st-joseph",
+        "F7QZ2836": "st-joseph",
+    }
+
+    @staticmethod
+    def normalize_model_key(model_key: str) -> str:
+        """Return the canonical model slug for a name or alias."""
+        key = str(model_key).strip().lower().replace("_", "-").replace(" ", "-")
+        normalized = UsgsScienceBase._MODEL_ALIASES.get(key)
+        if normalized is None:
+            valid = ", ".join(sorted(UsgsScienceBase._MODEL_REGISTRY))
+            raise ValueError(
+                f"Unknown ScienceBase model '{model_key}'. Known models: {valid}"
+            )
+        return normalized
+
+    @staticmethod
+    def get_model_info(model_key: str) -> dict:
+        """Return registry metadata for a model."""
+        slug = UsgsScienceBase.normalize_model_key(model_key)
+        return UsgsScienceBase._MODEL_REGISTRY[slug].copy()
+
+    @staticmethod
+    def list_models() -> list[str]:
+        """Return list of available model slugs."""
+        return list(UsgsScienceBase._MODEL_REGISTRY.keys())
+
+    @staticmethod
+    def _download_file(url: str, dest: Path, desc: str = "") -> Path:
+        """Download a file with progress bar."""
+        resp = requests.get(url, stream=True)
+        resp.raise_for_status()
+        total = int(resp.headers.get("content-length", 0))
+        with open(dest, "wb") as f, tqdm(
+            total=total, unit="B", unit_scale=True, desc=desc or dest.name,
+            mininterval=2.0,
+        ) as pbar:
+            for chunk in resp.iter_content(chunk_size=8192):
+                f.write(chunk)
+                pbar.update(len(chunk))
+        return dest
+
+    @staticmethod
+    def _get_file_url(sciencebase_id: str, filename: str) -> str:
+        """Build the ScienceBase catalog file download URL."""
+        return f"{SCIENCEBASE_CATALOG_URL}/file/get/{sciencebase_id}?name={filename}"
+
+    @staticmethod
+    @log_call
+    def download_model(
+        model_key: str,
+        output_dir: Path,
+        required_only: bool = False,
+        extract: bool = True,
+    ) -> Path:
+        """
+        Download a USGS ScienceBase model to output_dir.
+
+        Args:
+            model_key: Model slug, alias, or DOI suffix
+            output_dir: Parent directory for the model folder
+            required_only: If True, skip optional files (rasters, field data, DEM)
+            extract: If True, extract ZIP files after download
+
+        Returns:
+            Path to the model directory
+        """
+        slug = UsgsScienceBase.normalize_model_key(model_key)
+        info = UsgsScienceBase._MODEL_REGISTRY[slug]
+        sb_id = info["sciencebase_id"]
+
+        model_dir = Path(output_dir) / slug
+        model_dir.mkdir(parents=True, exist_ok=True)
+
+        for filename, file_info in info["files"].items():
+            if required_only and not file_info["required"]:
+                logger.debug(f"Skipping optional file: {filename}")
+                continue
+
+            dest = model_dir / filename
+            if dest.exists() and dest.stat().st_size > 1000:
+                logger.debug(f"Already downloaded: {filename}")
+                continue
+
+            url = UsgsScienceBase._get_file_url(sb_id, filename)
+            logger.debug(f"Downloading {filename} ({file_info['size_mb']} MB)...")
+            UsgsScienceBase._download_file(url, dest, desc=filename)
+
+        if extract:
+            for filename in info["files"]:
+                if filename.endswith(".zip"):
+                    zip_path = model_dir / filename
+                    if zip_path.exists():
+                        extract_dir = model_dir / filename.replace(".zip", "")
+                        if not extract_dir.exists():
+                            logger.debug(f"Extracting {filename}...")
+                            zipfile.ZipFile(zip_path).extractall(model_dir)
+
+        return model_dir
+
+    @staticmethod
+    def get_project_path(model_key: str, base_dir: Path) -> Path:
+        """Return the path to the .prj file for a downloaded model."""
+        slug = UsgsScienceBase.normalize_model_key(model_key)
+        info = UsgsScienceBase._MODEL_REGISTRY[slug]
+        return Path(base_dir) / slug / info["project_file"]
+
+    # ------------------------------------------------------------------
+    # Discovery helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _sb_request(
+        url: str,
+        params: Optional[dict] = None,
+        request_delay: float = _SB_REQUEST_DELAY,
+        max_retries: int = 3,
+    ) -> Optional[dict]:
+        """Make a ScienceBase API request with retry and rate limiting."""
+        for attempt in range(max_retries):
+            try:
+                time.sleep(request_delay)
+                resp = requests.get(url, params=params, timeout=30)
+                if resp.status_code == 429:
+                    wait = min(60, request_delay * (2 ** (attempt + 1)))
+                    logger.warning("Rate limited by ScienceBase, waiting %.0fs", wait)
+                    time.sleep(wait)
+                    continue
+                resp.raise_for_status()
+                return resp.json()
+            except requests.exceptions.HTTPError as exc:
+                if exc.response is not None and exc.response.status_code >= 500:
+                    logger.warning("ScienceBase server error %s, retry %d/%d",
+                                   exc.response.status_code, attempt + 1, max_retries)
+                    time.sleep(request_delay * 2)
+                    continue
+                logger.error("ScienceBase request failed: %s", exc)
+                return None
+            except (requests.exceptions.ConnectionError,
+                    requests.exceptions.Timeout) as exc:
+                logger.warning("ScienceBase connection issue (%s), retry %d/%d",
+                               type(exc).__name__, attempt + 1, max_retries)
+                time.sleep(request_delay * 2)
+                continue
+        logger.error("ScienceBase request failed after %d retries: %s", max_retries, url)
+        return None
+
+    @staticmethod
+    def _search_sciencebase(
+        query: str,
+        max_results: int = 500,
+        fields: str = _SB_DEFAULT_FIELDS,
+        request_delay: float = _SB_REQUEST_DELAY,
+    ) -> List[dict]:
+        """Paginated search of ScienceBase catalog. Returns raw item dicts."""
+        all_items: List[dict] = []
+        start = 0
+        total = None
+        while True:
+            params = {
+                "q": query,
+                "max": _SB_MAX_PER_PAGE,
+                "start": start,
+                "fields": fields,
+                "format": "json",
+            }
+            data = UsgsScienceBase._sb_request(
+                f"{SCIENCEBASE_CATALOG_URL}/items",
+                params=params,
+                request_delay=request_delay,
+            )
+            if data is None:
+                break
+            items = data.get("items", [])
+            if not items:
+                break
+            if total is None:
+                total = data.get("total", 0)
+            all_items.extend(items)
+            start += len(items)
+            if start >= min(max_results, total or start + 1):
+                break
+        return all_items
+
+    @staticmethod
+    def _get_item_detail(
+        item_id: str,
+        request_delay: float = _SB_REQUEST_DELAY,
+    ) -> Optional[dict]:
+        """Fetch full metadata for a single ScienceBase item."""
+        return UsgsScienceBase._sb_request(
+            f"{SCIENCEBASE_CATALOG_URL}/item/{item_id}",
+            params={"format": "json"},
+            request_delay=request_delay,
+        )
+
+    @staticmethod
+    def _detect_model_files(
+        files: List[dict],
+    ) -> tuple:
+        """Detect HEC-RAS/HMS files from a ScienceBase file list.
+
+        Returns (ras_files, hms_files, model_type_guess).
+        """
+        ras_files: List[str] = []
+        hms_files: List[str] = []
+        for f in files:
+            name = f.get("name", "")
+            suffix = Path(name).suffix.lower()
+            if suffix in _RAS_EXTENSIONS:
+                ras_files.append(name)
+            if suffix in _HMS_EXTENSIONS:
+                hms_files.append(name)
+            if suffix in _MODEL_ARCHIVE_EXTENSIONS:
+                lower = name.lower()
+                if any(kw in lower for kw in ("ras", "hydraulic", "model", "hec")):
+                    ras_files.append(name)
+                if "hms" in lower:
+                    hms_files.append(name)
+        if ras_files and hms_files:
+            guess = "HEC-RAS+HMS"
+        elif ras_files:
+            guess = "HEC-RAS"
+        elif hms_files:
+            guess = "HEC-HMS"
+        else:
+            guess = "unknown"
+        return ras_files, hms_files, guess
+
+    @staticmethod
+    def _extract_version(text: str) -> Optional[str]:
+        """Try to extract a HEC-RAS or HEC-HMS version from text."""
+        m = re.search(r"HEC-RAS\s+(?:version\s+)?(\d+\.?\d*\.?\d*)", text, re.IGNORECASE)
+        if m:
+            return m.group(1)
+        m = re.search(r"HEC-HMS\s+(?:version\s+)?(\d+\.?\d*\.?\d*)", text, re.IGNORECASE)
+        if m:
+            return m.group(1)
+        return None
+
+    @staticmethod
+    def _extract_doi(item: dict) -> Optional[str]:
+        """Extract DOI from ScienceBase item identifiers."""
+        for ident in item.get("identifiers", []):
+            if ident.get("type", "").upper() == "DOI":
+                return ident.get("key")
+            scheme = ident.get("scheme", "")
+            if "doi" in scheme.lower():
+                return ident.get("key")
+        return None
+
+    @staticmethod
+    def _extract_state(item: dict) -> Optional[str]:
+        """Extract US state from spatial or tags."""
+        for tag in item.get("tags", []):
+            if tag.get("type") == "Place":
+                return tag.get("name")
+        spatial = item.get("spatial", {})
+        rep_point = spatial.get("representativePoint")
+        if rep_point:
+            return f"{rep_point.get('latitude', '')},{rep_point.get('longitude', '')}"
+        return None
+
+    @staticmethod
+    def _classify_sciencebase_item(
+        item: dict,
+        discovery_source: str,
+        discovery_query: str,
+        fim_site_no: Optional[str] = None,
+    ) -> dict:
+        """Transform a raw ScienceBase item into a candidate model dict."""
+        files = item.get("files", []) or []
+        ras_files, hms_files, model_type = UsgsScienceBase._detect_model_files(files)
+
+        title = item.get("title", "")
+        summary = item.get("summary", "")
+        combined_text = f"{title} {summary}"
+        version = UsgsScienceBase._extract_version(combined_text)
+
+        total_size = sum(f.get("size", 0) for f in files) / (1024 * 1024)
+
+        has_prj = any(Path(f.get("name", "")).suffix.lower() == ".prj" for f in files)
+        has_geo = any(Path(f.get("name", "")).suffix.lower().startswith(".g0") for f in files)
+        title_mentions_model = bool(re.search(
+            r"HEC-RAS|HEC-HMS|hydraulic model|flood.inundation.*model",
+            title, re.IGNORECASE
+        ))
+
+        if has_prj or has_geo:
+            confidence = "high"
+        elif ras_files or hms_files or title_mentions_model:
+            confidence = "medium"
+        else:
+            confidence = "low"
+
+        tags = [t.get("name", "") for t in item.get("tags", []) if t.get("name")]
+
+        sb_id = item.get("id", "")
+        candidate = {
+            "sciencebase_id": sb_id,
+            "title": title,
+            "url": f"{SCIENCEBASE_CATALOG_URL}/item/{sb_id}",
+            "doi": UsgsScienceBase._extract_doi(item),
+            "discovery_source": discovery_source,
+            "discovery_query": discovery_query,
+            "has_children": item.get("hasChildren", False),
+            "parent_id": item.get("parentId"),
+            "files": [{"name": f.get("name"), "size": f.get("size", 0),
+                        "content_type": f.get("contentType")}
+                       for f in files],
+            "ras_files_detected": ras_files,
+            "hms_files_detected": hms_files,
+            "model_type_guess": model_type,
+            "ras_version_guess": version,
+            "state": UsgsScienceBase._extract_state(item),
+            "tags": tags,
+            "total_size_mb": round(total_size, 2),
+            "confidence": confidence,
+        }
+        if fim_site_no:
+            candidate["fim_site_no"] = fim_site_no
+        return candidate
+
+    # ------------------------------------------------------------------
+    # Discovery cache
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _cache_key_hash(key: str) -> str:
+        return hashlib.md5(key.encode()).hexdigest()[:12]
+
+    @staticmethod
+    def _load_cache(cache_dir: Path, cache_key: str) -> Optional[Any]:
+        if cache_dir is None:
+            return None
+        path = cache_dir / f"{cache_key}.json"
+        if not path.exists():
+            return None
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+            return data.get("payload")
+        except (json.JSONDecodeError, OSError):
+            return None
+
+    @staticmethod
+    def _save_cache(cache_dir: Path, cache_key: str, payload: Any) -> None:
+        if cache_dir is None:
+            return
+        cache_dir.mkdir(parents=True, exist_ok=True)
+        path = cache_dir / f"{cache_key}.json"
+        data = {
+            "_cached_at": datetime.now(timezone.utc).isoformat(),
+            "payload": payload,
+        }
+        path.write_text(json.dumps(data, indent=2, default=str), encoding="utf-8")
+
+    # ------------------------------------------------------------------
+    # Strategy 1: Paginated keyword search (CLB-547)
+    # ------------------------------------------------------------------
+
+    _DEFAULT_KEYWORD_QUERIES = [
+        '"HEC-RAS"',
+        '"HEC-RAS" model',
+        '"hydraulic model" "HEC-RAS"',
+    ]
+
+    @staticmethod
+    def _discover_keyword_search(
+        queries: Optional[List[str]] = None,
+        max_results_per_query: int = 500,
+        cache_dir: Optional[Path] = None,
+        request_delay: float = _SB_REQUEST_DELAY,
+        seen_ids: Optional[Set[str]] = None,
+    ) -> Dict[str, dict]:
+        """Search ScienceBase with paginated keyword queries."""
+        if queries is None:
+            queries = UsgsScienceBase._DEFAULT_KEYWORD_QUERIES
+        if seen_ids is None:
+            seen_ids = set()
+        results: Dict[str, dict] = {}
+
+        for query in tqdm(queries, desc="Keyword search", unit="query"):
+            cache_key = f"search_{UsgsScienceBase._cache_key_hash(query)}"
+            cached = UsgsScienceBase._load_cache(cache_dir, cache_key) if cache_dir else None
+            if cached is not None:
+                items = cached
+            else:
+                items = UsgsScienceBase._search_sciencebase(
+                    query, max_results=max_results_per_query,
+                    request_delay=request_delay,
+                )
+                UsgsScienceBase._save_cache(cache_dir, cache_key, items)
+
+            for item in items:
+                sb_id = item.get("id", "")
+                if sb_id in seen_ids or sb_id in results:
+                    continue
+                candidate = UsgsScienceBase._classify_sciencebase_item(
+                    item, discovery_source="keyword", discovery_query=query,
+                )
+                results[sb_id] = candidate
+                seen_ids.add(sb_id)
+
+        return results
+
+    # ------------------------------------------------------------------
+    # Strategy 2: FIM program crawler (CLB-546)
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _query_fim_sites(
+        request_delay: float = _SB_REQUEST_DELAY,
+    ) -> List[dict]:
+        """Query the USGS Flood Inundation Mapping ArcGIS REST endpoint."""
+        sites: List[dict] = []
+        offset = 0
+        page_size = 50
+        while True:
+            params = {
+                "where": "1=1",
+                "outFields": "SITE_NO,COMMUNITY,STATE,DATA_LINK,SHORT_NAME",
+                "returnGeometry": "false",
+                "resultOffset": offset,
+                "resultRecordCount": page_size,
+                "f": "json",
+            }
+            data = UsgsScienceBase._sb_request(
+                _FIM_SITES_URL, params=params, request_delay=request_delay,
+            )
+            if data is None:
+                break
+            features = data.get("features", [])
+            if not features:
+                break
+            for feat in features:
+                attrs = feat.get("attributes", {})
+                sites.append({
+                    "site_no": str(attrs.get("SITE_NO", "")),
+                    "community": attrs.get("COMMUNITY", ""),
+                    "state": attrs.get("STATE", ""),
+                    "data_link": attrs.get("DATA_LINK", ""),
+                    "short_name": attrs.get("SHORT_NAME", ""),
+                })
+            if len(features) < page_size:
+                break
+            offset += page_size
+        return sites
+
+    @staticmethod
+    def _discover_fim_sites(
+        cache_dir: Optional[Path] = None,
+        request_delay: float = _SB_REQUEST_DELAY,
+        seen_ids: Optional[Set[str]] = None,
+    ) -> Dict[str, dict]:
+        """Cross-reference FIM sites with ScienceBase to find model archives."""
+        if seen_ids is None:
+            seen_ids = set()
+        results: Dict[str, dict] = {}
+
+        cached_sites = UsgsScienceBase._load_cache(cache_dir, "fim_sites") if cache_dir else None
+        if cached_sites is not None:
+            fim_sites = cached_sites
+        else:
+            fim_sites = UsgsScienceBase._query_fim_sites(request_delay=request_delay)
+            UsgsScienceBase._save_cache(cache_dir, "fim_sites", fim_sites)
+
+        if not fim_sites:
+            logger.warning("No FIM sites retrieved")
+            return results
+
+        by_state: Dict[str, List[dict]] = {}
+        for site in fim_sites:
+            st = site.get("state", "unknown")
+            by_state.setdefault(st, []).append(site)
+
+        for state, state_sites in tqdm(by_state.items(), desc="FIM cross-ref", unit="state"):
+            cache_key = f"fim_state_{UsgsScienceBase._cache_key_hash(state)}"
+            cached = UsgsScienceBase._load_cache(cache_dir, cache_key) if cache_dir else None
+            if cached is not None:
+                items = cached
+            else:
+                query = f'"flood-inundation" "{state}"'
+                items = UsgsScienceBase._search_sciencebase(
+                    query, max_results=200, request_delay=request_delay,
+                )
+                UsgsScienceBase._save_cache(cache_dir, cache_key, items)
+
+            site_numbers = {s["site_no"] for s in state_sites if s.get("site_no")}
+            community_names = {s["community"].lower() for s in state_sites if s.get("community")}
+
+            for item in items:
+                sb_id = item.get("id", "")
+                if sb_id in seen_ids or sb_id in results:
+                    continue
+                title_lower = item.get("title", "").lower()
+                summary_lower = item.get("summary", "").lower()
+                combined = f"{title_lower} {summary_lower}"
+                matched_site = None
+                for sno in site_numbers:
+                    if sno in combined:
+                        matched_site = sno
+                        break
+                if matched_site is None:
+                    for cname in community_names:
+                        if cname and cname in combined:
+                            for s in state_sites:
+                                if s["community"].lower() == cname:
+                                    matched_site = s["site_no"]
+                                    break
+                            break
+
+                candidate = UsgsScienceBase._classify_sciencebase_item(
+                    item, discovery_source="fim",
+                    discovery_query=f"FIM {state}",
+                    fim_site_no=matched_site,
+                )
+                results[sb_id] = candidate
+                seen_ids.add(sb_id)
+
+        return results
+
+    # ------------------------------------------------------------------
+    # Strategy 3: Alternate keyword search (CLB-549)
+    # ------------------------------------------------------------------
+
+    _ALTERNATE_KEYWORD_QUERIES = [
+        '"hydraulic model archive"',
+        '"flood-inundation study"',
+        '"streamflow simulation" model',
+        '"dam breach" "HEC-RAS"',
+        '"sediment transport" "HEC-RAS"',
+        '"HEC-HMS"',
+        '"HEC-HMS" "HEC-RAS"',
+        '"step-backwater"',
+        '"rain on grid" "HEC-RAS"',
+        '"levee breach" model',
+    ]
+
+    @staticmethod
+    def _discover_alternate_keywords(
+        max_results_per_query: int = 500,
+        cache_dir: Optional[Path] = None,
+        request_delay: float = _SB_REQUEST_DELAY,
+        seen_ids: Optional[Set[str]] = None,
+    ) -> Dict[str, dict]:
+        """Search ScienceBase with alternate/expanded keyword queries."""
+        return UsgsScienceBase._discover_keyword_search(
+            queries=UsgsScienceBase._ALTERNATE_KEYWORD_QUERIES,
+            max_results_per_query=max_results_per_query,
+            cache_dir=cache_dir,
+            request_delay=request_delay,
+            seen_ids=seen_ids,
+        )
+
+    # ------------------------------------------------------------------
+    # Strategy 4: Child item traversal (CLB-548)
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _get_item_children(
+        parent_id: str,
+        request_delay: float = _SB_REQUEST_DELAY,
+        max_depth: int = 2,
+        _current_depth: int = 0,
+    ) -> List[dict]:
+        """Recursively fetch child items of a ScienceBase parent."""
+        if _current_depth >= max_depth:
+            return []
+        params = {
+            "parentId": parent_id,
+            "max": _SB_MAX_PER_PAGE,
+            "fields": _SB_DEFAULT_FIELDS,
+            "format": "json",
+        }
+        data = UsgsScienceBase._sb_request(
+            f"{SCIENCEBASE_CATALOG_URL}/items",
+            params=params,
+            request_delay=request_delay,
+        )
+        if data is None:
+            return []
+        children = data.get("items", [])
+        all_children = list(children)
+        for child in children:
+            if child.get("hasChildren"):
+                grandchildren = UsgsScienceBase._get_item_children(
+                    child["id"],
+                    request_delay=request_delay,
+                    max_depth=max_depth,
+                    _current_depth=_current_depth + 1,
+                )
+                all_children.extend(grandchildren)
+        return all_children
+
+    @staticmethod
+    def _discover_children(
+        parent_candidates: Dict[str, dict],
+        cache_dir: Optional[Path] = None,
+        request_delay: float = _SB_REQUEST_DELAY,
+        seen_ids: Optional[Set[str]] = None,
+    ) -> Dict[str, dict]:
+        """For items with children, traverse child items for model files."""
+        if seen_ids is None:
+            seen_ids = set()
+        results: Dict[str, dict] = {}
+
+        parents_with_children = {
+            k: v for k, v in parent_candidates.items()
+            if v.get("has_children")
+        }
+        if not parents_with_children:
+            return results
+
+        for sb_id, parent in tqdm(parents_with_children.items(),
+                                   desc="Child traversal", unit="parent"):
+            cache_key = f"children_{sb_id[:12]}"
+            cached = UsgsScienceBase._load_cache(cache_dir, cache_key) if cache_dir else None
+            if cached is not None:
+                children = cached
+            else:
+                children = UsgsScienceBase._get_item_children(
+                    sb_id, request_delay=request_delay,
+                )
+                UsgsScienceBase._save_cache(cache_dir, cache_key, children)
+
+            for child in children:
+                child_id = child.get("id", "")
+                if child_id in seen_ids or child_id in results:
+                    continue
+                candidate = UsgsScienceBase._classify_sciencebase_item(
+                    child,
+                    discovery_source="children",
+                    discovery_query=f"child of {parent.get('title', sb_id)[:60]}",
+                )
+                if candidate["model_type_guess"] != "unknown":
+                    results[child_id] = candidate
+                    seen_ids.add(child_id)
+
+        return results
+
+    # ------------------------------------------------------------------
+    # Version filter
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _parse_version_tuple(version_str: str) -> tuple:
+        """Parse '6.0' or '4.3.1' into a comparable tuple of ints."""
+        parts = []
+        for p in version_str.split("."):
+            try:
+                parts.append(int(p))
+            except ValueError:
+                break
+        return tuple(parts) if parts else (0,)
+
+    @staticmethod
+    def _version_filter(
+        candidates: Dict[str, dict],
+        min_ras_version: Optional[str],
+        min_hms_version: Optional[str],
+    ) -> Dict[str, dict]:
+        """Filter candidates by detected version. Keeps items with no detected version."""
+        if not min_ras_version and not min_hms_version:
+            return candidates
+        filtered: Dict[str, dict] = {}
+        min_ras = UsgsScienceBase._parse_version_tuple(min_ras_version) if min_ras_version else None
+        min_hms = UsgsScienceBase._parse_version_tuple(min_hms_version) if min_hms_version else None
+
+        for sb_id, c in candidates.items():
+            v = c.get("ras_version_guess")
+            if v is None:
+                filtered[sb_id] = c
+                continue
+            v_tuple = UsgsScienceBase._parse_version_tuple(v)
+            mtype = c.get("model_type_guess", "")
+            if "HMS" in mtype and min_hms:
+                if v_tuple >= min_hms:
+                    filtered[sb_id] = c
+            elif min_ras:
+                if v_tuple >= min_ras:
+                    filtered[sb_id] = c
+            else:
+                filtered[sb_id] = c
+        return filtered
+
+    # ------------------------------------------------------------------
+    # Main orchestrator
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    @log_call
+    def discover_models(
+        cache_dir: Optional[Path] = None,
+        strategies: Optional[List[str]] = None,
+        min_ras_version: Optional[str] = "6.0",
+        min_hms_version: Optional[str] = "4.3",
+        include_hms: bool = True,
+        max_results_per_query: int = 500,
+        request_delay: float = _SB_REQUEST_DELAY,
+        export_json: Optional[Path] = None,
+        verbose: bool = False,
+    ) -> Dict[str, dict]:
+        """Systematically discover HEC-RAS/HMS models on USGS ScienceBase.
+
+        Runs multiple discovery strategies (keyword search, FIM cross-reference,
+        alternate keywords, child item traversal) and returns deduplicated
+        candidate model entries.
+
+        Args:
+            cache_dir: Directory for caching intermediate API results.
+            strategies: Subset of ["keyword", "fim", "alternate", "children"].
+                        Defaults to all four.
+            min_ras_version: Minimum HEC-RAS version (e.g. "6.0"). None = no filter.
+            min_hms_version: Minimum HEC-HMS version. None = no filter.
+            include_hms: If False, exclude HEC-HMS-only results.
+            max_results_per_query: Max items per search query.
+            request_delay: Seconds between API requests.
+            export_json: Path to write final results as JSON.
+            verbose: If True, print summary statistics.
+
+        Returns:
+            Dict keyed by sciencebase_id, each value a candidate model dict.
+        """
+        all_strategies = ["keyword", "fim", "alternate", "children"]
+        active = strategies if strategies else all_strategies
+        seen_ids: Set[str] = set()
+        all_candidates: Dict[str, dict] = {}
+        errors: List[str] = []
+
+        strategy_bar = tqdm(active, desc="Discovery strategies", unit="strategy")
+
+        for strategy in strategy_bar:
+            strategy_bar.set_postfix(current=strategy, found=len(all_candidates))
+            try:
+                if strategy == "keyword":
+                    found = UsgsScienceBase._discover_keyword_search(
+                        max_results_per_query=max_results_per_query,
+                        cache_dir=cache_dir,
+                        request_delay=request_delay,
+                        seen_ids=seen_ids,
+                    )
+                elif strategy == "fim":
+                    found = UsgsScienceBase._discover_fim_sites(
+                        cache_dir=cache_dir,
+                        request_delay=request_delay,
+                        seen_ids=seen_ids,
+                    )
+                elif strategy == "alternate":
+                    found = UsgsScienceBase._discover_alternate_keywords(
+                        max_results_per_query=max_results_per_query,
+                        cache_dir=cache_dir,
+                        request_delay=request_delay,
+                        seen_ids=seen_ids,
+                    )
+                elif strategy == "children":
+                    found = UsgsScienceBase._discover_children(
+                        parent_candidates=all_candidates,
+                        cache_dir=cache_dir,
+                        request_delay=request_delay,
+                        seen_ids=seen_ids,
+                    )
+                else:
+                    logger.warning("Unknown strategy: %s", strategy)
+                    continue
+                all_candidates.update(found)
+            except Exception as exc:
+                msg = f"Strategy '{strategy}' failed: {exc}"
+                logger.error(msg)
+                errors.append(msg)
+
+        if not include_hms:
+            all_candidates = {
+                k: v for k, v in all_candidates.items()
+                if v.get("model_type_guess") != "HEC-HMS"
+            }
+
+        all_candidates = UsgsScienceBase._version_filter(
+            all_candidates, min_ras_version, min_hms_version,
+        )
+
+        if verbose:
+            by_type: Dict[str, int] = {}
+            by_conf: Dict[str, int] = {}
+            for c in all_candidates.values():
+                by_type[c["model_type_guess"]] = by_type.get(c["model_type_guess"], 0) + 1
+                by_conf[c["confidence"]] = by_conf.get(c["confidence"], 0) + 1
+            print(f"\nDiscovered {len(all_candidates)} candidate models")
+            print(f"  By type: {by_type}")
+            print(f"  By confidence: {by_conf}")
+            if errors:
+                print(f"  Errors: {len(errors)}")
+
+        if export_json:
+            export_json.parent.mkdir(parents=True, exist_ok=True)
+            output = {
+                "_discovery_meta": {
+                    "timestamp": datetime.now(timezone.utc).isoformat(),
+                    "strategies": active,
+                    "min_ras_version": min_ras_version,
+                    "min_hms_version": min_hms_version,
+                    "total_candidates": len(all_candidates),
+                    "errors": errors,
+                },
+                "candidates": all_candidates,
+            }
+            export_json.write_text(
+                json.dumps(output, indent=2, default=str), encoding="utf-8",
+            )
+            logger.debug("Exported %d candidates to %s", len(all_candidates), export_json)
+
+        return all_candidates

--- a/ras_commander/sources/state/co_champ.py
+++ b/ras_commander/sources/state/co_champ.py
@@ -1,0 +1,345 @@
+"""
+Colorado CWCB CHAMP (Colorado Hazard Mapping Program) HEC-RAS model source.
+
+Provides access to hydraulic models published through the CHAMP portal.
+This is a small source (~2 actual HEC-RAS models) included for completeness.
+
+API: https://coloradohazardmapping.com/api/hydraulicModels
+Download: https://coloradohazardmapping.com/file/{UUID}
+"""
+
+import logging
+import re
+import zipfile
+from pathlib import Path
+from typing import List, Optional, Union
+
+import requests
+
+from ras_commander import get_logger
+from ras_commander.LoggingConfig import log_call
+from ras_commander.sources.base import (
+    DownloadResult,
+    ModelMetadata,
+    ModelSource,
+    ModelType,
+    SourceStatus,
+)
+
+logger = get_logger(__name__)
+
+CHAMP_API_URL = "https://coloradohazardmapping.com/api/hydraulicModels"
+CHAMP_FILE_URL = "https://coloradohazardmapping.com/file/{uuid}"
+REQUEST_TIMEOUT = 30
+
+
+class ColoradoChampModels:
+    """
+    Colorado CWCB CHAMP - Colorado Hazard Mapping Program hydraulic models.
+
+    Queries the CHAMP portal for published HEC-RAS hydraulic models.
+    The catalog is very small (~8 entries total, ~2 with actual HEC-RAS files),
+    so no pagination is needed. No authentication required.
+
+    Example:
+        >>> source = ColoradoChampModels()
+        >>> models = source.list_models(location="Boulder")
+        >>> result = source.download_model(
+        ...     model_id=models[0].source_id,
+        ...     output_folder="champ_models"
+        ... )
+    """
+
+    SOURCE_NAME = "Colorado CHAMP"
+
+    @property
+    def source_name(self) -> str:
+        """Human-readable source name."""
+        return self.SOURCE_NAME
+
+    @property
+    def source_type(self) -> str:
+        """Source category."""
+        return "state"
+
+    @staticmethod
+    @log_call
+    def list_models(
+        location: Optional[str] = None,
+        model_type: Optional[ModelType] = None,
+        hecras_version: Optional[str] = None,
+        tags: Optional[List[str]] = None,
+        limit: Optional[int] = None,
+        **kwargs,
+    ) -> List[ModelMetadata]:
+        """
+        Query CHAMP API for HEC-RAS hydraulic models.
+
+        Args:
+            location: Filter by county name (case-insensitive substring match)
+            model_type: Filter by model type (most CHAMP models are STEADY_1D)
+            hecras_version: Filter by HEC-RAS version string
+            tags: Filter by tags (AND logic)
+            limit: Maximum number of results to return
+            **kwargs: Additional filters (unused)
+
+        Returns:
+            List of ModelMetadata for matching HEC-RAS models
+        """
+        try:
+            response = requests.get(CHAMP_API_URL, timeout=REQUEST_TIMEOUT)
+            response.raise_for_status()
+            items = response.json()
+        except requests.RequestException as e:
+            logger.error(f"Failed to query CHAMP API: {e}")
+            return []
+        except ValueError as e:
+            logger.error(f"Invalid JSON from CHAMP API: {e}")
+            return []
+
+        if not isinstance(items, dict):
+            logger.error(f"Unexpected CHAMP API response type: {type(items)}")
+            return []
+
+        models: List[ModelMetadata] = []
+
+        for uuid, item in items.items():
+            title = item.get("title", "") or ""
+            # Skip entries explicitly marked as having no models
+            if "(no models)" in title.lower() or "(without models)" in title.lower():
+                continue
+
+            metadata = _parse_champ_item(uuid, item)
+
+            if location and location.lower() not in metadata.location.lower():
+                continue
+            if model_type and metadata.model_type != model_type:
+                continue
+            if hecras_version and metadata.hecras_version != hecras_version:
+                continue
+            if tags and not all(tag in metadata.tags for tag in tags):
+                continue
+
+            models.append(metadata)
+
+            if limit and len(models) >= limit:
+                break
+
+        logger.info(f"Found {len(models)} models in CHAMP catalog")
+        return models
+
+    @staticmethod
+    @log_call
+    def download_model(
+        model_id: str,
+        output_folder: Union[str, Path],
+        extract: bool = True,
+        overwrite: bool = False,
+        credentials: Optional[dict] = None,
+    ) -> DownloadResult:
+        """
+        Download a model by UUID from CHAMP.
+
+        Args:
+            model_id: The UUID string for the model file
+            output_folder: Directory to save the downloaded model
+            extract: Whether to extract ZIP archives after download
+            overwrite: Whether to overwrite existing files
+            credentials: Not required (CHAMP is public)
+
+        Returns:
+            DownloadResult with download status and path
+        """
+        output_folder = Path(output_folder)
+        output_folder.mkdir(parents=True, exist_ok=True)
+
+        # Fetch catalog to get metadata for this model
+        metadata = _find_model_by_uuid(model_id)
+        if metadata is None:
+            # Build a minimal metadata for the result
+            metadata = ModelMetadata(
+                source_name="Colorado CHAMP",
+                source_id=model_id,
+                name=f"CHAMP Model {model_id[:8]}",
+                description="",
+                location="Colorado",
+                model_type=ModelType.UNKNOWN,
+            )
+
+        # Build output path
+        safe_name = re.sub(r"[^\w\s-]", "", metadata.name).strip().replace(" ", "_")
+        if not safe_name:
+            safe_name = model_id[:12]
+        model_folder = output_folder / safe_name
+
+        if model_folder.exists() and not overwrite:
+            if any(model_folder.rglob("*.prj")):
+                logger.debug(f"Model folder already exists with content: {model_folder}")
+                return DownloadResult(
+                    success=True,
+                    model_path=model_folder,
+                    message="Model already downloaded (use overwrite=True to re-download)",
+                    metadata=metadata,
+                    extracted=extract,
+                )
+            logger.warning(
+                f"Model folder exists but contains no .prj file (possibly a failed prior download); re-downloading: {model_folder}"
+            )
+
+        model_folder.mkdir(parents=True, exist_ok=True)
+
+        # Download file
+        download_url = CHAMP_FILE_URL.format(uuid=model_id)
+        logger.debug(f"Downloading from {download_url}")
+
+        try:
+            response = requests.get(download_url, stream=True, timeout=REQUEST_TIMEOUT)
+            response.raise_for_status()
+        except requests.RequestException as e:
+            logger.error(f"Download failed for {model_id}: {e}")
+            return DownloadResult(
+                success=False,
+                model_path=None,
+                message=f"Download failed: {e}",
+                metadata=metadata,
+            )
+
+        # Determine filename from Content-Disposition header or fallback
+        filename = _extract_filename(response) or f"{model_id[:12]}.zip"
+        file_path = model_folder / filename
+
+        # Stream to disk with optional progress
+        total_size = int(response.headers.get("content-length", 0))
+        try:
+            from tqdm import tqdm
+
+            progress = tqdm(
+                total=total_size or None,
+                unit="B",
+                unit_scale=True,
+                desc=filename,
+                disable=total_size == 0,
+            )
+        except ImportError:
+            progress = None
+
+        try:
+            with open(file_path, "wb") as f:
+                for chunk in response.iter_content(chunk_size=8192):
+                    f.write(chunk)
+                    if progress is not None:
+                        progress.update(len(chunk))
+        finally:
+            if progress is not None:
+                progress.close()
+
+        logger.debug(f"Downloaded {file_path.name} ({file_path.stat().st_size} bytes)")
+
+        # Extract if ZIP
+        extracted = False
+        if extract and file_path.suffix.lower() == ".zip":
+            try:
+                with zipfile.ZipFile(file_path, "r") as zf:
+                    zf.extractall(model_folder)
+                extracted = True
+                logger.debug(f"Extracted {file_path.name} to {model_folder}")
+            except zipfile.BadZipFile:
+                logger.warning(f"{file_path.name} is not a valid ZIP archive")
+
+        return DownloadResult(
+            success=True,
+            model_path=model_folder,
+            message=f"Successfully downloaded {file_path.name}",
+            metadata=metadata,
+            extracted=extracted,
+        )
+
+    @staticmethod
+    @log_call
+    def get_source_status() -> SourceStatus:
+        """
+        Check if the CHAMP API is reachable.
+
+        Returns:
+            SourceStatus.AVAILABLE if the API responds, UNAVAILABLE otherwise
+        """
+        try:
+            response = requests.get(CHAMP_API_URL, timeout=REQUEST_TIMEOUT)
+            response.raise_for_status()
+            return SourceStatus.AVAILABLE
+        except requests.RequestException as e:
+            logger.warning(f"CHAMP API unreachable: {e}")
+            return SourceStatus.UNAVAILABLE
+
+
+# ---------------------------------------------------------------------------
+# Private helpers
+# ---------------------------------------------------------------------------
+
+
+def _parse_champ_item(uuid: str, item: dict) -> ModelMetadata:
+    """Parse a CHAMP API entry (UUID + item dict) into ModelMetadata."""
+    title = item.get("title", "") or "Unnamed Study"
+    desc_obj = item.get("description", {})
+    description = desc_obj.get("html", "") if isinstance(desc_obj, dict) else str(desc_obj)
+    file_info = item.get("file", {}) or {}
+    file_size_bytes = file_info.get("fileSizeBytes", 0) or 0
+    file_size_mb = round(file_size_bytes / (1024 * 1024), 1) if file_size_bytes else None
+
+    # Infer model type from title/description
+    model_type = ModelType.STEADY_1D
+    text = (title + " " + description).lower()
+    if "2d" in text or "two-dimensional" in text:
+        model_type = ModelType.UNSTEADY_2D
+    elif "unsteady" in text:
+        model_type = ModelType.UNSTEADY_1D
+
+    # Extract HEC-RAS version if mentioned
+    hecras_version = None
+    version_match = re.search(r"HEC-RAS\s+(\d+\.?\d*)", text, re.IGNORECASE)
+    if version_match:
+        hecras_version = version_match.group(1)
+
+    tags: List[str] = ["colorado", "champ", "cwcb"]
+
+    download_url = CHAMP_FILE_URL.format(uuid=uuid)
+
+    return ModelMetadata(
+        source_name="Colorado CHAMP",
+        source_id=uuid,
+        name=title,
+        description=description[:200] if description else "CHAMP hydraulic model",
+        location="Colorado",
+        model_type=model_type,
+        hecras_version=hecras_version,
+        url=download_url,
+        file_size_mb=file_size_mb,
+        tags=tags,
+    )
+
+
+def _find_model_by_uuid(uuid: str) -> Optional[ModelMetadata]:
+    """Fetch the full catalog and find the entry matching the given UUID."""
+    try:
+        response = requests.get(CHAMP_API_URL, timeout=REQUEST_TIMEOUT)
+        response.raise_for_status()
+        items = response.json()
+    except Exception:
+        return None
+
+    if not isinstance(items, dict):
+        return None
+
+    item = items.get(uuid)
+    if item:
+        return _parse_champ_item(uuid, item)
+    return None
+
+
+def _extract_filename(response: requests.Response) -> Optional[str]:
+    """Extract filename from Content-Disposition header if present."""
+    cd = response.headers.get("Content-Disposition", "")
+    if not cd:
+        return None
+    match = re.search(r'filename[*]?=["\']?([^"\';]+)', cd)
+    return match.group(1).strip() if match else None

--- a/ras_commander/sources/state/co_champ.py
+++ b/ras_commander/sources/state/co_champ.py
@@ -211,7 +211,7 @@ class ColoradoChampModels:
         # Stream to disk with optional progress
         total_size = int(response.headers.get("content-length", 0))
         try:
-            from tqdm import tqdm
+            from tqdm.auto import tqdm
 
             progress = tqdm(
                 total=total_size or None,
@@ -219,6 +219,7 @@ class ColoradoChampModels:
                 unit_scale=True,
                 desc=filename,
                 disable=total_size == 0,
+                mininterval=2.0,
             )
         except ImportError:
             progress = None

--- a/ras_commander/sources/state/in_dnr.py
+++ b/ras_commander/sources/state/in_dnr.py
@@ -1,0 +1,825 @@
+"""
+Indiana DNR H&H Model Library - HEC-RAS model source.
+
+Provides access to ~11,400 HEC-RAS floodplain analysis models from the
+Indiana Department of Natural Resources Hydrology & Hydraulics Model Library.
+
+Programs represented: APPROX_ZoneA (5797), PERMIT (2616), FARA (1434),
+FIS (1231), APPROX (889), LOMR (40), OTHER (16), HYDRO (3).
+
+API: ArcGIS REST (gisdata.in.gov) with three-step download workflow:
+  1. Query model metadata from HydromodelView_RO/FeatureServer/20
+  2. Look up download link ID from HydroModelLibrary/FeatureServer/0
+  3. Download ZIP from dowunity.dnr.in.gov
+
+No authentication required.
+
+This module follows the centralized logging configuration from ras-commander.
+
+Logging Configuration:
+- The logging is set up in the logging_config.py file.
+- A @log_call decorator is available to automatically log function calls.
+- Log levels: DEBUG, INFO, WARNING, ERROR, CRITICAL
+- Logs are written to both console and a rotating file handler.
+- The default log file is 'ras_commander.log' in the 'logs' directory.
+- The default log level is INFO.
+
+To use logging in this module:
+1. Use the @log_call decorator for automatic function call logging.
+2. For additional logging, use logger.[level]() calls (e.g., logger.info(), logger.debug()).
+3. Obtain the logger using: logger = get_logger(__name__)
+
+-----
+
+All of the methods in this class are static and are designed to be used without instantiation.
+
+List of Functions in IndianaDnrModels:
+- list_models()
+- download_model()
+- get_source_status()
+- list_counties()
+- _get_download_link()
+- _parse_hecras_version()
+- _infer_model_type()
+- _build_where_clause()
+- _query_feature_server()
+"""
+
+import re
+import zipfile
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple, Union
+
+import requests
+from tqdm.auto import tqdm
+
+import logging
+from ras_commander import get_logger
+from ras_commander.LoggingConfig import log_call
+from ras_commander.sources.base import (
+    DownloadResult,
+    ModelMetadata,
+    ModelSource,
+    ModelType,
+    SourceStatus,
+)
+
+logger = get_logger(__name__)
+
+
+class IndianaDnrModels:
+    """
+    Indiana DNR H&H Model Library - Floodplain analysis HEC-RAS models.
+
+    Provides unified search and download access to ~11,400 HEC-RAS models
+    published by the Indiana Department of Natural Resources. Models span
+    multiple floodplain analysis programs including FEMA FIS studies,
+    Approximate Zone A studies, FARA, permits, and LOMRs.
+
+    All methods are static -- no instantiation required.
+
+    Three-step download workflow:
+      1. Query metadata via ArcGIS REST (HydromodelView_RO FeatureServer layer 20)
+      2. Look up iimagelinkid via HydroModelLibrary FeatureServer layer 0
+      3. Download ZIP from dowunity.dnr.in.gov/AppFileInfo/download
+
+    Example:
+        >>> from ras_commander.sources.state.in_dnr import IndianaDnrModels
+        >>>
+        >>> # List models in Marion County
+        >>> models = IndianaDnrModels.list_models(location="MARION", limit=10)
+        >>> for m in models:
+        ...     print(f"{m.source_id}: {m.name} ({m.hecras_version})")
+        >>>
+        >>> # Download a specific model
+        >>> result = IndianaDnrModels.download_model(
+        ...     model_id=models[0].source_id,
+        ...     output_folder="indiana_models"
+        ... )
+        >>> if result.success:
+        ...     print(f"Downloaded to: {result.model_path}")
+        >>>
+        >>> # List all counties with model counts
+        >>> counties = IndianaDnrModels.list_counties()
+        >>> print(counties[:5])  # Top counties by name
+    """
+
+    SOURCE_NAME: str = "Indiana DNR"
+
+    # ArcGIS REST endpoints (gisdata.in.gov -- maps.indiana.edu is dead)
+    _METADATA_URL: str = (
+        "https://gisdata.in.gov/server/rest/services/Hosted/"
+        "HydromodelView_RO/FeatureServer/20/query"
+    )
+    _DOWNLOAD_LINK_URL: str = (
+        "https://gisdata.in.gov/server/rest/services/Hosted/"
+        "HydroModelLibrary/FeatureServer/0/query"
+    )
+    _DOWNLOAD_BASE_URL: str = (
+        "https://dowunity.dnr.in.gov/AppFileInfo/download"
+    )
+
+    # Pagination settings
+    _PAGE_SIZE: int = 1000
+
+    # Known programs for reference / validation
+    PROGRAMS: Tuple[str, ...] = (
+        "APPROX_ZoneA", "PERMIT", "FARA", "FIS",
+        "APPROX", "LOMR", "OTHER", "HYDRO",
+    )
+
+    @property
+    def source_name(self) -> str:
+        """Human-readable source name."""
+        return self.SOURCE_NAME
+
+    @property
+    def source_type(self) -> str:
+        """Source category."""
+        return "state"
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    @log_call
+    def list_models(
+        location: Optional[str] = None,
+        model_type: Optional[ModelType] = None,
+        hecras_version: Optional[str] = None,
+        tags: Optional[List[str]] = None,
+        limit: Optional[int] = None,
+        **kwargs,
+    ) -> List[ModelMetadata]:
+        """
+        Query ArcGIS REST for HEC-RAS models in the Indiana DNR library.
+
+        Args:
+            location: Filter by county name (scountyname), case-insensitive
+                substring match. E.g. "MARION", "Hamilton", "Allen".
+            model_type: Filter by ModelType enum. Most Indiana models are
+                STEADY_1D; a few HEC-RAS 5.x models may be UNSTEADY_1D.
+            hecras_version: Filter by exact HEC-RAS version string
+                (e.g. "4.1.0", "5.0.7").
+            tags: Filter by tags (AND logic). Matched against the program
+                field (e.g. ["FIS"], ["PERMIT"]).
+            limit: Maximum number of results to return. None returns all
+                matching records (may be thousands -- use with caution).
+            **kwargs: Additional filters:
+                - river (str): Filter by water body name (swaterbodyname),
+                  case-insensitive substring.
+                - program (str): Filter by program name exactly
+                  (e.g. "FIS", "PERMIT", "FARA").
+
+        Returns:
+            List of ModelMetadata objects matching all specified filters.
+
+        Example:
+            >>> # Models in Allen County
+            >>> models = IndianaDnrModels.list_models(location="Allen", limit=5)
+            >>>
+            >>> # FIS models on specific river
+            >>> models = IndianaDnrModels.list_models(
+            ...     river="White River", program="FIS"
+            ... )
+        """
+        river: Optional[str] = kwargs.get("river")
+        program: Optional[str] = kwargs.get("program")
+
+        where_clause = IndianaDnrModels._build_where_clause(
+            location=location,
+            river=river,
+            program=program,
+        )
+
+        out_fields = (
+            "hydromodelid,sitemmeta,swaterbodyname,scountyname,"
+            "program,strhydromodelinfo,dtmhydromodeldate"
+        )
+
+        # Paginate through all results
+        all_features: List[Dict] = []
+        offset = 0
+
+        while True:
+            params: Dict = {
+                "where": where_clause,
+                "outFields": out_fields,
+                "f": "json",
+                "resultRecordCount": IndianaDnrModels._PAGE_SIZE,
+                "resultOffset": offset,
+                "returnGeometry": "false",
+            }
+
+            try:
+                data = IndianaDnrModels._query_feature_server(
+                    IndianaDnrModels._METADATA_URL, params
+                )
+            except Exception as exc:
+                logger.error(f"Failed to query IN DNR metadata API: {exc}")
+                return []
+
+            features = data.get("features", [])
+            if not features:
+                break
+
+            all_features.extend(features)
+            logger.debug(
+                f"Fetched {len(features)} records (offset={offset}, "
+                f"total so far={len(all_features)})"
+            )
+
+            # If we got fewer than PAGE_SIZE, we've reached the end
+            if len(features) < IndianaDnrModels._PAGE_SIZE:
+                break
+
+            offset += IndianaDnrModels._PAGE_SIZE
+
+            # Early exit if we already have enough for the limit
+            if limit and len(all_features) >= limit:
+                break
+
+        logger.debug(f"Retrieved {len(all_features)} total records from IN DNR API")
+
+        # Convert features to ModelMetadata and apply post-query filters
+        results: List[ModelMetadata] = []
+
+        for feature in all_features:
+            attrs = feature.get("attributes", {})
+            metadata = IndianaDnrModels._parse_feature(attrs)
+
+            # Post-query filter: model_type
+            if model_type is not None and metadata.model_type != model_type:
+                continue
+
+            # Post-query filter: hecras_version (exact match)
+            if hecras_version is not None and metadata.hecras_version != hecras_version:
+                continue
+
+            # Post-query filter: tags (AND logic)
+            if tags:
+                if not all(
+                    any(t.lower() == meta_tag.lower() for meta_tag in metadata.tags)
+                    for t in tags
+                ):
+                    continue
+
+            results.append(metadata)
+
+            if limit and len(results) >= limit:
+                break
+
+        logger.debug(
+            f"Returning {len(results)} models after filtering "
+            f"(from {len(all_features)} raw records)"
+        )
+        return results
+
+    @staticmethod
+    @log_call
+    def download_model(
+        model_id: Union[str, int],
+        output_folder: Union[str, Path],
+        extract: bool = True,
+        overwrite: bool = False,
+        credentials: Optional[Dict] = None,
+    ) -> DownloadResult:
+        """
+        Download a HEC-RAS model from the Indiana DNR library.
+
+        Three-step process:
+          1. Look up iimagelinkid from the hydromodelid
+          2. Download the ZIP archive from dowunity.dnr.in.gov
+          3. Optionally extract the ZIP
+
+        Args:
+            model_id: The hydromodelid (from ModelMetadata.source_id).
+                Can be string or int.
+            output_folder: Directory where the model will be saved.
+                A subfolder named after the model_id will be created.
+            extract: If True, extract the downloaded ZIP archive.
+            overwrite: If True, overwrite existing files.
+            credentials: Not required (Indiana DNR is public access).
+
+        Returns:
+            DownloadResult with success status, model path, and metadata.
+
+        Example:
+            >>> result = IndianaDnrModels.download_model(
+            ...     model_id="12345",
+            ...     output_folder="my_models",
+            ...     extract=True
+            ... )
+            >>> if result.success:
+            ...     print(f"Model at: {result.model_path}")
+        """
+        model_id_str = str(model_id)
+        output_folder = Path(output_folder)
+        output_folder.mkdir(parents=True, exist_ok=True)
+
+        model_folder = output_folder / f"IN_DNR_{model_id_str}"
+
+        # Check if already exists
+        if model_folder.exists() and not overwrite:
+            logger.debug(
+                f"Model folder already exists: {model_folder}. "
+                "Use overwrite=True to re-download."
+            )
+            return DownloadResult(
+                success=True,
+                model_path=model_folder,
+                message="Model already downloaded (use overwrite=True to re-download)",
+                metadata=None,
+                extracted=extract,
+            )
+
+        # Step 1: Fetch model metadata for the DownloadResult
+        metadata = IndianaDnrModels._fetch_single_model_metadata(model_id_str)
+
+        # Step 2: Get download link ID
+        try:
+            image_link_id = IndianaDnrModels._get_download_link(model_id_str)
+        except Exception as exc:
+            logger.error(f"Failed to get download link for model {model_id_str}: {exc}")
+            return DownloadResult(
+                success=False,
+                model_path=None,
+                message=f"Failed to get download link: {exc}",
+                metadata=metadata,
+            )
+
+        if not image_link_id:
+            return DownloadResult(
+                success=False,
+                model_path=None,
+                message=f"No download link found for hydromodelid={model_id_str}",
+                metadata=metadata,
+            )
+
+        # Step 3: Download the ZIP
+        download_url = (
+            f"{IndianaDnrModels._DOWNLOAD_BASE_URL}?fileID={image_link_id}"
+        )
+
+        model_folder.mkdir(parents=True, exist_ok=True)
+        zip_path = model_folder / f"IN_DNR_{model_id_str}.zip"
+
+        logger.debug(f"Downloading model {model_id_str} from {download_url}")
+
+        try:
+            response = requests.get(download_url, stream=True, timeout=300)
+            response.raise_for_status()
+
+            total_size = int(response.headers.get("content-length", 0))
+
+            with open(zip_path, "wb") as f:
+                if total_size > 0:
+                    with tqdm(
+                        desc=f"IN DNR model {model_id_str}",
+                        total=total_size,
+                        unit="iB",
+                        unit_scale=True,
+                        unit_divisor=1024,
+                        mininterval=2.0,
+                    ) as pbar:
+                        for chunk in response.iter_content(chunk_size=8192):
+                            written = f.write(chunk)
+                            pbar.update(written)
+                else:
+                    for chunk in response.iter_content(chunk_size=8192):
+                        f.write(chunk)
+
+            logger.debug(f"Downloaded ZIP to {zip_path}")
+
+        except requests.exceptions.RequestException as exc:
+            logger.error(f"Download failed for model {model_id_str}: {exc}")
+            # Clean up partial download
+            if zip_path.exists():
+                zip_path.unlink()
+            return DownloadResult(
+                success=False,
+                model_path=None,
+                message=f"Download failed: {exc}",
+                metadata=metadata,
+            )
+
+        # Step 4: Extract if requested
+        extracted = False
+        if extract:
+            try:
+                logger.debug(f"Extracting {zip_path} to {model_folder}")
+                with zipfile.ZipFile(zip_path, "r") as zf:
+                    zf.extractall(model_folder)
+                extracted = True
+                logger.debug(f"Extraction complete for model {model_id_str}")
+
+                # Remove ZIP after successful extraction
+                zip_path.unlink()
+                logger.debug(f"Removed temporary ZIP: {zip_path}")
+
+            except (zipfile.BadZipFile, Exception) as exc:
+                logger.warning(
+                    f"Extraction failed for model {model_id_str}: {exc}. "
+                    "ZIP file retained."
+                )
+
+        return DownloadResult(
+            success=True,
+            model_path=model_folder,
+            message=(
+                f"Successfully downloaded and {'extracted' if extracted else 'saved'} "
+                f"model {model_id_str}"
+            ),
+            metadata=metadata,
+            extracted=extracted,
+        )
+
+    @staticmethod
+    @log_call
+    def get_source_status() -> SourceStatus:
+        """
+        Check if the Indiana DNR ArcGIS REST API is reachable.
+
+        Returns:
+            SourceStatus.AVAILABLE if the API responds, UNAVAILABLE otherwise.
+
+        Example:
+            >>> status = IndianaDnrModels.get_source_status()
+            >>> print(status)  # SourceStatus.AVAILABLE
+        """
+        try:
+            params = {
+                "where": "1=1",
+                "outFields": "hydromodelid",
+                "f": "json",
+                "resultRecordCount": 1,
+                "returnGeometry": "false",
+            }
+            response = requests.get(
+                IndianaDnrModels._METADATA_URL,
+                params=params,
+                timeout=15,
+            )
+            response.raise_for_status()
+            data = response.json()
+
+            if "features" in data:
+                logger.debug("Indiana DNR API is available")
+                return SourceStatus.AVAILABLE
+            else:
+                logger.warning("Indiana DNR API returned unexpected response")
+                return SourceStatus.UNAVAILABLE
+
+        except Exception as exc:
+            logger.warning(f"Indiana DNR API health check failed: {exc}")
+            return SourceStatus.UNAVAILABLE
+
+    @staticmethod
+    @log_call
+    def list_counties() -> List[str]:
+        """
+        Get distinct county names that have HEC-RAS models in the library.
+
+        Returns:
+            Sorted list of county name strings.
+            Top counties include: Marion (477), Hamilton (421),
+            Allen (419), Lake (359).
+
+        Example:
+            >>> counties = IndianaDnrModels.list_counties()
+            >>> print(f"{len(counties)} counties with models")
+            >>> print(counties[:10])
+        """
+        params = {
+            "where": "sitemmeta LIKE '%HEC-RAS%'",
+            "outFields": "scountyname",
+            "returnDistinctValues": "true",
+            "returnGeometry": "false",
+            "f": "json",
+            "resultRecordCount": 200,
+        }
+
+        try:
+            data = IndianaDnrModels._query_feature_server(
+                IndianaDnrModels._METADATA_URL, params
+            )
+        except Exception as exc:
+            logger.error(f"Failed to query counties: {exc}")
+            return []
+
+        counties: List[str] = []
+        for feature in data.get("features", []):
+            county = feature.get("attributes", {}).get("scountyname")
+            if county and county.strip():
+                counties.append(county.strip())
+
+        counties = sorted(set(counties))
+        logger.debug(f"Found {len(counties)} counties with HEC-RAS models")
+        return counties
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    @log_call
+    def _get_download_link(hydromodelid: Union[str, int]) -> Optional[str]:
+        """
+        Step 2: Look up the iimagelinkid for a given hydromodelid.
+
+        This queries the HydroModelLibrary FeatureServer to retrieve the
+        file ID needed to construct the download URL.
+
+        Args:
+            hydromodelid: The model's unique hydromodelid.
+
+        Returns:
+            The iimagelinkid string, or None if not found.
+
+        Raises:
+            requests.exceptions.RequestException: On network errors.
+        """
+        params = {
+            "where": f"lnghydromodelid={hydromodelid}",
+            "outFields": "iimagelinkid",
+            "f": "json",
+            "returnGeometry": "false",
+        }
+
+        data = IndianaDnrModels._query_feature_server(
+            IndianaDnrModels._DOWNLOAD_LINK_URL, params
+        )
+
+        features = data.get("features", [])
+        if not features:
+            logger.warning(
+                f"No download link found for hydromodelid={hydromodelid}"
+            )
+            return None
+
+        image_link_id = features[0].get("attributes", {}).get("iimagelinkid")
+        if image_link_id is not None:
+            image_link_id = str(image_link_id)
+            logger.debug(
+                f"Found iimagelinkid={image_link_id} for "
+                f"hydromodelid={hydromodelid}"
+            )
+
+        return image_link_id
+
+    @staticmethod
+    def _query_feature_server(url: str, params: Dict) -> Dict:
+        """
+        Execute a query against an ArcGIS REST FeatureServer endpoint.
+
+        Args:
+            url: The full query URL for the FeatureServer layer.
+            params: Query parameters dict.
+
+        Returns:
+            Parsed JSON response as a dict.
+
+        Raises:
+            requests.exceptions.RequestException: On HTTP errors.
+            ValueError: If response is not valid JSON or contains an error.
+        """
+        response = requests.get(url, params=params, timeout=60)
+        response.raise_for_status()
+        data = response.json()
+
+        # ArcGIS REST returns errors in the JSON body, not via HTTP status
+        if "error" in data:
+            error_info = data["error"]
+            code = error_info.get("code", "unknown")
+            message = error_info.get("message", "Unknown ArcGIS error")
+            raise ValueError(
+                f"ArcGIS REST error (code={code}): {message}"
+            )
+
+        return data
+
+    @staticmethod
+    def _build_where_clause(
+        location: Optional[str] = None,
+        river: Optional[str] = None,
+        program: Optional[str] = None,
+    ) -> str:
+        """
+        Build a SQL WHERE clause for the ArcGIS REST query.
+
+        Always includes the base filter for HEC-RAS models. Additional
+        filters are appended with AND.
+
+        Args:
+            location: County name substring filter (scountyname).
+            river: Water body name substring filter (swaterbodyname).
+            program: Exact program name filter (program).
+
+        Returns:
+            SQL WHERE clause string.
+        """
+        clauses: List[str] = ["sitemmeta LIKE '%HEC-RAS%'"]
+
+        if location:
+            # Case-insensitive LIKE for county
+            safe_location = location.replace("'", "''")
+            clauses.append(f"UPPER(scountyname) LIKE '%{safe_location.upper()}%'")
+
+        if river:
+            safe_river = river.replace("'", "''")
+            clauses.append(f"UPPER(swaterbodyname) LIKE '%{safe_river.upper()}%'")
+
+        if program:
+            safe_program = program.replace("'", "''")
+            clauses.append(f"program = '{safe_program}'")
+
+        return " AND ".join(clauses)
+
+    @staticmethod
+    def _parse_feature(attrs: Dict) -> ModelMetadata:
+        """
+        Parse a single ArcGIS feature's attributes into a ModelMetadata.
+
+        Args:
+            attrs: The 'attributes' dict from a feature JSON object.
+
+        Returns:
+            A ModelMetadata instance populated from the feature attributes.
+        """
+        hydromodelid = str(attrs.get("hydromodelid", ""))
+        sitemmeta = attrs.get("sitemmeta") or ""
+        water_body = attrs.get("swaterbodyname") or "Unknown"
+        county = attrs.get("scountyname") or "Unknown"
+        program = attrs.get("program") or ""
+        description = attrs.get("strhydromodelinfo") or ""
+        model_date_raw = attrs.get("dtmhydromodeldate")
+
+        # Parse HEC-RAS version from sitemmeta
+        hecras_version = IndianaDnrModels._parse_hecras_version(sitemmeta)
+
+        # Infer model type
+        model_type = IndianaDnrModels._infer_model_type(sitemmeta, hecras_version)
+
+        # Build location string
+        location = f"{county} County, Indiana"
+        if water_body and water_body != "Unknown":
+            location = f"{water_body}, {location}"
+
+        # Build human-readable name
+        name_parts: List[str] = []
+        if water_body and water_body != "Unknown":
+            name_parts.append(water_body)
+        if county and county != "Unknown":
+            name_parts.append(f"{county} Co")
+        if program:
+            name_parts.append(f"({program})")
+        name = " - ".join(name_parts) if name_parts else f"IN DNR Model {hydromodelid}"
+
+        # Parse model date (ArcGIS returns epoch milliseconds or ISO string)
+        study_date: Optional[str] = None
+        last_modified: Optional[datetime] = None
+        if model_date_raw is not None:
+            try:
+                if isinstance(model_date_raw, (int, float)) and model_date_raw > 0:
+                    # Epoch milliseconds
+                    dt = datetime.utcfromtimestamp(model_date_raw / 1000.0)
+                    study_date = dt.strftime("%Y-%m-%d")
+                    last_modified = dt
+                elif isinstance(model_date_raw, str) and model_date_raw.strip():
+                    dt = datetime.fromisoformat(
+                        model_date_raw.replace("Z", "+00:00")
+                    )
+                    study_date = dt.strftime("%Y-%m-%d")
+                    last_modified = dt
+            except (ValueError, OSError, OverflowError):
+                logger.debug(
+                    f"Could not parse date '{model_date_raw}' for "
+                    f"hydromodelid={hydromodelid}"
+                )
+
+        # Build tags from program and software info
+        tags: List[str] = ["Indiana", "DNR", "floodplain"]
+        if program:
+            tags.append(program)
+        if hecras_version:
+            tags.append(f"HEC-RAS {hecras_version}")
+
+        return ModelMetadata(
+            source_name="Indiana DNR",
+            source_id=hydromodelid,
+            name=name,
+            description=description if description else f"Indiana DNR {program} model",
+            location=location,
+            model_type=model_type,
+            hecras_version=hecras_version,
+            url=None,  # URL requires two-step lookup, set on download
+            tags=tags,
+            study_date=study_date,
+            last_modified=last_modified,
+        )
+
+    @staticmethod
+    def _parse_hecras_version(sitemmeta: str) -> Optional[str]:
+        """
+        Extract HEC-RAS version from the sitemmeta field.
+
+        The sitemmeta field typically contains strings like:
+          "HEC-RAS 4.1.0", "HEC-RAS 5.0.7", "HEC-RAS 3.1.3"
+
+        Args:
+            sitemmeta: Raw software metadata string from the API.
+
+        Returns:
+            Version string (e.g. "4.1.0", "5.0.7") or None if not found.
+
+        Example:
+            >>> IndianaDnrModels._parse_hecras_version("HEC-RAS 4.1.0")
+            '4.1.0'
+            >>> IndianaDnrModels._parse_hecras_version("HEC-RAS")
+            None
+        """
+        if not sitemmeta:
+            return None
+
+        match = re.search(r"HEC-RAS\s+([\d]+(?:\.[\d]+)*)", sitemmeta, re.IGNORECASE)
+        if match:
+            return match.group(1)
+
+        return None
+
+    @staticmethod
+    def _infer_model_type(
+        sitemmeta: str, hecras_version: Optional[str]
+    ) -> ModelType:
+        """
+        Infer the model type from software metadata and version.
+
+        The vast majority of Indiana DNR models are 1D steady-state.
+        Some HEC-RAS 5.x models may include unsteady plans. No 2D or
+        rain-on-grid models are known in this library.
+
+        Args:
+            sitemmeta: Raw software metadata string.
+            hecras_version: Parsed HEC-RAS version (e.g. "5.0.7").
+
+        Returns:
+            ModelType enum value.
+        """
+        text = (sitemmeta or "").lower()
+
+        if "unsteady" in text:
+            return ModelType.UNSTEADY_1D
+
+        if "2d" in text or "two-dimensional" in text:
+            return ModelType.UNSTEADY_2D
+
+        if "dam breach" in text or "dam break" in text:
+            return ModelType.DAM_BREACH
+
+        if "sediment" in text:
+            return ModelType.SEDIMENT
+
+        # Default: the vast majority are 1D steady
+        return ModelType.STEADY_1D
+
+    @staticmethod
+    def _fetch_single_model_metadata(
+        hydromodelid: Union[str, int],
+    ) -> Optional[ModelMetadata]:
+        """
+        Fetch metadata for a single model by its hydromodelid.
+
+        Args:
+            hydromodelid: The model's unique identifier.
+
+        Returns:
+            ModelMetadata if found, None otherwise.
+        """
+        params = {
+            "where": f"hydromodelid={hydromodelid}",
+            "outFields": (
+                "hydromodelid,sitemmeta,swaterbodyname,scountyname,"
+                "program,strhydromodelinfo,dtmhydromodeldate"
+            ),
+            "f": "json",
+            "resultRecordCount": 1,
+            "returnGeometry": "false",
+        }
+
+        try:
+            data = IndianaDnrModels._query_feature_server(
+                IndianaDnrModels._METADATA_URL, params
+            )
+            features = data.get("features", [])
+            if features:
+                return IndianaDnrModels._parse_feature(
+                    features[0].get("attributes", {})
+                )
+        except Exception as exc:
+            logger.warning(
+                f"Could not fetch metadata for hydromodelid={hydromodelid}: {exc}"
+            )
+
+        return None

--- a/ras_commander/sources/state/mn_dnr.py
+++ b/ras_commander/sources/state/mn_dnr.py
@@ -1,0 +1,659 @@
+"""
+Minnesota DNR Hydraulic Model Download - FEMA floodplain HEC-RAS models.
+
+This module provides access to the Minnesota Department of Natural Resources
+Hydraulic Model Download portal, which hosts ~2,384 HEC-RAS models covering
+FEMA-effective floodplain studies across Minnesota counties.
+
+All models in this portal are 1D steady-state HEC-RAS models.
+
+Data source: MN DNR Hydraulic Model Download application
+API: ArcGIS REST MapServer (Table layer ID 1, "Models")
+Download: Azure Function endpoint (no authentication required)
+
+This module follows the centralized logging configuration from ras-commander.
+
+Logging Configuration:
+- The logging is set up in the logging_config.py file.
+- A @log_call decorator is available to automatically log function calls.
+- Log levels: DEBUG, INFO, WARNING, ERROR, CRITICAL
+- Logs are written to both console and a rotating file handler.
+- The default log file is 'ras_commander.log' in the 'logs' directory.
+- The default log level is INFO.
+
+To use logging in this module:
+1. Use the @log_call decorator for automatic function call logging.
+2. For additional logging, use logger.[level]() calls (e.g., logger.info(), logger.debug()).
+3. Obtain the logger using: logger = logging.getLogger(__name__)
+
+-----
+
+All of the methods in this class are static and are designed to be used without instantiation.
+
+List of Functions in MinnesotaDnrModels:
+- list_models()
+- download_model()
+- get_source_status()
+- list_counties()
+"""
+
+import logging
+import zipfile
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple, Union
+
+import requests
+from tqdm.auto import tqdm
+
+from ras_commander import get_logger
+from ras_commander.LoggingConfig import log_call
+from ras_commander.sources.base import (
+    DownloadResult,
+    ModelMetadata,
+    ModelSource,
+    ModelType,
+    SourceStatus,
+)
+
+logger = get_logger(__name__)
+
+
+class MinnesotaDnrModels:
+    """
+    Minnesota DNR Hydraulic Model Download - FEMA floodplain HEC-RAS models.
+
+    Provides discovery and download of ~2,384 HEC-RAS models from the Minnesota
+    DNR Hydraulic Model Download portal. All models are 1D steady-state and
+    represent FEMA-effective floodplain studies.
+
+    All methods are static/class methods, so no initialization is required.
+
+    Example:
+        # List all models
+        models = MinnesotaDnrModels.list_models()
+
+        # Filter by county
+        models = MinnesotaDnrModels.list_models(location="Hennepin")
+
+        # List available counties
+        counties = MinnesotaDnrModels.list_counties()
+
+        # Download a model
+        result = MinnesotaDnrModels.download_model(
+            "Hennepin/Some_Model",
+            output_folder="mn_models"
+        )
+
+        # Check API status
+        status = MinnesotaDnrModels.get_source_status()
+    """
+
+    SOURCE_NAME: str = "Minnesota DNR"
+
+    # ArcGIS REST MapServer endpoint (Table layer ID 1 = "Models")
+    _CATALOG_URL: str = (
+        "https://gis.dnr.state.mn.us/appserver/rest/services/"
+        "ewr/app_hydraulic_model_download/MapServer/1/query"
+    )
+
+    # Azure Function download endpoint
+    _DOWNLOAD_BASE_URL: str = (
+        "https://r29p-hydradownload-func-001-gqefa2d2hbh3gtbk."
+        "centralus-01.azurewebsites.net/fileget"
+    )
+
+    # ArcGIS REST pagination limit
+    _PAGE_SIZE: int = 2000
+
+    # HTTP request timeout in seconds
+    _REQUEST_TIMEOUT: int = 60
+
+    # Download chunk size in bytes
+    _DOWNLOAD_CHUNK_SIZE: int = 8192
+
+    # For ModelSource protocol
+    @property
+    def source_name(self) -> str:
+        """Human-readable source name."""
+        return self.SOURCE_NAME
+
+    @property
+    def source_type(self) -> str:
+        """Source category."""
+        return "state"
+
+    @staticmethod
+    @log_call
+    def list_models(
+        location: Optional[str] = None,
+        model_type: Optional[ModelType] = None,
+        hecras_version: Optional[str] = None,
+        tags: Optional[List[str]] = None,
+        limit: Optional[int] = None,
+        **kwargs,
+    ) -> List[ModelMetadata]:
+        """
+        Query MN DNR ArcGIS REST API for HEC-RAS models.
+
+        Queries the Models table (layer ID 1) of the MN DNR Hydraulic Model
+        Download MapServer. Handles pagination automatically since the API
+        returns a maximum of 2000 records per request.
+
+        Args:
+            location: Filter by county name (case-insensitive substring match).
+            model_type: Ignored -- all MN DNR models are STEADY_1D.
+            hecras_version: Filter by HEC-RAS version string (substring match).
+            tags: Ignored -- MN DNR catalog does not provide tags.
+            limit: Maximum number of results to return. None returns all.
+            **kwargs: Additional keyword arguments (reserved for future use).
+
+        Returns:
+            List of ModelMetadata objects matching the query criteria.
+
+        Raises:
+            requests.exceptions.RequestException: If the API is unreachable.
+
+        Example:
+            >>> models = MinnesotaDnrModels.list_models(location="Hennepin")
+            >>> print(f"Found {len(models)} models in Hennepin County")
+            >>> for m in models[:5]:
+            ...     print(f"  {m.name} ({m.source_id})")
+        """
+        # All MN DNR models are 1D steady; if caller asks for another type, return empty
+        if model_type is not None and model_type != ModelType.STEADY_1D:
+            logger.debug(
+                f"MN DNR only has STEADY_1D models; requested {model_type.value}, "
+                "returning empty list"
+            )
+            return []
+
+        # Build the WHERE clause for the ArcGIS query
+        where_clauses: List[str] = ["hydraulic_model_used LIKE '%HEC-RAS%'"]
+        if location:
+            safe_location = location.replace("'", "''")
+            where_clauses.append(f"county LIKE '%{safe_location}%'")
+        if hecras_version:
+            safe_version = hecras_version.replace("'", "''")
+            where_clauses.append(
+                f"hydraulic_model_used LIKE '%{safe_version}%'"
+            )
+
+        where = " AND ".join(where_clauses)
+
+        # Paginate through all results
+        all_features: List[Dict] = []
+        offset = 0
+        total_fetched = 0
+
+        logger.debug(f"Querying MN DNR catalog: WHERE {where}")
+
+        while True:
+            params = {
+                "where": where,
+                "outFields": "*",
+                "f": "json",
+                "resultRecordCount": MinnesotaDnrModels._PAGE_SIZE,
+                "resultOffset": offset,
+            }
+
+            try:
+                response = requests.get(
+                    MinnesotaDnrModels._CATALOG_URL,
+                    params=params,
+                    timeout=MinnesotaDnrModels._REQUEST_TIMEOUT,
+                )
+                response.raise_for_status()
+                data = response.json()
+            except requests.exceptions.RequestException as e:
+                logger.error(f"Failed to query MN DNR catalog: {e}")
+                raise
+
+            features = data.get("features", [])
+            if not features:
+                break
+
+            all_features.extend(features)
+            total_fetched += len(features)
+
+            logger.debug(
+                f"Fetched {len(features)} records (offset={offset}, "
+                f"total={total_fetched})"
+            )
+
+            # If we got fewer than the page size, we have all records
+            if len(features) < MinnesotaDnrModels._PAGE_SIZE:
+                break
+
+            # Check if limit is already satisfied
+            if limit is not None and total_fetched >= limit:
+                break
+
+            offset += MinnesotaDnrModels._PAGE_SIZE
+
+        logger.debug(f"Retrieved {total_fetched} total records from MN DNR")
+
+        # Convert features to ModelMetadata
+        results: List[ModelMetadata] = []
+        for feature in all_features:
+            attrs = feature.get("attributes", {})
+            metadata = MinnesotaDnrModels._feature_to_metadata(attrs)
+            if metadata is not None:
+                results.append(metadata)
+
+            if limit is not None and len(results) >= limit:
+                break
+
+        logger.debug(
+            f"Returning {len(results)} models"
+            + (f" (limit={limit})" if limit else "")
+        )
+        return results
+
+    @staticmethod
+    @log_call
+    def download_model(
+        model_id: str,
+        output_folder: Union[str, Path],
+        extract: bool = True,
+        overwrite: bool = False,
+        credentials: Optional[dict] = None,
+    ) -> DownloadResult:
+        """
+        Download a model ZIP from MN DNR.
+
+        The model_id must be in the format "CountyName/model_name" (matching
+        the source_id stored in ModelMetadata). The download is served by an
+        Azure Function endpoint and requires no authentication.
+
+        Args:
+            model_id: Model identifier in "County/ModelName" format. This
+                corresponds to the source_id field of ModelMetadata objects
+                returned by list_models().
+            output_folder: Directory where the downloaded (and optionally
+                extracted) model will be placed.
+            extract: If True, extract the ZIP archive after download and
+                remove the ZIP file. If False, keep the ZIP only.
+            overwrite: If True, overwrite existing files. If False and the
+                output already exists, skip the download.
+            credentials: Ignored -- MN DNR downloads are public.
+
+        Returns:
+            DownloadResult with success status, output path, and message.
+
+        Example:
+            >>> result = MinnesotaDnrModels.download_model(
+            ...     "Hennepin/Example_Model",
+            ...     output_folder="mn_models",
+            ...     extract=True,
+            ... )
+            >>> if result.success:
+            ...     print(f"Downloaded to: {result.model_path}")
+        """
+        # Validate model_id format
+        if "/" not in model_id:
+            msg = (
+                f"Invalid model_id '{model_id}'. Expected format: "
+                "'CountyName/model_name' (as returned in ModelMetadata.source_id)"
+            )
+            logger.error(msg)
+            return DownloadResult(
+                success=False, model_path=None, message=msg
+            )
+
+        county, model_name = model_id.split("/", 1)
+
+        output_path = Path(output_folder)
+        if not output_path.is_absolute():
+            output_path = Path.cwd() / output_path
+        output_path.mkdir(parents=True, exist_ok=True)
+
+        zip_filename = f"{model_name}.zip"
+        zip_path = output_path / zip_filename
+        extract_dir = output_path / model_name
+
+        # Check if already downloaded
+        if not overwrite:
+            if extract and extract_dir.exists():
+                msg = (
+                    f"Model already extracted at {extract_dir}. "
+                    "Use overwrite=True to re-download."
+                )
+                logger.debug(msg)
+                return DownloadResult(
+                    success=True,
+                    model_path=extract_dir,
+                    message=msg,
+                    extracted=True,
+                )
+            if not extract and zip_path.exists():
+                msg = (
+                    f"Model ZIP already exists at {zip_path}. "
+                    "Use overwrite=True to re-download."
+                )
+                logger.debug(msg)
+                return DownloadResult(
+                    success=True,
+                    model_path=zip_path,
+                    message=msg,
+                    extracted=False,
+                )
+
+        # Build download URL
+        download_url = (
+            f"{MinnesotaDnrModels._DOWNLOAD_BASE_URL}"
+            f"?filename={county}/{model_name}.zip"
+        )
+
+        logger.debug(f"Downloading MN DNR model: {model_id}")
+        logger.debug(f"URL: {download_url}")
+
+        # Download with progress bar
+        try:
+            response = requests.get(
+                download_url, stream=True, timeout=300
+            )
+            response.raise_for_status()
+
+            total_size = int(response.headers.get("content-length", 0))
+
+            with open(zip_path, "wb") as f:
+                if total_size > 0:
+                    with tqdm(
+                        desc=f"Downloading {model_name}",
+                        total=total_size,
+                        unit="iB",
+                        unit_scale=True,
+                        unit_divisor=1024,
+                        mininterval=2.0,
+                    ) as progress_bar:
+                        for chunk in response.iter_content(
+                            chunk_size=MinnesotaDnrModels._DOWNLOAD_CHUNK_SIZE
+                        ):
+                            size = f.write(chunk)
+                            progress_bar.update(size)
+                else:
+                    for chunk in response.iter_content(
+                        chunk_size=MinnesotaDnrModels._DOWNLOAD_CHUNK_SIZE
+                    ):
+                        f.write(chunk)
+
+            logger.debug(f"Downloaded to {zip_path}")
+
+        except requests.exceptions.RequestException as e:
+            msg = f"Failed to download model '{model_id}': {e}"
+            logger.error(msg)
+            if zip_path.exists():
+                zip_path.unlink()
+            return DownloadResult(
+                success=False, model_path=None, message=msg
+            )
+
+        # Extract if requested
+        if extract:
+            logger.debug(f"Extracting to {extract_dir}...")
+            try:
+                extract_dir.mkdir(parents=True, exist_ok=True)
+                with zipfile.ZipFile(zip_path, "r") as zf:
+                    zf.extractall(extract_dir)
+                logger.debug(
+                    f"Successfully extracted model '{model_id}' to {extract_dir}"
+                )
+            except (zipfile.BadZipFile, Exception) as e:
+                msg = f"Failed to extract model '{model_id}': {e}"
+                logger.error(msg)
+                return DownloadResult(
+                    success=False,
+                    model_path=zip_path,
+                    message=msg,
+                    extracted=False,
+                )
+            finally:
+                # Clean up ZIP after successful extraction
+                if extract_dir.exists() and any(extract_dir.iterdir()):
+                    if zip_path.exists():
+                        zip_path.unlink()
+                        logger.debug(f"Removed temporary zip: {zip_path}")
+
+            return DownloadResult(
+                success=True,
+                model_path=extract_dir,
+                message=f"Model '{model_id}' downloaded and extracted to {extract_dir}",
+                extracted=True,
+            )
+
+        return DownloadResult(
+            success=True,
+            model_path=zip_path,
+            message=f"Model '{model_id}' downloaded to {zip_path}",
+            extracted=False,
+        )
+
+    @staticmethod
+    @log_call
+    def get_source_status() -> SourceStatus:
+        """
+        Check if the MN DNR Hydraulic Model Download API is reachable.
+
+        Performs a lightweight query (1 record) against the MapServer endpoint
+        to verify connectivity and service availability.
+
+        Returns:
+            SourceStatus.AVAILABLE if the API responds successfully,
+            SourceStatus.UNAVAILABLE otherwise.
+
+        Example:
+            >>> status = MinnesotaDnrModels.get_source_status()
+            >>> if status == SourceStatus.AVAILABLE:
+            ...     print("MN DNR API is online")
+        """
+        params = {
+            "where": "1=1",
+            "outFields": "objectid",
+            "f": "json",
+            "resultRecordCount": 1,
+        }
+
+        try:
+            response = requests.get(
+                MinnesotaDnrModels._CATALOG_URL,
+                params=params,
+                timeout=15,
+            )
+            response.raise_for_status()
+            data = response.json()
+
+            if "features" in data and len(data["features"]) > 0:
+                logger.debug("MN DNR API is available")
+                return SourceStatus.AVAILABLE
+            elif "error" in data:
+                error_msg = data["error"].get("message", "Unknown error")
+                logger.warning(f"MN DNR API returned error: {error_msg}")
+                return SourceStatus.UNAVAILABLE
+            else:
+                logger.warning("MN DNR API returned unexpected response")
+                return SourceStatus.UNAVAILABLE
+
+        except requests.exceptions.RequestException as e:
+            logger.warning(f"MN DNR API is unreachable: {e}")
+            return SourceStatus.UNAVAILABLE
+
+    @staticmethod
+    @log_call
+    def list_counties() -> List[str]:
+        """
+        Get distinct county names from the MN DNR catalog.
+
+        Paginates through all HEC-RAS records and deduplicates county names
+        client-side (the MapServer table does not support returnDistinctValues).
+
+        Returns:
+            Sorted list of county name strings.
+        """
+        counties: set = set()
+        offset = 0
+
+        while True:
+            params = {
+                "where": "hydraulic_model_used LIKE '%HEC-RAS%'",
+                "outFields": "county",
+                "returnGeometry": "false",
+                "f": "json",
+                "resultRecordCount": MinnesotaDnrModels._PAGE_SIZE,
+                "resultOffset": offset,
+            }
+            try:
+                response = requests.get(
+                    MinnesotaDnrModels._CATALOG_URL,
+                    params=params,
+                    timeout=MinnesotaDnrModels._REQUEST_TIMEOUT,
+                )
+                response.raise_for_status()
+                data = response.json()
+            except requests.exceptions.RequestException as e:
+                logger.error(f"Failed to query MN DNR for counties: {e}")
+                raise
+
+            features = data.get("features", [])
+            if not features:
+                break
+
+            for feature in features:
+                county = (feature.get("attributes", {}).get("county") or "").strip()
+                if county:
+                    counties.add(county)
+
+            if len(features) < MinnesotaDnrModels._PAGE_SIZE:
+                break
+            offset += MinnesotaDnrModels._PAGE_SIZE
+
+        result = sorted(counties)
+        logger.debug(f"Found {len(result)} counties with HEC-RAS models")
+        return result
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _feature_to_metadata(attrs: Dict) -> Optional[ModelMetadata]:
+        """
+        Convert a single ArcGIS feature attributes dict to ModelMetadata.
+
+        Args:
+            attrs: Dictionary of attribute values from an ArcGIS REST feature.
+
+        Returns:
+            ModelMetadata if the feature has enough data, None otherwise.
+        """
+        # Extract fields — actual API field names from MapServer/1
+        model_name: str = (
+            attrs.get("hydraulic_model_name") or ""
+        ).strip()
+        county: str = (
+            attrs.get("county") or ""
+        ).strip()
+        water_name: str = (
+            attrs.get("water_name") or ""
+        ).strip()
+        hydraulic_model: str = (
+            attrs.get("hydraulic_model_used") or ""
+        ).strip()
+        flood_zone: str = (
+            attrs.get("flood_zone") or ""
+        ).strip()
+        download_url_raw: str = (
+            attrs.get("url") or ""
+        ).strip()
+        objectid = attrs.get("objectid")
+
+        if not model_name:
+            return None
+
+        # Build source_id as County/ModelName for download URL construction
+        source_id = f"{county}/{model_name}" if county else model_name
+
+        # Build description from available fields
+        description_parts: List[str] = []
+        if water_name:
+            description_parts.append(water_name)
+        if flood_zone:
+            description_parts.append(f"Zone {flood_zone}")
+        if hydraulic_model:
+            description_parts.append(hydraulic_model)
+        description = "; ".join(description_parts) if description_parts else (
+            f"FEMA floodplain HEC-RAS model in {county} County, MN"
+            if county
+            else "FEMA floodplain HEC-RAS model from MN DNR"
+        )
+
+        # Build location string
+        location = f"{county} County, Minnesota" if county else "Minnesota"
+
+        # Extract HEC-RAS version from hydraulic_model_used if possible
+        hecras_version = MinnesotaDnrModels._parse_hecras_version(
+            hydraulic_model
+        )
+
+        # Use the URL field from the API directly, or construct it
+        download_url = download_url_raw or None
+        if not download_url and county and model_name:
+            download_url = (
+                f"{MinnesotaDnrModels._DOWNLOAD_BASE_URL}"
+                f"?filename={county}/{model_name}.zip"
+            )
+
+        # Build tags
+        tags: List[str] = ["FEMA", "floodplain", "Minnesota", "1D", "steady"]
+        if county:
+            tags.append(county)
+        if water_name:
+            tags.append(water_name)
+
+        return ModelMetadata(
+            source_name=MinnesotaDnrModels.SOURCE_NAME,
+            source_id=source_id,
+            name=model_name,
+            description=description,
+            location=location,
+            model_type=ModelType.STEADY_1D,
+            hecras_version=hecras_version,
+            doi=None,
+            url=download_url,
+            file_size_mb=None,
+            last_modified=None,
+            projection=None,
+            tags=tags,
+            spatial_extent=None,
+            study_date=None,
+            effective_date=None,
+        )
+
+    @staticmethod
+    def _parse_hecras_version(hydraulic_model_str: str) -> Optional[str]:
+        """
+        Attempt to extract a HEC-RAS version number from the
+        hydraulic_model_used field.
+
+        Args:
+            hydraulic_model_str: Raw string like "HEC-RAS 5.0.7" or
+                "HEC-RAS Version 4.1".
+
+        Returns:
+            Version string (e.g., "5.0.7") if found, None otherwise.
+        """
+        if not hydraulic_model_str:
+            return None
+
+        import re
+
+        # Match patterns like "HEC-RAS 5.0.7", "HEC-RAS Version 4.1",
+        # "HEC-RAS v6.0"
+        match = re.search(
+            r"HEC-RAS\s*(?:Version\s*|v)?(\d+(?:\.\d+)*)",
+            hydraulic_model_str,
+            re.IGNORECASE,
+        )
+        if match:
+            return match.group(1)
+        return None


### PR DESCRIPTION
## Summary

- **Register `RasEbfeModels` with `ModelCatalog`** so eBFE models appear alongside other sources in the unified catalog
- **Add notebook 958** (`model_sources_showcase.ipynb`) — self-contained download + screenshot workflow for all 6 model sources (USGS, eBFE, MN DNR, IN DNR, CO CHAMP, M3)
- **Fix blank screenshots** in `RasMap.screenshot_model()` — root cause was `capture_rasmapper_snapshot()` sleeping before window detection instead of after, wasting the entire delay on process startup
- **Add `configure_layers` to `screenshot_model()`** — enables terrain + geometry layers and zooms to model extent before capture
- **Fix CO CHAMP false-positive download** — `download_model()` now re-downloads when folder exists but contains no `.prj`
- **Fix MN DNR location filter** — replaced zero-result `location="St. Louis"` with full catalog search + name grep
- **Use `tqdm.auto`** across all 6 source files for clean Jupyter progress bars (single animated widget instead of flooding output lines)
- **Add pre-RASMapper notes** for 1D models (MN DNR, IN DNR, M3) that structurally lack `.rasmap` files

## Test plan

- [x] Notebook 958 executes end-to-end with zero exceptions (23/23 code cells pass)
- [x] Screenshots render visible terrain colormaps (437 KB USGS, 378 KB eBFE — vs 27-42 KB blank before fix)
- [x] CO CHAMP iterates past non-HEC-RAS entries to find valid model
- [x] tqdm progress bars display as single animated widget in Jupyter

🤖 Generated with [Claude Code](https://claude.com/claude-code)