### PR TITLE
fix(unsteady): harden stage/flow hydrograph writer

### DIFF
--- a/ras_commander/RasUnsteady.py
+++ b/ras_commander/RasUnsteady.py
@@ -8466,7 +8466,8 @@ class RasUnsteady:
             s = f'{v:.{decimals}f}'.rstrip('0').rstrip('.')
             if len(s) <= 8:
                 return s.rjust(8)
-        return f'{v:8.0f}'
+        s = f'{v:.0f}'
+        return s[:8].rjust(8)
 
     @staticmethod
     @log_call

--- a/ras_commander/RasUnsteady.py
+++ b/ras_commander/RasUnsteady.py
@@ -8364,6 +8364,8 @@ class RasUnsteady:
                 pass
 
         if isinstance(unsteady_file, str) and len(unsteady_file) <= 2:
+            if ras_obj is None or getattr(ras_obj, 'project_folder', None) is None:
+                raise ValueError("Cannot resolve unsteady number without an initialized ras_object")
             unsteady_num = unsteady_file.zfill(2)
             unsteady_path = ras_obj.project_folder / f"{ras_obj.project_name}.u{unsteady_num}"
         else:
@@ -8454,6 +8456,19 @@ class RasUnsteady:
         return pd.DataFrame({'stage': stages[:min_len], 'flow': flows[:min_len]})
 
     @staticmethod
+    def _fmt8(v: float) -> str:
+        """Format a value into an 8-character fixed-width field matching HEC-RAS style."""
+        if v == 0.0:
+            return ' ' * 8
+        if v == int(v) and abs(v) < 1e8:
+            return f'{int(v):>8}'
+        for decimals in range(6, 0, -1):
+            s = f'{v:.{decimals}f}'.rstrip('0').rstrip('.')
+            if len(s) <= 8:
+                return s.rjust(8)
+        return f'{v:8.0f}'
+
+    @staticmethod
     @log_call
     def set_stage_flow_hydrograph(
         unsteady_file: Union[str, Path],
@@ -8488,7 +8503,11 @@ class RasUnsteady:
         Returns
         -------
         dict
-            Metadata about the write: ``pair_count``, ``location``, ``file``.
+            - ``pair_count`` (int): Number of stage/flow pairs written.
+            - ``matched_location`` (str): Raw ``Boundary Location=`` value matched.
+            - ``unsteady_file`` (str): Path to the written file.
+            - ``boundaries_df_refreshed`` (bool): True when ``ras_object``
+              boundaries were refreshed after writing.
 
         Raises
         ------
@@ -8509,6 +8528,8 @@ class RasUnsteady:
                 pass
 
         if isinstance(unsteady_file, str) and len(unsteady_file) <= 2:
+            if ras_obj is None or getattr(ras_obj, 'project_folder', None) is None:
+                raise ValueError("Cannot resolve unsteady number without an initialized ras_object")
             unsteady_num = unsteady_file.zfill(2)
             unsteady_path = ras_obj.project_folder / f"{ras_obj.project_name}.u{unsteady_num}"
         else:
@@ -8535,8 +8556,7 @@ class RasUnsteady:
         formatted_lines: List[str] = []
         for i in range(0, len(interleaved), 10):
             row_vals = interleaved[i:i+10]
-            row_str = ''.join(f'{v:8.2f}' if abs(v) < 1e6 else f'{v:8.0f}' for v in row_vals)
-            formatted_lines.append(row_str + '\n')
+            formatted_lines.append(''.join(RasUnsteady._fmt8(v) for v in row_vals) + '\n')
 
         KEYWORD = 'Observed Stage and Flow Hydrograph='
 
@@ -8616,6 +8636,16 @@ class RasUnsteady:
         with open(unsteady_path, 'w', encoding='utf-8') as f:
             f.writelines(lines)
 
+        boundaries_df_refreshed = False
+        if ras_obj is not None:
+            try:
+                ras_obj.boundaries_df = ras_obj.get_boundary_conditions()
+                boundaries_df_refreshed = True
+            except Exception as exc:
+                logger.debug(f"boundaries_df refresh skipped: {exc}")
+
+        matched_location = lines[target_idx].replace('Boundary Location=', '').rstrip('\r\n')
+
         loc_parts = []
         if river:
             loc_parts.append(river)
@@ -8632,8 +8662,9 @@ class RasUnsteady:
 
         return {
             'pair_count': pair_count,
-            'location': '/'.join(loc_parts) if loc_parts else 'first matching',
-            'file': str(unsteady_path),
+            'matched_location': matched_location,
+            'unsteady_file': str(unsteady_path),
+            'boundaries_df_refreshed': boundaries_df_refreshed,
         }
 
     # ------------------------------------------------------------------

--- a/ras_commander/RasUnsteady.py
+++ b/ras_commander/RasUnsteady.py
@@ -3708,6 +3708,8 @@ class RasUnsteady:
 
         # Resolve unsteady file path
         if isinstance(unsteady_file, str) and len(unsteady_file) <= 2:
+            if ras_obj is None or getattr(ras_obj, 'project_folder', None) is None:
+                raise ValueError("Cannot resolve unsteady number without an initialized ras_object")
             # It's an unsteady number, resolve to full path
             unsteady_num = unsteady_file.zfill(2)
             unsteady_path = ras_obj.project_folder / f"{ras_obj.project_name}.u{unsteady_num}"
@@ -4531,6 +4533,8 @@ class RasUnsteady:
 
         # Resolve unsteady file path
         if isinstance(unsteady_file, str) and len(unsteady_file) <= 2:
+            if ras_obj is None or getattr(ras_obj, 'project_folder', None) is None:
+                raise ValueError("Cannot resolve unsteady number without an initialized ras_object")
             # It's an unsteady number, resolve to full path
             unsteady_num = unsteady_file.zfill(2)
             unsteady_path = ras_obj.project_folder / f"{ras_obj.project_name}.u{unsteady_num}"
@@ -5495,6 +5499,8 @@ class RasUnsteady:
 
         # Resolve unsteady file path
         if isinstance(unsteady_file, str) and len(unsteady_file) <= 2:
+            if ras_obj is None or getattr(ras_obj, 'project_folder', None) is None:
+                raise ValueError("Cannot resolve unsteady number without an initialized ras_object")
             unsteady_num = unsteady_file.zfill(2)
             unsteady_path = ras_obj.project_folder / f"{ras_obj.project_name}.u{unsteady_num}"
         else:


### PR DESCRIPTION
## Summary
- Add `ras_object` guard to `get_stage_flow_hydrograph()` and `set_stage_flow_hydrograph()` to prevent `AttributeError` when resolving unsteady number without initialization
- Replace naive `f'{v:8.2f}'` formatter with `_fmt8()` that matches HEC-RAS GUI output style (blanks for zero, integers without decimals, trailing-zero stripping)
- Add `boundaries_df` auto-refresh after `set_stage_flow_hydrograph()` writes, consistent with other write methods
- Return richer metadata dict: `matched_location`, `unsteady_file`, `boundaries_df_refreshed`

Cherry-picked improvements from deleted `feature/CLB-718-stage-flow-hydrograph-v2` branch.

## Test plan
- [ ] Verify `get_stage_flow_hydrograph("01")` raises `ValueError` without initialization (not `AttributeError`)
- [ ] Verify `set_stage_flow_hydrograph()` writes values matching HEC-RAS GUI format
- [ ] Verify `boundaries_df` is refreshed after writing

🤖 Generated with [Claude Code](https://claude.com/claude-code)