### PR TITLE
feat(hdf): depth-varying Manning's n with polygon mask API and Linux solver proof (CLB-757)

### DIFF
--- a/examples/414_depth_varying_mannings_n.ipynb
+++ b/examples/414_depth_varying_mannings_n.ipynb
@@ -14,38 +14,44 @@
     "tags": []
    },
    "source": [
-    "# 414 â€” Depth-Varying Manning's n for HEC-RAS 2D Models\n",
+    "# 414 — Depth-Varying Manning's n for HEC-RAS 2D Models\n",
     "\n",
-    "Manning's roughness coefficient varies with flow depth â€” this is well-established\n",
-    "in hydraulic literature (Chow 1959, HEC-15, Limerinos 1970, Jarrett 1984) but\n",
-    "often ignored in practice because HEC-RAS 2D models default to uniform roughness.\n",
+    "Manning's roughness coefficient varies with flow depth — this is well-established\n",
+    "in hydraulic literature (Chow 1959, HEC-15, Limerinos 1970, Jarrett 1984) and is\n",
+    "a frequent topic in HEC-RAS community discussions because many 2D models still\n",
+    "start from uniform roughness values.\n",
     "\n",
-    "This notebook demonstrates a complete workflow for implementing **depth-varying\n",
-    "Manning's n** in HEC-RAS 2D face property tables using `ras-commander`:\n",
+    "This notebook demonstrates a complete `ras-commander` workflow for applying\n",
+    "**depth-varying Manning's n** to HEC-RAS 2D face property tables:\n",
     "\n",
-    "1. **Literature grounding** â€” formulas that relate n to hydraulic radius\n",
-    "2. **Geometry preprocessing** â€” generate face property tables from HEC-RAS\n",
-    "3. **Depth-varying n application** â€” replace uniform n with a depth-dependent formula\n",
-    "4. **Face property table extension** â€” extend tables to higher elevations with\n",
-    "   depth-varying n using the HEC-15 vegetal retardance concept\n",
-    "5. **Spatial filtering** â€” strategies for limiting modifications to channel faces\n",
+    "1. **Literature grounding** — formulas that relate n to hydraulic radius\n",
+    "2. **Windows preprocessing** — generate solver-ready `.tmp.hdf` face tables\n",
+    "3. **Direct `.tmp.hdf` edit** — apply and extend depth-varying Manning's n before the solver starts\n",
+    "4. **Linux RasUnsteady execution** — run the pure solver without regenerating face tables\n",
+    "5. **Engineering result review** — compare baseline and modified WSE/depth maps\n",
+    "6. **Polygon mask API** — demonstrate selective channel-only application using calibration regions or computed channel polygons\n",
+    "7. **Channel polygon strategies** — calibration regions, fluvial/pluvial classification, bank lines, and external GIS sources such as NFHL\n",
     "\n",
     "**Key insight**: HEC-RAS 2D face property tables store Manning's n as a function\n",
-    "of elevation for each cell face. By modifying these tables with a depth-varying\n",
-    "formula and **extending** them to higher elevations, we can model the physical\n",
-    "reality that roughness decreases with increasing flow depth.\n",
+    "of elevation for each cell face. By modifying and extending the preprocessed\n",
+    "`.tmp.hdf` tables with a depth-varying formula, the Linux solver can consume the\n",
+    "edited tables directly rather than rebuilding them from the geometry settings.\n",
     "\n",
     "**API methods demonstrated**:\n",
     "\n",
     "| Method | Purpose |\n",
     "|--------|---------|\n",
-    "| `GeomStorage.get/set_2d_flow_area_settings()` | Uniform Manning's n in `.g##` |\n",
-    "| `HdfMesh.get_mesh_face_property_tables()` | Read face-level n from geometry HDF |\n",
-    "| `HdfMesh.set_face_mannings_n_values()` | Replace n column with custom function |\n",
+    "| `GeomStorage.get_2d_flow_area_settings()` | Read the original uniform Manning's n from `.g##` |\n",
+    "| `RasPreprocess.preprocess_plan()` | Generate `.tmp.hdf`, `.b##`, and `.x##` files on Windows |\n",
+    "| `RasCmdr.compute_plan_linux()` | Run native Linux `RasUnsteady` against the edited `.tmp.hdf` |\n",
+    "| `HdfMesh.get_mesh_face_property_tables()` | Read face-level n from geometry, `.tmp.hdf`, or output HDF |\n",
+    "| `HdfMesh.set_face_mannings_n_values()` | Replace n column with custom depth-varying function |\n",
     "| `HdfMesh.extend_face_property_tables()` | Extend tables to higher elevations |\n",
     "| `HdfMesh.get_face_ids_in_polygon()` | Spatial filter: faces within a polygon |\n",
     "| `HdfMesh.get_face_ids_in_calibration_region()` | Filter by named calibration region |\n",
-    "| `HdfMesh.pin_property_tables()` | Set Pinned attribute on mesh group |"
+    "| `HdfMesh.pin_property_tables()` | Set Pinned attribute on mesh group |\n",
+    "| `HdfFluvialPluvial.generate_fluvial_pluvial_polygons()` | Channel delineation |\n",
+    "| `HdfXsec.get_river_bank_lines()` | Bank line extraction for channel polygon |\n"
    ]
   },
   {
@@ -66,23 +72,22 @@
     "\n",
     "```mermaid\n",
     "flowchart LR\n",
-    "    A[Read Geometry<br/>Settings] --> B[Preprocess<br/>Geometry]\n",
-    "    B --> C[Read Face<br/>Property Tables]\n",
-    "    C --> D[Apply Depth-<br/>Varying n]\n",
-    "    D --> E[Extend Tables<br/>Higher Elevations]\n",
-    "    E --> F[Pin Tables]\n",
-    "    F --> G[Spatial Filtering<br/>Options]\n",
-    "\n",
-    "    style A fill:#e1f5fe\n",
-    "    style D fill:#fff3e0\n",
-    "    style E fill:#fff3e0\n",
-    "    style G fill:#e8f5e9\n",
+    "    A[Extract Baseline<br/>and Modified Copies] --> B[Read Existing<br/>Manning's n]\n",
+    "    B --> C[Preprocess Baseline<br/>on Windows]\n",
+    "    C --> D[Run Baseline<br/>Linux Solver]\n",
+    "    D --> E[Preprocess Modified<br/>on Windows]\n",
+    "    E --> F[Edit Modified<br/>.tmp.hdf Tables]\n",
+    "    F --> G[Extend + Pin<br/>Face Tables]\n",
+    "    G --> H[Run Modified<br/>Linux Solver]\n",
+    "    H --> I[Verify Output HDF<br/>Tables Persist]\n",
+    "    I --> J[Compare WSE + Depth<br/>Baseline vs Modified]\n",
+    "    J --> K[Demonstrate Polygon<br/>Mask API]\n",
     "```\n",
     "\n",
-    "The critical steps are **D** and **E** â€” we replace the uniform Manning's n\n",
-    "in each face's property table with a depth-varying formula, then extend the\n",
-    "tables above the preprocessed terrain elevation so HEC-RAS has depth-varying\n",
-    "roughness data for deep flood events."
+    "The important handoff is between **E** and **H**: the Windows preprocessor\n",
+    "creates a solver-ready `.tmp.hdf`, `ras-commander` edits that exact file, and\n",
+    "the Linux `RasUnsteady` binary reads it without calling the Windows table\n",
+    "builder that would otherwise regenerate uniform face-property tables.\n"
    ]
   },
   {
@@ -101,14 +106,14 @@
    "source": [
     "## Literature: Why Manning's n Varies with Depth\n",
     "\n",
-    "Manning's n is **not a constant** â€” it varies with the ratio of flow depth to\n",
+    "Manning's n is **not a constant** — it varies with the ratio of flow depth to\n",
     "roughness element size (relative roughness R/k_s). At shallow depths, roughness\n",
     "elements dominate the water column and form drag is high. At greater depths,\n",
     "skin friction dominates and effective roughness decreases.\n",
     "\n",
     "> *\"If the depth of flow is shallow in relation to the size of the roughness\n",
     "> elements, the n value can be large, and the n value decreases with\n",
-    "> increasing depth.\"* â€” Chow, V.T., 1959. *Open-Channel Hydraulics*\n",
+    "> increasing depth.\"* — Chow, V.T., 1959. *Open-Channel Hydraulics*\n",
     "\n",
     "### Key Formulas\n",
     "\n",
@@ -118,11 +123,11 @@
     "\n",
     "where X is a retardance class coefficient (A=15.8 through E=37.7).\n",
     "\n",
-    "**Limerinos (1970)** ([USGS WSP 1898-B](https://pubs.usgs.gov/wsp/1898b/report.pdf)) â€” gravel-bed rivers:\n",
+    "**Limerinos (1970)** ([USGS WSP 1898-B](https://pubs.usgs.gov/wsp/1898b/report.pdf)) — gravel-bed rivers:\n",
     "\n",
     "$$n = \\frac{0.0926 \\cdot R^{1/6}}{1.16 + 2.0 \\cdot \\log_{10}(R/d_{84})}$$\n",
     "\n",
-    "**Jarrett (1984)** â€” high-gradient streams (S > 0.002):\n",
+    "**Jarrett (1984)** — high-gradient streams (S > 0.002):\n",
     "\n",
     "$$n = 0.39 \\cdot S^{0.38} \\cdot R^{-0.16}$$\n",
     "\n",
@@ -132,14 +137,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "6bcada36",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-23T01:39:03.108536Z",
-     "iopub.status.busy": "2026-05-23T01:39:03.108292Z",
-     "iopub.status.idle": "2026-05-23T01:39:03.616003Z",
-     "shell.execute_reply": "2026-05-23T01:39:03.615217Z"
+     "iopub.execute_input": "2026-05-12T12:22:40.896170Z",
+     "iopub.status.busy": "2026-05-12T12:22:40.895765Z",
+     "iopub.status.idle": "2026-05-12T12:22:41.373062Z",
+     "shell.execute_reply": "2026-05-12T12:22:41.372242Z"
     },
     "papermill": {
      "duration": 0.481427,
@@ -150,18 +155,7 @@
     },
     "tags": []
    },
-   "outputs": [
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAxYAAAHqCAYAAACZcdjsAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjgsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvwVt1zgAAAAlwSFlzAAAPYQAAD2EBqD+naQAAt0FJREFUeJzsnQd4U9Ubxr/ulr132XvvjaBMUQQBGaJMwcEUHKBMUUGUpaCICqiA8EdREWSDiLKn7L1nmWV25v+8J9z0Jk3atEnJen/Pc0juvjm5Kec93/IzGAwGIYQQQgghhBAH8HfkYEIIIYQQQgihsCCEEEIIIYQ4BVosCCGEEEIIIQ5DYUEIIYQQQghxGAoLQgghhBBCiMNQWBBCCCGEEEIchsKCEEIIIYQQ4jAUFoQQQgghhBCHobAghBBCCCGEOAyFBSHEbfDz85NGjRq5+jYIcSmFCxdWLa2PcQb8zaYNo0ePVn37119/pdEVCEkbKCwI8UBOnz6t/tNBy5Mnj8TGxlrd79ChQ6b9XDHo8BTQN+4saLp37276HtECAwMla9asUrZsWenSpYv8/PPPEh0d7erbJF4w0MT59c+aZcuSJYt4CtY+S4YMGSQ8PFyefvppGT9+vFy8eNGlf8Px2ybEmwh09Q0QQlIPBphXrlyRP//8U5577rlE27/77jvx9/ec+QMIoXTp0rn6NtyWXr16SYECBcRgMEhkZKQcO3ZM/vjjD5k/f76UKVNGFixYIBUrVnT1bRIHWbt2rcv7sFq1avLss88mWh8aGiqehv6z3L9/Xy5fviybNm2SFStWyJgxY2TChAnSv39/V98mIV4BhQUhHkzdunVl7969MmvWrETCAlaMuXPnSpMmTWTDhg3iCZQuXdrVt+DWvPLKK1K7dm2zdXfu3JFRo0bJ5MmTpVmzZrJr1y7Jly+fy+6ROE6xYsVc3o3Vq1dXVhJvwNZn+f3335VYHzBggKRPn1569uzpkvsjxJvwnKlMQkgiwsLCpFOnTrJs2TK5evWq2balS5cqa4at/yzhAoABKQaquXLlkpCQEOUS9MYbbyQ6l94d59SpU/L5558rEYBjChUqpGb94uPjzfafM2eO2h+vq1atUiII1ojs2bNLt27d5Pr163b5a6f0utqs5DvvvKNcHjDDWr58efnmm29MrhH2DJhu374tI0eOVO5GcJ/IlCmTFC9eXN37mTNnkj1ef60dO3ZI06ZNJWPGjJI5c2Z5/vnnlSuEM8A5J02apPoJ3/eHH36YaB98n2+++aa6f/Rdjhw5pF27drJ//36r58T+Q4YMkVKlSqlnLFu2bFKrVi357LPPrLpywNKEz4TvFuv0nw2Dt8aNGyvXLe27wHni4uIS9fcnn3wiDRs2VMIoODhYvXbt2lVOnDiR6B4fPnwoEydOlEqVKqk+xcAQz2+HDh2U2LbE3vvA8/Ttt99KzZo11efG54eVqFWrVna5IVWpUkXdj/68OCfOhb7Bua25OOnFv2W8BH4TeNbBk08+maR74927d2XgwIGq7/Bdw4IFV7nHzbVr12TQoEFSpEgRdR/4G4PvxvKZmzp1qvoslveIY7G+fv36Zuu1565Hjx4O32Pr1q1N13333Xfl3r17ZtthGcSkTb169dTvH3+/IFKwLilXNViKK1SooJ6z/Pnzq98eJgA08DcR/QK+//57M1cta88YLJKVK1dWz2LevHnV9/vgwQOHPz8haYKBEOJxnDp1yoCfb/PmzQ1bt25V7z/77DOzfVq1amXIli2b4eHDh4aQkBBDoUKFzLb/9NNPhvTp0xuee+45w4ABAwxDhgwxPPXUU+pcRYsWNdy6dcts/27duqlt7dq1M+TIkcPQvXt3dVzBggXV+vfee89s/9mzZ6v1zz//vCE4OFgdh2vUqFFDra9Xr16iz4X1DRs2dOi6sbGxhieffFJtq1ChguGdd94xvPLKK4aMGTOqPsH6UaNGmR2DvtFfNz4+3lCrVi3Tfb755pvq3tu3b2/IkiWLYfXq1cl+R+vXr1fHt2zZ0hAWFqZe9X1crFgxw4MHD5I9j74PNm/ebHOfEydOqH2yZ8+u7l/j+PHjhgIFCqhtzZo1U/fw8ssvG9KlS6e+/y1btpid5/Dhw4a8efOq/evXr6/6r2/fvoZGjRoZsmbNmugZRP9kypRJvQ4ePFjd64ULF9Q+Q4cOVfvkz5/f0LNnT9WP1atXV+vQl3rw2fCc4Jl+4403DG+//bb6vgICAtRzfPr0abP9O3TooM5TsWJFw8CBA9V9du7c2ZAnTx7DN998Y7ZvSu4D59G+H3xuHIv+KlKkiOH9999P9rvCuXH8tm3bTOt27dql1qG9+OKLZvs/8cQThtDQUPU71T+P+t8rfkt4PnE8+hfPL9rkyZPNjsmXL5+hTp06htKlSxv69eunPiu+Zz8/P8PKlSsN9qA9t6+++qpd+1v7zV69elX1H7bhuUEfduzYUX2XuJ+NGzea9t27d6/aD9+5HnyvWB8UFGS4e/euaf2sWbPU+u+//95pn6VBgwZqvyVLlpjW4TeE5wnrS5Qooc7Rv39/1bdYh9+RHnwfWI9nFp+xR48ehnfffddQrVo1tb527dqG6Ohote/u3bvVM4v1lSpVMn2faPhd6c+Hv3v4neK5wbNVpkwZq88RIe4ChQUhHi4sQPny5Q3lypUzbb906ZIhMDBQ/UcIrAmLK1euGO7cuZPo3PgPG+f+8MMPrQ5uMcC6ePGiaX1ERIQabGPgHhUVlUhY4D7++ecfs4E/BhvWBspJCQt7r/vtt9+q/Z9++ml1LY0DBw6oAZw1YWHJf//9p/Zr06ZNom0YAFrrN1uDGrQFCxaYbcNAFesh7pwlLEB4eLjaDyJDo27dumpAt2LFCrN9jxw5ovoO4kuPNuCeOXNmovOfO3cu0TOINnLkyET7rlq1yvSM6geGGLC99tpratvPP/9sWg8he/369UTnWbduncHf31+JQ/2+GCxj0Kb/jgGWb968mer7gIjBAP3evXuJ7sXa/VmCwSnO+cknn5jWTZw4Ua1r3LixEm0a9+/fV2IKYlOPpbDQDzTxXFkD+2N769atzX4Pa9asMftbYe9zi77VD3i1dujQoWR/sxhUY/2wYcPM1i9btkytL168uCEuLs70PUAMY8Csce3aNfX9or+wv14Uab+ds2fPOk1YjBgxQu2HVw08/1iHz6IJAoC+1SYoduzYkej7wfcJsaSBzwcRYDn5o/1+8Nu2hna+zJkzK7Gvf2ZKliypfhOagCfEnaCwIMQLhMWkSZPUsjb7PH78eLWMmTFbwsIW+I8QM9AY/Fsb3GLG0BJtGwbklsKia9euifbXtn3++ed2Cwt7r6uJFswSW9KnT58UCQvMWKYWbVCDGWlb2zDD70xhoVlZYMXSz5Rj5toauD6279u3Ty1r1i9r92zrGYSFQD+Q1YAlDNvPnDmTaJsmDDAbaw8QP4ULFzYt375922Qt0VtnrJHS+4CwwLX0FoSUgHNCyOkH8s8++6yhVKlSptl2bXCuDfo/+OADpwmLkydPWt2Gz2UPekFsrf36669J/mbxLEDAQyxYE2dNmzZVx/z999+mdeh/rMOECIDQ0z4r/nZh5l8D1jdYVFPyWZITFl999ZXa7/XXXzezmMBSgIG8rb8PequF9v3oBbAGrG14JjABlFJhYU20a9v0FhZC3AUGbxPiBbz00kvKRxi+v/CFnz17tvL1hl9uUixevFi+/vprFfB78+ZNM79wW2kYkWHFEvigg1u3bjm8vy3sPQ/86+Fvj89vCXylZ86cmey1kGEJvuk//fSTnD9/Xtq0aaP83NGfKc2y5azPnxq2bNmiXhF7YS2u5PDhw6ZXxBxs27ZNLSMI3F4Q44B4CGvXxvdgzR8dwF9cu74G/MunTJkiW7duVT76+jTK+mvA371ly5YqG1rVqlXlhRdeUN9PjRo1JCgoyKH7QMzSl19+qfoD7xHTUKdOHbWfPSC+As/eP//8IzExMep5+fvvv1VaYJwLrF+/XsUK4RVo6x0FqWA1333L523z5s0pOterr74qM2bMSPE9oC8R/4LPZC3DG9avXr1a9uzZIw0aNDCt++WXX1R/dO7cWb0idgjxFYgB0/rp+PHj6veIgOu0BDFa+/btU3EqiPuxBN+r9lkt0T6THsSDId7rwIEDKi20td+LO/79ICQ1UFgQ4gXkzJlTBZci3SgGWUeOHJEvvvgiyWMQ+PrWW2+pYzGQxH9W2uAJg7uoqCirx2FQZy3tLbAMhE3N/raw9zxIw4r/xK2RO3duu66F865bt04NxjHgQSAzQF/169dP3n//fQkICHDqfTsDTQziPsGNGzfUK4L70WyhBa0igBog4NRebPUprg1hoAUdJ3VdsGjRIunYsaMKlG/evLkKTMbAVEsAYBkwj/0//vhjFdiK70PrawT1Yr02qE3pfSCYGINziHMEwqMhCBeBx/jNIPA9OTBQRsD+9u3bldDBM/nUU0+ZgrIxUH799dfVK+4TgeLOAKLGGnjerCU5SAvwWZN6LhB8rN8P6AWXJiyeeOIJdd/YNnbsWLW/s4WYrd8NJllgjLlw4YLdz42Grc+N9Qg8RxA3khzYy+P8+0GIM6CwIMRLwCweLBDI0oOBEGZIbYGBFv6zxn/ymDlExhYN/IeKvO6eCv4jjoiIsLoNM/f2gv/8Ic6QiQozkxAaWEYmLQwWhw0bJu7EyZMn5dy5c2pwpGUL0gYluG8IouTQip9hQGUvGPhbA9fGNlge7AEiDs/tzp07pUSJEmbbIJgtwYBcG/gjYxgGnZhhhzBAxhxY4lJzHxi0QXCjYcCJbE0QGT/88IOqf7By5cpkz4GB76effqruCbPT+mxn2IaMbcjeBOGB9SmZwXZ3tGfO1m8NfajfDyDzGgbe6C9kJDt48KApmx36C8/Gxo0bTRmTnC0stPPC4qW/N1gLIBBTgq3PjfV4DmCJIcSbYbpZQrwEzPJiphmDQrjuIK2mLTDIwuw0XDz0ogLgP1JPTmUI1xzMJEIwWYKiWCkFgwG4RvXt21e5cIAlS5aIuwGhCDDrrw324RYH7HWD0WbOkR7YUXBtpBRGET97QEpZ9LOlqLh06ZISTUkBCwMGohABsHjov5+U3oceuMJgBh2F1JCqd82aNXb9NuAOo1m9MFhG6lHN0gHLBYQvhA9cauyt+K5ZyNx9lhouXhCIEE1wKbI1iLd000Q/wNXpxx9/NPUTgCsULKlaX+L5cGadFjwzEC34O6hdE4N/PItIo5xSdyOcyxJY2yD6y5UrZxKRnvJ9EpJSKCwI8RLwH9Vvv/0mv/76q4wbNy7JffGfKP6zRmyF/j9/uAB4egVazVIzfPhwM/cPWB2QM94e4LJgrc6ENhvpTtWHMfMNVy24C8EC9d5775kJBQysESuycOHCRMeif/T1EzBji4aYANT9sCQllgwUHQMY8FurWYKZawzc9H7oGFjqZ3zhqw+XIc2nXQMDc2s1OPD8woVP//2k5D5wrDXxCaGKfoalyp4YG4gb1DvAuTDQ1Aas+tl2zXff3tl31MEAGKC6Mxg4Q4xh8sLy7xAEGiw+EGmId9Kj7xd8VkwQaOfDvhAcEJnOtFagaj3quWjX1ceE4LnB38bevXtbdXmClcza3whYtv777z8zCzB+kxAQsCZrYOIHEwDu/n0SklLoCkWIF4HBDFpyYHCEQnhagTHEZ8CHefny5WqA58mVm+Fjj0EIYgoQRPv0008rP3u406BIHQYTyQ0OYe1o27atGpjDTSNPnjxqUA3hhmNR8MoVoLgaBmcYrMBXG7PwEAZ4j9lQfEbNh10DogKDMQQiI3YGwc4QlWfPnlWWDAzSMYDXmDdvnpo97tOnj+pHWLWwHYGnu3fvtjo4t0aLFi1kxIgRypKCgSSW8WzheAgIDLjhxoSZYQBBi4bvrH379spdDxYifFY8o/qid/gusB/WI8geljqcF0XwIELgxpSa+4A1AoPYkiVLKjeYggULKkEB1yUIEJwXxd7sAX2uBc/rB8O4V8y647uDANHcb+w5HwaiGKTiu0A8BVzX7HFxe9xgkI7nEv0KcQVxi0E44mIweIdrmeVvUOsjPI8otqjfjm2wFun3SwmwwmrJC/AsQ6DgvvD947cwffp0s0G/FryO7w+TEf/++680adJE/V2E8MUkBRIMIL7HskghLMf4zeD3BrfEtWvXquvD8qKftNG+e4j4l19+WT0T+Mx4j+eTEI/F1WmpCCGOp5tNDmvpZpGb/aOPPlLFn7AdBeeQPhE1Gqylu9RSnmoFnJJLhamllMWrrTSQlmlfk0o3a+91AeoV4LOgHgE+W9myZVVeei2Npb6wmDVQrwFFvVDUKleuXCo3Pfqnbdu2yaZ8Te4z2pNq0hKtD7SG1JWo4YHP1aVLF8OiRYvMcu1bcuPGDcPw4cNVuksU68uQIYP63pFff/HixYn2v3z5sirghbSe+OxIVYpUtkhrnNLPgGKCyPufM2dOVewM6WlRxG3s2LFmtQiQNnbGjBmqHgvSlWK/Xr16qWJrWnE4DdSpGD16tEqLi7oQuEd81y1atDAsX7481feBPkT9CRQSRFpTnDd37tzqOvPnz082ta0erX4GvivLYpNa2mNbv19rvz8wZ84clXoXzzSO1+9j6xhg2X9pXSBPqzODQpa4J/Q3iluiGKGW2tgaKGCI833xxRdm6zdt2mR69rWUtCn5LPqG4nX4btH3SMutr41jjYULFxqaNGmiikPic+AekdIatUnwGa39LUKBRjzH+J7wfOK3FBkZmejcqCWDwpn4LSPtsf5vWVLphZP620qIq/HDP64WN4QQ8jiAe9RHH32k0pTCkkEIIc4AFhFkkEIciL1xM4R4I4yxIIR4HXB1sASZZpDhCe4j/I+fEEIIcT6MsSCEeB0I+IVPN2IkECSJjEOIrYD//XfffWd3sTNCCCGE2A+FBSHE60CRQNQ0QF0PpNVFoGTDhg1V9iQEVxJCCCHER1yhkKEBmRaQMhDZJLZt22ZzX6RERM5wzEqiIXOD5f4IIxk5cqTKloKZSuxjmdMcWWOQphKFceAqgWJjyAZCCPE88FtGth+kvISVAmlIUZuBooIQklYxFhhr0M2S+DpuJyyQa33w4MGqui1y7COdIAYDqMZpDRTbQc5sBEwhdWJ4eLg0a9bMLN86qgjDtxozmEgRlz59enVOfYpFDESQwg/pDZFaECngkG6REEIIIYQQkjxulxUKFgrkdp42bZqpgBPEAvI/Dx06NNnjUYQGlgsc37VrVzWDgNzTcIHQcpvDNSJ37tyqoBRyTaM4EnLVo1KoVgMAueJbtmwp58+f9+ic/oQQQgghhPhcjEV0dLTs3LlThg0bZlqHgjFwXYI1wh5QKROuD1qVUlTHRGEjnEMDhYUgYHBOCAu8wv1JX1gM++PasHCgWI8lqNCKpgEBBHeq7NmzqyJGhBBCCCGEeDpaUVZMtCdXYNathAX8oWFxgDVBD5ZR6dIe3n33XfXBNSEBUaGdw/Kc2ja85sqVy2x7YGCgEifaPpaMGzdO5awmhBBCCCHE2zl37pwUKFDAc4SFo4wfP14WLFig4i4Q+J2WwKqCWBANuFcVLFhQzpw5owLAXcnJkyLVqhkVZYcOBvn6a/fxdoNlBwIyR44cyapewv50BXxG2Z/uDp9R9qe7w2fUu/ozMjJSChUqJBkzZkx2X7cSFuiwgIAAuXLlitl6LOfJkyfJYz/77DMlLNasWSMVK1Y0rdeOwzmQFUp/zsqVK5v2sQwOj42NVa5Ntq4bEhKimiVwqXK1sNDfcmws7knc6scBlzf0E4UF+9Md4TPK/nR3+IyyP90dPqPe1Z/aNe1x9XerKePg4GCpVq2arF271qwzsVynTh2bxyHr09ixY1XAtT5OAhQpUkSJA/05obwQO6GdE6+3bt1S8R0a69atU9dGLIankS5dwvv79115J4QQQgghxFdwK4sFgHtRt27dlEBA1dwpU6bIvXv3pEePHmo7Mj3lz59fxTiATz75RNWomD9/vqp9ocVEoCAWGtTVoEGD5MMPP5QSJUoooTFixAgVh9GmTRu1b5kyZaRFixbSu3dvlZIWwd/9+vVTgd2emBGKwoIQQgghhIivC4uOHTtKRESEEgsQCXBXgiVCC74+e/asmRnoq6++Uuah9u3bm50HdTBQsAa88847SpygLgUsE/Xr11fn1MdhzJs3T4mJxo0bq/O3a9dO1b7wRIKCYLaCtYcWC0IIIYQQ4qN1LDwVuFchjS2CuF0dYwEQX4PC4WXLihw4IG4D3MsQz4IsXIyxYH+6I3xG2Z/ujrs+o8jqCIu/J/bn9evXVbp4d+pPT4Z96ln9GRQUpGKcnTHGdTuLBXGeOxSExYMH7FFCCCFpB+Yn4WEAjwBPvX8M3JCnn3Wo2Ke++oxmyZJFxSQ7en4KCy9Fi7Ng8DYhhJC0RBMVsKCkS5fO4wbnGLQhEyTqV3navbsr7FPP6U+cG8Wlteyo+gyqqYHCwkuhsCCEEPI43J80UQE3DU+Eg2D2qa8/o2FhYepVc7FMyi0qOehM6KU8ekaUxYJRNIQQQtICLaYClgpCiOei/YYdjZOisPBStL/xcXF4SFx9N4QQQrwZuhAR4tk46zdMYeGlsJYFIYQQQgh5nFBY+ICwYGYoQgghhFjy119/qZlqT8zotXbtWlXgGHE+JOnvFbXbUBcOmaXSGgoLL4UWC0IIIcQ23bt3lzZt2iQ7KNOWrTVkxNLn+n///feldOnSqgAvUnc2adJEFi9erIJvbTFz5kxp1KiRqg9ga5BfuHDhRNceP358sl/v7t275YUXXlBFhnFPJUqUkN69e8vRo0fd5tFYv369tGzZUgX/w8+/bNmyMmTIELlw4UKSx6H48fDhwx0KNE4L5syZo1K3upPIa9GihapVgWLQaQ2FhZdCYUEIIYQ4jyNHjsilS5fMGjLoAAwG69atKz/88IMMGzZMdu3aJX///bd07NhRDYBRWMwWSPWJgd97772X5PU/+OADs2v3798/yf2XLl0qtWvXlqioKDWgPHTokMydO1cVOhsxYoS4A19//bUSXxBhv/zyixw8eFBmzJih+mvixIk2j/vnn3/kxIkT0q5du8d6v54upD///PO0vxAqbxPHuX37NqYj1Ks7MGAApkeMbcsWg9sQFxdnuHTpknol7E93hM8o+9Pdcadn9MGDB4aDBw+qV0+jW7duhtatWxvi4+MN0dHR6hWsX79e/X9+8+ZNq8vWeP311w3p06c3XLhwIdG2O3fuGGJiYpK9n6SuU6hQIcPkyZPt/mz37t0z5MiRw9CmTRur2219tmvXrhk6depkyJcvnyEsLMxQvnx5w/z5882OXbRokVofGhpqyJYtm6Fx48aGu3fvms5Xo0YNQ7p06QyZM2c21K1b13D69Gmr93Du3DlDcHCwYdCgQUneozX69u1raN++vWn5yJEj6nMcOnTIbL9JkyYZihYtalret2+foUWLFuq7ypUrl+Gll14yREREmLZHRkYaXnzxRXX/efLkUcc3bNjQMHDgQNM+Dx8+NAwZMkT1EfarWbOm+tz6/hRdGzVqlNr2ww8/GKpVq2bIkCGDIXfu3IbOnTsbrly5oradOnUq0XF4PgF+5x999JGhcOHCqs8rVqyovgM9y5YtM5QoUUJtb9SokWH27NmJnqUzZ86odcePH0/xbzklY1xaLLwUWiwIIYSQtAd+6wsWLJAuXbpIvnz5Em3PkCGDqj/gKHB9grtQlSpV5NNPP1V1DWyxcuVKuXbtmrKWWMOWq87Dhw+lWrVqsmzZMtm/f7/06dNHXn75Zdm2bZvaDktJ586dpWfPnsoCAvedtm3bmuoswLWsYcOGsnfvXmWxgduVrWxDixYtkujo6BTfI9i4caNUr17dtFyyZEm1bOnqg+UXX3zRZFV66qmnVP/t2LFDxR1cuXJFOnToYNp/8ODB8u+//8qSJUtk9erV6jqwPunp16+fbN68WX3n//33n3I1g8Xp2LFjymo1ZcoU5damWZbeeustUxrXsWPHqr757bff5PTp08qKAMLDw5XFRm8Zmzp1qloeN26c/PjjjzJt2jT1nbz55pvy0ksvyYYNG9T2c+fOqe+gVatWsmfPHnnllVdk6NChifqsYMGCyiUOnyktYYE8L4XCghBCiKvAmE8XfvDYyJNHZMcO+/eHu1DGjBnN1tkKBi5QoIDZcqFCheTAgQNqAH/z5k0VW5FWDBgwQKpWrSrZsmWTTZs2KXcrDD4nTZpkdX8MckFK7yl//vymgTCAuxVEyv/+9z+pWbOmuiYEBAay+PygQoUK6vXGjRvKhenZZ5+VYsWKqf2wzZawwD1iAJ6aSs9nzpxJJOIg7DD4xuAdII5k586dyv0LYBtExccff2w6ZtasWWpQj31xH99//73Mnz9fGjdurLbPnj3b7Dpnz55V6/CqrUd/QaRg/ccff6xczfCZ4d6lB2JMo2jRosotqUaNGnL37l0lPvHdArjXaaIKbmw4J0QO9oVARd/CFQxuZBBxX331lVqnuY6VKlVK9u3bJ5988kmifsM9o+/SEgoLL4VZoQghhLgKiIpkYm/dgieffFK+/PJLs6rGW7duVTPClmCmVy9CEAwLkgrM1oMBon5Qi3gCzCLbA2bSNSpWrCjBwcHy6quvqtnskJCQRPvbe0+WQFThHiEkEDwNiwIGt1rxtEqVKqlBNwRD8+bNpVmzZtK+fXvJmjWrGhhjBh7rmzZtqvq2U6dOVq042j2mtnbCgwcPVDC6HlwLg/wtW7ao2BJYKyDGNHEFSwECxTGItwTxGjgnrAoQUBoQCRioa2DAjj6ChUQP+ii5yvM7d+6U0aNHq/uAENUyNEGkIGDdGsePH1cxOOhnPfheIJIALEe1atUy216nTh2bFbZxvrSEwsJLocWCEEKIq7CYrHXb66ZPn16KFy9uJizOnz9vdd8iRYpYdc/JmTOnWn/48OEkr/Xaa6+Zud3YGnDbAwaSuGe40+gHvhrawBf3ZGuQaQ24WMEFB+48EA/on0GDBqmBLEAGJsyew2qyatUq+eKLL1QmLIgx9A9m7WFdWb58uXJ1GjVqlNofA31r9wgLB6wgKbVa5MiRQw3O9cBCAFcnWBxwPby+/vrrpu2wDMBdyNpMPq6PQXxy4BzoA4gEy2xU1gSLxr1795TgQoPgwTMDQYFlrW9tXU+zrMGNSXtGgTVBmRywKuHaaQmFhZcSFpbwPo3FKSGEEGJGStyRPB1/f381Ww4/eAykLQUDBoeYXceMvubu4ijwpcd1taxUlmCGG4PvCRMmyK+//ppoO+INrIkkxBe0bt3aZLHBrDrchPQz6hjY1qtXT7WRI0cqlyhcQ7OqYCYdNRPefvtteeKJJ0wDfUtg6UAsAO5x8uTJdt+jdg1YfCyBOxRiNhAHcvLkSfW9aMB6gTgGpO61FvMC9yRYobZv326yJEH44PPjc2jXhcXi6tWr0qBBA6v3FhwcnMidDgLv+vXrKk4GrlcAcR6WxwH9seh3CAiIEPS3XlhooJYHYkL0wGpjLX4GlhnN0pFWMHjbS6HFghBCCHEeGEyiboW+wXUGfPTRR2rACEsCUs5i0IsYAvjwYyCnzTxbA+eBUNBmzOFug2XMLgMECsOCABcaDJYx460F8MIFyRqwNHz77bcqCPu5556TNWvWKOsGBrMYeMN6Yg3UudAsEnCxgbsVApw1YJmAqxTOg8EuanRERESowe2pU6dU7AfuF378OA/6ANusgf6CoICFpFevXioYGcdB3OC6WqyENTDTjzgDSxD7cefOHWWpgCuWXuT17dtX9SlEB8QDBtmIH+nRo4cazMPNrVu3bkoQwWUK8TO4Lwg4bTAPKwvES9euXdVnx2dGYDtc0tDXAMIF3zcK+CH+Bq5HECoQDrDw4DuEELD8fBBouA6sE+hTnAP3BPcuiDY8V7hnBJPjPIgHAfgu0c+4bwR+Q8ihloYlEBsQKSmxYKWKZPNGEY9MN/vHHwnpZseONbgN7pQm0Rtgf7JP3R0+o97dp76UbtZa27x5s+l8t27dMgwdOlSl/UQaVaQUbdKkieHXX381ndsaSEdq7dxIGQp27txpqFWrlkrfinSiZcqUMXz88ccq7WlybN++3dC2bVtDzpw5DSEhIYbixYsb+vTpYzh27JjVz3r9+nXVJ0iJinSsw4cPN3Tt2lWtA/iumzdvbjpfyZIlDV988YXadvnyZZXeNm/evOrzI0XuiBEjkn1OV69erc6ZNWtW9flKly5teOuttwwXL160eQzuE/sePnw40bYOHTqozzRr1qxE244ePWp4/vnnDVmyZFHpdHEtpLvVvh9r6WaRThbfqwaelZEjR6r0r0FBQerz4pz//fefaZ/XXnvNkD17drN0s0jbi2PQb3Xq1DEsWbJEbd+9e7fpuA8++EBd18/Pz5RuFveGVMPoa1wPfY/+2rBhg+m4P/74Q323OHeDBg3UZ7dMN4vv/dVXX7XZp85KN+uHf9JWuvgGqLiJIB+YzZDlwNWsWyfyKKmBDBuGoDFxC2BWxawPzLeYBSDsT3eDzyj7091xp2cU7hWYtYV/vWUwraegpUq15mZC3LdPMUOPsReyI6UViI1ApixkXIL1wlP789q1ayoWB5Ym/FZT+ltOyRiXIzsvhVmhCCGEEOKtIGgc7kNadiVnsHv3bvnpp59MLkdwewKIO/FkTp8+rbKf2RIVzoTB214KYywIIYQQ4q0gsPu9995z+nk/++wzFauAmAgUC0SaYQTCezLVq1c3KyiYllBYeCnMCkUIIYQQYj8ItEcqWZJ66ArlpdBiQQghhBBCHicUFl4KhQUhhBBCCHmcUFh4KRQWhBBCCCHkcUJh4aWggKOWhfDBA1ffDSGEEEII8XYoLLwUpDnWArjv33f13RBCCCGEEG+HwsIH3KEoLAghhBBCSFpDYeHFUFgQQgghqQMVjn/77TeXdN+cOXNUnQZXc/36dVXhHQXWbPHXX3+pvrp165b4Avfv35d27dqpCtRJfe6hQ4dK//79xdegsPBiKCwIIYQQ63Tv3l3atGljs3suXbokTz/9tEu6r2PHjnL06FFxNR999JGqOl24cOEUHbdy5UqpX7++GnznzJlTDcRtiZN///1XAgMDpXLlyg7d640bN1SlbFwToqxXr15y9+7dJI9p1KiREgf69tprryV5zPfff6+K5m3atEk9Izdv3lTH7dmzx2y/t956S+178uRJ8SUoLLwYCgtCCCEkdeTJk0dCQkIee/fFxMRIWFiYshS4emb+u+++UwP0lHDq1Ckl2DBo3717txIZ165dk7Zt2ybaF7P9Xbt2lcaNGzt8vxAVBw4ckNWrV8vSpUvl77//lj59+iR7XO/evZVA0NqECROS3P/EiRNSpkwZKV++vHpGICqskSNHDmnevLl89dVX4ktQWPiAsIiLwx8qV98NIYQQ4pmuUJhtx/L//vc/adCggRr416hRQ1kVtm/fLtWrV5cMGTIoC0dERITZeb799ls1EA0NDZXSpUvLl19+adqmnXfhwoXSsGFDtc+8efMSuUKNHj1azej/+OOPynqQOXNm6dSpk9y5c8e0T1RUlAwYMEAJEpwHFgPcmwZm1jH4hgUB91+iRAmZPXu2zc//559/KmFVu3btROtLliypzvHkk08mskSgcnVcXJx88MEHUqxYMalataqavceMPkSTHlgHXnzxRalTp444wqFDh2TFihWqr2vVqqU++xdffCELFiyQixcvJnlsunTplEDQGiwetoBYmjhxohIt+N6wXKRIEVPVbr9H6zRatWql7sGXoLDwYrSsUIAB3IQQQohjjBo1SoYPHy67du1S7jsYFL/zzjsydepU5R5z/PhxGTlypGl/iAQsw6UIg9+PP/5YRowYoVxkLP3xBw4cqPbBLLetmXIIHczGo23YsEHGjx9v2o77+OWXX9S5cX/FixdX54KLEMB1Dx48KMuXL1fXwUw6ZtVtgc9TrVo1s3Xnzp1TlgcMmCEUXnnlFXXvenCMv7+/ug8IjNu3bytB1KRJEwkKCjLtB1EDNyH0qTXQVxBrSbWzZ8+qfTdv3qyEGASeBq6H+9i6daskBb4j9AMsEMOGDVOWGlssXrxYWTgghGDdwPK2bdvUtjVr1pjWadSsWVPOnz+fZIyKtxHo6hsgj69IXubM7G1CCCGPiUmTjC05qlYVWbLEfN1zz4ns2pX8sYMHG9tjAjPv2sAfQqBz586ydu1aqVevnloHtyFYGzQwaMYMt+YGhNltDO6//vpr6datm2m/QYMGWXUV0hMfH6/OnTFjRrX88ssvq2tDtNy7d08JBWzX4kK++eYb5RYEd6a3335bDcIxq64NvpOLmzhz5ozky5fPbB2uASsEPhMoVaqU7Nu3Tz755BPTPviMcH9CnMgbb7yhxAUG4rB0aBw7dkwJEogXCDRrwJrRoUOHJO9Ru7/Lly8nch3DebNly6a22QLCsFChQuo8//33n7z77rty5MgRM3GgB+eDhSM4OFhZN0BkZKR6zZ49u2md5f2hL1Map+KpUFh4May+TQghxGVgwHXhQvL7hYcnXgd3InuOfTSoe1xUrFjR9D537tzqtUKFCmbrrl69qt5jsA8rA8QGZrk1YmNjlSuTHv1Muy0wMNVEBcibN6/pWrgO3Iw0gQNgHcCMOawT4PXXX1dB1LBmNGvWTMVB1K1b1+b1Hjx4oFyq9OBccDXSY+nGhIE8Yhteeukl5XqFAGpYbdq3b6+EDgQSBvRjxoxRLlW2wCAeLS3Rx2Dge0SfIt4D/QkB5Shhj1xHkrKCeBsUFl4MhQUhhBCXAV/1/PmT3y9nTuvr7Dk2CX/4tEDvyqMF7Vquw8AZaBmJYDmwHIwHBASYLadPnz5F17a8lj3AkoGZc1gOMMDHALpv377y2WefWd0f7kGIy0gp06dPV8IJblqwGuA+586dK+Hh4cotCXEmO3bsUIHd/fr1U8fgcxgMBrX/qlWr5KmnnlKuUGhJAetPwYIFlaVAE1l6AQc3MEsrQlJo3xNc2pwhLG48ckNDXIuvQGHhxVBYEEIIcRmOuClZukZ5ILBewBUGcQSYuU9LMAiGew5St8K1B8CCgeBtuFlpYIALFyw0BKHDRcqWsIDbFASBHgShL7H4brZs2WK2jNl5xDZYE1IQEAiOhvuUHgS0r1u3Tn7++WdTMHRKXKFgNUGGKQSOa3EhOB+uZynqkkJLGQvLhb2g3wFcvizZv3+/EoTlypUTX4HCwkeExb17rrwTQgghxP1AYDEGk5jd1mbX4SuP2XVnAHcfZGrCDH6LFi1U5ibM1sMSMNiJsSGweMDVCUIB7kOYxUfaVAzytXSxcEfCoBuDXNwHAsAhFGyBWBIEM+Nes2bNahrsI74C10HgNgby+pgS8Mwzz8jkyZPlww8/NLlCvffee0rwQKxAdCBQWo+WyUq/PiWuUPgc6F+4nM2YMUOJKlhDkDlLEx8XLlxQVpoffvhBuYjB3Wn+/PnSsmVL9Z0jxuLNN9+UJ554wszlLTlw73B5QlaqAgUKqM+hubohhkTLIuYrMCuUF6P/PV6/7so7IYQQQtwPVI1GOlQMNPGKgS/EgLPA4BspUJEBCT78SCmLgbg2K+9M4HqEGAoEdeOzwJ0HQdSaKMDMOoQCBs0YPMOKkFQqVNwvzoMUuxoQLMg8hexUlSpVUoN4S3cluDEh0xIsGzgeA36krcXAOy0H2Lgm3KwgHiAWkHJ25syZpu0QGwjM1uId0B/I5IR4Exw3ZMgQ1X9//PFHiq4LQfr555+rgPx8+fKpgoIa6F99fI0v4GeAUxtxGGQFgELF7EdSOZAfJ8hm17278f20aSJ9+7r6joxmUPhBQuFbmkoJ+9Md4DPK/nR33OkZffjwoSqIhoGyZaCvp4BhkN5iQRJYtmyZsk7ApSclzxr7VFRaX4gVWEJsZb5yp/5M6reckjGu243sEPSDzAf4UPCL0/IDWwMVFqEusT86esqUKYn20bZZNgQsOVLS3RPQxwpZ1OshhBBCCEkSuDUhcxLciEjKuHfvnrJUOSoqPA23+rSoPAmfQ5jWICogFODjB9OVtdL2MGcVLVpUXnjhBeUXZw0ELukDaqC6mzZtqo7RA1MVqkRqIE+xp6PvMotkCYQQQgghyaIP/ib20759e5/sLreyWEyaNEkN8Hv06CFly5ZVAgMD/FmzZlndv0aNGvLpp5+q4Bz471kDGRD0pdoRrITsCfBzTG1Jd0+BwoIQQgghhPicxSI6OlplF0BgkQb8+VCSHaXanXUNpE6DVcTSRw1BP9gGUYFS9SNGjEjSaoGMCmgaWuVF+L6mJK90WpI9e4J2vHrVIPHxrg+n0XJVu0sfeTrsT/apu8Nn1Lv7VLsXrXkq2r178mdwN9inntWf2m/Y2jg2JX9r3EZYXLt2TbksaZUsNbB8+PBhp1wDWQyQ57i7FtGcypLuYNy4cVYzR0RERKgAGHchQ4Zccveuv1y8GCdXr15z9e2ohxPBP3h4XR106A2wP9mn7g6fUe/uU2Tawf0gsBTNE0E/ai7TDN5mn/rqMxobG6t+y9evX09UjPHOnTueJyweB999952qPKnlNHakpDssK/oc1LBYIO81XK/cyY0qd24/QfHPGzcCrMapPG7w0OJHgX5y9X+I3gD7k33q7vAZ9e4+xUQaBh0IUPX0IFXLwRRhn/rSMxoYGKj+nqCmh2VWqJRkfHObvwIoHY+cyleuXDFbj+WUlGO3BcrYI19xUlaIlJR0R0yHtbgOfCmu/kOvB1rixAmRmzf9JC7OT9zh7yb+Q3S3fvJk2J/sU3eHz6j39imur8+o6Kmzwdq9e+pncDfYp57Xn9pv2NrflZT8nXGbkR0KlaAi5Nq1a81mZbCMUu2OgpRfmLFH6rS0KOnuCSlnr7neE4oQQgghhHgpbmOxAHAt6tatm1SvXl1VwUS6WeQBRpYo0LVrV8mfP7+Kb9CCsQ8ePGh6jzzLEAUZMmSQ4sWLmwkUCAuc29JU66yS7p6SGcoLtBIhhBBCCHFD3EpYdOzYUQU/jxw5Ui5fviyVK1dWJeC1gO6zZ8+amWMuXrwoVapUMS1/9tlnqiGV7F9//WVaDxcoHNuzZ89E19RKumsiBnESKLo3fPhw8QaYcpYQQgjxPpC9Eu7iM2fOFF8Dk8klS5aUn3/+WU1GE/fBbVyhNPr166fiIZDKdevWraZ4BwCxMGfOHLOq2vo0d1rTiwrQrFkztR4PoSUQEhs2bFBR8AhCO3bsmEyYMMGtArAdgcKCEEIISQwyRLZp08Ztrn369Gnl4665YycFJl+nTp0q77//vmkdJmZff/11KViwoIoBRXwqigz/+++/qb5PeHE0aNBABe9ivITxUXJgIvfZZ5+VzJkzq4nht99+O1HGMIzTqlatqu4THib6sR0YPXq0WewOWunSpc0mhd966y2VxZO4F25lsSDOh8KCEEIISZtUu5ZZejCTjkFvWvPtt99K3bp1Vap8DXhb4Prff/+9FC1aVFkzEKeKidPUgGyXmJhFPTEULN63b5/y/MiSJYtZNk09SImKWFaIGkzaQuzADR399PHHH6t9Tp06pfZ57bXXVA0x3OMrr7yi4lohhDTKlSunPEo0LF3Zu3TpIkOGDJEDBw6ofYl74HYWC+JcKCwIIYSQpFm5cqWamcegGfGWmHFHDKalNWHhwoXK3Roz+BgUa5aHjz76SKWyL1WqlNr/3Llz0qFDB3W+bNmySevWrdU5tNl4DP5///1302w8ZvCLFCmitsPFG+saNWpk834XLFigivlqoEbXxo0b5ZNPPpEnn3xSCQ7EqiI1/nPPPZeqrx+fD0Jl1qxZauDeqVMnGTBggEyaNMnmMatWrVKxrz/++KNyZ0eK/7Fjx8r06dPVuQBECj7rxIkTpUyZMspTpX379jJ58mSzc0FIQKBoDdlD9WTNmlXq1aun+oK4DxQWXg6FBSGEEJI0iLFE4pYdO3aoGXTEcz7//POJKg4PHTpUBg4cKIcOHTLNrmN/FNVdvXq1LF26VFkysC1jxoxqsA9XJCSVadGihRpcw4UHogPLly5dUg3Wh23btqnzYZYe62ylx79x44YavOtjC3B+NBQChiu5LTDQ1/a11vQz/5s3b1aJbPQWGHwufNabN29aPT+OQT0wfbFjHAPrBywL2j6wgujBPlivB67pEGuwvsA6ARcrSyCe0MfEfaArlJejTzcbEeHKOyGEEOJLTNo8STVHmdt2rjQqnDB7/9fpv+SlxS+p94PrDFbNUdq2batmyLUaAZilRwFCDODLly9v2m/QoEFqXz3p06dXrknaAHzu3LlKkGCddj5kpoT1ApYJuBeFhYUpAaCv04XrAVhMkqrfhQE24kb1xX5x74hT6N27t7IIIH4BlhVYGfQZLnFPDx48sHluvWsX4jg0K4qGJhiwDRYDS7BeLyosj0lqH4gP3Bv6BvG1+DywAEFkjRkzRlmU9u/frwSbBvoAcbnEfaCw8HL0lkOkmyWEEEIeB5FRkXLhzgWHzxMVG5VoWTsvruEMMDsOlx0kjbl27ZrJUoFBvF5YWMtAhBl6/az+3r17VYFd/QAYIEGM3r0qtWjCwLIaMmIsELuAGfwtW7bI8uXLVbA1xARctgBS9nsCsKxoQBhBaMC963//+5/06tXLtA0i5P79+y66S2INCgsvB7FO2bOLIHaLwoIQQsjjIlNIJsmf0fGBbEhgSKJl7by4hjOA2xMyTX7zzTdqFhzCAoJCiwvQWycssVx39+5dVfAXMQqWaFYJR9BiDeCOZHk+iI2mTZuqhnS0CIoeNWqUSVhgwJ6U6xAG75rLEqwmCADXoy3bsqhgvebSZesYW+dFNk4IBWvA2oPMnhBslm5hzuhT4jwoLHwkzoLCghBCyOPEWW5KlsAt6vzg8047H7ImHT16VIkKxBSAf/75J9XngxsSgrxz5cplM3U9LBzIoGS5Dliut6RYsWLqvHDTspZGX0/ZsmVV3EVqXKHq1Kmj0tnqs18hjgTuSdbcoLRjEMh+9epVFbSuHYP7xb1o+/z5559mx2EfrLcFxBqsPS+//LLZerhG6euZEdfD4G0fCuC+d8/YCCGEEGIEg2TENUBYYEZ83bp1Mnhw6gURAo1hVUAmKFgHkF4VsRXIqHT+vFEQwTqCGhEIhIbrFQbvECKYsUdhYMzg37592+r5EViO4Ge9+IE4euqpp1R8B86Lay5atEi5QuE+NOAKhboRtpo+fe2LL76oxA5cj2DFgFhC7Qx93/z6669m9SUQPwIB0bVrV+UShmxbKDjct29fVbMCIM3syZMn5Z133pHDhw/Ll19+qVycEDyvgQB3pKtFJq1NmzYpi1JAQIB07tzZrC/Qv7gmcR8oLHwsMxQDuAkhhBBR7k4IesZAHQPynTt3KvcnDHA//fTTVHdRunTp5O+//1aF6hDojZSqGJwjxkKzYCDIGjP/iNmAKw8yR+FePv/8c/n666+VO5ZeEFgCFyekWdViQZDRCXEISNkKqws+B1yhcJ1p06al6nOgwB3Sx0KkwLULNSNGjhxpVsMC4gfiSAODf2TGwivuAxYGiIwPPvjAtA8CwpctW6asFJUqVVJpZ2FJ0dewgACDiEAfIYMWhB/iRvRuT8gihesjVS1xH/wMSC1AHAbZDPAjxEPublW7+/UTmT7d+H7rVqRnc9294I8gTKSYmcEfc8L+dDf4jLI/3R13ekYxWMbAE4NFy2BidwfpXjFL/8UXX6jK0PqsUO4Ohm4QEhBBlrP47nJ/ad2nHTt2VMLkvffeE2/H8Bj6M6nfckrGuBzZ+QBMOUsIIYSIKegZs+pwT7Ksp+ApYHA5c+ZMNdj0RRBUj2xcevcp4h4weNsHYJE8QgghxEjPnj1l+/btyrUnKXcjdweVrdF8EcR+IHaDuB8UFj4AhQUhhBCSEHCshx7hhDgPukL5ABQWhBBCCCEkraGw8AEoLAghhBBCSFpDYeEDUFgQQgghhJC0hsLCB8iSRSTwUTQN61gQQgghhJC0gMLCB0DKYy3l7NWrrr4bQgghhBDijVBY+Jg7FIQFSyISQgghhBBnQ2HhY8IiJkbk9m1X3w0hhBDivaD4HorY3bp1yynnO336tDrfnj17JC2ZM2eOZIH/tA4U4gsPD1dV3qdMmZKm1yeeD4WFj8AAbkIIIcQIBulaw4AZBdfwqq0bPXq0Q11Vt25duXTpkmTOnNmjurxjx45y9OhR03JkZKT069dP3n33Xblw4YL06dNHvJGzZ8/KM888I+nSpZNcuXLJ22+/nWxV8xs3bkiXLl0kU6ZMSoz16tVL7t69m6hGymeffSYlS5aUkJAQyZ8/v3z00UfizbBAno8Ki5IlXXk3hBBCiOvAoF9jwYIFMmrUKDl8+LASFSBDhgwOnR9CJU+ePOJphIWFqaYfcMfExKhBd968eVN9XpwjKChI3JG4uDj1+fB9bdq0ST0bXbt2Vff78ccf2zwOogL7rl69Wn2+Hj16KOE1f/580z4DBw6UVatWKXFRoUIFJUbQvBlaLHwEWiwIIYQQIxhEag1WBQgKvM+YMaOaXV6xYoVZV/3222+SPn16uXPnjsktCYIElonQ0FApX768bNiwIUlXqH///VcaNWqkZsWzZs0qzZs3l5s3b6ptuF79+vXVzHf27Nnl2WeflRMnTqTo68L1cJ96cD64NwHtvhcvXixPPvmkuo9KlSrJ5s2brbpC4T0Gw6Bo0aLqWJwDfPXVV1KsWDEloEqVKiU//vij2XVh/fn666+ldevWqt8wSw8rUOXKlWXWrFlSsGBBJd7eeOMNNbCfMGGC6n9YC5Kb0e/evbu0adNGDdYhdtBfffv2VYP71ICB/8GDB2Xu3Lnq/p5++mkZO3asTJ8+XaKjo60ec+jQIfWdffvtt1KrVi313X3xxRfqmbh48aJpH/TT77//Ls8995wUKVJEqlWrJk2bNhVvhsLCR9CyQgGmnCWEEJLWwJUEDe4gGvHx8WodBpPO3tcZYBDcqVMnmT17ttl6LLdv314JDw24ywwZMkR2794tderUkVatWsn169etnhexEY0bN5ayZcuqgfw///yj9tc+271792Tw4MGyY8cOWbt2rRqYP//88077XHref/99eeutt9Q9QUR17tzZqtsP3KLWrFmj3m/btk3NziPW4tdff1Uz8fjs+/fvl1dffVXN1q9fv97seAzOIQD27dsnPXv2VOsglpYvX64G5T/99JN89913ylpw/vx5Jcw++eQTGT58uGzdujXJz4Br4Vx4/f7775UI0gQUeO2115RwSapp4PuAgMqdO7dpHUQf3MAOHDhg9fo4BgKsevXqpnVNmjRR35t273/88YcSZEuXLlWionDhwvLKK694vcWCrlA+Ai0WhBBCHieLFi1SrxggY1Zfm8X977//1IALM70amEXHIBszuxjcA/j6Y9BeqFAhZRnQWLJkiURFRUnLli1NMQwnT56U4sWLO+W+MfjTYiQwI3716lX5888/TYNsDcQetGvXTr3HzDQGyxgov/POO4nOiRl5DEK//PJL07py5cqZ3mvn0cCsfs6cOdVMOqwhzgSiAoN5MGbMGHUfx48fl9KlS5vtB5coWAMA7kVz7YKlAFYDWBsABNGWLVvUelhCNCDQIDg09zIAoYTPBoEGkYX9jxw5ovoXg3JYPyAuIBj0z4clsPhMmzZNAgIC1H3j80CQ9e7dW23/4IMP1Oe0h8uXL5uJCqAtY5utY2Bd0RMYGCjZsmUzHYNn8syZM+p38MMPP6jn+80331QCdd26deKt0GLhI1BYEEIIIclTs2ZNNdjGTDiAiwzEzRNPPGG2H6wU+kElhAOEU1IWC1scO3ZMWQ4guBAMjNltLcbB2VSsWNH0XoubgHiyF3zGevXqma3DsuVnr1q1aqJj8bn0Vh8M4CEwICr065K7H3w/EBX6z6E/BoN+CM2kWloTHx+vBDBERYMGDZQbHIQnRBPElLdCi4WPQGFBCCHkcfLCCy+oV/0AsEyZMmpWWj+LDdq2bZtoX7jpYABouS+sGpb7YkDuTGC1gI/90KFDlRuU5cx7StEHRFsDblEQL998843ky5dPDUphqbDl428N3J/ePQxYizvQB1FrnyktXK40y5Ota2vXt7YuuftJ7hi4QkEQJoWWwQmWGLh66bly5YppmzWw3lL8wJ3sxo0bpmMgdiA48Rzrn39NMOJ34I3QYuEjUFgQQgh5nGBQhaYfkGNmGuv0osBZ+zqTl156SbmxfP7558odqVu3bon2gfuPflC5c+dO08DRmpUArjrWQFwGZrARWwCrBs6hBXWnBLgr6bNdwQpy//59cTa4PwSi68EyLA/uAlyhYCVKquktT4gD0QsFZHqC5cjWZ8IxCMzHd64B96b4+HiTCxesOHgu9EH4WipfiEhvhRYLHwETB+nSieBvTAosnoQQQojPAR9+WFEQoN2sWTMpUKBAon1g0ShRooQaaE+ePFmJAS1I2ZJhw4apAGHEJWA2HdmU4BIDqw788hHLgEJ0mOXGbDYsJSnlqaeeUnEHGPTCnx+1J9IixSv6pEOHDlKlShUVsIwgZcTIWMaguBK4QlnGQNgC3y8ExMsvv6xiYRAjAZGHTFOoPQFg0UAKWohD1KLAd96iRQsV0zFjxgxlGULMTadOnZTFCaBv4A6GZwKFBSE6cE5khdJbMbwNWix8CO03RmFBCCGEJA0KnsEVyZZYGD9+vGpI2YosTwgqz5Ejh9V9MZBEWtO9e/eqGA4M/pGGFJYXWFuQphSz33B/QoDvp59+muKvZ+LEiSprE/z5X3zxRRW8jJSyzgaZnqZOnaqCtRHrgLSycBdDDIEnAosYMjfhFd8LrFUQEbB6aMDyA6uS3rVs3rx5KnAcViYkEkDK2ZkzZ5q243uF6MIzgfgcBJhDkOC79mb8DJYOeSRVIC0ZslPcvn1bmc/ckZo1RbZvhy8i/C7xY3r89wDFDnMjZhKcbbr2Rdif7FN3h8+od/fpw4cP5dSpUyqdppb5ydPAMAguK5buVajNgEE+6hLAwqCBWg74vMhYhboHxP4+Je7bn0n9llMyxuXIzgctFpCSNlJtE0IIIT4NZqfhFw9rBGo06EUFISRpKCx8CAZwE0IIIUkDP3u4uCC7D2IjCCH2w+BtH4LCghBCCEma0aNHq2YL1GKgFzkh1qHFwoegsCCEEEIIIWkFhYUPQWFBCCEkLeAMPiGejbN+wxQWPgSFBSGEEGei1UlIi0JshJDHh/YbdrT2CWMsfIicORPeR0S48k4IIYR4A8j9nyVLFlPVYtRN8LT0okyNyj715WfUYDAoUYHfMH7LlpXuUwqFhQ9BiwUhhBBng+xJQBMXngYGVqgNgpogniaK3BX2qef1J0SF9lv2KmExffp0VXESJdVRzfKLL75QVSqtceDAARk5cqSqVnnmzBmZPHmyDBo0yGwfZHYYM2aM2bpSpUrJ4cOHzYqCDBkyRFVDjIqKkubNm8uXX34puXPnFm+1WHjo339CCCFuBgY6efPmVQX79JWJPQUM2K5fvy7Zs2d3ecFBb4F96ln9CfcnRy0VbiksFi5cKIMHD5YZM2ZIrVq1ZMqUKWqQjzLq+INlCUw3RYsWlRdeeEFVx7QFSs6vWbPGtAxTkh4cu2zZMlm0aJGqLNivXz9p27at/Pvvv+JNoMZPliwit25RWBBCCHEuGJg4a3DyuAdtGFih2jCFBfvUHYn3oGfUre5u0qRJ0rt3b+nRo4eULVtWCQz4a86aNcvq/jVq1FDWjU6dOklISIjN80JIwLyjtRw5cpi2oTz5d999p6791FNPSbVq1WT27NmyadMm2bJli3gbmj6jxYIQQgghhDgTt7FYREdHK5cmfZVLqLImTZrI5s2bHTr3sWPHJF++fErp1alTR8aNGycFCxZU23BNmG5xHQ1U3MR2XLd27dpWzwmXKTSNyMhIk6pEc1dy5fKTo0f9BLd7/368hIY+3uujbzRfQcL+dEf4jLI/3R0+o+xPd4fPqHf1Z0qu6zbC4tq1axIXF5corgHL+niIlAKXqjlz5qi4ikuXLql4iwYNGsj+/fslY8aMKpYjODhYBa1YXhfbbAFxYhm7ASIiIlTMhruSMSM+p1FNHDp0TfLnj3/sDyesRPiBuLs5zxNgf7JP3R0+o+xTd4fPKPvU3Yl38djpzp07nics0oqnn37a9L5ixYpKaBQqVEj+97//Sa9evVJ9XlhWEA+it1iEh4dLzpw5JVOmTOKuhIcnZBMwGHKYZYp6XD8OBPqhnygs2J/uCJ9R9qe7w2eU/enu8Bn1rv6Ex4/HCQvEPSDo68qVK2brseyM9FcasEyULFlSjh8/rpZxbrhh3bp1y8xqkdx1EdNhLa4DX7g7D5j1BqFr13Cvj/8e8ONw937yJNif7FN3h88o+9Td4TPKPnV3/Fw4dkrJNd1mZAd3JAROr1271kyhYRlxEc7i7t27cuLECZUaD+CaiLTXXxdZqM6ePevU67oLrGVBCCGEEELSArexWAC4FnXr1k2qV6+ualcg3ey9e/dUlijQtWtXyZ8/v4pvALA0HDx40PT+woULsmfPHsmQIYMUL15crX/rrbekVatWyv3p4sWLMmrUKGUZ6dy5s9qO9LJwicK1s2XLptyY+vfvr0SFrcBtT4bCghBCCCGEeL2w6Nixowp+RtE7BE5XrlxZVqxYYQrohhVBb46BUKhSpYpp+bPPPlOtYcOG8tdff6l158+fVyIChUXgm1a/fn2VRhbvNVBYD+dt166dWYE8b4TCghBCCCGEeL2wAChOh2YNTSxoFC5cWEXIJwWqadsTlIKK32jeDoUFIYQQQghJC9wmxoI8HnSGGhbJI4QQQgghToPCwsfIlg3R/cb3ERGuvhtCCCGEEOItUFj4GAEBSO1rfH/1qqvvhhBCCCGEeAsUFj6IFmcBYZFMiAohhBBCCCF2QWHhw8Li4UPU9XD13RBCCCGEEG+AwsIHYWYoQgghhBDibCgsfBAKC0IIIYQQ4mwoLHwQppwlhBBCCCHOhsLCxy0WTDlLCCGEEEKcAYWFD0JXKEIIIYQQ4mwoLHwQCgtCCCGEEOJsKCx8XFhcvuzKOyGEEEIIId4ChYUPEh4u4udnfH/ihKvvhhBCCCGEeAMUFj5ISIhI4cLG90ePsvo2IYQQQghxHAoLH6VkSeNrZKTI1auuvhtCCCGEEOLpUFj4uLAAR4648k4IIYQQQog3QGHho+iFBdyhCCGEEEIIcQQKCx+lVKmE9xQWhBBCCCHEUSgsfBRaLAghhBBCiDOhsPDhlLPIDgUYY0EIIYQQQhyFwsJH8fcXKVEioZZFbKyr74gQQgghhHgyFBY+jBZnERMjcuaMq++GEEIIIYR4MhQWPgzjLAghhBBCiLOgsPBhWMuCEEIIIYQ4CwoLH4YWC0IIIYQQ4iwoLHwY1rIghBBCCCHOgsLCh8meXSRbNuN7FskjhBBCCCGOQGHh42juUOfOidy/7+q7IYQQQgghngqFhY+jj7M4dsyVd0IIIYQQQjwZCgsfh3EWhBBCCCHEGVBY+DjMDEUIIYQQQpwBhYWPQ2FBCCGEEEKcAYWFj1O8eML7I0dceSeEEEIIIcSTobDwcdKlEylYMEFYGAyuviNCCCGEEOKJUFgQkzvUrVsi16+zQwghhBBCSMqhsCCMsyCEEEIIIQ5DYUHMhAXjLAghhBBCSGqgsCCsZUEIIYQQQhyGwoLQFYoQQgghhHifsJg+fboULlxYQkNDpVatWrJt2zab+x44cEDatWun9vfz85MpU6Yk2mfcuHFSo0YNyZgxo+TKlUvatGkjRyz8fRo1aqSO17fXXntNfIVChUSCgozvjx519d0QQgghhBBPxK2ExcKFC2Xw4MEyatQo2bVrl1SqVEmaN28uV69etbr//fv3pWjRojJ+/HjJkyeP1X02bNggffv2lS1btsjq1aslJiZGmjVrJvfu3TPbr3fv3nLp0iVTmzBhgvgKAQEJ9SyOHROJj3f1HRFCCCGEEE8jUNyISZMmqQF+jx491PKMGTNk2bJlMmvWLBk6dGii/WGJQAPWtoMVK1aYLc+ZM0dZLnbu3ClPPPGEaX26dOlsihNfoFQpkUOHRKKiRM6eFSlc2NV3RAghhBBCPAm3ERbR0dFqsD9s2DDTOn9/f2nSpIls3rzZade5ffu2es2WLZvZ+nnz5sncuXOVuGjVqpWMGDFCiQ1bREVFqaYRGRmpXuPj41XzNEqU8BMRNJHDh+NNRfOcDfrGYDB4ZB+5I+xP9qm7w2eUferu8Blln7o78S4eO6Xkum4jLK5duyZxcXGSO3dus/VYPnz4sNM6ZtCgQVKvXj0pX768af2LL74ohQoVknz58sl///0n7777rorDWLx4sc1zIXZjzJgxidZHRETIw4cPxdPIkydMRDKr97t23ZXKle+nyXXwHUDc4QcC4UjYn+4Gn1H2p7vDZ5T96e7wGfWu/rxz547nCYvHAWIt9u/fL//884/Z+j59+pjeV6hQQfLmzSuNGzeWEydOSLFixayeC5YVxIPoLRbh4eGSM2dOyZQpk3ga1aolvL90CYHuGdLsx4HgePQThQX70x3hM8r+dHf4jLI/3R0+o97Vn0iolObCYuXKlfLdd9/JyZMn5ebNm0pF6UEHYGBuLzly5JCAgAC5cuWK2XosOyP2oV+/frJ06VL5+++/pUCBAknui2xU4Pjx4zaFRUhIiGqW4Av3xAFz6dIJ748e9RN/f6NbVFqAZ8NT+8kdYX+yT90dPqPsU3eHzyj71N3xc+HYKSXXTJWw+PTTT1WwNNyUatasqWb5HSU4OFiqVasma9euVSlhNYWGZYiC1ALB079/f/n111/lr7/+kiJFiiR7zJ49e9QrLBe+Qq5cIpkzIwaFKWcJIYQQQkjKSZWwmDp1qjz11FPy559/SpBWAMEJwLWoW7duUr16dSVYUJcCaWG1LFFdu3aV/Pnzq/gGLeD74MGDpvcXLlxQoiBDhgxS/FH+VLg/zZ8/X37//XdVy+Ly5ctqfebMmSUsLExZVbC9ZcuWkj17dhVj8eabb6qMURUrVhRfwc/PWChv+3aRM2dEECaSAssXIYQQQgjxcVIlLOD61L59e6eKCtCxY0cV/Dxy5EglACpXrqzSxWoB3WfPnjUzx1y8eFGqVKliWv7ss89Ua9iwobJOgK+++spUBE/P7NmzpXv37spSsmbNGpOIQZwEiu4NHz5cfA1NWMCrDV5s5cq5+o4IIYQQQohXCwtYEyyrVzsLuD3Zcn3SxIIGKm5bxnZYktx2CAkU0SNGYaGBr5fCghBCCCGE2EuqIkC+/PJLlYoVLkTEu4rkaRw96so7IYQQQgghPmGxgMtSbGysvPzyy/L666+rLEvI6GQZvb53715n3Sd5zBYLCgtCCCGEEJLmwgJVqxHoXKJEidQcTtwU/ddJYUEIIYQQQtJcWFjGOhDvIEMGkXz5EBRvjLEghBBCCCHEXlihjFiNs7h2TeTqVXYOIYQQQgixDwoLYka1agnvN29m5xBCCCGEEPugsCBm1KuX8P7ff9k5hBBCCCHEPigsiBl16iS8p7AghBBCCCH2QmFBzECR8+LFje937BB5+JAdRAghhBBCkofCgth0h4qOFtm5kx1ECCGEEELSSFjcuXNHzp07Z7bu4sWLMnLkSHn33Xdl27ZtqTktccM4i02bXHknhBBCCCHEq+tY9OnTR06dOiVbtmxRy5GRkVK7dm05f/68+Pv7y9SpU2XFihXSqFEjZ98vcUEA99tvs9sJIYQQQkgaWCz++ecfefbZZ03Lc+fOVRaLTZs2yc2bN6VixYry4YcfpubUxA0oXVoka9YEi4XB4Oo7IoQQQgghXiksrl27Jvnz5zctL1myROrXr6+sFhkzZpSuXbvK3r17nXmf5DHi7y9St67xfUSEyLFj7H5CCCGEEJIGwiJLlixy+fJl9f7BgweyceNGadasmWl7YGCg3L9/PzWnJm6CJiwA084SQgghhJA0ibGoW7eufPnll1K6dGkVS/Hw4UNp3bq1afvRo0fNLBrE8+MsevRw5d0QQgghhBCvFBaffPKJslC0a9dOLQ8ZMkTKlSun3sfFxcmiRYukRYsWzr1T8lipUQOWJ5HYWGaGIoQQQgghaSQsihcvLkeOHJGDBw9K5syZpXDhwqZtcIGaNm2aVKpUKTWnJm5CunQiVauKIHPwoUMiN26IZMvm6rsihBBCCCFeVyAvKChIiQe9qAAI3oZblOV64nmwngUhhBBCCHG6sDh79myiRnwrzoIQQgghhBCHXaFggfDz81PvDQaDeo94CuK9MDMUIYQQQghxurBYv3693Scl3kHevCJFioicOiWyfbtIdLRIcLCr74oQQgghhHi0sGjYsGHa3glxW3coCIuHD0V27RKpXdvVd0QIIYQQQrwqeJv4BgzgJoQQQgghaZZutmfPnkluR/xFaGioFChQQBo1aiR16tRJzWWIGwZwDx7syrshhBBCCCFeJSzWrVsnDx48kIiICLWcNWtW9Xrz5k31mjNnTomPj5fr168rkdG8eXP5+eefJR2KIxCPAnUPM2cWuX3bKCwMBghHV98VIYQQQgjxCleo5cuXS0hIiIwePVqJB61du3ZNRo0aJWFhYfLvv/8qoTFixAhZsWKFeiWeh7+/iGZwunJF5ORJV98RIYQQQgjxGmHRr18/admypYwcOdJkrQDZsmVTwqJFixZqH1Tlhvjo1KmTslgQz4T1LAghhBBCSJoIiy1btqiq27bAtk2bNpmWGzRoIFcw3U08EtazIIQQQgghaSIssmTJIqtWrbK5Ha5PsFZo3L17VzJlypSaSxE3oFYtkYAA43udXiSEEEIIIcQxYdG7d2/5/fffpX379rJ27Vo5c+aManiPdUuXLlX7aPz5559SuXLl1FyKuAHp04toX9+BAyK3brn6jgghhBBCiFdkhUIcBbJCTZ48WX799VezbQEBATJ48GC1D3j48KF0795dKlas6Jw7Ji6Ls9i505gVavNmkaef5hdBCCGEEEIcFBZIIfvJJ5/IkCFDTBYLUKhQIWncuLHkypXLtC/qWXTr1i01lyFuRP36Ip9/bnwPLzgKC0IIIYQQ4rCw0ICA6Ny5syOnIB5CkyYigYEisbEiixeLTJrEehaEEEIIIcRJwuLOnTvKWoF6FQb4yFjwxBNPOHJ64kYgqzDExYoVImfPiuzYIVKjhqvvihBCCCGEeLSwQDE81Kn45ZdfJC4uTq2DsICLlP69to14B+3aGYUFQFkSCgtCCCGEEOKQsEDGpz/++EMGDBigalToi+QR76VNG5HXXhOBXoSwGD+e7lCEEEIIIcQBYYEaFm+++aZMmDAhNYcTDyVHDpFGjUTWrhU5eVJk796ENLSEEEIIIcS3SVUdi3Tp0knhwoWdfzfEI9yhNGC1IIQQQgghJNXC4qWXXkpUv8JZTJ8+XYkWpKmtVauWbNu2zea+Bw4ckHbt2qn9EdMxZcqUVJ0TtTb69u0r2bNnlwwZMqhzXrlyxemfzRt4/vkE9ycICysx+4QQQgghxAdJlbBAde0bN25IixYtZPHixbJ9+3bZtWtXopZSFi5caCquh+MrVaokzZs3l6tXr1rd//79+1K0aFEZP3685MmTJ9XnhFsXYkYWLVokGzZskIsXL0rbtm1TfP++ALoZNS3AkSMiBw+6+o4IIYQQQog74Gewlic2Gfz9E/SIlglKT2qzQsGaUKNGDZk2bZpajo+Pl/DwcOnfv78MHTo0yWNhkRg0aJBqKTnn7du3JWfOnDJ//nwlmMDhw4elTJkysnnzZqldu7Zd9x4ZGSmZM2dW58uUKZN4MyiUN3Cg8f3o0ajEbv+x6H+IOtRA0T9HJHWwP50P+5T96e7wGWV/ujt8Rr2rP1Myxk1V8Pbs2bPF2URHR8vOnTtl2LBhpnXovCZNmqgBflqdE9tjYmLUOo3SpUtLwYIFkxQWUVFRquk7Xfvy0bw9O9TAgcYH+5dfDDJihP3aFH0D4entffS4YH+yT90dPqPsU3eHzyj71N2Jd/HYKSXXTZWw6Natmziba9euKQtH7ty5zdZjGRaEtDrn5cuXJTg4WLJkyZJoH2yzxbhx42TMmDGJ1kdERKiYDW8mOFikWrVssnNnsOzb5yebN1+TYsXi7H44oXjxA6HFwnHYn86Hfcr+dHf4jLI/3R0+o97VnyiI/Vgqb/sysIIgdkNvsYCLFdyqvN0VCnTqBGuP8f2GDdmlTh37fxxwk0M/UVg4DvvT+bBP2Z/uDp9R9qe7w2fUu/oTyY+cKix69uypPtDMmTMlICBALScH9v/uu+/svpEcOXKoc1tmY8KyrcBsZ5wTr3CZunXrlpnVIrnrhoSEqGYJvnBfGDAj7ezbbxvf//KLv7z3nv3H4tnwlX56HLA/2afuDp9R9qm7w2eUferu+Llw7JSSa9olLNatW6dOCsWEgTqWrQVt60luuyVwR6pWrZqsXbtW2sCJ/5FCw3K/fv1SdK6UnBPbg4KC1DqkmQVHjhyRs2fPSh17p+F9kCJF0HdGqwUSgKFgXtGirr4rQgghhBDiKuwSFqdPn05y2VnAtQjxG9WrV5eaNWuquhT37t2THj16qO1du3aV/Pnzq/gGAEvDwUf5TvH+woULsmfPHlWLonjx4nadE1HuvXr1Uvtly5ZNuTEhYxREhb0ZoXwV6DDNHWrxYpG33nL1HRFCCCGEEFfhVjEWHTt2VMHPI0eOVIHTlStXlhUrVpiCr2FF0JtjUG+iSpUqpuXPPvtMtYYNG8pff/1l1znB5MmT1XlhsUCmJ9S5+PLLLx/rZ/dUYaG5QKFYHoUFIYQQQojvkqo6Fnru3r0rN2/eVJHqliBlq6/gS3Us9FSqJPLff8b3Z8+KhIe7dy5mb4P9yT51d/iMsk/dHT6j7FN3J97b61ggnSpSrSI4+/r16zb3S2mBPOKZVgtNWMAdSiucRwghhBBCfItUCYs33nhDvv/+exUQ3aBBA8maNavz74x4BChWrlXeXriQwoIQQgghxFdJlbBYvHixvPLKK/L11187/46IR1G2rEi5ciIHDoigmDkyRFWt6uq7IoQQQgghj5tUOWohlWxVjh7JI/TZgKdOZbcQQgghhPgiqRIWrVu3ljVr1jj/bohH0rWriOYN99NPIpcvu/qOCCGEEEKIRwiLESNGyMmTJ6VPnz6yc+dOlc71xo0biRrxDdKlE3n1VeP7mBgRZuolhBBCCPE9UhVjUaJECfW6e/dulRnKFswK5Tv07Ys6IiKxsSJffWWsbxEa6uq7IoQQQgghbi0sUGwOcRaEaBQoIPLCC0ZXqGvXRObPF+nZk/1DCCGEEOIrpEpYjB492vl3QjyeQYOMwgJMmSLSowcC/V19V4QQQggh5HHA0sfEadSsKVKnjvH9vn0i69axcwkhhBBCfIVUWSzAzZs35aefflJB3HhvMBjMtsNVKqn4C+K9VgvUs9CsFo0bu/qOCCGEEEKI2wqLlStXSvv27eXevXuSKVMmq5W3GYPhm7RtKxIeLnLunMjSpSLHjiHY39V3RQghhBBC3NIVasiQIZInTx7Zu3ev3Lp1S06dOpWowZJBfI/AQJH+/ROWWTCPEEIIIcQ3SJWwOH78uAwYMEAqVKjg/DsiHs8rrxhrW4DZs+E25+o7IoQQQgghbiksUMfizp07zr8b4hXAMw4ZocD9+yIMtSGEEEII8X5SJSw+/PBD+fLLL+X06dPOvyPiFQwYkPD+iy+MhfMIIYQQQoj3kqrg7bVr10rOnDmlTJky0rRpUwkPD5eAgIBEwdtT6WDvs5QsKfLMMyLLlomcPSsyZ47RRYoQQgghhHgnqRIW06ZNM71fitQ/VqCwIEOHGoUFGD5cpGNHkfTp2S+EEEIIId5Iqlyh4uPjk21xcXHOv1viUdSvL9KunfH9lSsi48a5+o4IIYQQQkhawcrbJE2ZMEEkONj4ftIkEYblEEIIIYR4JxQWJE0pWlRk4EDj+6gokffe82OPE0IIIYR4IakWFsuXL1eB29mzZ5fAwEAVvG3ZCAHvvy+SI4exLxYu9JMdO4LYMYQQQgghXkaqhMUvv/wizz77rFy5ckU6deqkYio6d+6s3oeFhUnFihVl5MiRzr9b4pFkzizywQcJy6NGZZT4eFfeESGEEEIIcQthMW7cOKlZs6bs3r1bxowZo9b17NlT5s2bJ/v375dLly5JkSJFnH2vxIPp3VukXDnj+127gmXBAlffESGEEEIIcbmwOHjwoLJOwN0JblAgJiZGvRYuXFjeeOMN+eSTT5x6o8SzwWMycWLCMmItUJWbEEIIIYT4sLBIly6dBD9K9ZMlSxYJCQlRVgqN3Llzy6lTp5x3l8QraN5cpEULg3p/7pyfTJ7s6jsihBBCCCEuFRalSpVSVguNypUry48//iixsbHy8OFDmT9/vhQsWNBpN0m8h08/NUhAgFFcoK6FTo8SQgghhBBfExbPP/+8/P777xKF/KEq68/78tdffynrRc6cOWXjxo0yFGWXCbGgbFmRl182+kDduyfy5psiBqPOIIQQQgghviYs3nrrLTl79qxygQLIEAVh0bt3b3n11Vdl7dq10r17d2ffK/ES3nrrrmTNalQTCxeKzJvn6jsihBBCCCGOYoy8dgINGjRQjZDkyJ7dINOnG+TFF43F8vr2FalfH4H/7DtCCCGEEE+FlbeJS+jYES5RxveRkcb3cXH8MgghhBBCvN5i8dxzz6XoxH5+fioOgxBbTJsmsnGjyOnTIv/8IzJ+vLFKNyGEEEII8WJhsXTpUgkNDZU8efKIwY5oWwgLQpIiUyaRuXNFnnhCVCXu0aNFmjUTqVGD/UYIIYQQ4rXCIn/+/HLhwgXJkSOHvPjii6pAHkQGIY5Qrx6K5Yl8+KFIbKxIly6ozC2SIQP7lRBCCCHEK2Mszp07J+vXr5cqVarI2LFjJTw8XJo0aSKzZ8+WO3fupO1dEq9m5EiRmjWN748dExk82NV3RAghhBBC0jR4u2HDhvL111/L5cuX5eeff5bs2bNLv379JFeuXNK2bVu1TqttQYi9BAUZXaLSpzcuf/ONyG+/sf8IIYQQQrw+K1RQUJC0bt1aFi5cKFeuXDGJjY4dO8qECROcf5fE6ylRQmTq1ITlnj1Fjh515R0RQgghhJDHlm4W1omVK1eq7E+7d+9Wwd2FWYyApBKIibZtje9v3hR55hmRa9fYnYQQQgghXiks4uPjlZhAZe3cuXNL586d5cGDB/LNN9/I1atX5WWtOIEDTJ8+XQkUCJVatWrJtm3bktx/0aJFUrp0abV/hQoV5M8//0yUocpa+/TTT0374HqW28cj/yl5bCCR2KxZIuXLG5ePHxdp3Vrk4UN+CYQQQgghXiMsNm3apOIp8ubNK88884wcP35cPv74Y7l48aIayL/00kuSXnOSdwC4Vw0ePFhGjRolu3btkkqVKknz5s2VaLF1XxA3vXr1UlaTNm3aqLZ//37TPpcuXTJrs2bNUsKhXbt2Zuf64IMPzPbr37+/w5+HpIzMmUWWLRPREo5t2iTSvbsxHS0hhBBCCHFf/Az2FKWAAvH3l7CwMGnZsqUayNvj8lS1atUU3xAsFDVq1JBpqJ72yEKCDFQY5A8dOjTR/ojruHfvnqqzoVG7dm2pXLmyzJgxw+o1IDyQyWrt2rWmdfg8gwYNUi01REZGSubMmeX27duSCQUaiFXwfUIkIuAfz5Qtdu401re4f9+4PGyYyMcfs1NT25/EftinzoX96XzYp+xPd4fPqHf1Z0rGuHbXsQBwefrll19k8eLFSe4HrQKLQFxcXEpOL9HR0bJz504ZhlHkI9CBSGu7efNmq8dgPSwcemDh+M1GWiEEmy9btky+//77RNvg+oRUugULFlS1Ot58800JDExRFxEnUa2ayIIFEIFGa8W4cSJFi4q88gq7mBBCCCHEHbF71Ix6FWnNtWvXlBhB7IYeLB8+fNjqMchGZW1/rLcGBEXGjBlVelw9AwYMUBaWbNmyKfcqiBu4Q02aNMlm4Lo+tS7UnKYq0Yh10DcQnvb0EYK3J08WGTjQqM5fe80g4eEGadqUvZua/iT2wT51LuxP58M+ZX+6O3xGvas/U3Jdu4VFt27dxBtAfEWXLl1UoLcevdWjYsWKEhwcLK+++qqMGzdOQkJCEp0H68eMGZNofUREhDxktHGSDydMafiB2GPO69BBZN++jPLtt+klLs5PXnjBID//fEMqVoxN/sv2AVLan4R9+rjhM8o+dXf4jLJP3Z14F/9fn5JC2G7l55MjRw4JCAhQ7kp6sJxHi+a1AOvt3X/jxo1y5MgRFSBuT6xHbGysnD59WkqVKpVoOywaejECiwViQXLmzMkYi2R+HHCTQz/Z++P48kuRq1cNsmSJn9y54y8dO2aXP/80SK1adh3u1aSmPwn79HHCZ5R96u7wGWWfujvxLv6/3nIy3mOEBawE1apVU0HVCLDWOhPLyEhljTp16qjt+qDr1atXq/WWfPfdd+r8yDSVHHv27FFfHgJlrAErhjVLBo7hAC9p8ONIST9ht/nzRVq0EPnnH5Fbt/ykeXM/QVbh+vXtOoVXk9L+JOzTxw2fUfapu8NnlH3q7vi58P/6lFzT7UYisAKgJgZiIQ4dOiSvv/66yvrUo0cPtb1r165mwd0DBw6UFStWyMSJE1UcxujRo2XHjh2JhAgsCqh38YqV6F8EgE+ZMkX27t0rJ0+elHnz5qnAbaTQzZo162P41CQ5kMl4+XKRJ580LsMq17y5yLp17DtCCCGEEHfArSwWWvpYxCmMHDlSBWAjbSyEgxagffbsWTPlVLduXZk/f74MHz5c3nvvPSlRooTKCFVeq7L2iAULFijfNKTKtQSWB2yHKEFAdpEiRZSwsMw2RVxLhgzGGheIu1+xwpiKFgHev/5qtGYQQgghhBAPqGNBkoZ1LB5fLmYk40JQ95IlxuXgYJH//c9YpdvXcHVua2+Efcr+dHf4jLI/3R0+o97VnykZ43Ik4k34iEZEaMvPP4u88IJxOTpapH17kZ9+cvWdEUIIIYT4LhQW3iIoULSwZk1ENrv6bh4LQUHGgO6XXjIux8aKvPiiyIgRxoJ6hBBCCCHk8UJh4Q188olIu3YiO3aIDB8uvgKKos+ZI9KnT8K6Dz80Wi/u3nXlnRFCCCGE+B4UFt5Aly7GtEla0YedO8VXCAgQmTFDZOJEY1pagGDuunVFTp929d0RQgghhPgOFBbeQHi4yOjRCW5Rr78uEhcnvoKfH9IUGzNGZc5sXLdvn0iNGiIbNrj67gghhBBCfAMKC29h4ECRcuWM77dvF/nmG/E1kHJ261aRkiWNy9euiTRpYrRo+EhcOyGEEEKIy6Cw8KZoZrhBaaCI4NWr4muUKiWyZYuxeJ4W1A0DDtLT3rjh6rsjhBBCCPFeKCy8iSeeQGly43tkh3rnHfFFUCx96VKje5QG0tNWrMhK3YQQQgghaQWFhbcxYYJIlizG999/L7Jxo/giyBiFgG4ICggNcOGCSOPGIm+9ZSyyRwghhBBCnAeFhbeRO7fIxx8nLPuo1UIDWXj/+88oKDQgOGrVEjlwwJV3RgghhBDiXVBYeCMo7FC9urGgw6JF4usUKCCyapXIZ5+JBAcb1+3da+wiGHhiYlx9h4QQQgghng+FhbcWd1i/3igqMKomqsbFkCEi27aJlC1r7JCHD0XefVekalWRf/5hJxFCCCGEOAKFhbeSIYOr78AtqVTJWKAc2XlR/wLs3y/SoIHIK6+IXL/u6jskhBBCCPFMKCx8BUQu9+8vEh0tvk5YmMiUKUbrRbVqCeu/+86YrnbOHNa9IIQQQghJKRQWvgCm6FGGeto0kX79OGp+BGIsUFDviy9EMmY0roPFokcPkfr1RTZtcuF3RgghhBDiYVBY+AKITtaqw6EiN6briSkcBVrr8GGRjh0TOgWiol49keefN24jhBBCCCFJQ2HhC9SpY/Tz0UAhh2XLXHlHbke+fCILFoisXClSunTC+t9+EylfXuTVV0UuXnTlHRJCCCGEuDcUFr5Cly4iw4cb38fHi3TubIxaJmY0ayayb5/IzJkiefMa18XFGZeLFxd5//0E4w8hhBBCCEmAwsKXGDPGWNsC3Lkj8uyzIlevuvqu3LJqd+/eIseOiXz4YUL8xYMHxtqDhQoZ6w5evuzqOyWEEEIIcR8oLHytmMP33yekQjpzRqRhQ5GzZ119Z25J+vRGC8XJk8b0tEFBxvV374p8+qlIkSLG+Ax2HyGEEEIIhYXvkS6dyJIlCYXzEJmMKOXISFffmduSI4cx3h0WjDfeEAkJSSiwN326SLFiIj17ihw65Oo7JYQQQghxHbRY+Gqk8saNIiVKGJdR3yJTJlffldsDFygIiVOnjFW8YdEAsbEis2cbK3o3b26Mi0cYCyGEEEKIL0Fh4WRiY2PFYDCYluPj49W6OEQAW+zn0n0LF5bYv/+W2KlTxYAsUcmcF8tYj+0auEZK90XztH0t+zJnzliZMCFeeZKNGCGSJYtBAgNjVVu1yqBCV0qWhJUjXq5fd8PvPoX7av2Tkn3d+ftMq3095ftM6+eEfyPife454d+I5H8Drv6O3GFf/o0w7x9Pe07sJdDuPYld/Prrr9KlSxcJDQ1Vy4cOHZL//vtPihYtKrVq1TLtt3jxYvWFPvfcc5L+0dT30aNHZffu3VKoUCGpW7euad8lS5ZIVFSUtGzZUjJnzqzWnTx5UrZv3y758+eXJ554wrTvsmXL5P79+9KsWTPJnj27Wnf27FnZvHmz5M6dW5566inTvit37pTInDnlqYgItQ1cvHhRNq5cKTkKFpSmTZua9l2zZo3cuHFDXQvXBFeuXJH169dLlixZ5Omnnzbti3URERFSr149KViwoFp37do1dQ581po1a5r23bhxo1y6dEn1DfoI3Lp1S1asWCFhYWHSpk0b0774DOfOnZNq1apJSYzcVbzDXVm6dKkEBQVJey0wXUT1zalTp6Ry5cpSpkwZte7Bgwfy+++/i5+fn3Tq1Mm0765du+T48eNSvnx5qVChgloXExMjv/zyi3rfsWNHdQzYu3evHD58WEqXLi1VqlSRDz4QGTzYINOnL1KWjB9+aCcxMcFy4oTIrFkHZNeu/ZIrV3Hp0qWGVKlivN7PP/+sfrStW7eWdHBNE5EjR47Inj17pEiRIlK7dm3Tvf3222/qXp599lnJ+CiKHPe6c+dOCQ8PN3tO0A/4jC1atJCsWbOqdadPn5atW7dK3rx5pVGjRqZ9ly9frvquSZMmkjNnTrXu/Pnz8u+//6plrNdYtWqV+k6efPJJyZMnj1qH7+zvv/+WbNmySXOYaR6xbt069V03aNBACjxyt7t69apanylTJnnmmWdM+27YsEE9Q3Xq1JHChQurdXjGcD30C/pHA/d14cIFqVGjhhRHei6B916k/PnnnxISEiJt27Y17YvPe+bMGfX94HsC+E3gdxQQECAdOnQw7btjxw71W6pYsaKUK1dOrcNvbfXq1eq8L774omlffD/4jZYtW1YqVaqk1uE3vGjRIvX+hRdekEBE/gsyi+2TgwcPqucUz6uGtu/zzz/vGX8jVq5U/Yx1Zn8jNm6UHDly2PU3At89+hKf2Z6/ERkyZJBWrVp5zd8IgN+79t23a9dOgoOD1fsDBw7I/v371TONZ1sjub8R+r+hyf2NqI9qn4/g3wjbfyMePnyo+h2/YXv+RuD/etAZGRYfwb8RCX8j8P8Dnl38/XL2OMIX/0YUK1bM1A/OHkfY8zcC34e90GJBzNm8Gb9okS1b6M9jJ/Aiw98yjMf+9z8R3ZhcuUlt2CBStaqxwZUK9QoJIYQQQrwNP4Pe3kFSDWb1MFN4/fp1pfI0ZQoTEhqWMVuqoZmVsM5t9j11SuIrVJD4qCg8GBLQuLExi1SePGrmFI+Kv7+/agDLWG953qT2xX1gxiJXrlxqW1L7Am0GOLnzpuW+1voyuX0PHhT54ot4mTcvXu7d85P4+IT+SZ8+VjCB0qNHgDz5pJ9K1pXa7xMNFgH0p2ZWdfZzovVPSvZ15+8zuX2xDrNf6FNt1ii1z4lH/O6d/JxY9g9myjDzCKuZvo/d8bt/nH8jHOn3x/G796W/EbhPzJzDgoflx/mcuONv2Rn7Yn1Kfvee8Jw4+7v3T8G+2I7xpTZ2etzfJyxA+H3cvn1beR8kBYWFk4WFPZ2eFpy6eUqmbp0qr1Z7VcrkNJrsUgw05rhxxhyrGnCTQWSyzoXFEfCAav8haj8ob+b2bWNFbxQ+37498XZ4C8GaCms6LKKPfsd242v9+Thgn7I/3R0+o+xPd4fPqHf1Z0rGuByJeAnf7PpGCYuyX5aVRnMayYL9CyQqNiplJ8Go9r33RFavTig7HRFhLKQ3YIAxvypJEXB3f/VVkW3bRP77z1gPI1u2hO3nz4t89pmxtAhcOFHD8OhRdjIhhBBCPA8KCy8AJrL5++abljec2SCdf+ks4ZPD5d3V78qx68dSdkIECezdK6ILjpIvvhBBwOCBA068c98C8Vyoh3HxosjChUa9prOkypEjIqNHi5QqZYzHGDvW2N10ViSEEEKIJ0Bh4QXAD27Xq7tkcvPJUip7KdP6iPsRMmHTBCk5raTU/KamTNo8SS5EXrDvpHCB+v13Y7Txo+w1sm+fSPXqxkINJNWgwB6Sjvzxh8jlyyJff20sgK53g9q9W2TkSJHy5UWQtGTYMKPVgyKDEEIIIe4KhYWXkC0smwyqPUgO9T0k67utl07lO0mQf5Bp+/aL22XIqiHKigFXqa93fC3X719P+qQY6aLUNIIDMMIFYWEiujRmxDGQ7bNPH5G//kLKzwS3KD1wjRo/XgSZSMPDjftD8929y94nhBBCiPvA4G0vCd62xtV7V+X7Pd/L/P3zZc/lPYm2B/oHSoOCDeS5Us9Jq5KtpFi2YrZP9uCBcQodNQQQNKAnMtLuyt2uDkDyFFB877ffUBfFWCTdWiVvJCxq2NAgDRrckY4dM0jJkuxPZ8Bn1LmwP50P+5T96e7wGfWu/kzJGJfCwgWd7goOXzssP+37SX7a/5Mcu2E95mJK8ykysPbAlJ346lWRsmWNaY0QIPCo4Ja7/jg8EcTPL1mCgmkia9eiOJP1/VBLA/XKECKDmhr6IHFiP3xGnQv70/mwT9mf7g6fUe/qT2aFIokonaO0jHlyjBzpd0R29N4hQ+oMkaJZjRUqNRoUamC2fPT6UZm5c6ZKZWsTpKa9fl1k2jQRVE9+912U0uQ34EQQ7tKrlzG05cYNY2zG66+L6IpwKk6eNMZrvPCCSI4cIijkiyRfECP37/MrIYQQQkjawiljHwz0rpavmnzW7DM53v+4HHjjgIxrPE65Q1XJYywtr/HLwV/k1aWvStHPi8oPe39IfDJEEhcrJvKonLxy+p8wQaRIEZFBg0Qu2BkoTuwGXY1sUl9+KXL6NJJ3xcv7799RLlFBQeZfzY4dxrIksGBkySJSr55RB65axfgMQgghhDgfCgsfFxllc5aVofWHyu+dfjdVWdRYfXK16X298Hpm2/4+87f0WfqqzG1ZQM7uXGcM8taqFCMeY+pUo28OptYxAiZp8P0ZY+r79bsn69YZ5OZNkeXLRQYPFqlY0XzfmBiRTZtEPv5YpHlzkaxZjTH4Q4YYXayQnYoQQgghxBF0WfQJMWdC0wmy8vhK2R+xP1Fg97Kjy1RRPjRQsERBqfvd01J7/y2pvWiLVD4TJSHR0SIzZojMnCmyYYNI/frs4jQkfXqRFi2MDcAjDW5Q6HpkndIX3ouNFdm61dgmTTKugw6sW9do2YDogGjR19kghBBCCEkKDhuITarnq66aNf4996/Z8tnbZ1VbECYiXUWCDQFS5ZJBap+Nl5r3Mkm14lmkhEGX2ogFGdKc3LlFXnzR2MClS0aRobVDhxLHaKDNnZuQWRipb1EXEalu8VqokHm9DUIIIYQQDQoLkipWvbxKtpzfIhvPbJS/z/4tm89tlgexD0zbo/3iZGs+UU3klsjXFSRDcAYVx1E6c2lpsHyvVI/PI6U69xP/J58SCQjgN5HG5M0r0qmTsYFr14zuUWj//mssV6LPOAWPtn/+MTZ9IDnEBiqDa68UG4QQQghx2xiL6dOnS+HChSU0NFRq1aol21ByOAkWLVokpUuXVvtXqFBB/vzzT7Pt3bt3V/ED+tZC8xd5xI0bN6RLly4qVWyWLFmkV69ecpcVyGySLiidPFXkKRnVaJSs7bpWbg+9Lbv67JIvW34pXSt1NasArnE3+q5sPLtRvtn3jXQtsE2q5l0i8c2bGdMbwdl/5045c/O03HxwM6WPDEkFyBz13HPG4nuolYFyJJs3i0ycKNKxozHJl7XUtytWGGM12rUzxulDbDRrJvLOOyLz5ons32+M6SCEEEKIb+F2FouFCxfK4MGDZcaMGUpUTJkyRZo3by5HjhxR+Xst2bRpk3Tu3FnGjRsnzz77rMyfP1/atGkju3btkvJatWiB33kLmT17tmk5JCTE7DwQFZcuXZLVq1dLTEyM9OjRQ/r06aPOR5InKCBIquStotrrNV5X6248uCHbLmyTHRd3yM5LO2XnxZ1yLvKc6ZjyV0UC4R118aLR0X/SJBnwSgZZUuCu5A/LLbv77pOc6XOa9jcYDIkCzInzQOw9Yiv0hdVRpgSWDGh7xGMg0xSyC+vB8urVxqaBn1e5ciKVKhkbfopocM8ihBBCiHfidgXyICZq1Kgh01AX4VFRkPDwcOnfv78MHTo00f4dO3aUe/fuydKlS03rateuLZUrV1biRLNY3Lp1S35DKWMrHDp0SMqWLSvbt2+X6tWNMQUrVqyQli1byvnz5yVfPuXP49EF8tyFK3euyLrD6+Rk5BHJfvyCvLY8QgQWpkdT3IUHiZzJIpIhSiRySVnx271HtDyq76x+RxYeWKhqcpTOXtr4+qjlyZDHJ0XH4y6ag78W584p45Jqu3YZXyFA7AHWDU1koKG2YpkyydZV9KlCRN4G+5N96u7wGWWfujvxHlQgz60sFtHR0bJz504ZNmyYaR06sEmTJrIZPhpWwHpYOPTAwmEpIv766y/1hWTNmlWeeuop+fDDDyX7o9EMzgH3J01UAFwT1966das8//zzTv6kvgssEE+GPykdc3UU/8b+Iq8qPzSRX36R+Hlz5dmjf8ve3CIZokX8cuU2iQqw/+p+U5D4qhOrzM6bKSSTlMxeUkpkK6Gaep/d+D5rWFYXfFLvBNoNnmto2s8CYgNGp717E9qePcYsVJbTFnClWr/e2PTAGKmJDLTSpY0tf378DXh8n48QQgghqcethMW1a9ckLi5Oclv4S2D58OHDVo+5fPmy1f2xXu8G1bZtWylSpIicOHFC3nvvPXn66aeVoAgICFD7WrpZBQYGSrZs2czOoycqKko1vZrTVCUasQ76BkYysz5C9TaUlu7VSz7HdPjPP4vfkiUS3/55HGDaLTQgRDJH+cntkMRGtsioSOVyhWZJtrBsUixrMVVpHK/DGwyXkEBzVziv6k8XBYaj6UOXUO0b8Rb79okcOOCn3h84gN9sYssSLB5oSIurJ106g5QsKaqVKoVXg5QoIVK8uLEWhzf3qbfA/mSfujt8Rtmn7k68i/9fSsl13UpYpBWdtDQ4Iiq4u2LFilKsWDFlxWjcuHGqzomYjjFjxiRaHxERIQ8fPnTofr0ZPJwwpeEHYtWcB+f8Ll2MDeh8bL7J0EuyjftNrqYXOZwjoR3KEyCH8wbL2dCHYpDEogOxHmjbL26X0MBQ6Ve2n5nb1Be7v5BNFzdJwUwFZVDVQZI3fV7xmv50MQgAR2vVKmHdtWt+cvRokBw+HCjHjgXIsWOBcvRooEREJM4Mdv++n7J+oBlJ+N6yZo2XokVjpUiROClSJFYKF45TrVChWMmWDfE43tmnngb7k33q7vAZZZ+6O/Eu/n/pzp07nikscuTIoSwIV1DZSweW8+TJY/UYrE/J/qBo0aLqWsePH1fCAvvCd01PbGysyhRl6zxw19K7YMFigViQnDlzMsYimR8HBvXopxT/ODBC7dtXcq1ZI7mPHJGGZ7QNcUiOKlEBIiezihwJD5NjH78lx2Iuy/Ebx1U7H3leiQ5YLCwtXPtu7ZO/zhunysc2HSu5MiVYr77d/a1M3DRRCmYpqIRHocyFJDxzuIRnetQyhyux4pH96SI0tydLbtyIV7U1Dh6EG5WfHDlidKdCbY24uMQq4eZNf9m5M1jFeFiSKZNBFfzTWuHCBpXBCg3pcUNDvatP3Rn2J/vU3eEzyj51d+Jd/P8Ssq56pLAIDg6WatWqydq1a1VmJ60zsdyvXz+rx9SpU0dtHzRokGkdMjthvS0QkH39+nXJC9+NR+dAcDfiO3B9sG7dOnVtBJNbA1mlLDNLAXzhHIwkDX4cqeonRPs+CuqXs2cTUhGtWaNSE4XEiZS5JlImKItI8zFmldwefj5JTp/aLXfDS4n/qVPG0eaj7VfuGYVpkH+Q5M+U3+y+IEqO3jiqmi1ypstpEhv5M+aXApkKqIZzqdeM+SV9cHpxu/50w/S3DRoYmx4UcIe40ITGsWMJ7cIF6+eKjLRt6QDIxwCRAa0KoaFv4eHe06fuAvuTferu8Blln7o7fi78fykl13QrYQFgBejWrZsKpK5Zs6ZKN4usT0j/Crp27Sr58+dXrkhg4MCB0rBhQ5k4caI888wzsmDBAtmxY4fMnDlTbUctCrgstWvXTlkfEGPxzjvvSPHixVWQNyhTpoyKw+jdu7fKJIV0sxAycKGyJyMUcQGIHn4Ul6HiMBAxjGIMf/9tzGlq4QcTuuBnKW1KADDCOIqtUUNVedtS5V2JqFdQLmYJkAB/c3ecuPg4SR+UXu7F3LN5KxH3I1TbdWmXzX3+7fmv1A2va1o+FHFIVp9cLfky5pOa+WtKwcwFU90VvpAGVwvmtgRxHMePG9uJE8YGEYLXM2dg6bB+TgSbo6EwYGL8JXv2nFKokJ8pUB0NggOvBQrAUoo4LGd/UkIIIcSzcbv/GpE+FnEKI0eOVIHTSBuL1K+a+8rZs2fNlFPdunVVrYnhw4eroOwSJUqojFBaDQu4Vv3333/y/fffK6sEhEKzZs1k7NixZhaHefPmKTEB1yicH0Lk888/d0EPkBSD56FKFWMbMCDxdqSy3b3bfB3KTi9frhokCJyfciEaGPU0unc37Tax+UT5rNlnKkbjzO0zKiPVudvnjK+R54zt9jm5eOeixBnibAc3ZzCP2/j7zN8ycMVA9f7bVt9Kr6q9TNtO3TwlPZf0VCl0cRxetZY7fW7JnSG35EiXQwL93e7n+9hJl06kYkVjs/a1w7AFA5W1llSK3OvXA1R9DqTTtfXIweAJkQHBgVfMQSCLlb6FhTnvsxJCCCHujluOTDDAt+X6hIBrS1544QXVrBEWFiYrV65M9prIAMVieF4KUtbCZwaV3lDlTWuWld5u3sSDYL7uv//Er1MnyV6hgmpVIVjLNBOpVsxsyjo2Plau3L0iF+5cUPEc+oZ1eTOaCwus07DcBtHy1+nEz7keP/GT7OmyK6GRNSirFMhaQAmOXOlzmVq5nOWkWLZi4stfe7FixmYNWDsgPGDZOH3a+GpsBjl1Kl6uXPG3GtsBYCTDI4WGR8kW0KoQGFrWLIgP/avWKEAIIYR4A24pLAhxOhAMcH175P6mCixgNAlLBhqmpvEKq4ceuFghohjtf/8zH7Ui7+mjoguB5cpJ/s6dVVwFXJuSo2O5jlI8W3G5dOeSVMhVwWybFvORFAhEv3b/mmqKi4n3QVrdsU+NNS0/iHkg9WbVU7VEGhRsIMOfGG62P1y5EIgOawhS9Hq7RQTWDmsuVvHxBrl6NUKyZcslV674KfGBLMgQHefPJzSss8gbkQhoVTSk2k0K1BuCwICLFV5hoMV7vGoNywh815V2IYQQQtwK7x45EGILxGBoaYLatrXdT6joBid/RBBb+tkgfREagD9M587m+3z7rdHfBkUXECyOqfNHxRfK5SqnmjU6lOsgLUu0lMt3L5s1iBCIjqv3rqpXWEjw+jDWenpjWC3MPsr9CNl92egSliE4Q6L92/2vnZy+ddq0nCU0i2QPy64sIxAb6v2jZbxCfGjv8YplxKN4SwV0GKTwtaLZAo8FYjUgMvCqWTH07dIlkeQyUKMMDhoC1JMDjxCEBkSG9qo1VDbXXtGwL+PPCSGEPC4oLAhJCqQU7t/fGB1srPSWYMFAiiJNcKCCmyWzZqGsu/k6FAOEwEjIg2pMg1TOXGRg4A+LBlpSoKDkqQunJD5dvFx7cE2Jjoh7Eeq1XsF6ZvvefHBTWSHgtoVMVpaYrB+PuPXwlmonbp6w+xlBOt/jA46brZu2bZrKrgXhMaTOELMMWbinqLgoyRqa1SOLFkJzarU6bAHj2K1bRoGhBY1r71F/E++117t3k7+mZgWxUTPUjIAAY54CNE1s6N9nz56wHQ3LsOQQQgghqYHCgpDkgO8JXJ7Q9CDlEKKAITKspB5WwsMSjDBReEFffOHTT82FxY0bIn36mKci0l4xHa2bgoZ1ACIkV7ZcUtLfirjRUSlPJYkeHq3EQrzBvIomll+r9poSJxAm1x9cl+v3ryuxcfPhTbufkUwhmRKtW3xosaw/vV69h7DQM2XLFPng7w/U+7DAMMkallWJDFhL8B6vWUKymC1nDslsXI/3ocb3OMYyo5e7AAMOLAdo1up36IGwgMiAixWa/r22rFUpt0eE4BHVjrUXxHtAYOgbPAktl7V1eMVno4sWIYQQCgtCUgumg+HmhGZtmhr1NVBsQZ8DFa9w2kf0r4bldDdiP375xfo1MXrTpx+aPt18O/xpIDwyJHZ10oQIBuiW+Pv5y6fNPrV6DFLuQlxAZEBsQHQgS5bZ+0evJbKVSHS8JkxQJyRdkPl0uF60PIh9IA/uPFAZtlLKX93+koaFG5qWN57ZKB9u/FCJkO6VuyvXMtN1Yh7IyhMrlQjCdrxqzZXFDgG+NluPlLXgc01kQDjAaw/v8aq9R0MCNCwn546l8eBBQhxJSsiY0SgwNKGhvWbJ4idBQelV5iwIEU1kGbcZG1P3EkKId0BhQUhaTVNXrmxslsB9CuICIgMRwZZFGOGwbwvEdmjpi8Ds2SJ37iRsnzhR5IMPjKM8feohLRIYr2gQM6VK2fVRYAlAjAVaavj5hZ+Va9ad6DuJ4i/K5yovrUq2UgIDblHaK0RGSoDVQs+pW6dk1YlV6v0ThZ4w23bp7iV5fuHzVs8D8QOBkT4wvWRNl9UkODKGZJRMwZnMlivmrihPFXnK7HhkAYPlBduDA4IlLYHLUnJuWHqdCyGiiQ5NbCAxGt5rr1rDMhoeN3vBY4iGR9scfOcZkxVUEBh6sYGWOXPi93i1fJ+CorCEEELSEAoLQlzhmJ/UtHTLlgmWDYgMNLxHwzQyIoIx6sOUMPxW9MICjvoA6xAJbCsauFkzEcs0zCg2CP8aCBDNCd+y4ZopjAZGyltbaW/7VOujmiXRcdFy++FtU5wHBIf2Xr/+dpTxvWWgOvbRgFVCT2RUpM17jYmPMbqByXU5eyfRCNmMHpV7JBIWFb6qoO6nZPaScqSfed+/s/od+e/Kf0p0wH0tY3BG1dR73Tr9sr5BsKQ2MB6HpU9vbPYIEU2M3LuXIDK0Bk89fdPWa7EfWJcSQQLw2KGl1Eqi/0lpIgMNWbYs3+PVWoMG197jPIQQQlIPhQUh7gbcnbSMVbaAXwumli1BCtyGDROig2054sNqYcmyZck742OEiqB0XRFB5fiPwoKWDvl6R/wUTiljth9pcdFSwxs13pCXK72sBvkIGtcDETKu8TglPiAyIqMjE95HRSqxcvvBbbkbc1cFltsCIkCPwWAwiRbLbWDL+S2y8exGSS1wV0PWrctvXTZzKftx74+y5OgSte3deu9KmZwJsUAo3ohijBAmCJrHPnhVy4/e41w4t7WvGpYEtEKF7L9PTZBoIuP69Xg5ffq2xMdnltu3/U0CBO32bWPYEd7jFQ2uWCkFRkDNGuMICJXShIb+1fI9GvpFv6xfp/UbM3IRQnwNCgtCPBEM1OG0ro/VAG+/bWwasFxoUb9aw3KlSubH4Tz2jMowasQISw8C2BGAntz9QmSgoMOjlLuKtWtF/v3X3Ole7w+DqWZMs6dwph7uW1qAtyX5MuaTofWH2jw2Pj5erl69Krly5VIWDLhwaaID7U6UcdkyYxeybbUv215tt5bN6260HdHWSYAAe5zDMg4EKYR/Pvizem9p/dl6Yau89OtLyZ4b1hBNZGiCQ//arVI3eabkM6b970Xfkzl75qjt+Kz1C9Y3bcNXdTPunARlDZKiudJL2YBQKVs2yjLvgE2iohIEh9b0y3ivNctlhBjhFUHrqQHXRrOm2VPrrqYXGlrT1uHR1q/Xlq29au/p9kUIcWcoLAjxZrSp1OSigTHiw4hMHwmsOeLrG9ZB0OixrGBuy8ICCwruRQ/csZITJQiSR2FDWFT0jBljnBK39IGx9H1BHtVUlrZGClw0e+JLggKCZGH7hTa3b31lqxIGECoQH3jFstawTtuOgbvldrQ4Q1wi64JesEAE6MF57EEFzicR14KCinoQM9NveT/1vlP5TmbCAtT6tpaKZdEI9g+WdMHplHCx1SBu9O/zZMgjfWv2NTvv7ku7lUUJ+1TJU0X1uV54oSI9YjoQT6IXG9YatkF34732qjVt2bJ8TUrBfaClJCuXfW5tfhIWllMyZvQziQ59g6Cxtmzt1bLhp+IlpWgIIS6AwoIQYkSbNkV9jZRQt67I+vUJDvj6V835XnO8t0z/g23Jgelna1Pd8+YZs24lB9y03nwzYRlWm2efTezHovNnCYNlBkHvrVqZiyH46eBzYFQGwZMCMAhW6XStZOVyhInNJqoq6hARRbKau8/VyF9DpraYqrbdi7mnXiFE1PtHy5av2H4/5r6q7q6hrz0CsF0jXWDiwhc4l57o+GiJfmhMdWwvyDBmKSxGrB8hy44ZBWbE2xFmgm/8P+Nl+LrhEhYUpoSJ1dfgMAnLGyZh4QnrClrs81yp56RwFmMgCqwX56/dkj0XDkncwzAJi80nQdG5TIHqkZEG9Xr3rp8pTsS4nBDMDrcwbR3O5yh4NI3XC3DY9csW1gSHJjpsLeO9tmztvbVlxLRQxBDiXVBYEEIcAy5OjRql7tghQ0Rat05wsrd0vtderRUgxDZ7sHTdgsjR1xGxABLGFO6NIHq9sEA19QEDjO8xMtL7suj9VSDOJk82P/Effxinrq1NL1tOJacg/yoCvdGsUTZnWdVSCuJFUNFdExuWYihvxrzyfZvvlcBAoLolrUu1Vu5iOB7pfRGzEmOIUftrLbnMX5apiS0FDYSAHlwHYkg7v6QiVgOUyl7KJCwQc3H8wVZpv7yFWh75xEgZ02KMad87UXclyydZJDRzqIRmD1X3BFc1CBS8ZgsMk3yBoeo9WrB/qARKmATEh4pfXKj4xYeKxIZKDr+SUjm4nUmcQIwcuveP3HsYIzH300n6m7XUOm3bnYf3JDIyXqLuh8n9u4Gpikuxx9KS1kBU6IWGvsHly9Yy3mvL+tek3usbBQ0haQeFBSHEdZQubWypYcOGBBGi+bVY+r5gGQHtejAygwXEMj7FGpauW/pgeIzm0Kw55FeokHjd1KnGmBJ7qr0jbbAG7hMxMdamii1fX3rJPO0TXNv27k16xGZllIXsU2oWPyjMqhsYAuK7Vupq8yP88PwPVmNW/HWWJ7guQbyYiY2YByYxYq0Se5cKXaRGvhpKlFjGmkDsaNtwPF61cyYVhG8JPrMevQCyvCa24XOYxEwqeabEMzKuYzuzdSW/6CnHbhyTrLmyyo2vbpht6/brG/LDf8Y+DvQPlAyBoRISAOESIkH+oRLsFyoBEiKBEioBhlDxjw8Rf4iYuBAlaAwxIWKICZWKt98TuZdLiQj8LCLkgESEbpHYhyHid76exEYUMYmMGLkvkv2IOofEhjx6DU14Hwe3tJT5UGlpkB+HiNGDx10vNEJC/CQwMIdkyOBnsT7x+9S8as1yGfMHtNgQb4PCghDimaRWkNSoIRIbaxzNaP4quhZ/+7bcuXRJMvr7i7+ltQPpkZo2NY7CtOllrelHR9YKFOIYe4BA0APxgqB3e3jiCXNhsWmTyPPWa3aYwMgGMSmWbmkTJogsWZL8FHD58iIdOpgfu2KFsY8xegoOliD0DVzLtONDQsQ/NFTSpU8v6VJQH6VX1V5JZgJDs4YmYjTBkdRr6Rzmz1WRLEVkUK1B6vhq+aolsuxUz1fdJF7wiv3UtR6JDnuwVpgR50hum5Y0QMXgSAqSA0DfhYj88uFAKaIzRn2xdZ0MWGG0yM0dN1e6VExwrdt69pDUnl09ydMG+UHMhChRE2AIEX+txRvFh19ciOS+0U7ynetv0uVoZ8v3l7iYAIm/UUQMmweaF3Ms+YdIums6QRP8SMgE60RNsI1twSLxgYkEDwSNdm0jfi4ZDuGnpxcayTXMAdizTXtv7dWebUhMSMFDUguFBSHE99AXdrBMvRsfLw+uXpWM1tIYvfiisVkDlgVt6teaNWTECGMNEmzX9tO/au8tCxdilAWxYc+0rmWQuj0+MhhloVmCGijI2JUc7dsnFha9e5uKUqAHs9s6duZM474aiJmBW509I6lp04ypjDVwr6tXWx1d+YeESLpgBJAHG7OO1atnfh/4XhA7kzlY5IG/SFykaaRVKU8lmdzCwq3tEbkz5Jbtvbdb3QbRgaxiUbFRJqGhiQ5N5OAVgsSyDgsYUGuAqm5vzSUM7m318tWTeP94k6DBq3Yt7bwQHUlhaRXSW3Yst8VK8qXbYwxREiM665Axlt74EDwabbz4ZBWZ3MK8n/w/mKbe18xfU7auG6geR8Sj4PFtunCc7LyyWVKNwU/8DcHyzJ57EvUwQP2c0M6Gfyo3CswViQ2W9Ou+kdjzFSU62k+iovxE8m8VqT1VJ1a0ZrlspemPuV5SJDI84V78Y0UyXjBui0kvhqhMpvtxNyAu9ILDUoAk14KC/CQuLqNkzuxnY7t9y/r1luu0V4S7UQi5DxQWhBDiDCBCtHgLW4UPUwMGzxAc+mlWiAxrr5axKGXLigwfnnCcZcOIBq8QWJbYG2lsLf+pvSMljFT04HMie5g9WMawQFggU1hywE3tv//M13XrZttNDaMWbWQzaJDI6NHmiQVgAbMy2vELDpbgoCAJDg6WjFiHeKIyZcxF1P/+92j/kyJBO43vH7W3gsJFgopardo3omgP6RvfQLLlzq1Ek/44UwsMlNgAP4mCuIkzCg5NeGjLOdOZ14lpXqy5KiiJ7ci6pQfi57VqryWc65GQsfWq7YNil1iGyLImWLT1altASCJXJYO/gxHvfgbx84+VJb+bJ1sYsPycfLHN+BxsWPlQCgcZ3fWghObuOSXd/vjJsesim9q9yVLm9iBTGuOb8RdlZVmjRTH75Q5SZMdC0zaVKKBtCYkPjRBDrCZUghILl3gr67T9sO1ubpH1Y81vpPRvIllPGPfZ00MkWvc3KttxkRyHE50rJj5IYrTzPgwSuWdxHby3Yg3SdTzSPsjjQvvpWRMfSb1Pal1S61PTAgOTXuctrnEUFoQQ4gngfxwtxkI/U58UiM2wrFliL3PnisyZkyBANBGCEZC2jKYGY1asM4hxefhQDA8fyv1btySdn5/4IX8rjtHOER6e+DMinTH204+4rFlULAfc9goha+W1k8orC/GgCTHLkuJY3r3bvusi/kUvLA4eNIq+5MCIw+L+/MaPlxxffZXsoYHPPiuBf/wh6fUDvNq1Rc6dMx/VPHqt8Kip5TfDRVoXMx1WIjaTfPVT5KP904kEZTbupz+H9r5fP/N6NQcOSPymfyU60E/8LgWKLFxo2j8wwF92VvhCov0Mki5j4oxpI8u8LpfzX5AoiZMoQ4xEq9dYiZZYiYqPVesgnqKxDu9jH4kZnaixVrE+wC9ABdtjHxTk1M8POCxmHtHphWB5o0bC8vEb0VLiC+P7Fk2DZK7FV5jz01ty7f5t5aaWWnIGFpFPXh6rfg7az2j2gzlyyPC72t6nfgcJfJjBtH1vxl/kv1y26/okixIbQSI/LxA52iphfb4dIm26GUXI7p4iWx8lvQB+cSId2yYIFDOxYvGa1LY7+URONlWnxGdRP5O8O0UCHxqPO6XrfBB607gt0fmSEkiPl4AAW0LET/z8ckiTJn7K0OvOUFgQQgix8T9EYEIa3pSgZc6CJ0p8vNy5elXCcuUSv+Qq5EEEYdCrB6IC8Rp6oYGGAop6unQxWg+07dqoShtxaMu5cye+bpMmIvnzJ+wDwaA/TmuWx2Id/te3FBzWwH567DkmNUIoqWtq6ZbtsQp17my+jOxs8+fbd92XX05UCNN/4ECxYttSXlJVtQUkWjhqXtCx9Se/Ja5hYw2ImS8ejdo1IMDx/OA5HpnPOGp7JGgmBwTI5MCial1cg9sSUSaf6bB20cWkwfa6Eh3kL1GBfhId5KdEUVSASEwA3ot6H43W/WUlbGB5gUiJPvCfRJ8+IdEBBqm2bJfIyg+N1w0IkDC/u9IxqIpE+8VJ9RuJe6OEf07JFhwkMYY4iZE4iTbEmQSTWmdI2rUNZA0T6dHolOmaaOuX35VDZ43bx43xl2w6g8XYDdHy31+SegJiVPvhBz9pmNf4aOLR3nDupry++aDapUufK/LymIRtdx9GS7djS8RRstxqKOV3NDWdF6/Hm/SSqKx7lUtazq8fmrap1vh9kRo2BHl8gHXxAtFhuW7xXJHrOpfVwutFan1u3L6zt0nsKBAf1OBj83PhVTuf6b1xW1x8oMTFBclDy33v5BeJKCsXL1qZZHEzKCwIIYS4L5ht1qbtbLmZAaT4TWkNFo2RI1N3HIL7MXLRxI9+hINXTaSgFTGvMaLiPBAcbzby0R2rNSv1UgwNGsiDBw8kLDBQ/HBd7Ke9ag3L5colvmcE0cMKoz9Gf6yGZcpje4WQtWNx/tQc58ix+E6QWtoO/CzilzLcui8Zlm2y77pT1prHYv08RGTS948WzGOU8ovIAm2hSS6RV8xPtWm2v8iBhMKSlmBIGQMx8/FYie7/hsTEGcVM1IUzEtOwgdoWEH9KZIj57+D9cJEeGY1CKEObcyKVElzgGh16IGPXG4VTTKD26q/EU4y/UUQpMZU+VKKfqKcEFK6rXk+dkOjImxLjL1Jk+BApePsD4/Pq7y8XckRKhor+alvJyzukec+E+7n9MFrkE3GY6pnPyeqmCdfEa7moy3IwXiRDoMjVc1Fm7pavzL4s3z0SWInwR72kOPhxJnvdL/ttlwLxkRIT56/aWv+N8k3Ib2pb2+K1pIx/U9PP6WrcVZmXzXqMVkoIPdxNwlbOUjEr7g6FBSGEEOIs8WMvWgHG1PDyyxLZvLmE2mMFsmRzEoHQGIxDdGAwbyloEL+DuBC9KNELEm0ZDdXu9TRrZqwBY3mcdi2tWXPxQxY2JFjQH2N5HNYXL25+HBIoIHMctmv761/157L83uwVM/jeLfsf57MHawU2kzkWQ8rgOJHgoPQiYdkSNtw2iFjJeq1RT28EDDK3lDQILCoNNkCyJDMTnj+7yIyliRM3/PLLo4WjZpuaoM6LZpToZe7yiLo7l75KL7EP7inhAcEDUYT3+le1fti7ElOvdoKYOXJIYsZ9qPbJf+ekyJFRZufuWUfkYkaRoPhHlkudsKh6JkquH7Z+rVh/3bp0IRKTL49JRCEJQszd2xIj8WqfRl++LGV0/X27msg3j37KzwT/LT1HDzFt238yUub9KA7zYtRc+Wzyk5IZ1kA3cduyBYUFIYQQQowDZS1WwppLluXg3V6QkhgtNSDoPTVg4H7okH37QoSg5oteCCFGyFKQaO/16625ZKHop6WQsTzOMhsdGDrUWBdHv7/lcWjVzNMeq7irHj2sH2fZLK1+EIHVq1vfF/2ivYcQtvZMIBOdfl9r8VAW4svfz1/y3EERE3v8nWqIlG6TsHz7H5FdH9rcfchm29d9I66qvLHwz+SvWbda4ox4tWqJbNtmdfeX94q0OmIUJVnfNH/Oi2YsKP9+ZxQtsRYixnI5Ztg7ElOwgBIySszs2SmxixaqbdUuxYm0Fo+AwoIQQgghxDK2KDVAfKVWgCE7WWqAOJg1K3XHtmljbKnBWswNhEV8vMTHxMjVy5clV7Zs4m/Nknf0aGIBY/mKZuneCIG6Zo1xH/1+1s5hmbHuueeMsVT6fay9xz7Wki80aJCwn+64sLg4CXv0uaVKLbPD0oVlkrq12id9Ta2V726e4OHuSpG7x9U2Q0i83EjtM/mYobAghBBCCCHOsXpphSUwsIeFxJq7nrXBuz0gaUPjxqk7Fskd0FJD//6pOy5DBpFFi1J3bPPmxvYoCUaM3qrmxqTQOZMQQgghhBBCEkNhQQghhBBCCHEYCgtCCCGEEEKIw1BYEEIIIYQQQhyGwoIQQgghhBDiMBQWhBBCCCGEEIehsCCEEEIIIYQ4DIUFIYQQQgghxGEoLAghhBBCCCEOQ2FBCCGEEEIIcRgKC0IIIYQQQojDUFgQQgghhBBCHIbCghBCCCGEEOIwFBaEEEIIIYQQh6GwIIQQQgghhDgMhQUhhBBCCCHEO4XF9OnTpXDhwhIaGiq1atWSbdu2Jbn/okWLpHTp0mr/ChUqyJ9//mnaFhMTI++++65anz59esmXL5907dpVLl68aHYOXM/Pz8+sjR8/Ps0+IyGEEEIIId6E2wmLhQsXyuDBg2XUqFGya9cuqVSpkjRv3lyuXr1qdf9NmzZJ586dpVevXrJ7925p06aNavv371fb79+/r84zYsQI9bp48WI5cuSIPPfcc4nO9cEHH8ilS5dMrX///mn+eQkhhBBCCPEG3E5YTJo0SXr37i09evSQsmXLyowZMyRdunQya9Ysq/tPnTpVWrRoIW+//baUKVNGxo4dK1WrVpVp06ap7ZkzZ5bVq1dLhw4dpFSpUlK7dm21befOnXL27Fmzc2XMmFHy5MljarBwEEIIIYQQQjxMWERHR6sBf5MmTUzr/P391fLmzZutHoP1+v0BLBy29ge3b99Wrk5ZsmQxWw/Xp+zZs0uVKlXk008/ldjYWIc/EyGEEEIIIb5AoLgR165dk7i4OMmdO7fZeiwfPnzY6jGXL1+2uj/WW+Phw4cq5gLuU5kyZTKtHzBggLJ0ZMuWTblXDRs2TLlDwYJijaioKNU0IiMj1Wt8fLxqxDroG4PBwD5yEuxP58M+ZX+6O3xG2Z/uDp9R7+rPlFzXrYRFWoNAbrhE4cv56quvzLYhrkOjYsWKEhwcLK+++qqMGzdOQkJCEp0L68eMGZNofUREhBIvxPbDCYsRvgNYo4hjsD+dD/uU/enu8Bllf7o7fEa9qz/v3LnjmcIiR44cEhAQIFeuXDFbj2XEPFgD6+3ZXxMVZ86ckXXr1plZK6yBbFRwhTp9+rSKzbAEFg29GIHFIjw8XHLmzJnsuX39xwE3NPQThQX70x3hM8r+dHf4jLI/3R0+o97Vn8i66pHCAlaCatWqydq1a1VmJ60zsdyvXz+rx9SpU0dtHzRokGkdgrWx3lJUHDt2TNavX6/iKJJjz5496svLlSuX1e2wYlizZOAYDpiTBj8O9pPzYH86H/Yp+9Pd4TPK/nR3+Ix6T3+m5JpuJSwArADdunWT6tWrS82aNWXKlCly7949lSUKoAZF/vz5lSsSGDhwoDRs2FAmTpwozzzzjCxYsEB27NghM2fONImK9u3bq1SzS5cuVTEcWvwF4ikgZhDovXXrVnnyySdVZigsv/nmm/LSSy9J1qxZXdgbhBBCCCGEeAZuJyw6duyo4hRGjhypBEDlypVlxYoVpgBtpIjVK6e6devK/PnzZfjw4fLee+9JiRIl5LfffpPy5cur7RcuXJAlS5ao9ziXHlgvGjVqpCwPECSjR49WAdlFihRRwkLv6kQIIYQQQgixjZ8BkSDEYRBjgZoZCK5hjIVt4NqGYodwMaPLmOOwP50P+5T96e7wGWV/ujt8Rr2rP1MyxmVaHkIIIYQQQojDUFgQQgghhBBCHIbCghBCCCGEEOIwFBaEEEIIIYQQh6GwIIQQQgghhDgMhQUhhBBCCCHEYSgsCCGEEEIIIQ5DYUEIIYQQQghxGAoLQgghhBBCiMNQWBBCCCGEEEIchsKCEEIIIYQQ4jAUFoQQQgghhBCHobAghBBCCCGEOAyFBSGEEEIIIcRhKCwIIYQQQgghDkNhQQghhBBCCHEYCgtCCCGEEEKIw1BYEEIIIYQQQhyGwoIQQgghhBDiMBQWhBBCCCGEEIehsCCEEEIIIYQ4DIUFIYQQQgghxGEoLAghhBBCCCEOQ2FBCCGEEEIIcRgKC0IIIYQQQojDUFgQQgghhBBCHIbCghBCCCGEEOIwFBaEEEIIIYQQh6GwIIQQQgghhDgMhQUhhBBCCCHEYSgsCCGEEEIIIQ5DYUEIIYQQQghxGAoLQgghhBBCiMNQWBBCCCGEEEIchsKCEEIIIYQQ4jAUFoQQQgghhBAKC0IIIYQQQojrocWCEEIIIYQQ4jAUFoQQQgghhBDvFBbTp0+XwoULS2hoqNSqVUu2bduW5P6LFi2S0qVLq/0rVKggf/75p9l2g8EgI0eOlLx580pYWJg0adJEjh07ZrbPjRs3pEuXLpIpUybJkiWL9OrVS+7evZsmn48QQgghhBBvw+2ExcKFC2Xw4MEyatQo2bVrl1SqVEmaN28uV69etbr/pk2bpHPnzkoI7N69W9q0aaPa/v37TftMmDBBPv/8c5kxY4Zs3bpV0qdPr8758OFD0z4QFQcOHJDVq1fL0qVL5e+//5Y+ffo8ls9MCCGEEEKIp+NnwHS+GwELRY0aNWTatGlqOT4+XsLDw6V///4ydOjQRPt37NhR7t27p8SARu3ataVy5cpKSODj5cuXT4YMGSJvvfWW2n779m3JnTu3zJkzRzp16iSHDh2SsmXLyvbt26V69epqnxUrVkjLli3l/Pnz6vjkiIyMlMyZM6tzw+pBrIPvEyIxV65c4u/vdrrW42B/sk/dHT6j7FN3h88o+9TdiXfx2CklY1y3GtlFR0fLzp07lauSBjoQy5s3b7Z6DNbr9wewRmj7nzp1Si5fvmy2DzoHAkbbB69wf9JEBcD+uDYsHIQQQgghhJCkCRQ34tq1axIXF6esCXqwfPjwYavHQDRY2x/rte3auqT2gQrUExgYKNmyZTPtY0lUVJRqGlBx4NatW0pZEuugb6B8g4ODabFwAuxP58M+ZX+6O3xG2Z/uDp9R7+pPXBvY4+TkVsLCkxg3bpyMGTMm0fpChQq55H4IIYQQQghJK+7cuaO8fjxGWOTIkUMCAgLkypUrZuuxnCdPHqvHYH1S+2uvWIesUPp9EIeh7WMZHB4bG6syRdm67rBhw1SQuV5NYv/s2bOLn59fCj+57wDVi5iZc+fOMRaF/emW8Bllf7o7fEbZn+4On1Hv6k9YKiAq7Ik5dithARNPtWrVZO3atSqzkzZgx3K/fv2sHlOnTh21fdCgQaZ1yOyE9aBIkSJKHGAfTUjgC0LsxOuvv246B1yYEN+B64N169apayMWwxohISGq6UGcBrEP/DAY5O482J/Oh33K/nR3+IyyP90dPqPe05/JWSrcUlgAWAG6deumAqlr1qwpU6ZMUVmfevToobZ37dpV8ufPr1yRwMCBA6Vhw4YyceJEeeaZZ2TBggWyY8cOmTlzptoO6wFEx4cffiglSpRQQmPEiBFKdWnipUyZMtKiRQvp3bu3yiQVExOjhAwyRtmjzgghhBBCCPF13E5YIH1sRESEKmiHwGlYGZD6VQu+Pnv2rFngSt26dWX+/PkyfPhwee+995R4+O2336R8+fKmfd555x0lTlCXApaJ+vXrq3OioJ7GvHnzlJho3LixOn+7du1U7QtCCCGEEEKIBwoLgAG+Ldenv/76K9G6F154QTVbwGrxwQcfqGYLZICCQCFpC9zHUPzQ0o2MsD/dBT6j7E93h88o+9Pd4TPqu/3pdgXyCCGEEEIIIZ6HWxXII4QQQgghhHgmFBaEEEIIIYQQh6GwIIQQQgghhDgMhQV5LPz999/SqlUrlb4XwfTI3EVSD9It16hRQzJmzCi5cuVSqZOPHDnCLk0lX331lVSsWNGUIxy1bZYvX87+dCLjx483pf8mKWf06NGq//StdOnS7EoHuXDhgrz00kuquG1YWJhUqFBBpawnqaNw4cKJnlO0vn37sktTQVxcnCqRgFIJeD6LFSsmY8eOVQXr3BW3zApFvA+k+61UqZL07NlT2rZt6+rb8Xg2bNig/lBDXKBKPFItN2vWTA4ePCjp06d39e15HAUKFFADX6Srxh/s77//Xlq3bi27d++WcuXKufr2PJ7t27fL119/rcQbST14FtesWWNaDgzkf+GOcPPmTalXr548+eSTaiIhZ86ccuzYMcmaNSsfUwd+6xgMa+zfv1+aNm2aZOZOYptPPvlETXzh/yT8/iF6UdcNxeoGDBgg7gj/KpHHwtNPP60acQ6ow6Jnzpw5ynKB6vFPPPEEuzmFwJqm56OPPlJ/zLds2UJh4SB3796VLl26yDfffKMKlZLUAyGRJ08edqETB23h4eEye/Zs0zrMDJPUA3GmBxM2mGVHIWOScjZt2qQmuVAAWrMI/fTTT7Jt2zZxV+gKRYgXcPv2bVM9FuIYmG1bsGCBsrLBJYo4Bixr+E+xSZMm7EoHwWw63EmLFi2qxBoKxpLUs2TJEqlevbqaTcfETJUqVZQAJs4hOjpa5s6dqzwV4A5FUg6KQK9du1aOHj2qlvfu3Sv//POPW0/U0mJBiIcTHx+v/NZh0tdXnCcpY9++fUpIPHz4UDJkyCC//vqrlC1blt3oABBou3btUu4RxDFq1aqlLJOlSpWSS5cuyZgxY6RBgwbK1QSxViTlnDx5UlkmBw8erNxJ8ZzCvSQ4OFi6devGLnUQxFLeunVLunfvzr5MJUOHDpXIyEgVTxUQEKAmvmBRx8SCu0JhQYgXzAhjcIFZDJJ6MGDbs2ePsv78/PPPamCBWBaKi9Rx7tw5GThwoKxevVpCQ0P5aDqIfoYSsSoQGoUKFZL//e9/0qtXL/ZvKidlYLH4+OOP1TIsFvhbOmPGDAoLJ/Ddd9+p5xZWNpI68PueN2+ezJ8/X7nl4v8oTCSiT91V/FJYEOLB9OvXT5YuXaqybiEAmaQezFIWL15cva9WrZqavZw6daoKOiYpB/E+V69elapVq5rWYbYNz+q0adMkKipKzcCR1JElSxYpWbKkHD9+nF2YSvLmzZto4qBMmTLyyy+/sE8d5MyZMyrRwOLFi9mXDvD2228rq0WnTp3UMrKWoW+RGZLCghDiNJC5qH///spd56+//mLAYRrNZmLwS1JH48aNlXuZHmQzgUn/3XffpahwQlD8iRMn5OWXX+YjmkrgPmqZphu+7LAEEcdAQDziVrSgY5I67t+/L/7+5uHQmJDB/0/uCi0W5LH9J6ifWTt16pQy6SHYuGDBgvwWUuH+BNPo77//rvyrL1++rNYjBR1yXZOUMWzYMGWyx7N4584d1bcQbCtXrmRXphI8l5YxP0iFjHoBjAVKOW+99ZbKXoZB78WLF2XUqFFqgNG5c2c+o6nkzTffVMGxcIXq0KGDyrQzc+ZM1UjqwaAXwgIz6kyJ7Bj4zSOmAv83wRUKKdAnTZqkAuLdFgMhj4H169ejmkui1q1bN/Z/KrDWl2izZ89mf6aCnj17GgoVKmQIDg425MyZ09C4cWPDqlWr2JdOpmHDhoaBAweyX1NBx44dDXnz5lXPaP78+dXy8ePH2ZcO8scffxjKly9vCAkJMZQuXdowc+ZM9qmDrFy5Uv1/dOTIEfalg0RGRqq/mQULFjSEhoYaihYtanj//fcNUVFRBnfFD/+4WtwQQgghhBBCPBvWsSCEEEIIIYQ4DIUFIYQQQgghxGEoLAghhBBCCCEOQ2FBCCGEEEIIcRgKC0IIIYQQQojDUFgQQgghhBBCHIbCghBCCCGEEOIwFBaEEEIIIYQQh6GwIIQQJ3P69Gnx8/OTOXPmuKxvcf3Ro0eblnEvWId78/S+xOfCOpI6tP67du2aQ13YsmVL6d27t9m6Y8eOSbNmzSRz5szqGr/99pvN4w8ePCiBgYGyf/9+h+6DEOI+UFgQQrwebVC9Y8cOq9sbNWok5cuXf+z35en9qTUMDvPnzy/du3eXCxcuiDcTHx8vOXPmlAkTJiQ7cNdaunTppGDBgtKqVSuZPXu2REVFPZZ7/fjjj5Mc2DvCv//+K6tWrZJ3333XbH23bt1k37598tFHH8mPP/4o1atXl/nz58uUKVMSnaNs2bLyzDPPyMiRI9PkHgkhjx8KC0II8QFefvllefDggRQqVMhp5/zggw/U4HHGjBny9NNPy9y5c6Vhw4by8OFDSUuGDx+uPosr2LZtm5rpx4A4Ob766ivVP1988YW88sorcuPGDenZs6fUrFlTzp0759HC4tNPP5XGjRtL8eLFTevwnWzevFl69eol/fr1k5deekkKFChgU1iA1157TX799Vc5ceJEmtwnIeTxEviYr0cIIeQR9+7dk/Tp0z+W/ggICFDNmUBMYEYaYOCcI0cO+eSTT2TJkiXSoUMHSStgIUFzBX/++acSZ+XKlUt23/bt26s+0cDM/Lx586Rr167ywgsvyJYtW8QTuXr1qixbtkwJSj0RERHqNUuWLHafq0mTJpI1a1b5/vvvlVAlhHg2tFgQQogFmHWvVKmS1X4pVaqUNG/e3LR869Yt5QIEn3IMqOAKgnWWYJ8MGTKomVn4pmfMmFG6dOmitm3cuFENNOEuExISIuHh4fLmm28mmpWHyxaatXMXLlw4ye/RVozF8uXL1efF/WTKlElq1KihZphTQ4MGDdSrfvY5OjpaDairVaum+ghCCvutX78+0fH29qVljEVSMS2WsSZ37tyRQYMGqf5CX+fKlUuaNm0qu3btsuszYkBtj7XCFvjOIcK2bt0qq1evNtuGdS1atFCfH+5T+F7gcmTtsx8+fFiJN3xn2bNnl4EDB5pZirAPhCsG7JpLFvrWWn+jr3HNHj16yP379+3qg9jYWCUK9PelWcPefvttdT30MZ5X7H/mzBnTfeif1aCgILXP77//noreJIS4G7RYEEJ8htu3b1sNWI2JiUnkNoSgVASV6mMvtm/fLkePHlWuOMBgMEjr1q3ln3/+US4dZcqUUW4dGBBbA4MxiJL69evLZ599pgaPYNGiRWpA9/rrr6tBItxt4D5z/vx5tS2twEAcrjmYfR82bJgaYO7evVtWrFghL774YorPp4kWzEBrREZGyrfffiudO3dWfYqB/Xfffaf6AZ+zcuXKqerL1IJz//zzz8pVBz7+169fV9c8dOiQVK1aNcljL1++rPrH0Zl1PF8zZ85UMQoQNWDdunXKAgQBNmrUKPH391fxGE899ZQSnnCf0gNRgQH6uHHjlOXj888/l5s3b8oPP/ygtsMFCwIGx/Xp00etK1asWKJzFClSRJ0DwgrfE4QWrE5JsWnTJvWc6t3q2rZtq54fCGJ81xDPENIQkvjd4VmePHmy2hfr9eAzQ1jgWYFQIoR4MAZCCPFyZs+ebcCfu6RauXLlTPvfunXLEBoaanj33XfNzjNgwABD+vTpDXfv3lXLv/32mzp2woQJpn1iY2MNDRo0UOtxXY1u3bqpdUOHDk10f/fv30+0bty4cQY/Pz/DmTNnTOsaNmyomiU4d6FChczW4VqjRo1K1AenTp0yfcaMGTMaatWqZXjw4IHZsfHx8Tb7Un+uNWvWGCIiIgznzp0z/Pzzz4acOXMaQkJC1LK+P6KiosyOv3nzpiF37tyGnj17mtalpC/xufT/feEzWe5jqx8yZ85s6Nu3ryE1fPfdd4awsDCr35ce7f7QN9bA58f2559/3tTfJUqUMDRv3tys73GdIkWKGJo2bZro3M8995zZOd944w21fu/evaZ1eFbxbNi6P33/A9xP9uzZk+2H+vXrG6pVq5ZovfY9fPrpp2brn3nmmUTPp5758+er47Zu3ZrstQkh7g1doQghPsP06dOV+4llq1ixotl+cAvB7PlPP/2kZtJBXFycLFy4UNq0aWOKi4C/PXz9YWnQQBxD//79bd6Dfl+NsLAw03u4r8CqUrduXXVtzJCnBfjcsB4MHTpUQkNDzbbZm8oVrjDIkATXLcQToF8QX4GAXX1/BAcHmzIqIYAZlhvEZujdj1LTl6kBs+pwObp48WKKj8U9Pvnkk2bfV2rQZuzR/2DPnj0qTSusRLCg4PtHw7OAAOm///5b9Z2evn37mi1r/YR7TIn1Rg9c1HB9WA6SAvvorVKOop3L0fS3hBDXQ1coQojPALcQLdjYcmBjOahBgC2EBNxQnnjiCVmzZo1cuXJFubFowG88b968iVw7EIdhDQyc9YNujbNnz6o4BAzK4c6iB24kaYEWB+FIml0ItZIlS6p7nDVrlhoAI27BEvj5T5w4UcUF6N3O4IaT2r5MLUgTC/cqiCG44MBlB9910aJFkzwO9w0xBrchR7l79656RVwLgKgASbl9oY/1g/kSJUqYbYebE9ynUlKnBDE9erTz4xlMziVJE9zOQDsXa5MQ4vlQWBBCiBUQA5A7d26VQhXCAq958uQxC1hNKRh0Y/CnB5YQ+NljJh81AUqXLq1m/lEPAoG1+plqDLysDehwDlcLNVhyEDuCWfcjR46YBAL6DZ8D2xHUCx9+WCIwQHdWilFbA1Jr/YK4AszMI34DMQ5Im4qYgsWLF6sYB1sgDgMz+RAijqIVhNNStWrfMe5FizmxxFJwWZKaQbmtLGHJiQbEV1gKYEfQzqXPoEUI8UzoCkUIITYGXRgkI9AXAx/UA0BQqn4whuDVS5cumWagNTCwthcUE0NAOGb0ISzgggXxki9fvkT7YkbZWpYkzPanFC2Q11lVjzWxABejadOmmdaj/2ANwMAd1h4INnw+y1oXjvSlNtNu2Te2+gWWkTfeeEN9p6dOnVIDZRR0SwpkNkKwd3LZt+wBgdVAyy6mfRewEqBvrDVkT9KjWTk0jh8/rgSK/v7SygIA8Yt+s5fk7gPnguCG9YsQ4tlQWBBCiA0wEIaoePXVV9WAFwW/9GD2GvECKISmnyVHRid70YSKfpYY76dOnZpoXwxA4U6k1QsAe/fuTZSS1B6aNWumXHEgBiwH+al1c0HaUFgxUAxNO6e1z4cYBxRSc1ZfYkCO2W64Yun58ssvzZZxPkvXMlhQIOKSq4aN2AVH0sxqIJUvsi/VqVNHxU8AuGThu0WmMEthBfTft94NTY/WT3qrCyxf1oSoo+De8bs4efKkXftrmaFssXPnTpWZDLFNhBDPhq5QhBBigypVqqgYBKR8RfpTy3SkrVq1knr16qkAaPi2Y0YbM/MpiYvA7C8GlW+99ZZyf8Ig+ZdffrHqaoLUsJMmTVIz3ahujEJlKFKGQVlyAbeW4DpI/4mUpKhdAesMZv4hVJD6FnERqQHuTqjJgVS2CA5+9tlnVZ88//zzamCO2WncM/pKP4h2tC/xOcaPH69e4Z4FkQFLkB4ESyPGBYHmqFMC96L/t3fHrIkEYRjHc00qEQN2WukHMDYKFlqYUlJIsBCsxC6VEIt0Nn4CsRGsBCGdRhALC2sLOwn4DYT0gsgcz8Bynlk9L8thzvx/YJDo6uzMFr4684zWzihGWL8YHaI2K452t+g5hX6t0XtoLw+N7Xg8tkWg3ns3Rljf1qvYUFGgsdR+EqFQyB6j/T40Vq+vrx/adH9/b/e9UJGmKWcaw939V1Sw6Px0zah40pqWZDJ55ZXGUeuF9NpOlO0xaofWK1WrVXutqU803s7alel0an9BAnABzh1LBQD/mhOPOpvNXB9XhOtu3OwuxZ/q2Eaj4fr4+/u7KZVKxu/32yhT3Z/P565xs4r/dLNYLMzd3Z3x+XwmGAyaSqViY0PdIlS73a6JRCLm+vra3N7emvF4/Km4WcdgMDCpVMrGqOocEomE6fV6ru08pT+3262JRqP2prhYxaeq79Q+RdHG43EzHA5d23xqX+7HzTrRrOVy2R6nGN1CoWBWq9Vv/aDY26enJxOLxexzNB6632q1jp5vs9m0r7vZbI4+b799zk3RxeFw2ORyOdPpdMx6vXY9Tueaz+dt5Kv6Sv2j85hMJh9eW9fMw8ODPY+bmxvz+Pj4ITb47e3NpNNpO7Y6xomePRSHe+gacaO422w2e1LcrOKZi8WiCQQC9vHdcR+NRvZ/y+Xyj+8J4Ov7oT/nLm4A4KvSlCRt+qVv0fdTdPA9OJu9vby8nLspdofrer1up0edc7Gz0tI09U1T8/YTqv6GFvVrDYYW0wP4/zEVCgAO0Pcu2iU6k8lQVHxj+gCtJCn8ov7QOh3F97bb7U91jaaXDYdDu48HgMtAYQEAe7QxmfaU0Px2pTb1+3366Bur1WrnbsKXNBqNPB2vdUtasA/gclBYAMAeTTPRQljt0vz8/GwXyQIAgONYYwEAAADAM/axAAAAAOAZhQUAAAAAzygsAAAAAHhGYQEAAADAMwoLAAAAAJ5RWAAAAADwjMICAAAAgGcUFgAAAAA8o7AAAAAAcOXVT27melFMrg+NAAAAAElFTkSuQmCC",
-      "text/plain": [
-       "<Figure size 800x500 with 1 Axes>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "import numpy as np\n",
     "import matplotlib.pyplot as plt\n",
@@ -196,19 +190,19 @@
     "ax.set_ylim(0, 0.20)\n",
     "ax.grid(True, alpha=0.3)\n",
     "fig.tight_layout()\n",
-    "plt.show()"
+    "plt.show()\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "664021c1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-23T01:39:03.618083Z",
-     "iopub.status.busy": "2026-05-23T01:39:03.617872Z",
-     "iopub.status.idle": "2026-05-23T01:39:04.915737Z",
-     "shell.execute_reply": "2026-05-23T01:39:04.914816Z"
+     "iopub.execute_input": "2026-05-12T12:22:41.380263Z",
+     "iopub.status.busy": "2026-05-12T12:22:41.379917Z",
+     "iopub.status.idle": "2026-05-12T12:22:42.369950Z",
+     "shell.execute_reply": "2026-05-12T12:22:42.369048Z"
     },
     "papermill": {
      "duration": 0.994348,
@@ -223,28 +217,68 @@
    "source": [
     "from pathlib import Path\n",
     "import sys\n",
+    "import logging\n",
+    "import contextlib\n",
+    "import io\n",
     "import numpy as np\n",
     "import pandas as pd\n",
     "import matplotlib.pyplot as plt\n",
     "\n",
-    "try:\n",
-    "    from ras_commander import (\n",
-    "        init_ras_project, RasCmdr, RasExamples, ras,\n",
-    "        get_logger\n",
-    "    )\n",
-    "    from ras_commander.geom import GeomLandCover, GeomStorage\n",
-    "    from ras_commander.hdf import HdfMesh, HdfResultsMesh, HdfResultsPlan\n",
-    "except ImportError:\n",
-    "    current_file = Path(\".\").resolve()\n",
-    "    sys.path.append(str(current_file.parent))\n",
-    "    from ras_commander import (\n",
-    "        init_ras_project, RasCmdr, RasExamples, ras,\n",
-    "        get_logger\n",
-    "    )\n",
-    "    from ras_commander.geom import GeomLandCover, GeomStorage\n",
-    "    from ras_commander.hdf import HdfMesh, HdfResultsMesh, HdfResultsPlan\n",
+    "# nbconvert starts kernels from the notebook directory. Walk upward to the repo root\n",
+    "# so this example uses the active checkout rather than an installed package.\n",
+    "for candidate in [Path.cwd(), *Path.cwd().parents]:\n",
+    "    if (candidate / \"ras_commander\" / \"__init__.py\").exists() and (candidate / \"examples\").exists():\n",
+    "        REPO_ROOT = candidate.resolve()\n",
+    "        break\n",
+    "else:\n",
+    "    raise RuntimeError(\"Could not locate ras-commander repository root\")\n",
     "\n",
-    "logger = get_logger(__name__)"
+    "repo_root_str = str(REPO_ROOT)\n",
+    "if sys.path[0] != repo_root_str:\n",
+    "    if repo_root_str in sys.path:\n",
+    "        sys.path.remove(repo_root_str)\n",
+    "    sys.path.insert(0, repo_root_str)\n",
+    "\n",
+    "from ras_commander import (\n",
+    "    init_ras_project, RasCmdr, RasExamples, RasPreprocess, ras,\n",
+    "    get_logger\n",
+    ")\n",
+    "from ras_commander.geom import GeomLandCover, GeomStorage\n",
+    "from ras_commander.hdf import (\n",
+    "    HdfMesh, HdfResultsMesh,\n",
+    "    HdfFluvialPluvial, HdfLandCover, HdfXsec,\n",
+    ")\n",
+    "\n",
+    "# Keep the notebook readable; terminal logs capture detailed ras-commander traces.\n",
+    "logging.getLogger(\"ras_commander\").setLevel(logging.WARNING)\n",
+    "for logger_name in list(logging.root.manager.loggerDict):\n",
+    "    if logger_name.startswith(\"ras_commander\"):\n",
+    "        logging.getLogger(logger_name).setLevel(logging.WARNING)\n",
+    "logging.getLogger(\"ras_commander.hdf.HdfResultsPlan\").setLevel(logging.ERROR)\n",
+    "\n",
+    "logger = get_logger(__name__)\n",
+    "\n",
+    "def read_linux_compute_log(project_path, plan_number):\n",
+    "    \"\"\"Read the RasUnsteady log written by RasCmdr.compute_plan_linux().\"\"\"\n",
+    "    log_path = Path(project_path) / f\"compute_linux_{str(plan_number).zfill(2)}.log\"\n",
+    "    assert log_path.exists(), f\"Missing Linux compute log: {log_path}\"\n",
+    "    return log_path.read_text(errors=\"replace\")\n",
+    "\n",
+    "\n",
+    "def blocking_compute_errors(messages):\n",
+    "    \"\"\"Return compute-log lines that represent blocking hydraulic errors.\"\"\"\n",
+    "    if not messages:\n",
+    "        return []\n",
+    "    return [\n",
+    "        line for line in messages.splitlines()\n",
+    "        if \"ERROR\" in line.upper()\n",
+    "        and \"VOLUME ACCOUNTING\" not in line.upper()\n",
+    "        and \"WSEL ERROR\" not in line.upper()\n",
+    "        and \"ITERATIONS\" not in line.upper()\n",
+    "    ]\n",
+    "\n",
+    "\n",
+    "print(f\"Using ras_commander from: {Path(sys.modules['ras_commander'].__file__).parent}\")\n"
    ]
   },
   {
@@ -266,14 +300,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "id": "c40f05f0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-23T01:39:04.918036Z",
-     "iopub.status.busy": "2026-05-23T01:39:04.917595Z",
-     "iopub.status.idle": "2026-05-23T01:39:04.921143Z",
-     "shell.execute_reply": "2026-05-23T01:39:04.920427Z"
+     "iopub.execute_input": "2026-05-12T12:22:42.383099Z",
+     "iopub.status.busy": "2026-05-12T12:22:42.382523Z",
+     "iopub.status.idle": "2026-05-12T12:22:42.386768Z",
+     "shell.execute_reply": "2026-05-12T12:22:42.386018Z"
     },
     "papermill": {
      "duration": 0.009694,
@@ -287,14 +321,23 @@
    "outputs": [],
    "source": [
     "PROJECT_NAME = \"Muncie\"\n",
-    "RAS_VERSION = \"6.6\"\n",
-    "PLAN_NUMBER = \"03\"          # Unsteady Run with 2D 50ft Grid (uses g02)\n",
+    "RAS_VERSION = \"7.0\"\n",
+    "PLAN_NUMBER = \"04\"          # Muncie plan using g04 with a Manning's n calibration region\n",
     "MESH_NAME = \"2D Interior Area\"\n",
-    "GEOM_NUMBER = \"02\"\n",
+    "GEOM_NUMBER = \"04\"\n",
+    "CALIBRATION_GEOM_NUMBER = \"04\"\n",
+    "CALIBRATION_REGION_NAME = \"Flat Area\"\n",
+    "RAS_LINUX_EXE_DIR = \"/mnt/c/Program Files (x86)/HEC/HEC-RAS/7.0/Linux\"\n",
+    "\n",
+    "WORK_DIR = REPO_ROOT / \"working\" / \"414_depth_varying_mannings_n\"\n",
+    "PROJECT_DIR = WORK_DIR / \"example_projects\"\n",
+    "PROJECT_DIR.mkdir(parents=True, exist_ok=True)\n",
     "\n",
     "# Depth-varying n parameters (exponential decay toward asymptote)\n",
     "N_ASYMPTOTE = 0.045   # Deep-flow Manning's n\n",
-    "DEPTH_HALF = 1.0      # Depth at which n decays to ~37% of excess above asymptote"
+    "DEPTH_HALF = 1.0      # Depth at which n decays to about 37% of excess above asymptote\n",
+    "EXTENSION_HEIGHT = 5.0\n",
+    "ELEVATION_STEP = 0.5\n"
    ]
   },
   {
@@ -318,14 +361,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "id": "e68cf3b7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-23T01:39:04.922982Z",
-     "iopub.status.busy": "2026-05-23T01:39:04.922839Z",
-     "iopub.status.idle": "2026-05-23T01:39:05.590199Z",
-     "shell.execute_reply": "2026-05-23T01:39:05.589439Z"
+     "iopub.execute_input": "2026-05-12T12:22:42.398997Z",
+     "iopub.status.busy": "2026-05-12T12:22:42.398786Z",
+     "iopub.status.idle": "2026-05-12T12:22:43.020051Z",
+     "shell.execute_reply": "2026-05-12T12:22:43.019189Z"
     },
     "papermill": {
      "duration": 0.626049,
@@ -336,252 +379,22 @@
     },
     "tags": []
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-22 21:39:05 - ras_commander.RasExamples - INFO - Successfully extracted project 'Muncie' to G:\\GH\\ras-commander\\examples\\example_projects\\Muncie_414_baseline\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-22 21:39:05 - ras_commander.RasExamples - INFO - Successfully extracted project 'Muncie' to G:\\GH\\ras-commander\\examples\\example_projects\\Muncie_414_modified\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-22 21:39:05 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 7.0 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\7.0\\Ras.exe via filesystem (x86)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-22 21:39:05 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 6.7 Beta 5 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.7 Beta 5\\Ras.exe via filesystem (x86)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-22 21:39:05 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 6.5 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.5\\Ras.exe via filesystem (x86)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-22 21:39:05 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 6.3.1 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.3.1\\Ras.exe via filesystem (x86)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-22 21:39:05 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 6.2 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.2\\Ras.exe via filesystem (x86)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-22 21:39:05 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 6.1 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.1\\Ras.exe via filesystem (x86)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-22 21:39:05 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 6.0 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.0\\Ras.exe via filesystem (x86)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-22 21:39:05 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 5.0.7 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\5.0.7\\Ras.exe via filesystem (x86)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-22 21:39:05 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 5.0.6 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\5.0.6\\Ras.exe via filesystem (x86)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-22 21:39:05 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 5.0.5 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\5.0.5\\Ras.exe via filesystem (x86)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-22 21:39:05 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 5.0.4 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\5.0.4\\Ras.exe via filesystem (x86)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-22 21:39:05 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 5.0.3 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\5.0.3\\Ras.exe via filesystem (x86)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-22 21:39:05 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 5.0.1 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\5.0.1\\Ras.exe via filesystem (x86)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-22 21:39:05 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 5.0 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\5.0\\Ras.exe via filesystem (x86)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-22 21:39:05 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 4.1.0 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\4.1.0\\Ras.exe via filesystem (x86)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-22 21:39:05 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 4.0 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\4.0\\Ras.exe via filesystem (x86)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-22 21:39:05 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 6.6 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.6\\Ras.exe via filesystem (x86)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-22 21:39:05 - ras_commander.RasUtils - INFO - Discovered 17 installed HEC-RAS version(s)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-22 21:39:05 - ras_commander.RasPrj - INFO - HEC-RAS 6.6 found via version discovery: C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.6\\Ras.exe\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-22 21:39:05 - ras_commander.RasMap - INFO - Successfully parsed RASMapper file: G:\\GH\\ras-commander\\examples\\example_projects\\Muncie_414_baseline\\Muncie.rasmap\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-22 21:39:05 - ras_commander.RasPrj - INFO - ras-commander v0.91.0 | An open-source project of CLB Engineering Corporation (https://clbengineering.com/) | Docs: https://ras-commander.readthedocs.io | GitHub: https://github.com/gpt-cmdr/ras-commander\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-22 21:39:05 - ras_commander.RasPrj - INFO - Project initialized: Muncie | Folder: G:\\GH\\ras-commander\\examples\\example_projects\\Muncie_414_baseline\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-22 21:39:05 - ras_commander.RasPrj - INFO - Using HEC-RAS executable: C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.6\\Ras.exe\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-22 21:39:05 - ras_commander.RasPrj - INFO - \n",
-      "═══════════════════════════════════════════════════════════════════════\n",
-      "ras-commander | HEC-RAS Automation Library\n",
-      "Docs: https://gpt-cmdr.github.io/ras-commander/\n",
-      "Repo: https://github.com/gpt-cmdr/ras-commander\n",
-      "═══════════════════════════════════════════════════════════════════════\n",
-      "\n",
-      "PROJECT DATAFRAMES (single source of truth — use these, not file globbing):\n",
-      "  ras_object.plan_df        Plans, HDF paths, geometry/flow associations\n",
-      "  ras_object.geom_df        Geometry files and HDF preprocessor paths\n",
-      "  ras_object.flow_df        Steady flow files\n",
-      "  ras_object.unsteady_df    Unsteady flow files and configurations\n",
-      "  ras_object.boundaries_df  Boundary conditions (type, name, location)\n",
-      "  ras_object.results_df     Lightweight HDF results summaries\n",
-      "  ras_object.rasmap_df      RASMapper layers, terrain, land cover paths\n",
-      "\n",
-      "KEY APIS (static classes — call directly, never instantiate):\n",
-      "  Execution:    RasCmdr.compute_plan() / compute_parallel() / compute_test_mode()\n",
-      "  Plan Files:   RasPlan.clone_plan() / clone_geom() / set_geom()\n",
-      "  Unsteady:     RasUnsteady — IC/BC management, gate openings, precipitation\n",
-      "  Geometry:     GeomCrossSection, GeomBridge, GeomStorage, GeomLateral, GeomMesh\n",
-      "  HDF Results:  HdfResultsPlan.get_wse() / get_compute_messages()\n",
-      "                HdfResultsMesh.get_mesh_max_ws() / get_mesh_cells_timeseries()\n",
-      "                HdfMesh.get_mesh_cell_points()\n",
-      "  QA/QC:        RasCheck.run_check() / RasFixit (geometry repair)\n",
-      "  DSS:          RasDss.get_timeseries() / check_pathname()\n",
-      "  USGS:         UsgsGaugeSpatial, GaugeMatcher, RasUsgsBoundaryGeneration\n",
-      "  Precipitation: StormGenerator, Atlas14Storm, PrecipAorc, Atlas14Variance\n",
-      "  Terrain:      RasTerrain.create_terrain_hdf() / RasTerrainMod\n",
-      "\n",
-      "MULTI-PROJECT: Pass ras_object= to all API calls when using local RasPrj instances.\n",
-      "\n",
-      "EXAMPLES: 100+ notebooks in examples/ (100s=execution, 200s=geometry, 300s=unsteady,\n",
-      "  400s=HDF results, 500s=remote, 800s=QA/QC, 900s=data integration).\n",
-      "  Review relevant notebooks before assembling new workflows.\n",
-      "\n",
-      "PLATFORM: Most HEC-RAS operations require Windows. Linux/Wine support for\n",
-      "  headless execution, data access, geometry modification, and preprocessing\n",
-      "  is available via RasProcess (HEC-RAS 6.6+). See ras_commander/RasProcess.py.\n",
-      "  Remote distributed execution: ras_commander/remote/ (PsExec, Docker, SSH, cloud).\n",
-      "═══════════════════════════════════════════════════════════════════════\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Baseline: G:\\GH\\ras-commander\\examples\\example_projects\\Muncie_414_baseline\n",
-      "Modified: G:\\GH\\ras-commander\\examples\\example_projects\\Muncie_414_modified\n",
-      "\n",
-      "Plan 03: Unsteady Run with 2D 50ft Grid\n",
-      "Geometry: g02\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "baseline_path = RasExamples.extract_project(PROJECT_NAME, suffix=\"414_baseline\")\n",
-    "modified_path = RasExamples.extract_project(PROJECT_NAME, suffix=\"414_modified\")\n",
+    "baseline_path = RasExamples.extract_project(\n",
+    "    PROJECT_NAME, output_path=PROJECT_DIR, suffix=\"414_baseline\"\n",
+    ")\n",
+    "modified_path = RasExamples.extract_project(\n",
+    "    PROJECT_NAME, output_path=PROJECT_DIR, suffix=\"414_modified\"\n",
+    ")\n",
     "\n",
-    "print(f\"Baseline: {baseline_path}\")\n",
-    "print(f\"Modified: {modified_path}\")\n",
+    "print(f\"Baseline: {baseline_path.relative_to(REPO_ROOT)}\")\n",
+    "print(f\"Modified: {modified_path.relative_to(REPO_ROOT)}\")\n",
     "\n",
     "baseline_ras = init_ras_project(baseline_path, RAS_VERSION, ras_object=\"new\")\n",
     "plan_row = baseline_ras.plan_df[baseline_ras.plan_df['plan_number'] == PLAN_NUMBER].iloc[0]\n",
     "print(f\"\\nPlan {PLAN_NUMBER}: {plan_row['Plan Title']}\")\n",
-    "print(f\"Geometry: g{str(plan_row['geometry_number']).zfill(2)}\")"
+    "print(f\"Geometry: g{str(plan_row['geometry_number']).zfill(2)}\")\n"
    ]
   },
   {
@@ -607,14 +420,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "id": "1d46ed8e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-23T01:39:05.591889Z",
-     "iopub.status.busy": "2026-05-23T01:39:05.591719Z",
-     "iopub.status.idle": "2026-05-23T01:39:05.607681Z",
-     "shell.execute_reply": "2026-05-23T01:39:05.607164Z"
+     "iopub.execute_input": "2026-05-12T12:22:43.035591Z",
+     "iopub.status.busy": "2026-05-12T12:22:43.035404Z",
+     "iopub.status.idle": "2026-05-12T12:22:43.050955Z",
+     "shell.execute_reply": "2026-05-12T12:22:43.049989Z"
     },
     "papermill": {
      "duration": 0.021514,
@@ -625,30 +438,9 @@
     },
     "tags": []
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "2D Flow Area: '2D Interior Area'\n",
-      "  Uniform Manning's n: 0.06\n",
-      "  Spatially varied: False\n",
-      "\n",
-      "Land cover table (7 classes):\n",
-      "Table Number            Land Cover Name  Base Mannings n Value\n",
-      "           7                     NoData                   0.06\n",
-      "           7                   Building                  10.00\n",
-      "           7 Medium Density Residential                   0.08\n",
-      "           7                 Open Space                   0.04\n",
-      "           7                       Park                   0.06\n",
-      "           7                      Trees                   0.12\n",
-      "           7                      Urban                   0.10\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "baseline_geom = baseline_path / f\"{baseline_ras.project_name}.g{GEOM_NUMBER}\"\n",
-    "modified_geom = modified_path / f\"{baseline_ras.project_name}.g{GEOM_NUMBER}\"\n",
     "\n",
     "settings = GeomStorage.get_2d_flow_area_settings(baseline_geom)\n",
     "area_row = settings[settings['name'] == MESH_NAME].iloc[0]\n",
@@ -661,1252 +453,91 @@
     "\n",
     "original_mannings = GeomLandCover.get_base_mannings_n(baseline_geom)\n",
     "print(f\"\\nLand cover table ({len(original_mannings)} classes):\")\n",
-    "print(original_mannings.to_string(index=False))"
+    "print(original_mannings.to_string(index=False))\n"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "f7ffc75a",
-   "metadata": {
-    "papermill": {
-     "duration": 0.003108,
-     "end_time": "2026-05-12T12:22:43.058102+00:00",
-     "exception": false,
-     "start_time": "2026-05-12T12:22:43.054994+00:00",
-     "status": "completed"
-    },
-    "tags": []
-   },
+   "id": "82aaf288",
+   "metadata": {},
    "source": [
-    "## Step 3: Preprocess Geometry\n",
+    "## Step 3: Run Baseline Model\n",
     "\n",
-    "We run both projects with `force_geompre=True` to generate the geometry HDF\n",
-    "files containing face property tables. The baseline stays pristine for\n",
-    "comparison; we'll modify the face tables in the modified copy."
+    "The baseline project is computed first with the original uniform Manning's n. The\n",
+    "geometry preprocessor generates the reference face property tables, and the plan\n",
+    "HDF stores the maximum water surface elevations used for comparison.\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
-   "id": "bc38dc37",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-05-23T01:39:05.609516Z",
-     "iopub.status.busy": "2026-05-23T01:39:05.609371Z",
-     "iopub.status.idle": "2026-05-23T01:40:08.022685Z",
-     "shell.execute_reply": "2026-05-23T01:40:08.021824Z"
-    },
-    "papermill": {
-     "duration": 0.042665,
-     "end_time": "2026-05-12T12:22:43.103833+00:00",
-     "exception": false,
-     "start_time": "2026-05-12T12:22:43.061168+00:00",
-     "status": "completed"
-    },
-    "tags": []
-   },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-22 21:39:05 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 7.0 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\7.0\\Ras.exe via filesystem (x86)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-22 21:39:05 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 6.7 Beta 5 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.7 Beta 5\\Ras.exe via filesystem (x86)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-22 21:39:05 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 6.5 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.5\\Ras.exe via filesystem (x86)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-22 21:39:05 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 6.3.1 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.3.1\\Ras.exe via filesystem (x86)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-22 21:39:05 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 6.2 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.2\\Ras.exe via filesystem (x86)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-22 21:39:05 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 6.1 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.1\\Ras.exe via filesystem (x86)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-22 21:39:05 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 6.0 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.0\\Ras.exe via filesystem (x86)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-22 21:39:05 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 5.0.7 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\5.0.7\\Ras.exe via filesystem (x86)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-22 21:39:05 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 5.0.6 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\5.0.6\\Ras.exe via filesystem (x86)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-22 21:39:05 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 5.0.5 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\5.0.5\\Ras.exe via filesystem (x86)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-22 21:39:05 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 5.0.4 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\5.0.4\\Ras.exe via filesystem (x86)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-22 21:39:05 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 5.0.3 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\5.0.3\\Ras.exe via filesystem (x86)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-22 21:39:05 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 5.0.1 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\5.0.1\\Ras.exe via filesystem (x86)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-22 21:39:05 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 5.0 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\5.0\\Ras.exe via filesystem (x86)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-22 21:39:05 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 4.1.0 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\4.1.0\\Ras.exe via filesystem (x86)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-22 21:39:05 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 4.0 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\4.0\\Ras.exe via filesystem (x86)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-22 21:39:05 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 6.6 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.6\\Ras.exe via filesystem (x86)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-22 21:39:05 - ras_commander.RasUtils - INFO - Discovered 17 installed HEC-RAS version(s)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-22 21:39:05 - ras_commander.RasPrj - INFO - HEC-RAS 6.6 found via version discovery: C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.6\\Ras.exe\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-22 21:39:05 - ras_commander.RasMap - INFO - Successfully parsed RASMapper file: G:\\GH\\ras-commander\\examples\\example_projects\\Muncie_414_baseline\\Muncie.rasmap\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-22 21:39:05 - ras_commander.RasPrj - INFO - ras-commander v0.91.0 | An open-source project of CLB Engineering Corporation (https://clbengineering.com/) | Docs: https://ras-commander.readthedocs.io | GitHub: https://github.com/gpt-cmdr/ras-commander\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-22 21:39:05 - ras_commander.RasPrj - INFO - Project initialized: Muncie | Folder: G:\\GH\\ras-commander\\examples\\example_projects\\Muncie_414_baseline\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-22 21:39:05 - ras_commander.RasPrj - INFO - Using HEC-RAS executable: C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.6\\Ras.exe\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-22 21:39:05 - ras_commander.RasPrj - INFO - \n",
-      "═══════════════════════════════════════════════════════════════════════\n",
-      "ras-commander | HEC-RAS Automation Library\n",
-      "Docs: https://gpt-cmdr.github.io/ras-commander/\n",
-      "Repo: https://github.com/gpt-cmdr/ras-commander\n",
-      "═══════════════════════════════════════════════════════════════════════\n",
-      "\n",
-      "PROJECT DATAFRAMES (single source of truth — use these, not file globbing):\n",
-      "  ras_object.plan_df        Plans, HDF paths, geometry/flow associations\n",
-      "  ras_object.geom_df        Geometry files and HDF preprocessor paths\n",
-      "  ras_object.flow_df        Steady flow files\n",
-      "  ras_object.unsteady_df    Unsteady flow files and configurations\n",
-      "  ras_object.boundaries_df  Boundary conditions (type, name, location)\n",
-      "  ras_object.results_df     Lightweight HDF results summaries\n",
-      "  ras_object.rasmap_df      RASMapper layers, terrain, land cover paths\n",
-      "\n",
-      "KEY APIS (static classes — call directly, never instantiate):\n",
-      "  Execution:    RasCmdr.compute_plan() / compute_parallel() / compute_test_mode()\n",
-      "  Plan Files:   RasPlan.clone_plan() / clone_geom() / set_geom()\n",
-      "  Unsteady:     RasUnsteady — IC/BC management, gate openings, precipitation\n",
-      "  Geometry:     GeomCrossSection, GeomBridge, GeomStorage, GeomLateral, GeomMesh\n",
-      "  HDF Results:  HdfResultsPlan.get_wse() / get_compute_messages()\n",
-      "                HdfResultsMesh.get_mesh_max_ws() / get_mesh_cells_timeseries()\n",
-      "                HdfMesh.get_mesh_cell_points()\n",
-      "  QA/QC:        RasCheck.run_check() / RasFixit (geometry repair)\n",
-      "  DSS:          RasDss.get_timeseries() / check_pathname()\n",
-      "  USGS:         UsgsGaugeSpatial, GaugeMatcher, RasUsgsBoundaryGeneration\n",
-      "  Precipitation: StormGenerator, Atlas14Storm, PrecipAorc, Atlas14Variance\n",
-      "  Terrain:      RasTerrain.create_terrain_hdf() / RasTerrainMod\n",
-      "\n",
-      "MULTI-PROJECT: Pass ras_object= to all API calls when using local RasPrj instances.\n",
-      "\n",
-      "EXAMPLES: 100+ notebooks in examples/ (100s=execution, 200s=geometry, 300s=unsteady,\n",
-      "  400s=HDF results, 500s=remote, 800s=QA/QC, 900s=data integration).\n",
-      "  Review relevant notebooks before assembling new workflows.\n",
-      "\n",
-      "PLATFORM: Most HEC-RAS operations require Windows. Linux/Wine support for\n",
-      "  headless execution, data access, geometry modification, and preprocessing\n",
-      "  is available via RasProcess (HEC-RAS 6.6+). See ras_commander/RasProcess.py.\n",
-      "  Remote distributed execution: ras_commander/remote/ (PsExec, Docker, SSH, cloud).\n",
-      "═══════════════════════════════════════════════════════════════════════\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-22 21:39:05 - ras_commander.RasCmdr - INFO - Using ras_object with project folder: G:\\GH\\ras-commander\\examples\\example_projects\\Muncie_414_baseline\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-22 21:39:05 - ras_commander.geom.GeomPreprocessor - INFO - Clearing geometry preprocessor file for single plan: G:\\GH\\ras-commander\\examples\\example_projects\\Muncie_414_baseline\\Muncie.p03\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-22 21:39:05 - ras_commander.RasCmdr - INFO - Force-cleared all geometry preprocessor files for plan: 03\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-22 21:39:05 - ras_commander.RasUtils - INFO - Successfully updated file: G:\\GH\\ras-commander\\examples\\example_projects\\Muncie_414_baseline\\Muncie.p03\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-22 21:39:05 - ras_commander.RasCmdr - INFO - Set number of cores to 2 for plan: 03\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-22 21:39:05 - ras_commander.RasCmdr - INFO - Running HEC-RAS from the Command Line:\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-22 21:39:05 - ras_commander.RasCmdr - INFO - Running command: \"C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.6\\Ras.exe\" -c \"G:\\GH\\ras-commander\\examples\\example_projects\\Muncie_414_baseline\\Muncie.prj\" \"G:\\GH\\ras-commander\\examples\\example_projects\\Muncie_414_baseline\\Muncie.p03\"\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Preprocessing baseline geometry...\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-22 21:39:36 - ras_commander.RasCmdr - INFO - HEC-RAS execution completed for plan: 03\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-22 21:39:36 - ras_commander.RasCmdr - INFO - Total run time for plan 03: 30.99 seconds\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-22 21:39:36 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 7.0 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\7.0\\Ras.exe via filesystem (x86)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-22 21:39:36 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 6.7 Beta 5 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.7 Beta 5\\Ras.exe via filesystem (x86)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-22 21:39:36 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 6.5 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.5\\Ras.exe via filesystem (x86)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-22 21:39:36 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 6.3.1 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.3.1\\Ras.exe via filesystem (x86)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-22 21:39:36 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 6.2 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.2\\Ras.exe via filesystem (x86)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-22 21:39:36 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 6.1 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.1\\Ras.exe via filesystem (x86)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-22 21:39:36 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 6.0 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.0\\Ras.exe via filesystem (x86)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-22 21:39:36 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 5.0.7 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\5.0.7\\Ras.exe via filesystem (x86)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-22 21:39:36 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 5.0.6 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\5.0.6\\Ras.exe via filesystem (x86)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-22 21:39:36 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 5.0.5 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\5.0.5\\Ras.exe via filesystem (x86)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-22 21:39:36 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 5.0.4 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\5.0.4\\Ras.exe via filesystem (x86)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-22 21:39:36 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 5.0.3 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\5.0.3\\Ras.exe via filesystem (x86)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-22 21:39:36 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 5.0.1 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\5.0.1\\Ras.exe via filesystem (x86)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-22 21:39:36 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 5.0 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\5.0\\Ras.exe via filesystem (x86)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-22 21:39:36 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 4.1.0 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\4.1.0\\Ras.exe via filesystem (x86)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-22 21:39:36 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 4.0 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\4.0\\Ras.exe via filesystem (x86)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-22 21:39:36 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 6.6 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.6\\Ras.exe via filesystem (x86)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-22 21:39:36 - ras_commander.RasUtils - INFO - Discovered 17 installed HEC-RAS version(s)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-22 21:39:36 - ras_commander.RasPrj - INFO - HEC-RAS 6.6 found via version discovery: C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.6\\Ras.exe\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-22 21:39:36 - ras_commander.RasMap - INFO - Successfully parsed RASMapper file: G:\\GH\\ras-commander\\examples\\example_projects\\Muncie_414_baseline\\Muncie.rasmap\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-22 21:39:36 - ras_commander.RasPrj - INFO - ras-commander v0.91.0 | An open-source project of CLB Engineering Corporation (https://clbengineering.com/) | Docs: https://ras-commander.readthedocs.io | GitHub: https://github.com/gpt-cmdr/ras-commander\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-22 21:39:36 - ras_commander.RasPrj - INFO - Project initialized: Muncie | Folder: G:\\GH\\ras-commander\\examples\\example_projects\\Muncie_414_baseline\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-22 21:39:36 - ras_commander.RasPrj - INFO - Using HEC-RAS executable: C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.6\\Ras.exe\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-22 21:39:36 - ras_commander.RasPrj - INFO - \n",
-      "═══════════════════════════════════════════════════════════════════════\n",
-      "ras-commander | HEC-RAS Automation Library\n",
-      "Docs: https://gpt-cmdr.github.io/ras-commander/\n",
-      "Repo: https://github.com/gpt-cmdr/ras-commander\n",
-      "═══════════════════════════════════════════════════════════════════════\n",
-      "\n",
-      "PROJECT DATAFRAMES (single source of truth — use these, not file globbing):\n",
-      "  ras_object.plan_df        Plans, HDF paths, geometry/flow associations\n",
-      "  ras_object.geom_df        Geometry files and HDF preprocessor paths\n",
-      "  ras_object.flow_df        Steady flow files\n",
-      "  ras_object.unsteady_df    Unsteady flow files and configurations\n",
-      "  ras_object.boundaries_df  Boundary conditions (type, name, location)\n",
-      "  ras_object.results_df     Lightweight HDF results summaries\n",
-      "  ras_object.rasmap_df      RASMapper layers, terrain, land cover paths\n",
-      "\n",
-      "KEY APIS (static classes — call directly, never instantiate):\n",
-      "  Execution:    RasCmdr.compute_plan() / compute_parallel() / compute_test_mode()\n",
-      "  Plan Files:   RasPlan.clone_plan() / clone_geom() / set_geom()\n",
-      "  Unsteady:     RasUnsteady — IC/BC management, gate openings, precipitation\n",
-      "  Geometry:     GeomCrossSection, GeomBridge, GeomStorage, GeomLateral, GeomMesh\n",
-      "  HDF Results:  HdfResultsPlan.get_wse() / get_compute_messages()\n",
-      "                HdfResultsMesh.get_mesh_max_ws() / get_mesh_cells_timeseries()\n",
-      "                HdfMesh.get_mesh_cell_points()\n",
-      "  QA/QC:        RasCheck.run_check() / RasFixit (geometry repair)\n",
-      "  DSS:          RasDss.get_timeseries() / check_pathname()\n",
-      "  USGS:         UsgsGaugeSpatial, GaugeMatcher, RasUsgsBoundaryGeneration\n",
-      "  Precipitation: StormGenerator, Atlas14Storm, PrecipAorc, Atlas14Variance\n",
-      "  Terrain:      RasTerrain.create_terrain_hdf() / RasTerrainMod\n",
-      "\n",
-      "MULTI-PROJECT: Pass ras_object= to all API calls when using local RasPrj instances.\n",
-      "\n",
-      "EXAMPLES: 100+ notebooks in examples/ (100s=execution, 200s=geometry, 300s=unsteady,\n",
-      "  400s=HDF results, 500s=remote, 800s=QA/QC, 900s=data integration).\n",
-      "  Review relevant notebooks before assembling new workflows.\n",
-      "\n",
-      "PLATFORM: Most HEC-RAS operations require Windows. Linux/Wine support for\n",
-      "  headless execution, data access, geometry modification, and preprocessing\n",
-      "  is available via RasProcess (HEC-RAS 6.6+). See ras_commander/RasProcess.py.\n",
-      "  Remote distributed execution: ras_commander/remote/ (PsExec, Docker, SSH, cloud).\n",
-      "═══════════════════════════════════════════════════════════════════════\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-22 21:39:36 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 7.0 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\7.0\\Ras.exe via filesystem (x86)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-22 21:39:36 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 6.7 Beta 5 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.7 Beta 5\\Ras.exe via filesystem (x86)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-22 21:39:36 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 6.5 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.5\\Ras.exe via filesystem (x86)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-22 21:39:36 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 6.3.1 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.3.1\\Ras.exe via filesystem (x86)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-22 21:39:36 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 6.2 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.2\\Ras.exe via filesystem (x86)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-22 21:39:36 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 6.1 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.1\\Ras.exe via filesystem (x86)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-22 21:39:36 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 6.0 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.0\\Ras.exe via filesystem (x86)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-22 21:39:36 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 5.0.7 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\5.0.7\\Ras.exe via filesystem (x86)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-22 21:39:36 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 5.0.6 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\5.0.6\\Ras.exe via filesystem (x86)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-22 21:39:36 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 5.0.5 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\5.0.5\\Ras.exe via filesystem (x86)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-22 21:39:36 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 5.0.4 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\5.0.4\\Ras.exe via filesystem (x86)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-22 21:39:36 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 5.0.3 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\5.0.3\\Ras.exe via filesystem (x86)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-22 21:39:36 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 5.0.1 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\5.0.1\\Ras.exe via filesystem (x86)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-22 21:39:36 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 5.0 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\5.0\\Ras.exe via filesystem (x86)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-22 21:39:36 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 4.1.0 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\4.1.0\\Ras.exe via filesystem (x86)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-22 21:39:36 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 4.0 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\4.0\\Ras.exe via filesystem (x86)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-22 21:39:36 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 6.6 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.6\\Ras.exe via filesystem (x86)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-22 21:39:36 - ras_commander.RasUtils - INFO - Discovered 17 installed HEC-RAS version(s)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-22 21:39:36 - ras_commander.RasPrj - INFO - HEC-RAS 6.6 found via version discovery: C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.6\\Ras.exe\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-22 21:39:37 - ras_commander.RasMap - INFO - Successfully parsed RASMapper file: G:\\GH\\ras-commander\\examples\\example_projects\\Muncie_414_modified\\Muncie.rasmap\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-22 21:39:37 - ras_commander.RasPrj - INFO - ras-commander v0.91.0 | An open-source project of CLB Engineering Corporation (https://clbengineering.com/) | Docs: https://ras-commander.readthedocs.io | GitHub: https://github.com/gpt-cmdr/ras-commander\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-22 21:39:37 - ras_commander.RasPrj - INFO - Project initialized: Muncie | Folder: G:\\GH\\ras-commander\\examples\\example_projects\\Muncie_414_modified\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-22 21:39:37 - ras_commander.RasPrj - INFO - Using HEC-RAS executable: C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.6\\Ras.exe\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-22 21:39:37 - ras_commander.RasPrj - INFO - \n",
-      "═══════════════════════════════════════════════════════════════════════\n",
-      "ras-commander | HEC-RAS Automation Library\n",
-      "Docs: https://gpt-cmdr.github.io/ras-commander/\n",
-      "Repo: https://github.com/gpt-cmdr/ras-commander\n",
-      "═══════════════════════════════════════════════════════════════════════\n",
-      "\n",
-      "PROJECT DATAFRAMES (single source of truth — use these, not file globbing):\n",
-      "  ras_object.plan_df        Plans, HDF paths, geometry/flow associations\n",
-      "  ras_object.geom_df        Geometry files and HDF preprocessor paths\n",
-      "  ras_object.flow_df        Steady flow files\n",
-      "  ras_object.unsteady_df    Unsteady flow files and configurations\n",
-      "  ras_object.boundaries_df  Boundary conditions (type, name, location)\n",
-      "  ras_object.results_df     Lightweight HDF results summaries\n",
-      "  ras_object.rasmap_df      RASMapper layers, terrain, land cover paths\n",
-      "\n",
-      "KEY APIS (static classes — call directly, never instantiate):\n",
-      "  Execution:    RasCmdr.compute_plan() / compute_parallel() / compute_test_mode()\n",
-      "  Plan Files:   RasPlan.clone_plan() / clone_geom() / set_geom()\n",
-      "  Unsteady:     RasUnsteady — IC/BC management, gate openings, precipitation\n",
-      "  Geometry:     GeomCrossSection, GeomBridge, GeomStorage, GeomLateral, GeomMesh\n",
-      "  HDF Results:  HdfResultsPlan.get_wse() / get_compute_messages()\n",
-      "                HdfResultsMesh.get_mesh_max_ws() / get_mesh_cells_timeseries()\n",
-      "                HdfMesh.get_mesh_cell_points()\n",
-      "  QA/QC:        RasCheck.run_check() / RasFixit (geometry repair)\n",
-      "  DSS:          RasDss.get_timeseries() / check_pathname()\n",
-      "  USGS:         UsgsGaugeSpatial, GaugeMatcher, RasUsgsBoundaryGeneration\n",
-      "  Precipitation: StormGenerator, Atlas14Storm, PrecipAorc, Atlas14Variance\n",
-      "  Terrain:      RasTerrain.create_terrain_hdf() / RasTerrainMod\n",
-      "\n",
-      "MULTI-PROJECT: Pass ras_object= to all API calls when using local RasPrj instances.\n",
-      "\n",
-      "EXAMPLES: 100+ notebooks in examples/ (100s=execution, 200s=geometry, 300s=unsteady,\n",
-      "  400s=HDF results, 500s=remote, 800s=QA/QC, 900s=data integration).\n",
-      "  Review relevant notebooks before assembling new workflows.\n",
-      "\n",
-      "PLATFORM: Most HEC-RAS operations require Windows. Linux/Wine support for\n",
-      "  headless execution, data access, geometry modification, and preprocessing\n",
-      "  is available via RasProcess (HEC-RAS 6.6+). See ras_commander/RasProcess.py.\n",
-      "  Remote distributed execution: ras_commander/remote/ (PsExec, Docker, SSH, cloud).\n",
-      "═══════════════════════════════════════════════════════════════════════\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-22 21:39:37 - ras_commander.RasCmdr - INFO - Using ras_object with project folder: G:\\GH\\ras-commander\\examples\\example_projects\\Muncie_414_modified\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-22 21:39:37 - ras_commander.geom.GeomPreprocessor - INFO - Clearing geometry preprocessor file for single plan: G:\\GH\\ras-commander\\examples\\example_projects\\Muncie_414_modified\\Muncie.p03\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-22 21:39:37 - ras_commander.RasCmdr - INFO - Force-cleared all geometry preprocessor files for plan: 03\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-22 21:39:37 - ras_commander.RasUtils - INFO - Successfully updated file: G:\\GH\\ras-commander\\examples\\example_projects\\Muncie_414_modified\\Muncie.p03\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-22 21:39:37 - ras_commander.RasCmdr - INFO - Set number of cores to 2 for plan: 03\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-22 21:39:37 - ras_commander.RasCmdr - INFO - Running HEC-RAS from the Command Line:\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-22 21:39:37 - ras_commander.RasCmdr - INFO - Running command: \"C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.6\\Ras.exe\" -c \"G:\\GH\\ras-commander\\examples\\example_projects\\Muncie_414_modified\\Muncie.prj\" \"G:\\GH\\ras-commander\\examples\\example_projects\\Muncie_414_modified\\Muncie.p03\"\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Preprocessing modified geometry...\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-22 21:40:07 - ras_commander.RasCmdr - INFO - HEC-RAS execution completed for plan: 03\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-22 21:40:07 - ras_commander.RasCmdr - INFO - Total run time for plan 03: 30.78 seconds\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-22 21:40:07 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 7.0 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\7.0\\Ras.exe via filesystem (x86)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-22 21:40:07 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 6.7 Beta 5 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.7 Beta 5\\Ras.exe via filesystem (x86)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-22 21:40:07 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 6.5 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.5\\Ras.exe via filesystem (x86)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-22 21:40:07 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 6.3.1 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.3.1\\Ras.exe via filesystem (x86)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-22 21:40:07 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 6.2 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.2\\Ras.exe via filesystem (x86)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-22 21:40:07 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 6.1 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.1\\Ras.exe via filesystem (x86)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-22 21:40:07 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 6.0 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.0\\Ras.exe via filesystem (x86)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-22 21:40:07 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 5.0.7 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\5.0.7\\Ras.exe via filesystem (x86)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-22 21:40:07 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 5.0.6 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\5.0.6\\Ras.exe via filesystem (x86)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-22 21:40:07 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 5.0.5 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\5.0.5\\Ras.exe via filesystem (x86)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-22 21:40:07 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 5.0.4 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\5.0.4\\Ras.exe via filesystem (x86)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-22 21:40:07 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 5.0.3 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\5.0.3\\Ras.exe via filesystem (x86)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-22 21:40:07 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 5.0.1 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\5.0.1\\Ras.exe via filesystem (x86)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-22 21:40:07 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 5.0 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\5.0\\Ras.exe via filesystem (x86)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-22 21:40:07 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 4.1.0 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\4.1.0\\Ras.exe via filesystem (x86)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-22 21:40:07 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 4.0 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\4.0\\Ras.exe via filesystem (x86)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-22 21:40:07 - ras_commander.RasUtils - INFO - Discovered HEC-RAS 6.6 at C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.6\\Ras.exe via filesystem (x86)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-22 21:40:07 - ras_commander.RasUtils - INFO - Discovered 17 installed HEC-RAS version(s)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-22 21:40:07 - ras_commander.RasPrj - INFO - HEC-RAS 6.6 found via version discovery: C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.6\\Ras.exe\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-22 21:40:07 - ras_commander.RasMap - INFO - Successfully parsed RASMapper file: G:\\GH\\ras-commander\\examples\\example_projects\\Muncie_414_modified\\Muncie.rasmap\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-22 21:40:08 - ras_commander.RasPrj - INFO - ras-commander v0.91.0 | An open-source project of CLB Engineering Corporation (https://clbengineering.com/) | Docs: https://ras-commander.readthedocs.io | GitHub: https://github.com/gpt-cmdr/ras-commander\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-22 21:40:08 - ras_commander.RasPrj - INFO - Project initialized: Muncie | Folder: G:\\GH\\ras-commander\\examples\\example_projects\\Muncie_414_modified\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-22 21:40:08 - ras_commander.RasPrj - INFO - Using HEC-RAS executable: C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.6\\Ras.exe\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-22 21:40:08 - ras_commander.RasPrj - INFO - \n",
-      "═══════════════════════════════════════════════════════════════════════\n",
-      "ras-commander | HEC-RAS Automation Library\n",
-      "Docs: https://gpt-cmdr.github.io/ras-commander/\n",
-      "Repo: https://github.com/gpt-cmdr/ras-commander\n",
-      "═══════════════════════════════════════════════════════════════════════\n",
-      "\n",
-      "PROJECT DATAFRAMES (single source of truth — use these, not file globbing):\n",
-      "  ras_object.plan_df        Plans, HDF paths, geometry/flow associations\n",
-      "  ras_object.geom_df        Geometry files and HDF preprocessor paths\n",
-      "  ras_object.flow_df        Steady flow files\n",
-      "  ras_object.unsteady_df    Unsteady flow files and configurations\n",
-      "  ras_object.boundaries_df  Boundary conditions (type, name, location)\n",
-      "  ras_object.results_df     Lightweight HDF results summaries\n",
-      "  ras_object.rasmap_df      RASMapper layers, terrain, land cover paths\n",
-      "\n",
-      "KEY APIS (static classes — call directly, never instantiate):\n",
-      "  Execution:    RasCmdr.compute_plan() / compute_parallel() / compute_test_mode()\n",
-      "  Plan Files:   RasPlan.clone_plan() / clone_geom() / set_geom()\n",
-      "  Unsteady:     RasUnsteady — IC/BC management, gate openings, precipitation\n",
-      "  Geometry:     GeomCrossSection, GeomBridge, GeomStorage, GeomLateral, GeomMesh\n",
-      "  HDF Results:  HdfResultsPlan.get_wse() / get_compute_messages()\n",
-      "                HdfResultsMesh.get_mesh_max_ws() / get_mesh_cells_timeseries()\n",
-      "                HdfMesh.get_mesh_cell_points()\n",
-      "  QA/QC:        RasCheck.run_check() / RasFixit (geometry repair)\n",
-      "  DSS:          RasDss.get_timeseries() / check_pathname()\n",
-      "  USGS:         UsgsGaugeSpatial, GaugeMatcher, RasUsgsBoundaryGeneration\n",
-      "  Precipitation: StormGenerator, Atlas14Storm, PrecipAorc, Atlas14Variance\n",
-      "  Terrain:      RasTerrain.create_terrain_hdf() / RasTerrainMod\n",
-      "\n",
-      "MULTI-PROJECT: Pass ras_object= to all API calls when using local RasPrj instances.\n",
-      "\n",
-      "EXAMPLES: 100+ notebooks in examples/ (100s=execution, 200s=geometry, 300s=unsteady,\n",
-      "  400s=HDF results, 500s=remote, 800s=QA/QC, 900s=data integration).\n",
-      "  Review relevant notebooks before assembling new workflows.\n",
-      "\n",
-      "PLATFORM: Most HEC-RAS operations require Windows. Linux/Wine support for\n",
-      "  headless execution, data access, geometry modification, and preprocessing\n",
-      "  is available via RasProcess (HEC-RAS 6.6+). See ras_commander/RasProcess.py.\n",
-      "  Remote distributed execution: ras_commander/remote/ (PsExec, Docker, SSH, cloud).\n",
-      "═══════════════════════════════════════════════════════════════════════\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "Baseline HDF: Muncie.g02.hdf\n",
-      "Modified HDF: Muncie.g02.hdf\n"
-     ]
-    }
-   ],
+   "execution_count": null,
+   "id": "2a794d1b",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "baseline_ras = init_ras_project(baseline_path, RAS_VERSION, ras_object=\"new\")\n",
-    "print(\"Preprocessing baseline geometry...\")\n",
-    "RasCmdr.compute_plan(PLAN_NUMBER, ras_object=baseline_ras, num_cores=2, force_geompre=True)\n",
+    "print(\"Preprocessing baseline model on Windows...\")\n",
+    "baseline_preprocess = RasPreprocess.preprocess_plan(\n",
+    "    PLAN_NUMBER,\n",
+    "    ras_object=baseline_ras,\n",
+    "    max_wait=300,\n",
+    "    clear_existing=True,\n",
+    ")\n",
+    "assert baseline_preprocess.success, baseline_preprocess.error\n",
+    "assert baseline_preprocess.tmp_hdf_path and Path(baseline_preprocess.tmp_hdf_path).exists()\n",
+    "print(f\"Baseline tmp HDF: {Path(baseline_preprocess.tmp_hdf_path).name}\")\n",
+    "\n",
+    "print(\"Running baseline model with native Linux RasUnsteady...\")\n",
+    "baseline_result = RasCmdr.compute_plan_linux(\n",
+    "    PLAN_NUMBER,\n",
+    "    ras_exe_dir=RAS_LINUX_EXE_DIR,\n",
+    "    ras_object=baseline_ras,\n",
+    "    timeout_sec=7200,\n",
+    "    num_cores=2,\n",
+    "    retry=False,\n",
+    ")\n",
+    "assert baseline_result.success, \"Baseline Linux solver run failed\"\n",
     "baseline_ras = init_ras_project(baseline_path, RAS_VERSION, ras_object=\"new\")\n",
     "\n",
-    "modified_ras = init_ras_project(modified_path, RAS_VERSION, ras_object=\"new\")\n",
-    "print(\"Preprocessing modified geometry...\")\n",
-    "RasCmdr.compute_plan(PLAN_NUMBER, ras_object=modified_ras, num_cores=2, force_geompre=True)\n",
-    "modified_ras = init_ras_project(modified_path, RAS_VERSION, ras_object=\"new\")\n",
+    "base_hdf_path = Path(baseline_ras.plan_df.loc[\n",
+    "    baseline_ras.plan_df['plan_number'] == PLAN_NUMBER, 'HDF_Results_Path'\n",
+    "].iloc[0])\n",
+    "messages = read_linux_compute_log(baseline_path, PLAN_NUMBER)\n",
+    "lines_out = messages.splitlines()\n",
+    "errors = blocking_compute_errors(messages)\n",
+    "print(f\"Baseline Linux compute log: {len(lines_out)} lines, {len(errors)} blocking errors\")\n",
+    "assert not errors, \"Baseline compute produced blocking errors\"\n",
+    "assert \"Finished Unsteady Flow Simulation\" in messages, \"Baseline Linux solver did not report completion\"\n",
     "\n",
     "baseline_geom_hdf = baseline_path / f\"{baseline_ras.project_name}.g{GEOM_NUMBER}.hdf\"\n",
-    "modified_geom_hdf = modified_path / f\"{modified_ras.project_name}.g{GEOM_NUMBER}.hdf\"\n",
-    "\n",
-    "print(f\"\\nBaseline HDF: {baseline_geom_hdf.name}\")\n",
-    "print(f\"Modified HDF: {modified_geom_hdf.name}\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "91e89ca3",
-   "metadata": {
-    "papermill": {
-     "duration": 0.003334,
-     "end_time": "2026-05-12T12:22:43.110643+00:00",
-     "exception": false,
-     "start_time": "2026-05-12T12:22:43.107309+00:00",
-     "status": "completed"
-    },
-    "tags": []
-   },
-   "source": [
-    "## Step 4: Read Baseline Face Property Tables\n",
-    "\n",
-    "The face property tables encode Manning's n as a function of elevation for\n",
-    "each cell face. After preprocessing with uniform n=0.06, every face has the\n",
-    "same constant roughness at all elevations. We'll visualize this structure\n",
-    "before applying depth-varying modifications."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 7,
-   "id": "433ed937",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-05-23T01:40:08.024858Z",
-     "iopub.status.busy": "2026-05-23T01:40:08.024680Z",
-     "iopub.status.idle": "2026-05-23T01:40:08.289080Z",
-     "shell.execute_reply": "2026-05-23T01:40:08.288261Z"
-    },
-    "papermill": {
-     "duration": 33.559633,
-     "end_time": "2026-05-12T12:23:16.673514+00:00",
-     "exception": false,
-     "start_time": "2026-05-12T12:22:43.113881+00:00",
-     "status": "completed"
-    },
-    "tags": []
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Faces: 11164\n",
-      "Total rows: 47055\n",
-      "Uniform n: 0.0600\n"
-     ]
-    },
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAABKMAAAIDCAYAAADYNt3FAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjgsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvwVt1zgAAAAlwSFlzAAAPYQAAD2EBqD+naQAAz41JREFUeJzs3Qd8U9X7x/FvB3vI3gjKBpUlKg4UZavIEBEH7ol/Rf25RaYLcYsDB24cFETEASgOEBVQBJkKKgiylL0Kbf6v58TbJm1aOtImbT/v1yvNHWlyc+7Nzclzz3lOjM/n8wkAAAAAAADIB7H58SIAAAAAAACAIRgFAAAAAACAfEMwCgAAAAAAAPmGYBQAAAAAAADyDcEoAAAAAAAA5BuCUQAAAAAAAMg3BKMAAAAAAACQbwhGAQAAAAAAIN8QjAIAAAAAAEC+IRgFAEAGXn31VcXExLj7rKpfv767oXDz+Xxq27atunTpErFtsGPztNNOS7f8119/Ve/evVWzZk3FxsaqQoUKEdm+aHPgwAENGzZMjRo1UokSJVz5ffDBB5HeLBRif/zxhzvOLr300nx93X///VeHHXaYbr/99nx9XQDIDoJRAApERS6z27Zt21QQ2I/GwO22H4kVK1bUKaec4oId9uO2sMpJUCc3ZXuo25dffqmCavfu3XrggQfUpk0blS1b1v2orlOnjjuO7rrrLq1atapABMci9SMtXF5//XX9+OOPGjFiRMhj0d5fRrLymJxKSkpSr1699PHHH+vMM8/UfffdpzvvvDPsr1MQPfrooxo+fLhq1aql//3vfxo6dKiaNm2qgsjOYWnPayVLltSRRx6pq666Kk+OLRQclSpV0o033qinnnpKf/75Z6Q3BwBCig+9GACiS4MGDXTRRReFXGcV8ILk1ltvdUEE+9G4evVqTZo0SbNnz9aCBQv09NNPR3rzCiQLaKRtIWItHn7++Wddcskl6YIx0RicyYqdO3fq5JNP1qJFi9SwYUP3mahcubK2bNmiH374QQ899JD7rNgNeSc5Odm1sLEA4AknnBCxol62bJlKly4dtOz333/X0qVLXUBi3LhxEdu2aPTRRx+5c++MGTNUvHhxFQbWOu+ss85y03ZhxoJUL730khISEvT999+7VmCInNq1a7vPqbVSym+DBw/Www8/rFGjRunFF1/M99cHgEMhGAWgQLAf3vbjrzCwK/I1atRImV+8eLGOP/54jR07VrfccouOOOKIiG5fQRSqdY21DLBgVKhAVUH1xBNPuEDUlVde6QIN1hoibSBi//79Edu+ouKTTz5xx9c999wT0e0I1apn/fr17t5a/yB92VjwtrAEosyxxx4b9N1oLWwtAP/GG2/o/vvvz7PWqMiaYsWKRaz1nR3r3bt314QJE1yrwPLly0dkOwAgI3TTA1AoWKuiG264QUcddZS7AlmqVCkdffTRrqWI5QkJZdOmTa6VUpMmTdzjrVm7BYXGjBmT7rEWADj//PNdDhb7IVOvXj393//9n/75559cb7tt56mnnup+RMyfP98tswCKBRqs5ZRVIps3b+66YwUGXX755Redd955qlatmltnQSy7Ehpqm7yuWnbl/JprrnHBMGtR1rp1a1dRDcW255VXXtFJJ53kKrHWAsN++NiytOzHkNf9zX78WBcye7wFgWybL7vsMvc4uw/sVmKspU98fLz+/vvvkNsxcOBA99i5c+cqtxITE13rs65du6pu3bqu3Kz8+vTpo59++inT/50yZYqOO+44976qVq2qyy+/XBs3bszya2enPDPilcGgQYPSBaKMHQPeDx+vG5x10bBbYLl7P169rj42/+2337r8R5ZfyHvuwPXZ6WZ3qM+WHSNe0PW1114L2YXS+wyE6m4UeLx5DvVewrUPzPjx493z9u3bV3nRlXX69Ok68cQT3fbZD0oLLoT6XKfNGWWfcTuXGOuOlnZ/G2tFZ+cJK3/v+LfziJ1P0jrUecg7r2zfvl3XXXedOz+WKVNGHTp0cF0YvQCQteCz17FjwfaL5bTKKq9Lo5fvyV7PtqFx48Z69tlns/Qc3vFiwdrAz4LXQjIrx451j/W69dm5045p6wY5Z86cDF/PnteOFTvH23u3MrduU96xaGVqnxF7PmvBZF0/c8te184PZt68eek+q9ZKx/KJ2XGV9vNl57gzzjjDdR+3bbLvU/vMWivejI7VrJ4XvWN13bp17pxu30HWVT3wM2xlZecJa71mN5vOLJj29ddfuy6p1atXd8eEndPtXG4tjQNl53O/b98+t19atmzp6hJ2PNtxYp8Ru7gR2DrSWqDZe7djwfavdZc+++yzg95TRufJnBzX9tm9+uqr3WfJ3kO7du00efLkTLvB23bbsfv+++9nWI4AECm0jAJQKFgT9KlTp7ofQT169NCePXtchdBy6FiF3LosBFqxYoU6duzoAiAWDLEKrVXYlixZ4vLxWOslz4cffugqdFZxPuecc1yF17rBPPPMM/rss89cVwirvIdD2gCDBby+++4796PHKrlWCTVW2baAigVXzj33XFeRtUDFk08+6bqi2P9UqVIl6LnssZ06ddKuXbt08cUXu/f73nvv6YILLnCVXHutwMr7hRde6AJV9iPJHmNBOOvecsUVV7j3Hypo98gjj2jWrFmunOwHXVxcnKswWxDMfrTY8latWgX9jwXH7Aed/RC5++67g9bZ/02cOFEtWrRQ+/btw5LU1X6IW/cqO05sv9kPbdvH1trFftzY9qZlx4/taytrK0MrX9veb775xnWPO9T+z2l5pmU/IM3KlSvTlWNa9mPafjxbaypj79uTtqWY/QC3494+E/ZjZ82aNcqprHy2bNtvuukmd7zajz57TLi6UGb0XsK1D+x57Bi3IEK4PveB7FicNm2a+7xbQMqOSQtSWC6wtD+y07J9vHDhQhfgs6CUt5+9+82bN7vPkT2XLbMAuwVo7DNmr2nHuO2ztDI6D3nnlc6dO7sf8f3793eBCDuv2OfE9oWdpyxIZQGp3377zZ2n7XksKGLnh6waMGCA+6xZSw/7P3sNC7pYyxPrkpgZ7/2n/SykTeye0bFj7+300093r2+Bdvt/e5/vvvuuKzM7pvr165fude317HvIznv2/3YesePeAgkW/LZ562JnAaB33nknpUuxfY/lxfeJlb91K7XgmAVHLMDptRKz70q7eGPdyiygY4EYO7/ddttt7jsuVDAju+dFez07/ix4Y8eelavXWsfyG9mFAnt9+zx6z28XMKys7FwRyOZvvvlmFwSy4Nrhhx/uAl32GbHj2TuOs/u5t31gx9YxxxzjXtsCRGvXrnWfeatL2PnKK6/Ro0e7LtH2nOXKlUt5/ZkzZ2a5NW5Wj2v73rbPtG2vnRfsGPnrr79cOdpnLCPe9+bnn3+eUq4AEDV8ABDFfv/9d8vq7WvQoIFv6NCh6W5z5851j/vzzz99Bw8eDPrf5ORk3+WXX+7+f/bs2UHrjj32WLd83Lhx6V5z7dq1KdNbtmzxlS9f3le7dm3fH3/8EfS4CRMmuOe44YYbsvReTj31VPf4v//+O2j5L7/84itVqpQvJibGvV9zySWXuMfWqVPHvbdASUlJrjxs/aeffhq07rbbbnPL7X0HqlevnlveoUMH3/79+4Pea5UqVXwlSpTw/fXXXynLrVzs8ZdddpkvMTExZbn979lnn+3WzZ8/P2W57QtbVqZMGd+iRYvSvffx48e79Xaf1t69e32VKlXyHXnkkW6fBXrmmWfc/z3xxBO+7PLKcNasWSnL9u3bF/Q+A/dB2bJlfZ06dQq53aHK+s477wy5/62s7RYou+WZkSlTprjHlitXznfrrbf6PvvsM3eMZibU9nisbLz398orr2S43vZvRp9NK+ecfLYy+v+0+8/7TATyjrfAfXuo9xKufbBkyRL32AsvvDDTz3mo7c7sMd6xFh8fH3S+svPaaaed5tZ55zuPLbPnyuo+s/du6+66666g5dOmTXPLGzZs6M4vnszOQ4HnlX79+vkOHDiQsvzhhx92yytUqOC7+eabgz7X1113nVuXkJCQYfmEKqvjjz/et3379pTly5cvd2XVpEmTLD1PZp+FQx07w4cPT9nnge/lxx9/9BUvXty9zx07dqQ7Pu28tmrVqpTla9ascY8/7LDDfI0bN/Zt2rQpZd13333n/seOxazwtvmaa64JWm7b5+0329+BnzW73Xfffemea/r06W5d165dfbt27Qp6rmuvvdatmzhxYq7Oi97jbZvSfld/9dVXbl2zZs1827ZtS1n+77//unKydV9//XXK8oULF/piY2N9tWrVSvc5s21et25djj739tr2Pdy2bdt022jzW7duTZm3fWuvv3v37nTl+c8//xzyPJfd4/ree+91j7/66quDls+cOTOlbEN9v5qKFSv6Dj/88JDrACCSCEYBiGqBlehQt8cffzzT/1+wYIF73LBhw1KWff/99ymBmUN57LHH3GNff/31kOvbtGnjgjlZ4VU+LYhgP1ascmk/biwQZctvvPHGlMd6PyaefPLJdM9jlXJb171793Trdu7c6SrJJUuWDAo6eT8a0wblzMiRI926MWPGpCw75phjXGBpz5496R5vwSbvfaT98WU/PEPJLBhl7P9svVWsA7Vu3doFygIr97kJRmXGfpjYD8XAHyzedqcNUnllbT9CLVgZ+AM+1A/e7JZnZh599FEXOAv8HFhwctCgQb6VK1fmKBhlx3Fm67MajMrOZyuvglEZvZdw7QMLANpjb7nlljwJRg0cODDd4711Tz31VI6DUXY+sPNC5cqVQ/6A7ty5c7of/ZmdhwLPK2kDVRZ0seV2nKZ9Le/8FSookllZffHFFxmuCwwE5SYYldGxY4HyYsWKBQVTPVdddVW67wjv+LQgVlqnn366W/faa6+FfJ2sBg28bbbAiXdxZvDgwb5WrVqlBMJ+++23oM9ajRo1gr4XPD179gy5HwMDNH379s3VedEeb+fXzZs3p/sf76LRu+++m27dW2+9le4CixfQDBU4zM3n3oJCNn/SSSeluzCSlpVv/fr13QWOzBwqGJXV49pey8pvw4YN6R7fpUuXTL9fmzZt6gJch3pPAJDf6KYHoECwZuiffvpphuutq4h1m7OuDsuXL3dN2v313+CkvsaaxBvrRnYo1u3AWDcF69qSlnUzsC5udkvbLS4jlo/C60JhXRQsd4U1n7c8GmlZPoq0vNxGoboBWJ4Nez7LOWPdpaw7hsfyMoXq6mZd1gKf17o4WlJ1S4BsI/Gk5eXgsnLOyvZmhXWJefzxx113S+uy4uUBs22yLhDWrSNcrBuTda+w7hQbNmxIl1PM9qV1KwpVRmnL2rqbWTcc6+pnSfZDyU15hmJJ7q37hn0erFuR5Rmz49MS4L/88suu61DPnj2VHaG6JuZEdj5beSXUewnnPvByN6Xt4hXO0dHSslw0XrfVnLL3Zucr64KWdgQ+Y8ut65J9PtIe75l9rq0rlnWRCuR9fqxbVNrX8tYFnpPDUS7WTSovjp0dO3a4z3ezZs1SXi9tudl5y8rNuj8HCtWV1nv/Ga2zz3J22HnSbsa6n1k3Nzs/WHJ9y20YyLqYhUrebt9zlhspo9xp1hUu1Gcju+dFy5kV6nsys+80K19j5Zvd80x2P/f2fWzdtz/++GPXHdO6Xto22XFh3eYCWfc4y+1kebVs2rbTvl+trMJ9XNsxaLmnLGeb5cdKy3Jh2Xd+Ruz78+DBg+758qJrMQDkFMEoAIWC5aywXCSW/NPyllhOE6s8WuXLcksEjjBmyXaNVdqzkmPI2A/9zFhOnKwGoyyXTuBoepkJVfG0imlG6wJ/7HiP89j2Wd6rjF7DK5etW7e6QJ7lv7AkyJm956xsb1ZYUmDLh/HBBx+4H/uWG8mSw5pD5YPJDgveWO4W74eM/Vi2H08WGLTXtgS1oUajy+h9pS27UHJTnhmxHyj2Q8nLU2Ovb/m27MeRBTbttbIzYlhO91ta2fls5ZVQ7yWc+8D7sWmBnVC8z5glOM6Ity7U5zHUiFcWSDZpE0lnR07PG5n9z6G2N7N1GQ0skZPXyU255NX5NqdlY0GD7LCce88//3yWHpvRe7DvOXvdcJ3vMzovZvR4Kzv7LFgC9FDPZefnwPK157VlaS8ahONzb7mxLG/Y22+/nTJapu0ryx9ly73gqtUrLLhmObJGjRrlbpb03fJL2gWnrNYHsnJce+89MFdbds7fe/fudfehgtAAEEkEowAUeJZU1AJR1nrKkvAGJsW1K75pE596LRqsgprViqJdXbUroPkt1Ihp3jZlNJKbtfYJfFxgix/7EZz2B7D3PJawNvD/7IqtN7pfbrY3q6699lp99dVXLlmz/cDyEs5mNRFsVthQ5xZssgS7aRM127ESOFpSoIzKOm3ZhZKb8swqe31rGWjHv40WZsdrqCvu2d1v3rES6gdyqABcdj5bh5Ld187KZyYc+8D7wewFqtPyjgULqh555JEhH2OfxcDH5oecnjdy+7kuSMJ5vo1GGe1H23Zb5x2XWZXd82Jmr2/fTZZgP23AxUbmtIBSYPnaecaW2YWdzALfOfncW8DGCy5Zcn9LXG7BPqtHWFDnhRdeSAkY2WAMdrNWfvbdZYEp+/6yY8ISu4eL9z6sLEI51Kiudq6yCxiWjB0Aokn6S3IAUMB43edshKa0ozNZ0CEtr8tJZs3aPTa0tLGR6qJF69at3X3g8NGBV3it0m2tN2y0r0D2oz7U+/DKyHteq7RalxQb7So33YICefslsxYMNoKT/dC3FlF2ddoCDldeeaXCfaxYl4W0gSjrzuENRR9KqOPIuoJa1xH7oZBR0CGvyjMU+6FnXW1ClX1OW454XTpCBZe8rjU5/Wwd6pjI7mtnJpz7wEZ2tECZdYMNxesam9E5w4JUv/76q+valp/BKGt9aC03LHhvx3ta3vnkUKM0FjXe59tGogt1LBaGcrPvOe+4zI7cnBez+p0Wqnyzep7J7efeWj5dfvnlLtBkLWhtpMtQrBugjYpnXaetW6KNpue1RgoHK0sbZdGOwVABKWvxmxGrE9ioe4Fd9gEgWhCMAlDgeXkx0g57bkPJP/jgg+keb/kf7GZDpluuj7QCf3BY03yr0FpzfXu+tOxHnZdXKr9YfggbTvqTTz5xld5AdjXXflRYxThUNy3rymX5tTxWSbUrvnbF1PJeeGyYbXtv1kUuVPcMu2JsOSyyysv5ZENkZ8S214Ybt6GrbTutm6XNh/tYsa4bgfvSgiF2dduuymfEyjntlW5rZWU/cCzXV6juVoHCVZ52Vd6CCaFYN0P70WWtBgJb8VnZW4uHjLqVZcYCmnb824+wwJZAdiXejrXcfLYs2GQBtIyOCS9/z6uvvhq03IZttx+H2RWufWDla8O+W9A3VFc8G0bejodHHnnEfb4C2eNvu+02FxgOlSMuL9nny84LdiykPS/aj2g7vu2HtJ1fEOySSy5x3QrvuuuuoFyEixYtcsenBRV79epVYIvNPhvGAi9eTrRA1tLHzi3hPi8Glq+xrnRpu+N53eu8x3itaC2Yfe+997qWoIFs/wTmI8vO596+A3755Zd0j7HvDGtRa8FcY9OhAkD2/BaMs++urL73rLLzin13Dx06NF2wLrNWWJZPzL7jrBs8AEQbuukBKPDsKqnd3nvvPdds/4QTTtCaNWvcD2hrLWU/XtN66623XPcvS5z9xhtvuMSj9mPdghTW6sKrkFtLHesuZrl5LPlrt27dXAsDq4xaBdZ+FJ944omZJlcPN6vk2g8g65ZoyVZt2yzIYi0xrGJqgaqHHnoo3f9Zfg2rLNsP6bPPPttNW5nZe33qqaeCujtYNzkLsr322muaM2eOOnXq5K7+WhDCkr1akl3LqWFXa7PCS+z6xBNPuIq919XJfkwEstcdM2aM+zHRt2/fDHNk5NT//d//uavp1jLKcnvYjwsrMwuS2PEQ6sq8Oeuss1yZWW4ye89WNtZ9w8p6xIgRh3zdcJWnBSDth5gXNLDnsP1ox6y1UrBjw/JGBXbHsBxZFjjp3r27SzhsQYkOHTq426HYY63MLFeKJfQ955xztHPnTtct1n7chErqn9XPlrU08AJXlvjZumTa9tu0Hc/2Wla+dqxbwMpaT9gP4i+++CIlyXB2hPOY7t27t/tRaM9nn/+0ATw7hm+99VaXcNjeh70f+5FtCcLttaxMLOCa3yyJs52zLJBoP6atRYydx6wlonVPsm5G4f4RXRjcfvvtrgusHc92DNogC9ZCxQYLsMCiBV7DkUA9Uux7bciQIRo5cqQ7t9i8HbP2WbXWOHZusWPGWhmF87zosXORnWeefvppF0i3c78FlRISElxA1wJKgecra+Vj3yW23FoqWiDQtteCZnY+se99W5/dz719D9h5xr7r7XvSvhOtDKZMmeKCkXbRwlirJzv/Wo5K6wJorRwtCPXRRx+5bbDHhbtL3B133OHKw7oMWsDMzuVWNvYdbvvAzsmhPrt2zjEFOVgKoBDL9/H7ACAbvGGRu3btmunjNm3a5IZ+rlWrlhu+/Oijj/aNHTvWt3r16gyHj7chkm+66SY3nLYNmWxDNR9//PG+xx57LN1jly9f7rviiivcsOD22IoVK7rXuPHGG30//PBDlt6LN1zz33//fcjHZjasfeCw1Oeee66vSpUqbthx2zZ7P6GGzvaGNP/33399V199ta969eq+EiVK+Fq2bOl7++23M3wNG2rbhu+292uvUbt2bd9pp53me/TRR4NexxvK3IYbz8i0adN87dq185UqVco9NqOvoJNPPtmt+/TTT3254ZVh2m2aOHGiG8K9dOnSruzOO+8836pVq0KWuTeEud1/8MEHKdtfuXJl36WXXhpyX2Y0fHx2yjMjdhyOHj3a17lzZ98RRxzhjnW7NWjQwG3//PnzQw61bsPP16xZ0xcXF+fej+2vwOHhvflQbHj2YcOG+erWreuO/caNG/uefPLJsHy2VqxY4evRo4cbCt6Gj0+7v2xf9OrVy1euXDk3PPsZZ5zhmzdvXsjjLSvvJRz7wKxbt84NlW5DzGfEhmy3ba9Ro4Z7rA11f9xxx7nXCTUcfOCxllZG782W2XklK4/12Hu085Ydo/b+7TNg55HFixdn+zyU2bEeatsyG+r+UOfNnJ4ns7K9WTl2du3a5RsyZIg7/u2YtmO2e/fuvm+++SbdYzM7H2a2zZm914y2+ZprrjnkY7Na5jNmzPCdffbZvqpVq7pjw47d9u3b+0aOHOlbs2ZNrs6LGR0PgV555RX3XHZutptN27LMyuCss85y5xfbJ3Xq1PH17dvXN2fOnBx97rdu3erOdR06dHDnS3tOq1N069bN98knn6Q8V2Jiou/hhx/2denSxb2mPc6+U+3/7Ps0OTn5kGWfk+Pa6jlWD7HPrJ3327Zt65s0aZJvzJgx7vGTJ09O91z2PdGqVatMyx0AIiXG/kQ6IAYAyFtea4/sdK2LBGtBY8NaW6sZGxacVhqIVtaCy0sYX5BbxQDZZa0VrQu7taQLd1dqZN9FF13kWqRaF/fA1mvWjbJz586uVVh+dwsGgKygLTYAIGrYjxvrFmFdKwhEIZpZtyXrrmNdiwAgr1kagrSs2+0777zjugen7UZp+bYs8bsFqwAgGpEzCgAQcZbjypLHWoJuyxN1/fXXR3qTgExZjhprcXCoYdUBIBwsV57lXrQAk42cai2hLF+lJXNPGxS3AScst5nlk+LCDoBoRTAKABBxNkqVjUBkiWOtUp2fQ94DOWVJ8AEgP9iIgtYdz1pC2UASNrKnBZvs+9MGIwhko6gOGzaMHQMgqpEzCgAAAAAAAPmGnFEAAAAAAADINwSjAAAAAAAAkG8IRgEAAAAAACDfEIwCAAAAAABAviEYBQAAAAAAgHxDMAoAAAAAAAD5hmAUAAAAAAAA8g3BKAAAAAAAAOQbglEAAAAAAADINwSjAAAAAAAAkG8IRgEAAAAAACDfEIwCAAAAAABAviEYBQAAAAAAgHxDMAoAAAAAAAD5hmAUAAAAAAAA8g3BKAAAAAAAAOQbglEAAAAAAADINwSjAAAAAAAAkG8IRgEAAAAAACDfEIwCAAAAAABAviEYBQAAAAAAgHxDMAoAAAAAAAD5hmAUAAAAAAAA8g3BKAAAAAAAAOQbglEAAAAAAADINwSjAAAAAAAAkG8IRgEAAAAAACDfEIwCAAAAAABAviEYBQAAAAAAgHxDMAoAAAAAAAD5hmAUAAAAAAAA8g3BKAAAAAAAAOQbglEAAAAAAADINwSjAAAAAAAAkG8IRgEAAAAAACDfEIwCAAAAAABAviEYBQAAAAAAgHxDMAoAAAAAAAD5hmAUAAAAAAAA8g3BKABIo379+jrttNPSlcuzzz6rpk2bqkSJEoqJidEff/xB2eUj2ye2bwAAQNHx6quvunrXl19+GelNKTJ1XiA/EIwC0rAvOvvCy+j23XffRW2Z/fDDD7rxxht10kknqWzZsm577Qs8I/v379d9992nI444wgVYGjRooFGjRunAgQMhv6wyKpMtW7ake/z69es1cOBAVa1aVaVKldKxxx6r999/P9fv8dJLL800EORVWDJ73zkxa9YsDRo0yAWjnn/+eb3xxhvuvRUEVlbevjrrrLNCPsb2ub0fewwBHz8rBzveAKAgoP4S3fUXz4YNG3TPPfeobdu2qlChgooVK6Zq1arpjDPO0JgxY/TPP/+osBo2bJg++OADRQOvPund4uLi3H7o2bOnvv32WxUm0VTuQKD4oDkAKQYMGKAePXqkK5GGDRtGbSl9/PHHGjt2rAuYtGzZ8pBfpv3799eUKVN0+eWXq3379po7d66GDBmi3377LWQwx57XKlBplStXLmj+33//1cknn6xNmzbplltuUZ06dfT222/rvPPO0yuvvKLLLrtM0WzFihWuYhJoxowZ7t62v1KlSiqISpYsqU8//VR///23atasGbTuww8/dJVye0y0mj59unw+X6Q3AwCiGvWX6K2/2Hfw+eefrz179qhPnz66+OKLddhhh7nvX6uD2Ta++OKLrh5SGA0fPlyXXHKJevXqla3/s3KycitevHjYt+m5555zF3DtAu3ixYtd+X/yySeaOXOmTj31VBX2cg9V5wXyjQ9AkFmzZtmvXd8jjzxS4Epmw4YNvl27drnp999/372P8ePHh3zstGnT3PpbbrklaLnN2/I5c+YELa9Xr57v1FNPzdJ23Hbbbe45Pvzww5RlBw8e9LVr185XqVIl386dO305dckll7jn/v3330Out/eb2fvOqcsuu8w9b7jt2bPHd+DAAV9esrKybT/33HN98fHxvocffjjdY3r06OE75phjfC1atHD7Gv5j3o43ACgIqL9Ed/3ll19+8ZUuXdpXt25d39KlSzOsx919992+wsrKNjvfqzt27MizbfHqk5s3bw5aPnHiRLfc6kUZSU5OztWxkB8SExN9e/fuzVG5A/mFbnpADrvDWfPexo0bq3Tp0u7KmnWNmzx5coZNsq373JFHHum6w1kz4M6dO6e0tvH8+uuv7uqPtVqxqz/WtPy2227T7t27s7Rd1atXV5kyZbL0WLvSZwYPHhy03Jt/8803Q/7fwYMHtWPHjkM+t3X5O/vss1OWWfPn//u//3NXHa0FV6Dly5dr1apVyite170vvvjCNYG3bbP9YPvvtddey7T/vNfFbfz48W7ea84d2L9+0aJF6t27typXruxaFjVv3lyjR49WUlJSyCbhmzdvdq3RvP31119/uSbUtm7p0qVuH9gxYMeWNdv3rpBOmjRJbdq0cd0GbBvHjRuXrXKw17PWft578VhLqc8++yzDK77ZOd6997h9+3Zdd9117li3MrHHf//99yG7lNj+sW1q0aKF2y/16tVz5ZeVnFHeMutWYa0BKlas6Laxa9euWrlyZbrnsP3Zt29flS9f3t3OOecc/f7771nOmTBt2jR3pbRKlSpuPxx++OHu6nao10rLew073s8880xXjnZF/Nxzz3XnCADIa9RfIld/sbQI1iLq5ZdfVrNmzTL8nr7//vvTLc9O/TC7dRLrFmjT9r1m30vWesb7TrJ6hm2rPY+1LrPW9KG8++67rkWZ/b99Bx9//PGaOHFiynqvLmWs3hXYPc5j07Ydn3/+uXsua63k7YeMckYlJia699aqVSv3uvadat0qn3nmGeWU1R+M9RJIW1ex3gdWnlYeVp/06sUPP/xwynIrdyt/a2UVyCsDq+9NmDBBxxxzjHu81SNsmT1PWlY/s7qUPcb2e61atXT11Ve7lnuBvDrkkiVLUlr02XO/8847hyz3jOo/8+fPd+/DjgurmzVp0sQdm2m3016zX79+ql27tntcjRo11LFjR1dfAg6FbnpABqzCkDaXgJ1k7YvWfoRbBcSabdsPZ/sit5O8/Sh96623dMEFFwR9+dgP8Y0bN7ocBPYlaZUHyz1lTYAtKGUWLFig008/3eUPuOaaa9xJ/eeff9ZTTz2lOXPm6KuvvnJ5BcJl3rx57jXq1q0btNzm7cvO1qdlwQT7srecDPaFbz/kH3zwQff4wC/OdevW6cILL0z3/yeccELKa1vZeayiY+WY1wnB7777bu3du9eVr+1La5ptFR/remn7KBTLGWH5oaxC9s0337hpr8LofVlbcML2jeWUsi/hqVOn6o477nD7z46HtGyf2+OsS6QdC1bh8lgzapu3bbWg1aOPPuoqRiNHjtTtt9/uKiUWyLLKrL0Pq/xYpS2r7H+tomndAaxrprFj1yrbF110kV566aV0/5Od491j22xlZ5Vve/xjjz3mAjAW+EnbLcJycNnn44orrnDHvwVCrfysMhXqudOyMuzQoYM7vh544AH3Gk8++aQ7Pn/55Rf33oxtxymnnOJe69prr3XHne1TqzRlJeBrn0HLJXHUUUfprrvucttqQTD7HFul1YJ1h2KfDav0WQXvkUceccfICy+84AK81g0RAHKL+kv01V/27dvnfpzbY716X1Zlp36YkzpJt27d3PftiBEj3HeZPa99R9l3vNV97LvZAhu23C6e2MUXyzXquffee12Qwp7H6iqxsbGu3mABCgsK2XZ4dSkLqNn3sAVUQrHtT0hI0FVXXeXqQ5mxQJTVNSxY1KVLF1eHse20IJBdvLvhhhuUExb4MxaECfTEE0+4eoRtm5WrV3+24+W9995z+9XqaBbIs6CV1bGsjtG6det0aRFWr16dsn9s3rrR/fnnn0EXC9esWeOew96n7QMLktr+sbqr5TG1srJjOZBti10ou/XWW13AyV47K+Welh2rtv+tfmzPZekprN5odbqFCxem5FCz8rBj01i9yo5v++1k22afOav3AZnKtzZYQAFr5h7q1r9/f/cYrytcoN27d/saN27sa9asWdDy7t27u//99NNP0/1PUlJSyrR1kWrSpEm6JsmTJk3KUbezQ3XTK1u2rO+4444Luc6ao9esWTNomTVXHjlypGu+PGHCBN8111zji4uL89WuXdu3bt26lMfNnz/fve7tt98esoxs3YABA4KW27Ksdg3LSTc9b1mrVq18+/fvT1n+119/+YoXL+47//zzD9mk33vdtE488URXDj///HNQ8+1+/fq5x8+cOTPdc1x44YXpnmfo0KFu3VlnneX+3/Pkk0+65eXKlfOtWbMmZfmmTZt8JUqUSLftmXXTGzRokOsSWL16dd9VV12Vst6O2759+7rpUN30snO8e+/xuuuuC1r+3nvvueXPP/98us+aHWvbtm0Leu4qVar4TjjhhKDnsH2SdttsmT1H2q6Ho0ePTve587pfvPnmm0GP9ZYfqhvHzTff7B63ceNGX07Yttv/v/vuu0HLr7/+erd8+fLlOXpeADDUX6K3/rJo0SL32J49e6ZbZ12prKtY4C2w+3526oc5qZPYd1Co7zrrTrh9+/aU5factvzOO+9MWbZgwQK37K677kr3vs455xxXdwnc7sy6i3l17RkzZqRb59Xj7Bj32Pd+Rq8dWL/OiPf+V6xY4crcjoVPPvnE17x586D6ive5qlixYrrv/+nTp7t15513XlDdbeHChW4/nHzyyenqYrGxsa7cPPZ/vXr1cuvmzp2bstyOlapVq/rWrl0b9Jrz5s1zz231xrR1SKvHhEr9kFm5p63z2vFo9cRTTjkl3XM99thjQfthypQpIes1QFbRTQ/IgF09sG50gTe7+mMCu8LZFUi7MmD3dnVg2bJlKd3YrEm3Jau0q0Ves99AdvXI2FUca1ZtrUAsgaJdVfBu1urFXi/crSZse611UCh2ZcnWp71KYu/fujhZEklrzfL666+7q4hDhw4Nel4T6rm95Nhpn9u+J/O6VZS5/vrrg5Jf2tVFa83iXQXLLmsmbUnirbWMNbf22NUoL1FqqK5s//vf/zJ8TuvOGdh82q5kGXuNwFZsdpXRmkxnd9vj4+PdFTJrUm+txOyqql3ltBZTGcnq8R7o5ptvDpr3rpyF2l7rHhh4dc+uXttV6Ky+N/scWbkd6vXs6rB1cbDufFndH4G8bbSrtqGa02eFXYUPvKqe0bYCQE5Rf4m++ov3PWndw9OyFsn2nR54s9Yn2a0f5rROkjZdg1fvsNb8gdtrz2nzgd9V1tLKnt9aMQVum91sO3bu3Ola1GSVDb7TqVOnLD3WXtu65ltrnYzq11lhdSkrc6sTdu/e3bV4fuihh1wrtEBWHpZ6IJBXnla+gXU3ex/WxXD27NmulXsga0FlKRc89n/W8j3w+SzVwUcffeTK0I69wHK1bnXWYinU7wLbl1bPyw37vWMtyK1utm3btqDX9gZ28l7bqxdZwvdDpfAAQqGbHpCBRo0aZfiFaF/4VrGxvvNp+20bO3nbF7Y1p7WKStomumnZD3pjlaLAilEg+2IIJ/vBbxWbjJqT2/pDscqRfQEH9gv3/i/Uc9vzBj4mL4UaGcRydqVlffutaXROWHcwY7mO0rKm+1YZsqbYaWXWnSvtNlpFywQ2iQ9cl5NttwqG5TqwoIo19bYASahgaXaP98zeh5WzCTVkdUb7JavDW9v2px0FMNTr2f467rjj0lVSrXJp3R8OxZr8WxlYUNO6PNgPAQs0W3DLKrJZkdF7TbutAJBT1F+ir/7ifUeG+sFuXectH5OxIJmXDiC79cOc1kmyW+8I/K6y7bN6rrf9mW1fVmSlu7vHgmKWKyq3owBbXcj2j3Xpt+9jK6tQaTFCbZuVuZVrqBxgth8++OAD95jAOkKox1rKBePtH8sVmpyc7FIy2C2r9YnslF9GvGMus4uU3j61LqEWpLN8WhYcbNeunfvtZKN1e+8JyAzBKCCb7EvX+qbbyfqmm25yOaDsyoB9iVlfb0t+aV8g2X1OY/2y7cdtKF7lIFzsB7xdFQzFltsVoqywKzTWuibweb3nCPW8JqvPHYr1hQ91ddLj5f7xHhfIyx2UUfnnl8wqsxltYzi33SoIllzUchpYTiULsmT2/Dk53rOzvRk9Nqsy+/9w7lurpFq+EMsBYVcOv/76a9cCzH4gWFJbLwdXNGwrAIQ6x1B/iUz9xQKE1uLK8jalZfma7GasJU3afZbX9cPc1Dts2i7+WcuYjB4fKjiWkfy4WJmW5ZxMmx8q0tvmlbHlwcood1aoem44ttF7bctracG+UAJzrVkOUUumb8eA1Y8s16nlELMcWznN24Wig2AUkE3WXNoqE9Ys2BIOBkqb/Nma0dqXtNfcOrNKirEv8qw2T84tu3phVzHWrl0b1P3L5q2JsjUNzgpr/eUl8zbWDcoqa5agPS1vmQU0csq7UmfBkVBXXbwrOqGu6IWb9xo2kkhalvDbgjShrlxFA7vi5TVBz+zqV3aO92hnPzzseLX9Etg6ylp7WeuurLDPqCUg90aesfJp27atRo0axcgxAKIa9ZfI1V+s9Y4lc7bE2nYxI6tJzLNTP4xEncS2z9JR2GhvGY0QmFesFZC9L2vJllHaibxm5WnlanXPwK6RxkZHDlUf9eqpoR7r7R/v94MlL8+v3wVpjznrAprV17aBXexmQSmrT9kFzzvvvNMlaQ/VUwHwkDMKyCbvyk/aVgzWwiRtX3wbfcL6n9vVAhtxKy3vOawbn53ELY9BqCbUlp/G8k+Fk5c3x65cBPLmA0eTyei1rWXNX3/9FTQEsvfcNtSx5ejx2JDCTz/9tOsO5fU5z8nQyDYCjn2x2Qgt9iUdyIJoNoytVYoC++PnFevedeKJJ7r3afs/cL/aKD3GRqSJRpY3w1r02KhzXsUjt8d7tLPj1EZLsiGVA3nDMx9K2tE1jXVNsKuT4f58AkC4UX+JbP3FRquzlis2MlqogESo79rs1A8jUSexHJTGRgC2cjpUFz0bLThc35dWT926dau7GBSplsbWxdJY+Qa+ppW/jZJn3fnTduO3YOSPP/4YtK2jR48Oej5riW3HmgUvQwVH7X/S5qLKTHbK3dI22LFkebNC/Y/lG7VcYMbWp20db58TC8BZDwaveyuQEVpGAdlkV36sybF9cdiJ1hIfWgJoG5796KOPdkPwBrKgiVUOLChlTW2tFYWdyG3IU2up8fDDD7vgiuUIsETGdmXFWqrYa9jz25U7+zKyL7pLL700022z/EFergHvyphVSqzC5VUabNhVY1fozjrrLD322GMuUaJ1MbIkk9Y33ZoF2xeox3IY2HJrIm7bbJUfG0rX+sLbULNpW8zY1RAb9tVyMtxyyy3uSqMFAKyLk7WmKVeuXLoyzcrQyMbK257fysMCTtYv3a5sWmXQntu+IG17c9v1K6ssmGN95i3hpzdMryWd/Oyzz9z7P+OMMxSNLD/CsGHDwn68RzPL82TdCi1n1g8//OACSdak3BK+WhP9Q129s+Gc7bNk3VzseLXPsSWCt2POciYAQDSj/hLZ+ot9l1p+IrsYZAmu+/Tp4+pe9n1sgQV7DctLaF3hva532a0f5nedxFrZW13Cbtalq1+/fq4Ll134sfqBdWEPvHBog5PYxVmr+9qFQ3t/Vh45YakDrI5rwSgrO/tuthZoVv+1nEuhLgKHm7Vws0FJ7EKoBcasXr1hwwYX7LRteeqpp9L9j+1725+2f6w1nu1z21arowd293/uuedcXdy6EVodwwKTFvixoKT9jy3LSj0uu+VuLaKsHm2BMavz2TFnLbWsxZMFX+2Ys4uR1kLcHvf444+7IKc9xnJtffXVV+54s3IJ1ZUQCJLlcfeAIsIbwvWRRx7J8DF//PGH79xzz3XDz5cqVcoNJWxD7HpDq9rwrYH++usvN5SwDZNbrFgxX7Vq1XydO3cOGmLXe157nA2zao+rVKmSr02bNm4Y3TVr1mR52zO6BQ6J6w3fes8997jXK168uO+II47wjRgxwpeYmBj0uNmzZ/vOPvtst/0lS5b0lShRwte0aVPfHXfc4du6dWvIbbH3fNFFF/kqV67sHt+6dWvfO++8E/KxWR0aOZA912mnneY77LDDfPHx8W4YWtsnNuRtVoYE9thwtmlfO+0wt4FDAIdiQ/jaEMY27K+Vo5WNDTl88ODBLD9HRseONxRw4BC+mW17KN5zDBo06JCPbdGiRbrnzM7xntl7TDu0sHe8Bg5LndnzhHq/GZVBRuW2evVqX+/evX1ly5Z1Q07b0Mm2zI7T7t27Z1o2CQkJ7nNgw4Hbfrby6NChgxsuPCtCHVeHKgcAyCrqLwWj/rJ+/Xrf3Xff7Z63fPnyrg5TtWpVX8eOHV3dc8uWLen+Jzv1w9zWSTL7Tsroe+yjjz7ydenSJeU169Sp4+vWrZvvueeeC3rcypUrXf3Xvn+9umlGdYSs1OOsHjtq1Chf8+bN3b6yOuGxxx7rGzt2bMjnCfX+N2/enOnjDvUdfeDAAd9DDz3kytneu5WBlf+iRYsyrJe8/fbbvqOPPjqlrIYMGZLu2DW2bf/73/98jRo1Snl/Rx11lO/GG2/0LVmy5JB1yKyUe0b7dPHixb4LL7zQV6tWrZTfLu3bt3e/E/755x/3mJ9++sk3cOBAX4MGDXylS5d2z3/MMcf4xowZ49u3b1+m5QqYGPsTHJ4CAKDosJGBrGWU5dCyrhAAAADhZK3nrPuapUjIaosmoLAjZxQAoMiwrnVpWV4Ek9WEsgAAAAByh5xRAIAiwxKCWn4PyzdmuRc+//xzl0/D8rp5iUMBAAAA5C2CUQCAIsOSi1rCTUu+aa2k6tSpo1tvvdU1m8+vpPcAAABAUUfOKAAAAAAAAOQbckYBAAAAAAAg3xCMAgAAAAAAQL4hZ1QIltR2/fr1KleunGJiYvJvbwAAgCLH5/Np586dqlWrlmJjw3OdkLoMAACI5roMwagQLBBVt27dcO8fAACADK1du9Yl1Q8H6jIAACCa6zIEo0KwFlFeQZYvXz68e+e/q5WbN29W1apVw3YFtKiiLCnHaMLxSDlGE47HglOWO3bscBfBvPpHOFCXKZr43Ecf9kl0Yr9EH/ZJwd4vOanLEIwKweuaZ4GovApG7du3zz03wSjKMhpwTFKO0YTjkXIsqsdkOFMDUJcpmjh/Rh/2SXRiv0Qf9knh2C/ZqcvQLAcAAAAAAAD5JuqCUZb0avDgwapXr55KlSqlE088UfPmzUtZP2zYMDVt2lRlypRRxYoV1alTJ33//fchn2v//v1q1aqVi84tXLgwH98FAAAAAAAACkQw6sorr9SMGTP0xhtvaPHixerSpYsLOK1bt86tb9y4sZ555hm3bvbs2apfv757jPVjTOv222932dwBAAAAAAAQHaIqZ9TevXuVkJCgKVOmqEOHDiktoaZOnarnnntOo0aN0gUXXBD0P4899phefvllLVq0SGeccUbK8k8++UTTp093z2fTAACYpKQkHThwoEj08bf3af38yU8Y2bIsVqyY4uLicrkVAAAAhUdUBaMOHjzofiSULFkyaLl117NWUGklJiZq3LhxOuyww9SyZcuU5Rs3btRVV12lDz74QKVLl86XbQcARDefz6cNGzZo27ZtKirv14Io1v09nImxi6JwlGWFChVUo0YN9gUAAEC0BaNsGMD27dtr5MiRatasmapXr64JEyZo7ty5atiwYcrjPvroI51//vnas2ePatas6br1ValSJaXCeOmll+raa6/Vscceqz/++OOQr2u5pewWOCyhsYqn3cLNntOr2IKyjAYck5RjUTgeLRC1fft2NzStXagoCgEaa81jrXIQubK0Y9nqK5ZOwKYtIJVWOI516jLwjiXqmNGFfRKd2C/Rh31SsPdLTuoyURWMMpYr6vLLL1ft2rVdk/Y2bdpowIABWrBgQcpjOnbs6BKSb9myRS+++KLOO+88l8S8WrVqevrpp92Vy7vuuivLr/nggw9q+PDh6ZZbxdGa5Ieb7Sj7QWQ7la4TlGU04JikHAv78WjP+c8//7iLHNaatiiw8jP2XVoUAm/RXJZ2zNkxaC23Tdrj2uotuUVdBobv8+jDPolO7Jfowz4p2PslJ3WZGJ9Xw4oyu3fvdi2UrOVT//79tWvXLk2bNi3kYxs1auQCWBaA6tWrl8sxFVhZtK5/VoG88MIL9dprr2XpamLdunW1detWlS9fPk92qAW67Oo8wSjKMhpwTFKOhf14tAsL1lLWBr2wrt9FBS2joqcsLS+mdwymTUdg9Q4bIdgqezmtd1CXgeH7PPqwT6IT+yX6sE8K9n7JSV0m6lpGecqUKeNuFhD67LPPNHr06EwLyAsmPfXUUy7RuWf9+vXq2rWr3n33XR1//PEh/79EiRLulpYVdl4FiyxYlpfPX5RQlpRjNOF4jM5ytOfxnrOotBKya03eey0q7zmayzLwGEx7XIfjOKcuAw/fQ9GHfRKd2C/Rh31ScPdLTuoyUReMssCTVfqaNGmi3377TbfddpuaNm2qyy67zLWWuv/++9WzZ0/XYsq66Y0dO1br1q1Tv3793P8ffvjhQc9XtmxZd9+gQQPVqVMnIu8JAAAAAAAAflHXLMeadQ0aNMgFoAYOHKiTTz7ZBai8YZGXL1+uvn37qnHjxjr77LNdDpBvvvlGLVq0iPSmAwAQ1ayL2BNPPBGU1L1z586uJbKN9gYAAAAUyWCUJSNftWqV63b3999/65lnnklJNms5FiZNmuRaQtl664I3ZcoUtWvXLtOKt7W0atWqVT6+CwBFzaRJUuvWMapfv7q7t3kgHE477TQNHjw43fJXX3012wGkefPm6eqrr06Zf/zxx913rQ0KsnLlShVW1oray9VkXfZ/+OGHQ/7P+++/7y6M2f8cc8wx+uSTT9I9ZtmyZa61ttVTLKBn9ZE1a9bk0bsA8t7M1TPVfGxzdw8AKPgmTZJatpQsZardR9NvlKgLRgFAQWMn9b59pcWLLYlwjLu3+Wg62QPGkk+WLl06pTDs4k/btm3dQCA2Im1OJCYmRnXhWs7IW265RUOHDtWPP/6oli1bulySmzZtyvB/vv32WzeS7xVXXKGffvpJ55xzjs4991z98ssvQWVnrbctYPXll19q0aJFGjJkSLrk5EBBYRdv7/78bi3bsszdR+kYRwCAHPxG2bdPUfcbhWAUAOTS8OGW2M8q8v7ExnZv8yNGULSFUbReYbr00kvdiLJjxoxxeRWrVKmiG2+80Y0CF6qbnk0nJCTo9ddfd4kp7f+Nteyx4IvlXLTRUKzF8saNG1OeY9iwYa618UsvvaQjjjgiJfhiz/HCCy/orLPOcgGvZs2aae7cuS7/o7XuspZDJ554ogviZMRGm7PnsVbQHTt2dM9jwSN7npx67LHHdNVVV7nck82bN9fzzz/vnveVV17J8H+efPJJdevWzeWttPcxcuRItW7d2rXW9txzzz3q0aOHG2DF1lluSmslldOgHhBpCcsSNG/9PDdt99NXTY/0JgEAcmjdOmnQIP+0d23B7qPpNwrBKADIJevdlPYCss2vWEHRFjbRfoVp1qxZLthj99aNzwJNdp9Rlz0LuFiwybrqWQDGRqe1QNS///6rr776SjNmzNDq1avVv3//oP+1AJMFsixoZF38PBa0sXyPtsxaDF1wwQW65pprdNddd2n+/PmupcUNN9xwyPdhgZ7//e9/7nksR6S1Ujp48GBKsMwCZZndHnjggZRWWwsWLFCnTp2CRnux+cwCXLYu8H+M5db67rvv3LSV07Rp09y2WSsrC0BZ978PPvjgkO8NiEb22Rw9Z7TiYuLcvN0PmTWE1lEAUIDs3StNmCB162YDu1lu0PSPiabfKFE3mh4AFDSNG/uDEoEBKbvq0KRJJLcKWXHssaG/qDPiNRAKvMJkLFZTvXrWn6dGDWn+/PDvo4oVK7rWOzbgh41K2717d33xxRdBeaICu+yVKFFCpUqVUg3bIMkFnxYvXqzff/9ddevWdcssoGWDhFjwysvRaEEeW27PEchaH1lwy9xxxx1q376967pmARtz0003ucccigWizjzzTDc9fPhw9/oWALMAV61atYICYKFUqlTJ3duou0lJSaqeZufYvA2IkhFL7B7qf2y5sS5+u3bt0kMPPaRRo0bp4Ycf1qeffqo+ffq4QOCpp556yPcIRBNrBeW1ijJJvqSU1lFdG/o/vwCA6OPz2UU0yyVqqQmkHTsyf3w0/UYhGAUAuTR0qL91jGSRCeuq53Nd9Ww5opvFFqwZc25Zo51wPE9uWdDGAlEe6663ZMmSLP+/JeS2IJQXiDLWtc0Spds6LxhVr169dIEoY4m+PV4w5+ijjw5atm/fPu3YscN1AcxI4PPYe/ACQBaMio+PV8OGDRVJ1jLKWCuym2++2U1b10XLNWXdAAlGoaC1irJWULGKVbL8x7axeVvepUEX130WABA91qyR3nhDeu016ddf06+vV0867jgbkMVLJ5J6Hy2/UQhGAUAu9ekjJST4W8dYUCI+XnrvPal3b4o22v3XIChbLaP+6y0WxPZ5dltGZZUFbbZv355u+bZt21JGm/UUK1YsaN5+QHqBk3Cy/E+hBL6+9+M11LJDbVNm/2Pd9CxAlpm7777b3SxvlgXnAnNeGZv3WoOFYusy+x97XguKpd0Oyy81e/bsTLcNiDaJSYlas31NUCDK2PzaHWvd+hLxJSK2fQAAv927/akhLAD1xRfp04RY9axfP+mSS6QOHSw1gf/xliPKuuZZiygLREXLbxSCUQAQpoCUBSOsdYzdR8tJHpnLblc5L2dU2itMeRl8tO5206enTyRsI8NZzqJwsmDK2rVr3c1rHbV06VIX+DpUACi/ZKebXvHixd1ogZ9//rlL7u4FtWw+s9xV1r3QHjN48OCUZTZ/wgknpDyvtRJbkSbpwsqVK12rMaCgsaCvtYDq3qC7OtTvkLK8WplqBKIAIIKSk6VvvvEHoKyV065d6R/TsaMNZOP/PVK2bPA6W2a3aEQwCgCAbLaCy88rTNddd53LA2Uj41155ZUuz5Mlz54wYYKmTp0a1teypN3Wre7CCy90o+5Z0vDrr7/edTs71hJsRYHsdtO75ZZbdMkll7jtP+6449z72r17d1DuKku6Xrt2bT344IMpua3sPT/66KMud5WVtSVCHzduXMr/2Eh7lti9Q4cObuQ/yxll++PLL78M8zsG8tYXv3+hDbs2uFv1MtU1uH1qEBYAEBmrV1veTv/t99/Tr2/QwN8C6uKLbYRkFUgEowAAyIb8vsJ05JFH6uuvv3YjzFmwyJKHW+6k999/342GF+7WEVOmTNH//d//uSCLjTxnr/H000+roLKA0ebNm3Xfffe5BOSW28kCR4EJyq3rn71Xz4knnqi3335b9957r+vu16hRI02cOFFHHXVUymN69+7t8kNZAMsChdaCzUYYPPnkk/P9PQK5MWlZ6nCgfZpF6eVzACgCdu6UJk70JyP/+uv068uV86cFsVZQJ57ob6FfkMX4LGshglhiVcvDYTk6MkuwmlPWRcASsdpQ0IGVX1CWkcIxGR516vi0bl2Matf26a+/Cvi3QyE7Hi1pto0Qd8QRR6hkyZIqCuzr3Vo2WUsikg9HviwzOwbzot5BXaZoyu75Myk5STUfranNezarVHwpbbl9i0oXK50v21pUUMeKTuyX6FNU90lysjRrlj8AZekg9uwJXm/Vjs6d/a2gLONA6dLRuV9yUu+gZRQAAABQBH279lsXiDLdGnYjEAUA+eTXX/15oKwb3tq16ddbKghrAXXRRXbBu3DuFoJRAAAAQBE0efnklOneTRl5AwDy0rZt/kFvLAj17bfp11eoIA0Y4G8FddxxBb8b3qEQjAIAAACKYPdTLxgVHxuvsxqfFelNAoBCJylJmjHDH4D64APrth+8PjZWshSgFoDq2VMqItkkHIJRAAAAQBHz88af9ce2P9z0afVPU8VSFSO9SQBQaCxd6g9AvfmmtH59+vVHHeUPQF14oVSzpookglEAAABAETN5GV30ACCc/v1XeucdfzLyefPSr69cWbrgAn8uqNatC383vEMhGAUAKDJsRBCAYw+QFvy9IKUYejXtRZEAQA4cPCh9+qm/FdSHH0qJicHr4+OlM8/0t4Ky++LFKWYPwSgAQKFXvHhxNxzt+vXrVbVqVTcfU8gvR1k+mIMHDyo+Pr7Qv9doLkv738TERG3evNkdg3bsAdFg6oCpWrxpsb776zvVKlcr0psDAAXKokX+ANRbb0kbN6Zf36qVvwWUJSSvVi0SWxj9CEYBAAo9CwIcccQR+vvvv11AqiiwIIi1BLP3TjAq8mVZunRpHX744e45gGhgx/Ix1Y9xNwDAoW3eLL39tj8I9dNP6ddb0MlyQFkrqJYtKdFDIRgFACgSrEWKBQOshUuSDW1SyFnw5J9//lHlypUJgES4LOPi4mihBgBAAWTd7j7+2J8Hato0f7e8QNbg+eyz/QEoGxWvWLFIbWnBQzAKAFCkWgIUK1bM3YpCAMXeZ8mSJQlGUZZAUEs/WksCQMZ8Pn/LJ2sBZS2htmxJ/5h27fwBqPPP9ycmR/YRjAIAAACKiBd/fNHdejftrUtbXUq+KAD4z4YN/hxQFoRavDh9sdSsKV18sT8I1bw5xZZbBKMAAACAIiJhWYLmr5/vbt0adiMYBaBI27dPmjrVH4CyUfHSZnIoUULq3dsfgOrUyT86HsKDogQAAACKgG37tumL379w0/UOq6fWNVpHepMAICLd8ObN8+eBeucdaevW9I9p394/Gt5550kVKrCT8gLBKAAAAKAImLZymg4m+7Pv9mrai9xRAIqUdeukN9/0B6GWL0+/vk4daeBA/61Jk0hsYdFCMAoAAAAoAiYvn5wybTmjAKCw27tX+uADfwBq5kwb4CV4falSUt++/m54HTvaCLiR2tKih2AUAAAAUMjtPbBXn/z2iZuuUrqKTj785EhvEgDkWTe8b7/154F6911px470j+nQwR+AOvdcqXx5dkQkEIwCAAAACrkZq2doz4E9brpn456Ki+XyP4DCZc0a6fXX/UGo335Lv75+fX8AyrrhHXlkJLYQgQhGAQAAAEWpi14zuugBKBx275YSEvwBqFmz/K2iApUpI/Xr509GfsopUmxspLYUaRGMAgAAAAoxS1r+4YoP3XTZ4mXV6chOkd4kAMgxy/v0zTf+PFATJ0q7dqV/zOmn+1tB9ekjlS1LYUcjglEAAABAIfbLpl+0Y78/aUqPRj1UMr5kpDcJALJt9erUbnh//JF+fcOG/gDUxRdL9epRwNGOYBQAAABQiLWq0Uqbb9usaSunqV4FfqEBKDh27pTef98fgPr66/TrLfl4//7+INSJJ0oxMZHYSuQEwSgAAACgkKtQsoIuPObCSG8GAGSpG94XX/gDUJYPau/e4PUWcOrc2Z8HqlcvqVQpCrUgIhgFAAAAAAAiatWqOD31VIzefFNauzb9+qZN/QGoiy6SateOxBYinAhGAQAAAACAfLdtm/Tee5aMPEZz51ZNt75CBWnAAH8Qql07uuEVJgSjAAAAgELqlPGnqFGlRurbrK/ObHxmpDcHAJSUJM2Y4e+GN3mytH+/FUpqsqe4OKlbN38eqLPPlkoy5kKhRDAKAAAAKISWbV6m2Wtmu9tv//5GMApARC1d6g9AvfGG9Pff6dc3bXpAV1wRp4suilWNGpHYQuQnglEAAABAITR5+eSU6d5Ne0d0WwAUTf/+K02Y4A9CzZuXfn3lytKFF0oXX5ys2rX/UfXq1RQbG4ktRX4jGAUAAAAU9mBUM4JRAPLHgQPSZ59ZHihp6lQpMTF4fXy8dOaZ/jxQPXpIxYv7R9DbtIk9VJQQjAIAAAAKmbXb12r++vluulWNVqpfoX6kNwlAIbdokb8FlI2GFyqw1Lq1Pw/UBRdIVdPnKkcRQzAKAAAAKGQ+WP5ByjRd9ADklc2bpbff9gehfvop/fpq1aSLLvIHoY45hv2AVASjACAMJk2SNm70T9u9zffpQ9ECACLj5Z9eTpkmGAUgN6xeO3y4tHKl1LixdM89UrFi/gDUtGnSwYPBj7dudz17+gNQXbv6HwukRTAKAMLwBd23b+q8fSHbfEICASkAQP7bvHuzft74s5suEVdCLaq2YDcAyFU9NyZG8vn8XfH69w/92Hbt/Hmgzj9fqlSJAkfmyFMPALlkV4rsC1pyf9y9zY8YQdECAPLfQ3MeSpnen7RfM1bPYDcAyJGhQ1MDUaHUqiXdfru0ZIn0ww/S9dcTiELW0DIKAHLJmiyn/YK2+RUrKFoAQP7y+Xx6Y9EbKfOxMbEaMmuIujToohj/lRMAOKTff5eee0765ZfQ62NjpY8/ljp1kuLiKFBkHy2jACCXrO982vq9zTdpQtECAPLXl399qX/2/pMyn+xL1rz18zR91XR2BYBMJSdLM2b48z01aCA98kjox1k99+ij/fmgCEQhpwhGAUAYmi/7W0Z5zaN8bt6WAwCQn62iHp73sGLTVPFt3lpH2XoASGvHDunpp6XmzaUuXaSpU1Nb/cf/15fKu/DqddmjnovcIhgFALlko+ZZsnLvy9ruLdlj794ULQAg/yQmJWr9rvVKVnLQcptfu2OtWw8AnmXLpBtukGrXlm68MTjFRJ060v33S+vW+eu5xxwjlSzpv6eei3AgZxQAhCkgVb26/wvb7glEAQDyW7G4YvqkzyfylfIp1hK6BKhWpppKxJdgpwBFXFKS9NFH/pZQn3+efv1pp/kDVOeck3qh1eq5dgPCiWAUAAAAUAiMnjNak5ZM0sDWAzWw1UBVKFkh0psEIEps2SK9/LI/KfmffwavK11auvhifxDqqKMitYUoaghGAQAAAAWc5YN6+5e3tWTzEi34bIF6Nu1JMAqAfvxReuYZ6e23pf37gwukYUNp0CDp0kulCsSukc8IRgEAAAAF3OJNi10gypxU9yTVr1A/0psEIEISE6WJE/1BqLlz06/v0cPfCspGw0vToxfINwSjAAAAgALu7cVvp0wPOGpARLcFQGSsXy+98IL/tnFj8LrDDpMuv1y6/np/iygg0ghGAQAAAAVYsi85JRgVHxuvfs37RXqTAOQTn0+aM8ffCspGvTt4MHi95YD6v/+TLrxQKlOG3YLoQTAKAAAAKMDmrJmjtTvWuulT65yqKqWrRHqTAOSxPXv8eaAsCPXzz8Hr4uL8IztbV7wOHaSYGHYHog/BKAAAAKCQdNHr3bB3RLcFQN5avdo/Ip6NjLd1a/C6qlWlq6+Wrr1WqlOHPYHoRjAKAAAAKKASkxL13tL33HSp+FLqVr9bpDcJQJglJ0szZ/pbQX30kb9rXqDjj/e3gurXTypRguJHwUAwCgAAACigpq+arn/3/uumezbpqTLFSAoDFBY7dkivviqNHSutXBm8rnhx6fzz/UGodu0itYVAzhGMAgAAAAqopZuXKi4mTkm+JEbRAwqJpUv9AajXX5d27QpeZ93vrrtOuuoqf7c8oKAiGAUAAAAUULefdLsua3WZJi6dqK4NumrbP9sivUkAcsBGwbMueE8/LX3xRfr1HTv6W0H17CnF8ysehQCHMQAAAFCAVS1TVde1u07JllgGQIGyZYv00kv+pORr1gSvK11aGjhQGjRIOuqoSG0hkDcIRgEAAAAAkI8WLPAnJJ8wQdq/P3hdw4b+VlCXXCJVqMBuQeFEMAoAAAAoYPYd3OdyRRWLKxbpTQGQRYmJ0sSJ/q54330XvC4mRurRwx+E6tJFio2lWFG4cYgDAAAABcz4n8ar9mO1dcPHN2jVv6sivTkAMrF+vXTffdLhh0sXXhgciLKWT7fc4h8tz3JGdetGIApFAy2jAAAAgALm7V/e1uY9mzV23lhd2ebKSG8OgDR8Pmn2bH9XvEmT/AnKAx19tPR//yddcIFUpgzFh6KHYBQAAABQgPy57U/NXjPbTTev2lwtq7eM9CYB+M+ePdLbb/uDUD//HFwscXFSnz7+rninnOLvmgcUVQSjAAAAgAJkwi8TUqYvOOoCxfCLFoi41aulZ5+VXn5Z2rYteF21atLVV0vXXCPVqROpLQSiC8EoAAAAoAB5e/HbKdMDjh4Q0W0BirLkZGnGDH8rqGnT/F3zAh1/vL8r3rnnSiVKRGorgegUdQnMd+7cqcGDB6tevXoqVaqUTjzxRM2bNy9l/bBhw9S0aVOVKVNGFStWVKdOnfT999+nrP/jjz90xRVX6IgjjnD/36BBAw0dOlSJNnQBAAAAUIAt3rhYizctdtPt67TXkRWPjPQmAUXO9u3SU09JzZr5E45b4nEvEGVBp0sukX74wZ+o3BKWE4gCCkDLqCuvvFK//PKL3njjDdWqVUtvvvmmCzgtXbpUtWvXVuPGjfXMM8/oyCOP1N69e/X444+rS5cu+u2331S1alUtX75cycnJeuGFF9SwYUP3XFdddZV2796tMWPGRPrtAQAAAOHponf0BZQkkI+WLJHGjpVef13avTt4Xd260nXX2e9ZqWpVdgtQoIJRFlxKSEjQlClT1KFDh5SWUFOnTtVzzz2nUaNG6QIbbiDAY489ppdfflmLFi3SGWecoW7durmbx4JWK1ascP9PMAoAAAAFVbIvOaWLXlxMnPo17xfpTQIKPRsFb+pUf1e8L75Iv75jR39XvLPPluKj6tc1EN2i6uNy8OBBJSUlqWTJkkHLrbvdbBsXMw3rejdu3Dgddthhatky41FEtm/frkqVKuXJNgMAAAD5Ye7aufpz+59uutORnVS9bHUKHsgjW7ZIL70kPfectGZN8LoyZaSBA6VBg6QWLdgFQIEPRpUrV07t27fXyJEj1axZM1WvXl0TJkzQ3LlzXZc7z0cffaTzzz9fe/bsUc2aNTVjxgxVqVIl5HNa972nn34601ZR+/fvdzfPjh073L1197NbuNlz+ny+PHnuooaypByjS+r4vHy+c47PdXhQjgWnLMPxvNRliob1O9erRtka2rBrgwYcNSDdscPnPvqwTwreflmwwFpBxejdd+3cmlq3M40a+XT99T4XiKpQwXuu/Nrqwo3PSsHeLzmpy0RVMMpYrqjLL7/c5YeKi4tTmzZtNGDAAC2ws8J/OnbsqIULF2rLli168cUXdd5557kk5tVszMwA69atc132+vXr5/JGZeTBBx/U8OHD0y3fvHmz9u3bF+Z36N9R1lrLdmpsbNTlkC9QKEvKMZokJVmCgDglJSVr06bNkd6cAovPNeVY1I5JG7wlt6jLFA2nVD5F8wfM17frv1XrSq21adOmoPWcP6MP+6Rg7Bdrl/DRRyU1fnxpLVhQPOixMTE+nXHGfl1++R6demqi7GvAxsZK8/FDmPcJCtZ+yUldJsZnzxqFLOG4tVCylk/9+/fXrl27NM3GywyhUaNGLoB11113pSxbv369TjvtNJ1wwgl69dVXMy24UFcT69atq61bt6p8+fJ5skMt0GUJ1/mgUZbRgGMy9yZNkgYMiNHBgzGKj/dpwgSf+vQJwxMXQRyPlGNROyat3mEjBFtlL6f1Duoyhd/M1TM1+LPBeqLrE66LXiicP6MP+yQ6JST4NHRoslavjtdhh0nW/mDHjuBWUBUq+HT55dK11/rUoEHENrXI4LNSsPdLTuoyUdcyylOmTBl3s4DQZ599ptGjR2daQIHBJGsRZa2n2rZtq/Hjxx+y4liiRAl3S8v+L6+CRTExMXn6/EUJZUk5RkMgqp/LIetLSXTZr1+sEhJEQCqH+FyHB+VYMMoyHM9JXaZws2vH9866V8u2LHP3nRt0dsdkKHzuow/7JPrqbeedZ1N27o1J18Lp6KP9CckvvDBGpUvbktCfNYQfn5WCu19yUpeJumCUBZ7sC7dJkyYu39Ntt92mpk2b6rLLLnOtpe6//3717NnTtZiybnpjx451wSfrimds2lpE1atXz+WJsiiep0aNGhF8ZwAKK+vla78JfD6vshLj5keMIBgFAMi9aSunad76eW7a7qevmq6uDbtStEA2ffeddOml3lxwkMlaSNmoeSef7K/XAchbUReMsmZd1t3ur7/+ciPg9e3b1wWgihUr5kbaW758uV577TUXiKpcubLatWunb775Ri3+G8bAkplbEMtuderUCXruKO2RCKCAW7nSzi/By2x+xYpIbREAoLCw+uvN029OmY+NidWQWUPUpUGXDFtHAQj8DElffy2NGiXNnJlxyVhHm1NOoeSAIhuMsmTkdgulZMmSmmTtKjNx6aWXuhsA5JfGjaXFi4MDUvb7oEkT9gEAIHesFdRv//6WMp/sS6Z1FJAFVi/77DN/EGrOnHRrg1pGUW8D8h8JiwAgl4YO9QJRXjTK5+ZtOQAAuWkVdc8X96RbHit/6yha/QPp2QjzH3wgtWsnde8eHIiyROTXXeelVPDX2/ypFqi3AfmNYBQA5JKNmmfJyuP/a2tq99aIs3dvihYAkHOJSYlatXVVuuXJStbaHWvdegB+SUnSO+9ILVv662ALFqSWTLNm0ptvSsuXS88+K73/frKaNTuokiV9OuYY6m1AJERdNz0AKKgBqerVbRAF/z2BKABAbpWIL6EzG52ptxa/5eYf7vSwOh3ZyU1XK1PNrQeKugMHpLfekh54QPr11+B1rVpJ997rr5cFDvZl9baTT/5H1apVU2wsudeASCAYBQAAAEShpOQkzVg9w02Xii+lQe0GqUzxMpHeLCAq7NsnjR8vPfyw9OefwetOOMEfhOrRg5HxgGhFMAoAAACIQt+u/Vabdm9y090adiMQBUjavVsaN0565BHp77+Di6RjR38Qyu4ZbBKIbgSjAAAAgCiUsCwhZbpPsz4R3RYg0nbskMaOlR57TNqyJXidJSq/5x7ppJMitXUAsotgFAAAABBlbKS8ScsmueliscV0VuOzIr1JQET884/01FP+27ZtwessF5QFodq2ZecABQ3BKAAAACDK/LP3H9U9rK4bNe+MI89QhZIVIr1JQL7asMHfCspGv7OueR5LRN6/v3T33dJRR7FTgIKKYBQAAAAQZaqUrqI5l8/R+p3rtW1fmuYgQCG2dq0/H9SLL/qTlHvi46WBA6U775QaNYrkFgIIB4JRAAAAQJSqVa6WuwGF3apV/pHxXn1VOnAgdXmJEtIVV0i33y7VqxfJLQQQTgSjAAAAAAARsWyZ9MAD0ttvS8nJqctLl5auvVa69VapFvFYoNAhGAUAAABEkY27NqpamWqKYWx6FGILF0r33y8lJFjC/tTl5ctLN9wgDR4sVa0ayS0EkJcIRgEAAABRpPMbnbV9/3b1bdZXY7qMUWxMbKQ3CQib777zB6E++ih4eaVK0s03+wNRFcjXDxR6BKMAAACAKPHrP79q8abFbvrbtd8SiEKhYC2fvv5aGjVKmjkzeF316tL//ufvkle2bKS2EEB+IxgFAAAARIlJyyalTFvLKKCgB6E++8wfhJozJ3hd3brSHXdIl18ulSoVqS0EECkEowAAAIAoMWl5ajCqT7M+Ed0WIKcsEfmHH/qDUAsWBK9r0EC66y7p4oul4sUpY6CoIhgFAAAARIG129fqh3U/uOmW1VuqQaUGkd4kIFuSkqT33vOPjvfLL8HrmjWT7rlH6t9fiudXKFDkcRoAAAAAosDk5ZNTpmkVhYLkwAHpzTelBx+Ufv01eF2rVtK990q9e0ux5OIH8B+CUQAAAEAUSFiWkDJNvigUBPv2SePHSw8/LP35Z/C6E07wB6F69JBiYiK1hQCiFcEoAAAAIMI27tqob/78xk03rtxYzas2j/QmARnavVsaN0565BHp77+D13Xs6A9C2T1BKAAZIRgFAAAARNiUFVPkky+lVVQMv+IRhbZvl8aOlR5/XNqyJXhd9+7+nFAnnRSprQNQkBCMAgAAACJsV+IuVShZQdv2bSNfFKLOP/9ITz4pPfWUPyAVyHJBWRCqbdtIbR2AgohgFAAAABBht7S/Rf933P/p6z+/Vtua/KpHdNiwQXrsMenZZ/1d8zyWiNxGxbv7bumooyK5hQAKKoJRAAAAQBQoFldMZxx5RqQ3A9Datf58UC++6E9S7omPlwYOlO68U2rUiIICkHMEowAAAAAAWrXKPzLeq69KBw6kFkiJEtIVV0i33y7Vq0dBAcg9glEAAABAhOw7uE+JSYkqX6I8+wARs2yZ9MAD0ttvS8nJqctLl5auvVa69VapVi12EIDwiQ3jcwEAAADIhqkrpqrqI1V15ttn6tu131J2yFcLF0r9+kktWkhvvpkaiCpf3p+U/M8/pUcfJRAFIPwIRgEAAAARkrAswbWM+vjXj7XnwB72A/LFd99JZ50ltW4tTZwo+Xz+5ZUqSSNH+oNQo0ZJVaqwQwDkDbrpAQAAABHqojft12luumLJijq13qnsB+QZCzh99ZU/yPT558HrqleX/vc/f5e8smXZCQDyHsEoAAAAIAJmrJqhXYm73PQ5Tc9xo+kBeRGE+uwzfxBqzpzgdXXrSnfcIV1+uVSqFGUPIP8QjAIAAAAiYNLySSnTfZr2YR8grCz/04cf+oNQCxYEr2vQQLrrLunii6XixSl4APmPYBQAAACQzw4kHdCU5VPcdNniZdW5QWf2AcIiKUl67z3p/vulJUuC1zVr5k9M3r+/FM8vQQARxCkIAAAAyGdf/vGltu7b6qbPanyWSsaXZB8gVw4c8I+I9+CD0q+/Bq9r1Uq6916pd28pliGsAEQBglEAAABAPpu0jC56CI99+6Tx46WHH/aPghfohBP8QagePaSYGEocQPQgGAUAAADko6TkJE1ePtlNW4uo7o26U/7Itt27pXHjpEcekf7+O3hdx47+IJTdE4QCEI0IRgEAAAD5aMOuDapZrqY27t6org26upxRQFZt3y6NHSs9/ri0ZUvwuu7d/TmhTjqJ8gQQ3QhGAQAAAPmodvna+uman7R662rtPbCXskeW/POP9OST0lNP+QNSgSwXlAWh2ralMAEUDKSvA4AwmDRJ2rjRP233Ng8AQCgzV89U87HNXTCqRbUWFBJC1itatpRKlZKaN5d69ZLq1ZNGjkwNRFki8gEDpMWL/Y8nEAWgICEYBQC5ZBXAvn2lgwf983Zv8wSkAABp+Xw+3f353Vq2ZZm7t3kgVL3CgkyWnHzZMmnKFH+OKBMfL11+ubR8ufT229JRR1F+AIpAN709e/ZoxowZmjNnjpYuXaotW7YoJiZGVapUUbNmzXTSSSepU6dOKlOmTN5sMQBEmeHD/clBfT5vmJoYNz9ihNSnT4Q3DgAQVSYunah56+e5abufvmq6ujbsGunNQhQZMsR/nzZOaXWL666Tbr/d30oKAIpEy6jFixfr0ksvVY0aNdS7d2+NHTtWv/32mwtE2RWdlStX6plnnnHr7DH2WPsfACjsVq5MX2G0+RUrIrVFAIBolJycrIsnX5wyHxcTpyGzhtA6Co61fLJueEuXhi6Q4sX9icsJRAEoMsGo/v37q3Xr1lq+fLmGDRumn3/+WTt27HDzc+fO1XfffacVK1Zo586dbp09xubtfwZYR2YAKMQaN04/bLLNN2kSqS0CAESjl358SfuT9qfMJ/mSUlpHoeiy7v3jxkkNG0r33Rf6MVavaNo0v7cMACIcjIqNjdX8+fNd0OmWW27R0Ucfrbi4uHSPs2W27tZbb3VBKvsfACjshg71WkZ5zaN8bt6WAwDgvhl8Pg3/eni6wohVLK2jiiirK1guqKOPlq65RtqwITUxufEudPlTAVCvAFAEg1ETJkxQq1atsv3k9j/2vwBQmFleqIQEf0JRY/eWfNSGWQYAwCQmJWrT7k3pCiNZyVq7Y61bj6Jj7lzplFP8o+RZInKP1R2WLPHXK445RipZ0n9PvQKAinoCc/P666+rQ4cOql+/fsj1f/zxh77++msNHDgwt9sHAAUmIFW9urRunf+eQBQAINBfO/7SwWT/sKstqrbQ671fT1lXrUw1lYgvQYEVkTyTd92VfsTdE0+URo+WTjrJP29d8hgEBUBhluUE5oEuu+wyffvttxmu//77791jAAAAAEiTlqVGHy4+5mK1qdkm5VanfB2KqJDbuFG6/nqpefPgQJTll5w8WZo9OzUQBQBFQXxO+7xnZvfu3Yr3+qsAAAAARVzCsoSU6T7N+kR0W5B/du2Sxowpq+efj3Gj5XmsFfXw4dIVV6R28weAoiTLp75FixZp4cKFKfPffPONDtrQD2ls27ZNzz//vBrb8FIAAABAEWdd9L5f972bPrra0WpUuVGkNwl57MAB6aWXLOAUo40by6YsL1NGuv126ZZbpLKpiwGgyMlyMGry5MkabuF7N6JDjF544QV3C6VChQourxQAAABQ1E1eNjllum+zvhHdFuQt60Bi3e4sL5Tlh5L8Q+LFx/t09dUxuu8+f6soACjqshyMuvrqq3XWWWe5LnrHHXecRo4cqW7dugU9xoJUZcqUUYMGDeimBwAAAFjPgX3bVKZYGe0+sFt9mxOMKqzmzJFuu80/Ul6gM8/cpzFjiqtpU39gCgCQxWBUmzZt9MADD6QEn8aPH6/mzZurbdu2lCEAAACQiSGnDtH/TvyfvvrzKzeSHgqX5culO++UpkwJXn7KKdJDDyXryCO3qVq1apHaPAAouKPpWb6oLVu2pMxffvnl+vXXX/NyuwAAAIBCo1SxUurWsJvrSYDC4e+/pWuukY46KjgQ1ayZf/6rr6QTTojkFgJAAQ9G1atXTzNnzlRSUpKbt656fJECAAAAKGp27pTL/dSwoTRunPTfTyTVrOmfX7RI6tnTUphEeksBoIAHo6699lqXkLxkyZIqX768C0RdccUVbjqj22GHHZb3Ww8AAABEqX0H92nPgT2R3gyESWKi9MwzUoMG0siR0p7/dm25ctKoUZJ1HLnqKktWTpEDwKFk6VR52223qWXLlpo1a5Y2btyo1157Te3atdORRx6ZlX8HAAAAipyJSyfqmo+uUfeG3XXXyXepbS3yrRbUEfImTpTuvlv67bfU5RZ0uu46acgQqWrVSG4hABQ8WY7bd+nSxd3Mq6++qmuuuUYXXHBBXm4bABQYkyZJGzf6p+3e5vv0ifRWAQAi6bn5z7mWUQnLEnTT8TexMwoA+/4ePlxauVJq3Fjq10/66CPp+++DH3feedL99/u76gEAsi9HjUiTk5Nz8m8AUGgrrn0DRuo+eNA/n5BAQAoAiqqd+3dq7tq5bjo+Nl7t67SP9CYhi9/nluvJWkNZ7ie7BTr1VGn0aOm44yhOAMjznFFr167N8Qvk5n8BoCCwK6j+JKVeptIYNz9iRGS3CwAQOQ/PeVg++dz0weSD+vz3z9kdBeT73AJRabVo4W8hNWsWgSgAyLdgVMOGDXX55Zfrhx9+yPITf/vttxo4cKAaNWqUm+0DgKhnTfnTVlxtfsWKSG0RACCSbOTpZ+c9mzIfGxOrIbOGuOWITrZrli0LHYiy3FA//yydeSYj5AFAvnbT++abb3TvvffqhBNOUL169XT66aerTZs2OuKII1SxYkX3xbp161b9/vvvmj9/vr744gutW7dOHTt21Ndffx22jQWAaGQ5JRYvDq7A2pXVJk0iuVUAgEiZvGyytu7bmjKf7EvWvPXzNH3VdHVt2JUdE4UXla6/XjpwIP06+z63VlFxcZHYMgAo4sGo4447TtOnT9fChQs1fvx4TZkyxd2bGH/flJQrPXXr1lWvXr1cS6pWrVrl5bYDQFQYOtTLGWXnQTsn+uTzxbjlAICixerEt864Nd3yWPlbR3Vp0CWl/ozI2rdPeugh6cEHpcTE9Ou9Lnt8nwNAhBOYW3DpySefdLf169dr+fLl+ueff9y6ypUrq2nTpqpVq1YebCYARC8bNc+Slffv709ebs3533tP6t070lsGAMhviUmJWrdjXbrlyUrW2h1r3foS8SXYMRE2c6a/NdSvv6YuO/xwyQYL/+QTf1d7a+FsgSi+zwEgSkbTMxZ0IvAEAKkBqerVpXXr/PdUXAGgaNq8Z7MOJPv7e9UpX0cf9P8gpSVUtTLVCERF2IYN0q23Sm+/nbrMLiLdcot0331SmTL+llIAgCgNRgEAAAAIZq2iWlRtoSWbl+jK1leqba22FFEUSEqSxo2T7rpL2r49dflJJ0nPPScdfXQktw4Aih6CUQAAAECYHF/neC2+brEWbVzkWkIh8n76Sbr2WilwYPBKlaTRo6XLLpNiszS+OAAgnAhGAQAAAGFk3fJa1mhJmUbYzp3+rndPPSUlJ6cuv/RSfyCqatVIbh0AFG0EowAAAAAUGjYC3qRJ0k03+XM5epo183fJO/XUSG4dAMBEXaPUnTt3avDgwapXr55KlSqlE088UfPmzUtZP2zYMDdqX5kyZVSxYkV16tRJ33//fdBz/Pvvv7rwwgtVvnx5VahQQVdccYV27doVgXcDAACAoiDZl6ylm5dGejOKvN9/l846Szr33NRAVMmS0gMPSAsXEogCgGgRdcGoK6+8UjNmzNAbb7yhxYsXq0uXLi7gtO6/b5PGjRvrmWeecetmz56t+vXru8ds3rw55TksELVkyRL3PB999JG+/vprXX311RF8VwAAACjMvvnzG7V4toVaPd9Kk5dNjvTmFDmJif5R8Fq0kD7+OHV59+7SkiX+xOXFi0dyCwEAYemmt3XrVk2YMEGrV6920z5rD5umr/zLL7+crefcu3evEhISNGXKFHXo0CGlJdTUqVP13HPPadSoUbrggguC/uexxx5zr7No0SKdccYZWrZsmT799FPXmurYY491j3n66afVo0cPjRkzRrVq1crpWwYAAABCemvxW+7+540/a+/BvZRSPvr6a3+C8mXLUpdZld9yRfXpY79L2B0AUCiCUZ999pnOPfdc7d6923WFs+5yaVkwKrsOHjyopKQklbS2tAGsu561gkorMTFR48aN02GHHaaWLf1JIufOneu65nmBKGMtq2JjY113vt69e2d7uwAAAICM7D+4X+8vfd9NlylWRuc0OYfCygdbtki33y6NH5+6zEbG+7//k0aMkMqXZzcAQKEKRt16662qUaOGJk2apKOPPjpsG1OuXDm1b99eI0eOVLNmzVS9enXX+soCTA0bNkx5nHW9O//887Vnzx7VrFnTdcerUqWKW7dhwwZVqxY8jG58fLwqVark1oWyf/9+d/Ps2LHD3ScnJ7tbuNlzWkuyvHjuooaypByjS2oQns93zvG5Dg/KseCUZTiel7pMZH208iNt27fNTfdq2kul4ktF5HugqHzu7e29+qp0xx0x+vff1O/edu18evZZn9q0SX1cpBWVfVLQsF+iD/ukYO+XnJzjchSM+u233/TII4+ENRDlsVxRl19+uWrXrq24uDi1adNGAwYM0IIFC1Ie07FjRy1cuFBbtmzRiy++qPPOO8+1ekobhMqqBx98UMOHD0+33PJQ7du3T+FmO2r79u1up1qLLVCWkcYxGR5JSTZGdJySkpK1aVNqHjtwPEYCn+uCU5Y2eEtuUZeJrFfmv5IyfWbdM7Vp06aIbEdR+NwvXx6vO+4orx9+SE0AVa5csu6+e6cuvniv4uKkCBV/kd0nBRH7JfqwTwr2fslJXSZHwahGjRqFpeIUSoMGDfTVV1+5LoDWQslaPvXv319HHnlkymNsJD1rKWW3E044wW2P5Y266667XIuttBUA6/5nI+zZulDs/2655ZaUeXvdunXrqmrVqq4bYl7sUOvGaM/PlxJlGQ04JsMjLs5/dTYuLjbHwXFwPIYLn+uCU5Zp0xPkBHWZyLEWUTPXzHTT1cpUU9/WfRUfm+O0rLlSmD/3u3dLo0bF6LHHrG6f2hrq/PN9evRRqUaNchaWUrQpzPukIGO/RB/2ScHeLzmpy+Tom9ISiQ8aNMglE7fR7PKCBZzsZsnRLUfV6NGjMy0gr5uddfPbtm2ba0nVtm1bt+yLL75wjzn++OND/n+JEiXcLS0r7Lz60rAdmpfPX5RQlpRj9EgdyIHPdu7wuQ4PyrFglGU4npO6TORMWj5JiUmJbnrAUQNUPD6yQ7YVxs/9Rx9JN9wg/fln6jLL4PHss1LnzhaYiu4M5YVxnxQG7Jfowz4puPslJ+e3HAWjPv/8cxcZs7xOnTt3dq2IrEtd2g1+8skns/3cFniyJmBNmjRx3QFvu+02NW3aVJdddplrLXX//ferZ8+ersWUddMbO3as1q1bp379+rn/t23q1q2brrrqKj3//PM6cOCAbrjhBpdjipH0AAAAkBej6JkLj76Qwg2jtWulm26SJk9OXVa8uLUElO68067EU9wAUFDlKBj1zDPPBCUTDyWnwSjrj2hNzf/66y+XdLxv374uAFWsWDE30t7y5cv12muvuUBU5cqV1a5dO33zzTdq0aJFynO89dZbLgB1xhlnuAidPcdTNrYrAAAAECZrt6/Vl3986aYbV26sY2uljuaMnDt4ULKq+333+bvnec44w98aqnFjShcAimQwKi9Hg7Bk5HbLqB+ijeB3KBbEevvtt/Ng6wAAAAC/PQf2qE+zPm40PWsVZRdjkTvffSdde63088+pyywN4+OPSwMG2AVvShgACoPIZFcEAAAACrgmVZoo4bwEl8Tc0kwg57Zu9Xe/GzdO8orSAk8WmLr/fqliRUoXAAqTXAWjfv/9d33yySf6879sgvXq1VP37t11xBFHhGv7AAAAgKhWoWSFSG9CgWWBp7fekm69VQocELtVK+n556UMxh8CABTVYNStt97qckKl7bJnOZoGDx6sMWPGhGP7AAAAABRCK1ZI119vI1+nLitbVho50j96Xjx9OACg0MrR+KKPPvqoHn/8cfXp00dz587Vtm3b3M2mzz33XLfObgAAAEBhk+xL1pTlU7Tv4L5Ib0qBtG+fNHSodMwxwYGoPn2kZcukwYMJRAFAYZej6w0vvviievbsqffeey9o+fHHH6933nlH+/bt0wsvvKCbb745XNsJAAAARIWv//xavd7tpcNKHKZRp4/SDcfdEOlNKjCmT/e3hlq1KnVZvXo2Wrd01lmR3DIAQNS3jPrjjz/UtWvXDNfbOnsMAAAAUNi8uehNd799/3ZVKV0l0ptTIPz9t380PPsJ4QWirBvenXdKS5cSiAKAoiZHLaOqVaumnwPHW03D1lWtWjU32wUAAABEHeuaN3HpRDddtnhZ9WzSM9KbFNWSkvyJyO++W9qxI3X5ySf7l7doEcmtAwAUqJZR/fr100svvaSHHnpIu3fvTllu0w8//LBb179//3BuJwAAABBx01ZOcy2iTJ9mfVS6WOlIb1LU+vFH6YQT/MnIvUBU5crSK69IX31FIAoAirIctYwaOXKkFi5cqLvvvlv33XefatWq5ZavX79eBw8eVMeOHTVixIhwbysAAAAQUW8tfitl+sKjL4zotkQrCzwNGeLPAxU48Pbll0sPPyxVoWcjABR5OQpGlS5dWp9//rmmTJmiTz75RH/++adb3q1bN/Xo0UNnn322YmJiinzhAgAAoPDYunerpv06zU3XKFtDpx9xeqQ3Kar4fNLEidJNN/lzRHmaN/d3yTvllEhuHQCgwAejPOecc467AQAAAIWd5YpKTEp00+e3OF/xsbmqShcqq1dLgwZJn36auqxUKWnoUMkG2C5ePJJbBwCINnyDAgAAAFnw5mL/KHrmomMuoswkJSZKY8ZYGg9p377UIjnzTH83vfr1KSYAQA6DUUcccYRiY2O1fPlyFStWzM0fqhuerV/ljdsKAIXcpEnSxo3+abu3+T59Ir1VAIBweWvRW/r6z6/ddJPKTdSmZpsiWbj2/TZ8uLRypWRpY/fvl9atS11fu7b09NNSr172eyCSWwoAKPDBqFNPPdUFlywgFTgPAPBXzPv2TS2Jgwf98wkJBKQAoDDw+Xx65NtH3HTxuOIucXlRrAt733f21i0/lHXN88TF+XNFDRsmlSsXya0EABSaYNSrr76a6TwAFGV2hdhfMfd+mMS4eRtUlNZRAFDwTV81XT9v/NlNW86oVjVaqWh/3wUvt9xQ334rtSqaxQIAyAF/U6dsev311/XHH39kuN5G17PHAEBRYF0V0lbMbX7FikhtEQAgnK2ihswaoriYODdv9yO/HumWFyWWD2rJkvTfdyY5mUAUACAfglGXXXaZvrXLHxn47rvv3GMAoCho3Dh9Xgybb9IkUlsEAAhnq6h56+cpyZfk5u3e5m15UWFBqHbtpCR/EaT7vmvaNBJbBQAocsGoQ10J2r17t+LjGagPQNFgw1b7T4veudHn5m05AKDgsjrvvV/ca52vg5bHKta1lirsraPs7T37rHTssdIvv6Qu9y7AeF32+L4DAGRXliNGixYt0sKFC1Pmv/nmGx20LL1pbNu2Tc8//7waW1MBACgCLC+UJSvv39+fvNxi8e+9J/XuHektAwDkhuWHWrV1lV1iCFqerGSt3bHWrS8RX6JQFvKWLdIVV0gffpi67Kij/Mssfax1RbcWwBaI4vsOAJBnwajJkydruGUtdFdBYvTCCy+4WygVKlQgZxSAIheQql7dP7y13VMxB4CCzwJNnY/srPeWvufmHzz9QXVp2MVNVytTrdAGoj7/XLr4Yunvv1OX/d//SQ8/7E9WPnhwJLcOAFCkglFXX321zjrrLNcc+bjjjtOIESPUvXv3oMdYkKpMmTJq0KAB3fQAAABQoO07uE+frvrUTZcrXk43nnCjShcrrcIqMVEaMkR65JHUROVVqkjjx0tnnRXprQMAFMlgVM2aNd3NzJo1S82aNVO1atXyctsAAACAiPlo5UfasX+Hm+7TrE+hDkT9+qt0wQXS/Pmpyzp3ll57zX4HRHLLAACFUY4SmJ966qkEogAAAFCovbnozZTpi465SIWRtYCyHFCtW6cGoooVk8aMkT79lEAUACBv5HjIuw0bNujll1/Wjz/+qO3btys5OTldl73PrcM5AAAAUMD8u/dfffzrx266Ztma6li/owqbbduka6+V3n03dZmNQTRhgtSmTSS3DABQ2OUoGGUj65122mnau3evmjRposWLF6t58+ZuJL1169a5nFF169YN/9YCAAAA+eD9Je/rQPIBNz3gqAGKi40rVOU+Z46/W96aNanLbKS8J56QypaN5JYBAIqCHHXTu/POO1W2bFmtWLFCM2fOdEnNn3zySa1du1bvvvuutm7dqoceeij8WwsAAADkgzcXp3bRu/CYCwtNmR88KNkA2R06pAaiKlSQ3ntPeuklAlEAgCgORs2ZM0fXXHONDj/8cMXG+p/C66bXr18/XXjhhbrtttvCu6UAAABAPvhj2x+avWa2m25WpZla12hdKMr9zz+l006Thg2zurt/2SmnSD//bHX4SG8dAKAoyVEwygJP1atXd9MVKlRQXFyc/v3335T1Rx99tBYsWBC+rQQAAADySdXSVfVar9fU+cjOGthyoMuFWtBZXqiWLf3d80xcnDRihI2SLR1+eKS3DgBQ1OQoZ9QRRxyh33//3U1byyibt+565513nlv27bffuiAVAAAAUNCUKV7GBaHsZukoCrJdu6Qbb5TGj09dVr++9NZb0oknRnLLAABFWY5aRnXp0kXvv/9+yvx1112nl156SZ06ddIZZ5yh1157TRdYRkQAAACgACvIraLmz/ePihcYiDr/fGnhQgJRAIAC2DLqnnvu0YABA3TgwAEVK1ZMgwcP1u7du5WQkOC67A0ZMkR33313+LcWAAAAQKYsH9SYMVZn9ycsNzZC3tix0sUXW4CNAgQAFMBgVMWKFdW2bdugK0b33nuvuwFAUTRpkrRxo3/a7m2+T59IbxUAIDuSkpPU992++mnDTxp39jh1bdi1wBSgfe8MHx6j5curq3hxf/c8T7t20ttvSw0bRnILAQDIZTe9Z599Vps3b87JvwJAoWM/APr2Tb36bPc2b8sBAAXHrN9nacrKKVqzY40unHRhgckX5X0PLV4sJSbGaNeu1KZPd94pzZ5NIAoAUAiCUTfccINq166tzp076+WXXw4aSQ8Aiprhw70uD17lP8bN2yhFAICCY/S3o1Om/9n7j6avmq6CYNgw/73PF9z/rkED6cEH5VpKAQBQ4INRy5cvd13y/v77b1111VWqWbOmevTooTfeeEM7duwI/1YCQBRbudJ+AAQvs/kVKyK1RQCA7Np/cL+++P2LlPm4mDgNmTUk6ltH7dwpLVkSet26dfm9NQAA5GEwqnHjxrrvvvv0yy+/aPHixbr99tu1evVqXXLJJapevbp69eqld955JydPDQAFTuPG6ZPB2nyTJpHaIgBAdo35doySfEkp8zY9b/28qG4d9eef0kkn+ROWp8X3EACg0AWjArVo0UIjR450raV++uknN7LerFmzdNFFF4VnCwEgyg0d6rWM8q6e+9y8LQcARD9r/fTE90+kWx6r2KhtHTV3rnTccf48UZ6YGF/KPd9DAIBCHYzyLFq0SO+9954mTpyonTt3qkSJEuF6agCIajZqXkKCFP/f+KR2b8lke/eO9JYBALJi74G9+mfPP+mWJytZa3esVWJSYlQV5FtvSR07Sps2+edtlLynnpKOPloqUcLn7vkeAgBEs/9+OuXM0qVL9e6777og1MqVK1WsWDF17dpVw4cPV8+ePcO3lQBQAAJS1av783PYPYEoACg4flj/g7VpddOn1z9dj3R5JGVdtTLVVCI+Oi6yWne8++6T7r8/dZkFpSZOlCpVkgYN8mnTpk2qVq2aYmPT9B8HAKCgB6OsW54FoCwYFRcXpzPOOEN33nmnyxV12GGHhX8rAQAAgDySsDQhZfrKNleqTc02UVfWe/ZIl1ziDzx5rrpKGjtWKlYsklsGAEA+BaNGjBihU089VTfeeKP69OmjypUr5+RpAAAAgIhK9iVr8vLJbrp4XHGd2fjMqNsj1ur2nHOkBQv887Gx0qOPSjfdlH4ADQAACm0wat26da75LwAAAFCQxShG75z7jmsdtefAHpUvUV7RxAJQlv1i/Xr/fLlykg1a3aNHpLcMAIB8DkZ5gaj9+/frxx9/dH3TTzrpJFWpUiUXmwIAAADkr5iYGJ18+MnuFm2sS97AgdLevf75+vWlqVOlo46K9JYBABCh0fSeeuop1axZUyeffLLrqmej6ZktW7a4oNQrr7ySy00DAAAAih6fTxo1SurXLzUQddJJ0vffE4gCABThYNT48eM1ePBgdevWTS+//LJ89o35HwtEnX766XrH2g8DAAAAyLJ9+6SLLpKGDEldZq2jPv/ceidQkACAItxN79FHH9U555yjt99+W//880+69W3btnUtpwAAAIBo9drC17QrcZd6N+utWuVqRXpztHGj1KuX9N13/nlLTv7gg9Ltt5OoHABQuOSoZdRvv/2m7t27Z7i+UqVKIYNUAAAAQLR4aM5DuuGTG3T444fr373/RnRbLONFu3apgajSpaVJk6Q77iAQBQAofHIUjKpQoYLLDZWRpUuXqkaNGrnZLgAAACDPLNu8TMu3LHfT7eu2V6VSlSJW2paU/MQTpbVr/fN16kizZ/tbSQEAUBjlKBjVo0cPjRs3Ttu2bUu3bsmSJXrxxRfV08agBQAAAKJQwrKElOm+zfpGZBss7eqYMdI550i7d/uXHXec9MMPUuvWEdkkAACiNxg1atQoJSUl6aijjtK9997rhsR97bXXdNFFF+nYY49VtWrVdN9994V/awEAAIAwB6P6NOuT72WamChdcYV0223+oJTp31/68kupZs183xwAAKI/GFWrVi0tWLDAjab37rvvutH03njjDU2dOlUDBgzQd99950bVAwAAAKLN6q2rtXDDQjfdrlY7HX7Y4fn6+pbtonNnG6E6ddmwYdKECVKpUvm6KQAAFJzR9Iy1fnrppZfcbfPmzUpOTlbVqlUVG5uj+BYAAACQLyYtmxSxVlFLl0pnny2tXu2fL1lSevVVf6soAACKihwHowJZEAoAAAAoCCKVL+qzz6TzzpN27PDP23g/U6b480QBAFCUZCkYNWLEiGw/seWRGjJkSE62CQAAAMgTf+34S9/99Z2bPrra0WpUuVGel7TlhHrmGWnwYCk52b+sVSvpww+lunXz/OUBACiYwahh1ok9mwhGAQAAINpMXjY5X1tFHTgg3XST9Nxzqct69ZLefFMqUybPXx4AgIIbjLJ8UAAAAEBB169FP8XFxrmuen2b520wautWf7e8mTNTl911l41MLZFmFQBQlIUlZxQAAABQENQoW0PXt7ve3fLSr7/6E5WvWOGfL15cevFFaeDAPH1ZAAAKhCwPfffDDz/o33//zdJjf//9d73++uu52S4AAACgQJo1Szr++NRAVJUq0uefE4gCACDbwaj27dvr008/TZm3wFTp0qX11VdfpXvst99+q8suuyyrTw0AAAAUCtb6qUsXfxc906KFXdSVTj450lsGAEABDEb5bBiQNPP79u1TUlJSXmwXAAAAEDbb9m3TzZ/erG/+/EZJyeGvv1qV+Oabpauvlg4e9C/r0cMu0kpHHBH2lwMAoGgEowAAAICCauqKqXri+yfU4dUOGjJrSFife8cOqWdP6YknUpdZYOrDD6Xy5cP6UgAAFAoEowAgDCZNkjZu9E/bvc0DAKLHc/OfS5nu0ahHrp/PzvMtW0olSkjVqkkff+xfHh8vjRsnPfaYFBeX65cBAKBQYjQ9AAjDD5K+AaODW/cMm09IkPr0oXgBINJ27t+p7/76zk3Hx8arfZ32YTnvx8RY6orU5WXKSFOnSh075naLAQAo3LIVjPrjjz/0448/uunt27e7+19//VUVKlRIN5oeABQVw4d7P0hi/lsS4+ZHjCAYBQDR4MHZD8onf9ToYPJBzVw9U10bdg3DeT94ed26BKIAAAh7MGrIkCHuFuj6669P9zhLbh5j39AAUASsXJn+B4nNe0N6AwAix+qlz89/PmU+NibW5Yzq0qBLjuury5alP++bP/7IzZYCAFB0ZDkYNX78+LzdEgAooBo3lhYvDv5hYr9vmjSJ5FYBAMzUlVO1dd/WlMJI9iVr3vp5mr5qeo5aR73yinTgQPrlnPcBAMiDYNQll1ySjacFgKJj6FAvZ5RFo+wqu8912bPlAIDItoq6dfqt6ZbHKmetoywx+TXXpF/uddnjvA8AQAEcTW/nzp0aPHiw6tWrp1KlSunEE0/UvHnz3LoDBw7ojjvu0NFHH60yZcqoVq1aGjhwoNavXx/0HCtXrtQ555yjKlWqqHz58jr55JM1a9asCL0jAEWBJSm3ZOU2gpKxe0tu27t3pLcMAIq2xKRE/bXjr3TLk5WstTvWuvVZNXZscCDqrLP8o+mVLCkdcwznfQAACuxoeldeeaV++eUXvfHGGy7Y9Oabb6pTp05aunSpypYt65KnW86qli1bauvWrbrpppvUs2dPzZ8/P+U5zjrrLDVq1EhffPGFC2g98cQTbtmqVatUo0aNiL4/AIU7IFW9urRunf+eQBQARJ61eioeV1z7Du5T6fjS+nzg5yoeX9ytq1ammkrEl8jS8zzxhHTzzanzt98uPfSQv0UUAAAowMGovXv3KiEhQVOmTFGHDh3csmHDhmnq1Kl67rnnNGrUKM2YMSPof5555hkdd9xxWrNmjQ4//HBt2bLFje738ssv6xi7RCWrKDykZ5991gW5CEYBAAAUHXExcZrYb6ISliWoRFwJnVD3hGw/xyOP+INPnnvukUaOJBAFAEChCEYdPHhQSUlJKmltnQNY66bZs2eH/J/t27e7K14VKlRw85UrV1aTJk30+uuvq02bNipRooReeOEFVatWTW3bts2X9wEAAIDoEBcbp84NOrtbTjzwgD/45Bk2TLrvPgJRAAAUmmBUuXLl1L59e40cOVLNmjVT9erVNWHCBM2dO1cNGzZM9/h9+/a5HFIDBgxwuaGMBaZmzpypXr16ueeLjY11gahPP/1UFStWzPC19+/f726eHTt2uPvk5GR3Czd7TkuomRfPXdRQlpRjdEntr8HnO+f4XIcH5VhwyjIcz0tdJrwsGbm1fho+PDW96qhRybrrLv+6wNFTowmf++jDPolO7Jfowz4p2PslJ3WZqAlGGcsVdfnll6t27dqKi4tzrZss2LRgwYKgx1ky8/POO88VinXh89j8oEGDXADqm2++ca2qXnrpJZ199tkuEXrNmjVDvu6DDz6o4cOHp1u+efNmF/QKN9tR1qrLttcCZqAsI41jMjySkqradXglJSVr06bNYXrWoofjkXIsasekDeCSW9RlwscCTQ8/XFZPPlk2ZdmQITt0xRV7tGmTohrnz+jDPolO7Jfowz4p2PslJ3WZGJ89a5TZvXu3a51kwaP+/ftr165dmjZtWlAgavXq1S5JuXXN83z++efq0qWLS27utZYyltD8iiuu0J133pnlq4l169ZN9zzh3KEW6KpatSrBKMoyKnBMhsfhh8do3boY1a7t05o1UXdqLTA4HinHonZMWr3DWnBbZS+n9Q7qMum9+OOLrpveOY3PUeXSqfXFzFit+M47YzRmTGpL18ceS9ZNN6lA4PwZfdgn0Yn9En3YJwV7v+SkLhNVLaM8ZcqUcTcLBn322WcaPXp0UCDKkpTPmjUrKBBl9uzZ4+7TFpLNZ9ZszHJL2S0t+7+8arlkXQrz8vmLEsqScoweqQEoPtu5w+c6PCjHglGW4XhO6jLBkn3JGvn1SK3buU43FbtJm2/brNLFSh8yEHXrrf6R8zzPPCMNGlSw6mp87qMP+yQ6sV+iD/uk4O6XnNRloioYZYEna6hlSch/++033XbbbWratKkuu+wyF4g699xz9eOPP+qjjz5yyc43bNjg/q9SpUoqXry4yzll0bhLLrlE9913n+um9+KLL+r333/XmWeeGem3BwAAgHwwb908F4gyp9U/7ZCBKLtmeeON0tixqcteeEG6+uq83lIAAIqmqLrUY026LOeTBaAGDhyok08+2QWoihUrpnXr1unDDz/UX3/9pVatWrkufN7t22+/df9fpUoVl6zcuvWdfvrpOvbYY91IfFOmTFHLli0j/fYAAACQDxKWJaRM923W95CBqOuuSw1ExcRIL79MIAoAgLwUVS2jrAue3UKpX7++azV1KBaAsgAWAOSnSZOkjRv903Zv8336sA8AIL9ZffGNRW+46VjFqmeTniEfZ+fpYcOkpUttAAr/Mutl8Oqr0sUX5+cWAwBQ9ERVyygAKIjsB03fvtLBg/55u7d5Ww4AyF8LNyzUhl3+VA5lipdR5VKVMzxvL16cGogy1lWPQBQAAHmPYBQA5NLw4f5uHZI3+lKMmx8xgqIFgPz2yLePpEzvTNyp6aumhzxvp2Xn7Vmz8nrrAACAIRgFALm0cqV/FKZANr9iBUULAPndRW/ysskp83ExcRoya0i6VA/WNS/9/3LeBgAgvxCMAoBcatzYaxmVyuabNKFoASA/vfTjS9qXtC9lPsmXpHnr5wW1jnrppdRu1YE4bwMAkH8IRgFALg0d6rWM8q68+9y8LQcA5A9r/TT8q/T97yyJudc66oMPpGuuSV3nXUiwe87bAADkH4JRAJBLNmpeQoIU/9/4pHZvyXF796ZoASC/JCYlan/S/nTLk5WstTvW6vOvEnX++VJysn/5WWdJxxwjlSzpv+e8DQBA/vnvpxMAILcBqerVpXXr/PcEogAgf5WIL6Efr/5Rm/dsTrfunzXVdG7XEtr/X6zqoouk116TYrksCwBARBCMAgAAQKFQ97C67hbo99+lM3tJ27f757t1k155hUAUAACRxPUgAAAAFEqbNkldukgbNvjnjz9emjhRKlYs0lsGAEDRRjAKAAAABdr6net118y7NH/9fJeo3OzcKfXoIf32m/8xTZtK06ZJZcpEdlsBAADBKAAAABRwk5ZN0kNzHlK7F9vpkW8fcbmhLHffggX+9XXqSJ99JlWuHOktBQAAhpZRAAAAKNASliWkTHc+opsGDpQ+/9w/X7GiPxB1+OGR2z4AABCMYBQAAAAKrM27N+vrP7920w0rNdRLDxyt997zrytVyt81r3nzyG4jAAAIRjAKAMJg0iRp40b/tN3bPAAg7z04+0El+5Ld9KqpffXs2Bg3HRcnvf++1L49ewEAgGhDMAoAcskCT337SgcP+uft3uYJSAFA3rJk5c//8HLq/JI+KdPXXy+deSZ7AACAaEQwCgByafhwKcZdiPdfjbd7mx8xgqIFgLzOFbU3eUfqglL/+s/CMdLX/p57AAAgChGMAoBcWrnSrs4HL7P5FSsoWgDIy1ZR/5v+v4AFMdLp99kE52AAAKIcwSgAyKXGjb2WUalsvkkTihYA8sr0VdP15/Y/A068Pqn2PKnBdM7BAABEOYJRAJBLQ4d6LaO85lH+q/K2HACQN62i7ph5R+pp15McK50+xK3nHAwAQPQiGAUAudSnj5SQIMXH++ft3pKX9+5N0QJAXkhMStSvG/5OTdXniU1WfOW1endiIudgAACi2H8/nQAAuQ1IVa8urVvnvycQBQB554OEEtrz+HypzGbXJe/pp6X27f3rqpWppjrlS1D8AABEMVpGAUAYWEuojRv903Zv8wCA8LHzasuWUokS0vl3z5Qu7upGz3vstjYa1KeN2tT03+qUr0OxAwAQ5QhGAUAYfiD17SsdPOift3ubJyAFAOE9zy5eLCUm+qQz7paqLlO5XnfrxhvTJo4CAADRjmAUAOTS8OHeaHpe8pIYNz9iBEULAOE8z7rBIhp85h81T9LO8vM0Y/V0ChkAgAKGYBQA5NLKld5oeqlsfsUKihYAwnue9Uldbwk42UpDZvlHzwMAAAUHwSgAyKXGjb2WUalsvkkTihYAwuGII/6baDBdqrYs4GQrzVs/T9NX0ToKAICChGAUAOTS0KEBV+wdn5u35QCA3KtU6b9zbKc7U0+1/4lVLK2jAAAoYAhGAUAu9ekjJSRI8fH+ebu3ZLu9e1O0AJBbn38uzZkjKS5RqvRbanq+/yQrWWt3rFViUiKFDQBAAfHfTycAQG4DUtWrS+vW+e8JRAFA7u3fLw0a9N+ML06HlSqn7cm73OyH53+o2uVru+lqZaqpRHwJihwAgAKCYBQAAACi0qOPpg4G0eTsj7Qi+W83fWajM3V2k7Mju3EAACDH6KYHAACAqPPHH9KoUf7p2FipQpexKesGtfOaSwEAgIKIYBQAAACizk03SXv3+qcvvGm5vt880003qNhAXRt2jezGAQCAXCEYBQAAgKgydar04Yf+6Zo1pbZ9vlbMf5nLr293vWJjqMICAFCQkTMKAAAAUWPPHunGG4PzRg04+Wqdc1QXvTD/BV3W6rJIbh4AAAgDglEAAACIGg8+6M8XZU4/XTr/fP90/Qr19WCnByO6bQAAIDxo4wwAAICosHKlNHq0f7pYMWnsWCnG3zsPAAAUIgSjAAAAEHE+nzRokJSY6J//3/+kynU360DSgUhvGgAACDOCUQAAAIi499+XZvoHzNPhh0v33CNd//H1qv9kfY34aoR2Je6K9CYCAIAwIRgFAACAiNq5U7r55tT5p56StiWt0+Rlk7V+53o9O+9ZFY8rHslNBAAAYUQwCgAAABE1bJi0fr1/+swzpZ49pXELxinJl+SWXdXmKoJRAAAUIgSjAAAAEDGLF0tPPumfLlnS3yrqQHKixv04zi2Li4nTNcdewx4CAKAQIRgFAACAiCUtv/56KcnfAEp33y0deaQ0adkkbdi1wS3r1bSX6pSvwx4CAKAQIRgFAACAiHj9dWn2bP90o0bSbbf5p8fOG5vymEHtBrF3AAAoZAhGAQAAIN9t3ZoafDLPPOPvprdo4yLNXuOPUDWv2lyn1T+NvQMAQCFDMAoAAAD57p57pM2b/dP9+klduvinx/4Q3CoqJiaGvQMAQCFDMAoAAAD5at486fnn/dNly0qPP+6f3rZvm95c/KabLle8nC4+5mL2DAAAhRDBKAAAAOQbS1ZuScstebkZNkyqXds/fSDpgK5uc7UOK3GYBrYcqHIlyrFnAAAohOIjvQEAAAAoOsaNk+bP908fdZR0442p66qWqarHuz2uUaeP0t6DeyO2jQAAIG8RjAIAAEC+2LRJuvvu1Plnn5WKFUv/uDLFy7gbAAAonOimBwAAgHxx++3Stm3+6UsukU45hYIHAKAoIhgFAACAPPfNN9Jrr/mnK1SQRo9OXffHtj80es5o/bPnH/YEAABFAMEoAAAA5KkDB/xJyz0PPCBVq5Y6/9y853THzDtU+7Ha+nDFh+wNAAAKOYJRAAAAyFNPPy398ot/+thjpauvTl237+A+vfzTy2462Zes42sfz94AAKCQIxgFAACAPLNunTR0qH86JkZ67jkpLi51/bu/vKt/9vq75/Vr0U/Vy1ZnbwAAUMgRjAIAAECeueUWadcu//S11/pbRgUaO29syvSgdoPYEwAAFAEEowAAAJAnpk+X3nvPP121qnT//cHrf1j3g+atn+emW9VopfZ12rMnAAAoAghGAUAYTJokbdzon7Z7mweAosrOgcccI3XrlrrskUekihWDH3fPF/ekTN/Q7gbFWD8+AABQ6BGMAoAw/Ojq21c6eNA/b/c2T0AKQFE+Jy5eLPl8qcvLlg1+3Obdm/X56s/ddFxMnM4/6vx83lIAABApBKMAIJeGD/cn5ZW8K/oxbn7ECIoWQFE+J6ay+ZEjg5fdOfNO+eSPViX5kjR7zex83EoAABBJBKMAIJdWrgy++m9sfsUKihZA0ZOVc2JycrIm/DIhZT42JlZDZg2RL+0/AgCAQolgFADkUuPGoVsBNGlC0QIomufEtNKeE2esnqG9B/emzCf7kl0i8+mrpufTVgIAgEgiGAUAuTR0qNcKwLui73PzthwAiprBg9MHogLPidb6yVpBxaaphto8raMAACgaCEYBQC716SMlJEjx8f55u7cEvr17U7QAip59+1Kn4+L8o+oFnhMTkxK1ZvsaJSs56P9sfu2OtW49AAAo3P776QQAyG1Aqnp1ad06/z2BKABF1bvvpk4vWCC1bBm83vJDzbtqnjbv2Zzuf6uVqaYS8SXyYSsBAEAkEYwCAABAWFhA/uuv/dOWI8paRQXanbhbTZ5pojMbnakbjrtBR1c/mpIHABtVNClJBw4cKLJlYQNb2Pvft2+fYmPpwBVt+8WOz3DvF4JRAAAACIv3308dSe/889MP7vDW4re0buc6jftxnA4kH9Ar57xCyQMo0iyP3oYNG7Rt2zYV9XKwwMfOnTsVk/bLA1GxXypWrKgaNWqEbf8QjAIAAEBYvPNO6nT//ukrtGPnjU2ZH9RuEKUOoMjzAlHVqlVT6dKli2wgxr4jDh48qPj4+CJbBtG6X6xlVGJiojZv9nevr1mzZuELRlm0bciQIZo8ebI2bdqk1q1b68knn1S7du1cAdx77736+OOPtXr1ah122GHq1KmTHnroIdWqVSvoeaZNm6YRI0Zo0aJFKlmypE499VR98MEHEXtfAAAAhd3vv0vff++ftjxRzZoFr5+9ZrYWbVzkpk+oc4La1mobga0EgOhhXZ+8QFTlypVVlBGMit79YgHCcuXKuSChxWnseI2zEUpyKao6Y1555ZWaMWOG3njjDS1evFhdunRxAad169Zpz549+vHHH12wyu4nTZqkFStWqGfPnkHPkZCQoIsvvliXXXaZfv75Z82ZM0cXXHBBxN4TAABAUUtcbl300qJVFAAE83JEWYsoINp5x2m4cptFTcuovXv3ukDSlClT1KFDB7ds2LBhmjp1qp577jmNGjXKBaoCPfPMMzruuOO0Zs0aHX744a5Z30033aRHHnlEV1xxRcrjmjdvnu/vBwAAoCjJrIve3zv/VsKyBDddtXRV9WveL5+3DgCiF93SUBSP06gJRlkgyZopWre6QKVKldLs2bND/s/27dtdgVSoUMHNW4spa0VlWd6ti5/1v23VqpULTh111FEZvvb+/fvdzbNjxw53b4m67BZu9pxeIjBQltGAYzJcUk/QfL5zjuMxPCjHglOW4XjeSNdlli2Tfv7Z3+D++ON9qlfP1qU+ftyCcTqYfNBNX9H6ChWLLcZ5Mg/wuY8+7JPoFC37xdsO71bUeWVAWUTvfvE+N2k/Ozn5LEVNMMr6ILZv314jR45Us2bNVL16dU2YMEFz585Vw4YN0z3ehny84447NGDAAJUvX94ts1xSXouqxx57TPXr19ejjz6q0047TStXrlSlSpVCvvaDDz6o4cOHp1tuCbrsdcLNdpQF0mxHMmwlZRkNOCbDIympqqQ4JSUla9Mmf4I/cDxGCp/rglOWljMztyJdlxk/vqwku0k9euzUpk17Uh57IOmAnpv3nJuOjYlV33p9Xc4JhB+f++jDPolO0bJfrLuTbYs1zLBbQfTdd9+539tdu3Z1vZxyyvaFNU4xtBSLHoH7xY5RO17/+ecfFStWLNd1magJRhnLFXX55Zerdu3aLiFWmzZtXLBpwYIF6T605513nisY68KXNhp3zz33qG/fvm56/PjxqlOnjt5//31dc801IV/3rrvu0i233BJ0NbFu3bqqWrVqSqArnGw77QNmz08wirKMBhyT4REX528ZFRcX6xL7geMxkvhcF5yyTNsqPCciWZeJiYnVRx/5z38xMT5ddllZVavmD0yZ95e+r417NrrpsxufrTYN2oR9e5B+v1DHjA7sk+gULfvFLhbYj3hLEG23gujVV1/VDTfcoFdeecVdaEg7uFjaoMah3mfaIAeig+0X23/2ebFk+2nrLjmpy0TVEd+gQQN99dVX2r17t6tE2ZCB/fv315FHHpkuEPXnn3/qiy++CKpgeUMMBuaIKlGihPt/yyuVEXuM3dKygs6rk5Od/PLy+YsSypJyjAaTJkkbN/qbsG7cKH3wQaz69In0VhVcfK4px6J0TIbjOSNVl7Fz3d13x+rXX/3LmjWLUd26wTklftn0i+uWdyD5gG447gbqPnmM82f0YZ9Ep2jYL/bath3eLTf1UGscu3Kl1LixNHSo8qUeumvXLr333nuaP3++Nm7cqNdee0133323W/fll1+qY8eO+vjjj3Xvvfe6AcqmT5/u8kM//PDDGjdunEur07hxYzdImTUmsTKwgIc1IrHf+rbeckNff/31Ljc08p8FEb1j0ztOQ31ucvI5ispISJkyZVxgaevWrfrss890zjnnBAWifv31V82cOTPd8Jdt27Z1FTEbZc9j//PHH3+oXr16+f4+ABQNVgGwxphe62q7t3lbDgCF1bRpJdSvX2ogyixdGnzus0rsZ6s+c4GoxpUb6/T6p0dkWwGgsNdDFy+2llb++/yqh1ogqmnTpmrSpIkuuugi1zoqbb6nO++8Uw899JCWLVumY445xnUrf/311/X8889ryZIluvnmm93/WqMUr9Wa17Np6dKluu+++1yAy14LhUtUtYyywJMdvHYw//bbb7rtttvcwX3ZZZe5oNK5557rkpR/9NFHLmJqkVJjuaCKFy/uWklde+21Gjp0qGuabgEoS15u+vVj1BYAecOuRNkFA5/Pu6JlVw2kESPy56oUAETCo4+Wdd3yUs99Snfum75quuatn+emV/6zUjNWz1DXhl3ZYQCQiWOPlf77qXtI1iLfeDEg795GNa1ePevFXKOGNH9+9nbLyy+/7AJJplu3bi4PlwWVLIeUZ8SIEercubObtoE2HnjgAdewxPJFG+vFZAOWWUupk046yXUHC8yBeMQRR7g80haMsoYpKDyiKhhlB6/lPPjrr79cgMma6t1///3ugLTWTR9++KF7nI2QF2jWrFkpB7wFn6wf6sUXX6y9e/fq+OOPd038KlasGJH3BKDwsybRaQdAsfmARpoAUOisXh0fFIhKe+6zC4xDZg1RXEycknxJ7t7muzToQnJaAMiEBaLWrctdEVlL/dw+R2asN9IPP/ygyZMnu3n7DW4pdixAFRiMOtYia/+xBid79uxJCU55EhMT1bp165T5sWPHulZWlmrHftPb+rQxABR8URWMskhnRtFOGxkvK0M8WuBqzJgx7gYA+cH65luT6MBTlLUOaNKE8gdQeB155EEtXx4ckAo89z0699GUVlHGAlI2b62laB0FAJm3UsoqaxkVaiA+yxOe3ZZR2WFBJxtdLTBhuf1et7Q5zzzzTFAKnsAcU2batGlu0LJA1tPJvPPOO/rf//6nRx991LWeKleunGtw8v3332dvAxH1oioYBQAFkSWJ9A/gadEo+1Hm77ZiywGgsLr11l268srUluf+7sr+c6Ll/Lj3i3vT/U+sYmkdBQCHkJ3ucl7OKO8c7N1biqXevfOmqC0IZXmfLGDUpUuXoHW9evXShAkTXLqdtGygMQtWWYunU089NWidBbLseefMmaMTTzzRJS33rFq1Km/eCCIqKhOYA0BBYrlREhL8V6CM3VvFIK8qAAAQDc48c79atEhtEtqsWeq579NVn2p/0v50/5OsZK3dsVaJSYn5vLUAULjrocccI5Us6b/P63qo5XC2wcauuOIKHXXUUUE3S7VjraZCsVZO1urJkpbbyHsWZLKc0E8//bSbN40aNXKj81k+6ZUrV7qR9ubNS21li8KDllEAEKaKgDWFtr75dk8gCkBhl5Qk/fmnf7puXWnJktR14xaMS5l+uNPD6nRkp5T5amWqqUR8iXzdVgAozKwemp+D5liwqVOnTjrssMPSrbNg1OjRo7Vo0aKQ/zty5EhVrVrVjaq3evVqVahQQW3atHG5o80111yjhQsXuvxTMTExGjBggGsl9cknn+T5+0L+IhgFAACAbPv113jt2uXPF3XccanL12xfo6krp7rpWuVq6eYTblaxuGKUMAAUElOn+s/xoRx33HEpuZ5vvPHGdOstwHTTTTe5W6huetaNb/z48e4WyIJXKFzopgcAYWDNob2hde3e5gGgMHvttVIp03PmpJ737ph5h5J9yW76mrbXEIgCAADpEIwCgFzyEkd6I5nYvc0TkAJQWNn57dVXU0dIsiC8nffeeX+fJi6ZmLL8qjZXRWgLAQBANCMYBQC5NHy4f+QS/0h6/nubHzGCogVQOI0c6R851OON4HTjB/fpoC91jPFFG0PnDAEAAEUbwSgAyKWVK/0/xALZ/IoVFC2Awsl/fvMC8Kn5PjbXfzZlPjYmVkNmDUnJHQIAAOAhGAUAudS4sdcyKpXNN2lC0QIonKpWDbGw+41S8d0ps5Y3at76eZq+anq+bhsAAIh+BKMAIJe6dvVaRnlX/31u3pYDQGHMF/XXX2ki8EqWWr+S7rGxonUUAABIj2AUAOTSZ595U6k5o4KXA0DhypMXmC/KOeV+qfiedI9NVrLW7lirxKTEfNs+AAAQ/eIjvQEAUNAtWxZ6+dKl+b0lAJBf57zAllHJUof7g1pDNa3SVK/3fl0xMTGqVqaaSsSXYNcAAIAUBKMAAACQcz2vkIrtD2oNtXTLUm3Zs0VdG9JfGQAApEc3PQDIpQMHsrccAAqy4HNbktT61XSPIVcUACDanHbaaRo8eHC+v+6rr76qChUq5PvrRjuCUQAAAMiZU0YF99j7D7miAKBwev7551WuXDkdPHgwZdmuXbtUrFgxF+wJ9OWXX7ru2qtWrTrk89pjixcvrm3btkUsgGRBI9teu8XGxqpOnTq67LLLtGnTplw9b//+/bVy5UrltWHDhqlVq1YqKAhGAQAAIAeSpVMfCLnm8PKH64crfyBXFAAUMh07dnTBp/nz56cs++abb1SjRg19//332rdvX8ryWbNm6fDDD1eDBg1UUJQvX15///23/vrrL7344ov65JNPdPHFF+f4+Q4cOKBSpUqpWrVqKigSE/Nn0BGCUQCQS/XqhV5evz5FC6AQn/MafSTFh66w/r3rb1UtXTVftwsAirKZq2eq+djm7j4vNWnSRDVr1nQtmTw2fc455+iII47Qd999F7TcglcmOTlZDz74oHuMBWdatmypiRMnunV//PGHTj/9dDddqVIl1zLp0ksvdbevvvpKTz75ZEqLJXus+eWXX9S9e3eVLVtW1atXdwGjLVu2pLz27t27NXDgQLfetvfRRx/N0vuz17DAWq1atdzz33jjjZo5c6b27t3r1r/00ktq1qyZSpYsqaZNm+rZZ59N+V/bNvv/d999V6eeeqp7zFtvvZWum57XgumVV15xwTrbxuuvv15JSUkaPXq0e30LXt1/f+rgIMZajV155ZWqWrWqC5pZmf38889unb3G8OHD3bxXVrbsUP8XuD323mz/2HbnB4JRAJBLjz3mTfmC7lOXA0Dh4T+3+aSOQ1NPe2lUKFHBVYQBAHnP5/Pp7s/v1rIty9y9zeclCzBZqyePTVt3OgvAeMsteGMtpbxglAWiXn/9ddfNb8mSJbr55pt10UUXuWBT3bp1UwJTy5cvdy2TLABlt/bt2+uqq65yy+xmj7XgigVUWrdu7Vpoffrpp9q4caPOO++8lG267bbb3HNPmTJF06dPd4GxH3/8Mdvv1QJnFkizbokWWLrvvvtckGjZsmV64IEHNGTIEL322mtB/3PnnXfqpptuco/p2jX0QB6rVq1yra5s2ydMmKCXX35ZZ555pmuRZdv98MMP695773Vl6OnXr5/rMmj/t2DBArVp00ZnnHGG/v33X9cV8NZbb1WLFi1SysqWHer/PL/99psSEhI0adIkLVy4UPmB0fQAIJf69JESEqw/uGTd5+Pjpffek3r3pmgBFD69ekmKS5QqrQ6ZL6pyqcqae+VcuugBQC48NvcxdzuUNjXbaFC7QZq3fp6bt/v2L7fXX//f3n2AR1GtfQA/IQFCSUIIvYOACAQUC4JcUGoUkXYtiBRpUlREpYlIu1a4eAUsIFyQKxbwKnKpgqDSJDQRRDpXpIWIQAKRJJDzPf/Xb/bObram7O5s/r/nWcLOzs7OnpnZOfPOe85JOenxvc82e1YevkKACf04IUCDoNPu3bslEIUmaQg2wdatW1V6errMi78I3CDDCMElqFWrltq0aZOaPXu2vBcZUYCMoNjYWNtnoR+p4sWLS7aQYdasWRKIwjINyDJCoAp9MyGrCcGdDz/8UIIugIAR+oDyxeHDh+X73HbbbdJP1oQJEyTDqhsq/0pJFtH+/fvlO/Tp08f2PpSNMY8rWVlZss5Ybv369aWcDh48qFauXCn9VSEDDQEpBPeaNm0qZZWYmChBpaJFi8oypk2bppYuXSqBvEGDBkmGVUREhF1ZefM+o2kegoXInvIXBqOIiPIAzjflyyt16tSffxmIIqJQlZaGQfSKKHWpilKR+2Xawi4LVYNyDeT/5UqUU1WifavwExGRvZT0FHUq9ZTHYsHv7fgN41V4WLi6rq/L333n9qkrmVe8+oycQBYUmsFt375dXbhwQdWtW1eCGAgqocNv9BuFTCQEnNAMDZlQaWlpql27dnbLQQAEQSVfoYkZgjQIvjjLOEKADMtGEMeAYBcCPJ5cunRJlotgEb5HixYtpPkavi+W3b9/f8nUMiAgFxMTY7cMBK88qVGjhgSiDGhqGB4eLoEo8zSj83R8Z/TVFRcXZ7ccfFd3HcR7+77q1av7NRAFDEYREeWBzz9XKinpz//jL557uCFCRGRJS5YopZrOUKr8n4Go2sVuV70a57xzVyIiyi66aLSqHFXZq6IxsqIAASkEopClGhkR6fEzcqJ27dqSZYSAEIJRCEIBMpKQnbRlyxZ5zegHCsEQWLFihapc2f47Gdk6vsDyOnXqJJlDjtA/FJqc5RQCRGjOh6AQloVmeoBmgIBOzc1BLkAQyaxEiRIeP6dw4cJ2z9G03dk0BMWM7+zYV5fB3B+VI2/f58065zUGo4iIcgmBp+7d//ccTfXwHE33GJAiolD7vevXTys1arJt2pGPhqrPa/P3jogoL3nThA59QzWd21QVUoVUFkY4/X94Xiu2lto2YFu+9d+HZmUIcCAYhf6ZDC1btpS+idA0bMiQITINzdAQdDpx4oQtcOUIzfEAnXg7Tnechj6P0L8RsovQLM0RRu9DYAf9LSEzC7CeaMLn6vMNCEIh2OYIWUoIth07dkz17NlT+VuTJk3U2bNn5fviezvjqqw8vS9Q2IE5EVEuTZqEOxf4n3GyxwgWSk3+37UaEVHI/N6pOquUKv6/Tk/VH3H8vSMiCoCM6xnqxKUTdoEowPNfU36V1/MLglHojwidXZsDPPg/+lBCMzmj83JkGz3//PPSaTn6bkLzMGQfzZw509b5N5qJIXC2fPlylZycbMumQgAFQSWMVIfR8pApNGzYMOl8u0ePHtJUEMtbs2aNNBFEMAbN7NCcDkGy9evXy8h7GJnP3AQuJzBaHTpinzFjhgS29u7dq+bPn6+m+2HUorZt20p/W126dJEO2VEeyEAbN26cdOJulNXx48dlm6Cs0FeXN+8LFGZGERHl0qFDuDNlPw3PDx5k0RJRaDl4SCvVa6JSWeFKFbquVFYhpVpNUQf+db8pIE9ERP5QNKKo2j5wu0pOS872Gvrvw+v5BYEm9DtUr149yRoyB6NSU1OlfyY0DzNMmTJF+iRCMAfZRWgihqydF154QV5H8z2MVDd27FjVr18/1bt3b7VgwQIJYqFzcGRX4fMQbEHQZfPmzWr06NGqffv2EnRBMCshIcEWcJo6daqtOR+CYRhpDv1B5caAAQOkM3UsG4EuNG2Lj4+XDsvzW1hYmHRujiASgm4I2KGjcmSiGeXfvXt3GQ0P2wYjDiJQhiCcp/cFSpjO73EfLSglJUU6IcPOGh2ds3a07iCai47IMFJAbqOzBR3LkuUYDBo3VmrvXvuAFDKjGjVSyk8jo4YUHtcsx4K2T+ZHvSO/6jK12q1Rx1skZJtec/Nqdewr58NXk//w9zP4cJsEp2DZLuggG8EVjMoWGem+f6dQh7AEOgNHc7L8alpIudsuCPq52l9zUu9gJISIKJcmTPgzEBUW9mc0Cn/xHNOJiEKpQlqo3fg/s6HMsgqp8Lbj5XUiIiIibzAYRUSUS+ikHJ2Vx8djRBAtf9HJb9euLFoiCh3oe+RyoRNKFbLvmwTPL4fnb98kREREFFrYZxQRUR4FpLp00aaUb6YXE1Ho9k2CJi7oPLZ06dLSxCW/+yYhIiKi0MJgFBERERF5pWpMVXlIfyvhge9vhYiIiKyJtQciIiIiIiIiIvIbBqOIiIiIiIiIAoQDQFBB3E8ZjCIiIiIiIiLys8KFC8vftLQ0lj0FPWM/Nfbb3GKfUURERERERER+Fh4erkqVKiUD4EDx4sVVWFhYgc26uXbtmoqIiCiwZRCs2yUzM1NlZGSo5ORk2V+x3+YFBqOIiIiIiIiIAqBChQry1whIFeSgBwbHwKAYDEYF53aJjY217a95gcEoIiIiIiIiogBA4KVixYoyOikyUAoqBDzOnz+v4uLiOEprEG4XBKHyqnmegcEoIiIiIiIiogBC06e8av5k1aAHgh2RkZEMRgXhdsmPfZMdmBMRERERERERkd8wGEVERERERERERH7DYBQREREREREREfkN+4xy0WM8pKSk5Fu7y9TUVLaHZVkGDe6TLMdgwv2R5VjQ9kmjvmHUP/IC6zIFE38/gw+3SXDidgk+3CbW3i45qcswGOUEChuqVq3q+9YiIiIiymH9IyYmJk/KjnUZIiIiCua6TJjOy9twIRT9O336tIqKipKhNvMaooYIdP36668qOjo6z5dfkLAsWY7BhPsjyzGYcH+0TlmiKobKW6VKlfIs84p1mYKJx33w4TYJTtwuwYfbxNrbJSd1GWZGOYHCq1Klispv2JgMRrEsgwn3SZZjMOH+yHIsSPtkXmVEGViXKdj4+xl8uE2CE7dL8OE2se528bUuww7MiYiIiIiIiIjIbxiMIiIiIiIiIiIiv2EwKgCKFi2qJkyYIH+JZRkMuE+yHIMJ90eWY7DhPskysQruq8GH2yQ4cbsEH26Tgrdd2IE5ERERERERERH5DTOjiIiIiIiIiIjIbxiMIiIiIiIiIiIiv2EwioiIiIiIiIiI/IbBqBx6++23VY0aNVRkZKRq2rSpSkxMdDv/kiVLVL169WT++Ph4tXLlSrvX+/btq8LCwuweCQkJtte/+eabbK8bj+3btyur8nc5wqFDh1Tnzp1VmTJlVHR0tGrRooXasGGDsrJAlOOuXbtUu3btVKlSpVRcXJwaNGiQunz5srKyvC5H+Pnnn9UDDzygYmJiVIkSJdTtt9+uTpw4YXv96tWratiwYVKGJUuWVN27d1dJSUnKygJRjnPmzFF33323HNPYXy9evKiszt/l+Pvvv6unnnpK3XjjjapYsWKqWrVq6umnn1aXLl1SVheIffKJJ55QN9xwg5Rl2bJl5bxz4MABFSp8LVPKO6+++qrsb1FRUapcuXKqS5cu6uDBg3bzhOK5xUpee+01ORc988wztmncJoFx6tQp9dhjj8mxgN9j/Kbv2LHD9rrWWr300kuqYsWK8nrbtm3V4cOHA7S2oe/69etq/PjxqmbNmlLeOE9OmTJFtoOB2yT/fffdd6pTp06qUqVK8lu1dOlSu9e92QaoN/bs2VPq3rge7N+/v+/Xgpp89sknn+giRYrof/7zn/qnn37SAwcO1KVKldJJSUlO59+8ebMODw/Xb7zxht6/f79+8cUXdeHChfXevXtt8/Tp00cnJCToM2fO2B6///677fX09HS71/AYMGCArlmzps7KyrLkVgxEOUKdOnX0fffdp/fs2aMPHTqkhw4dqosXLy7zWlEgyvHUqVM6NjZWDx48WB84cEAnJibq5s2b6+7du2uryo9yPHLkiC5durQeOXKk3rVrlzz/8ssv7ZaJMqxatar++uuv9Y4dO/Sdd94pZWlVgSrHN998U7/66qvywKntwoUL2soCUY6Yt1u3bnrZsmXyGvZJ/F5a+bgO5D45e/Zs/e233+rjx4/rnTt36k6dOsmxfu3aNW11vpYp5a0OHTro+fPn63379ukffvhB6jTVqlXTly9fDtlzi5WgTlSjRg3dqFEjPXz4cNt0bhP/Q921evXqum/fvnrbtm362LFjes2aNfKbbXjttdd0TEyMXrp0qVwbPPDAA3J99ccffwRgjUPfyy+/rOPi4vTy5cvl/LhkyRJdsmRJ/dZbb9nm4TbJfytXrtTjxo3Tn3/+udSbv/jiC7vXvdkGuFZs3Lix/v777/XGjRt17dq1dY8ePXxaDwajcuCOO+7Qw4YNsz2/fv26rlSpklwEOfPQQw/pjh072k1r2rSpfuKJJ+wu/jt37uz1OmRkZOiyZcvqyZMna6sKRDkmJyfLAffdd9/ZpqWkpMi0tWvXaisKRDniIqtcuXLyWYYff/xRyvHw4cPaivKjHB9++GH92GOPufzMixcvykUuTsSGn3/+Wcpx69at2ooCUY5mGzZsCIlgVKDL0bB48WIJOmRmZmqrCpayRGUO+6b5IqiglCnlr3Pnzsm+heBnqJ5brCI1NVWC+KhTtmrVyhaM4jYJjNGjR+sWLVq4fB039CtUqKCnTp1qm4ZtVbRoUf3xxx/7aS0LFpxf+/XrZzcNN8J69uwp/+c28T/HYJQ32wA36/C+7du32+ZZtWqVDgsLk6QFb7GZno8yMjLUzp07JVXNUKhQIXm+detWp+/BdPP80KFDh2zzoyke0q3RRGLIkCHq/PnzLtdj2bJl8vrjjz+urChQ5YgUXUxfuHChunLlirp27ZqaPXu2zH/rrbcqqwlUOaanp6siRYrIZxmQwgmbNm1SVpMf5ZiVlaVWrFih6tatK9NRlmjKYk6DxWdmZmbaLQdNg9A8ytXnBrNAlWOoCaZyRBM9pF9HREQoKwqWssT5Zv78+dIsoWrVqsrKclKmlL+MprSlS5cOyXOLlaBpZMeOHbP9hnCbBAaul2677Tb14IMPym/1Lbfcot5//33b68ePH1dnz561215oeo3fdB4r+aN58+bq66+/lm5TYM+ePXLtcO+993KbBAlvjgv8RdM8HF8GzI/6wLZt27z+LAajfPTbb79JW9fy5cvbTcdzbDRnMN3T/OiPBwESHJyvv/66+vbbb+WgxGc5M2/ePKkEV6lSRVlRoMoRbWLXrVundu/eLX0toK+L6dOnq9WrV6vY2FhlNYEqx9atW8v8U6dOlQuTCxcuqDFjxshrZ86cUVaTH+V47tw5aTeNfiNQnl999ZXq2rWr6tatm5SnsQwE9fBj7u3nBrNAlWOoCZZyxHqgHwf0B2dVgS7Ld955R/rrwWPVqlVq7dq1csxbWU7KlPIPgqPol+iuu+5SDRs2DMlzi1V88skn0p8m+vRyxG0SGMeOHVPvvvuuqlOnjlqzZo3cXEVfiB988IFtuwB/z/wH1wuPPPKIBMgLFy4sAUL8hqHvIW6T4ODNcYG/CPCa4cYlbor4cp6x5q3OEISD0oCO9Ro1aiQduiE7pU2bNnbznjx5Un5QFy9eHIA1tXY5IhMRd61w8GzcuFGyeebOnSsduKEjeHTSRp7LsUGDBnIif/bZZ9XYsWNVeHi4nNzxI2XOliroFwiATotHjBgh/7/55pvVli1b1HvvvadatWoV4DW0BpZjYMoxJSVF7u7Xr19fTZw4MY/WouCVJSrXGOgBQfpp06aphx56SG3evFluhBDlBdRp9u3bZ8ms5FDy66+/quHDh0vAmcd3cP1eI3PjlVdekecIfOB4wW91nz59Ar16BRKuXxctWqQ++ugjuZ744YcfJBiFjrS5TQoeXjX6CCOw4cLbcUQSPK9QoYLT92C6L/NDrVq15LOOHDmS7TWk+qO5GUbxsapAleP69evV8uXL5e4V7iI2adJE7lwjKGXcJbGSQO6Pjz76qES+MUoJmvDhgjU5OVnmtZr8KEcsE3cIcDFvdtNNN9lG3MK8yCxzHPnN0/YIVoEqx1AT6HJMTU2VjB9kj37xxRdy59KqAl2WSGvHHfmWLVuqzz77TEbTQ5laWU7KlPLHk08+KXUajAhszpQPtXOLFaAZHrImUa/E7wMeyJScMWOG/B8367hN/A83mT3Vw4C/Z/4zcuRIW3YUbnj36tVLbuwYGYXcJoHnzTbAX/zmmaH7G4yw58t5hsEoHyHtGX0LofmSOeqO582aNXP6Hkw3zw+4c+JqfiP7CRf4jpk6yOxBMKp3796WvkAIVDmmpaXJX8fsHTw37nZbSaD3R0AFC01QPv30U7kbiCwAq8mPcsQyMfS243DbaCNfvXp1+T8+E8exeTmYH5Ukd9sjWAWqHENNIMsRGVHt27eX+dHXhtXv8AfTPvn/g8ZIn3sFrUwpb2E/QiAKgU3cZENfZGahdm6xAmSN7927V7I8jAcycpAdafyf28T/cOPZ3W81jh1cOJuPFZwH0ecNj5X8gWsxx+sw3OAwrsO4TQLPm22Av7jhgUC8AecjbEf0LeW1POuGvQDBkMboTX7BggXSk/ygQYNkSOOzZ8/K67169dJjxoyxGyY6IiJCT5s2TUYzmTBhgt0w0Rh54/nnn5cRTjDE5bp163STJk1kNI6rV6/afTZew2bDcqwuEOWI0fQwnChGbcBwyAcPHpT3YDl4bkWB2h9nzpwpw5WjDGfNmqWLFStmNyxrQS9HwHCpmDZnzhwZZRBlhiHjMfypeahnDMm9fv16GX67WbNm8rCqQJXjmTNn9O7du/X7779vGzETz8+fP6+tKBDleOnSJRk1Lj4+XkZ8Q5kaj2vXrmmrCkRZHj16VL/yyityTP/yyy+yzE6dOunSpUvrpKQkbXWeypTy15AhQ2TI7W+++cbuOE1LSwvZc4sVmUfTA24T/0tMTJTf85dffll+qxctWqSLFy+uP/zwQ7sh7PH79eWXX8rI0BhN2nEIe8o7GLG7cuXKevny5XKdgfNpmTJl9KhRo7hN/AjXe6gn44F68/Tp0+X/qLN4e1wkJCToW265RW/btk1v2rRJrhV79Ojh03owGJVDqHjiJI8hrzHE8ffff2938sGB5jg8dt26dWX+Bg0a6BUrVtheQ+Whffv2umzZslK5rV69uh44cKDTSh02cPPmzXWoCEQ5YghKzIeLgqioKH3nnXfqlStXaisLRDniAg5liGU0atRIL1y4UFtdXpajYd68ebp27do6MjJSN27cWC9dutTudfyoDx06VMfGxkoFqWvXrnJRYWWBKEcEDHAydXzMnz9fW5W/y3HDhg1OyxAPVBitzN9liWGN7733Xl2uXDn5Ha1SpYp+9NFH9YEDB3SocFemlL9cHafm37tQPLdYPRjFbRIY//nPf3TDhg0lgF6vXj25iWCGYezHjx+vy5cvL/O0adNGbrRS/khJSZHjAucPnD9r1aqlx40bp9PT07lN/MhVnc+oD3lzXOCGL2ITJUuW1NHR0frxxx+XIJcvwvBP3iZ2EREREREREREROcc+o4iIiIiIiIiIyG8YjCIiIiIiIiIiIr9hMIqIiIiIiIiIiPyGwSgiIiIiIiIiIvIbBqOIiIiIiIiIiMhvGIwiIiIiIiIiIiK/YTCKiIiIiIiIiIj8hsEoIiIiIiIiIiLyGwajiIhyqUaNGqpv374sRyIioly6fPmyKleunFq0aJHfP3fAgAGqQoUKKiwsTD3zzDMu583MzFRVq1ZV77zzjl/X0eoWLFggZfvf//5XBYuCWIdzdYytXr1a3XzzzSoyMlK208WLF10u47333lPVqlVT6enpflhjClUMRhFR0FVS8Ni0aVO217XWUvnD6/fff78qSL755pugq8AREZF1IHCC80jTpk1VMHvrrbdUVFSUeuSRR/z6ua+88orUQ4YMGaL+9a9/qV69eqktW7aoiRMnZrsoL1y4sHr22WfVyy+/rK5everT53Tv3l3dd999Tl9LTEyUbfTmm29me61z587y2vz587O91rJlS1W5cmWf1mPlypXy3RylpaXJdNQ7AgWfb9QH8ShevLiqX7++evHFF1VKSooKpWMS+1wwHGPnz59XDz30kCpWrJh6++235RgoUaKEHBdLly7NtgwE8DIyMtTs2bP9vPYUShiMIqKggzsyH330Ubbp3377rTp58qQqWrSoCiYHDx5U77//fqBXg4iIyCVkQSALBAGPI0eOBGVJIeMIF8rIUAoPD/frZ69fv17deeedasKECeqxxx5Tt956qwSjJk2a5DRD5PHHH1e//fab0/qKu++3du1a1bFjR6evN2nSRAIvzm7IYV0iIiLU5s2b7aYjILB9+3Z11113KV+DUfhuzoJRmB7IYJTh3XfflaDI9OnTVb169ST4l5CQIDcnQ6EOF4hglKtjDPtQamqqmjJliurfv78cAwi6ugpGoa7ep08f2TZ5uT2oYGEwioiCDu4YLlmyRF27ds1uOip8qBwihT6YIDiGEzYREVEwOn78uAQzcOFYtmxZr5vA4TyMYIe/LF++XCUnJ0uGhr+dO3dOlSpVyuv5MW/79u19CiZs3LhRLvhdBaMQbELmmmPACQETBL5QLo6Bqp07d0p2VosWLVSo+etf/ypBkcGDB6vPP/9cdevWTW3dulV9//33uVougid//PFHSNbhPB2zro4x7P/gyzGAZfzyyy9qw4YNuVhjKsgYjCKioNOjRw9JF8bdQwNOrJ999pl69NFHnb5n2rRpqnnz5iouLk5SjBG0wvyOkO795JNPyl2ehg0bSiWkQYMG0k7eWYo47h4jFRkn55iYGLkTiruG7vobMJobojKJNH5U/JHq3LVrV6kAmGVlZclnVapUSe6G3nPPPWr//v1e9WFw+PBhSfdHcA53qKpUqSIp15cuXXL7vrvvvlu+Oz4Hn4fPRXr/G2+84fZ9RERkTQg+xcbGShAEF/jOglFoBo5zF86n//jHP9QNN9wg50icK+DAgQPy3tKlS8s557bbblPLli2zW8bvv/+unn/+eRUfH69KliypoqOj1b333qv27Nnj1Xri3IzzHz7b7OzZs3L+xXkO61SxYkVptmZuuo4Aw9/+9jeZxzif/vTTTx7Pp0YzeATsVqxYYWsahveMHDlS5qlZs6Ztuvkz27VrJ8EhfG9vYPloboZ1cgVBpaSkJLvsNdQnUJaDBg2yBabMrxnvM6xatUr95S9/kboHmmNhu6MsDPhuaIoF5uZw+G6oswCyo4zp5uZ83uwHgM9r3bq11MmwTbBtUOfJDSwPsK0Ay8O+inoc1qV8+fLqiSeeUBcuXLB7H8ob3TusWbNG1hfrZDQvc1WHw3Z9+umnpTxQB8RyURdFllzv3r3leMJj1KhR2TKDvFkvfC7KCFn/RjmjfmbA56DfMnRPgX2+du3a6vXXX7crQ0/HrLfHGD4XWU5w++232/Z//L1y5Yr64IMP7I4LA+ra2A++/PJLn7YjkSHC9j8ioiCBk2SzZs3Uxx9/LJVYo2KFIAuCLTNmzMj2HqQcP/DAA6pnz55SWfjkk0/Ugw8+KHeAHO9AooKBO2xDhw6VShqWh6DOiRMnJJjleNcHldBXX31V7dq1S82dO1c6fUSFwJOnnnpKKipI+UeFARUFBMI+/fRT2zxjx46VIFCnTp1Uhw4dpMKOv576oMB3xHzoOBKfg4DUqVOn5PuiAoPAmTuoECHVHXcZ8R0RuBs9erRcQBhlTkREoQHBJ/zeFylSRG74oPkTmuXgwtMR+iTCOQiBD1zY4mITF81oBoYbF2PGjJEgx+LFi1WXLl3Uv//9b7nZAseOHZOLXZx/ce5EUAUX/a1atZILZNx4cQfZW2iq5gjnaKwDzneoIyCLAzescN42AjsvvfSSBDyQXY0HztnIXPKU2XXTTTdJU7ARI0ZI0OS5556T6Tgf4r2oi6APpzJlysh0I1hjXIwjEIH19qYvSzSN8zSfEVRCXQUBCCPghCaEyJpCFg8+D3Ue4zXUZRo3bizP8V0QWEAdAXUV3EDD9sZyd+/eLeWFwMjp06elDDG/Ad8N86LfLGxT7DPQqFEj+evtfoDgIYKByNIx5pszZ44EgXLj6NGj8teoq+F7IHiEQCUCRwhSzZo1S74nysWc8YQgHvZ9vGfgwIHqxhtvdPtZRt0KQTlkYmH9EZRC2aPjbjRfw/acOnWq3OBDgMrgzXqhTojPQNB23Lhx8j4ErQDbDMcM6nVYFj4Pn4s645kzZ+S9no5ZX44xfD7KA99x8uTJcuwiWNW2bVtpznfHHXfIssExUIxlOWbyEXlNExEFifnz5+PWkt6+fbueNWuWjoqK0mlpafLagw8+qO+55x75f/Xq1XXHjh3t3mvMZ8jIyNANGzbUrVu3tpuO5RcpUkQfOXLENm3Pnj0yfebMmbZpEyZMkGn9+vWze3/Xrl11XFyc3TSsT58+fbJ9j7Zt2+qsrCzb9BEjRujw8HB98eJFeX727FkdERGhu3TpYre8iRMnyvvNy3S0e/dumWfJkiXaV61atZL3Lly40DYtPT1dV6hQQXfv3t3n5RERUfDasWOH/OavXbtWnuO8VKVKFT18+HC7+Y4fPy7zRUdH63Pnztm91qZNGx0fH6+vXr1qm4blNG/eXNepU8c2Da9fv34923KLFi2qJ0+e7HY9MzMzdVhYmH7uuefspl+4cEHWa+rUqS7fi/XFuR11A/N594UXXvB4PjU4q1vgM/F+fAdnTp8+La+//vrrHpd/7NgxmXfDhg1u50tJSZG6Qv/+/W3TbrzxRj1p0iT5/x133KFHjhxpe61s2bK6Xbt28v/U1FRdqlQpPXDgQLtlor4RExNjN33YsGGyPo6Sk5NlOupBjrzdD5555hlZxrZt2+y2EdbBXXk61sEOHjwo64P5Z8+eLftR+fLl9ZUrV/TGjRtlnkWLFtm9d/Xq1dmmY9tiGl5z5KoO16FDB7t9qVmzZrJ/Dh482Dbt2rVrciyhXmXwZb0aNGhg917DlClTdIkSJfShQ4fspo8ZM0b2jRMnTng8Zn05xhzr4GZYD3fHz6BBg3SxYsU8fjaRM2ymR0RBCdk6aM+PTB/0r4C/rprogfluG7J+kEWFFHXcGXWEOz3mOzu444f0d9zRdYR+CsywTDQh9GY0F9xFQkqz+b3Xr1+X9vXw9ddfy11DZGiZ4U6ZJ0bmE1LOHZsNegN34tAPgwF3y3Hny1kZEBGRtbOikHGBTBXAeenhhx+WDGKck5xlIZmzf9AEDZ1747yM8zGaiOGBcyGyb9BkHBkcgKyMQoX+vLzAsjEPzjfIunB2PjbD5+CeETKKHc/vOEehOZ1j8yvDunXrJIsJ50/zeRfNnPKTsa7mZnPumujh3O2pbydkOaFeYvQNhWUjqwddEQAyk4xMlEOHDknzf2OZyHRCdjQygIzthAc6qkZWVW769vFlP0DGEDK5UK8wYJ9C9rovsN/gfcjUQYYQMsVQjmiGib5FUZ5oKmn+rshWwz7n+F2xDKynt9CJt3lfQvlh/8R0A8oVzf7MdSdf18sZLAN1Ruxf5mWg/orj6rvvvnN7zPp6jOUGloX6ek7qokRspkdEQQknVZx00Wk5TnA4+aKPAlcQrEJ6/g8//CBN1wzmioQB6c7OTqbOKrmO8xoncMyLAJY77t4LRlDKSMM3IL3aU0UBlSr0R4XOaHGhgUoLUvYRYPLURA/QFMGxbPCZP/74o8f3EhGRNeDciaATAlFGPzvGhfXf//53uSmCpmyO5xcz9F2EC9jx48fLwxk0m0PTLfRng2bzGCUMn2cOdjk2g3fFsf8dBLjQ3AzN5xBUQ5ADTd3QLMoY0MQ4n9apUydbXSIvL7xdrauzuoYjBFFQ1uik3BMEl2bOnCkBCDSrQtAD3xsQlEL5oq7j2F8UAkLmvpUceaq3uOPLfoDtgX3MkaemcY7Q9A/rjGZtqLeYbyTiu+LGI7pOcLUu7vZrTxzrcEbdCn04OU431x99XS9nsAzUx1wFmHL73fJy9DtfjgEiRwxGEVHQQiYU2vWj7wH0Y+RqhA+MToNATMuWLaWCho5NUXFBG3pnQy67Gi7a2cnZl3nz8r3ewIUEOpJEx5FfffWV9EuAvq3QtwEqbYFcNyIiCjxksqCPGQSk8HCEmxmOwSjHfn2MDpPRMbmrzBLjpgr60UGgol+/fjJEPG6uIFMKGUqeOq/GvLigdXZjCO9H34rojwoZwfgMnO/w/W655RYVKMa6Gv1JuYKbasjsQn9M3jCCUQg2IRhldAhvBKMQiEKfX8ieQnDLCFQZZYx+oJyNPOxNIMwVX/aDvIJ6nauyxfog4ONqZEjHQI6v/VW5qic5m26uO/m6Xs5gGcisQufoztStWzdH383dMZZTWBYy1XLbHxgVTAxGEVHQQkeYSMtGcMXc6bezO2cYrQQVVNxBNSAYFcyqV69uu9tovquFlHdvKwqooOLx4osvSoUV6fvvvfeeZIkREVHBhgtiXBgbI6eZYSCPL774Qs4Z7i4ka9WqJX9xkwcZy+5gMAxkYc2bN89uOpqOeQrYIFCCzBdzBpcZXkN2FB7IHLn55pvlpsyHH35oO59iurG+gCZsubnw9pTtYawrOkF3B0EzBJC8HSDE3In51q1b5dxuQCfw+L4IVOGBYByCAWBkDmGbe9pWrr6bq+m+7AdYPyNLywzNDfMKviuaZ6JsgikQ4st6uSprLOPy5csey9lXno6xnB4DnvZ/IlfYZxQRBS3cBcRdRAwpjDuiruAuFU6W5uYAGL0Od1CDWZs2baRi4HinFCOueII+q9DflBmCUrgDbW6mSEREBRP6cUHACU3a0Mzd8YHRXdH3z7Jly9wuB4ENDP2OUfGQZeUIAR/z+dgxwxb93xh9CXmCkXR37NiRLavIcYRZXFCjbyXjfIeLdgRJkE1k/nzHUcd8hVHgjGCaMzt37pT6B9bbHfShhL6FjNHSPEHACTep0IwS5WH0F2XAc9RxENwx90GFjCU0a0OGWmZmpttt5eq7GYEtx+m+7AcYzRA3EhMTE+1ed5UtlBPouwr1PmTgOUL9yNU2y2++rBe2gbP1xDIQhMRNVkeY37H+5wtnx5g7rtbRgL7gHPdPIm8xM4qIghqGJ/akY8eO0ndSQkKCNO1DW3rcBUa6eDD3gYRK6fDhw+XOLpoZYv337NmjVq1aJXeQ3d2Nwl1WXEhg+Gyka6NigrR8XAigI0siIirYEGRCsAnnF2fQtAtNhhAgQIfm7uCciqAHbnqg+TyyZJKSkuSC+eTJk3LuAgS+MDQ8hrTHBerevXtl+eZsJXc6d+4s5zJ0zG00RcL/cfMGF+j169eXmzjI6MLnP/LIIzIPvgeaj6HpHtYBwZDdu3fbzqc5hU6nYdy4cfJZCHjh5pgRyEGH4ciA8dQfFoJRKBNfoLxRFmDOjAKU7ccff2ybz4BAFG5w9erVSzVp0kTWGWVz4sQJ6bMKyzFueBnfDU38EcRC/QHzI5sH5YyMdGwDNO1q2LChPLzdD9C8DOuOeg3qOSivOXPmSMZUXtXLWrVqJdnz2OboLxTNTbF9kJGFACj6LnPX12h+8WW9sA2wvZDNjjorAn7o72vkyJFy/GJfRncMmO/KlStyPCH7EDdcc7pfOzvG3MFnI9ML9WwjSGr0B4ZgLDpFxzKJcsTpGHtERAHgalhZb4ZfnjdvngwrjGF/69WrJ8syhgY2w3MMZ+xsmeaha433YkhhZ+toHpbY1bDAjt8Dwzk7DuuMYYHHjx+vK1SoIEPjtm7dWv/88886Li7ObvhgZ0NE9+vXT99www06MjJSly5dWt9zzz163bp12hMMI4zhhB3hO+C7EBGR9XXq1EnOD1euXHE5T9++fXXhwoX1b7/9ZhsmfurUqU7nPXr0qO7du7ecr/CeypUr6/vvv19/9tlntnmuXr0qw8ZXrFhRzml33XWX3rp1q5x3nA1h7yg9PV2XKVNGhrY3YN1w3sa5HcPMx8TE6KZNm+rFixfbvff69et60qRJts++++679b59+7Kdo32pWwDWBd+1UKFCduf/ixcv6iJFiui5c+e6XS7WAe9LTEzUvpg9e7a8D5/taNeuXfIaHklJSdleRz2jQ4cOUlbYB1BXwLbesWOHXf3jqaee0mXLltVhYWF29aUtW7boW2+9Vb4fpqNO5Mt+AD/++KNsc3w+5kE5oq7mWIdyxlUdzJk5c+bIumKbR0VF6fj4eD1q1Ch9+vRpj9vWlzqcq3XCe7Ff5mS9zp49K+uF17Fs8zGSmpqqx44dq2vXri3bAcdF8+bN9bRp03RGRobM4+mY9fYYc/e9Dxw4oFu2bCnfA6+by2r06NG6WrVqOisry+vPJzILwz85C2MREVF+QDo0Rv/BnTLcjSUiIioo0LwJfT4ik8RVJ9K+qFGjhjQvW7BggcpLaAL4xhtvqKNHj7rtGwjzIKsETds44hiFyjGGJrI4tsaMGSPZb0Q5wT6jiIgC3KeHI6OPC1SeiYiICpIRI0ZI583ORv8LFuiPCQEmDB7iqZNqXLC/+eabDERRSB1jCGah+eHgwYPzdN2oYGFmFBFRAOFOLR7o3wIdtmPkHPQDgT4GnHVcSURERIHPjCIiotxhB+ZERAHUqFEj6YwVafwYIc/o1BxN9IiIiIiIiEIRM6OIiIiIiIiIiMhv2GcUERERERERERH5DYNRRERERERERETkNwxGERERERERERGR3zAYRUREREREREREfsNgFBERERERERER+Q2DUURERERERERE5DcMRhERERERERERkd8wGEVERERERERERH7DYBQRERERERERESl/+T9xNVqR2NmQTQAAAABJRU5ErkJggg==",
-      "text/plain": [
-       "<Figure size 1200x500 with 2 Axes>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "base_tables = HdfMesh.get_mesh_face_property_tables(baseline_geom_hdf)\n",
+    "base_tables = HdfMesh.get_mesh_face_property_tables(base_hdf_path)\n",
     "base_df = base_tables[MESH_NAME]\n",
     "n_col = \"Manning's n\"\n",
-    "sample_face = 1050\n",
     "\n",
-    "print(f\"Faces: {base_df['Face ID'].nunique()}\")\n",
-    "print(f\"Total rows: {len(base_df)}\")\n",
-    "print(f\"Uniform n: {base_df[n_col].mean():.4f}\")\n",
-    "\n",
-    "sample_df = base_df[base_df['Face ID'] == sample_face]\n",
-    "\n",
-    "fig, axes = plt.subplots(1, 2, figsize=(12, 5), sharey=True)\n",
-    "\n",
-    "ax = axes[0]\n",
-    "ax.plot(sample_df[n_col], sample_df['Elevation'], 'b-o', markersize=4, linewidth=2,\n",
-    "        label=f'Uniform n={original_n}')\n",
-    "ax.set_xlabel(\"Manning's n\", fontsize=12)\n",
-    "ax.set_ylabel('Elevation (ft)', fontsize=12)\n",
-    "ax.set_title(f'Face {sample_face}: Uniform Manning\\'s n', fontsize=13)\n",
-    "ax.legend(fontsize=10)\n",
-    "ax.grid(True, alpha=0.3)\n",
-    "\n",
-    "ax = axes[1]\n",
-    "ax.plot(sample_df['Area'], sample_df['Elevation'], 'b-o', markersize=4, linewidth=2,\n",
-    "        label='Area')\n",
-    "ax.plot(sample_df['Wetted Perimeter'], sample_df['Elevation'], 'g--^', markersize=4,\n",
-    "        linewidth=2, label='Wetted Perimeter')\n",
-    "ax.set_xlabel('Area (sq ft) / Wetted Perimeter (ft)', fontsize=12)\n",
-    "ax.set_title(f'Face {sample_face}: Geometric Properties', fontsize=13)\n",
-    "ax.legend(fontsize=10)\n",
-    "ax.grid(True, alpha=0.3)\n",
-    "\n",
-    "fig.suptitle('Face Property Table Structure (Uniform n from Preprocessing)', fontsize=14, y=1.02)\n",
-    "fig.tight_layout()\n",
-    "plt.show()"
+    "print(f\"\\nBaseline output face tables: {base_df['Face ID'].nunique()} faces, {len(base_df)} rows\")\n",
+    "print(f\"Baseline mean n: {base_df[n_col].mean():.4f}\")\n",
+    "assert base_df['Face ID'].nunique() > 0, \"Expected face property tables\"\n"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "61681e12",
-   "metadata": {
-    "papermill": {
-     "duration": 0.007965,
-     "end_time": "2026-05-12T12:23:51.016208+00:00",
-     "exception": false,
-     "start_time": "2026-05-12T12:23:51.008243+00:00",
-     "status": "completed"
-    },
-    "tags": []
-   },
+   "id": "4d541d6f",
+   "metadata": {},
    "source": [
-    "## Step 5: Apply Depth-Varying Manning's n\n",
+    "## Step 4: Apply Depth-Varying Manning's n to the Modified `.tmp.hdf`\n",
     "\n",
-    "Instead of uniform roughness, we apply a physically-based formula where n\n",
-    "**decreases with flow depth** â€” consistent with HEC-15 and Limerinos. We use\n",
-    "an exponential decay model:\n",
-    "\n",
-    "$$n(d) = n_{\\text{asymptote}} + (n_{\\text{base}} - n_{\\text{asymptote}}) \\cdot e^{-d/d_{1/2}}$$\n",
-    "\n",
-    "This captures the key physics: at shallow depths, n equals the base value\n",
-    "(set during preprocessing). As depth increases, n decays toward the asymptote.\n",
-    "\n",
-    "We apply this to the modified project's **already-preprocessed** geometry HDF\n",
-    "using `HdfMesh.set_face_mannings_n_values()`, which replaces the n column in\n",
-    "each face's property table while preserving elevation, area, and wetted perimeter."
+    "The modified project is preprocessed on Windows only to create the solver-ready\n",
+    "`.tmp.hdf`. The geometry HDF and plan/output HDF are not edited. All depth-varying\n",
+    "roughness changes are applied directly to the `.tmp.hdf` that the Linux solver\n",
+    "will consume.\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
-   "id": "72a54f1f",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-05-23T01:40:08.290981Z",
-     "iopub.status.busy": "2026-05-23T01:40:08.290805Z",
-     "iopub.status.idle": "2026-05-23T01:40:10.486194Z",
-     "shell.execute_reply": "2026-05-23T01:40:10.485591Z"
-    },
-    "papermill": {
-     "duration": 2.019136,
-     "end_time": "2026-05-12T12:23:53.044424+00:00",
-     "exception": false,
-     "start_time": "2026-05-12T12:23:51.025288+00:00",
-     "status": "completed"
-    },
-    "tags": []
-   },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-22 21:40:10 - ras_commander.hdf.HdfMesh - INFO - Wrote face property tables for 11164 faces in mesh '2D Interior Area' (47055 total rows)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-22 21:40:10 - ras_commander.hdf.HdfMesh - INFO - Modified Manning's n for 11164 faces in mesh '2D Interior Area'\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "C:\\Users\\bill\\AppData\\Local\\Temp\\ipykernel_32504\\264333612.py:42: UserWarning: Tight layout not applied. The left and right margins cannot be made large enough to accommodate all Axes decorations.\n",
-      "  fig.tight_layout()\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Applied depth-varying n to 11164 faces\n"
-     ]
-    },
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAABSQAAAHaCAYAAAAZuEcHAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjgsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvwVt1zgAAAAlwSFlzAAAPYQAAD2EBqD+naQAArfBJREFUeJzs3Qd0FGXbxvF7k0BC7713EBEEEUUsCCpYwIaIjWp79RXra+8F7OJnV0BFRcWGHXsHVBBB6UrvvUNIst+5nmHDJtmE1N1N9v87Z05mZ7bMzm42yZX7eW6f3+/3GwAAAAAAAACEQVw4HgQAAAAAAAAAhEASAAAAAAAAQNgQSAIAAAAAAAAIGwJJAAAAAAAAAGFDIAkAAAAAAAAgbAgkAQAAAAAAAIQNgSQAAAAAAACAsCGQBAAAAAAAABA2BJIAAAAAAAAAwoZAEkDMWLx4sfl8PrvrrrusJGvcuLEdd9xxkT6MEoFzCQAAAACFj0ASUe+7775zIVJ2y5QpUyxa/frrr3bVVVfZUUcdZeXLl3fH+/LLL2d7/T179tgdd9xhTZo0scTERGvWrJndd999tnfv3pBBSXbnZP369Vmuv3LlSrvooousRo0aVqZMGTvssMNswoQJBX6OCveCH7t06dLuMY444gi75pprbObMmRZOmzdvdsek901hu+GGG9xz/OCDD3K83rHHHmvx8fG2bNkyi1XB37dXXnllyOusXbvWvV90HQJUTywE5gAAAACQwClAcTFgwAA7+eSTs2xv3ry5RatPP/3Unn76aWvdurW1b9/efvnllxyv379/f5s4caINGTLEjjzySJs8ebLdfvvttnDhwpBBpu731ltvzbK9QoUKGS5v3LjRunXr5gKga6+91urXr29vvPGGnXPOOTZmzBgbPHhwgZ/rPffc44LU1NRU27Rpk82YMcNGjx5to0aNco/5yCOPWLgCybvvvtutF3bINXToUPc8xo4da6effnrI6/zzzz/2448/2oknnmgNGjSwSJg3b54LtqJBUlKSe689+uijLmQPNm7cOPP7/ZaQEL0/iqLpXAIAAABASRG9fwUCmXTs2NEuuOCCYnVeLr/8cldVV65cOXvnnXdyDCQVXiqMVHin8EaGDRtmlStXtscee8wuueQS69q1a4bb1KpVK1fnZOTIkbZo0SL78MMP7bTTTksP1xR6Xn/99davXz9XwVkQvXv3dlWXwXTcum89H1VN3njjjVacKQDWa6DXas2aNe78Z6bgWCGbzm9h2LZtW5aA+UAyB3+RdMYZZ9j48ePde1sBeDAFu/onw9dff23RKprOJQAAAACUFAzZRomgodGDBg2yli1bWtmyZV2Ao2HS77//fsjrr1692g2lbtq0qQscatasaSeccIJ9+eWXGa63YMECu/DCC61OnTpuaKmGSStg3LFjR66OS4GVwsjcUBWZXH311Rm2By6/9tprIW+XkpJiW7duPeB9a/h3IIwUDSn+73//66onFbAFmzt3rqv0K6iqVau6YeEVK1a0ESNGZDlvuT2/em1VpbZu3To37LxatWruvPbo0cOmT5+eYZiwqjRFVZKBIcO638w+/vhj69y5s6vg0+PrcXUuD0RBo66n6r7M0tLS7JVXXnHH17dvX3f5/vvvt2OOOcZq167tnmPDhg1dUL1hw4Zs57d86623rFOnTm5ovV6j4cOHu306X5mtWrXKVRiqqjaneQ8D2/TannLKKe57pFKlSnb22We774fMNNReVZ46z3o+AwcOdFMB6Dj0euTlHwmHHHKICx8zf8/+/fff2VbnfvHFF65iWN+jOg8K5nU833//fZbr6nnp+WlaAlVSV6lSxX0OnHTSSTZ//vwsgbGewzfffOOqXfV9oc8AfXbotcssGs7lq6++aocffrg7B7oPnZPzzz/ffT8cSOAxVG2tqQQCx6B/dmzfvv2AtwcAAACAokAgiWJj586d7o/44EXVY6LgUeGAKrA0RFjDmBW0nXnmmelBX3Dwo7DnmWeecaHC448/7sIohWZfffVV+vWmTZvmKv5++OEHu/TSS93Q61NPPdWefPJJF16GmtexIH777TerV69elmG+uly3bl23P7OpU6e64EVhiMIKBR0KZTIHVitWrHBzOmYW2Jb5vtu0aePCvsKgUFJVclu2bLGffvqpQOe3V69e7vkotFNQ+/vvv7uQ5a+//ko/br2eosdUaKjliSeeyHA/CmAV4KmqU9fXcHqFUw899NABn4/eY6omzRywid4/mjdSVasKH5OTk+3hhx+2Fi1auPdY4LlpKLvee9qfmeanVGCp56rr6xgvvvhit0/D6zNTiKZh8gqYDkTvAz2uQlEd13nnnWfvvfeeC3mDKfg8+uijXYil4F7hrsIvHVN+6FwrYNTjB+i56B8Bes1DUXCo72Ed2//93/+5+UjnzJnj3pcaEp+ZQmwFvwraH3jgATdvpQJqBcM6P5ndcsst7r2h955e97i4OBfc/fzzz7l6TuE6lzpGfV8rONe0CHov6/2loeSagiE3NH2CzrMCeFUtKxzVe1DV2AAAAAAQEX4gyn377bd+vVVDLf3793fX2b59e5bb7dixw9+yZUt/mzZtMmzv3bu3u+3nn3+e5Tapqanp64cccoi/VatW/q1bt2a4znvvveduP3bs2Dw9jwkTJuR4u/Lly/sPP/zwkPs6d+7sr1OnToZtJ598sv/ee+/1v/POO/7x48f7L730Un98fLy/Xr16/hUrVqRf7/fff3eP+7///S/kOdK+AQMGZNiubY0aNcrV87rzzjvd9X/77bdsr/Poo4+66zz55JP5Or8DBw5028444wx/Wlpahufm8/n8J510Uvq2RYsWuevquDIL7CtbtqxbD9B9tm3b1l+7du1cPechQ4a4+5k6dWqG7eeee67b/ueff6bf786dO7Pc/qWXXnLXe+utt7IcW0JCgn/27NlZbnPkkUe690BKSkqG7S1atMjyHtdrd+yxx2bZlvkx5T//+Y/bPnfu3PRt/fr1c9t++umnDNc955xz3Ha9Hrn9vn344Yf969ev95cuXdp///33u306J5UqVfJfd9117nK5cuWyHG+o7+nVq1f7q1Wr5r6Hg+m2eqwHH3www/aHHnooy/e63lfa1qFDB/+ePXvSty9fvtwdo17DaDqXes9XqFDBv3fvXn9+6DH0PTJlypQsnx96r23bti1f9wsAAAAABUGFJIoNzaGoIdXBy2233eb2BQ+LViWlhsPq6/HHH++qqgJDmlVx9fnnn7vqJA3nzExVUjJr1iw3zFJVT+p8HVyVqeYwejxVfBUmHW9289WpOkr7g33yySfu+Z911ll27rnn2nPPPeeGdqpy684778xwvxLqvnW/wdcJUI6hStLCoupTCbwO+T2///vf/zI0GFGlqyoOVZmYl+GnakgTPIxb99m9e3c33DY39xOYHzK4SlLNdFTdqKpPDVEO3K+GG4uq9HQdPUe9LwMVrplpCLAqPUO9/1UdGjy8XtWlqsDL7XyVqrTNPI9j4FgCw8F1nHoMDRHWtAfBrrvuOssPDRHu06dPemMmVRKqYjZ4mHlmwd/Tek30Pa3qxy5duoQ8b/reVQViTs8t2H/+8x9XxRqg6mQN2w513UieS1U/6/tT3+9evph3mitW5y3zsWrqgcL8PgcAAACA3CKQRLGhYa89e/bMsBx88MFun4YuKrAJzNlYvXp110RFIZ0oCBJ1q9Yf9YceemiOj6UQUxTs6X6CFw0z1fBQNTUpTBp6rXAulN27d7v9B6KAT0Gbwovg+5VQ9637Db5OUQkEkYFgMr/nN1RQd9BBB7ngZ8mSJbk+Hs3BFyo0k8DcjgrBFFAGL4Eh1mpsowY3b775Zvo51NQAWs8csr399tsuDFIwqbkN9RwDj69u5JkpFAtF8ykqnNJQ2wCtK1TLPEy4IM9bw4l1/lu1apXluqG25ZbmilRQp2H7Gq6tkE6vXXY0h6mCdp0zzdEY+J5WwBfqvCkgDATs2T233JyLUNeN5LnU0PJGjRq5EF3PX/+AeOmll9KnqyisYwUAAACAcKLLNoo9BYyaE00hl5p/qEJNwY2qqVTBpqBIzUXyep+BKqbs5npTUFKYFKgEz7EXTNtVwZUbCiSD58HT/QbuI9T9Sm7vO79UDRkcwkTi/AbTeyM7gWPTnJKa7y/Yt99+m97gRMGjKjZV7acgWO81hY5aD9A+BYkK3zS3qeYDVWimAFXPO9T7MrtwWPetuQOff/55F9bqsjq3q/JQQVVhPe+ioopkvc90TnUen3322WyvqzBY80EqzNNcoe3atXOhpKog1RxJDWkK+tyyu35uz0O4zqX+ETN79mzXiVyLmvpoTlGF+aqQVVOeaDlWAAAAAMgtAkkUewq7/vzzT7vjjjuyBEiqJArWvHlzN4xWTR4OFAIE/pBXJWY4qOHE66+/7pqiBDe20WU1qlHwlBuqAlWlaIA6SCsImjJlSpbrBrYpxC0qGiavpkMKiTUcuyDnV6Fz5uY8Cmt0P6oik+Ah3QWhqsPA8Qao+U3wflWvKYjUEG012FHnYz3P4IYkCiAVwAUHjWrAlB+qAlbzHzWyCQzlze1w7dxSuKkqYzVNySzUttzSa6RzpkBRYaq6YWdHwZve86qkzNyFOzBNQ3FQWOdS0y2cfPLJbhFViWpovxrU6P0AAAAAAMUNQ7ZR7AWqfzJX+qjzsoKwzB2f1bX4s88+y9BROyBwHxrSreHgGvL977//Zrme5l5T0FaYAgFN5o7QgcsKuwKye2yFE8uXL7fTTjsty31rCOxHH32Uvk1VeuperO7cgaAjODDT9QtKx9mvXz83ZFudzwOhXH7Pr7ohB7/O06dPd6+jOi+r87UEvhb09dEw18xTBARXbSr0VediVeup67dkDgf13lRAGlwJqeO/77778nVMCj5VbamgTsO11eFZ1cGFSces75Fff/01S8fpRx99tED3fdlll7nKPr3ugeH72R1DqO9pzSsaav7IaFUY51JzjmbWsWNH97WwP4MAAAAAIFyokESxp3kF27Zt68IqVYxpWPD8+fPd0FYN9Zw2bVqG6z/11FNuDkAFBQMHDnSNUXbt2uWCDg13fvDBB12IpOo2NX5QCKThuXoM3b8qEDUUV5VegwYNyvHYNK+h7kf+/vtv91WhoEJDufDCC9Mr+1TxpIBLVU9q+KFGFJMnT3bBk4bqBlfrqXmNtmvYr45ZAd53333nmqpoCGfmStGbbrrJJkyY4IYTX3vtta5icvz48fbbb7+5KlINh818TnVceWl4oZBXQabCN83x98cff7hAWHPd3XDDDW4JyO/51fnU0F9Vi6rBi15LVds9/PDDGebGUyWs5nfUuQjMK5o5pC0MCiB1zt99910XYAaGcwecffbZbp+ep6oD9+7d666fuYlQXqskhw0b5tYV7gUaMRUmBaaTJk1y768rr7zS6tev7+Yl1ZyIBalCVYAaCG9zovd67dq13ZB+vQf1+Kpq1ntG39NqilRcFPRcKnDWPw2OPvpoVzmt+XDVHEi30+cHAAAAABRHBJIo9lSFpD/wr7/+ejeUVfPOqfpO6xrKnTmQbNKkiRtee++997qhjwr3VPmm4bgKewI6dOjgQjUFYx9++KGr6lJwpwBQQZmq8g5k0aJFdvvtt2fYprBNSyB4CQSSotBQAcZrr73mwhcFh/fcc48LFDMP71Zl3ltvveWCDVWS6XndeOON7roKMIIppFOFlvapilJz9KmhiEI7zXFYGDRkXkqVKuWq3xTQKWjUkNtA1+lg+Tm/6pCuQFVBnEJkDd9WGJn5/jX0/ZprrnFDqhX+6RwXRSCpUFtzdGp4sY45c7ikpiwKZB9//HH3/tT7TMcxcuTI9KYieaX71DnQa5h5OHNhUaiv+Ql1zJr7UsPOFZbrvaPXNdA5vKjo/asQT3N0qopXgbv+caDvVwXxxSmQLOi5vPzyy11jJP2DRRWRet+owljnRZ3hAQAAAKA48vmZ0R5AlFPYp4CZjyuvW7rmBVUordAunBTua75RhciZQ3JwLgEAAAAgt5hDEgCKEVV/akh8cDVvUVAFajCFwZoWQU444YQifeyShnMJAAAAABkxZBsAigHNPao5NDUHo4bbn3766UX6eBpSr7kvNWejpkHQ4//4449uiL+GT4NzCQAAAAD5RSAJAMXAf//7XzdXpcJANSIKdKIuKn379nUhpOYy1RyOmqNU865qnlJwLgEAAACgIJhDEgAAAAAAAEDYMIckAAAAAAAAgLAhkAQAAAAAAAAQNswhGUJaWpqbq61ChQrm8/nC92oAAICYoy7227Zts7p161pcHP8rBgAAQMlHIBmCwsgGDRqE/9UAAAAxa9myZVa/fv1IHwYAAABQ5AgkQ1BlZOAPg4oVKxZ6FYQWUfVlpCowVQW6bt06q1GjRkxXY3AeOA+8H/ie4LOBz8hI/6zYunWr+0do4PcPAAAAoKQjkAwhEBIqjCzsQDIlJcUmTJjg1vv162cJCQkR++Nq9+7d7vnFeiDJeeA88H7ge4LPBj4jo+FnBdPEAAAAIFbEbhIFAAAAAAAAIOyokAyz+Ph4O+uss9LXAQAAAAAAgFgSdRWS6jJ59dVXW6NGjaxMmTLWtWtX++2339L333XXXda6dWsrV66cValSxXr27GlTp04NeV979uyxDh06uCFQM2bMsGigYyldurRbGJoFAAAAAACAWBN1FZLDhg2zv/76y8aNG2d169a11157zYWOs2fPtnr16lnLli3tqaeesqZNm9quXbvs8ccftxNPPNEWLlzoJpsP9r///c/dx59//hmx5wMAkaDmWZqzNjU1Nc9z5e3du9fNlxfr88tyHjgPhfl+KFWqFCMjAAAAgH18/kDL5yiggFEdJidOnGinnHJK+vZOnTpZ79697b777gvZmbJSpUr21VdfWY8ePdK3f/bZZ3bttdfau+++a23btrU//vjDVUvmRuA+t2zZUuhNbfRHzd9//+3WdVyR+oNfx7F27VqrWbNmzIcOnAfeDyXt+yI5OdlWrVplO3fuzPNt9SNB50HPP5aruDkPnIfCfj/odvXr17fy5cuH9fcOAAAAIBpFVYVkoJonKSkpw3YN3f7pp59C/tH9wgsvuF/i27dvn759zZo1dvHFF9sHH3xgZcuWPeDjami3luA/DER/fGgp7Oc4a9Yst96qVauIdtkO/IEVyzgPnIeS9n7Qsf/777/us0UV4qrKymuAokow3S7WcR44D4X1ftDnyvr162358uXWrFmzLJWSxfkzBwAAACj2gaSqI4888ki79957rU2bNlarVi0bP368TZ482Zo3b55+vY8//tjOPfdcV/1Tp04d+/LLL6169erpv/QPGjTILrvsMjvssMNs8eLFB3zcESNG2N13351l+7p169zwrMKkwFXPK3D/kWpsoz9+VImh81WcK8EKivPAeShp7wf900OLwkj9MyevAkXz+myK9QpJ4TxwHgrr/VC5cmX3D8/Vq1dnCTY1fzYAAAAQS6IqkBTNHTlkyBA3X6R+8e/YsaMNGDDApk2bln6d7t27uyY1qjZ48cUX7ZxzznGNbTTM8v/+7//cL/Y333xzrh9T19Xw7gD9wdCgQQM3J2VRDJ1SiBoNwYv+qNJzLK7BS2HgPHAeStr7Qf9E0WeYAo+CVGBTIcl54P1QuN8Xuq0+V6pVq5ZlJEjmywAAAEBJF3WBpIYyff/997Zjxw73R7XCu/79+7smNgHqsK2KSS1HHHGEtWjRwkaPHu2CxW+++cZVVCYmJma4X1VLnn/++fbKK69keUxdN/P1RX84FNdQIjcUvJT055gbnAfOQ0l6PwTmuAss+akEC9wu1iskOQ+ch8J8PwS+J0N9vhTXzxsAAACgxASSwaGjlk2bNtmkSZPsoYceyrGqKTAH5JNPPpmh+c3KlSvtpJNOsrfeesu6dOkSlmMHAAAAAAAAEFrU/Ute4ePnn39uixYtcnNDanh269atbfDgwa5q8pZbbrEpU6bYkiVL3DBuDe9esWKF9evXz92+YcOGdvDBB6cvLVu2TK+8VHfLSJs7N8XuuONNu/76N+3mm1NswYJIHxEAIFjjxo3tiSeeSL+sqjY1SSvOMj+HuXPnuhEGGircoUOHiB5bVEtJUec7ddHbv+iytgMAAAAoOYGkGkpcccUVLoS86KKLrFu3bi6k1NxLmlNSf0SdddZZLmg87bTTbMOGDfbjjz9a27ZtLdqNHWt2yCFm//zjt1Wr/PbYY2atW5u9/HKkjwwAMtm40Wzp0qyLthcRNSQLHm6uufZ69eplM2fOjOjLs2rVKuvdu3fEg9GAu+66K88hYubncOedd7pRCPPmzbOvv/7aSuow6zvuuMNN/aIGTz179rQFufgv4NNPP+3OvcLaLocdZr9+9JHZkiUWv3y5+6pl8gcf2PHdu7tzqLmmjznmGNu1a1dYnhcAAABQEkTdkG01qNESiv44eO+99/J0f/qjItAdM5L0N9CwYRpeHm/vv9/XbUtO9jpsDx1q1q2bWVAjcQCIHIWO111ntn591n01apiNGmVWtWqRPLQCyLH6742Z60Z822232amnnmpLFYZGSO3ata24y/wc/vnnHzvllFOsUaNG+b7P5ORkK126tEUrTfWiaVw0d3STJk3s9ttvd1O4zJ49O9smMpreRU3unnvuOety6KH2xIgRdtLQoTb3yy+tht7zcXE2edo06zVkiN184432f0895ZpH/fnnn8wDCQAAABTnCsmSaswYDZnTms927SrrFq27LT6z0aMjfYQASjwNNc1u2bt3//W2bzdbu9ZMYVPlyvsXXV6zxmzTptzdbz6owZjCMy2qArzpppts2bJltm7duvTr3Hjjja5KvmzZsq7hmYKmvUHHr3BI031UqFDBVa916tTJfv/99/T9P/30kx199NGuaq5BgwZ21VVXuSlBcjPcefHixe6y/jmmx9AxtG/f3jVTC5bXxyiI4447zt3///73P6tatao7d6qizO45aF1Tntxzzz1uPXDdWbNm2fHHH++OWdWpl1xyiW3XeyGogvX000+3+++/3+rWrWutWrVKPx9vv/12+vPt3LmzzZ8/33777TfXUK58+fKuOjP4Nczsu+++c/ejak3dRue1a9euroIzP/SPSFWXKtDu27evHXLIIfbqq6+6eaVzGn7/2GOP2cUXX+ymiTmoTRt77u67rWyZMjbm3XfNr8YzcXF2zQMP2FUXXmg33XCDG52h86B/pIZqjgcAAAAgNALJMFm8WH8ghd6n7doPAEXqqquyX557LuN15841mz1b6d7+RZfnzPHmnwh2yy2h77OAFIa99tpr1rx5cxeQBShofPnll12l26hRo+zFF1+0xx9/PH3/+eef7+YMViCm4E2hpqb9CFQGqgpTU39oKLgq4hQeXnnllXk6tltvvdWuv/56mzFjhgtHBwwYYCn75hXMzWMoBFQFf2FRFaCGD0+dOtVVBips1DzM2Q3fVpB23XXXuXU9D4Wlqh6sUqWKO28TJkywr776yv773/9muK0CQ4WEuu+PP/44wxBwhX/Tp093FYPnnXeeC0j1+mhalYULF7rh07k5r48++qgLkHU/mic6QPejcDOn5fXXX3fX1TzUqrDVMO2ASpUqueZ2mcPj4IpPvV+Cb6Pu1z27drUpv/5qvh07bO369TZ1xgyrWa2adT3uOKtVq5Yde+yx7vUFAAAAUIyHbJdU+rtTlZBxcWnWqpVX8TFvXitLS4tz2wvx71IAKLYUcilYEoVkmv9P2xQMBSj4ClCop0DtzTffdAGYaHj3DTfc4OYilhYtWqRff8SIES6wvPrqq9P3aVivQqVnn30226G8mekxNeRZ7r77bhfwKXTTY+bmMapXr+6arRUWVQAqFAw83lNPPeXCwxNOOCHLdVVBqbBP5zkwlFuh7u7du10VoYJN0X1orub77rvP6tWr57Zp30svvZQ+VFsVkoHzoUBThg8f7gJaPf5RRx3ltg0dOtSFyAei6kudJ1GQrHOs49I5U+WkAuCcKCAUhZHBl4P3B/Zltn79ektNTc16m+rVbe7ChW7932XL3Ne7nnrKHnnwQevQubM7Zz169LC//vorw3sNAAAAQPYIJMNERR4PPeQFkh06eH9QLVjQwgWSqpDUPJIAUKSefDL7fUGBn6MwT3Pm7QsHHQ3f1fySgwdnvO4DDxTaIWoYtEI72bRpkz3zzDNuuO+vv/6aPt+hKg4V8KkSUVWUqkzU0OwAzQE4bNgwGzdunKt269evX3r4p+HcqloMVNIFhvempaW5qro2bdrkOgAMUGgqa9eudYFkbh5D1ZJ5rcrM7fEEjknHk1tz5sxxQ88DYaQoTNQxa/h1IJBs165dyHkjgx8/EOjpusHbcnM82Z3Xhg0buuHgqpYNO/2Q3rek7auCvbR/fxs8cKDmGLBDDz3Uha9jxoxxYTQAAACAA2PIdpioaMKbJ9JnixY1cUtams9lANpOQxsARU5z3GW37BvSnE4fTpoHUp2DA4sua3vm62Z3n/mgQEyhkxbNRahqPFVKqoJPNNxW1Ycnn3yyq5z8448/3DBfDbcNHg79999/u+q6b775xg466CB7//333T4FmJdeeqmrtAssChDVfTkvFYuBIeCiuQ9F4V1hPoZC1i1btmTZvnnzZjf8OLvjCRxT4HgKU3BgeaDzkXlbbo4np/OalyHbgcrPNZrzNIguZ9ekSFWr8fHx+28TH2+WkGBr1q+32tWrm8/vtzr7mjkd1LKlt38fhcyRbLwEAAAAFDdUSIbRoEHqph1vBx98hPu7Xn/XTJ1KGAkgyqgqsnp1r8u2gsjMXbaDqyaLmEIpDdfete84fvnlF1cpqRAyYMmSJVlup3kdtVxzzTVu+LA6d59xxhnWsWNHN/dkUVbaFdZjqFmK5jTMTPM0al9hUqCmIdUKfwOh488//+zOvc5jNMjLkG111VbwqMpFNUeSrVu3ujk2L7/88pC3VeWnGiDpNmreozAyrX59+/rXX+2K8883f7ly1rhlS9fQZ96GDW5/gKpIVckLAAAAIHcIJMNMf5+WKeMVGunvfSojAUQd/bdk1ChN4ph1n8LIfVViRWHPnj3pc/xpyLbmMVTFoeYyFM3Rp0o0zRmpCspPPvkkvfpRFFxq/sizzz7bhVLLly93TVrUYCbQofuII45ww6U1rFvhm8JDNWnRYxWG3DyGvuq4FX5lR2GqOldrXsUzzzzTzW84fvx4VyWqoeyFSVWnmoNy4MCBrsJUHbHV0ObCCy/MMqdipORlyLaCbM3hqfkv9Z7Re0Hd2BUmurBxH839qKA6MHxew/11DhR+Hn744a5T946dO21wv36uy3ZcYqJ7f+lctT/0UBd2qqHQ3Llz7Z133imy5w4AAACUNASSEbBvFFq2XbcBIOIUOgZ1tg6Xzz//PH3uQHXT1pyM6vh83HHHuW19+vRxQZ0CJIWXGpatoEkhmmjI7YYNG+yiiy5yQ281DFdhnhrPBOYo/P77712FpcI+ze2oYdT9+/cvtOeQm8dQAxXNgZmTrl272meffeY6ZqvztKoVNS+jQsyDDz7YClPZsmVt0qRJriGNgl5dVoirxy2u1ORIFZ+XXHKJG+berVs39/4Kblyk10CvRYBeI4Wx6giuYFyB4+effmq1atRIHzquoFONdvQ+3Lhxo5t7U2FzYTYpAgAAAEo6n19/KSEDDevS/Fyauyu4UUJhUPOFgQM/ME13NnPm6TZvXmQyYf1hpUYBNWvWzNC9NtZwHjgPJe39oKBEjVNUEZbbjtHB9CNBn1PqwhyYwy8WcR44D+nS0sy/bp37fIirVct8+fxsyOl7syh/7wAAAACiERWSEVCq1N70pp0AACCKKYCsWdN12I6L4ZAeAAAAKEwEkmGm4YTffXeqbdyo3hD7O3QCAAAAAAAAsaB4jkksxjQEcufOCrZtWwXz+6m0AAAAAAAAQGwhkIyAwIivffPjAwCAaKUf1suWWdyKFcy1AgAAABQShmyHmSbFb9RooVWqZJac3JxMGACA4hBK8l9EAAAAoNBQIRmBQLJt22l22GHTzOejRBIAAAAAAACxhQrJCMwhuWZNA9u2TeEkc0gCAAAAAAAgthBIRqDL9p9/drOVK83q1Qv3owMAAAAAAACRxZDtSJz0fWfd74/EowMAAAAAAACRQyAZwS7bBJIAEF7fffedmzpj8+bN7vLLL79slStXznCdF154wRo2bGiJiYn2xBNP2F133WUdOnQo0OMuXrzYPe6MGTOsuBk6dKidccYZVlwUxusFAAAAoGgRSIZZSkqKHXPMB3b66R+Yz5cS7ocHgFxbsMDs5pvNBgzwvupyURo0aJAL7S677LIs+6644gq3T9cpTP3797f58+enX966datdeeWV9r///c+FiJdccoldf/319vXXX1u4BULMwFKhQgVr27atOxcLiuDFKM6habAieb2SkrwFAAAAQKEgkIyAxMRdVqbMrkg8NADkytixZq1bmz38sNnbb3tfdfnll4v2BDZo0MDefPNN27Vr/2fk7t277Y033nBVi4WtTJkyVrNmzfTLS5cutb1799opp5xiderUsbJly1r58uWtWrVqFilfffWVrVq1yv7880974IEHbM6cOda+ffuIhKSRlJycnKvrFfrrpXlWatWytBo19g9xAAAAAFAgBJIRaGrz66+97PPPe1lKSny4Hx4ADkjFdxdfbJaWZpaamvHr0KFmCxcW3Uns2LGjCyXfe++99G1aVxh56KGHZrjunj177KqrrnKBYlJSknXr1s1+++23DNf59NNPrWXLli547N69u6sCDBY8ZFvr7dq1c+vNmjWz0qVLu+uHGgL80ksvWZs2bdzjtm7d2p555pkM+3/99Vd3vNp/2GGH2R9//JHvc6JwrXbt2ta0aVPr27evCyi7dOnihlKn6oXZZ+LEie786TF13bvvvttV5Qeo+vHZZ5+13r17u/Oh67zzzjvp+5s0aeK+6rh13eOOOy7DcTzyyCMupNXxqEpTwW0oqjLV/X/22WcZtr///vuuynPnzp3u8o033uheG4W+Opbbb789w30GzrvOtY5Nz+vVV191j6/XPtjpp59uF154YYbbBaiqVvtzOn4Fvgqhddx6LAXgjRs3dkP2s5Ob+wUAAAAQGoFkmOmPvB07qtimTVXM76fSAkB4HHaYWf36B14aNDDr0iXBhY+haLtywdzclxY9bl4NGTLExqpEc58xY8bY4MGDs1xPw6rfffdde+WVV2z69OnWvHlzO+mkk2zjxo1u/7Jly+zMM8+00047zQ1DHjZsmN100005Dt9W2CdTp0511ZIKRzN7/fXX7Y477rD777/fVSuqalFhmo5Dtm/fbqeeeqoddNBBNm3aNBeQaRhxZgq8tC+v4uLibPjw4bZkyRJ3//Ljjz/aRRdd5LbPnj3bnn/+eRew6hiD6TjPOussV215/vnn27nnnuueQyBEDa7IDA6Fv/32W/vnn3/cVz1P3beWUCpWrOiev0K9zOdNAZ4CSFE4qfvQ8Y4aNcpefPFFe/zxxzPcZuHChe411rHoNezXr58LYT/88MP066xdu9Y++eQT977JzoGOX+du5cqVbo5RPZ7mEdX9HkhezgsAAACAIH5ksWXLFvW/dl+LQtOmamfj91evHrmTn5qa6l+1apX7Gss4D5yHkvZ+2LVrl3/27Nnua7B69bzPnXAvetzcGjhwoL9v377+tWvX+hMTE/2LFy92S1JSkn/dunVun64j27dv95cqVcr/+uuvp98+OTnZX7duXf9DDz3kLt98883+gw46KMNj3Hjjje7zfdOmTe7y2LFj/ZUqVUrf/8cff7j9//77r7u/tLQ0/5133ulv3759+nWaNWvmf+ONNzLc77333us/8sgj3frzzz/vr1atWobX4Nlnn3X3q/sPOP744/3/93//l+35WLRoUZbbBMyZM8fte+utt9zlHj16+B944IEM1xk3bpy/Tp066Zd1/csuuyzDdbp06eK//PLLs308Pf8LL7zQ36hRI39KSkr69n79+vn79++f7bG///77/vLly/t37NjhLuvnqV7Hzz77LNvbPPzww/5OnTqlX9Z512us90MwHW/v3r3TLz/66KP+pk2bumMN3C749dJ7JqfjD5zL3377LX3/ggUL3LbHH39cHwz+tKVL/SmLF/vTgj4bDnS/uf3eDMfvHQAAAEC0SQgOJ1H00tLSrE6dxe5P9W3bGlOkCiAsatfO7TX9tmWLqvy0HrqKu3x5s0qVCvtx96tRo4YbPqtKM+VoWq9evXqG66gqTUNjjzrqqPRtpUqVssMPPzy94k9fNbQ52JFHHmkFsWPHDvfYGi59sca176Oh0ZX2nRQ97iGHHOKGGOf0uAWZA9LLF72qe1HF488//5yhIlKVhJp/U0OkA1WJmY9Dl3PTxEbNdDTlSICGKM+aNcutq0JUS4AqHk8++WT3eqiSUVWYqjpU5WTPnj3Tr/fWW2/Zk08+6c6nqkp1DnWdYI0aNXLvh2A67507d7YVK1ZYvXr13Psk0BApP8c/b948S0hIcMPdA1RtW6VKlf13EJizIA/3CwAAACB7BJIRCCTbtJlq6s3w1Vdq0MCoeQBF7/ffc3c95Vxz5qRYu3ahh22rv4emQ2ze3IqUht+q27U8/fTTFi0UnImGF2cOO4ODqaIWCF0D8z7quDRnpIaoZxYcjOaXwsVgCv/080zUFf2cc85J31e3bl0X8J199tlu2LYCSX3VkHhtl8mTJ7sh4zpmDbNXmKtmRo8++miGxylXrlyWY9Ecl2rqo/kkTzzxRPv777/dkO38Hn9BFNX9AgAAACUdgWSY6Y+VjRvr2IYNKrhgDkkA0adFCzVtMRs2zGsqrJAy8HX06KIPI6VXr16uq7I+MxVYZRZoOqOqQFXRiSom1dTm6quvdpfVdCZ4rkGZMmVKgY6rVq1aLnD7999/XaAWih533LhxrjoxEAYW9HGDKfBSZaHCyECjH1X3qdJPlX050XFovsTgy4H70PmU4EY5uVG1alW3ZKbzc8IJJ7jA8JtvvrH77rsvfd8vv/ziXrdbb701fZvmxMwtzQeqhjOqklTVZai5PnOrVatWrjpTjYc6deqUPnflpk2b8n2fAAAAAHJGIBlmqqD566/jbP783A95BIBwGzTI7OijvQBSjakbN/Y6bIcjjAx8VgaqAENVHqpy7vLLL7cbbrjBhWHqwv3QQw+54ckaTh2o3FPFna6jAEsNYAqj4Yiq+tTdW1V9Ck7V8fn33393Ada1115r5513ngvaNLT45ptvdp261Yk5sx49etgZZ5yRXgmanQ0bNtjq1avdc/vrr79cEKcGNKoKDJwbNdlRIxmdB1UmqvGNhnHr+sFB4IQJE1zXb3UkV5MZ3c9ovchmrlu5ukx//vnnVr9+fRemZh5CnRfHHHOM6w6uYFLhaXBFaYsWLVzTIFVFavi1nou6cOeWzrEaBalSVZWSBaEu6Qo1L7nkEteFXFWP1113nTsXOQ0DBwAAAJB/jBeOgMDfN/umAAOAqKTwccQIs/Hjva/hCiMDFIblFIiNHDnSdYy+8MILXYWgqtomTZqUPvefwjnNXfjBBx+4Ib7PPfdchrkO80vh5ksvveQ6gbdr186OPfZYF3QGhk+XL1/ePvroIzeXoKoPFU4++OCDWe5HcyeuX7/+gI+nsExzE+qx1CVcFZgzZ8607t27p19HVaQff/yxffHFFy7gO+KII1zH6kD1aHCYqhBQc1wqyBs/frzrBi4aTq3KS3XoVhVo3759C3SeFOYNGDAgvaN3sD59+tg111zjwtgOHTq4ikl1AM8thcF67XWu1bm7oHQuVP2qEFUhscJkdQEvjOHuAAAAALLyqbNNiO0xbevWre6PnS1bthSoOiQ7bdqYzZ1rVqGCHssiQkP+1q5d6ypiVEkTqzgPnIeS9n7QMOFFixa5cCw/YYp+JGj4qsKpWK4OK4nnQc9DVYh5CfCi+TyowlRNZRSiFrbly5e7YeBfffWV9eje3fxLl7rPh7jGjc2Xz8+GnL43i/r3DgAAACDaMGQ7zPSHXefOn7k52n74oTcvAQAAeaCh8d99951bnnnmmUI5d5rjUo2BVIW6atUq+9///meNGzd2FZNOYqLXaRsAAABAoSCQjIAyZbZbSgpDtgEAyCsNg1coqWHwakhTGNQQ6ZZbbnHNijRUu2vXrm6OzfQu2rVrW1pKisVFWZUoAAAAUFwRSIaZGhDMnNnTFi5UtWTWRg0AABSFkjJDi5oEFTbNwRmqmzsAAACAokEgGWaag2v79hqmPgZlyoT70QEAAAAAAIDIKp5dG4o5umwDAFBMpKWZrVhhcatWMdcKAAAAUEgIJMNMXTqrV19qDRsu1aVwPzwAAMgrTfysBQAAAEChIJCMQCDZsuXPdtRRP5vPRyAJAAAAAACA2MIckhGYQ3Lbthq2dq3CSbp1AgAAAAAAILYQSEagy/bcuT1t+nSzBM4+AAAAAAAAYgxDtiOApjYAAAAAAACIVQSSEUAgCQDZmzx5sqsmP+WUU4rNabrrrrusQ4cOYbtduDz99NPWokULK1OmjHXp0sV+/fXXA95mwoQJ1rp1a0tKSrJ27drZp59+mu11L7vsMjeVyRNPPJFhe+PGjd324GXkyJGF8pwAAAAARB6BZJilpqZa69afWe/en5nPl2o332y2YEG4jwIAotfo0aPtv//9r/3www+2cuXKSB9OzHrrrbfsuuuus9tuu82mTZtm7du3t5NOOsnWahLkbPzyyy82YMAAGzp0qP3xxx92+umnu+Wvv/7Kct3333/fpkyZYnXr1g15X/fcc4+tWrUqfdF7IuzUWTs52Swuzlu0vmcPHbcBAACAAiKQDLNXXvFbaupmq1x5s/l8fnv4YbPWrc1efjncRwIg1qSkpLjF7/enb0tLS3Pb9M+Swr5ufmzfvt0FYZdffrmrkHw504fjpk2b7Pzzz7caNWq4qj1V740dO9btO/744+3KK6/McP1169ZZ6dKl7euvv06vvLvvvvvsoosusvLly1ujRo3sww8/dNfr27ev23bIIYfY77//nn4fOobKlSvbBx984B5PlX8K5pYtW5a+/+6777Y///wzvZovcNxLly5Nv9+KFSvaOeecY2vWrDng7TZv3mzDhg1zz1O303PT9bKzePFid/v33nvPunfvbmXLlnUBoqpN8+uxxx5zxzBw4EA76KCD7LnnnnP3O2bMmGxvM2rUKOvVq5fdcMMN1qZNG7v33nutY8eO9tRTT2W43ooVK1zA+Prrr1upUqVC3leFChWsdu3a6Uu5cuUs7GHk0qXesnu3+RREan3JEu+r9gMAAADIFwLJMFIl5MUXx9u333Z3S2pqvOnvev3dPnSo2cKF4TwaALFGQ2m17FGwss+cOXPctuAALlC9pu07d+5M3zZ//ny3berUqRmuq0BP27du3Zq+7d9//83XMb799ttuuG+rVq3sggsucOFXcNB5++232+zZs+2zzz5zx/7ss89a9erV3T6FZ2+88UaG5/faa69ZvXr1XKAX8Pjjj9tRRx3lKvgUel544YUuoNTjTZ8+3Zo1a+ZCuODH1Xm4//777dVXX7Wff/7ZBYbnnnuu29e/f39XSdi2bdv0aj5tUyirMHLjxo32/fff25dffunOi/bldDvp16+fq0TU81R1okK9Hj16uPvKya233mrXX3+9zZgxw1q2bOmqFRUWB8JRBaM5LQ888IC7bnJysnvcnj17pt93XFycu5xTyKl9wbcRhbfBt9F50TlXaKnnnh0N0a5WrZodeuih9vDDD6c/j7DRD2g9pioj1YUuPt77qsvanimYBwAAAJB79HkOIxWVqIJl9eraIeeVHD3abMSIcB4RAETfcG0Fg6JKuy1btrgw77jjjksP1RRQHXbYYekVjwFnnnmmq5CcOHGiq0QUVRwOGjTIffYGnHzyyXbppZe69TvuuMOFmp07d3YhoNx444125JFHukrG+vXru2179+51VX6aR1FeeeUVVwGoORUPP/xwF+YlJCS4Sr4ABZCzZs2yRYsWWYMGDdw2BZoK4X777Tf3mKFu99NPP7n7VSCZmJjotj3yyCOuQvOdd96xSy65JNvzpzAyMPemqi/1WAsXLnQhr4ZGK6jMSdWqVd3X9evXu0rYWrVqZdivy3Pnzs329qtXrw55G20PePDBB91zvuqqq7K9H+1TCKvj0TDwm2++2QW2qtoMu33DtRVP+7Qu+awABgAAAOAhkAyjxYvNggpuMtB27QeAohII3NQwJkChmqoRgwM7OeOMM9y24Ouq4q558+ZZrtunT58s99u0adM8H9+8efNcEKfqTFFopYpBhZSBQFJDuc866yxXyXjiiSe6+Qm7du3q9mkotSrvVFWpQFLX0dyFquAMpiHZAYHwTM1XMm9TIBgIJHUsChADFPBpGLeqNBVIhqJ9CiIDYaRo6HPgdsH3F0xDszV0XdWBwXbt2mX//PNPjucw+LnVqVMn/XnoePUc9PpFkqouNaxbr03m91Gwa6+9NsNz0rB7hcgjRoxID2nDRj+gd+40n76Ge9g4AAAAUEIRSIaRCnni4tKsdu1V7vKqVXXM7/eqLfR3WVChDwAUOgVSmWkYrpZQ180cGOV03VD3m1cKHjUsN7jJiYZNK4BSdWKlSpWsd+/etmTJEte5WRWIGsZ8xRVXuArCwLBtda1evny5m1tSQ7U1T2Sw4DkLA88x1Lb8zoNZUAojFSZ+9913WfYpzMxJTs9D1aUKRHNyyy23uEXD4BUwB+a7DNDl4GrOzLQvp9v8+OOPLiBt2LBh+n5VYmroujptay7MUFSZqveG9itADzudw+z+owgAAAAgzwgkw2jIELNHH02zY4/9wV2eMKGfpaR4f7Tr7xzNIwkAsUhhk4YzP/roo67yMZiqIMePH2+XXXaZu6xGL5rjUcvRRx/t5iIMBJKqdNRw7hdffNHNJ5m5mUpBjk/zbAaqIVXNqXkkVWEqquDL3OxH+9T4RkugSlLzX+p2gWAw1O00VFlDnBX0Bg9JL6i8DNnWcXXq1Mk1Azr11FPTg01dztw4KJiGuus6V199dfo2BcfaLqpgDTXHpLYPHjw42/vVcSvkrlmzpkUsjNSi14pgEgAAACgwAskwatHC7PnnffbWW94ffH6/hkN6f9to/sgIj6QDgIj5+OOPXQftoUOHukrIYBqirepJBZKa81FBmeZGVPMa3S4QCgaoSlKhmboya+h5YVDlobpCP/nkky4o1P0fccQR6QGlgkPNFangTMO81SFawZsCUnUFV/WfQs3//Oc/duyxx2aYAzPU7RTgKYh96KGH3FD5lStX2ieffOKeT+C2eZXXIdsaNq3QV3N26ng01HrHjh0ZgkM1A1LTIA2lluHDh7vnp2BZc1m++eabLsh94YUX3H4NQ888FF3nVhWUgcpHNcBR4yR1C9f50OVrrrnGzS1apUoVC5tAExs1sPH7vSHbgfA40OQGAAAAQL7QZTvMBg+Ot+3bT7JJk05yXbY1p/+8eWaDBoX7SAAgeihwVBCXOYwMBJIKtWbOnOkq99TgRPMKHnPMMW5YsUKvYOosrfBNXzWvZGEoW7asa3Zz3nnnuQ7dakbz1ltvZThGNeFRiKYKTlV0asi0GuwoRNOx6vlpbs3c3E5D0nUbhX8KJNXRW0PVMzeMKUqav1Pdre+55x4XSio0/fzzzzMcg4aBq9lMgObzVGWqAsj27du7JjxqxnPwwQfn+nE1RF+vqYJNBc/qbq5AMhBqho1CRw0t11K+vPk1f6TWNQWAvoaYqgAAAABA7vj8mqALGWzdutX9UazurhUrViz0s9O7t9nnn3vrGzeahbPgI0BD7zSPl4a/5Weut5KC88B5KGnvh927d7uKuyZNmuQrjNOPBFXyhZpDsrjQPIPNmjVznaw1/Dk/gs+DOmprCLKGWseakvB+KLC0NPMvXeo+H+IaN97fabsQvzeL+vcOAAAAINrw7/0ICP5bJtPUYQCAfNq7d69t2LDBbrvtNjecOr9hJAAAAACgaBXPEqBiTM0LGjb80k444UuLj08lkASAQvLzzz+77tSqjHzuuec4ryg8Gp7NEG0AAACg0FAhGYHhb2XKrLfq1c18Pr9r3gkAKLjjjjvOfcYWtkGDBrkFMTysoV49S0tJsbhYHbYOAAAAFDICyTDTvHTr1h1tP/6oask4KiQBAAAAAAAQUwgkIxBI7tlT35Yv9y4zhySAokC/MiC68D0JAAAA7McckhEQH79/nSHbAApTqVKl3NedO3dyYoHCoB/Uq1db3Jo1ShXzfTfJycnua3zwLwEAAABAjKJCMgIVEklJa61mTbN162paairzUQEoPAo7KleubGvXrnWXy5Yta748zHunz6iUlBRLSEjI0+1KGs4D5yFdWpr5d+60tLQ0i9u923yaUzKPdNt169a570d9bwEAAACxjt+KI9Blu0aNb6xHD7MJE/pZaiovAYDCVbt2bfc1EErmNYhzwUtcXMwHkpwH3g/7vinMNm60NL/ffHv35vv7Qt9TDRs2jOnvKwAAACCANCwCUlMr2tat3t84DNkGUNgUeNSpU8dq1qxpe/fuzdNtFcJt2LDBqlWr5gKUWMV54DykS042/8sv2+7duy3xnnssLikpX++p0qVLx/T3FAAAABCMQDLMNFRry5ZT7JNPvMs0tQFQlMO38zpfnYI4zUOZlJQU0+EJ54HzkM7nM//mzebftcuSEhPzHUgCAAAA2C92/9qMoOC/8amQBAAAAAAAQCwhkIyA4IIlKiQBAAAAAAAQSwgkI9DUpkKFb6x7928sPj6VQBIAgGhXvrz5y5WL9FEAAAAAJQZzSIaZOtiWKrXG1ATX51M323AfAQAAyLXERPM/8ohtW7vWyiQmcuIAAACAQkAgGWZqEpGcfKRNnqxqyTgqJAEAAAAAABBTCCQjEEj6/Y1t8WLvMnNIAgAAAAAAIJYwh2QkTjpdtgEAKB727jV77DEr+9xz3joAAACAAqNCMgJzSCYkbLSqVc02bapqqam+cB8CAADIrbQ0882fbwm7drl1AAAAAAVHhWQEumyXKvWFnXTSF3TZBgAAAAAAQMyhQjIiytqOHaqWpNgCAAAAAAAAsSXqKiS3bdtmV199tTVq1MjKlCljXbt2td9++y19/1133WWtW7e2cuXKWZUqVaxnz542derU9P2LFy+2oUOHWpMmTdztmzVrZnfeeaclJydbNEhISLC4uL724Yd9LTU1gaY2AAAAAAAAiClRF0gOGzbMvvzySxs3bpzNmjXLTjzxRBc6rlixwu1v2bKlPfXUU27fTz/9ZI0bN3bXWbdunds/d+5cS0tLs+eff97+/vtve/zxx+25556zW265xaJFfPz+dbpsAwAAAAAAIJZE1ZDtXbt22bvvvmsTJ060Y445Jr0i8qOPPrJnn33W7rvvPjvvvPMy3Oaxxx6z0aNH28yZM61Hjx7Wq1cvtwQ0bdrU5s2b527/yCOPWDSgyzYAAAAAAABiVVQFkikpKa7pS1JSUobtGnqtasjMNAz7hRdesEqVKln79u2zvd8tW7ZYVbW1zsaePXvcErB161b3VZWWWgqTnl9a2i92zDE++/nno2zvXl9Emnbqeanjd2E/v+KG88B54P3A9wSfDXxGHuAHhVmpUuZPSfF+ZhbBz81Y/1kMAACA2BNVgWSFChXsyCOPtHvvvdfatGljtWrVsvHjx9vkyZOtefPm6df7+OOP7dxzz7WdO3danTp13BDv6tWrh7zPhQsX2v/93//lWB05YsQIu/vuu7Ns1zDw3bt3W2GHrjt3LrV69RLM5/Pb6NHJVqfOdmvaNNXCSX/8KKhVKBkXXLIZYzgPnAfeD3xP8NnAZ2R2fJs2mW/HDvMPGuT+WVlx9mzz+XzmL1fO/FWqFOr82QAAAEAs8fmVSEWRf/75x4YMGWI//PCDxcfHW8eOHd28kdOmTbM5c+a46+zYscNWrVpl69evtxdffNG++eYb19imZs2aGe5L804ee+yxdtxxx9lLL72UpwrJBg0a2KZNm6xixYqF+vzGjEmzBx9cZH6/zxYtaqqXwG1/8UW/DRpkYQ3iFLjWqFEj5gNJzgPvB74v+GzgM5KfFVls3Gi+q6/WfyfNv29URunSpb2f2jVqmP+JJ8xyGH2RF/q9Q4369I/Cwv69AwAAAIhGUVUhKeqK/f3337vQUb+gqwKyf//+bi7IAHXYVsWkliOOOMJatGjh5pG8+eab06+zcuVK6969u+vSrWHdOUlMTHRLZqocLMzqwQULzC69NM7S0lpk2XfxxT7TtJlBhaBFTlUehf0ciyPOA+eB9wPfE3w28BmZxc6dZuvXm5Utq7ljzL97t/mSksy3a5fb7tP+bEZn5FWs/xwGAABA7Ina34AVOiqMVJXipEmTrG/fvjlW+wVXOKoyUlWRnTp1srFjx0bNL/pjxij8Cr1P20ePDvcRAQCAHGle6yVLLH7ZMi+c1AIAAACgZFVIKnzUKPJWrVq5+R9vuOEGa926tQ0ePNhVTd5///3Wp08fF1ZqyPbTTz/tAsh+/fplCCMbNWrk5o3UcNyA2rVrR/CZmS1ebO65VarkNc3ZskXDsryEUgPntR8AAEQR/YDW8O2UFG8dAAAAQMkLJDV/koZeL1++3HXGPuuss1wIWapUKdeheu7cufbKK6+4MLJatWrWuXNn+/HHH61t27bu9mpwoyBTS/369TPcd6Sny2zc2CwhIdVOPvlTd3nChH6WkpKQXiGp/QAAAAAAAEBJFnWB5DnnnOOWUJKSkuy9997L8faDBg1ySzQaMsTs0UfVRCfrfJXKSocOjchhAQCA7GiuyL17zVQhuX27uttwrgAAAICSFkiWZC1amL3wQoINGXJm+qgvVUYG5o8MZ0MbAACQg/LlXTdtW7NG/0m0uNRUN3Tb4uO97doPAAAAIF8IJMNMxZv6m2bYMO/yUUeZjR1LGAkAQFSpWtVs1CizDRvM7rzTknfvtsSRI12nbRdGaj8AAACAfCGQjIAmTfavd+tGGAkAQFRS6FiunAsg/aqMbNDArEyZSB8VAAAAUOzFRfoAYo0a86xe/Yt17fqLxcenahQYAAAAAAAAEDOokAwzdfresmWJNWpk9uuvhxNIAgAQzRITzf/cc7Z17VpLSszalA4AAABA3lEhGWZxcXHWrNmhNn36oZaWFkcgCQAAAAAAgJhChWQEAskmTVrbvHneZYZsAwAAAAAAIJZQIRkBwSO+du+OxBEAAIBc2bvX7Pnnrcyrr3rrAAAAAAqMCskIzCGZlrbTNe3csaOs7dnjC/chAACA3EpLM98ff1ipXbvcOgAAAICCo0IyAl22f/jhQ+vT50NLSKDLNgAAAAAAAGILFZIRUKpUvKWmeuvMIQkAAAAAAIBYQiAZ7hOekGD9+59j553nXSaQBAAAAAAAQCxhyHYkTnqcqiS9dQJJAAAAAAAAxBICyQhJSvK+0mUbAAAAAAAAsYRAMgJNbaZOnWqdO0+1uDia2gAAAAAAACC2MIdkmPn9fvv333+tUSMN3e7EkG0AAKJZ6dLmHzXKtq5da0mlS0f6aAAAAIASgQrJcJ/wuDg75JBDbPHiQywtLY5AEgCAaObzmSUmeovWAQAAABQYFZIRCCTbtm1rq1ebpaXR1AYAAAAAAACxhQrJCKGpDQAAxUBKitnLL1uZt97y1gEAAAAUGBWSEZhDcs+ePVaunC4l2t69PlcpGUc0DABA9ElNNd+UKVZq1y63DgAAAKDgiMEi0GX7/ffftw4d3reEBO8Pm+TkcB8FAAAAAAAAEBkEkpE68UFnfs+eSB0FAAAAAAAAEF4EkmGWkJBgAwYMsEWLBlhKijdinkASAAAAAAAAsYJAMsJNbWT37kgdBQAAAAAAABBeBJIRkpi4f50KSQAAAAAAAMQKumxHoKnNjBkzrGpVzSPZwdLS4gkkAQAAAAAAEDMIJMPM7/fb/PnzrVw5BZLtLS2NCkkAAKJW6dLmf/hh27ZunSWVLh3powEAAABKBIZsh/uEx8XZQQcdZGlpWrzTz5BtAACilM9nVqGC+cuX99YBAAAAFBiBZAQCyfbt2++rjvROP01tAAAAAAAAECsIJCOEpjYAABQDKSlm48db0vvve+sAAAAACoxAMgJzSKakpFjp0vqjxu+2MWQbAIAolZpqvu+/t9K//OLWAQAAABQcgWQEumxPmDDB0tImWEKC94cNgSQAAAAAAABiBYFkpE580JknkAQAAAAAAECsIJAMs/j4eOvXr5/VrNnPUlLi3TYCSQAAAAAAAMSKhEgfQKzx+XyWkJBgSUn7t9FlGwAAAAAAALGCCskIocs2AAAAAAAAYhEVkmGWlpZms2bNsu3bNY9kO0tLi2PINgAAAAAAAGIGgWQEAsnZs2fb1q0KJNsSSAIAEM1Klzb//ffbtnXrLKl06UgfDQAAAFAiMGQ7AnNItmzZ0kqVamlpaT637YsvzBYsCPeRAACAHG3caLZsmdmOHebbudNbX7rU2w4AAAAg36iQjECX7ZkzO9mVV6pa0tv2669mrVubjR5tNmhQuI8IAABkodBx+HCzdevM5/dbpeRk86lC0uczq1HDbNQos6pVOXEAAABAPlAhGWaqhBw2bH8YKX6/d3noULOFC8N9RAAAIAtN9rxundeFTtWRWqpUMStTxtuu/QAAAADyhUAyzMaM8YorQtF2VUkCAIAooQBy/XqLU8VkuXJmZctG+ogAAACAYo8h22G2ZEmK9e8/wVVFTpjQz1JS9r8E2rZ4cbiPCAAAAAAAAIjiQHLnzp325Zdf2s8//+y6Ra9fv941aqlevbq1adPGjjrqKOvZs6eVUxUBsmjUyJsPP7sKycaNOWkAAAAAAAAouXIdSM6aNcseffRRe++992z79u1WpkwZa9CggVWpUsX8fr/Nnz/fvv76a3vkkUdcGHnWWWfZddddZ+3atSvaZ1DMDB4cbx06nOHmjExJic+wTxWSmkcSAABECc0duXevfmh780YmJ0f6iAAAAIDYmEOyf//+duihh9rcuXPtrrvusj///NO2bt3qLk+ePNmmTJli8+bNs23btrl9uo4u6zYDBgwo+mdRjLRs6bNnnkmyvXuTVBOZvj0uzps/snnziB4eAACQ8uW9btq7d5vt2WNxCiI1j+SuXd527QcAAABQdBWScXFx9vvvv1uHDh1yvF58fLyriNSi6sgZM2bYgw8+mL8jK8EGDTLr1s3ssMPMtmzx5sufOZMwEgCAqFG1qtmoUWYbNpjdeacl795tiSNHmi8pyQsjtR8AAABA0QWS48ePz9edK8DM721LqrS0NJszZ45bb9q0jf3xR5wbBdasWaSPDAAAZKDQUXNily9v/vh4swYNvP8iAgAAACj6IduZvfrqq7Y4h3bQ2qfrIHQgOXPmTLdUrpzmtmlqKo0IAwAAUaZ0afPfcYdtv+46tw4AAAAgQoHk4MGD7Zdffsl2/9SpU911kJU6kjdt2tQtFSrsn0NSQ7cBAECU8fnM6ta1tNq1vXUAAAAA4euyHUxdtXOyY8cOS0jI112XeJpns0uXLm69UiXLEEjqbx0AAAAAAACgJMt1aqghxmpSE/Djjz9aiiY/zGTz5s323HPPWcuWLQvvKEuozIEkAACIMvpd55NPLFE/qM89l2HbAAAAQDgDyffff9/uvvvu9GHHzz//vFtCqVy5MnNI5gKBJAAAUS411XwKJHftMuvXL9JHAwAAAMRWIHnJJZfYqaee6oZrH3744Xbvvfdar169MlxHQWW5cuWsWbNmDNnOhqpK33vvPbdeseKZ6S8BFZIAAAAAAACIBbkKJDt27GgPPPBAegA5duxYO+igg6xTp05FfXwlUmpqqvtKhSQAAAAAAABiTVxu549cv359+uUhQ4bYggULivK4SnRTmz59+rilUqX49O1USAIAAAAAACAW5CqQbNSokX311VfplX0atq3h2ci7wLB2LZUr7z+HBJIAAAAAAACIBbkKJC+77DLXpCYpKckqVqzoQrWhQ4e69eyWSsHjkRHS1q371z/5xIyiUwAAosjGjWZLl5pt326+HTvMli3zLms7AAAAgKKdQ/KGG26w9u3b27fffmtr1qyxV155xTp37mxNmzbN/yPHqLS0NJs/f759/bXZ8OEt0zPh6dPNWrc2Gz3abNCgSB8lAAAxTqHj8OFma9aYzZljpdVt+4orNPeKWY0aZqNGmVWtGumjBAAAAEp2l+0TTzzRLfLyyy/bpZdeauedd15RHluJDSR//PEP++UXDd9unh5I+v3eMnSoWbduZs21CwAARMb27Wbr1pmVLWt26KG2NznZEqtUMdu929uu/QSSAAAAQNEGkplDNeSPhrsvWdLIlixRAJl1Hk5NzakqyREjOMMAAERcuXJuSdu1y6xMGbO4ODOtAwAAACjaOSSXac6kfCrIbUtql+1//ulqkyd3tdTU/V22A1QluXhxRA4NAAAAAAAAiI5Asnnz5jZkyBD79ddfc33Hv/zyi1100UXWokWLghxfidS4sVcJGYq2az8AAIgCGhWyfLnFrVrlrQMAAAAIz5DtH3/80W677TY74ogjrFGjRnb88cdbx44drUmTJlalShXz+/22adMmW7Rokf3+++/2zTff2IoVK6x79+72ww8/FPwoS5ghQ8weeij0vsA8kgAAIAqou/b8+RafkmJWrZpZcnKkjwgAAACIjUDy8MMPty+++MJmzJhhY8eOtYkTJ7qvgTkRRaGkNGjQwE4//XRXUdmhQ4eiPPZiKSUlxWbN+tBGjjS79dY+lpKS4EJI0bRUmj+ShjYAAERY+fJeN2112d6zx+JSU73O24Eu29oPAAAAoOib2ihgHDVqlFtWrlxpc+fOtQ0bNrh91apVs9atW1vdunXzdyQxZM+ePVa/vtmsWWaXXWb23Xfe9sceMxs0KNJHBwAAXAftUaPM9HvOnXda8u7dljhypPmSkrwwkg7bAAAAQHi7bIuCR8LH/DW1Ofnkk916xYrxGQJJRoEBABBFFDqqy3b58uZXZWSDBl6nbQAAAACRCSSRPxriXqlSpfTLDRvu37dkCWcVAAAAAAAAJVuuumyj6AQHkkuXcqYBAAAAAABQslEhGWZpaWn277//uvWmTZtanTpxVqqU2d69BJIAAAAAAAAo+aKuQnLbtm129dVXW6NGjaxMmTLWtWtX++2339L333XXXa55Trly5axKlSrWs2dPmzp1aob72Lhxo51//vlWsWJFq1y5sg0dOtS2b99u0RJI6vlo0bo6a6vBjTBkGwCAKFOqlPmvvdZ2aNJn/QcRAAAAQMkLJIcNG2ZffvmljRs3zmbNmmUnnniiCx1XrFjh9rds2dKeeuopt++nn36yxo0bu+usW7cu/T4URv7999/ufj7++GP74Ycf7JJLLrFomUOyXr16btF68LDtzZvNtm6N7PEBAIAg+s9hy5aW2qyZtw4AAACgwHx+v99vUWLXrl1WoUIFmzhxop1yyinp2zt16mS9e/e2++67L8tttm7d6prEfPXVV9ajRw+bM2eOHXTQQa4C8bDDDnPX+fzzz11n6+XLl+eqM3jgPrds2eKqLIvawIFmr77qrc+aZXbwwUX+kK46c+3atVazZk2Li+E/sDgPnAfeD3xP8NnAZ2Skf1aE+/cOAAAAoNjOIblp0yYbP368mw9R65lzTVX/jR49Ok/3mZKSYqmpqZaUlJRhu4Zuqxoys+TkZHvhhRfcL/Ht27d32yZPnuyGaQfCSFGFpf6A0NDuM844I8v97Nmzxy3BfxgE/gDRUtQaNFClpFctuXhxmh10UJE/pHtees3C8fyiGeeB88D7ge8JPhv4jMxRaqr5f/jBSm3ebGmnnlokw7Zj/WcxAAAAYk++AslJkybZ2WefbTt27HD/yddcjpkFhiPnhaojjzzySLv33nutTZs2VqtWLRd6KmRs3rx5+vU0DPvcc8+1nTt3Wp06ddzQ7OrVq7t9q1evdhUMGZ5kQoJVrVrV7QtlxIgRdvfdd2fZrmHgu3fvtqJWuXIZM6vk1v/+e5sddtiuIn9M/fGjSgyFkrFeIcl54DzwfuB7gs8GPiOztWePVRg71uKSk21tx44WV0Y/swt//mwAAAAgluQrkLzuuuusdu3a9t5771m7du0K9YA0d+SQIUPcHIvx8fHWsWNHGzBggE2bNi39Ot27d7cZM2bY+vXr7cUXX7RzzjnHVT9mDiJz6+abb7Zrr702Q4VkgwYNrEaNGoU+dEpVoJ999plb1zB0haXBQ7Q3bapoNWtWsHAEcQqN9RxjPZDkPHAeeD/wPcFnA5+R2dIICoWQPp9V0JDtIggkM48MAQAAAEq6fAWSCxcutIcffrjQw0hp1qyZff/99676UsGgKiD79+9vTZs2Tb+OOmyrYlLLEUccYS1atHDDwxUsKijVPE+ZQ0B13ta+UBITE92SmYK6wg7rdH+q7Ay+/8aN9+9ftsxncXF5ry7NDwVxRfEcixvOA+eB9wPfE3w28BmZrbg48/t8bmKVovqZGes/hwEAABB78vUbsALAoh5epNBRYaTmp9QQ8b59++ZY5RaYA1JDvjdv3pyhovKbb75x1+nSpYtFmqo+1RVci9aDu2zL0qWROzYAAAAAAAAgKgNJdbt+5plnbPHixYV+QAof1RV70aJFbm5IDc9u3bq1DR482FVN3nLLLTZlyhRbsmSJCx01vHvFihXWr18/d3vNPdmrVy+7+OKL7ddff7Wff/7ZrrzySjfnZG46bIejGq9atWpuCcyzWbas2b4pMG3JksgeHwAAAAAAABB1Q7a//vprN/egwr8TTjjBzbcYqPYLUNg2atSoPN+3Goxo6PXy5ctdI5qzzjrL7r//fitVqpTrwD137lx75ZVX3PyRCvU6d+5sP/74o7Vt2zb9Pl5//XUXQvbo0cMNg9J9PPnkkxbNVCW5fr3ZihUaYq5GPJE+IgAAAAAAAKDw5Sv2euqppzJ0vA4lv4GkGtRoyW7SdzXSORAFmW+88YZFIw0dX7pvXHbDhg3T541q1Mhs+nTtN1u5MuMwbgAAAAAAACCmA0mFasgfnbvJkye79fr166cHksEBpIZtE0gCABAFSpUy/xVX2M6NGy2pVKlIHw0AAABQIjAwOMxUOVqrVq309QAa2wAAEIX0j8N27Sxl7VpvHQAAAEBkA0k1nvnss89cgxlp1KiR9e7d25o0aVLwIyuhNNfm8ccfn2W7hmwH0GkbAAAAAAAAJVW+A8nrrrvOzRGZefi2hiBfffXV9sgjjxTG8cWMzEO2AQBAFEhNNZs82Upt2mTWqxdVkgAAAEAhyNfYo0cffdQef/xxO/PMM918iJs3b3aL1s8++2y3TwtyjyHbAABEoZQU8736qpV5+223DgAAACBCFZIvvvii9enTx97WL+dBunTpYm+++abt3r3bnn/+ebvmmmsK4RBLlpSUFJs0aZJbP+mkkywhwXsJatY0S0w027OHIdsAAAAAAAAoufJVIbl48WIXpmVH+3QdhLZ161a3BFN/m0CVpIZs+/2cPQAAAAAAAJQ8+aqQrFmzpv3555/Z7te+GjVqFOS4YqKpjdaDKZBcsMBs+3azzZvNqlSJ0EECAAAAAAAA0VQh2a9fP3vppZds5MiRtmPHjvTtWn/wwQfdvv79+xfmcZYYPp/PatWq5RatB6PTNgAAAAAAAEq6fFVI3nvvvTZjxgy75ZZb7I477rC6deu67StXrnRzJHbv3t3uueeewj7WmOu03b59JI8GAAAAAAAAiJJAsmzZsvb111/bxIkT7bPPPrMlSs/MrFevXnbyySfbaaedlqX6D560tDQX3IqC3Li4/UWqVEgCAAAAAACgpMtXIBnQt29ftyBvgeSPP/6YPvQ9OJAMrpBcupSzCgBAxJUqZf6LL7adGzdaUqlSkT4aAAAAoEQoUCCJvFPlaPXq1dPXgwUHkm++qaY3ZkOGmLVowZkGACDsNm70Os3VqGFp+pm9fLmZ/pFYvrxZ1aq8IAAAAEBRBpJNmjRxlXxz5861UqVKucsHGpKt/f/8809+j6vEUmftE044IeS+b77Zv75smdnDD5s99JDZ6NFmgwaF7xgBAIh5CiOHDzdbt858fr9VSk42X+nS+gXHBZQ2ahShJAAAAFCUgeSxxx7rAsbA8OLAZRSeBQvMLr8847bUVO/r0KFm3bqZNW/OGQcAICxUGblunVlSktnu3ebXNlVF7t7tbdd+qiQBAACAogskX3755Rwvo+DGjPGKLkLRdlVJjhjBmQYAIKwUSM6bZ/EpKWZNm3pDtnft4kUAAAAACmB/R5U8ePXVV23x4sXZ7lfXbV0HWaWmptqkSZPcovUAnU6/K7/ISttzON0AAAAAAABAyQ4kBw8ebL/88ku2+6dMmeKug6z8fr9t3LjRLVoPaNw45wpJ7QcAAAAAAABiMpAMDtJC2bFjhyUk0MA75AmPi7NjjjnGLYE5OUXdtHOqkNQ8kgAAIMx27jTbu9dbNG+kLgMAAAAokFynhjNnzrQZM2akX/7xxx8tRfMpZbJ582Z77rnnrGXLlgU7shJKIWS9evWybG/RwpsnUsFjWlrw9b3tNLQBACCMypf3ummvWWO2Z4/FaZoVdd6Oj/e2az8AAACAog0k33//fbv77rvdujpsP//8824JpXLlyswhmQ+DBnndtE86yezff71tkyaZ9eyZn3sDAAD5pg7ao0aZbdhgduedlrx7tyWOHGk+NblRGEmHbQAAAKDoA8lLLrnETj31VDdc+/DDD7d77rnHevfuneE6CirLlStnzZo1Y8h2NnT+1qjawsxq1arlzlkwVUKqSvLWW73Ly5fn9SUFAACFQqFjuXIugPSrMrJBA7MyZTi5AAAAQLgCyTp16rhFvv32W2vTpo3VrFmzoI8fc9RZW+dP+vXrFzK4Peqo/es//+xVTgIAgAhISDD/RRfZrk2bLIn5sQEAAIBCka/OM8cee2zhPHoMUkWkhrQH1kPp3Nn9/WOaovOnn8J8gAAAYD9VRnbtanvXrvXWAQAAABRYvlthr1692kaPHm3Tp0+3LVu2WFpwJ5Z9YdvXX39d8CMsYeLj47MMdc+sbFmzTp3Mpk41mzvXm76qWrWwHSIAAAAAAAAQXYGkOm4fd9xxtmvXLmvVqpXNmjXLDjroINdhe8WKFW4OyQaaZwn5pmHbCiTll1/MTjuNkwkAQNjpH66zZlmCOmxXr24WF8eLAAAAABRQvn6rvummm6x8+fI2b948++qrr1yjllGjRtmyZcvsrbfesk2bNtnIkSMLemwxLfM8kgAAIAL27jXf009b2TFj3DoAAACACAWSP//8s1166aXWsGFDi9tXKRAYsq1GLeeff77dcMMNhXB4JbOpjUJcLVrPTSDJPJIAAAAAAACI6UBS4WOtWrXcuhq0aF7EjRrKtE+7du1s2rRphXeUJYiqSdetW+cWrWdHp7d5c2/999/N9uwJ3zECAAAAAAAAURVINmnSxBYtWuTdQVycu6yKv4BffvklvZM0Mp3wuDg76qij3BKoLj1QlaTCSPJdAAAAAAAAxGwgeeKJJ9qECRPSL19++eX20ksvWc+ePa1Hjx72yiuv2HnnnVeYx1liKITUUPfg4e7ZYdg2AAAAAAAASpp8ddm+9dZbbcCAAbZ3714rVaqUXX311bZjxw5799133fDt22+/3W655ZbCP9oYQ2MbAAAAAAAAlDT5CiSrVKlinTp1Sr/s8/nstttucwtypnkj169f79arV6/uzl12Wrc2q1TJbMsWs88/V3dzs6FDzVq04CwDAFDkND/2hg1m27ebb/dus2XLzJKSzMqXN6talRcAAAAACOeQ7WeeecY1ZUHRddmWV17xwkhJTjZ75BEvpHz5Zc48AABFHkYOH2525ZVmCxZY/KJF5tP6JZd424Oa+QEAAAAIQyB55ZVXWr169eyEE06w0aNHZ+iwjQMrX768W3KyYIHZsGEZtym/TEvzqiQXLuRMAwBQZLZvN9M/X8uWdUMTUps00dAGszJlvO3aDwAAACB8geTcuXPd8OxVq1bZxRdfbHXq1LGTTz7Zxo0bZ1u3bs3fkcSIhIQEO+2009yi9eyMGaOh8KH3afvo0UV3jAAAYB8FkuXLm79cOW+oti4DAAAACH8g2bJlS7vjjjvsr7/+slmzZtn//vc/+/fff23gwIFWq1YtO/300+3NN98s2JHFuMWLNd9k6H3arv0AAKCI6Yfuli3m0z9cs/vBDAAAAKDoA8lgbdu2tXvvvddVTf7xxx+u4/a3335rF1xwQUHvOqY1bpxzhaT2AwCAIqa5UmbOtITZs711AAAAAJEPJANmzpxpb7/9tr3zzju2bds2S0xMLKy7LlHUyOa7775zS05NbYYMyblCUvNIAgCAIrZzp9nevd6ieSN1GQAAAEDkAsnZs2fbnXfeaW3atLFDDz3UHn30UTvooIPstddeszVr1hTsyEoov9/v5t7UovXstGjhzRMZF2cWH59xn5rdNG9e9McKAEDM0nyRNWqY7d5ttmePxSUne521d+3yth+gOR0AAACA7GXfVSUHGqKtakgFkvHx8dajRw+76aab3NyRlSpVys9dxoy4uDjr0qVL+npOBg0y69bNCyZ//dXsm2+87dOmeVWS2Q3pBgAABVS1qtmoUWYbNpjdeacl795tiSNHmi8pyQsjtR8AAABA+ALJe+65x4499li76qqr7Mwzz7Rq1arl79FjkELIpk2b5vr6qoQcMcILIA87zGz6dC+Q/Okns6OPLtJDBQAgtil03Ndd26/hCg0amJUpE+mjAgAAAGIzkFyxYoXVrFmz8I8G2VI15DXXmF14oXf5sccIJAEAAAAAABAjc0gGwsg9e/bY5MmTbeLEibZ+/frCPrYSSfNGbtq0yS05zSEZyjnnmNWp461PnGj2zz9Fc4wAAAAAAABA1DW1efLJJ61OnTrWrVs3N2xbXbZFwWT16tVtzJgxhXmcJYY6a3/++eduyanLdiilS5v997/eurLMJ58smmMEAAD7xMeb/8wzbfcpp2TtMgcAAAAgfIHk2LFj7eqrr7ZevXrZ6NGjM1T6KYw8/vjj7c0338zfEcWAMmXKuCU/Lr10//RVynw3by7cYwMAAEESEsxOPNGSjzvOWwcAAAAQmUDy0Ucftb59+9obb7xhp512Wpb9nTp1sr///rvgR1cCJSQkuG7kWrSen/n1Bw701rdvN3vppcI/RgAAAAAAACCqAsmFCxda7969s91ftWpV27BhQ0GOCzm4+ur96//3f2YpKZwuAACKRFqa2eLFFr9smbcOAAAAIDKBZOXKlXNsYjN79myrXbt2QY4LOWjVykxTWcnSpWbvvcfpAgCgSOzda76RI62cJm7eu5eTDAAAAEQqkDz55JPthRdesM0hJjDUUO0XX3zR+vTpUxjHV+Kokc1PP/3klrw2tQl2zTX71x9/vHCODQAAAAAAAIjKQPK+++5zYdrBBx9st912m/l8PnvllVfsggsusMMOO8xq1qxpd9xxR+EfbQmgBkDLli1zS3AzoLw6/nizQw7x1qdMMZs8ufCOEQAAAAAAAIiqQLJu3bo2bdo012X7rbfecsHauHHj7KOPPrIBAwbYlClTXLdthDjhcXGu6Y8WreeXz5dxLkmqJAEAAAAAAFAc5DsRUxXkSy+9ZBs3brQ1a9bYqlWrbNOmTTZmzBi3D9mc8Lg4a9mypVsKEkjKeeeZ1arlrb/7rptzHwAAAAAAAIhqBUvE9qlRo4bVqlWrwAEb8iYx0ew///HW1fhTHbcBAAAAAACAaJaQmyvdc889eb5jzSt5++235+eYSjQNb9++fbtbL1++vDtPBXHZZWYPPGC2Z4/ZSy+Z3XWXWYUKhXSwAAAAAAAAQCQCybuUcuURgWRoagb08ccfu/V+/fpZQkKuXoJsaXT8BReYjR5ttnWr2ZgxZsOHF+guAQBAQHy8+U85xfZs2WJJ8fGcFwAAAKAQ5GqMdVpaWp4XBW8IrVSpUm4pLNdcs3991CiFnpx5AAAKhf5xeNpptufEE711AAAAAAXGpI9hporIs88+2y0FrY4MaNvWTH8nyaJFZhMnFsrdAgAAAAAAAJELJH/99VfXUTs3Fi1aZK+++mpBjgsFqJJ8/HFOHwAAhcLvN1u50uJWr/bWAQAAAIQvkDzyyCPt888/T7+scLJs2bL2/fffZ7nuL7/8YoMHDy740SHXTjrJrE0bb/2nn8x++42TBwBAgSUnm++ee6z8o4+6dQAAAABhDCTVHTrz5d27dzNXZB5pbs0pU6a4pTDn2VSzbqokAQAAAAAAEO2YQzLMFORqSLuWzCFvQanbdvXq3vqECWbLlxfq3QMAAAAAAAAFRiAZZnFxcdahQwe3aL0wlSljdtll3npKitlTTxXq3QMAAAAAAAAFRiAZZgoh27Rp45bCDiTliivMSpf21p9/3mz79kJ/CAAAAAAAACDfEvJy5cWLF9v06dPd+pYtW9zXBQsWWOXKlTNcT8ORERm1a5sNGGD2yitmmzebHXec2QknmA0ZYtaiBa8KAAC5tnGj2YYN7r97vt27zZYtM0tKMitf3qxqVU4kAAAAEI5A8vbbb3dLsP/85z9Zrqe5EX3qsoKQ52bXrl1uvUyZMkVynpo02b8+bZrZjBlmDz1kNnq02aBBvCgAAOQqjBw+3GzNGrM5c6x0aqr5NAwhPt6sRg2zUaMIJQEAAICiDiTHjh2b38dAEHXWnjhxolvv16+fJSTkKRM+oAULzO65J+O2QDPvoUPNunUza96clwQAgBxpzpN167wJmhs3tpTkZCtdrZrZnj3edu2nShIAAADIl1ynYQMHDszfIyCLoqweHTNG9x96n7arSnLECF4UAAByRcOza9WyVI1uUDi5Y4fZvpEOAAAAAPKncMvzcOATnpBg5557bpGdqcWLNSw89D5t134AAAAAAAAgUuiyXcI0bpx9hWRgPwAAyCX9N08NbTRUGwAAAEChIJAsYdRNO7sKybQ0sw4dwn1EAAAUY5or8pdfrNSvv5pt2WK2c2ekjwgAAAAo9qIqkNy2bZtdffXV1qhRI9eBumvXrvbbb7+5fXv37rUbb7zR2rVrZ+XKlbO6devaRRddZCtXrsxwH/Pnz7e+ffta9erVrWLFitatWzf79ttvLZqa2ug5adF6YWvRwpsnMi7OawSqr8EVk9de6zUMBQAAB5g7Ut2091VHxiUne523NX+ktms/AAAAgOI/h+SwYcPsr7/+snHjxrnA8bXXXrOePXva7NmzrXz58jZ9+nS7/fbbrX379rZp0yYbPny49enTx37//ff0+zj11FOtRYsW9s0337hQ84knnnDb/vnnH6tdu7ZFmt/vt4ULF7r1Qw89tEgeY9Agr5u2gknNGdmwodn335tNnWqm/FZTWE6aVCQPDQBAyaAO2qNGmW3YYHbnnZa8e7cljhxpvqQkL4ykwzYAAACQbz6/ErIosGvXLqtQoYJNnDjRTjnllPTtnTp1st69e9t9992X5TaqMjz88MNtyZIl1rBhQ1u/fr3VqFHDfvjhBzv66KPTqy5VKfnll1+6cDM3tm7dapUqVbItW7a42xamtLQ0+/vvv91627ZtLU4ljGGgqsiOHb1AUq6/3m/XXbfGatasGbZjiEZ6PdauXct54DzwfuB7gs8GPiND27PH/P/9r/s9JemFFyxOnbYLWVH+3gEAAABEo6ipkExJSXFDmJNUeRBEVY4//fRTyNvoF3efz2eVK1d2l6tVq2atWrWyV1991Tp27GiJiYn2/PPPu7BJwWZ29uzZ45bgPwwCIY2WwqYgMqAo7j8UjS576y2z7t19lpLis0ce8Vnr1ok2cGB4Hj9a6fwrkw/X6xCtOA+cB94LfE/w2ZDtB6SbnFn/vXU/K4rg50Ws/wwCAABA7ImaQFLVkUceeaTde++91qZNG6tVq5aNHz/eJk+ebM2bN89y/d27d7s5JQcMGJBeTaBw8quvvrLTTz/d3Z8q/xRGfv7551alSpVsH3vEiBF29913Z9m+bt069zglhU7jnXeWtdtv987X8OEVrWXL9daiRVQUyUaE/ghUsK1QMtYrRTkPnAfeC3xP8NkQwp49VmHXLktOTrYta9cWSYWkRnMAAAAAsSRqhmyL5nkcMmSIG3IdHx/vqhxbtmxp06ZNszlz5qRfTw1uzjrrLFu+fLl999136YGknorCSO2/9dZbXXXlSy+9ZB9++KEb3l2nTp1cV0g2aNDAzVNZ2EOndIw6PilVqpQLUcNJr/YFF/jszTe9x23b1m+TJ/utXDmL2SBOwbOG+sd6IMl54DzwXuB7gs+GEPT7wVVX2S7NIfncc0U2ZFv/OGXINgAAAGJF1FRISrNmzez777+3HTt2uF/OFSD279/fmjZtmn4dhXnnnHOOmzdSjWuCA0Nd/vjjjzMEic8884ybP/KVV16xm266KeTjami3lswUUBV2SKWh6e+//75b79evnwtew+3FF81mzvTb7Nk++/tvn112mc9eey1jN+5YolC4KF7r4obzwHngvcD3BJ8NIZQqZWnHHWd7t261MqVKFcnPilj/+QMAAIDYE5W/AZcrV86FkQoWJ02aZH379s0QRi5YsMANzdackcF27twZ8hd7XWZ+pv3UHHTCBFVFenNWvfGG2dNPF/nLCgBA8ZOQYDZggO0+4wxvHQAAAECBRdVv1gofNaRZjWkWLlxoN9xwg7Vu3doGDx7swsizzz7bpk+f7qog1QBn9erV7nZVq1a10qVLuzkoNeRp4MCBdscdd7gh2y+++KItWrQoQ+fuSFJFpKo+JdzDtYO1bm32xBNb7OKLvbk1r71WHc3NjjwyYocEAAAAAACAGBBVgaTmTrr55pvd3JAKGTVP5P333+/mWly8eLGbC1I6dOiQ4XbffvutHXfccVa9enXXwEbzRx5//PEuxFRH64kTJ1r79u0tGiiEjGQQGezUU/fYtdf67bHHfKZpLVX8cc45auZj1rix2ZAhZi1aRPooAQCIkI0b1XHGLfFa37VL/1n0hhpUrcrLAgAAAJSEpjbRQvNXVqpUqURPLq8h7GvXrrWqVWvaCSfE2Q8/7N+nEe/KTPXOGD3abNAgK7EC50Hd2GN5Di/OA+eB9wLfE3w2ZKIAcvhwszVrzD9njqWlplpc27bmUyBZo4bZqFGFFkrGwu8dAAAAQLDYTWAiGPz88ccfbomGeS01HdYDD2TcpsNKTfW+Dh1qtnBhpI4OAIAI2b7dGzKQlKTud5ZWurQXQKrLtrZrPwAAAIB8IZAMM4WQc+fOdUs0BJLy8cdeVWQoqpRUlSQAADGpbFnXadstGqqtywAAAABKzhySsUDDgtWoJ7AeDRYvzn6fhm3ntB8AAAAAAADICwLJMFMIeeihh1o0UQOb7PrsqIizVq1wHxEAAAAAAABKqugo0UNEqZt2Tq2NPvqIKkkAQIzaudNs715v0byRugwAAACgQAgkw0xNzTV3pJZoaXDeooU3T6RGkKt5aOBrwL//mh15pNmMGZE8SgAAwkjzRaqb9u7dZnv2WFxystd5e9cub7v2AwAAAMgXhmyHWWpqqk2YMMGt9+vXzxLU5joKDBpk1q2bF0xqzkgN4z7xRLPLLjObP99s9Wqzo482e+89sxNOiPTRAgBQxNRRe9Qos82bzf/uu7Zjxw4rf8EF5lO3bYWR2g8AAAAgX6IjDUNUaN7cbMSIjNt+/tmsTx+zyZO9kWonn+yFlhddFKmjBAAgTBQ6arnuOtu5dq2Vr1nTG0YAAAAAoEAIJMMsPj7ezjrrrPT1aFe9utnXX5udd57ZBx+YpaSYDRxotny52c03Z98MBwAAAAAAAAiFf/OHmc/ns9KlS7tF68VBmTJm77xj9p//7N92663e5dTUSB4ZAABFTPM979njLVEy9zMAAABQ3BFIIldUzPnUU2YjR+7f9txzZmeeScNRAEAJlpxsvuHDreJtt7l1AAAAAAVHIBlm6q49a9Yst2i9OFFB5403mo0bZ1aqlLftww/NevQwW78+0kcHAAAAAACA4oA5JMNMIeRff/3l1tu0aWNxxXBy/AsuMKtd26uO3LbNbMoUs65dzZ591uyrr/Z36R4yxKxFi0gfLQAA+bRxo9mGDa6rm2/3brNly8ySkuiyDQAAABQQgWSYad7I5mpnvW+9uOrZ0+yHH7yu26tWmS1Y4G3T0G5NsaWn9tBDXkfuQYMifbQAAOQjjBw+3GzNGrM5c6x0aqr5rrjC+0FXo4bZqFFeB24AAAAAeVb8yvOKOXXW7ty5s1uKQ5ftnHTo4FVHNmu2f5ua3GgkeuDr0KFmCxdG8igBAMiH7dvN1q3zKiITEy2tdGkvgFSnN23XfgAAAAD5QiCJAmnY0Oy007Lfr0pJVUkCAFAslS3rTZyspXx57zIAAACAAiGQRIGtXm2W3VSYGr6tOSUBAAAAAAAAYQ7JMEtJSbF33nnHrZ999tmWkFD8XwI1sMluOkwN29YckykpZiXgqQIAYo1+wFWvbmnJydn/sAMAAACQJ1RIRoDf73dLSaFu2jk9ne+/NzvySLN9zcUBACg+1F27QQNLq1fPbOdObwEAAABQIASSYaZGNn379nVLcW9qE9CihTdPpIZt6ykFvqqQJFBM8vvvZp06md1/v9nevZE+YgAADkDzRaqb9q5dZhs2WNymTe6ru6zt2g8AAAAgXxhEG2Y+n8/KlsAJ8QcNMuvWzQsmNWekhnGrw7b+dhs82GzOHDONdrvtNrP33jMbO9bskEMifdQAAGRDHbVHjXLdtP1pabZl/XqrXr26+fRfN4WR2g8AAAAgXwgkUWiaNzcbMSLrtunTze6+2+yhh7w5JXX5sMPMbr/d7KabvMalAABEHYWO5cqZ77//tfKqjHzhBbMyZSJ9VAAAAECxx5DtMEtLS7M5c+a4ReuxICnJCyqnTDFr29bbpmHbd9xhdvjhZhMnmt18s9mAAd7XBQsifcQAAJjZxo1mS5e6Kknfjh1my5Z5l7UdAAAAQL5RIRlmCiFnzJjh1lu0aGFxGvoVIzp3Nps2zezee81GjjRLTTXTqTj99P3zTWpRJaWGfmsYOAAAEaHQcfhwszVr3LwjpVNTzXfFFd4kyZpDUsO5GbYNAAAA5EvspGFRNIdkkyZN3KL1WJOYaHbffWZTp5q1bLl/u7p0q2BUIaW+av7JhQsjeaQAgJi2fbvZunVemX9ioqWVLu0FkBqyre3aDwAAACBfCCTDTJ21jzjiCLeUlC7b+aGO23377u/CnZkCynvu8b4CABAxakSnyY61qJlNCWxMBwAAAIQbgSQiRlNx5RRIjhtn1qqVV1G5ZEm4jw4AAAAAAABFgUASEdO4cfaBZIAa3Kgbt67bvbvZ2LFm27aF6wgBAAAAAABQ2AgkwywlJcXeeecdt2g9lg0Zkv2QbAWVXbpk3Pbdd95tatUyu+ACsy+/9OacBACgyOzaZVaunPk1d6Q6be/cyckGAAAACohAMgL27t3rlljXooXXTVuNxjWdZvDXMWPMpkwxW7zYG7Id3ABHfxu+/rrZiSeaNWpkdtNNrgEqAACFR/NFqpv2nj1m1aqZv1o1s02bvB9C2q79AAAAAPLF5/fTNiSzrVu3WqVKlWzLli1WsWJFK0w63dv3deYsX758xDptp6Wl2dq1a61mzZoWpwQwgtRNW8GkwkcNzVaH7ebNM15H71J15n71VbM33/T+JszssMPMBg40O/dcs+rVi995iCTOA+eB9wLfE3w2hLBxo+umrc/I9evXW/Xq1b2fFQoj1XG7GPzeAQAAAESjhEgfQKxRAFmhQoVIH0ZUUfg4YkTO11Fue8QR3vL442Yff2z2yitmn32mYfDedX7/3VuuucbslFO8cFJfS5cOy9MAAJQ0Ch21pKVZWlKSWc2aXhk/AAAAgALht2oUO4mJZmedZfbhh2YrVpg98YRZx4779yugnDjR7MwzzerUMbvySrPffst+vkoAALK1Z4/5rrrKKtx6qzd8GwAAAECBEUiGmYZ9zZ8/3y1aR8GoWGX4cLNp08xmzTK74QYvhAwebff002aHH27Wtq3ZyJFmy5dz1gEAeZCcbL7kZE4ZAAAAUEgIJMNMIeS0adPcQiBZuA4+2Oyhh8yWLjX7/HOzAQPMNMIuQI1vbr7ZrGFDsxNOMBs3zmuYCgAAAAAAgPAhkIzAHJINGjRwS6Qa2pR0CQlmJ51k9sYbZmvWmL30ktkxx+zfr6HbX31ldtFFqqb02fDhlezbb90UYQAAAAAAAChiBJJhFh8fb926dXOL1lG01KxUXbu//97sn3/M7r7brGnT/ft37PDZ22+XsZ4946xJE7PbbjObP59XBQAAAAAAoKgQSCJmKIi84w6zhQvNfvrJ7OKLFVju73Sjod7332/WqpXZkUeaPfusNwclAAAAAAAACg+BJGKORsofdZTZCy+YrVzpt+ee22y9evktLui7YcoUs//8x2uQc/bZZh99ZLZ3bySPGgAAAAAAoGQgkAyzlJQU++CDD9yidURWmTJmffvutk8+8duKFWaPPGLWrt3+/Wqq+u67Zn36mNWrZ3b11WbTp3vzUAIAYkBcnPlbtrSUZs3cOgAAAICC4zfrCNi1a5dbEF1q1za77jqzmTPN/vjD7JprzGrW3L9/3TqzUaPMOnUyO+QQs4cfVoVlJI8YAFDkSpUyu/Za23nZZd46AAAAgAIjkAwzNbLp1auXW2hqE706dDB77DGz5cvNPv7YrF8/s9Kl9+//6y+z//3PrEEDs169zMaPN9u5M5JHDAAAAAAAkD/fffedvfnmmxYuCWF7JDg+n8+qVKnC2SgmVAxzyinesmmT2dtvm736qtkvv3j709LMJk3yFnX0VnA5cKBZt27eXJUAAAAAACB2vfzyy7Z8+XKLi4tzmVClSpXs2GOPtbZt21osI5AEckk58qWXesuCBWbjxnnh5JIl3v6tW81Gj/aWJk3MLrrI7MILzTTtGACgmNqzx3w332wVVAb/+OPe5MMAAABAHvTs2dOOOOII8/v9tmDBAnvrrbesXr16Vrly5Zg9jwSSYZaWlmaLFy92640bN3YJOYqfFi3M7rnH7K67zH780eyVV8wmTDDbvt3bv2iR2d13e4uqJRVOnnOOWaVKkT5yAECebd9uPuZ+BgAAQAGpQrJly5aWlJRkGzZscIFkcnKyvffee7Zs2TJLTU21WrVqWe/eva22Gl2Y2apVq+yTTz6xdevWuan/GjRoYAMGDHD7duzYYZMmTbJFCiHMXNWlws+EhNBxn+7riy++sNWrV1uZMmXsqKOOsk5qlBFCTvf93HPP2ZFHHmnt27dPv/7rr79uDRs2tKOPPjpX54I0LAKB5NSpU92idRRvypOPPdZszBizNWvMXnvN7MQTMw7X/ukns0su8ZrmnHuu2Wefqdt6JI8aAAAAAACEmyok586daykpKemBo7YdfPDBNnz4cLv++uvd9nfeecdtl08//dSFmDfddJNde+211rVr1/TbjR8/3sqVK2dXXXWVXX755bZmzRr74YcfQj729u3bbdy4cXbYYYfZDTfcYOeee66bN/Lff/8NeZw53fchhxxiM9UROOi+dT/anlsEkhFIw+vUqeMWraPkKFvW7Pzzvfkkly0ze/BBs4MO2r9/926zt94yO/lkrxnO9dd7Hb0BAAAAAEDJ9fXXX9vIkSPtgQcesLfffttVESrsk8TERBdIli5d2lUfdu/e3VVPbtu2ze1XVeSWLVvcZe1v1KiR275y5UrbuHGjnXjiiVaqVCkrW7asdevWzf5SF94Q/vzzT3dbVTpqtG7NmjWtQ4cONmvWrCzXPdB9t2vXzo3+3aq568zcfei+NT9mbjFkO8z0RjruuOPC/bAIs3r1vC7cN9xgNn26N6T7jTfMNmzw9q9ebfboo96ijt4a0n3eeWa1avFSAQAAAABQkvTo0cPNISkK+saPH++Gbatace/evW4YteaW3LVrV3rx2s6dO61ixYrWp08f+/777+2FF15wtzn88MPdsnnzZtu9e7c9qGqoINmNxtX19RgKRoMrITXMOtR1c7rvChUqWJMmTVwQqWHfqpbs0qVLns4JgSRQhPQ5oukYtDzyiDdcW41wPvrIbO9e7zozZniLwstevbwu3aedZpaUxEsDAAAAAEBJUrVqVWvRooULBxVITp482c3tOGTIEBdAZg4Cdf0zzjjDhYeaZ/LVV1+1+vXru2pEVVled911uXpcXb9169Z29tln5+q6B7pvDc/++eef3XNRRedBwUNEc4Eh20CYlC5t1rev2bvvaiJZs6eeMjv88P37U1PNPvnEa35Tp47ZZZeZ/fKL/mPBSwQAAAAAQEkQqFSsWbOmu7xnzx43FFvVj2pwo+HdmYdaa45GVU7qOvqqIdd169Z1AeY333zj7kOBZeC+swsQ1aBm9uzZrnmOFjW3WbFiRZbr5ua+27Rp47apulNBp4ac5wUVkmGmiUs/U5mcmeualF3nI5Rs1aqZXXGFt8yZYzZunLcsX+7t37zZ7PnnvaV5c29I94UXqjN7pI8cAGJMXJz5GzWy1O3bvU5mAAAAQB599dVXLtwThYpt2rSxY9Uh18x1q3733XftkUcecXM1ag7J33//Pf22ahbz5ZdfurCyfPnydsIJJ6Q3xDnvvPPcfT/99NMuOFRlY3ZdsxUwXnDBBe76H3/8sQsZa9SoEXJaQQWeB7pvzS2pqsgZM2a4+80rnz/QtgfpNCmnTrQmDdULVtiB5IQJE9x6v379IhZIatz/2rVrXSKvN1qsiqbzoArJ777z5ptUFeXOnVmvo88JhZOqsK5QoWSeh0jiPHAOeC/wPRGJz4ai/L0DAAAAiEaxmzxEsKlNz5493aJ1YP97QxPdenNMrllj9vLLZscf781DGaDAcsgQr/mN/gHx5ZdekAkAAAAAAFBcEEiGmcb6qyRWS6BzEpBZ+fJecxtNHbF4sdn995u1bLl//65dZq+/bnbiiWaNGpnddJPZ7NmcRwAAAAAAEP0IJIEo17Ch2S23mM2dazZlitnll5tVqbJ/v+afVQOutm3NOnc2+7//M1u/PpJHDAAlSHKy+W691co/8IBbBwAAAFBwBJIRmIdq6dKlbtE6kFsqqO3SxeyZZ7wu3e+8Y9anj1nwNKSa9/aqq7wu3aefbvb++/z9DAAFoqm2N2ywuE2bvHUAAAAABUaL5zBTCPnzzz+nN7WJ5QYiyL/ERLOzzvKWtWvN3nzTa4Yzfbq3PyXFbOJEb6la1WzAAK8ZjioomSkAAAAAAIDcUS9odZnetWuX7dy50y2Z17W/W7durglicTNv3jz77LPP3HM588wzrXXr1mF5XALJCM0hGVgHCkqfd6qK1PLXX15TnNde86ooZeNGs6ef9hZ9riiYVEOcBg049wAAAACA2CoS2717d7bBYnZfQ41wTUhIsLJly6YvCi5D2bhxowv8li9fbqVKlbIuXbrYUUcd5fbt2LHDJk2aZIsXL3ahZtWqVe24446zVq1apd/+iSeecNcLZEgqbLtJjSRC2LBhg3311Ve2bNkyS0lJcQGpmio31Fxw2dDjd+/e3dq3b+8u33333XbppZda7dq1rSgRSEaoyzZQFA4+2Oyhh8xGjDD76isvnNSwbTXBEc1Dqfkob73V6+CtxjlnnmlWpozZv//G2xNP+GzJErPGjb1u3i1a8DoBiGH6j86GDWbbt5tv926zZcvMkpK8zmMqPwcAAEDEpKamZhsqBtZDXQ4lMTHRypQpkx4uVqpUyQVygcvB+wLrChcPREHmm2++6QLGc8891zZt2mTjxo2zihUrWrt27Sw5Odk9jnKiChUq2Pz58+3dd9+1iy++OL2YTc4666xcVS4qbG3evLmdeuqp7jj/+OMPe+ONN+yqq65yxxzK5s2brVatWhZuBJJACRQfb3bSSd6ydas336SGdP/wg7df/7hRB28tapLTvr3PJk+ubppBQPv0jxcFm6NHmw0aFOlnAwARCiOHDzdbs8ZszhwrnZpqviuu8D5g9cvhqFGEkgAAAIVk7969uapaDF5XmBdKIDAMfK1evXqWbcHr+qrisaKgisX169e7ikM9ho7l0EMPtWnTprlAskqVKta1a9f06yu4rFatmqumDA4kc6tevXpuCejUqZOrmFyzZo01adIkw3V1DlV9qcrO0aNHuwpMPbYELh999NFuKQoEkkAJV7GiV+2o5d9/veHcqpz85x9v/44dZr/84pV+p6ZmvO3QoWbdupk1bx6BAweASNq+3WzdOq8iMjHR0lJSLE5VkfrFV9u1nypJAACAkPMt5rVyUcOLM9PQ5MwhoioXQ4WKgfWkpKSo6tURGMYdPJxb62v0T+8QNDRbAWbmisWPP/7YPvzwQxcYHnPMMdYil8MZ9TgKbkOFmzpnt9xyixuiPXTo0PQh2pkvFxUCyQiUFH/xxRdu/cQTTyyyFB4IpWlTszvuMLv9doWQXtWkwsk9e0KfL02ToSpLNcXp2NHs0EO94dxMfwogZmhoS6VKXrewChW8OTCyGeoDAABQkhTVfIuBEFHhWnZVi1pKly5d7Htv6DlWrlzZvv32WzdPo+aTnDFjhgttQ+VF77zzjrVt29bq1q2bvv2MM85wl3Uu5syZY2+//bYNGjQoQyVkKHrtNPxbzXbKa8qhKEMgGWZKwjU+P7AORII+0zWHrha9Hd95x29+f+gPelVV3n///stVqnjBpALKwKJ/zkTRP6EAoPDoH4edOtneXbssgQ86AABQgudbzLxNgVZu51usU6dOjpWLuZlvsSRSEZrmjlTjmMcee8zNHdmhQwc3ZDvz66OgUefptNNOy7CvUaNG6esa5j137lwXTOYUSOq1e+2116xBgwauSU40IpCMwJtRqXhgHYi0Zs28MDHzcO3sbNpk9s033hKgf7Z06JAxpGzTRv8FK7LDBgAAAICYo8ImzbeYl+HQuZlvMRAcRnK+xZJKna4vvPDC9MtffvllhpBRYeSECRPcV4WXBzq/B6oaDYSRGqat5jbRWmVKXBBmeiMU9Th8IC80t6Qa2JipYjfjB5WCym+/9Xo7TJ++f1m1KuN9aCq1n37ylgBNu9auXcaQUl3AtR0Aio2dO123L9dlW/+5Ybg2AAAoJMy3GBs0j6Oa1yhoVBdtDdm+6KKLMoSRCozPO+88N7Q92JYtW9woW1VDKk9SdeS8efNs4MCBIR9LQ8Fff/11N1S8T58++QojNbxbQ8uZQxJAkdJw6xdf9NvFF/vM5/OGbuszSzMKqMv2Mcd41zv99P23USD5xx9eOBn4unhxxvvV3+6//eYtAfpsbds2Y0jZvr1ZuXK8yACijEq/Nfm3JhyfOdNKaS6kwPwU2h6F8/AAAIDI0byJwdWJuekUnZ/5FrOrXCwJ8y2WVH///bf9/vvvrnGPmtX0798/vWnNsmXLXMCo1/whr1LICXS3VlD52WefuYBQzXr0Pjj77LOtfv366dd95pln3DyRhxxyiBvKrQ7dCkG1HqBKSe3PDY3q/fzzz+2jjz6yo446yt13UfD5mcgwi61bt7o5EJREa3x/YdKHzap95WWaYyFS3Z90HGvXrnWlw9HUgSrcOA/7z8PUqRts4sTqtmSJzzWuUYftvHTXVhVlIJwMLPPnH/h2+pnZunXGeSm1XrmyhR3vB84B7wW+J7J8sG3YYP4773RDXxJHjrQ4lXkrjCzEDttF+XsHAADI/3yLuW3kcqD5FkOFiMy3iFjHkO0IBB4//PCDW+/Xr19Mh4GILk2apNoDD/gtLi5//1XT3+Y9enhLwNatZn/+mTGknD3b694doEpM/eNGyxtvZOwIHlxJqZCyZs2CPEMAyMcHm0q4y5c3v+byadBAEy1xGgEAKEHzLYb6mp/5FjPPs8h8i0DOCCTDTCXUVfdVVVBOjZJOhT5HH+0twdOxzZqVsZpSlzP/zFd3by3vvLN/m6rSgwNKfVVjMUYmAAAAALEz32JeKhdV7ZiZCoMyh4garZDdcGgtSUlJ/A0PFCICyTDTJKYnnXRSuB8WiBply5p16eItAQojVTkZXEk5Y0bW3hHLl3vLhx/u36ap3IIrKbU0aUJICQAAABSX+RZz2yk61IxzpUqVyhAclitXzlUuMt8iEN0IJAFEXOnSZh06eIu6fov+kTlvXsbGOVo0DDzYunVmkyZ5S0ClSlmHe7dsqX8IhPd5AQAAACWdGnXkpZFLXuZbrFy5suu9kF3lor4qkARQ/ERVILlt2za7/fbb7f3333cNVw499FAbNWqUde7c2c37cNttt9mnn35q//77ryun7tmzp40cOdLq1q2b4X4++eQTu+eee2zmzJmurPrYY4+1Dz74IGLPC0DeKTw86CBvueACb5vmnly0KGMlpZb16zPedssWs2+/9ZbgykwFnsFBpe6b318AAACA/fMtZhciZle5GGq+RU1PlrlxS40aNXJs5KJFIwoBxIaoCiSHDRtmf/31l40bN86FjK+99poLHWfPnm3ly5e36dOnu8Cyffv2tmnTJhs+fLj16dPHtU8PePfdd+3iiy+2Bx54wI4//nj33xrdZ7TQ/BXffPONW9fx8YEL5J56QDVr5i39+nnbNGpDw7gzh5QrV2a8reau/OUXbwmuzDzkkP0BpQLLWrV4RQAE0SS11apZ2o4dzAUBACg2mG8RQLTz+UNNwhAB+s9KhQoVbOLEiXbKKaekb+/UqZP17t3b7rvvviy3+e233+zwww+3JUuWWMOGDV342LhxY7v77rtt6NCh+T6WrVu3ugrMLVu2WEV15ShEOsYJEyakd9lOSEiI2JwdqkKtWbNmTHf65jyU3POwZk3God5aVF15IPHxflc52bGjLz2obN/erEIFiwkl8b2QH5wHzkM43w9F+XsHACA25lsMtS038y1m7godar106dI0cwFQciskFdSpelBDrIPpA/Cnn34KeRv94q5ScM0rIaqgXLFihftjQcO9V69ebR06dLCHH37YDj744GwfW526tAT/YRD44NdS2I466qj09aK4/9zQ4+oHVKQeP1pwHkrueVCzmxNP9JaAjRu9ZjleUOlzX+fP13+QfenXSU31ua7fWl55xdvm8/ndHJReZ2+/+6qlShUrcUrieyE/OA+ch3C+H2L9+w0AYnW+xdw2cjnQfIuB4JD5FgEUJ1FTISldu3Z1/3154403rFatWjZ+/HgbOHCgNW/e3Oapu0UQfSgr2GvdurW9/vrrbtubb75pAwYMcNWSjz32mKuWfPTRR+2LL76w+fPnW9WqVUM+7l133eWqKjPTbVS1WRLpjx8FuqrIiPUqKM5DbJ+H7dt99vffCTZrVimbNSvB/vwzzhYuTHTB5IE0bJhiBx+cYu3a7XXLIYekWI0axTtYiOX3QjDOA+chnO8HzaHdsmVLKiQBoBgp6vkWQ11mvkUAJUlUBZL//POPDRkyxH744Qc3t2LHjh3dL+jTpk2zOXPmpF9PH/xnnXWWLV++3L777rv04U0KMs8//3x7/vnn7ZJLLnHbVPlYv359N+T70ksvzXWFZIMGDdw8lSV16JT+uFq3bp2bWDjWQwfOA+ch8/uhfPkaNnt23L4O314l5cyZZsnJBw4p69b1Kii97t5+97V+/dBTzy1YYDZ2rM8WLzZr3Nhs8GC/tWhhEcX3BOeB94NlLKvetMn8zz/v/pAsc/XVFqfJZ8uXN8vmn5z5od87qlSpQiAJABGiP4lV8JLXTtEa4ZeZ/rbKy3BofdUoQYWSABBLombItjRr1sy+//5727Fjh/vlvE6dOta/f39r2rRphjDynHPOcfNGqjlMcGCo68tBmgAuqIxdt1+6dGm2j6vraAn1w6Swwzr9sNM8VKK5qCL5g0ePXRTPsbjhPHAeMr8fypWLsy5dtOzfvnev2ezZGeek1PBvNcsJtnKlzzXU+eQTd29uW/Xq+xvnBMLK77830/9N9BGgfwvp68MP+2z0aLNBgyyi+J7gPPB+2BdGXnONm5DWP2eOlU1NtbgFC8yn7p+aE2LUqEILJWP95zAAFMV8i3mtXMxuvsXg4FCNVg/UKZr5FgGgGAaSAeXKlXOLKhQnTZpkDz30UIYwcsGCBfbtt99atWrVMtxODXAULGp4d7du3dJvs3jxYmvUqJFFW5ftSDa1AZA3pUp5zW20DB7sbdM/xVXlmLnD95YtGW+7fr3ZF194y4GoH5c+vpo35xUCImr7drN168w0t3VioqWlpFicAkgNtdN27S/EKkkAQN7nWwz1NT/zLWZXzcjfagBQdKIqDVP4qP9MtWrVyhYuXGg33HCDmyNy8ODBLlg8++yzXeOajz/+2AV7alojmhtS/4lSteRll11md955pxtyrRBSDW0C4V+0KKnDwIFYo0Kp1q295bzzvG3657q6eWcOKZVf5IZ6W6jv1dFHe6FkYNFQbhWBU0gFhFnZst5/JFTGrKHa+kN31y5eBgDI53yLuQ0Wteg22c23GBweqmrxQEOjqUYHgOgSVYGkJoy/+eab3dyQChk1T+T999/vSuVV5fjhhx+666lzdjBVSx533HFuXQGk/pN14YUXuh9mXbp0cRWJmpspGujYTjnllEgfBoAiosxCs0xoOfvs/SHlihVeMKn5KF980bucHc3q8O67WbeXKaOpLTIGlYFF81QqIAUAAAjnfIu57RQdar5F9Q3IHByqcpH5FgGg5IuqQFLDsbWEoo7Zuem/o/DykUcecQsAREtIqcBQS58+XoGVirdD/F6efv1QH3cqyvrrL2/JTH02FIJmDipVWdmwof4ZUvjPCwAAxMZ8i5m/5mW+xewqF5lvEQBiG3+iAkCYDRlitm9q3Cw0JFuBowLGhQuzLv/+601hl5m2zZ3rLZkpjGzSJHRlpbp767EAZEOdqzRkMCXFmzcy1DcgAETJfIt5beSS3XyL6vocHCJqtFndunWZbxEAUGgIJMNMQxXUSVyOPfZYN0wBQGxR1aK6aauBTXCXbX3V9jZtvOtpePZJJ2W8raoqly/3wkk11AkOK//5x6u+zEw5iq6rJVQAqp5fgYBSj1mjRqJ16uStq58HEJM0X6S6aa9Z476JfPrmU+ftQJdt7QeAIsB8iwCAWEAgGYFfMNboj5t96wBi06BBXjdtBZCLF3uVigooD9RdW1mIAkQtPXpkbYizcmXoykotO3ZkvT/dRk14tHz5pbbEmZk3565C0gYNQldWKqxUrw+gxFIH7VGjXFWkPy3NNq5fb9WrVzefUnyFkXTYBlBI8y2G2pbb+RZVuZhTIxdVOqoJDAAA0YZAMszU3e3II49MXwcQuxTsjRhRePenj5TAXJX7+nyl0/8/9L+QzCFloMpy69as96fbLF3qLd98k3V/3bqh56xUWFmhwoGPV489Zsz+QFZD2XV7AACifb7F3HaKPtB8i4Hg8EDzLWrRbQgXAQAlBYFkmCmEVIMeAAgnFUfUru0tqswMpr+T1q/3gsn589Ns5sydtmpVOfvnH5/bplGqoagaU8sPP2TdV6tW6MpKLZUrm40dazZsWMYh65pXUxWjqh4FIk5v/OHDzdatM5/fb5WSk82nCVf1ZtWQbVVPUiUJFFuRmG8xeD2BbnMAgBhHIAkAMS6Qr2jp0sVs7drtVrNmWYuL86XnMpqfMtQw8LVrQ9+nqjG1/Pxz1n0KJDdvDn07DVtXYHqgoetAkVMDm3XrzBITXZmwT5Oxtm1rtmePt137CSSBiFP1YXJyco6dokNt26tmVZmo+jC4A7S+BqoWc+oUzagnAADyjkAyAr80bdxXblS1alWGXQCIespctHTunHWfhnpnN2flqlWh7y+7MDIwp2XHjmaHHOLNk9mw4f45MwPr9BJBWJUp47pFuUCyXDlvItddu3gRgCKcbzGvlYvZzbeYOURkvkUAAKIHgWSY6RemL774wq3369eP4RoAirWKFb0AUUtmaqITqrJy6lSznTuzv89t27zKylDVlVKlStaQMji4rFnTq/oEAJT8+RYzVysy3yIAAMUDgWQE6BclACjpVEymSkctwW6+2ezhh/UPmuwL0nIqQNu0yVtmzAi9XyNsFVCGqq7UV3UO11SAOTXbGT3aZ/PmVbJWrXxuGDnNdmKUhnQqWd+713x6w2pdc8iFGOoJxMJ8i7kNFrXs0fQG2cy3GBweqmqxXr16OXaKZr5FAABKHgLJcJ/whATr27dvuB8WAKKGummrgU12ncJnzvQ6eC9bZrZkibeo03fw1+XL9Qdy6PvQ38AKFbWEourJOnVCV1dOn252992BZjtJ7qvCU5rtxCDNLTBnjvdG277d4lS19d133rwCakah/XrzAMV4vsXcDIfOzXyLgeCQ+RYBAEBuEUgCAMJK1YYK+FR5GNxlW1+1PdDQplUrbwlFxWqaozJUWBlY1HMkFD1OoEP4lCnZHaUvS4iqx+vUyax+fW/RcPXcUDA6ZozZ4sVmjRt79xWouMxpH6KAwkgFMQoh9cYJrAPFaL7FzF/zMt9iTo1cVOmoUBIAACA/CCQBAGE3aJDXTVsBZCCMU0CZ2+7a6isSCAaPOirrfmVHKmALDikzB5erV+f+eHV/t9yScVuFCt7w78BxBC+B7e+9Z3bxxRmDV1WH6nnr8rBhoffp/CDCtmzxJjRVeJOS4kXUSrn1YukNqP1AIVFImF11YnaVi9nNt1i6dOkMIWKFChWsZs2aOXaK1hyNhIsAACCcCCQj8Avnz/s6NRx11FHuP9IAEIsUPo4YUTT3rXBPzW+0tG8f+jqaClBDvwMh5WOPmf39t5c35YayqtmzvSWvVAkpoR5LwazC2gOFs1RXFrH1670KSf2cjo83vVQ+DdXeF1C6/UCY51usWrUq8y0CAIASgUAyzPSf7BUrVqSvAwAiIynJC/0Cwd/8+d6UgaGa7Whuy549zQ47zAsxNb+lvmrJqQFPdnL6+Nc+VVUqtNRcmvXqeV+Dh4iPHUt1ZZFTNaTeDFri470KyeTk/W+Q7OYEQEzNtxhqW27nW1TVYk6NXLTE6cMHAACgBCKQDDP9Ytm5c+f0dQBA9Dfbkaefzlq1qPBQHb8zh5RaPvvMbM2avB9HoHeKlmDly3vBpKo+p04NfVtVV2oIO/NQFoJA0hyYIy8wrj4wxj4/STSiYr7FvFQupoWYMzQw32LmTtHZDYfWkpiYyJBoAACAIASSYaYQsnluJ0kDAESo2Y4/qNmOL0OznWDaX7WqtxxySMZ9N9/sdegOVXGZHyrIUxVnTpSdtGnjzV9Zu7ZZrVr7vwavB74q5KQnRQ4ltEHckO0c9iN8mG8RAACg+COQBAAgU7Odl14ymzdvt7VqleQaz+Tn/0g5VVyqQF6BZ6ih29r3xBP7u4Frlo/gr5q7MicKQAONfA6kbNnsw0p9rVHDLCEh3sqV85r4xBQ9Yc0fGRjNoLS3VCnvq05yzJ2QoqHhzdkNfc5uW17nW8ypU3SC5gUFAABA2PFbWASGDG3dutWtV6xYkeE7ABBlFD4+8IDf1q7dYjVrJlpcXIa6uHxWXO4f8auv2i7Z7cupy/Z115mNGpV95WX16t59qefKgaYq3rnTbNEibwlNYVwNt6ZQMjdVl1oUdBZ7OpEKqxRABrpsa10nVdu1H1nmW8wuRMyuU3R28y1mDhFr1arFfIsAAAAlCIFkBIYZffrpp269X79+/GceAGKg4lIh4+LFZo0beyFkoOIyp33Zuewyr4IyFBXzTZ7s3YcaQa9bZ7Z6tTeXpZbAeuavGzYc+Lns2GH2zz/eciAqHswurMy8LWpHPjdq5HUxUgC5aJGlpKZaQtu2Kunztml/CRWu+RYzVysy3yIAAEDsIJCMAE1sDgCIDQoHR4zI+778Vl4GAk0V8dWp4y0Hooxt7dqsYeXq1X5bunS3bd6cZGvW+Nw2NfE5EA0r17Jw4YGvW6lSzsPGA/u0hPXHpybYVEqskxEXZ3E6wUp8Vf6psezaX4zmW8xLsKgwUqFkZqVLl84QHlaoUOGAlYulSpViNAgAAACyIJAMM81VdOaZZ4b7YQEAMVR5mVeaGrFePW8JlpaWdei6pu8LhJc5VV1q2bz5wI+9ZYu3HKhhj1SunLuqy5o1FZ5ZwahT0V132YIpG2z0XUvt3+3VrWnNJja070Zr0amit3+fbdu22dSpU+3QQw+1atWqWTjmW8zNcOjczLcYCA6ZbxEAAADhRCAJAEAxlJ/qysKgKsUGDbzlQHbv9sLLnELLwPq+6ZVzpIBTy9y5B76u8sIDVV0GGvcokM1i40Ybe+HXNmzyMPNZR/Obz3zjzR5+o4GNPvIlG/RxFUutVMkFkd9//737h+MhmVut53K+xfXr11u7du3sjz/+cMOes6tcTNE4/FzOt5hTIxctcYFmPQAAAEAEEEgCAIAiofkhGzb0lgPZtSv7sDLz1+3bD3x/Gzd6y5w5B76u+tNkDisTdsbbI5OHmd819tkX3rlRzH4bOnmYNf9xus1c8asLEzt06GCdOnVy1Yjz5s3LVeVi5vkWzzrrLPvxxx/TA8TgysXshkPrq6aBUSgJAAAAFCcEkhGYy0nVFNKlSxc32TsAALGuTBlv6LmW3DTYyc2Qca2rk/iBqCO5lr//Dt5aKZtr++zc896wr2csdEGgqh1V2aglp/kWK1asmO18i/rdoGnTprZu3TqrpEk1AQAAgBKOQDLM9IfLkiVL3Prhhx8e7ocHAKDYK1fOrGlTbzkQVVPmNFQ8+KuGmOfGqpV1rFmzpRYfn+yCxhYtWlirVq1cmBgYEq0h3Lm1detWNz8klY4AAACIFQSSYaY5mzTpfWAdAAAUHTXD1nybB2r4o6bS6gweCCcfu2+nffhFkqUFhmsH+eH7Y63LQR3twqvX2e+//27Tp0+3WbNmWY8ePfhnIwAAAJALBJJhphCydevW4X5YAACQA03DWLGit7RoYVb7ls324Re1900cGTxHo9/8fp8N7b/Tmrdo4aojt2zZ4kLJvFRFAgAAALGMEj0AAIBMWrRLct2048xv8b5Ui7NUizd99bvtzQ9OSr+uhmp3797dOnbsyHkEAAAAcoF/5UdgDkl11xRNZM98UQAARKGqVW3Qx2dbt79W20tvlrV5/6Raq2bxNuzcndb84LPdfgAAAAD5QyAZZuqk+eGHH7r1fv36MbwLAIBoVbWqNT/G7IFuabZ27VqrWbOKxcVVjvRRAQAAAMUegWQExMfHR+JhAQAAAAAAgIgjkAz3CU9IsHPOOSfcDwsAAAAAAABEBZraAAAAAAAAAAgbAkkAAAAAAAAAYcOQ7Qg0tfn999/d+mGHHcZ8kgAAAAAAAIgpVEiGmd/vt3///dctWgcAAAAAAABiCRWSYRYXF2eHHHJI+joAAAAAAAAQSwgkw0whZNu2bcP9sAAAAAAAAEBUoEQPAAAAAAAAQNhQIRlmmjdyz549bj0xMdF8Pl+4DwEAAAAAAACIGCokI9Bl+/3333eL1gEAAAAAAIBYQoVkCIHu11u3bi30E56SkmI7d+5Mv/+EhMi8BGlpabZt2zZLSkqK6eY6nAfOA+8Hvif4bOAzMtI/KwK/bwR+/wAAAABKOp+f336zWL58uTVo0CASrwcAAIhRy5Yts/r160f6MAAAAIAiRyCZTSXEypUrrUKFCiV2jkdVYyh01R8/FStWtFjFeeA88H7ge4LPBj4jI/2zQv8bVgVm3bp1Y3rUAgAAAGIHQ7ZD0B8DsVKhoD+sYjmQDOA8cB54P/A9wWcDn5GR/FlRqVKlIrlfAAAAIBrxb3gAAAAAAAAAYUMgCQAAAAAAACBsCCRjVGJiot15553uayzjPHAeeD/wPcFnA5+R/KwAAAAAwoumNgAAAAAAAADChgpJAAAAAAAAAGFDIAkAAAAAAAAgbAgkAQAAAAAAAIQNgSQAAAAAAACAsCGQLKaefvppa9y4sSUlJVmXLl3s119/zfH6EyZMsNatW7vrt2vXzj799NNsr3vZZZeZz+ezJ554Isu+Tz75xD1emTJlrEqVKnb66adbrJ2H+fPnW9++fa169epWsWJF69atm3377bdWks7DoEGD3HMPXnr16pXhOhs3brTzzz/fnYPKlSvb0KFDbfv27RZL52Hx4sXueTdp0sR9TzRr1sx1r09OTrZYei8E7Nmzxzp06OCuM2PGDIukSJ2Hkv4ZmZvzEAufkTJnzhzr06ePVapUycqVK2edO3e2pUuXpu/fvXu3XXHFFVatWjUrX768nXXWWbZmzZoieX4AAABAseNHsfPmm2/6S5cu7R8zZoz/77//9l988cX+ypUr+9esWRPy+j///LM/Pj7e/9BDD/lnz57tv+222/ylSpXyz5o1K8t133vvPX/79u39devW9T/++OMZ9r3zzjv+KlWq+J999ln/vHnz3GO/9dZb/lg7Dy1atPCffPLJ/j///NM/f/58/3/+8x9/2bJl/atWrfKXlPMwcOBAf69evdxzCiwbN27McD/ar3M0ZcoU/48//uhv3ry5f8CAAf5IicR5+Oyzz/yDBg3yT5o0yf/PP//4J06c6K9Zs6b/uuuu88fSeyHgqquu8vfu3duvHy1//PGHP1IidR5i4TMyN+chFj4jFy5c6K9atar/hhtu8E+fPt1d1vd/8H1edtll/v9v705go6q6AI4faKFYAaHIIltFS0WrJSxiWzAFW1lFBQTB0CASVhVUNIoQQaOyiERAERFChSggik2AStewFIGACEhElrAkLSJYLTQUZLtfzk1m0inThQ+cmfb9f8nQvjf3bWfaR97pufe2aNHCZGVlmV27dpmYmBgTFxfnk2sGAAAAAh0JyUqoU6dO5sUXX3QvX7161SbOpk+f7rX9oEGDTJ8+fTzWPfLII2b06NEe63Jzc02zZs3M/v37TXh4uEci7vLly/a9xYsXGyfH4cyZMzbZsnnzZve6c+fO2XUZGRmmqsRBkw5PPfVUqcfUh3S95p07d3ok56pVq2by8vKMU+LgjSYxWrVqZZwWg9TUVNOmTRub8PF3QtIfcXDKPbK8ODjlHvnss8+aoUOHlnrMgoICm8RcvXq1e92BAwdsHLZt23aTVwQAAABUfnTZrmS0K+jPP/8siYmJ7nXVq1e3y9u2bfO6ja4v3l716NHDo/21a9ckKSlJ3njjDYmKirpuH7t375a8vDx7rHbt2sldd90lvXr1kv3794uT4qBd7+677z5ZtmyZnD9/Xq5cuSJffPGFNGrUSDp06CBVJQ5q48aN9rr0eseOHSv5+fke+9Bu2h07dnSv033qsXfs2CFOiYM3Z8+elbCwMHFSDLQb6siRI2X58uUSGhoq/uSvODjlHlleHJxwj9T/J7RrfmRkpF2v16bdwFNSUtzt9ZiXL1/22I92AW/ZsmWpxwUAAACchIRkJfPXX3/J1atXpXHjxh7rdfnUqVNet9H15bWfOXOmBAcHy/jx473u4+jRo/brtGnTZMqUKbJu3To7PlrXrl3tWIJOiYOOl5aZmSm//PKL1KlTx44vNmfOHNmwYYONR1WJg44JpwmFrKwsG5NNmzbZ5Ioey7UPfQgvTuOmibjSjlsV41DSkSNHZP78+TJ69GhxSgy00l7HFdQxV4snqP3FX3Fwyj2yvDg44R55+vRpO17ujBkzbDzS09OlX79+0r9/fxsP1z5q1qxp/3BT0eMCAAAAThLs7xOA/2klx9y5c22Fjz5MeqMVIWry5Ml2YH61dOlSad68uR383x8JGH/EQZMvOkmBJuO2bNliJ65YvHix9O3bV3bu3GmroqqCwYMHu7/XCR2io6PthC1aGZWQkCBOcSNx0Oo4TU4MHDjQVgs6JQaagC0sLJRJkyZJVVZeHJxwj6xIHJxwj3R91jpxz6uvvmq/18mcfvrpJ1m4cKHEx8f7+QwBAACAwEeFZCWjs5YGBQVdN1OnLjdp0sTrNrq+rPb60KgVH9qVTKvc9HXixAmZOHGinZVUuR4iH3jgAfc+QkJC5J577vGYVbSqxyE7O9tWPq1cuVI6d+4s7du3lwULFtiH7q+++kqqQhy80c9Zj6UVgK59aKyK066ZWglW1n6qWhxcTp48Kd26dZO4uDhZtGiR+IO/YqC/E9oFVe8H+jsTERFh12u15LBhw8QpcXDCPbKiPw9V/R6p+9Sf9eKftbr//vvdn7W21e7iBQUFFT4uAAAA4CQkJCsZ7QKm43Bpd7ni1Rq6HBsb63UbXV+8vcrIyHC31zET9+3bJ3v27HG/mjZtasdRTEtLs230mPpwffDgQfc+dHys48ePS3h4uDglDkVFRe4xyIrTZVfVTGWPgze5ubl2nDhX0kXb6oO2VpW6aCJCj61jqTklDq7KSO2Wq8fXiriSPxtVPQbz5s2TvXv3un9nUlNT7fpVq1bJBx98IE6JgxPukRWJgxPukbrPhx9+2OOzVocOHXJ/1nrMGjVqeOxH22vCsqx4AgAAAI7h71l1cONWrlxpQkJCTHJysp3teNSoUaZevXrm1KlT9v2kpCTz1ltvudtv3brVBAcHm9mzZ9tZPqdOnWpn//z1119LPUbJ2aXVhAkT7CyyaWlp5vfffzcjRowwjRo1Mn///bdj4qAzyDZo0MD079/f7Nmzxxw8eNC8/vrrdj+6XBXiUFhYaK9JZ4I9duyYyczMNO3btzetW7c2Fy9edO+nZ8+epl27dmbHjh0mJyfHvj9kyBDjL/6Ig87IHhERYRISEuz3f/zxh/vllBiUpO38Pcu2v+JQ1e+RFYmDE+6Ras2aNXbdokWLzOHDh838+fNNUFCQ2bJli7vNmDFjTMuWLU12drbZtWuXiY2NtS8AAAAAxpCQrKT04UcfdGrWrGk6depktm/f7n4vPj7eDBs2zKP9t99+ayIjI237qKgos379+jL37y0heenSJTNx4kT7gF2nTh2TmJho9u/fb5wWh507d5ru3bubsLAwG4eYmBiTmppqqkocioqK7PU1bNjQPnBrDEaOHOl+eHfJz8+3CcjatWubunXrmuHDh9uEhZPisHTpUpt88/Zy0s9CoCUk/RWHqn6PrGgcqvo90mXJkiX2DxK1atUybdu2NSkpKR7vX7hwwYwbN87Ur1/fhIaGmn79+vntjxUAAABAoKmm//i7ShMAAAAAAACAMzCGJAAAAAAAAACfISEJAAAAAAAAwGdISAIAAAAAAADwGRKSAAAAAAAAAHyGhCQAAAAAAAAAnyEhCQAAAAAAAMBnSEgCAAAAAAAA8BkSkgAAAAAAAAB8hoQkANyku+++W55//nniCAAAAABABZCQBBAwkpOTpVq1avaVk5Nz3fvGGGnRooV9/4knnhAn2bhxo73u48eP+/tUAAAAAAC4KcE3tzkA3Hq1atWSb775Rrp06eKxftOmTZKbmyshISEBFfaDBw9K9er8fQcAAAAAgIrgCRpAwOndu7esXr1arly54rFek5QdOnSQJk2aSCDRBGmNGjX8fRoAAAAAAFQKJCQBBJwhQ4ZIfn6+ZGRkuNddunRJvvvuO3nuuee8bjN79myJi4uTBg0ayG233WYTl9q+JO32/NJLL0lKSoo8+OCDNpkYFRUlGzZs8Gg3bdo02/bIkSN2fMh69erJHXfcIcOHD5eioqIyx5B0dT3funWrvPbaa9KwYUO5/fbbpV+/fnLmzBmPba9du2aP1bRpUwkNDZVu3brJb7/9VqFxKQ8fPiwDBgywCVqtKm3evLkMHjxYzp49W+Z2Xbt2tdeux9Hj6XGbNWsms2bNKnM7AAAAAABuBRKSAAKOJuNiY2NlxYoV7nU//vijTbRpws2buXPnSrt27eS9996TDz/8UIKDg2XgwIGyfv3669rq+JTjxo2z+9Ik3MWLF21iT5OgJQ0aNEgKCwtl+vTp9ntNNr777rsVuo6XX35Z9u7dK1OnTpWxY8fK2rVrbTK0uEmTJtn9dezYUT766CNp3bq19OjRQ86fP1/mvjVBq+22b99uj/PZZ5/JqFGj5OjRo1JQUFDuuf3zzz/Ss2dPadu2rXz88cfSpk0befPNN22cAQAAAAD4LzGGJICApJWQmqy7cOGCrXj8+uuvJT4+3lYSenPo0CHbzkUTf+3bt5c5c+ZInz59PNoeOHDAVgfee++9dlmrBDUxpwnQkglDTXIuWbLEvaxJS12eOXNmudeg1Zrp6em2WtJVDTlv3jybWNVqyz///NOe39NPPy0//PCDeztNUGrVZMmqRp3Ux0XP/9ixY7Zr+zPPPONe/84770hFnDx5UpYtWyZJSUl2ecSIERIeHm6vrVevXhXaBwAAAAAA/w8qJAEEJK1G1GTkunXrbIWifi2tu7YqnozU6j9N+j366KOye/fu69omJia6k5EqOjpa6tata6sLSxozZozHsu5Tk5Lnzp0r9xq0YtGVjHRte/XqVTlx4oRdzsrKsuNkarVmcVrxWB5NaKq0tLTrupBXRO3atWXo0KHu5Zo1a0qnTp28xgAAAAAAgFuJhCSAgKTjLmriUCeyWbNmjU3kFa8ELEkTljExMXYsxbCwMLv9559/7nU8xZYtW163rn79+jaRWV5bbae8tb3RbV2JyYiICI92ev6utqVp1aqVHZ9y8eLFcuedd9ru29ptu7zxI110vMniyVLX+VXkugAAAAAAuBkkJAEELK2I1DENFy5caLsR68Qy3mzZskWefPJJm4xcsGCBpKam2glxdPvi3ZxdgoKCvO7nZtveym0rQsd+3Ldvn7z99tu2mnT8+PF2gp7c3Fy/nxsAAAAAAKUhIQkgYOms1NWrV7cTt5TVXfv777+3yUjtvvzCCy/Y5KVWVwY6HbNR6UzexWmX8IpWKj700EMyZcoU2bx5s03M5uXl2QQuAAAAAACBikltAAQsHedQu10fP35c+vbtW2a1n3Y/1m7dLrpNSkqKBLKEhAQ7G7he4+OPP+5e/+mnn5a7rY5hGRoaarcvnpzUBO6///77n50zAAAAAAA3i4QkgIA2bNiwctvoLNo6W3XPnj1tJeXp06fteIo6NqN2aQ5UjRs3lgkTJtiu19rlXM9/7969tpu6jgtZcozH4rKzs+2M4AMHDpTIyEg7Oc7y5cttcnbAgAE+vQ4AAAAAAG4ECUkAld5jjz0mS5YskRkzZsgrr7xiJ3yZOXOmrZIM5ISk0vPUSscvv/xSMjMzJTY2VtLT06VLly62G3pp2rZtayeyWbt2re2mrfvQdZrM1Ml9AAAAAAAIVNUMMxgAQEApKCiwM16///77MnnyZH+fDgAAAAAAtxST2gCAH+ns2CV98skn9mvXrl39cEYAAAAAAPy36LINAH60atUqSU5Olt69e9tJfHJycmTFihXSvXt36dy5M58NAAAAAKDKISEJAH4UHR1tZ8qeNWuWnTnbNdGNdtcGAAAAAKAqYgxJAAAAAAAAAD7DGJIAAAAAAAAAfIaEJAAAAAAAAACfISEJAAAAAAAAwGdISAIAAAAAAADwGRKSAAAAAAAAAHyGhCQAAAAAAAAAnyEhCQAAAAAAAMBnSEgCAAAAAAAAEF/5H+H001a1MONQAAAAAElFTkSuQmCC",
-      "text/plain": [
-       "<Figure size 700x500 with 1 Axes>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "n at base (d=0):   0.0600\n",
-      "n at top  (d=8.6 ft): 0.0450\n"
-     ]
-    }
-   ],
+   "execution_count": null,
+   "id": "75b79ad1",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "def vegetal_retardance(elevation, depth, current_n):\n",
     "    \"\"\"Exponential decay: n decreases from current_n toward N_ASYMPTOTE with depth.\"\"\"\n",
@@ -1914,206 +545,321 @@
     "        return current_n\n",
     "    return N_ASYMPTOTE + (current_n - N_ASYMPTOTE) * np.exp(-depth / DEPTH_HALF)\n",
     "\n",
-    "num_modified = HdfMesh.set_face_mannings_n_values(\n",
-    "    hdf_path=modified_geom_hdf,\n",
+    "\n",
+    "def extend_n_func(depth, base_n):\n",
+    "    \"\"\"Manning's n for extension rows using the same exponential decay.\"\"\"\n",
+    "    if depth <= 0:\n",
+    "        return base_n\n",
+    "    return N_ASYMPTOTE + (base_n - N_ASYMPTOTE) * np.exp(-depth / DEPTH_HALF)\n",
+    "\n",
+    "modified_ras = init_ras_project(modified_path, RAS_VERSION, ras_object=\"new\")\n",
+    "print(\"Preprocessing modified model on Windows to create .tmp.hdf...\")\n",
+    "modified_preprocess = RasPreprocess.preprocess_plan(\n",
+    "    PLAN_NUMBER,\n",
+    "    ras_object=modified_ras,\n",
+    "    max_wait=300,\n",
+    "    clear_existing=True,\n",
+    ")\n",
+    "assert modified_preprocess.success, modified_preprocess.error\n",
+    "modified_tmp_hdf = Path(modified_preprocess.tmp_hdf_path)\n",
+    "assert modified_tmp_hdf.exists(), f\"Missing modified tmp HDF: {modified_tmp_hdf}\"\n",
+    "print(f\"Modified tmp HDF: {modified_tmp_hdf.name}\")\n",
+    "\n",
+    "pre_tables = HdfMesh.get_mesh_face_property_tables(modified_tmp_hdf)\n",
+    "pre_df = pre_tables[MESH_NAME]\n",
+    "\n",
+    "# Use a stable representative face for the engineering table plots.\n",
+    "sample_face = 1050\n",
+    "if sample_face not in set(pre_df['Face ID']):\n",
+    "    sample_face = int(pre_df['Face ID'].iloc[len(pre_df) // 2])\n",
+    "pre_sample = pre_df[pre_df['Face ID'] == sample_face].copy()\n",
+    "assert not pre_sample.empty, f\"Face {sample_face} missing\"\n",
+    "\n",
+    "set_count = HdfMesh.set_face_mannings_n_values(\n",
+    "    hdf_path=modified_tmp_hdf,\n",
     "    mesh_name=MESH_NAME,\n",
     "    mannings_n_func=vegetal_retardance,\n",
     "    face_ids=None,\n",
     "    pin_tables=False,\n",
     ")\n",
-    "print(f\"Applied depth-varying n to {num_modified} faces\")\n",
+    "expected_faces = pre_df['Face ID'].nunique()\n",
+    "print(f\"Applied depth-varying n to {set_count} faces in .tmp.hdf\")\n",
+    "assert set_count == expected_faces, \"Expected all .tmp.hdf faces to be modified\"\n",
     "\n",
-    "# Read back and compare baseline vs depth-varying for sample face\n",
-    "after_tables = HdfMesh.get_mesh_face_property_tables(modified_geom_hdf)\n",
-    "after_df = after_tables[MESH_NAME]\n",
-    "after_sample = after_df[after_df['Face ID'] == sample_face]\n",
-    "base_sample = base_df[base_df['Face ID'] == sample_face]\n",
+    "after_set_tables = HdfMesh.get_mesh_face_property_tables(modified_tmp_hdf)\n",
+    "after_set_df = after_set_tables[MESH_NAME]\n",
+    "after_set_sample = after_set_df[after_set_df['Face ID'] == sample_face].copy()\n",
+    "assert after_set_sample[n_col].iloc[-1] < pre_sample[n_col].iloc[-1], \"n should decrease with depth\"\n",
     "\n",
-    "fig, ax = plt.subplots(figsize=(7, 5))\n",
-    "ax.plot(base_sample[n_col], base_sample['Elevation'], 'r--s', markersize=4,\n",
-    "        label=f'Baseline: Uniform n={original_n}', linewidth=1.5, alpha=0.6)\n",
-    "ax.plot(after_sample[n_col], after_sample['Elevation'], 'b-o', markersize=5,\n",
-    "        label='Modified: Depth-varying n', linewidth=2)\n",
-    "ax.axvline(x=N_ASYMPTOTE, color='gray', linestyle=':', alpha=0.7,\n",
-    "           label=f'Asymptote n={N_ASYMPTOTE}')\n",
+    "max_elev = pre_df['Elevation'].max()\n",
+    "target_elev = max_elev + EXTENSION_HEIGHT\n",
+    "rows_added = HdfMesh.extend_face_property_tables(\n",
+    "    hdf_path=modified_tmp_hdf,\n",
+    "    mesh_name=MESH_NAME,\n",
+    "    extension_elevation=target_elev,\n",
+    "    mannings_n_func=extend_n_func,\n",
+    "    elevation_step=ELEVATION_STEP,\n",
+    "    face_ids=None,\n",
+    "    pin_tables=True,\n",
+    ")\n",
+    "print(\n",
+    "    f\"Extended {len(rows_added)} .tmp.hdf faces, \"\n",
+    "    f\"total rows added: {sum(rows_added.values())}\"\n",
+    ")\n",
+    "assert rows_added, \"Expected extension rows to be added\"\n",
     "\n",
-    "base_elev = after_sample['Elevation'].iloc[0]\n",
-    "ax.annotate(f'Base elev\\n{base_elev:.1f} ft',\n",
-    "            xy=(after_sample[n_col].iloc[0], base_elev),\n",
-    "            xytext=(after_sample[n_col].iloc[0] + 0.02, base_elev + 1),\n",
-    "            arrowprops=dict(arrowstyle='->', color='gray'),\n",
-    "            fontsize=9, color='gray')\n",
+    "ext_tables = HdfMesh.get_mesh_face_property_tables(modified_tmp_hdf)\n",
+    "ext_df = ext_tables[MESH_NAME]\n",
+    "ext_sample = ext_df[ext_df['Face ID'] == sample_face].copy()\n",
     "\n",
-    "ax.set_xlabel(\"Manning's n\", fontsize=12)\n",
-    "ax.set_ylabel('Elevation (ft)', fontsize=12)\n",
-    "ax.set_title(f'Face {sample_face}: Depth-Varying Manning\\'s n', fontsize=13)\n",
-    "ax.legend(fontsize=10, loc='upper right')\n",
-    "ax.grid(True, alpha=0.3)\n",
-    "fig.tight_layout()\n",
-    "plt.show()\n",
-    "\n",
-    "print(f\"\\nn at base (d=0):   {after_sample[n_col].iloc[0]:.4f}\")\n",
-    "print(f\"n at top  (d={after_sample['Elevation'].iloc[-1] - base_elev:.1f} ft): {after_sample[n_col].iloc[-1]:.4f}\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "55997a13",
-   "metadata": {
-    "papermill": {
-     "duration": 0.010027,
-     "end_time": "2026-05-12T12:23:53.063958+00:00",
-     "exception": false,
-     "start_time": "2026-05-12T12:23:53.053931+00:00",
-     "status": "completed"
-    },
-    "tags": []
-   },
-   "source": [
-    "## Step 6: Extend Tables to Higher Elevations\n",
-    "\n",
-    "The preprocessed face tables only reach the terrain elevation at each face.\n",
-    "For deep flood events, water may rise above this â€” and HEC-RAS extrapolates\n",
-    "with the last n value (constant, not depth-varying).\n",
-    "\n",
-    "`HdfMesh.extend_face_property_tables()` appends rows from the current maximum\n",
-    "up to a target elevation, using a rectangular cross-section assumption for\n",
-    "area and wetted perimeter. The Manning's n function receives `(depth, base_n)`\n",
-    "so it can implement any depth-varying formula."
+    "print(f\"Face {sample_face}: {len(pre_sample)} rows -> {len(ext_sample)} rows\")\n",
+    "print(f\"Elevation range: {ext_sample['Elevation'].min():.2f} - {ext_sample['Elevation'].max():.2f} ft\")\n",
+    "print(f\"n at base: {ext_sample[n_col].iloc[0]:.4f}\")\n",
+    "print(f\"n at top:  {ext_sample[n_col].iloc[-1]:.4f}\")\n",
+    "assert len(ext_sample) > len(pre_sample), \"Sample face should have extension rows\"\n",
+    "assert ext_sample['Elevation'].max() >= target_elev - ELEVATION_STEP - 0.01\n",
+    "assert ext_df[n_col].round(6).nunique() > 1, \".tmp.hdf n values should not be uniform\"\n",
+    "assert ext_df[n_col].min() < original_n - 0.001, \".tmp.hdf should contain depth-varying n values\"\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
-   "id": "5fd47d09",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-05-23T01:40:10.488406Z",
-     "iopub.status.busy": "2026-05-23T01:40:10.488266Z",
-     "iopub.status.idle": "2026-05-23T01:40:13.934824Z",
-     "shell.execute_reply": "2026-05-23T01:40:13.934122Z"
-    },
-    "papermill": {
-     "duration": 3.396178,
-     "end_time": "2026-05-12T12:23:56.469740+00:00",
-     "exception": false,
-     "start_time": "2026-05-12T12:23:53.073562+00:00",
-     "status": "completed"
-    },
-    "tags": []
-   },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-22 21:40:12 - ras_commander.hdf.HdfMesh - INFO - Pinned property tables for mesh '2D Interior Area'\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-22 21:40:12 - ras_commander.hdf.HdfMesh - INFO - Wrote face property tables for 11164 faces in mesh '2D Interior Area' (476525 total rows)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-22 21:40:12 - ras_commander.hdf.HdfMesh - INFO - Extended 11164 face tables in mesh '2D Interior Area', total rows added: 429470\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Extended 11164 faces, total rows added: 429470\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Face 1050: 19 rows -> 71 rows\n",
-      "Elevation range: 925.24 - 959.79 ft\n"
-     ]
-    },
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAABKUAAAIDCAYAAADVKK2CAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjgsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvwVt1zgAAAAlwSFlzAAAPYQAAD2EBqD+naQAA2jZJREFUeJzs3Qd4FFUXxvGT0EF6B5EiVQSlWZAPG/ZOFSwIKnZF7BUEe8EudkRFUZrYO3ZABBEEQRFQqvTek/2e924m2WwmIXVL8v89z0J2dnZ29k7ZO2fuPTchEAgEDAAAAAAAAIigxEh+GAAAAAAAACAEpQAAAAAAABBxBKUAAAAAAAAQcQSlAAAAAAAAEHEEpQAAAAAAABBxBKUAAAAAAAAQcQSlAAAAAAAAEHEEpQAAAAAAABBxBKUAAAAAAAAQcQSlAABAtrz22muWkJDg/s+uBg0auAeyryiW2ZIlS9y+ddFFF0V7VRBj55Cc0vKPOeaYAls+ACB/EZQCgDi8cMvqsXHjRosHumgIXe/ExESrXLmy/e9//3MXLIFAwAqrgr4wCy/bfT2++eYbK2wU3Aj9jsWLF3f710EHHWTnnXeejRs3znbv3h2VdRsyZEiBlvumTZusbNmy7vvu3Lkzy3lfeuklty4DBgwokHWBv+wcl7Ec+AEAIL8Uz7clAQAi5sADD7Tzzz/f97XSpUvH1Za44YYbbL/99rOkpCRbtGiRTZgwwX744QebMWOGPf3009FevbgNyIS3FHjvvffst99+s759+2ZohVOYW+VcfPHFtv/++7sg5+bNm+2vv/6yDz74wN566y1r0aKFjRkzxlq3bm2FScWKFa1bt2725ptv2vjx410QLjOvvvpqajlFU926de2PP/5w615UVK1a1a6++uporwYAAFFFUAoA4lDjxo1da4vC4MYbb7RatWqlPp8zZ44dfvjh9uyzz9qgQYOsYcOGUV2/eOTXBUqt7BSU8gtYFWaXXHKJHXHEEemmbdmyxQYPHmyPP/64nXjiiTZz5kyrU6eOFSYKMikopaBTZkEpBYGmTp1qLVu2dMdcNJUoUcKaN29usU6t24499lgbOXJknrsaVqtWrdCcxwEAyC267wFAIaRWRroDf/DBB7uWB2XKlLFWrVrZgw8+aHv27PF9z+rVq12rpWbNmrn5q1Sp4i5UH3300Qzzzp49284991yrXbu2lSxZ0urXr2/XXHONrVu3Ls/rrvU8+uijXcuWX375JV1XLLWkeuyxx1wXrFKlSqW7KPz999+tZ8+eVqNGDfeaglkDBw70XScvZ4+6Ol522WUuKKYWZm3atLG3337bd720PrrAP+qoo6xChQque1T79u1TW5pk1j1LXWjatm3r5lcwSOvcr18/N5/+D++u06lTJ9fVbOXKlb7rceGFF7p5p0yZYnml7mtqjXbSSSdZvXr1XLmp/Lp27Wq//vprlu+dNGmSHXbYYe57Va9e3fr372///fdftj87J+WZ38qXL2/Dhw9320LrfO+99/oeD9dff70LAKtcFEBQ6yPtZ3nZn7QP3HPPPe5vBTe8be/XWm3r1q123XXXuYCZ1kEtutTtMDt0DKlF5eTJk11AMjutpHJ63gj93nqf9iHtu9rnc7ofZ5ZTyuuKqs/XcaXPU1k0bdrUnnvuOd9lr1271nVH1L6s/apDhw42ceLEuO3WptZ8Wu9TTz01Q7fm8Nf2dX4JD8wqIKntXKlSJXceUCvVcLnZBuvXr7fLL7/catasmW4bZCWnvysvv/yy21d1rGnfu/nmm/fZXRUAEHtoKQUAhZDyxKiLUufOnd3Fyvbt212A5LbbbrPp06e7Lj2hFixY4C6QdQGpi8mzzz7btm3bZnPnzrX777/ftWbyvP/++y74oxxQZ511lrsYmDdvnj3zzDP22Wef2bRp01wum/wQfiGlCxS17DjttNPsjDPOcBedogspXVApyNK9e3d30aSL3SeffNI+/PBD9x4FFUJp3i5durgL/wsuuMB933fffdf69OnjLmr1WR5d7Km1iQIMTZo0cfPooumLL75wF/T6/n7Bu0ceecQFBVROapFTrFgxd3Gmi3gFdTT90EMPTfceBTV+/PFH1xLj9ttvT/ea3qeghC4kjzzyyDyXry4cFbhTHi/tJ9puCvxpG3/yySf23XffufUNp/1H21plrTJU+Wp9v//+e/v555/3uf1zU57evpCfucbuuusuF6DQdlfLPO8z/v77b3chvmzZMrfddDwoSOV976+++ipDy6Ls7k9e0OXbb79N15VSQYFQCgDoszds2OCCYTqGFYDQsffpp5+617Ki76JA4R133OG2jRcI8+zdu9feeOMNV+5a39ycN2TXrl123HHHue995plnukCUAhH5vR/37t3b7VunnHKKO45UtldddZVrYXXppZemzqf1UEBO+1DHjh3dd9F2VLBD54h4pHXXNh81apQ7p+mY9QJ5XuDHC7hpX83q/OId9yoXnd8VFNYy1LVV79HvwNixY91ycrsNtN/o+FGrV21fbY+lS5dar169Mt1vc/q7MmzYMLv77rvdd9dnax3eeecd1/oPABBnAgCAuLF48WJdkQcOPPDAwODBgzM8pkyZ4ub7559/Anv37k333uTk5ED//v3d+3/44Yd0r7Vv395Nf/HFFzN85tKlS1P/Xrt2baBChQqBunXrBpYsWZJuvrffftst4+qrr87Wdzn66KPd/CtXrkw3/ffffw+UKVMmkJCQ4L6v9O3b1827//77u+8WKikpyZWHXv/000/TvXbTTTe56freoerXr++md+7cObBr165037VatWqBUqVKBZYtW5Y6XeWi+fv16xfYvXt36nS994wzznCv/fLLL6nTtS00rVy5coHZs2dn+O4jR450r+v/cDt27AhUqVIl0KhRI7fNQj3zzDPufU888UQgp7wynDx5cuq0nTt3pvueodtgv/32C3Tp0sV3vf3K+tZbb/Xd/iprPULltDzF+9ycfl/vmMhMvXr13Hx///136rSOHTsGihUrluE7LliwIFC+fPlAq1at8rQ/eftH6LbwW95ZZ52Vbnlffvmlm37SSSdlqwyWL1/uvoeWp+Mk1KRJk9yyunfvnjotp+cNbz21Ptu3b8/Tfuyd27Td/M4Thx9+eGDTpk2p0+fPnx8oXrx4oFmzZunmv/POO938AwYMSDfdK7vMjrvs0jbL6zJEy6hatarveVwPnU9DbdmyJdC4cWO3L/36669uO2k/1XkyfD/N6vwiffr0ca+/9NJL6ab/999/7nioXr2623653Qbe/n3ppZemm6719NsGOf1d+euvv9znan6ts0frpnXR/FpnAEB8ICgFAHHEu3DL7PH4449n+f4ZM2a4+YYMGZI6bdq0aakX1PsyfPhwN+/rr7/u+3rbtm3dRXh2eBc6N9xwg7uI0cXkeeed5wJSmn7ttddmCDA8+eSTGZbz3XffuddOOeWUDK/pQk4XxqVLl053ce9dTIdfZMuwYcPca48++mjqtNatW7sAU/iFtyjo5H2P8Iuy66+/3ve77+uiUe/T67qQDtWmTRt3Ubpu3bpAfgSlsqLgUMmSJdMFjbz1Dg9WeWVdqVIld3EZGgDxC0rltDzljz/+cI/8DkrpQlvz6TiQmTNn+gYyPYMGDXKvz5kzJ9f7U3aDUosWLfJ9Tft0dp122mluWZ9//nm66Qp4afrHH3+8z2X4nTdC1/O3337L8368r6DU119/nWH53mubN29OndagQQO3365atSrD/CeeeGJMBaWyemj7hJs+fXqgRIkSgebNmwduvPHGTM8xWZ1f1qxZ4wKVxx13nO96PfXUU+69H3zwQa63QcOGDd02CL/hIMcff3yGdcvp78o999zj5n/ssccyzPvGG28QlAKAOEP3PQCIQ+qGou4cmVFXInV7UHef+fPnuy4tod2eVqxYkfq3umPIvroDibppibpSqItTOOXzUFclPcK7y2VGOaJEXU+UW0h5hdSFSzlnwimHUTgv95Ff8m6N6qflff75566LovLjeNTNyK/rkLqyhS5XXVHUDUV5fR566KEM83u5dlTO2Vnf7FA+HCXhVneq448/PjXfj9ZJ3cGU7yu/zJo1yx5++GHXBXLVqlUZcgdpWyrHi18ZhZe1ugqpu5e6ACoXk5/clmekkmB7+7hyTfklofbWS/8rn01O96fsUnc+vyT/GkkwNJ+Ytp9GVgylLoFeN0Elev/oo49c/qgTTjjBTVNXRE3TskK7tOXkvOFRPp/Q46qg9uN27dr5loWou5ryhKkLmrq0KeecunWFU1c1nQuyS9s/vNujR/mavNxNHnVT0/6fXcrf53feyIzOZeq2duutt7r36XhTvq+cUDdMjXSqbpd++7dGpxQt//TTT8/VNli8eLHbBqEDWIQeD+r+mpffFQ3Y4C3Lb/kAgPhCUAoACiHl+lFuGCWiVR4P5V5Szg1dOCgniS5IPJs2bUodkn1flItElH8nK8qnk92glPJY+V28+PG70NRFUGaviRdQ8ebzaP2UvySzz/DKRTl9dGG+fPnyTC9Qve+cnfXNDgVgdIGrYIOS/GroeCX1ldDcLXn1008/uXxAXlBS+Z0UXFKAUJ+ti7/QfWVf3yu87PzkpTwLghdoUbL20H1cQRs9srt+2d2fskuJxv0o+JWcnJwuKBVejtp3vKCUAgtaB21Plb3y8rz++usup5TmCV3nnJw3PJonPPdbQezHClj7lYUoyBJ6jHu55vJ6PPoFuhX0Um4nv3xNfsnq85s+Vzm6tA8o6KecYDnh7d/K96VHTo6/gtoGOf1d8Y4lv8/I7TkXABA9BKUAoJDRnXBdWKoFhC6qlZA29I60Li5DeQmWFSTYF++iRC1dQluJRIrfxa+3TpmN/KbWP6HzeXTXXRd24YEEbzleUMB7n1oJeKMB5mV9s0vJh5UMWwEEJY32koL7XSjn1n333ecCDUpQrgT3obSveC0SwmVW1uFl5ycv5Znf1KJLCZgVkPICCt76aVRCjSiXXdndn/KbAkvhI9aFBw3U6lBJ90ePHu2+k5KPa98MbemT0/NGdvfxSOzHHm/bqSWYn5yMDilax/D1VEsoBaWUCDyrci8IakV4/vnnp56377zzTjfgg9daKSdlpJFW/QZniMY2yOnvincs6TM0Qt++lg8AiG0Zb+kBAOKa1/1BI9SFXliKgg+ZdTHLTrcWb8Sx0O5D0damTRv3v1+3Gd1ZV+BDQ56rq0wotRTx+x5eGXnLVZeUFi1auFGd1GIkP3jbxWtd4Kdr164uWKKWJRoNS60D1BUrv/cVdaEKD0ipi93MmTMzfZ/ffqSuXmq1owvMRo0aZfregijP3FJXKFGrIC+4ktt9PLv7U3a3f37SKHyiLnzqIqVRzTTKWuh2yul5I7sisR97tO8puLhw4ULfoIhaBsYztZBS90f9r5ET1cJIIyeGtpzb1/6l0TS1rxfUOVzbQN1OtQ28GwL72pdyeswdcsghmS4rL/sqACA6CEoBQCHj3TlWjqBQGv77gQce8L1I0eO7775zuV/ChbagUssKBRU0zLyWF07BDC8/SKQoT8yBBx5on3zyiX355ZfpXrv33ntdtyENZe7XzUUXd8qj49HQ8WoRUqpUKTcMu+faa691301djvy6tSiHirr1ZJeXS0etdDKj9VVLDAUQtJ7qRpXfLTO0r6hLV+i21IXsjTfeaGvWrMn0fSpnDdMe3upKQSa1yvHrxhYqN+WpHDc5yb+TFQXQ1FLktddec907Vb6hQVpdJKtFj4aYD6cAgFr++Mnu/pSd7Z+f1I1Ox4lyOel7i/K25eW8kV2R2I9DnXfeeW4bDB48ON10Ba3D99l48sUXX7j8e0cccYT7buqWedVVV7nvFZ5XKqv9S12le/bs6QJ0aj0XmjPMo8Cljs/cUqBM2+Duu+9ON103PsLzSeXmd0X5yBR4Gz58eLrgo7oO6pwPAIgvdN8DgEJGF9V6vPvuuy5fky5i/v33X3v//fddK4hx48ZleI+69aibinKU6A68EjYruawuEHQhq8COqMWDLtZ79Ojh7laffPLJ7oJXXcAURNDFeseOHbNMwp7fFABRcEHdjk499VS3brrA1l13XbApYOWXDFjBCAVEWrdu7brA6G+Vmb7rU089lS7Hlrod6aJI3XaUh6VLly4uUbe6iihQoou4t956K9s5ZVS+ar31xBNPuKCQl89I3XFC6XPVxUZ5j7p165Zpnpbcuuaaa9yFolpK6UJVSatVZgpEan/ILGmzLohVZspBpO+sspk8ebIr66FDh+7zc3NTnmpdJX4X0VlRCx3tj3rfli1bXCJn7af6u2XLli6pd3gid+3jakmkQJK2Udu2bd320nGk/UoBOx0fud2ftGy1VlGQRseYuiOpO1ZOugvmlIJQXh4hfZZaMOX1vJFdBb0fh7rlllts/Pjx9vzzz9vvv//uEl8rOKjvpe2iLor7CppGirp8+iUbD+36qCCS5uvbt68L3Oi48PI4qUy1LytIpUTyXoujfZ1fnnvuOTfww80335x6vtc+oSCWWpbqGNE+ULZs2Vx9Ly13woQJ7iaH9u/OnTu7ZWsbaF8Kz9WW098VDaKggJe+t443nbtUJtrueq7vBgCII9Ee/g8AkH3esOknnXRSlvOtXr3aDWlfp06dQOnSpQOtWrUKPPvss26Ieb9h10VDqF933XWBRo0aueG8Nez84Ycf7obrDjd//vzAxRdf7IaE17yVK1d2n3HttdcGfv7552x9F28ocb9hw8NpfTWvvn9mZs+eHejevbsbOlzDpmvd9H00BHo4vabH+vXrAwMGDAjUrFnTDVF/yCGHBN56661MP+Odd94JdOnSxX1ffUbdunUDxxxzjBuaPPRzBg8e7NZXw8dn5qOPPgp06NAhUKZMmdRh4P106tTJvfbpp58G8sIrw/B1GjdunBtyvWzZsq7sevbsGfj77799yzx0qPn33nsvdf2rVq0auOiii3y3pVfWeSlPyaqMsvq+3qNYsWKBSpUqBQ466KDAeeedFxg7dmxg9+7dmb5f+8add94ZOPjgg9133G+//QJNmjQJ9OnTJzBhwoQ870+vvfaaO2Y0n9YvtIyyKjPvuMmprVu3BsqXL+/ee+WVV+bLeSOr9czpfuyd28I/I6vvm9l5Qd9D5yftz/oe7dq1c9vs0UcfdfNPnDgxkFs6frxjIC9C983MHr/++qub9/TTT3fP33zzzQzLmTNnjvuOOm9v3rw52+eX7du3Bx5++GFXNuXKlXPzNWzYMHD22WcHXn/99cCePXvytA3WrVvnjoXq1aun2wah55C8/q689NJL7njWvPvvv3/gxhtvdN9Ly9c6AwDiQ4L+iXZgDACASPJa4OSky100qDWOkhhrRDwl5Y6VFh6Iz/2pqO/HShKuVqHqSui1vAMAANFF7RYAgBilUdLU/UvdnwhIIV5Fej9W17Nw6gKmrpoa8ICAFAAAsYOcUgAAxBjlwFLeohdeeMHl37nyyiujvUpA3OzHyi2nnEqHHnqolStXzrWMUj4iJcd++umnI7IOAAAge+i+BwAocmK9u5WSYGuUMiX91UW0kk4jdsX6/lTU9mMl+FY3vb///tsltFcSb40+eNttt6UmAwcAALGBoBQAAAAAAAAijpxSAAAAAAAAiDiCUgAAAAAAAIg4glIAAAAAAACIOIJSAAAAAAAAiDiCUgAAAAAAAIg4glIAAAAAAACIOIJSAAAAAAAAiDiCUgAAAAAAAIg4glIAAAAAAACIOIJSAAAAAAAAiDiCUgAAAAAAAIg4glIAAAAAAACIOIJSAAAAAAAAiDiCUgAAAAAAAIg4glIAAAAAAACIOIJSAAAAAAAAiDiCUgAAAAAAAIg4glIAAAAAAACIOIJSAAAAAAAAiDiCUgAAAAAAAIg4glIAAAAAAACIOIJSAAAAAAAAiDiCUgAAAAAAAIg4glIAAAAAAACIOIJSAAAAAAAAiDiCUgAAAAAAAIg4glIAAAAAAACIOIJSAAAAAAAAiDiCUgAAAAAAAIg4glIAAAAAAACIOIJSAAAAAAAAiDiCUgAAAAAAAIg4glIAAAAAAACIOIJSAAAAAAAAiDiCUgAAAAAAAIg4glIAAAAAAACIOIJSAAAAAAAAiDiCUgAAAAAAAIg4glIAAAAAAACIOIJSAIB0lixZYgkJCTZkyBBKBgAA5ItvvvnG1S9ee+01ShRAKoJSQJz+oGf2mDp1qsWqn3/+2a699lo76qijbL/99ttnxWTXrl129913W8OGDa1UqVJ24IEH2r333mt79uzJMG+DBg0yLZO1a9dmmH/FihV24YUXWvXq1a1MmTLWvn17Gzt2bJ6/owI53ueOGzfOd56JEyemzkPgJ22f1v8AAISj7hM/dZ/wR+nSpeNmhx4xYoRb5woVKtj27dujvTpAkVE82isAIHd69+5tp556aobpjRs3jtki/fjjj+3ZZ5+15s2b2yGHHGI//fRTlvP36tXLJk2aZP3797cjjzzSpkyZYnfddZctXLjQN5il5d5xxx0ZppcvXz7d8/Xr11unTp1s9erVNmjQINt///3trbfesp49e9qrr75q/fr1y/N3VSVs5MiR1r179wyv6TP0+s6dOy0W1a9f33bs2GHFi/MTAQCIHdR9YrvuM3ToUHcjMVSxYsUsXrzyyivuBujff//tgnV9+/aN9ioBRUMAQFyZPHlyQIfuI488Eog3q1atCmzdutX9PXbsWPc9Ro4c6TvvRx995F4fNGhQuul6ruk//vhjuun169cPHH300dlaj5tuuskt4/3330+dtnfv3kCHDh0CVapUCWzZsiWQW4MHD3bL7t27d6BYsWKBFStWpHt95cqVgeLFiwf69Onj5tP8RZ23T+t/AAAy+52g7hPbdZ/p06dnaztmVveLplmzZrl1e/311wNt2rQJdO7cOdvvVTlu27atQNcPKMzovgcUQuomd9FFF1nTpk2tbNmy7m6Zusyp25ifVatWuW51jRo1ct3katSoYSeccIJ98cUX6eb766+/7IILLrDatWtbyZIlXbPxm266ybZt25at9apZs6aVK1cuW/Pq7p0MHDgw3XTv+Ztvvun7vr1799rmzZv3uWzdCTvjjDPS3cm75ppr3J1EtegKNX/+fHfXLCfOP/98S0xMtNdffz3ddD1X03C97ue5556zE0880erWrevKWGWteZXnKZyWo+2sFmRHH320K9uqVavaJZdcYlu3bk03r+bT/Js2bbIrrrjCbWO11tJ+MW3atH3mlAqd9uGHH1qHDh3c+7V+2gdU7uHGjx/vWsRpvgMOOMDuuece+/LLL7OVT0KtyPRZzZo1c/twpUqVrFWrVu6zcpKzQq3VWrZs6fZrtQB7+OGH9/l+AED8oe4T/bpPbqkeedttt7n10+91rVq1XDfDf/75J11KB3U5DG+9dNlll7nf/Ouuuy5Da3t1w/Orn2TWSkqpJbp27erqTN99951rmR9OdQt9nuozw4YNc+uses67777rXg8EAq4bYLt27Vz9Rcs89thjbfLkyXmq8wGFGX0zgDilvu7h+QL0Q64AlIJPqkyoSbYuxNetW2ejRo1yP7SjR4+2Pn36pL5HP3wKTPz333+uAqD8AqocKDeVfnAVnJIZM2bYcccd54IDqgDoB/S3336zp556yn788Uf79ttvrUSJEvn2/aZPn+4+o169eumm63mdOnXc6+EUXFEFQHkXKlasaGeddZY98MADbn7PypUrbfny5XbeeedleP8RRxyR+tkqO0+LFi1cOeakkqCgz2mnneaCIrfcckvqdD0//fTTXT4HP48++qhbDwUJq1SpYr///ru9/PLL9vXXX9ucOXNc0CnUrFmz3PLU7F7bVQEZVawUEHvxxRczLP+kk05yn61cXdovhg8f7tZz8eLFGZr6+1GlVZWoyy+/3HWrVPdKrXPlypXt9ttvT53vnXfecd0sVFkbPHiw6wqoffCDDz7IVvldddVVrjuB9kl1M1ClUkFRlUN2Pf/8826/vvjii91+q0CmtoW6LIQeAwCA+EDdJ7brPrrxFV43VVAmq7xSWm/VTVSXVMqDG264wf3eK7Dz+eef2y+//OJ+t1XH7dixY4bgzldffeXqPKH1AwWGVB/63//+l61UBAp4qX6sz9cNPtURbrzxRlcPuf/++33fo9e17pdeeqkLfukmmujm7dtvv+2WpbqZt2zVpydMmGBnnnlmrut8QKEV7aZaAHLGa/rs9+jVq5ebx+siF0rNips2bRpo0aJFuumnnHKKe++nn36a4T1JSUmpf7du3TrQrFmzwObNm9PNM2HChFw1xd5X97399tsvcNhhh/m+pqbmtWvXTjft1FNPDQwbNiwwbty4wNtvvx247LLLXPe5unXrBpYvX5463y+//OI+9+abb/YtI6/rXShNUxP5nDZhVxP50K6G+l/PP/jgA/e6X/c9v2335ZdfunkfeuihDOuVkJAQmDp1aoayUBfB0Kb4ffv2dfNfccUV6eZ999133fTnn38+ddrixYszrJs3rWzZsu5vT3JycqBly5aBWrVqpU7bs2dPoE6dOoEaNWoE1q9fnzpd69OwYcNs7S+VK1d2+2ZejhHtIxs3bky3fatVqxY44ogjcrVcAEB0UPeJj7qP32PEiBEZtmNoHeDFF19009S9MNSHH37opp9//vmp0+6991437c8//3TP//nnn9R59L/SRMjs2bPd80cffTRb6z9mzJgMaQTOPvtsV5dR17xQWnfNqzp1eJc9r078wgsvpJuuelG7du0CDRo0cPWm3NT5gMKMllJAnBowYID16NEj3TQ1d5bQLnK6q6ik1apfqKWTWo+oe5vu6qi59qeffmonn3yyu0sVTneeRHdrZs+e7bpf6Y6PHh4lzdTn6W6WmjvnF6237or50R238FFRPvroo3TPzz33XOvcubO7K6iWOi+99FLqcsVv2d6dvPBlB+tmOXfKKae4baLWUbq7p//VNFvTf/31V9/3eNsuOTnZtmzZ4u7CqQuc7n6Gd7MTJYA//PDD003TdlaLJt3dPPjgg9O9dv3112eYV3RXMjvOPvts123Toybsapb+zDPPuC6DuiOqVnUa4efmm292Lag8ek0trEJbjmVG33fu3LnurmH4d8gu3aHUcjy6k6w7kuruCACIP9R9Yrvuo8FslDoilFpcZUWt+1XfVPe9UGrFfeihh7oW2aoTaR6vzqKWRE2aNHH/qwuiuvurNZKeq5W215rKm39f1MJcdRulQvCoTvvee++5erLWJZxSIaheEUotstXqXHWl8BZj6jap9VR9yyujnNb5gMKKoBQQp/Rj3KVLF9/XNLLKnXfe6X7I9Xe4jRs3uqCU+sqr0tGmTZssP+uPP/5w/6uCo4cfdZPKT/qhDw1+hecbCq8I+FHza41IE1pp897nt2xvNLzsLDs71GRczbhfeOEF1/xbXdpUiclqJBpVqDR6jSoj4aPzbdiwIcP8ygMWzmvure55+5o/q3n97OvzFHhSV0DxmrKH8pvm54knnnBlpzxS+kwFvlSh08MLluZ2XbP7XQEAsYW6T2zXfQ477DCXBiInVGdQV8PQm1ge5YRUmgIFeJQWQfksFfRRXUmpJPS/Pk+pAlRf8IJS+l/d4RTU2hflrVIXQOXjDM2hpcCRPksBK7+gVHjwzasvK7ikHKqZUX3Ze29O63xAYUVQCihkFGRS0kT9MCrpo36sdcdFgRC11FGiS92RyekyRf381arKj19lIi9UQVH+Az+arnxT2aE7X8pTELpcbxl+y5XsLjs7lHfpkUcecXctVVHR88won4O2XePGje3BBx90wyorqadaI+nup992yyrA5XeXM7P5s3tHNKefl1vKiaGWXmrxpXxlym+miqHyQ+hvJQTNy7oCAAoP6j6xVfcpKLrZp3qAWkJpmyuoo9yTXqsor1WV6g16rvrTvqhurPcoD6dfLk4N7rJmzZoMuUD9gnhaJ83nDdbjx2v9nZs6H1BYEZQCChl1s1MCciWyVne7UEqeGEo/hPrx012ofd2Z9C7yM2udld90N0xNsZcuXZou2bmeq2tYaKLIrKg1WOgdK3WfU8VLidzDedNyepcvK82bN3dd7DSSobrwZdVSSJWYpKQk++STT1zlxKPE8/F0x8zr3rdgwYIMr/lNy4zucmoUGj1U0bv11lvd6HmqdIZ3XQUAFF3UfWKr7pMTatWsLnJqxa9BSULNmzfPteyvVq1ahhQF48aNcwG1448/3k3X/2plrWTiWlZ2uu6pbqHR9NSiSq3L/Ean1uiEGjlZN2b3RfXlP//806UKUMvxrBSWOh+QH7LXBwJA3PBah4S3WlFuHvXbD7/oV34j/SCq9Uk4bxnq3qc7O8pHtWjRogzzaWQ05afKT2p+LapghPKeh44gk9lnK7fBsmXL0g1/7C1bTbRDR4JTxeDpp592FaJTTz01X4dF1h0wdXvUaDi52Xbq+hdPd8xUsVUFWBW90IqVck5pH9oXbQtVKEMpeOp1M83vfQ0AEN+o+8Re3Se7lH9JdRzVlUKpbqr8m7oJGdpt3ws2qV6lHFkaQVqUS0v7gZdmIjtBKdV91X1P6QI0Wl744+qrr3Y32jQKX3ao1Za+S3h+LL9UF4WlzgfkB1pKAYWMEkqqD75alChppVrm6K6N8hqpv72SUIdSgmq14FFwqm/fvtauXTuXGF392/VD/NBDD7mAwBtvvOF+4Fu3bu26oOkztHzdjdNdKQVc9pXoXD/8Wo4oibWocqTKk6hSoOGHRf33Tz/9dBs+fLgbYlitjZSgWl241HJGCdY9uoOl6epaqHVWkExDAStBpfIMhLcYU4ubsWPHurwLgwYNcncPNXyvmlKrNZlyCISXaU6HRQ6lipIe+3LOOefY448/7iqGSuaqLmpqYaU7wKF3CeOheb2GOVbgUPklLr74YjdNQSrldFL+iKya1Kubo4JaqogqEKU8EnqPhodWN9HwijYAoGij7hN7dZ/sUt1x1KhRrr6pz1J9SXXL5557zrX2UpAmlFo16aaq0lQcc8wxqYna1aJKN8VUf1UdYl8J1kV1R+natWum83Tr1s0ee+wx16JMLaCyokCWBllR3XrmzJmuHqv6m+q5qsPqe3k3dwtLnQ/IF9Ee/g9AznjD6T7yyCOZzrNkyZJA9+7dA9WqVQuUKVPGDSOsYWq9IXsXL16cbv5ly5a5YYTr1asXKFGiRKBGjRqBE044wQ1LG75czachgjVflSpVAm3btg3ceuutgX///Tfb657ZI3QoXtmxY0fgjjvucJ9XsmTJQMOGDQNDhw4N7N69O918P/zwQ+CMM85w61+6dOlAqVKlAs2bNw/ccsstgQ0bNviui76zhhCuWrWqm79NmzZuSGA/uRkWefr06VnOp9c1n+YPNXHiRFemZcuWdevWq1cvN+SxPv/oo4/OsF59+/bNsGxvuOLQ8tR8mZ3yw5ej/SN83fymhX/n8P3q3XffDbRq1cptO22bIUOGpA6X/M4772RaNrt27XL7lPZb7WN6v75/v379UoeBzorfkNPZKQcAQGyi7lM46j6Z/T5v3brV/e6rnqf6ZfXq1d16qt7pp2vXrm45qhOGuv322930Pn367HOd161b58pAda6s/PTTT26Zl156aaZ1rHCvv/56oFOnToHy5cu7z1A5nnPOORnKOid1PqAwS9A/+RPeAgAga7rbeOONN7o7hvu64wgAAACgcCMoBQDId7t373b5EkJHwFNOKXX/3Lx5s0tWn50R9AAAAAAUXuSUAgDkO+VMUJ4yDWusUWVWrlzpckZ4uaEISAEAAAAgKAUAyHfVq1d33fNGjx5tq1evdonOlWhfo+v07NmTEgcAAABA9z0AAAAAAABEXmIUPhMAAAAAAABFHEEpAAAAAAAARBw5pXwkJye7kaHKly9vCQkJkd8qAACgSAoEArZlyxarU6eOJSbm/d4hdRoAABDLdRqCUj4UkKpXr15Bbh8AAIBMLV261Pbff/88lxB1GgAAEMt1GoJSPtRCyiu8ChUq5P9WSdpt9sdjwb9b3GBWrKRFg+6erlmzxo2SlR93Y+MV5UA5sD9wXHB+4DwZK78XmzdvdjfGvLpIzNdp+B2lbNhnOJ4ihDo75cI+UzjrNASlfHhd9lR5K5AKXPJes3qHB/+uWMkssXjUdsSdO3e671jUg1KUA+XA/sBxwfmB82Qs/V7kV/qAAq/T8PtB2bDPcDxFCHV2yoV9pnDWaQhKRYOCUPXOjspHAwAAAAAAxIKi2zwGAAAAAAAAUUNLqWgIBMyS9wT/Tiyh9mxRWQ0AAAAAAIBoISgVDQpIzb0/+HfL26OW6BxA3iUlJdmePSlB5kLWz1zfS33Ni3rOOcqBcsjv/aFEiRJWrFgxi5Xhmvfu3evOZbnFcULZxMs+o+OuePHi+ZazDQCQdwSlACCXtm7dasuWLXMXdYWNvpMuGrZs2VKkK++UA+VQEPuD3quhkffbbz+Lpt27d9vKlStt+/bteVoOxwllE0/7TNmyZa127dpWsiQ3hQEgFhCUAoBcUKsCBaRUudVQqoUtcOO1nijqd5QpB8ohv/cHLUNDMOv80aRJk6i1mFJAYPHixe7z69Sp4y7Q8/KdOF9QNrG+z+gzFYjV8ad9X8dfUW4JDACxgqAUAOSCuh2ogquAVJkyZQpdGXKRSTmwPxTccaHzxpIlS9x5JFpBKV2cKzBVr149F1zPC84XlE287DP6vVb32X/++ccdA6VLl47YZwMA/MXU7QE14R04cKDVr1/f/Wh07NjRpk+fnm6eP/74w84880yrWLGilStXzjp06GD//vtv6uvqm37VVVdZ1apVXbP4bt262X///ReFbwOgKCjKrYgAxP95g5YiKGrY5wEgtsRUUOqSSy6xL774wt544w2bM2eOnXjiidalSxdbvny5e/3vv/+2Tp06WfPmze2bb76x2bNn21133ZXuLsf1119vH3zwgY0dO9a+/fZbW7FihXXt2jWK3woAAAAAAAAxG5TasWOHjR8/3h5++GHr3LmzNW7c2IYMGeL+HzFihJvnjjvusFNPPdXN06ZNGzvwwANdq6kaNWq41zdt2mSvvPKKDR8+3I477jhr166djRw50n766SebOnVqlL8hABQdxxxzjD3xxBMWi9S6Vi1p9ZtRUPSbc8QRRxTY8ouiSpUquRtS8ZJzrlWrVq51NxBN6oFw0UUXsREAADErZoJS3nDE4X271Y3vhx9+cHkPPvroI2vatKmddNJJLhB1+OGH23vvvZc674wZM1x+BrWu8qhV1QEHHGBTpkyxmJGQaFbxoOBDfwNAAQaHSpUqZeXLl3fdng8++GC74YYbXKLX/KILHl34xAv9JmjkRJVHQbnlllvcjRQUTcoTdeONN9rtt98e7VUpVOcxBZOrVKninqvOBwAA4l/MJDrXBdORRx5pw4YNsxYtWljNmjXt7bffdsEktZZavXq1u4h48MEH7d5777WHHnrIPv30U9c1b/LkyXb00UfbqlWr3OgxupsaSsvSa5nZtWuXe3g2b97s/lcgTI989+8ys7WNgn+vmWVWrZqukizS9N28IXmLMsqBcsjN/uDN5z1yasIEs6FDzf7806xpU7O77zYrqJ7GOm8qaKT1VMsNnWfVkvTnn39258fMeN8rO9/PrxxyWzZ5pZsTSmSbX3JSDvL777/bggUL7JRTTsnV99dNGgU18jPvUH6USU7LoSBkd5/K730gfB1C/8+Mclpec801LqGyAqHhy/DOM+Hnmrz+Jme3TpPXc1j4eaxJk2I2eLDOY4ECPY8pd+htt91mZ511li1durRAt3t+LS+ax04sHLextm5ZHX+xgHopZcM+w/FU4P7915JXr7ZiGzZYcuXKZup5VgDxiOyeY2MmKCXKJdW/f3+rW7euq5C3bdvWevfu7e6GeV9IlRDljZJDDz3Udc17/vnnXVAqtx544AG75557MkxXSwJVfvJT4rJlVv3IIy1h797UaYFSpWyNWoPtv79FkspU3Vf0w1yUkz5SDpRDbvYHXaxoXgUQ9MiJiRMTrFcvjTikinGCzZkTsO7dE+ydd/baOefkb+Xcq3h766jWpurW3L59e3vkkUfchZ78+uuvdvPNN7tcfWqJoNZUXpcPBbFmzpzpWqiqm7UCWffff7+dffbZ9swzz9jo0aNdAEXdp3Xx/dtvv7nPXblypWvZ6t1c0Ovq0hROLV5vvfVWmz9/fuo0BcxOO+00d9GpmxKXXXaZW66+h25gPPnkk9agQQM378UXX+x+MzRYxueff26DBg1y30vfpWHDhm4encu1bh9++KH7HioHLVc3MfR+XXjq/Z988onVrl3bnnvuOfe7ou+xbt06u/rqq+2rr75y3/2KK65wv0MaucmPvo/yH3qjS4mGHtfv28SJE11+RHXte+mll6xOnTrudd1QUXfHF1980RYuXOjKTuun7aCy0Ohoer/KSfvl66+/bk899ZSdfPLJ9vLLL7uBP2666Sa7/PLL3fKGDh3qttn+++/vciz27dvX7rvvPtctfsyYMa7LvFqbqBw1Epzo5o1aeOlGj17XtlILZbVY1oAhavmjXI3a1t27d3f7gFqvrF+/3gYMGGDfffed+86NGjWyd9991w1a8tZbb7kbSVp2hQoV7NJLL01tQRa+z2n52haifVa/y9pntG31vUUtqv2ON7/vq222r/0ms+0uGzdudOUZvt23b9/uXtcyVaYqT82r5T/77LOp21Rlo+NMeS61HqH0Xn1H7VvhQQ+tT15kt06Tl3OY33ns998tIucxjdam7attefrpp7vj2Tv2tR9oX8xqu+hYe+yxx1zdUcfYCSec4NJEqOWkRkTUuUHHps4hWu6yZctcvlO1elu8eLHbv1XGxx9/vFue1kv7jZanPKa1atWyxx9/3J37tN46R77wwgvuGDrkkEPs6aefdjdfRce8nm/YsMEN0KNgm45zfY72t19++cXt/2r1r31U5wHdoNUxpHOZtqfyr2o5XsvP77//3q699lr3XdRzoHLlyul+A2KFykbHczQS/2d1/MUC6qWUDfsMx1NBcvGITp2s+K5dVr2A4xHZrtMEYtDWrVsDK1ascH/37NkzcOqppwZ27doVKF68eGDYsGHp5r355psDHTt2dH9/9dVXqgUFNmzYkG6eAw44IDB8+PBMP2/nzp2BTZs2pT6WLl2aupykpKT8fUyfrvtBGR6anu+ftY/Hnj17XDnr/0h/diw9KAfKITf7w7Zt2wJz584NbN++PZCcnOwe7dolB+rW3fejePHkgFly2GkgOD0779dDn+V9blaPo48+2p3/wqfffvvtgcMOO8z9re9bpUqVwJgxY9z3nj17dqB27dqBTz75xL1+9913B4oVKxYYMWJEYPfu3YFJkyYFSpUqFfjrr7/c63379g1ce+21GT63bt26gV9//dW955JLLnHT/NZR52B9/vfff5867corrwxcfPHF7u9FixYFPvroI1fWGzduDHTv3j3QpUuX1Hn1+WXKlHHru3fvXvcb0q1bN7fe3jyjR48OHHTQQanL0zl+/fr1qe8vX7584Ouvv3bff+jQoYH69eunvrdPnz6BU045xf0mLF++PNChQwf3/szKvEePHoE777wz3TQtr0GDBoF58+a59bvwwgsDxx57bOrrWt6RRx4ZWLZsWWDHjh1uHr1H207ls2TJkkDLli0DL730kpv/1Vdfddvktttuc6//+OOP7jt888036baZ5lP5a3lDhgwJHHzwwW5ZmzdvDvTq1StwwgknuPlVbu3bt3dlsW7dOvee7777zq2L9vfDDz88cN1117nlrFmzJnDMMccE7rjjDvfeW2+9NXD66ae711R+M2fODKxduzawZcsW97vtrZPKe9q0aVnuc1988YV7/eWXXw7sv//+qeV10UUXBRITE9028itzv++bnf0mq+1+/vnn+2531Uf0+o033hg47rjj3GvaBoMGDQr873//S7deV111VeDSSy/NsL5aJ50/dB4JP7fo8/Q5qo/kRnbrNHk5h+XHeSy757Dw85i2rc432lZ+x/6+tovKol27du5Y0z6pY0D7V+i54eyzz3avaXl//vlnoHTp0oFx48a5fevdd991n/n333+79zzxxBOBhg0bBqan1ON0fKlc9dozzzwTaN26deD3339379W8Bx54oFuv+fPnu+VoH9e8K1euDMyaNcv93bt378CAAQPcvqbHDz/84N7jnV/0utZPx9i5557r9lW9pmO3YsWK6c7VJUuWdOWU3bKO5MM7liL9yOr4i4UH9VLKhn2G4ympIM8zn30WsXhEdus0MRmU8ugHVz+uL7zwgnuuCrt+eEOp4qAfZ1Gls0SJEq7i4NGPvgpiypQp2f5cFVpeKoRZmjEjEChmgUDXlEexlB1B0yNMO4oqQfq/KKMcKIfc7A+6WNfFhP731K3re44vkIc+Kzt0Mff4449nmP7cc88FGjdu7P5++OGH3bk0lIId3oXa4MGDAy1atEj3+sknn5x6k0AXPApYhH/uLbfckvpcF1X77bdfput5xRVXBC677DL3ty6mqlWr5oIifhToUlDM20b6/LPOOivdPB9//LG7UNT6y4knnhh45JFH3N+LFy9OdwND71eAxqOLVb2uwIouDvS78vPPP6e+rovSrO7pKPDhfZZHF9APPfRQ6vNVq1a5ZShgIPp74sSJ6T7j0EMPTbeMF1980V1sy8iRIwMVKlRwZeW5/PLLXSBPtM0OOeSQdO/X9lYQyKOLdn2u/p86dWqgXLly7mItnL67AkjeRbF8/vnngUaNGrm/FRDS77MuqEPpgl4X3c8//3yG31O/fU6B0v79+7u/9T39ymvy5MkZ1i+z75ud/Saz7a4Ah7a7Ag3h211lrmWovEK/s84FCpz9+++/6b6TggjZOX8UVB0ks+XFyznMO58oMKQ6Yc2aNQMnnXRS4Lfffstw7Gv/3Nd2UVm88847qa9r31fgRtvUOzdoX/Hce++97nwXSoGs++67z/3dvHnzwKhRo3zXW4FwHdfaZ7xjp06dOu7ctnDhwtRgV/hxp6D1mWee6QJioVavXu2+i+rHHs2jfVX77Ouvv+57rlY5xRqVR2i5RFJWx18soF5K2bDPcDwVCNUZn3giEFB93O+HuQDiEdmt08RU973PPvvMNedt1qyZ676grghqstyvXz/3up736tXLjc537LHHupxSahbvjcajpstqjq+uG+oKoK4CyuegptuMggSgoNWqlb35/vtP3QcyTi9eXDnw8vezMrN8+XJ3nhR18/j444/T5eNTtwp1QfOoK1YoPdcysl7HtJVU9zJ1OxF19/O6M2k5c+fOtQsvvNCNrqouOTq3K8+g9/nqdnTddde5bineiHnKmaMmwV6XlfCcPeo6o+516m6mrnP6X13esruuouWri5Me9erVS309/LPCqbuMl8cnvMw86g6m7l0qQ3U5C1+utolyU4VuE3XpCF0PdUcK7Xqi5et7Zrae6obkdV3z3q910HTlPVLXeXXVC6d1UTeo0PxjoV1v9NusbkQ9e/Z020e/0+r6pHLUb7S6SqmbnroDqiuofr8z2+f+97//ub/VDcqvvLIS/n2zs99ktt3VvSer7b527Vrbtm2bq4+Edj1S1zB1OfXep/1A+0O8yMl5xf88FrDixROydR7L6TlMXeb8BlTIzXYJ3bf0t84VoYM/hC4z/LgRdeHTdNGxo3OMH+3nF1xwgeuC59Fn6b3a10eNGuW696meq3qqRpdWagp1rVZXW3W/0/dQV+q7777bLU/nAa9bskddetVFNvy48b5ffqeiAADEma++MrvuOrO5cy0WxVRQSpVG9afXj7UulpQkVHkBvEr3Oeec4/rsq2Ki/vIKXim/SeiFk/rx68dZ71XlUxcm6usfM5TUPLzrvCramg4grv3yS/aTA3frpjwawVsT3v/vvqvzXGTyaUyaNMkFgUQXajq/KgeLJzQfknfhFerff/+1jh07ur9zmpPuvPPOc49QuiCrVq2ay5OiQS7OP//81ItK/S4oj49yBin/0axZs6xNmzbpkuOGr4Oe60Lutddec78V+i3IKql7ZrRO+g3SBa0XwNB3z4ouKrWO4ULLULls9BulQJDfd9A2UTL6qVOnZvo5ugANTcSs9cpseaLgly5qNXKt6CJW66DpKksFyHTxGj4KrtZFeXu0fOXzCc//ohHRNPiIHsqFc8YZZ7jfXeXDUt4dPbSemqY8ZMqf47fPhVLAzK+8shL+fbOz32Rnu3v7Teh2V/4f5feZNm2au3mWmXnz5rn8W4XtHOZ/HgvmlorUecxvu2d3u2jf8o4DbVcFrbSPeNs4dJk6PjQKdCgdRwp8eUEf3UjVDdBw2s9VL1Vwye/YUSBXD+VwU9BJAaw5c+a4482ru+q58l4pqHvUUUe5ddOxr++5r+PG+35aHgCgCPn3X92pUWVRARKzr79O/7pulqTcXHRU94tiPCKmslvrh1kJYFXxVJJX3T0KH7JbCSD/+usv9wOuCqYSn4dSZVoJLZV4VXfLJkyYkO5OaEyIvQFQAESQRtkbP96sdevgb4D+1wVeJC7klExcSYJ1E0CtSkUXQl9//bUL8nstg3R+VZJdz59//umS/ypQpeTXml8tYkQX7YsWLcrzCEpaDyX91fLVcsqj1ia6AFOrGiWm9Uvi7Ee/F/oNULJs/Z0bauGgoII+U2WmQI5a/mRFyZfVOsdrSeRRsmONyqffLyUU10Wt10rKbxlKjKwLUwWKtCy912sZLPqNU8sjtbzQRbhaoIUH+0Ip0Kfk5Aq0qNWatr8ulnUh26FDBxe8u/LKK12rKG1nXYjr91iv6eJaF81qRaTtrAtfJV4WBRK1f6gFh1ooK5ijC3CtvxK76z16rtf0f1b73PTp093rGuREv+VeeSnAlNPgZ273G2+7q06i1ip+213roiToCrx5I8DpM955553UeRQQ0/fxgr+F+zwWsFatAjZ+fCCiAalw2dkuopZICuxoX9d+fe6552a6f+k8p+NOgXwdFzqnKKm/3iNq9al9S/uvjg0FgTTKqVx11VU2ePBgtx97+6SWo2NC05RAXfu3gmIK7nrHhwYK0HK0PO2/2h/1muqzCuwqib9ahYn2TR1nosEhFFwOP1cDAIpYQKppU7N27czOOCN9QOqww8ymTTNbtMiSp0+3tZ995v43/U4VwOh7cRmUKhJSKhHp6O6v33QAhZYu6NSYZseO4P8FeSGnAIi6wynI37VrV3dho4CT1wJErWvUfVpBE41Apum66AntgqZR3tRqR61Y1SXqzTffTO2ycskll6R2B2ytK9RcUqBCF3tqzaLR+jy64FNLBHWDUkuBU045JVvLUxcbjX6mC0BdrOWWRrZS1zF16dGIdQpW6CIyMyoDlY0XtPEoMKZgi8pX5aUgUmZ0gfrll1+6kd/UdUgtQPr06eMuQD0HH3ywu/DUNlPgTC2L1TUuMwrsqMWYWnRomQoEaTuKLsjV1U6BFAWn1FLozjvvdIEmXRDrNV3EH3TQQW4/Unlqm4j+1/6hfUyva/kaOUzvVXdMBbT0HgWZxo0b5z7Lb5/TBby3z6msFERTFydtR+0TWn5O5Ha/8ShAmtV2V6ttfdfjjjvOrZtatmkEOI8Cbtoe4d2pCuN5TAMS/vJLUlQDUtndLqJ9y9s2mkf7aWZ0LlIgSsElneM0wp+CQNovRS33tb9r/9CyFOj1WlzpPKqbAHpNx4BG3dOIlKJg8l133eX2fR3fCh6pZado1Gm1RNV5QN9FqSnOPPNM95rmUaBKwWIFenWMaH7R+inope+jeTQyZ1aBagBAIRMImOlGjF/r8sGDzaZMCQamFIBq29b2qt7etm1UA1KSoMRSUV2DGKRKsSoPujuqH/x8NXOm2WHtzLwGXpOUSMPVQII7RATpgkFdItSsO6d3oAsTyoFyyM3+oNYr6qqk3B7h3Z0KA6/7nu7Oe60A3nvvPYs3Cm7oQu3RRx/Nczl4XW/UvVCtK9RqNzNTpkyx66+/PrX7nYJACm6plUN+0IWplufXTbAg+JVDUeNtd3XJ21c56DyibpzqnqhAXU7OH/ldB8lsefl5Doun/UPr9+uvv7rtEwnxVDaRFM1yifXfb+qllA37DMdTrihflPJGKX+Un7B4QyTONdmt08RUTikAAPKLuoOrZY7XiiC3FHxSVzm1ulLLm3vvvdd69OiR5XvUuiGrfFCIfdruqkSppY233bObH0qVu9mzZxf4OgIAgCJu40azIUPMnnkmfZ6oOEJQKtK8BGJeDwy1UyPROQDkK+V5UTeZW2+9NdORsbJLASl1LVSOGq8LpLq2oXDTdlc3L7Y7AACIKf/+q1FgzN5/X/kGgoEpj/KVaojcPXtiJpH5vhCUigYFMH+KyicDQI4p2XO8Ua4iPfKDuvkocXFeuphotK78pJEF9UDB0XbXwAChwkelRPwhawUAIO4DUk2aKDlh+ulq6HLHHWY33mi2Zk36nNUKSEU5b1RWCErFUqLzGN5RAAAAAABAlKxapaFdMwakREPiegP7KK4QR7GFopvdGgAAAAAAIJbt3m322GNmTZuaffih/zy1a1u8oqVUNBQzs9NT/tY+FZ/5yAAAAAAAQH530Vub0sNqyhSzxx/XCD6FtowJSkWauup5gSm/6QAAAAAAoGgGpJo1M9u5M+Nrym967rlmEyakjx/EeCLzfSEoFWlKQJaT6QAAAAAAoPBbutQ/INWqldnIkWbt2qVvSRUHicz3hZxSAICoGThwYJ5GkdMIaa+99lq+rhMAxMo5LCkpyVq3bm2///57kRnt9eyzz871+7ds2WIHHnigrfUbWAgAYlkgYPbuu2bduvm//uqrwYCUKADVtm3aI44DUkJQCgAKsWOOOcZKlSpl++23X+qjWjab91588cXuggsA4vEcpmBRvJ/DXn/9dWvSpIkdfPDBBbL8Bg0a2HvvvWeFRfny5e3CCy+0++67L9qrAgDZN2eO2XHHmfXqZfbff/7zJBbe0A3d9yJNFakEn657cdwHFEAuRLDZ7UMPPRT3F2b5Yc+ePVaiRIlorwZQ+M5jurublGRWs6ZZ/fr5/jFF+Rz27LPPutZDmeG8lrEs+vbt61qgKTBVtmzZiGwnAMjVNcDmzWZqLfvGG2bJyekDUKHP4zxn1L4U3nBbLAtEewUAxEQCQzXB9R56rukRNHPmTKtYsWJqt5ANGzbYAQccYKNGjbKnnnrK3n77bRsxYoRrmdCyZcvUSv/dd9/tukdUrVrVzjzzTFuxYkXqMhMSEuz55593d/UrVKjgXt+0aVPq69999521atXKLbNr166uq0Wov//+28444wyrXr261a9f3+69915LDvlRfuaZZ6xevXrus++4444sv5+6xOjCZPDgwVarVi0799xzbevWrXbWWWdZjRo13Hfv3Lmz/fbbb6nv0cWfPv/qq6+2SpUquXV4V02pU+zatcsuv/xyq1KlijVs2NBeeeUV952XLFniXg8EAq7smjdv7t6vVh5//PFHHrYSEPvnsYT27a3E4YebNW8e0fPYvs5ho0ePtueeey5uz2Far19//dWOPvrodOeo008/3a644gp3Hrr11lv3ed7ZvHmzO6dpffSdOnToYEuXLrUePXrYv//+a71793bfR+c2ufnmm928anV00EEH2dixY1OX9c0337jPePnll1O/h+YP9fTTT6e+duedd6broujXPU/L03L9ZGdd9Dul7d6xY8fU1l/67G+//TbL8gWAqF8DHHus2ahRaQGoRo3M3n/fbNEisxkz0h4LFsR9F72sEJSKNC8qqv+8RhLKnE/fdyD+tW9vtv/++35ovvAEhnqe3fd7y8ijtm3buoCNgjU7duxw3fX+97//ubvM1157rbtQ0YWPAjlz585179FF1I8//mg//PCDrVy50po2bereH0pBnK+//tpd7Cxbtswe1zC2KReMusDTxdHGjRutX79+9uabb6a+b/v27Xb88ce7x/Lly+3777+3MWPG2EgldTRzy9Tna/n6bNlXnhW9Xrx4cbcub7zxhrs47NOnjy1evNj+++8/a9OmjfXs2dNd1Hk+++wzF6xat26dDRs2zF2oeReeusD85ZdfXHnMmjXLJk6cmO7zdHGkQNUHH3zgcproolUXqLt3787j1gIiIKfnoLDzWEJOzmMROIedd955duWVV0b1HPbOO++4IFluzmE6x9StW9cFZEJ9+umndvjhh9vq1avdOWpf5x11Y1y4cKFNmTLFrfeLL75oZcqUcQEeBXN0A0JlpGCcHHLIITZ9+nQ3rwJ4F1xwgTtnenQ+nDdvnv3111+uHNWaywsqffXVV+4948ePd98xMTExtexzIzvrohsL8+fPTxeEUgBL5QcAMUXX/H5JzEuXNlO3Y50vzzgj2Oq4EOWM2qcAMti0aZOuTtz/+W7GDF36ZHxoeoQlJSUFVq5c6f4vyigHyiE3+8OOHTsC8+bNc/+nqlvX//guiIc+KxuOPvroQOnSpQMVK1ZMfXTp0iX19eTk5MDJJ58caN26daBRo0ap5z1Nv+CCCwLXXnttunnLlSsXmDVrVrpySExMDPz777/uuc6dn3zySerr9957b+D00093f7/++uuBFi1apFs/fXbfvn3d3++++27g0EMPTff6iy++GDjuuOPc3/379w9cccUVqa/t3r07UKFChcDIkSN9v7umV6lSJcttuWHDBrfOy5Ytc88HDx4cOPzww1Nf13tLliwZmD59unuuMho7dmzq6z///LN7/+LFi93zgw46KPDee++l+4w6deoEvvvuu0A807ZXeev/oiy/ysH3/FFAdZDMllfYz2Gic8t1110X1XPYCy+8EDj22GPdZ+f0HPbmm28GWrZsmW6azlGHHHJIumlZnXdWrVrlvtM///zj+xn169cPTJw4MZAVfZ7WRSZPnhxISEgIbNu2LfV1bY9HH33U/a3veNVVV6X7jtpm3nfU+p911lnpjiW9ruWGvp7dddF303k8XJ8+fQI33XRTjo+/WEC9lLJhnymkx9Py5YHAKaf4/yZ+9FGhLJvs1mnIKQUA+aVWrezNp7vXa9ZknF69ulnJkvn7WWb2wAMPZJqPRV1V1BJI3SkeffRR17UjM7oDv23bNteKSO/zlCxZ0nUFUXeN4KqlrVu5cuVSWxmpK4q6YYTS850pd4zUBU6tBtQdw6OWTd5y9X51S/Eod0jt2rWz/O5qZaA79R61prjhhhvs448/tvXr16e+pu+mecPXX99TLQpCv4O3PqJWBqH0Hc4//3wrVqxY6jS1VlBrCyDm5eC8kufzWBE6h+2vlmG5OIdVrlzZdb0Ll5PzjpLE6xH+nqyoZZi65+n9Kie1ogodzU5lHJqrKbyMcnqezsu6qBVZaHl7VG4FlRweAHJEvaKefNJs2DCzrVvz/vtbCBGUikqi84RgTNRDonOgcPjll5z1Jw9tvqtmu3p/hJvnqjvKNddcYwMGDLD777/f5RjxLl5CgzmiHB26EJk2bZrLXZJTderUsX/++SfdNHWPUX4n0QVhu3btbOrUqdl6v3LDeF1gMhP+HR577DGbMWOG63KiC0V1CdGFX2j3vX19B128quuMt/6h9B2eeOIJO/nkk7O1PCAuz2GZnMcCpUtbQoTPY7F+DtO5Ze/evbk6hykXk7oBKhCjnE+e8O+V1XlH3ZSVCy806BYqfFk6Nyrvk7oaqnuzXtd65PQc6dF3D/2O+h7q5uhRkNAv8JbddQlff4+6F6rrJgBENZH5jz+aDR+uuweZz1+6cCcxzw5ySkWl1ANmp1vwkXZTC0BRoQsmJSyMgQSGl1xyiWs18MILL7j8KMrBkqRRtMzchZZyd3gXAKr8q0WCWhp5Fx3Ku6ScKdlx2mmnuQusl156yV2ofPTRR+5iw6PkvbqAUmJitTzQeixYsCA1V4lyXClxsS4o1Qpg6NCh7oImJ3TxU7p0aReI0oXe7bffnqP3ax0efvhhW7VqlUt+rHwuoa666iqX90Tr7X3epEmTMiRDBgrTeSzwyy+2Z9o0s/nzI34ey+ocVrNmTVu0aFHUz2FerqOcnsMU4FEQZl8Ju7M676gMNLiDvreCQ2q5peTp+t5eGSk5u0fvVYsrJWrXvK+++uo+c/eF0nd86623XO49Bd2Uhy/0OyoPmHJbKQeUykjn4NBWa6Fyuy4K/Kk1lfYLAIhqIvNrr00LSOlcpwEllO8uBq4BYglBqUjzoqZq2e61bifROVD06McnQgkMb7nlFnd3OvShCxJdxOniRBdQXhcZXSToIkL69+/vLsA0wlPr1q1T5znyyCPtuOOOc90m1Crg888/z9Z6aDm6UHryySdTR2/SBaRH6/Xll1+6RLne6ElKSq4AkHTp0sUFgbp16+a6g+giJafdMwYNGuQucnQhpvfqu+SERpJS4l0l0dXF4qmnnuqmq3uMKAGykgor0bC6uLRo0cJdoAGF/jzWpk2Bncdyew5TwCra5zC9npdzmAJO3mAPmdnXeUeJ1tVKqn379m69FaBSV2ZRUEgjAmq6WhaptVX37t3dCIMKiilJ+VFHHZWt8vG+o5LPqzulukEqeKdk8t45UuV+2WWXuWVqPfU54YncPbldl9dff92Vh7oVAkDEg1J+icwPPTQYgBoxQiM4FK0k5tmQoMRS2ZmxKNGdGQ0xrLvgWeUmyJWZM80Oa2d2VsrzSWamG3raSbVTRpAqQxq5Ra0hMmv+XBRQDpRDbvYHXfioFVHDhg1dy5vCxutyopHrMruLXRTsqxx0x1/5U7Q/FOZyYn/I33LI6vyR33WQzJaXn+cw9o+CKxu1tlLXNY2Q17JlS4s3ahGm4JxGDAwNKBXUPqPWYSovnZvVwioef7+pl1I27DNxeDwppDJmjNl11/nnW1TXdrWcKmJlszmbdZqiG4kAACCH9OM9efJkd6GohL633Xaba/VQmANSAKJHLTtnz54dVwGpCRMmuJZY6ranVm4KSnXo0CEin61WVwsXLsw0IAUA+e6338yOPtqsTx//gJRQT8wSQamoJDoPm0aicwCICwpGXX/99e6uj7rvacS+p59+OtqrBQAx44033nDdE9XlbubMmfb++++7EQ4BoNB00VPvJ+UU7NEj2H39++/TXg9vdUQi831i9L1ooMMkAMQlXWjNUoJKAICviRMnUjIACie/EbQ9TZqYPfGEmXIFenmkvUYp5I3KEkGpSAvdQS0s0Tk7KwAAAAAAsUcDY/gFpDTK3sMPB3tACdf1OUL3vWjZkPIAAAAAAACxafnyYM6oSy/1f71v37SAFHKMllLRoNH2JkflkwEAAAAAwL6oR9Pw4Wb33We2bRvlVUAISkUl0XlCcNhID4nOAQAAAACIft4ojaKn5OWPPWa2bFnaa5UqmW3darZ3b9o0EpnnGUGpaAgNSAEAAAAAgOgHpJSwfPfu9NPVqOSqq8zuuScYlCKReb4ip1SkaQcuZmYnpzyKhSQ6BwAAQL5o2bKlffjhh9mad/To0daxY8d8+dxvvvnGKuluehw65phj7AmNHgUARc2WLWZ33ZUxICVvv2329NNmVaoEk5i3bZv2IKl5nhGUipayKQ8AiID+/ftbQkKC/fHHHzFZ3kOGDLGzzz47R+/R95k1a5bFgj179tjVV19tlStXtipVqtg111xje0Obdudy/h07dljjxo0zXODqwrFUqVK23377pT5WrFhRIN8NiLYvv/zS/ve//7n9vGLFinbKKafYzJkz9/m+uXPn2umnn56tzzjvvPPsp59+yoe1BQDEleRkszfeMGva1Oz11/3nUespFBiCUgBQyG3ZssXeffddF/x45ZVXor06hdK9995rP/zwg82bN89dCH///fd2//3353n+u+++2+rXr++7jIceesi2bt2a+qhTp06+ficgFrz//vsuYH3hhRfaypUrbcmSJda5c2f3+OWXX3zfowBvgFQJAIB90Q2OTp3MLrzQbNUqyitKCEpFJdF52DQSnQMoQO+8846VK1fOBTHeeOMN10rHs3jxYuvSpYtrfaCg1VFHHWXbt2+3J5980k0PNWbMGDvooINSWzapBcJll13m3tuwYUPXZeW9995zLXvUAuiOO+5Ife9rr71mhx56qN1+++1WtWpVO+CAA+y5555zr+k9Csiom43X6ke0nrfddpubt3r16tarVy9bo8STZnbYYYe5/9XdRvN7AZ2///7bzjjjDDe/gjkK/iTrDpgPb52GDRtmNWrUsJo1a+a628qrr75qd955p9WuXds99N2zCgBmZ/4ZM2bYp59+arfcckuu1gmIdwosXXfddXbrrbfapZdeauXLl3fnFp0XdD648cYb07WcfOaZZ+zggw925zsFahs0aODOL56nn37a6tWr585BOv50/Os8EHo+8Oi9Dz/8sB1xxBHuc48++mhbunRp6us333yzO8foNZ0Xx44dm+3vpZaOev/xxx/v1lWfsXz5cnde1blr//33t4kTJ6bO//nnn1v79u3duVbniyuvvNK1ohStU7Vq1eyLL75wz3fv3m1t27a1e5T3JBM6l7du3dq1wOzQoUOWLcTUIu3YY491vw86t7/00ktu+urVq61kyZL2zz//pM67a9cut32mTJmS7bIAgKjkjfrqK7Nu3czatTMLPWedcELw2jwUicwLHEGpaCDPOVB4Je3O/JG8Nwfz7sl83hxSsENdU84991zbtm2bffDBB6mvKRiiC421a9faf//9Z4888ogVL17czj//fPv5559d0MozcuRI69evX7oLpZNOOsnWr19vF1xwgXvPpEmT7LfffrMff/zRHnvssXRdbH7//Xd34ajWDgqU6ULzu+++c60gFKxSkMtr9SMPPPCAC1SpRZHWQ+/V9xCtm+hiSvPr/Qqm6SJPD13gqfWRLr603plRK6WyZcu6+bVON910kwtsiT5XF1i6SNT/uoALfejCUDZs2GDLli1Ld0Grv//991/btGlThs/Mzvxq6aGL8GeffdZd+PlRwE0Xim3atLHXM2tuDuSQ9r3wlkYK7GpaUlJSvs67L3/++adrGdWnT58Mr2majlEvOCNvvfWWOy9t3rzZBXtCffXVV67l4fjx4905KDEx0R3/WXnzzTft7bffdsFwLe8u5RpJccghh9j06dNt48aNbrk6B4aeL/dFy33qqafc+dMLeul41ropoKTj37uBUKZMGRcM0rw6t06ePNmGa4hyMxdke+GFF1xLMgWKFMTW8hR08/Pxxx+7YJ6CcFqeAnwK5K9bty7DvKtWrbITTjjBrrjiClcGCvANHjzYlaUC+SeeeKIrI49+W3S+PPLII7NdDgAQUYsWmR14oJluvE6YkDa9USOzTz9V5VY/ProzmPZYsIC8UQWMoFSk+SU0J9E5UHjMvT/zxz/vpJ/3j0cyn3fJ6PTzLngi7bUcUPewqVOnWt++fV2LonPOOSddi5wSJUqkdonR32p5pCCIWhIoSDRq1Cg3n4I23377rbvw8rRr1866du1qxYoVcwEvzaNAky7e1HJAd+JDg1KarpYAWr4uWhRgyiqYolZdurBSSymtuy7C1Bogs9xJH330kQseDRw40H2G3qdWFrpQzYxaGNxwww3uu6v1glpHeHmqOnXq5AJIuhjT/7r4DH14Lb28IFpo3ifvb3WdDJed+RUcVLBJXZT8KGCn4JkCiQ8++KDLSRXasgLILbX40UOtXjzKRadp4d3lJkyY4KYrIBwaSNK0adOmZeiGp+kKGGWXguXi1zVV0xT4UmDFo9ZHmq58awo6hdJ5QOcctbLU+UEBpvDAVTgFntUKtHTp0u69ar3o0XMFZrzzX/PmzXOUk0pBfCVi17rqvKwbBtdee627KdC7d28XJPJaISmfls4H+qxGjRq5Fqpqmerp1q2bnXnmma51q86pChRpXj8KdCv4rtZUKiOdw7XuClb5nYN1DurZs6dbnlqh6caEd05VIEzzhM4f+hsBADFl8mSzE0/UXZKMr+m8dtJJwb9JZB5xBKUAoBBTAEp39PUQBac+++wzF0Dygh9169Z1FzMKyCho5HV3u+iii9xFhlo26EJHd8Vr1aqVumx1d/OotZHfNC8AI7pYVPDHo64v3nr4UWsirVPo+3UBp+l+FFhTa6zQ1kwKOOluf2ZC11d0keoXSMqK190wtFWU97daLOR0/oULF9rzzz/vtk1mFNRTVx6Vp1qr6SJVLb2AwkRBY/ELRGuaAiVqXeRRIDozml+tijw6dtQVLiuh57vwc8Pjjz/ugko6DnWu0bnHC6JlR/i50u986p0/1SJL52jNU6FCBdcyNPyzFECbM2eOa0EW+j39zpN6f+h5UoF4v3Ox5lWwKnRete7SjQxRIEznV7Vc1fqouzFBKQCxJnHZMkvo1cvsuOOU58F/ppD6KSKveBQ+E5Kzax4A8aLl7Zm/lhB2H6DFTVnMG5Z8rtnAHK+Kun4oqKQLG+/iSgEmtS5Q1w113dOdfq/Fjy5o1FWjVatW7u65LoLU3UYtpNRiSq1z8kIXhVonLzCl7moKiEl4qwZRXhVdFB1++OHuuS5+1HpD00Xd+ULpQkytt9QyLD+o+59G+cqqpYOCR2qdpXXShd2BahJu5v7W+uiCNdy+5leLJ7WAaqpRYFK2oy6GdYGu1mBeeYTyKz8gN3r06OH+D21p06JFC2vWrFmGY07nCW//87rrab9Vl+DweRXACF/uvmhZCl6rq1tojjrRNOXAU9e27BwHCmqH5oTSuc0LruSUug0qgP/111+7Fkz6XHXBLajk6mo5pRZK6h6t4Jhy33m5sLw8UhphVTcddANBNxR0LvSj84xaVl5++eX7/FzNq1Zc6gbtRy3ItL/od0b7h85NoTcSACAq+aK8oL1a/I4da9VHjLCEnTvZGDGMWmyk6eBQve2LlIeXciGkmTyAOFasZOaPxOI5mDfsjk3oa9mk7jLqKqMudAp66KF8T+q2okTbuoDSqHwKDulv3QXXBaO6j4gutHRxo+5w6iKT3aHVM6PuKUoqrgsode0ZPXp0ao4otQBQVxVdKIYGfZTAXBeSCqwNGjTIBcq8rjx6j5f/SbR+CuYoyLZz5053kbxgwYJ03VxyQl1mFAxS1z39HzrSnR4KSHl0wXjfffe5wJkeWu9LLrkk02VnNb+6yqi1lLfNXn75ZdeCSn/rAlhdB9V6QV2m9B2V30Xroi48QF7p+NcjNKikc4GmhQeU8jrvvmhetUhSQFytPnXcaf/XoA0KlCgReU4CO+p2pi6ICvQqJ5vOSbmh86q+n/InqWWpzqdqKVVQ9Hk6Pysgpa6UI0aMSPe6uk2rBabWQ+cVfdfQVqqhrrrqKtcKU10Rdd7XeeTLL7/0bYGqVk8KvCkPl8pMD52H1HLLoy58Xu4+/Q0AUQ1INWsWTF6uR8eOlvj442kBqerVNXRxMHF5KBKZR13MBaVU8dcFkO6M6e6X8puE/vjpAkmVlNDHySefnG4ZuksTPo9ybsSE8Gz++5oOALmkizhdnChfiFpKeQ/lLVGrJSXL1YWJN4KduoRdfPHFqS0avODJ7NmzXYAotOtdbigfiYJO6jLTvXt3d/GkUZ1Ed9vVLUUXeV5+JSXgVdc0rZfO67ogCk2qqwCXvotaHukcr++giysFaTS/8mKpK0tW3ffyiwJ9Wk+1KNFDLTjURcajVgmhLROyml9dd9SSynuoTPQ7pr+VC0floETI2pb67tdff73Lt+W1cAEKE7XUUVBEQQ/t8+qip0CJzl9+rQYzo4C2knRrYAUtR+citcRSl+CcUr1T5zC1KlWQXAnTdQwXFCUyf/TRR905TucR5bDyqMucWrLq3KiA4NVXX+3OKWoN5UdJzXW+VCJ1nT+UM0ujrfqNUqqWrOrurc/XeVs3AhTUCs0Lptx7CporfyHnIABRpRZSPi2iAomJFrj22mAC85tvDiYuJ5F5TEkIFFRb41zSEL+626S7QPqh14+s7pLpx04/jgpK6U546GhKqlDoh9WjixFdWOkH16MfzH0ltPTox1ZdKJTjQxdJ+UpJf/2aVOvAaNvWIkkVEI3Uou47RbnrB+VAOeRmf1BLHI205CXBLWz006CLNrVq0oWIusQpqJRb6mqiLideEvF4K4ectvAobCiH/C2HrM4f+V0HyWx5+XkOi8f9Q+c2Ba4V1CnIgFI8lk0kRLNcYv33m3opZcM+kwvKzXnVVWajR2cc9fjFF63ixRcX6evdaJ1rsluniakto2F9dTdMzbE12odyEqjPvv4PbaqsIFToXf/QgFRoECp0nuwGpCJCLdpPSHlkP7UCAET8ouHpp592XcbyEpACgFig0QJV11S3vVtuucUFpTp06BDt1QIA5JZaeSrHnrrt+QSkJKl+fco3xsVUonPdMVF+jPC7FurGp6SSHuUHUURPwajjjjvO5QVQxSKUmiara4eaeav7hro3eHlSwilxbujQx16zZEUP/Zoz50mVKi5/cULIgEyBUqUsoNFj8vuz9kHfTRed+f4d4wzlQDnkZn/w5vMehY3OxTqvKrn2uHHj8vwdvffHY1nF87rnJ8oh/8rBO2/41TPy+puc3TpNfp/D4mH/UEJuJQTXOioxuRKHq1tyQa9zPJRNNESrXLI6/mIB9VLKhn0mm4nM5861BOWM+u231Jd1NgltexkoXdqSKleOyWO9KJxrkrO57JgKSql1k3JsKJik/vDqMqLRVaZMmeJaS3n9+DXai5rcKsGtcnBodCTN4yXVVI6Rtm3bumGCf/rpJ5eXRCOsKOeGHyXQVH6OcGvWrHFNfPNT4tq1Vj38tzcQcEPpJke4CbF2EjWl085YlJszUg6UQ272B+X10bwKpocm5y4s9P3VpFfnVXWtyOt3VE4qPeKtrLzRCqUod72hHPK3HHQc6Pyxbt26DLnalFszL7Jbp8nPc1i87B8a2CFcQZ+T4qVsIi2a5ZLV8RcLqJdSNuwz/hKXLbPqnTpZQiYDhO087TTbdtllrsGHRwGp9fvtZ0mrVxfp691onWuyW6eJuZxSCjTpLtZ3333nLoYUXFIiSiXj1Ygj4RYtWuSG1FZy2+OPP953mRqN5LLLLnMjkfgltPS7q6hhcDXiUkHklEo8ooPZWSnPJwVH4EtWMvco5JRSJVVJdIvyQUo5UA652R90cbdkyZKYzUmRH3TRGosV9kijHCiH/N4fvJw2yoHpl1NKLcFzm1Mqu3Wa/D6HcZxQNvGyz2R1/MUC6qWUDftMJn7+2RKPPDLD5EDDhhbQiMhdunA8xdi5Jrt1mphqKSUKMH377beuv7++hEb7UPLzRo0a+c6v6epeouGzMwtKaXQW3RVR5auZ+puGUaDKL1iljZPvGyiT5bnPiUJgSHenCuR7xhnKgXLI6f6g10JH+CxsdL/C+16F8ftlF+VAORTE/uCdN/zOM3n9Pc5unSY/z2EcJ5RNPO0zWR1/sSLW1y+aKJsiWi5ffmkWMohZqIQxYyzhsMOKbtnkQUGXTXaXG7NbRonJFZDSnT0NR3vWWV7TovSWLVvmmt9q3sxotCcViPJQAUB+irHGpgDiQCydN8izgaKGfR6II0uWmHXrZnbCCcG//WSSNxrxI+a2oAJQqqypRZNaP910003WvHlz69evn+t+pzwJ3bp1cyPqqavfzTff7PJNnXTSSe79yi01bdo0O/bYY12OKj1XknPlMvEbpS/iqlVLn31NdEdT0wHEDXU50N0Fr9lrYWtNxDDmlAP7Q8EcF1qGzht6fzS7x5YsWdLdsFuxYoU7h+l5Xr5TXsulsKJsYqdc9Jm7d+92x5/2fe3zAGI0kfmOHWajRpm9/rr6pae9rvNF6I0ddcHlOjruxVxQSv0NlZhcLaCUqFwBqPvuu89V3PTjNXv2bBs1apRt3LjR6tSpYyeeeKJLjO41Vdf/Y8aMsSFDhricCsqVoKDUoEGDLGboONoe7ZUAkBfKebf//vu7c5W6Bhc23mgcXhefoopyoBwKYn/Qe3X+8AZoiQZ9B9WRNBCMAlN5wXFC2cTTPlO2bFk3OjddeYAYDEgp1Y7fQGM1a5o99JDZ0UebrV+fNl0BqQMOiOhqoggEpXr27OkefsqUKeNaUmVFidGnTp1qMUuRXw028mnItKRdwekcUEBc2W+//axJkyYuWWth441MVLVq1SJdcaccKIeC2B90oy2aASmPWoro4lw3/byR0HKD44SyiZd9RscdLfqAGDVtmn9A6vzzzZ55xqxixeDzBg0ivmooYkEpAIgnquDGwsVlQVww6MJZIxMV9aAU5UA5FOb9wetGmJeuhIWxXPILZUO5ANiHjRvNBg8OBp78XH99WkAKhRJBKQAAAAAAEDlqoTtypNlttwV7DaHIIigVaer3qlL/X8rz77QVSHQOAAAAACgCicznzAnmiPrjj7TXlCNagaq9e9Omkci8SCAoFa1E5zEwECAAAAAAABEJSDVtmn40PY9ySj/ySPDv0FZTJDIvEghKRZpf00QdmCQ6BwAAAAAUNrt3mw0f7h+QeuEFswED0p4z+FeRQ1AKAAAAAADkv88+M7vuOrMFC/xfb9+eUi/iGCIFAAAAAADkn0WLzM4+2+zkkzMPSAG0lIoC9YtNCJumpG6aDgAAAABAvOaNWro0OKre66+b7dmT9lq7dsEE5+rK5yGROQhKRTHROQAAAAAAhcE//5g1aZI+ECU1apg99pjZeecFA1YkMkcYckpFmncQhgSISXQOAAAAAIhLs2eb9euXMSAl48aZ/e9/aUnMSWSOMASloiHJzD6MyicDAAAAAJB369ebDR5s9txzZsnJ/vOUK0dJI0sEpQAAAAAAQNb5orxeP0lJZl99Zfboo2br1lFqyBOCUpG2a1fOpgMAAAAAEM2AVLNmZjt3+r9etqzZ1VebPflk+utaEpkjGwhKRZpG2itmZkelPP8xpTufpgMAAAAAEEvUQiqzgFTv3mYPP2y2//5mV11FInPkGEGpaKkWtU8GAAAAAGDf1PLptdf8X3vpJbNLLkl7TiJz5AJBKQAAAAAAkN7HH5sNHGj211/+JdO2LSWGPCMoFWnVqpklhE1T1z1NBwAAAAAgmonMly41e+ops6+/znx+8kUhnxCUioZAVD4VAAAAAICcJTL/3//MbrvNrGbNtGlqVKHuekAeEZSKNC/6HN5PV9M5qAEAAAAAkbRmjX9Aqnr14Ih6555rlhDe3QfIHwSlAAAAAAAoin791ezii/1fmzDBrFOnSK8RipjEaK9AkZWU8gAAAAAAIJLWrTO74gqz9u3NfvvNf56yZdkmKHC0lIo09b1NTjCbFJJYikTnAAAAAICCTmS+d2+wBdTzz5tt2pT2urrnBUKuUUlkjgghKBUNoQc7AAAAAADRSGS+335md99tds45Zps3p00nkTkihKBUpJHoHAAAAAAQKXPn+gekTj3V7OWXzWrXZlsgasgpFa1S75jyYAsAAAAAAPKbAlH332/Wtav/68OGEZBC1NFSKho0mmatkL8BAAAAAMivdDEffGB2/fVmixZRpohpBKUiTX1zwwNRJDoHAAAAAOQlb9T69WZLlpg9+qjZlClpryUmBhOZJ4UM/04ic8QIglLRQJ5zAAAAAEA+SFy2zBI6dTLbtSvji8ccY/bUU2YVK6bPb0wic8QIglKRRqJzAAAAAEB+SE62Mu++awl+AakHHzS7+eZgKyk54ADKHDGHoBQAAAAAAPFmxgxLuOYaKx/aVS/UCSekBaSAGMXYbwAAAAAAxIs1a8wGDDDr0MESMgtIAXGCllKRRqJzAAAAAEBOE5mvWmU2bpzZiBFmW7emvrT3gAOs2MqVlrBnT9r8JDJHnCAoFQ17zWwCWwEAAAAAkI2AVJMmZrt3p59erpwl33OPre3Rw2okJ1uCRt/zkMgccYKgVKSR6BwAAAAAkN2A1MUXZwxIyYQJZl26mK1ebVajhlmDBpQp4g45pQAAAAAAiCU7dpgNG2bWvLnZl1/6z6PWUECco6VUtEKBHVL+nq5hPKOyFgAAAACAWBIImE2aZHb99WZLlkR7bYACR0upSFM0W6VeN+WhETpLlSLKDQAAAABFtYvezJlm48ebdexods45aQGpYsXM+vcPXjOGIpE5ComYC0pt2bLFBg4caPXr17cyZcpYx44dbfp0NScKuuiiiywhISHd4+STT063jPXr19t5551nFSpUsEqVKtnFF19sW0NGJ4i6QLRXAAAAAAAQEwGppk3N2rUz697dbOrUtNeOP95s9myzV14x+/NPsxkz0h4LFpgdcEA01xwonN33LrnkEvv999/tjTfesDp16tibb75pXbp0sXnz5lndumpaZC4INXLkyNT3lAqLGisgtXLlSvviiy9sz5491q9fPxswYIC99dZbFnUkOgcAAAAAJCebvfqq2a5dGcvikUfMbrjBLEFdaywYgCIIhUIoplpK7dixw8aPH28PP/ywde7c2Ro3bmxDhgxx/48YMSJdEKpWrVqpj8qVK6e+9scff9inn35qL7/8sh1++OHWqVMne/rpp23MmDG2YsWKKH0zAAAAAABSqDeQuurdc49/kRx3XFpACijEYqql1N69ey0pKclKq39sCHXj++GHH1Kff/PNN1ajRg0XjDruuOPs3nvvtapVq7rXpkyZ4rrstW/fPnV+tbRKTEy0adOm2Tnqnxtm165d7uHZvHmz+z85Odk98lVysm8k0H1Ofn/WPlcl2QKBQP5/xzhDOVAO7A8cF5wfOE/Gyu9FXpcd0TpNCn5HKRv2GY6nSIjrc4266Hk9Ztats4RXXrGEsWOzfEt2rw/julwKGGUTH3WamApKlS9f3o488kgbNmyYtWjRwmrWrGlvv/22CzSptZTXda9r167WsGFD+/vvv+3222+3U045xc1TrFgxW7VqlQtYhSpevLhVqVLFvebngQcesHt8ItRr1qyxnTt35ut3LL5qlSl8lhCWYmr9qlW2d/VqiyTtJJs2bXI7o4J2RRXlQDmwP3BccH7gPBkrvxfKrZkXkazTePgdpWzYZzieIiFezzWJy5ZZ9U6dLMGvi56Z7WnY0IovW2YJe/akTguUKmUKYSVn4/owXsslEiib+KjTxFRQSpRLqn///i5/lIJMbdu2td69e9sMJXMzs3PPPTd13latWlnr1q3twAMPdK2njlciuFy47bbbbNCgQenuKtarV8+qV6/ukqXnq1q10gWkRM+r1KplFhZMi8SOqETx+p5F+QRGOVAO7A8cF5wfOE/Gyu9FeGvxmK7TpOB3lLJhn+F4ioS4Pdco4OQTkArst58Fhg2zYldcYYGVKy0Qmnu4WjWrls38UXFbLhFA2cRHnSbmglIKMH377be2bds2V5GqXbu29erVyxo1auQ7v6ZXq1bNFi5c6IJSyjG1OiyirG6BGpFPr/lRjqrwZOmijZPvG0jLSzKzSSnPk9I+y70WYdoRC+R7xhnKgXJgf+C44PzAeTIWfi/yutyI1mlC8DtK2bDPcDxFQtyda5YsMbv5Zt+XEiZOtIQuXYJPGjQIPopKuUQQZRP7dZqY3WvLlSvnAlIbNmywzz77zM466yzf+ZYtW2br1q1z84q6/23cuDG1ZZV8/fXXLhKoxOcxIyktIAUAAAAAKCS2bzcbPNisRQuzyZP956lSJdJrBcSkmGsppQCU+jU2a9bMtX666aabrHnz5tavXz/bunWry5PQrVs31+pJOaVuvvlml2/qpJNOcu9XLirlnbr00kvt+eeftz179tjVV1/tuv3VqVMn2l/PNcV0oygElEkqhe5oajoAAAAAID4Tmesa76uvzJ580iyrkd/VrYnrPyA2g1JKtqV8CGoBpeTkCkDdd999VqJECdcNb/bs2TZq1CjXGkpBphNPPNElRg9tqj569GgXiFJ3PjUZ0zKeeuopixkJAbO2KX//GuV1AQAAAADkPiDVrJmZ32ASxYubDRxodtFFGh41bboCUtnMGQUUdjEXlOrZs6d7+ClTpoxrSbUvCma99dZbFpMUQVdm8/opz2e58ZuD0zkxAQAAAED8WLzYPyB1xBFmI0eaNW8ejbUC4kbM5pQCAAAAACAmJSWZvfyy2dln+7/+zDMEpIB4bCkFAAAAAEDMmjLF7JprzEIG18pAeYQB7BNBqagkOg+bRqJzAAAAAIjtROZr1pg9/bTZRx+lfz0x0Sw5Oe05icyBbCMoFQ0hA+8BAAAAAGI4INW0afpE5Z5WrYJBqoYNg0ErD4nMgWwjKBVpoScrD4nOAQAAACD2vP++f0DqllvM7r03OMKeMGgVkCskOgcAAAAAINTff5uddVYwd5QfjRjvBaQA5BpHUTQkmdlHIX8DAAAAAKJv2zazBx4we/RR/xZSAPIVQamoJDpPMNsVkliKROcAAAAAEL28UUpi/sUXZo8/brZ6ddprNWqYbdhgtmdP2jQSmQP5hqBUNATIdA4AAAAAMRGQatLEbPfu9NPVNe+GG8zuuCMYlCKROVAgCEpFmk5myuTVOuX5bBKdAwAAAEDErV9vdtNNGQNSMnas2dlnB/8uX55E5kABIdF5NCSYWaOUh/4GAAAAAERGUpLZCy+YNW1q9u67/vMwmh4QEbSUAgAAAAAUDT/8EBxRb9asaK8JAIJS0Up0HjaNROcAAAAAUDA5o5RCRcnLn3rK7JNP0r9+1llmn36afqQ9EpkDEUNLqWggzzkAAAAAFHxASl30QgNOnkMPNXv6abNOndICV6ENCei+B8RmUGr79u32xRdf2I8//mjz5s2ztWvXWkJCglWrVs1atGhhRx11lHXp0sXKlStXMGsc70JPdh6dJDWdEx8AAAAA5I+JE/0DUrfdZjZsmFmxYsHnug7jWgyI7UTnc+bMsYsuushq1apl55xzjj377LO2cOFCF5AKBAL2559/2jPPPONe0zyaV+8BAAAAACBi/vrL7LTTzAYO9H+9e/e0gBSA2G8p1atXLxs/fry1b9/ehgwZYieccIIddNBBVizsQE5KSnKtpz7//HMbN26ctWnTxnr06GFvv/12Qa0/AAAAAKCoCu16t3272Vtvmb38stmePdFeMwD5FZRKTEy0X375xQ5Vv9ssKEjVqlUr97jhhhts1qxZ9tBDD2XnI4oONR9NMrNPU54nhUwHAAAAAGQ/INWsmdnOnf6v16xptn59+gAVScyB+AtK5balk4JYtJLyGWlPtmcyHQAAAACwb2oh5ReQKl7c7Oabg7mjFJQiiTlQuEbfe/31161z587WoEED39eXLFli3333nV144YV5XT8AAAAAANJToOm++/xLZdw4s7POCv69334kMQcKQ6LzUP369bOffvop09enTZvm5kEmEsysVcpDfwMAAAAA9m3vXrNnnzVr2tRswgT/eerVoySBwtxSSqPtZWXbtm1WXE0mkVG1ambKD98k5fk8bYVSwekAAAAAgIyJzJOTrfQ331jCK6+YzZ+feQmRMwqIK9mOHM2ePdslLvd8//33tldR6jAbN260559/3poqcg1/Wcf0AAAAAAAhiczVxadSeIkoXczVV2vErbRputl/wAGUHVDYglITJ060e+65x/2dkJBgL7zwgnv4qVSpkss7BR+hSfYsZOQ9TefkCQAAAABBy5f7JzJv3txMLaY6dqSkgKISlBowYICdfvrpruveYYcdZsOGDbOTTz453TwKVpUrV84OPPBAuu8BAAAAAHJO6WI++MDsyiv9X1cDiA4dKFmgqASl2rZta/fff39qEGrkyJF20EEHWbt27Qp6/QAAAAAARYXyRQ0caPbZZ5nPE9pdD0DhH31P+aTWhnQ769+/v/31118FuV6Fl/o4h4+4V4pE5wAAAACKaN6omTPNvvsumCPq4IPTB6QS01+yBkhkDhS9llL169e3L7/80nr37m3FihVzXfjUVQ+5RKJzAAAAAEVdSCLzDOrVM3vsMbPDDjNbt86Sk5Nt/fr1VqVpU0sgFy9QtFpKXX755S5xeenSpa1ChQouIHXxxRe7vzN7VKxYseDXPh6pxVmSmX2Z8kgKSXQOAAAAAEWFWkf5BaQuuSTYja9HD7WQUD4Z99jbujWDQwFFsaXUTTfdZIcccohNnjzZ/vvvPxs1apR16NDBGjVqVPBrWFhtjvYKAAAAAEAUrF5tdvvtwRH0/FxxhVnZspFeKwCxPPreiSee6B7y2muv2WWXXWZ9+vQpyHUDAAAAABQWe/aYjRhhdvfdZps2RXttAMRTUCqU+vMiD4nO1WmyWcrz+WZWkkTnAAAAAApp3iilKvn5Z7NHHjFbtCjttXLlgqlM9u5Nm0Yic6BIyVZQaunSpVZPieZyIS/vLbSUI75Fyt9/RnldAAAAAKCgAlJNmwYDT+H69TO7/36z3bvT59fVTXwSmQNFRrYSnTdu3Nj69+9vPyu6nU0//fSTXXjhhdakSZO8rF/h45fQnETnAAAAAAqTHTuCQSe/gNRrr5m9+qpZrVrBAFRKInP3ICAFFCnZain1/fff25133mlHHHGE1a9f34477jhr27atNWzY0CpXrmyBQMA2bNhgixcvtl9++cW+/vprW758uR177LH2nUZUAAAAAAAUfoGA2XvvmQ0aZLZkif88rVpFeq0AxHNQ6rDDDrPPP//cZs2aZSNHjrRJkya5/yUhISHl3BNw/6ur3tlnn+1aVh166KEFue4AAAAAgFjxxx9m115r9uWX0V4TAIUx0bmCTE8++aR7rFixwubPn2/r1q1zr1WtWtWaN29uderUKah1LRzURzoYx0tTikTnAAAAAOI0ifmWLWYvvmj2zjtmSUlpr3fqFExwrrxRHhKZA8hpTik/Cj6pG1+PHj3cQ3/nR0Bqy5YtNnDgQNdNsEyZMtaxY0ebPn2677yXX365a6n1xBNPpJveoEEDNz308eCDD1rMCDYqAwAAAID4DUg1a2bWrp3ZMceYvfVWWkCqQQOzCRPMlMrlr7/MZsxIeyxYQN4oALlrKRUJl1xyif3+++/2xhtvuCDXm2++aV26dLF58+ZZ3bp1U+ebOHGiTZ06NdNA2NChQ+3SSy9NfV6+fHmL+UTnJPUDAAAAEA+++cZs586M0y+7zOzxx83KlAk+1zUO1zkA8rulVEHYsWOHjR8/3h5++GHr3LmzG/VvyJAh7v8RI0akzqck6tdcc42NHj3aSpQo4bssBaFq1aqV+ihXrpzFjGQzm5zy0N8AAAAAEA/++8+sf3+zvn39Xx8wIC0gBQDxFJTau3evJSUlWWn1Mw6hbnw//PCD+zs5OdkuuOACu+mmm6xly5aZLkvd9ZTnqk2bNvbII4+4ZcdU970NKQ+68gEAAACIdXv2BFtANW1qljLoFQAUqu57at105JFH2rBhw6xFixZWs2ZNe/vtt23KlCmutZQ89NBDVrx4cbtWozpkQq+1bdvWqlSpYj/99JPddttttnLlShs+fLjv/Lt27XIPz+bNm1MDYHrkqypVgnmuUkYrlECpUhaoUkUfaJGk76ZRE/P9O8YZyoFyYH/guOD8wHkyVn4v8rrsiNZpUvA7StmwzxTi48lLZD51qiU89pglLFmS+lJA6VF27LCEkJv/gdKlC+y6JubKJkZQLpRNvNdpYiooJcol1b9/f5c/qlixYi641Lt3b5sxY4Z7aOS/mTNnusBOZgYNGpT6d+vWra1kyZJ22WWX2QMPPGClNNJdGE2/5557Mkxfs2aN7fTrJ50HiWvXWnU1j2qaMuEvnb0DtnbtWksOayFW0LSTbNq0ye2MiYkx1WguoigHyoH9geOC8wPnyVj5vdCAL3kRyTqNh99RyoZ9pnAeT4nLlln1o46yhNCR81I6euzo08e23nabyymVuH596mvJVaoEr2lWry7UZRNLKBfKJt7rNAkBrUUM2rZtm7u7V7t2bevVq5dt3brVTjjhBBdwCi00dffT83r16tmSkMh9qLlz59rBBx9s8+fPt2YaISIbdxW1vA0bNliFChXy94vNnGmJR3QwOyvl+SR9CbNkjTDYtq1FekdUJbV69epF+sROOVAO7A8cF5wfOE/Gyu+F6iCVK1d2FcXc1EEiWqdJwe8oZcM+UwiPp+3bLeH66y3h5ZczvJT82mtmF1xQdMsmxlAulE2812ly3VJKlRt1rVu0aJH7Ozy2pZZMr7zySm4X7xKT66Flf/bZZy75ebdu3dxIfKFOOukkl2OqX79+mS5r1qxZrqBr1Kjh+7paT/m1oNJ78n0DZbI89zlROLlqOxXI94wzlAPlwP7AccH5gfNkLPxe5HW5Ea3ThOB3lLJhnykkx5Ou6caNM7vhBrOlS31nSWzVKirXLcK5hnJhnyl8dZpcBaUUJOrevbtrzaSIl6Jf4bLqXrevZSvApRZNCxcudAnNmzdv7oJOGmlPyctDaZpG1/NaQCn/1LRp0+zYY491Oar0/Prrr7fzzz/fdz0BAAAAoEjyckbJwoVmTzyhC6porxWAIiRXQakbbrjBBYImTJhgrRQpz0dq2qXE5MuWLXOJytU66r777nPBp+zQ3cExY8bYkCFDXPP1hg0buqBUaJ6pqAppUp+t6QAAAABQEAEp3djPLN9c584uwbmF5pRSvqhq1dgWAKIblFILpkceeSTfA1LSs2dP98iu8DxSSow+VSfPWOXTpD7L6QAAAACQ3/77zz8gVbeu2XPPmZ1xRrALn9eSShSQOuAAtgWA6AalmjRpkufRYQAAAAAAUfDTT2aXXOL/2tixZkceGfxbASiCUAAKUK4yWt1777323HPPZTraHQAAAAAgxqxcaXbhhWZHHWX2xx/+89CDA0Cst5T66quv3NCBLVq0sBNOOMENNVysWLEMic6ffPLJ/FrPwkNNXjVQ4Xcpz5NTTvz0zQYAAABQEInM9+wxe+sts5dfNtu+Pe11DU4VOoo6OaMAxENQ6plnnkn9+8MPP/Sdh6BUFhSICumaDQAAAAARS2SuUcmHDTM75RSzjRvTppMzCkA8BKWSkxVVQa6EJgoMHXlP0+mvDQAAACA//Pqrf0Cqa1ezF16gpwaA+M0phTxKMLNGKQ/9DQAAAAD5Yds2szvuMOve3f91vUbqEADx3FLKs3jxYvvkk0/sn3/+cc/r169vp5xyijVs2DC/1q/whgIPTflbRZcU5fUBAAAAEN+UG+qdd8xuvNFs+fJorw0AFGxQ6oYbbnCJzMO78iUmJtrAgQPt0Ucfze2iCzfdlQhvHUWicwAAAAC5SWIuf/5pNny42fTpaa8XLx4MVCWF3AEnkTmAwhCUeuyxx+zxxx+37t27u+CURuGTP/74w03Xo27dunb99dfn9/oWDiEDXAAAAABAviUxl1NPNXviieDN79CctiQyB1AYglIvvfSSnXnmmfbuu++mm3744YfbmDFjbOfOnfbCCy8QlPJDonMAAAAAefHff/4Bqf33N3v+ebPTTkubxmBKAApbovMlS5bYSSedlOnrek3zAAAAAADy0fffm513nv9rY8emD0gBQGEMStWoUcN+++23TF/Xa9WrV8/LegEAAAAAPEpermBU585mf/3lXy4lS1JeAAp/970ePXq4JOcNGjSwa665xsqVK+emb9u2zZ555hl7+eWXXbJz+CDROQAAAIDsJjLfvdts9GizV14x27Ej7fWEhGAicw9JzAEUlaDUsGHDbNasWXb77bfb3XffbXXq1HHTV6xYYXv37rVjjz3Whg4dmt/rWnhoAIyfUv5OP3ghAAAAgKJOASkNJuWXN6pqVbP77jM78USzDRvSppPEHEBRCUqVLVvWvvrqK5s0aZJ98skn9s8//7jpJ598sp166ql2xhlnWIIi98hIdzt0Q2NVyLRdu4LTSUIIAAAAYMYM/4BUz55mI0aYVakSfN6wIWUFoOgFpTxnnXWWewAAAAAA8mjLFtvvvvssQSPo+bnllrSAFAAU9aAUckmNyA5I+ftfC7acAgAAAFA0KTfUW29Zwk032X4rV0Z7bQAgtoJSDRs2tMTERJs/f76VKFHCPd9X9zy9/vfff+fXehYe6utdzMzapTxfpq1QKjgdAAAAQNFKZD5/vtnDD2sIc3fvWgIlSlhCcrJZkpLRpiCROYCiGpQ6+uijXZBJganQ58glWkYBAAAARTsg1bRpMLdsmJ0nnWQln37aEkqVCgatPCQyB1BUg1KvvfZals+RA6E/LB4SnQMAAABFw969Zs8+6xuQSn7ySdvYs6fVqFHDTA0CGAgJQCEXbPqUQ6+//rotWbIk09c1Gp/mAQAAAACk+PZbs7Ztg931/HTsSFEBKFJyFZTq16+f/fTTT5m+PnXqVDcPAAAAABR5S5eanXuu2THHmM2ZU+SLAwDyNPpeQKNDZGHbtm1WvDgD+/lSX/DwdFzqL06icwAAAKBw5Y1avtzszTfNXn3VbOfOtNdatTJbsMBs9+60aSQyB1AEZTtyNHv2bJs1a1bq8++//972qj90mI0bN9rzzz9vTZW4D/5IdA4AAAAUXv/8Y9akidmePemnV64c7LqnXiUKWIUnMt9/f7PVqyO+ugAQ80GpiRMn2j333OP+1sh7L7zwgnv4qVSpEjmlMqMfnmQzm5byXH+T6BwAAAAoHObPN+vfP2NASiZMCHbhEyUxD09knqyLAwAoOrIdlBowYICdfvrpruveYYcdZkOHDrVTTjkl3TwKVpUrV84OPPBAuu/tq6XU8txvNAAAAAAxZvNms6FDzZ58MjjCnp8KFSK9VgBQOIJStWvXdg+ZPHmytWjRIjhUKQAAAAAUxZxRrhdEstlHH5k980z67ngAgH3KVTbyo48+Ojdvg6V01VOi8zopxbEipeWUpgMAAACIj4BUs2bpk5eHDmJ0+eVmzz+fvo5PInMAyCDXQ+StWrXKXnnlFZs5c6Zt2rTJksP6P6sr31dffZXbxRde+pFKNLPDU55PMrOklOkAAAAAYt+ff/oHpI491uyVV8waNjQbNChjIvPwHFIAUMTlKiilkfiOOeYY27FjhzVr1szmzJljBx10kBt5b/ny5S6nVL169fJ/bQEAAAAgWpS8/LnnzO680//1Rx8NBqQyS2QOAEhHbXZy7NZbb7X99tvPFixYYF9++aVLfv7kk0/a0qVL7Z133rENGzbYgw8+mJtFAwAAAEDs+fprszZtzAYONNu6NdprAwBFt6XUjz/+aDfffLMdcMABtn79ejfN677Xo0cP++GHH+ymm26yb7/9Nn/XtjBQs13llAqlrnuaDgAAACB2kpjLypVmzz5r9skn6ecpVswsSXk4UpAzCgAiE5RSAKpmzZru70qVKlmxYsVSg1PSqlUrl28KmVBicwAAAADxlcRcDjvM7OmnzWrVImcUAEQjKNWwYUNbvHix+zsxMdE9Vze+nj17umk//fSTC1bBh98wsRqVQ9Ppcw4AAABE15o1/gGpypXNHnvMrG9fXQQFp1F/B4DI55Q68cQTbezYsanPr7jiCnv55ZetS5cudvzxx9uoUaOsT58+eVszAAAAAIikefPMrrzS/7WJE8369UsLSAEAotNS6o477rDevXvbnj17rESJEjZw4EDbtm2bjR8/3nXlu+uuu+z222/P+9oVVkq/NSPkbwAAAADRs2mT2ZAhwW55oXmiQpUvH+m1AoBCL1dBqcqVK1u7du1SnyckJNidd97pHtgHl9A8weyfkMRSJDoHAAAAIp/IXIM1ffBBMJH5unWZz08ScwAoELlqe/rcc8/ZGvW1LgBbtmxxLa/q169vZcqUsY4dO9r06dN957388stdQOyJJ55IN11J18877zyrUKGCy2118cUX29ZYGrY1QKZzAAAAIKqJzHWTvUMHs6FD0wJSZcoEny9YYDZjRtpDz8kfBQCxEZS6+uqrrW7dunbCCSe4UfZCR97Lq0suucS++OILe+ONN2zOnDkuf5VyVS1fvjzdfBMnTrSpU6danTp1MixDAam5c+e65Xz44Yf23Xff2YABAywm6I5MgpnVSnkkhCQ6BwAAAFCwFGDyS2TepYvZH3+Y3XWXWdOmZm3bpj0ISAFA7ASl5s+f77rqrVy50i699FKrXbu2nXrqqS6QtHnz5lyvzI4dO1xeqocfftg6d+5sjRs3tiFDhrj/R4wYkTqfAlTXXHONjR492uW0CvXHH3/Yp59+6hKvH3744dapUyd7+umnbcyYMbZixQqLmVLvmPIgTyIAAABQ8PbsMRs+3Oycc/xff+ghs/r12RIAEEG5Cok0bdrU7r77bvv9999da6abb77ZFi1aZH379rWaNWva2Wef7YJAObV3715LSkqy0uqzHULd+H744Qf3d3Jysl1wwQV20003WcuWLTMsY8qUKa7LXvv27VOnqaVVYmKiTZs2LTdfFwAAAEA8++ILs9atzW64wWzbtmivDQAgL4nOQykwNGzYMPf47bffXDBKOafUbe7cc8/N0bLKly9vRx55pFtWixYtXIDr7bffdoEmtZaShx56yIoXL27XXnut7zJWrVplNWrUSDdN81epUsW95mfXrl3u4fFaeykApke+qlLFEhKCvfY8gVKlLFClSjDRYgTpuwUCgfz/jnGGcqAc2B84Ljg/cJ6Mld+LvC47onWaFPyOUjYxuc94icyXL7eExx+3hG+/TX3JZXctVswSQkbZC5QuHZX6eDiOJ8qGfYbjqajVafIclPLMnj3b3n33XRs3bpxLVq7WTbmhLoD9+/d3OauKFStmbdu2td69e9uMGTPc48knn7SZM2e6BOf55YEHHrB77rknw3Qlc9/p1988DxLXrrXq4XnOAwFbu3atJYe1ECto2kk2bdrkdka1JCuqKAfKgf2B44LzA+fJWPm9UB0qXuo0Hn5HKZtY22cSly2z6p06WUJIgNazu10723zvvZZcrZolhuTFTa5SJVgXX73aoonjibJhn+F4Kmp1mjwFpebNm2fvvPOOC0b9+eefLr/TSSed5CpDZ555Zq6WeeCBB9q3335r27Ztc3f3lK+qV69e1qhRI/v+++9t9erVdkBIokF197vhhhvcCHxLliyxWrVquXnCuwUqGbte83PbbbfZoEGDUp/rc+vVq2fVq1d3I/jlq2XL0rWSkoTdu62a/ghr4RWJHVHBPX3Poh6UohwoB/YHjgvOD5wnY+H3IjyFQU5FtE6Tgt9Ryiam9hmNcv3aa74BqeTBg634nXdalRiu93I8UTbsMxxPRa1Ok6uglLrXKRCloJRaMx1//PF26623ulxSFStWtPxQrlw599iwYYN99tlnLvl5t27dXH6oUAqCKcdUv3793HN1/9u4caNrVdVOw7ya2ddff+0KXYnP/ZQqVco9wmnj5PsGymR57nOi8AOpHbFAvmecoRwoB/YHjgvOD5wnY+H3Iq/LjWidJgS/o5RNTOwzv/9uphQfkyf7vpyom+bF862jSIHheKJs2Gc4nopSnSZXZ+WhQ4fa0Ucf7fI6de3a1apWrWr5RQEoNSFr1qyZLVy40CU0b968uQs6qSVW+GdpmlpAaX5RLqqTTz7ZjQr4/PPP2549e+zqq692+a3q1KmTb+sJAAAAIAZs2GA2eLDZc8+pG0W01wYAkAO5CkotX748QzLx/KJ+jWp6vmzZMpecXK2j7rvvPhd8yq7Ro0e7QJRacCk6p2U89dRTFhOqVQtmV5yV8ly5v3RHU9MBAAAAZC+R+X//mU2aZPbss2YbN6a9plQfK1ea7dmTNk3dSKhvA0DhCEp5ASmN7qKk48rhdNRRR1m1fDjR9+zZ0z2yS3mkwimY9dZbb1nMUiBqUbRXAgAAAIjTgFSTJma7d6efrsDTXXeZKa+acsxq9D2PrlNC8tICAGJDrjsPquWRkpB36tTJdeHT6HuiUeQUnHr11Vfzcz0Lj9AfR48SMfpNBwAAAJBGLaCuuCJjQErGjze7/fZgcEoBqLZt0x4EpACg8ASlRo4caQMHDnS5m1555RWXA8qjgNRxxx1nY8aMyc/1LFw0/F61lEf4UHwAAAAA0lMQ6pFHzJo2Nfv4Y//SyWSkbQBAIeu+99hjj9lZZ53lusitW7cuw+sa9S5mcjjFaiiwc8rfk8yMfIwAAABA+i56Xk+CH380e/xxs8WLKSEAKGRyFZTSqHgaeS8zyunkF6xCSle9nEwHAAAAilpASiNr79yZ8bWEBLM+fczGjUtffyaROQAUnaBUpUqVXO6ozMybN89q0XzWn0bay8l0AAAAoKgFpfwCUoceaqa8tW3amN1/P4nMAaCo5pQ69dRT7cUXX7SNoUOvppg7d6699NJLduaZZ+bH+gEAAAAoCpSn9u23zbp29X/95ZeDASkhkTkAFN2g1L333mtJSUl28MEH25133mkJCQk2atQoO//88619+/ZWo0YNu/vuu/N/bQEAAAAUPr/9Znb00cGueWvW+M+jrnsAgEIlV9336tSpYzNmzLDbb7/d3nnnHTf63htvvGHly5e33r1724MPPuhG4YMPlUuCT9c9ygsAAABFwb//WvE//1QiWrPNmzW0t9lbb5klJ6fNk5iY/jk5owCgUMpVUErUGurll192jzVr1lhycrJVr17dEvUDgqwFKCAAAAAUQf/+awktWlg1v5xR0rix2RNPmLVqRc4oACgCch2UCqVgFLJJCeJ10+f3lOf6WyOHaLr6xgMAAACF1dq1luAXkCpTxmzIELPrrksbAIi6MQAUetkKSg0dOjTHC1aeqbvuuis361Q0Wkr9Ge2VAAAAACJo+XKz22/3f23iRLOTTmJzAEARk62g1BDdtcghglIAAAAAXK+A4cPN7rvPbNs2/wKh5wUAFEnZCkopXxTyiRKaK+1WxZTnG82sJInOAQAAUEj8+28wNUUgYPb992aPPx6cFtJpIN24PyQxB4AiK19ySiGH9Ct8bMrfkyg9AAAAFBIKPjVrZuaXN0oDIl15pQUuvtjWrV5tVapUCQ6SpJu25I8CgCIp20Gpn3/+2Ro3bux+PPZl8eLF9v3339uFF16Y1/UrfHTXKByJzgEAAFAY/POPf0CqbVuzkSPNWrdWNwzbu3q1hvMOBqoAAEVWtn8FjjzySPv0009Tn69fv97Kli1r3377bYZ5f/rpJ+vXr1/+rSUAAACA2KWuem++ada1q//rL74YDEgBAJCbllIB/dCEPd+5c6clJSVldxEAAAAACpuZM82uuUZ3pjOfJyFdFikAABxySkWa+syH/yaXItE5AAAA4iyR+YYNZs89ZzZhQvrX1SUvdKAkEpkDADJBUCoa0jc6AwAAAOI/kbmmP/mkWYsW6fOoksgcAJAJglKRRqJzAAAAxCvlmPULSA0caPbQQ2YlSwafM5oeACC/g1JLliyxmeozbmabNm1y///1119WqVKlDKPvIQtqzfxHyN8AAABArLeQuukms3ff9X/9ggvSAlIAABREUOquu+5yj1BXXnllhvmUBD2BZIZZd9/zglIAAABArFKrqEceMXvgAbMdO6K9NgCAohqUGjlyZMGuSZFKdJ4QHDbXQ6JzAAAAxFKrqDVrzL75xmz4cLMVK9Jeq1LFbPNms71706aRyBwAUNBBqb59++b2MxBOAakKKX9vpngAAAAQQwGpJk3Mdu/OOKLeNdeYDRkSDEqRyBwAkA9IdB5p+gEvZmZdUp5PMrNdu4LTSQgJAACAaFGw6Y47MgakZMwYsx49gn8rnyz1VgBAPkjMj4UAAAAAiFPJyWavvWbWtKnZm2/6z3PggZFeKwBAEUBLKQAAAKComj492C1v2rRorwkAoAiipVRUEp2HTSPROQAAACKZN+rLL83OPtvssMPSB6ROPjlYNw1FInMAQAGhpVQ0hAy8BwAAAETM33+bNW+efvQ8adzYbMQIsy5dgkErEpkDACKAoFSkhf7Ae0h0DgAAgIL21VdmAwZkDEjJ6NHBVlOiJOYkMgcARADd9wAAAIDCbMkSs+7dg62gFi3yn6c496oBAJHHr080JJvZXyF/AwAAAPkhtOvdzp1mY8eaPf988G8AAGIMQalIU1c95ZSa4zMdAAAAyEtAqlmzzANQNWqY3Xyz2Z13pp+HROYAgCghKBVp4aOZ7Gs6AAAAkB1qIeUXkCpWzOy668zuvtusYkWzHj1IZA4AiAkEpaKlbMr/26O2BgAAACgsNm40e+wx/9feecesW7e05yQyBwDECBKdR0MxMzs55aG/AQAAgNxITjZ75RWzpk3N3nrLf56GDSlbAEBMoqVUpFWrZpbg03VP0wEAAIDsJjKfMyfYOkr/Z4Z8UQCAGBZzLaW2bNliAwcOtPr161uZMmWsY8eONn369NTXhwwZYs2bN7dy5cpZ5cqVrUuXLjZt2rR0y2jQoIElJCSkezz44IMWM5ToHAAAAMhNIvN27YKPiy5KH5Dq2dPsp5/MZsxIeyxYEOyuBwBADIq5llKXXHKJ/f777/bGG29YnTp17M0333SBp3nz5lndunWtadOm9swzz1ijRo1sx44d9vjjj9uJJ55oCxcutOrVq6cuZ+jQoXbppZemPi9fvrzFBO/OVvjIe5pOhQEAAACZWbnSP5H5gQeavfSS2bHHUnYAgLgSUy2lFGQaP368Pfzww9a5c2dr3Lixaxml/0eMGOHm6dOnjwtSKSjVsmVLGz58uG3evNlmz56dblkKQtWqVSv1oZZVAAAAQFz6/HOzc8/1f025pAhIAQDiUEwFpfbu3WtJSUlWWn3fQ6gb3w8//JBh/t27d9uLL75oFStWtEMOOSTda+quV7VqVWvTpo098sgjbtkAAABAXFm0yOzss81OOslsyRL/eYrHXOcHAACyJaZ+wdS66cgjj7Rhw4ZZixYtrGbNmvb222/blClTXGspz4cffmjnnnuubd++3WrXrm1ffPGFVQtJFH7ttdda27ZtrUqVKvbTTz/ZbbfdZitXrnStqvzs2rXLPTxqeSXJycnuka+qVLGEhPS5zgOlSlmgSpXg6CkRpO8WCATy/zvGGcqBcmB/4Ljg/MB5MlZ+L/K67IjWaVLwO5rPZeMlMt+xwxJee83szTctYffu1JcDypcaSEtQGihdOir1yLxgn6Fs2G84njjXRFdyDNVpYiooJcol1b9/f5c/qlixYi641Lt3b5uhRI0pjj32WJs1a5atXbvWXnrpJevZs6dLdl6jRg33+qBBg1Lnbd26tZUsWdIuu+wye+CBB6yURroLo+n33HNPhulr1qyxnX799vMgce1aq65tsyhlguoUgYD7LslhLcQKmnaSTZs2uZ0xMTGmGs1FFOVAObA/cFxwfuA8GSu/FxrwJS8iWafx8Duaf2WTuGyZVe/UyRJCAouepBo1bMudd9ruI46wxA0b0j6jSpVgHXL1aosX7DOUDfsNxxPnmuhKjqE6TUJAaxGDtm3b5u7uqSVUr169bOvWrfbRRx/5ztukSRMXyFKLKD9z5861gw8+2ObPn2/NNGJJNu4q1qtXzzZs2GAVKlTIx29lZjNnWmKHDhkmJ2uEwbZtLdI7oiqpShBf1INSlAPlwP7AccH5gfNkLPxeqA6i0YVVUcxNHSSidZoU/I7mY9m8+64l9u6dYXLgggss8PTT6lZghQH7DGXDfsPxxLkmupJjqE4Tcy2lPEpMrocqUZ999plLfp5VgYZWwMKpVZUK2mtJFU6tp/xaUOk9+b6BMlme+5woBIYSEhIK5nvGGcqBcmB/4Ljg/MB5MhZ+L/K63IjWaULwO5rHslm/3mzwYLNnn/VfxsCBllCxohUm7DOUDfsNxxPnmuiKlTpNzAWlFIBS4y21aFq4cKHddNNN1rx5c+vXr59rPXXffffZmWee6VpQqcvbs88+a8uXL7cePXq49yv/lLryqYufclTp+fXXX2/nn3++i9LFDK++mHksDQAAAIVZUpLZK6+Y3X672bp10V4bAAAiLuaCUmrapW54y5Ytc4nKu3Xr5gJRJUqUcCPzqQveqFGjXEBKo+t16NDBvv/+e2vZsqV7v+4OjhkzxoYMGeJaTzVs2NAFpULzTEWVErKr1E9LeT5JW6FUcDoAAAAKNy+R+W+/maknwPz5aa8pN5RGjA4dNVrTqCcCAAqpmAtKKWm5Hn5Kly5tEyZMyPL9Sow+depUi2kxmcULAAAABR6QatpUyb8yvqZcUgpSabQiBa08CkgdcAAbBgBQKMVcUKrQC61keFQx0XQqHAAAAIWT6nuPPeYfkHrpJbNLLkl7Tp0QAFBEEJQCAAAACtInn5hdf73ZX3/5vx7hEZgBAIgVBKUAAACAgrBwoVW6+mpL/OILyhcAAB8FNzYw/FWrliGlVBKJzgEAAAqFT174185v+IONKtbfkpq1tNKhAan27c1Klkz/BhKZAwCKMFpKZWHv3r0WCAQsISHBPU9OTnYPPS9WrFi6+UTT9jXvRx/vtROKF7MSlmTBOc12JSfY5I/32smXJuV6uTmZV6MY6nuF0nNNz2zexMRE9wid1+1AxYvH1bx+5eNXDgVR7rEwr1c+fvOG7xPxsD0LYt7wsojl7VmQ+4lXFkX9HKFy8yuHonaO0DK87x3tbRTNeVUOXt3Ak9/bKJ7qNN683nzR3Gf9tms0zlefvbjUjr+iiZ1seyxJ8+ite812VqxhpUc8YUk9eljg338tcf36tOVWrWpJdeq4EffyWqfJybzRPgd55xVvfXO77fO6n+TXts/veVUWmlYQdd9ob/v8mFffNR7PEQUxb6jCdI7Ir/psdn6zY2l7JhbBOg1BqSxMnDjRzjvvPDfqn/zxxx82e/Zsa9SokR1++OGp82lEQG3sM88808qVK+em/fnnn/brr79a/fr1rWPHjqnzfjX1a9vSrbudsewDK7dtuxuJb0XDujZ5xudW/qCDrHPnzqnzfvTRR7Z9+3Y78cQTrWrVqm7av//+a1OmTLGaNWvacccdlzrvZ599Zps3b3bT9JqsWLHCvv/+e6tWrZqdcMIJqfN++eWXtn79evvf//6XusP+999/NnnyZKtUqZKdcsopqfNq2po1a+yoo46yA1KSbq5du9YtY7/99rMzzjgjdV591sqVK13ZqIxk48aN9umnn1qZMmXs7LPPTp1X32Hp0qXWrl07a6pRaMxs69at9uGHH1qJEiWse/fuqfNOnz7dFi9ebIceeqi1aNHCTduxY4dNmjTJHQTnnntu6rwzZ860hQsX2sEHH2ytWrVy0/bs2WPjx493f/fq1Sv1QPrtt99s/vz51qxZM6ujymDKATp27Fj3d7du3axkyt3MuXPn2u+//26NGze2Dh06pH7euHHj3HvOOussK1u2rJu2YMECmzVrljVs2NCOOOKI1Hnfe+89ty6nn366lS9f3k3Tus6YMcPq1atnnTp1Sp1X5aDvePLJJ1vlypXdtCVLlti0adOsdu3adswxx6TO+8knn7iy69Kli1WvXt1NW7Zsmf3444/uuaZ7Pv/8c7dNjj32WKtVq5abpm323Xffuc9RGXu+/vprt621n+y///5u2urVq930ChUq2GmnnZY677fffuv2oSOPPNIaNGjgpmkf0+epXFQ+Hq3X8uXLXTmqPEX77scff2ylSpWyrl27ps6r7/vPP/9YmzZtrHnz5m6ajon333/fnehCR+r85ZdfbNGiRda6dWtr2bKlm7Zr1y53HEtvjWqUQttHx+hBBx1khxxyiJumY1jbXtsz9DicM2eOzZs3z+2n2l893n5yzjnn5Os5Qt9N633qqadaxYoV3TR9Lx0HdevWjdg5Yt26de448vaTonqO0DbV+cErh6J6jtAxrv08dBsVxXOEtqfeo7qBV9nK73NEPNVpvPOV9kNPNM5X2pf0WfrMaJ6vGjduZ6/csNBOsT22pXx5+/D0063Enj3Wfdw4u6zqOBvV+382ferUjOer7dtt0tix+VKn0XGg4yHWz1c6blX30PlA55v8rtNUqVLFTjrppLg9X+n41Hro/JOXOo306NEjtb5fWOo02hZbtmyJu3NEQdVptO29cigs54j8qtNs2LDB/e575VNYzhG/FLI6DUGpCNu2zSxQItH2/lbCbFPa9B07Ir0mAAAAyCvdZF6+PDiwXvL2YHAk3J/LghdwAAAgvYRAeJs/uOilovlqKaBobX42Izy32XR7c1FHK7Z3b2r3veTERDuvyVR7c27biHffU0S4Ro0abp6i3H0vvBwKotzjofue9nmVg8quKHffUznojopei+XtWdDNnXVc6O6zyqEod9/zK4ei2H1Pd491x9Irt3jYnvk9r+766s6pysErt/zeRrr7rzrIpk2b3N3ZWK7ThHbf0/6h3w9v/qLSfe+//8yuuirJJk0KWHJyoh2SPMtmWjuXP9R139O8e/fauU1+sTF/tivwOk28dM3RtFWrVrnfWrUUycu2L2zd97T+as2hVh9030u/PfW3zsFq5UL3vayv6eL9HJGf9dns1OujfdwX9ToNLaWyoI3pFbqEbsjw+cJlNm/fQTVtz+XFrHix4MayJOWUKummh/e7zMlyczJv6E7n0ff0W4ZfX9DCMq9XPtkph/wo91iY1698/MohHrdnfs3rnVzjYXsW5H6iMgh9LZa2UaTm1fcPvSDY17yF+RyhZYS/FgvbKBrzFkTdwG/e/FaQ6x36+xEL+2wk9hddB779ttk116jbRtq8B7SpZjt+LW1lbKcLRskOK20XDqoakTpNbueVSM/rd17JrzpNvJ1X/ObN7u9PXvcTicd5w6cXpm2f03lzey1T2PcTrz6bnd++WNqeRbFOQ1Aqwk657ADr+sLvdlLDR9zzybP720U31baTBwT7LQMAACB2rVxpdvnlypeTNq1aNbPnnlP+ngPskxcW2KjH1to//5gdcEDAug4oaT2o5wEA4IugVBSUanKArdxb2/398Bdt7IAGYUMDAwAAIKaoddSbb5pde60SGqdN79XL7OmnzVJy7robkHqI190IAAD4IygVBa7rfErvvZSW3QAAAIhRSmR+2WUaISxtmlJojRhhFjJ4EgAAyKGMnQBR4EK7We7ZQ4EDAADEauuokSPNNOJ2aECqTx+zefMISAEAkFcEpaJgxYq0v7t1NZswIRprAQAAgHCqlx1yiFnp0mYVK5r172+2aVPwtVq1zCZNMhs92qxqMHc5AADIA4JSUajofP112vO/Fpp160ZgCgAAIBbqaaqXzZljtmuX2ZYtaa9deKHZ3LlmZ54ZzTUEAKBwISgVYffck7FZuEZhHDo00msCAACAUHffnVY/C9WwodmoUWZVqlBeAADkJxKdR9iff5olBxJt3vKD3HP9rYrPggWRXhMAAAB4Zs0K5onys3Il5QQAQEEgKBVhTZuazZ5d3MZO65k6TS2lmjWL9JoAAABANwdffNHsuusytpAS6mkAABQcuu9F2ODBGSs6qgCFTwcAAEDB2rw5OJLe5ZcHc0iF1s+8/6mnAQBQcAhKRVjXrmYDBqQ933//YFLNc86J9JoAAAAU7e567dubjRmTNu3aa4PPW7cOjr6n/6mnAQBQcOi+FwWdO+222mvvd3/XOPZ2O+ecktFYDQAAgCLdXc9rHVWxotmrrwZvHkqvXlFdRQAAigxaSkWBhhP2PPhg8A4cAAAACobqWoccEmz9pBH0QrvrtWtnNnNmWkAKAABEDkGpKFSKHn007fmqVWbduhGYAgAAKKi6l+pac+YEA1EbN6a9ds01Zj/+aNaoEWUPAEA0EJSKsHvuSUue6dHzoUMjvSYAAABFp+4VPrJe/fpmTz1lVqpUtNYMAAAQlIqwP//MWCnS8wUL2BkBAADy27x5Gete8t9/lDUAANFGUCrCmjb1bynVrFmk1wQAAKDwSkoyu/56s717M75G3QsAgNhAUCrCBg/2byml6QAAAMi7bduCicufeCLja15XPupeAABEH0GpCFMF6Z13Eu2f9U3sr1VNLDmQaO++a3bOOZFeEwAAgMJnxQqzzp3N3n8/+Lx4cbMrrkgbfa9162Dyc+peAABEX/For0BRdE634vb2O+fZ2LHB523bRnuNAAAA4t/s2Wann262dGnweYUKZuPHm3XpEu01AwAAfmgpFSUHHJD297//RmstAAAACodPPzXr1CktIKXR9X76iYAUAACxjKBUlKii5Pnnn2itBQAAQPx7/vlgC6ktW4LPDzvMbNo0s5Yto71mAAAgKwSloiFptzXdc5/dftZ9VqLYbrv11mBuAwAAAOyb6k1ejqjq1YM5ozTanpe/c/Jks5o1KUkAAGIdQakomPie2ZQf91iJYnvc8//+M+vWjcAUAABAdgJSqjfNmWO2a5fZ2rVpr914o7mcnWXLUo4AAMQDglJRcO+9weGIQ+n50KHRWBsAAID4cc89wXpTIJB+et26Zo88YpZI7RYAgLjBz3YU/PVXxoqUni9YEI21AQAAiB+qL4XXo2TdumisDQAAyAuCUlHQpIl/S6lmzaKxNgAAAPFhxQr/6dSjAACITwSlouDOO4N3+EIDU3q+cSN5pQAAAPzySLVoYbb//sE8UqG8rnyDB1NuAADEG4JSUXDO2Wa9epqVK5d++r//kvAcAADAL7H5/Pnpu+0ph5RG32vdOjjPOedQbgAAxJuYC0pt2bLFBg4caPXr17cyZcpYx44dbfr06amvDxkyxJo3b27lypWzypUrW5cuXWzatGnplrF+/Xo777zzrEKFClapUiW7+OKLbevWrRYzEhKsRYcGtnFvAwtYWnMpr/UUCc8BAADSWpj7VKWsWjWzHTvMZs0iIAUAQLyKuaDUJZdcYl988YW98cYbNmfOHDvxxBNd4Gn58uXu9aZNm9ozzzzjXvvhhx+sQYMGbp41a9akLkMBqblz57rlfPjhh/bdd9/ZgAEDLGYkljBrdJE9NuEi25tUIt1LJDwHAAAIUmoDtZAKR30JAIDCIaaCUjt27LDx48fbww8/bJ07d7bGjRu7llH6f8SIEW6ePn36uCBVo0aNrGXLljZ8+HDbvHmzzZ49273+xx9/2Keffmovv/yyHX744dapUyd7+umnbcyYMbYis+yYUdK0KQnPAQAA/KgV1Bln+I+0R2JzAAAKh+IWQ/bu3WtJSUlWWgkCQqgbn1pFhdu9e7e9+OKLVrFiRTvkkEPctClTprgue+3bt0+dT0GsxMRE183vHJ+EA7t27XIPj4Jckpyc7B4F5a67zHr0UFxQta1gNz5VvO66S59rBU7fLRAIFOh3jAeUA+XA/sBxwfmB82Ss/F7kddnRqNMURLns3WvWs2eC/fBDWpqDhISABQIJqf9Hqr6UF9QxKBf2GY4nzjOcg2NRcgzVaWIqKFW+fHk78sgjbdiwYdaiRQurWbOmvf322y7QpNZSHnXJO/fcc2379u1Wu3Zt102vmhILmNmqVausRo0a6ZZbvHhxq1KlinvNzwMPPGD33HNPhunqErhz5858/56WvNvKLX3JTqpn9urLV9t9D1S1v/8ObooKFZKsTZs1tnp1/n9shtVITrZNmza5nVFBu6KKcqAc2B84Ljg/cJ6Mld8L5dbMi4jXaQqgXHSDbtCgCvbhh2Xd83Llku3667fahAllXH3pwAP32g03bLWjjtoVkfpSXlDHoFzYZzieOM9wDo5FyTFUp4mpoJQol1T//v2tbt26VqxYMWvbtq317t3bZsyYkTrPsccea7NmzbK1a9faSy+9ZD179nStoMKDUdl122232aBBg9LdVaxXr55Vr17dJUvPd0m7LWFNcMP3vbCi9e2XaD17Bmz8+ATbvLmYTZxYw66/3iKyIyYkJLjvWdSDUpQD5cD+wHHB+YHzZCz8XoS3Fo/5Ok0BlMtttyXYmDHBFlIlSwbsvffMjjtuPwvG2tS6vJiZVbR4QB2DcmGf4XjiPMM5OBYlx1CdJuaCUgceeKB9++23tm3bNleRUkuoXr16uRxSHo28p5ZTehxxxBHWpEkTe+WVV1xFrFatWrY67LaZugVqRD695qdUqVLuEU4bp0A2UCAxNZlUgpafmGhDhgSHM9bdwYceSrTLL9f3tAKnHbHAvmccoRwoB/YHjgvOD5wnY+H3Iq/LjXidJp/LZfhws4cf9pZpNnp0gnXpktaFLx5Rx6Bc2Gc4njjPcA6ORQkxUqeJ2UiEAk8KSG3YsME+++wzO+uss7KM8nn5E9T9b+PGjelaVn399dduHiU+j1UHH6zcCcG/NZBgpUpmSpOlQBUAAEBhpvrOAQeY3XBD2rRnnzXr3j2aawUAAApazAWlFIDS6HmLFy92uaLUVa958+bWr18/13rq9ttvt6lTp9o///zjAk/q6rd8+XLr0aOHe79yUZ188sl26aWX2s8//2w//vijXX311S4HVZ06dSyWHXlk+gSfc+aYdetGYAoAABTugJTqO0uXpp9es2a01ggAABTZoJSSbV111VUuEHXhhRdap06dXKCqRIkSLsfU/PnzrVu3bta0aVM744wzbN26dfb9999by5YtU5cxevRo9/7jjz/eTj31VLcMjdIX6159Nf1zdeVT0/WhQ6O1RgAAAAXrjjsyTqP+AwBA0RBzOaWUtFyPzBJlTchGfzaNtPfWW29ZvPnzz4zTFJiaPz8aawMAAFCwtm83W7DAv/7jNx0AABQuMddSqkjQ7b+ydYKPlITn0rRpuqfpKmbKOVWmDHmmAABA/NM9RuXOLF8+WM8Jp/pQs2bRWDMAABBJBKWiIbGEWeMBwYf+TjF4cFqXvVC7d5vNnWu2cyd5pgAAQOHIIaXcmcnJadO9+o/+V31I9SIAAFC4EZSKIV27mo0fb9a6tboqBltOhY+iSJ4pAAAQz+65Jy3wFKpUqWD9R/UgBa7OOSdaawgAAIpsTqmiToEpPUIraGopFUqVuHnzIr5qAAAAeaZcUX5d9mTHDgoYAICihJZS0ZC8x2z+E8GH/s5C8+b+eab27DHr0sVs+vSCW00AAID8VqFCxmnkkAIAoGgiKBUNuj24e2Pwkdmtwn3kmZKvvjI77DCz7t0ZoQ8AAMS+n382W7s2/TRySAEAUHQRlIqzPFP6f+BAs0aN0ubR6y1bml18sdnSpdFcWwAAAH8asKVv37T7cbVqkUMKAICijqBUnASmZs0K5ln47Tezxx83++MPs+eeC1boRKPXvPqqWZMmZjfckPEuJAAAQDTdfXday+727YM30lS3UR2HpOYAABRNBKXiVMmSZldcYbZwodn995tVrBicvmuX2fDhwZZU555r1qqVWZkyZoccEhzJBgAAIJJU/2jc2OyRR4LPixc3GzUq+D8AACjaCErFuXLlzG67zWzRIrNbbgk2g5ctW8zeecfs99+DzeXnzDHr1o3AFAAAiGxASvWPv/9Om7Z3L7kwAQBAEEGpQqJKFbMHHwxW+i6/POPrXv6GAQPMPv44GKgCAAAoSPfck3GaEpsPHUq5AwAAglLRodpY6erBh9+wenlQp47ZiBHB7n1+1q0zO+00s6pVlb8hwd56q4z991/a3Ux186O7HwAAyCvVK9RS2+9G2YIFlC8AACAoFR2JJcyaXhV86O8C0Lx51vGu7dvN3n8/wW64oaLVrZtgTZsGm9er8kh3PwAAkB/d9ryW2qFUP2nWjPIFAAAEpQqtwYODFUEvMOX9f+utZv37m9WokTZvIJBgf/3l/Z32v95z001mmzZFeu0BAEC8d9vL7OaY6hiqpwAAADDuSSHVtavZ+PHBnA1qIq87kqoAekMuJyebTZuWbO+8s92+/rqczZmT4FtpVAL1SpXMtaTq0MHssMOC/x96aLCbHwAAQLg//8y8lZTqJ159BAAAFG0EpaIheY/ZwheDfzceUGBd+BSY0sNPYqLZ4YebNWy41YYPL2stWya44JVfBdKrXOoxenTwuYZxPvjg9IGqli3VJTB4d1TzKpClQFhm6wAAAApn172kJP+AVOvWBKQAAEAaglLRoMjPzjVpf8eA++4L5n5QhdHruqf/TzklmBx91iyz3bvTD+esaXq89FJwmpKrh86j/FRapu6IEpgCAKDo5JIK59Ur6LYHAABCJaZ7Bivq3f10B7N06eD/qlh+/LG6+Zlt2WL2yy9mzz1n1q9fsJWUWluFCg1IhcbbevUyO/pos8suMxs+PLhMdQsMvYvKyH8AAMS/QYP8p5cqFfytp9seAPy/vTuBk7n+/wD+nl3WbbHuHCtHbiGJFKKQciYpPRyRVD+S/KNcKVeHkkqH4hf9EkJCRO4iRI6S+8i5zuw61tr5/B+vz/TdnZmdnZndnZ3r+3o+Hl8z+53vfL8zH9/jM+/v5/P+EJE9tpQir7r7oRVU/fq2qX9/27yEBJFt20S2bLFNc+a4bviFVlXr1tkm5woquvjlzy+ycWPqXVSjhdW8ea7vthIREVHwQdDp6NH0X2dAioiIiJwxKEWZhmDSvffaJtizxxZQcg5MIf8UAlPOEhNtyxvsR/6DLl1EbrnFNlIgphIlUp87zytWzBY4IyIiosB4/fV0htsT24ArRERERM4YlCKfQZ4IV3mp0ILqvvtsowD+9ZfjdOCASFKS6/XhvceP2yZvYJRAdwEs+/lYNr2hqomIiCjjcJ1PD3NJERERkSsMSpHP81KNGWOrmOKuKCqhRnN9jNKHyR5aUCE/lauho5HbCsGjs2ddj+Lj7NIl24R1eZIzp611la2VlUWio6OlXDlLmmAW/sZy+CxERESUPnTJt28BbYiNZdc9IiIico1BqUBAE52oQqnPTZKXyhV07Rs3znULq//9z1aJtVpFLl4UiYtLnc6ccfzbft7ly563i9ZZJ0/aJhH8H+Rxu3zBgt63wipcOG0SeCIionDXubOSXbtS6zXG9RyDnBARERG5wqBUIETkFKn6QkA2HYotrBDgiYmxTdWqeV7f9eu21lXuAlj2813lu3KGQBcmdDf0JDIytRWWp1xYmPK4j4cRERGFhFOnLA4tkqtXd7yeExERETljUIpCsoWVO+hqV7asbfIEd3AvXLDKnj3nJTk5Rs6di3AbxEL3QE/Q1fD0advkbcJ4b1thFSliC3oREREFE7RAxg0myJvXdt3Mly/Qn4qIiIiCHYNSZGroWoDudpUqJeugj6dudzduOLbC8tQSC8t7kpBgmw4d8rwsPl/Rot4HsfiDgIiI/GHDhig5d87WUuqhh3j9ISIiIu8wKBUI1iSRQ9Ntz2/tZevORyEhKkrklltskzetsNDlz9sA1oULnteJ/FrGe7yBu9XpdRt0lQtryZJc8v77Fp0sHglr0e3CVy3YiIgoPM2fL9K/fyGHxOZERERE3mBQKhAQrbiqM2ynHXKOwqoVVnS0bapc2buuD+fOeR/EQu4sT65eFTlyxDZ58YlFpDB2Sv3Xzp22BPTNm9tGSESrK3Q1NCb7v109RwCPiIjCPyDVpQuaGafWZ958U6RhQ97UICIiIs8YlCIKEkgKW6qUbfIEsUx0+UsvebvzhGCX5/inkaDWcUTI1attU2a+j7vglTeBLee/8Yj1EhFRcHjtNdyEUaKU46h7GLyELW2JiIjIEwaliEIQKvwFCtimihU9L48RBs+fdx/EWrzY8UdFVqHl18WLtsmX0ALLV0Eu4zmmHDwbEhFlGLp7O187cBMEo+kSERERecKfYUQmgIALckdhSk+dOiK7dqW9243cUjNnpiZkv3Il9bnz3+5ew4ScWFmF5PHIv+VNDq6MjtpoC1ZZJHfuGClUyJLpIJfxHDm9PI2WiK4vaGnAPF5EFIpwXTl6FE1xHa8dt90W0I9FREREIYJBKSLSRoxQOi+I0Q0DPypwt3v8eJEGDbJeSFhXYmLGg1nevOaL1GzI0YXp/Hn8sPJdH8E8edIPXiGwtn596rJGHq+nnxZp1Mj2XgTLPD1i8hT8IiLyNQTVjx7Fs7QtpTBQBhEREZEnDEoRkYbcH9OmXZT33y+kW+3gLjd+VHTs6JsCQpDLCKAULeq7QsePn2vXfBnoUhIfr+TqVSTuzTp8Nkxnz3r/nk8/tU0ZgVxb3gSw7ANZ7pZBN8nExCgpWdLW4iu9ZX2R44utxYhCOZ9U2hsDGH3PV9cOIiIiCm8MSgWs5PMGbNNE6WnbNlF69VISEeG73FLZDT+IEDTB5AtWq5K4uDgpWrS4JCZGuO2OmJkgGAJU2QE5vDDFx/tqjQjKFfG4FFpoZSTY5fy4f7+te6jxw3bXLltrseHDRVq0EMmVyzZheeO5/TwExfDe7GALlllk794SKUFaJm4mSrVnj+uWqidOsJSIiIjIOwxKBUJklEj1/wvIponIOxERqUnQ3eXiyqjkZJGrV20BqubNjSTBqa8jwFKmjMiwYbbuhAhiuXp095r9I3JwZSd8HwTdMGWFUQbG4xtv2CZvOAeqXAWvnOd5Wnb3bpEPPzSCZRadbw3BMnRnbdXK1pIMyxmP9s/T60rprkVYVlqLsaUZEREREYUqBqWIiPwIAQtj5MRx42ytgoxWQsbj5Mm+6/qC5PLI5eVNAMs+2HXtmlXOnbsqkZH55Pp1S6YCY/6C74cpOxiJ/41HBAsxeQpoOgeqEBzEaJfO+cPq1bMNRLB5c9rXOnQQqVXLtg77yVgvpm3bRN58M21Ls3feEWnTxrYMWpO5esTnJMoKtM7MyHwiIiIiZwxKEREFCFrCfPutyJgxtuHTfZ3HCxB4QDc5TBkNZsXFJUjx4nkz1Z0TARIEYjwFsJ57TuTYsbStxYoXF+nZ07acEXQyJm/nYbp5U/wOZWfkEvMEQaX0LFxomzLT0mzwYNvkad9wF7RyfLSIUoUlXz5LSkDMu/f5/hFBvOzqsukOu3MSERERmSAoFR8fLyNGjJAFCxbovC5169aVyZMnS4MGDSQpKUmGDx8uS5culUOHDkl0dLS0bNlSJkyYIKVLl05ZR2xsrBy1DQeTYvz48TJ06FAJCtYkkSNf2Z7HPiES4buRvogo9AJT4ZinCEEDo7WQOwgcuWotNnWqb4Jz6F6YmaAWclq5youDJP2PPGILuGE549H+uat5p05J0EHwzAgYeoYokIf/TD9CgMo5WJWdgbAdO1x350RQORyPXyIiIiLTBqX69Okju3fvlpkzZ+pA06xZs3Tg6c8//5T8+fPLtm3bdNCqTp06cvHiRRk4cKC0a9dOtm7d6rCeMWPGSN++fVP+LoC+MsECv7gSjqQ+JyIyqexuLYbukplJhF+woBEsUzoIYTxiVMTMfLY6dWxd65xbhFWvbgsO/fVX2tduvdUWnDOCW66miRNFTp9Ou70iRUTatbMtg65UWXnE5ws2RmJ/5GfzJ/vunPg/wn7LoBQRERFRmASlrl27Jt9++6189913cu+99+p5o0ePlu+//16mTp0qb7zxhqxYscLhPR988IHceeedcuzYMSlXrpxDEKokxjInIqKgFoytxYxgGZKP792rdLBs9OjMB8sQaHPVIuz1122Prl576y2R++93v15c9ly9d9o03wX2bK3NrHLy5FmJji4myckRPgl2+eMxO6GcEUg1M3QBdRW0ZL4yIiIiCsmg1M2bNyU5OVlyY/gjO3ny5JENGza4fM8///wjFotFChUq5DAfXfpef/11Hah6/PHHZdCgQZIDiShcSExM1JPh8uXL+tFqterJ56xWsfx7S1xh/ZbA3IbGd1NKZc93DCEsB5YD9wceF64g0Xi7dlY5e/asFCtWTCIiIjLdagjrmjsXQShLygh7I0cqad/e9np6r3nanrv1+urUjkBXVJRV8uWzSuHC1pAJOOAyi5xivghujR5t+bc7Z2oyK7SeQ7DSavVti+esXpP9WaepWdOiE/Pbl4uI0gn6fV0uoYp1DJYL9xkeTzzP8Bxs1uuT1ct1B1VQCq2bGjVqpINJ1apVkxIlSsjXX38tGzdulEqVKqVZ/vr16/Lyyy9Lt27dpCD6WvxrwIABUq9ePSlSpIj88ssvMmzYMDl16pRMmjTJ5XaRb+o13A53gh8i2IbPWW9I/n/HT084GycSEeX7bXjzMaxWHdTDzogfW2bFcmA5cH/gceGP80OTJiLLlzvOi4vz/FpW1usr4XKeNHJRZbQ7p8WSS/r0KZymO+eAARclLi7R57k1s8KfdZoBA/xXLqEqXI4dX2O5sGy43/B44rkm/M/D8V7WaSwKnyKIHDx4UHr37i3r1q2TyMhIHVyqUqWK/Pbbb7Jnz56U5ZD0vHPnznL8+HFZs2aNQ1DK2RdffCH9+vWThIQEyeUi666ru4ply5bVOavcrTfTkm+I5c/x+qmqPkwkMnBBKfsWAGbFcmA5cH/gccHzA8+T3oy+hxZpRu4ztEjz5UiZ9nWQwoUL64piZuog/q7T+KtcQhXrGCwX7jM8nnie4TnYrNeny17WaYKqpRRUrFhR1q5dK1euXNFfolSpUtK1a1e5FRlf7QJSjz76qB5hb9WqVR4rWQ0bNtRdA48cOSK3ocbkBIEqV8Eq/Odky3+QikgZz9qC9QcwIISuj9n2PUMIy4HlwP2BxwXPDzxPuoNRFzt1suqRgYsXL55t182srtffdRp/lUsoYx2D5cJ9hscTzzM8B5vx+hTh5XqDtuaQL18+HZDCnb3ly5dL+38TbxgBqf3798vKlSslJibG47p+//13XSCoLAWNiJy2iYiIiIiIiIjIhIKupRQCUOhRiBZNBw4ckCFDhkjVqlWlV69eOiD1yCOPyLZt22Tx4sU6Kfrpf8fCRv6oqKgonX/q119/lebNm+scVfgbSc67d++um44FBXTXq/lqoD8FEREREREREVHABF1QCv0NkZgcuaIQaELeqLFjx0rOnDl197tFixbp5W6//XaH961evVqaNWumm6zPnj1bRo8erXMqVKhQQQelXnzxxQB9IyIiIiIiIiIiCvqgFLrmYXIlNjZWt6JyB4nRN23alE2fjoiIiIiIiIiIwjIoZQrWmyJHv7E9L99VJIL/DURERERERERkLoyGBIKyisTvT31ORERERERERGQyQTv6HhERERERERERhS8GpYiIiIiIiIiIyO8YlCIiIiIiIiIiIr9jUIqIiIiIiIiIiPyOQSkiIiIiIiIiIvI7jr7nglJKP16+fDl7Sj35hkhCou05thEZJYFgtVolPj5ecufOLRER5o1PshxYDtwfeFzw/MDzZLBcL4y6h1EXCfo6Da+jLBvuMzye/IR1dpYL95nwrNMwKOUC/nOgbNmykv0m+GEbREREFGp1kejoaJ+sx391GiIiIqKM1Wksyle34sIsanjy5EkpUKCAWCwWCVeIXKKS+vfff0vBggXFrFgOLAfuDzwueH7geTJYrheolqHyVrp0aZ/cufRHnYbXUZYN9xkeT/7Acw3LhftMeNZp2FLKBRRYmTJlxCywE5o5KGVgObAcuD/wuOD5gefJYLhe+KKFVCDqNLyOsmy4z/B44rkmcHgOZtmEap3GvImEiIiIiIiIiIgoYBiUIiIiIiIiIiIiv2NQysRy5colo0aN0o9mxnJgOXB/4HHB8wPPk7xe8DrKOgbrXsGA9VKWDfcZHk9mO9cw0TkREREREREREfkdW0oREREREREREZHfMShFRERERERERER+x6AUERERERERERH5HYNSIezDDz+U2NhYyZ07tzRs2FA2b97sdvm5c+dK1apV9fK1atWSpUuXprvsM888IxaLRd577700ry1ZskRvL0+ePFK4cGHp0KGDmK0c9u3bJ+3bt5eiRYtKwYIFpUmTJrJ69WoJp3Lo2bOn/u72U+vWrR2WuXDhgjzxxBO6DAoVKiRPPfWUJCQkiJnK4ciRI/p7V6hQQR8TFStW1EkDb9y4IWbbHwyJiYly++2362V+//13n36vUCmHcD9PelMOZjhPwp49e6Rdu3YSHR0t+fLlkwYNGsixY8dSXr9+/bo899xzEhMTI/nz55fOnTvLmTNnJFxktEzDwbp16+Thhx+W0qVL631/4cKFDq8rpWTkyJFSqlQpfQ5o2bKl7N+/P+ivn1k1fvx4vf8XKFBAihcvrs97e/fudVjGm+MBx0/btm0lb968ej1DhgyRmzdvSiibOnWq1K5dW/9/Y2rUqJH88MMPYvZycTZhwgR9TL3wwgti9rIZPXp0mussrkdmLxfDiRMnpHv37vr74zyLa/TWrVvF7Ofh2NjYNPsNJuwrQb3fKApJs2fPVlFRUeqLL75Qf/zxh+rbt68qVKiQOnPmjMvlf/75ZxUZGanefPNN9eeff6rhw4ernDlzql27dqVZdv78+apOnTqqdOnS6t1333V4bd68eapw4cJq6tSpau/evXrb33zzjTJbOVSuXFk9+OCDaseOHWrfvn3q2WefVXnz5lWnTp1S4VIOPXr0UK1bt9bfyZguXLjgsB68jjLatGmTWr9+vapUqZLq1q2bCpRAlMMPP/ygevbsqZYvX64OHjyovvvuO1W8eHE1ePBgFSiB2h8MAwYMUG3atFG4xGzfvl2ZrRzMcJ70phzMcJ48cOCAKlKkiBoyZIjatm2b/hvnAPt1PvPMM6ps2bLqp59+Ulu3blV33XWXaty4sQoHGS3TcLF06VL16quv6noCznMLFixweH3ChAkqOjpaLVy4UO//7dq1UxUqVFDXrl0L2uunL7Rq1UpNnz5d7d69W/3+++/6+C9XrpxKSEjw+ni4efOmqlmzpmrZsqW+fqCsixYtqoYNG6ZC2aJFi9SSJUv0uRDXhVdeeUWfT1BWZi4Xe5s3b1axsbGqdu3aauDAgSnzzVo2o0aNUjVq1HC4zp49e1aZvVwA9Y3y5cvr+vevv/6qDh06pOvhuAab/TwcFxfnsM+sWLFCX6dWr14d1PsNg1Ih6s4771TPPfdcyt/Jyck6eDJ+/HiXyz/66KOqbdu2DvMaNmyo+vXr5zDv+PHj6pZbbtEXSRzs9sGYpKQk/dq0adOUmcsBFwQc3OvWrUuZd/nyZT0PB364lAN+dLZv3z7dbeJHGr7zli1bHAI0FotFnThxQpmlHFzBj1hc+AIlkOWAi1fVqlX1D9RAB6UCUQ5mOU96KgeznCe7du2qunfvnu42L126pH94zp07N2Xenj17dDls3LhRhbqMlmk4cg5KWa1WVbJkSfXWW2857Ae5cuVSX3/9ddBeP7PrxxG+59q1a70+HnANiYiIUKdPn05ZBgH+ggULqsTERBVOcPMC1wqWi1Lx8fH6RgauD02bNk0JSpm5bBCUQsDEFTOXC7z88suqSZMm6b7O83AqHEsVK1bUZRLM+w2774UgdAv67bffdDNEQ0REhP5748aNLt+D+fbLQ6tWrRyWt1qt8uSTT+omejVq1Eizjm3btummkthW3bp1dXPINm3ayO7du8VM5YDmjrfddpt8+eWXcuXKFd2c8ZNPPtHNG+vXry/hUg6wZs0a/b3wffv37y/nz593WAeaut5xxx0p87BObPvXX38Vs5SDK//8848UKVJEAiGQ5YDmv3379pWZM2fqJr+BFKhyMMt50lM5mOE8iWsFumlWqVJFz8d3Q/c1+65c2GZSUpLDetD9oly5culuN1RkpkzN4PDhw3L69GmHckHXTuwbRrkE2/Uzu+BaCMb10JvjAY/ohlOiRImUZXB8Xb58Wf744w8JB8nJyTJ79mx9bkQ3PpaL6O5E6C7kfM41e9mguxm6Cd966626m5nRNdzs5bJo0SJ9/uzSpYu+9qK+9dlnn6W8zvNw6nV61qxZ0rt3b92FL5j3GwalQtC5c+f0Bc1+ZwH8jYqQK5jvafmJEydKjhw5ZMCAAS7XcejQoZQ+zsOHD5fFixfrXCnNmjXTfXLNUg44qFeuXCnbt2/XeROQR2PSpEmybNkyXR7hUg7ID4MflD/99JMuk7Vr1+of19iWsQ5cCOyh3FD5TG+74VgOzg4cOCBTpkyRfv36SSAEqhzQYAB5hpCHzf6HVqAEqhzMcp70VA5mOE/GxcXp3BPIgYLy+PHHH6Vjx47SqVMnXR7GOqKionQAwtvthorMlKkZGN/dXbkE2/UzOyBoi7xAd999t9SsWdPr4yG94854LZTt2rVL53DJlSuXvlYuWLBAqlevbvpyQYAON3SQk8yZmfcZBLJnzJihr5vISYZAyz333CPx8fGmLhejroUyqVy5sixfvlzfGMPvtv/+97/6dZ6HbXCT7NKlS7p+DsG83+TItjVTSEHkdPLkyfqigB8T6VUw4NVXX9VJ0WD69OlSpkwZnQw2UD/C/V0O+PGNOzqoUK5fv14nz5s2bZpOerplyxbdMiIcPPbYYynPETFHgk4k8UbriBYtWohZZKQc0EIGP05x5wYthsxUDgjEoaI0bNgwCWeeysEM50lvysEM50nj/xrJ3AcNGqSfI8H/L7/8Ih9//LE0bdo0wJ+QKHBw/KOF6IYNG/jf8C+0HsXgH2hBNm/ePOnRo0dKANus/v77bxk4cKCsWLFC37ygVLjRY8A1FkGq8uXLy5w5c/Q11cxw/cUN0HHjxum/0VIK5xtce3Fckc3nn3+u9yO0tgt2bCkVgjCSUWRkZJpM+fi7ZMmSLt+D+e6Wx48G3PVF8z3crcN09OhRGTx4sM7iD8aPCNzVMeBuD5qU2o80FO7lsGrVKt36AXd2cAewXr168tFHH+kLhBGhD/VycAX/z9gWWgIZ60BZ2UMXHbQGcbeecCsHw8mTJ6V58+bSuHFj+fTTTyVQAlUOOC7Q5BfnBBw3lSpV0vNRaQhEBSFQ5WCG86S3+0O4nyexTuzr9v/XUK1atZT/ayyL5vO4U+ntdkNFZsrUDIzv7q5cgu366WvPP/+8Pv4x2iYC8gZvjof0jjvjtVCGFgq4NqILM1oF1alTR98INXO54GYwjgVcI4x6NwJ177//vn6OFhpmLRtnaN2C7uK4zpp5nzHqWp6uvWY/Dx89elS3WO/Tp0/KvGDebxiUCtGLGi5o6DZhHzHG3+ib7grm2y8PuCthLI8cSjt37tR3cIwJUVXkVUKzSMA28ePKfnhf9Es9cuSIjtybpRyuXr2qH5H7wR7+Nu6ch3o5uHL8+HGdM8b40Y1lcVJDhcKAH6LYNu7m+FugysFoIYXuWdg+WsU47xtmKAdUIHfs2JFy3CxdulTP/+abb2Ts2LFilnIww3nSm3Iww3kS62zQoEGaIe/37duX8n+NbebMmdNhPVgeFWd35RkKMlOmZlChQgVdcbcvF+TiQK4oo1yC7frpK2ghiYAUuqXh+6As7HlzPOAR3dzsfyziuMOQ7c4/QkMd/r8TExNNXS5oWYvvZV/vxs0s5E8ynpu1bJyhu/jBgwf1ddbM+wzgZpe7a6+Zz8MG/B5Ba3XkajME9X6TbSnUKduHYcZILjNmzNCjuDz99NN6GGYjU/6TTz6phg4d6jC0dY4cOdTbb7+ts+xjRAfnoa2dOY86Z2Twx8hSGHbzr7/+Uk899ZQqXrx4ukPDh2M5YFSpmJgY1alTJz3kMYb2femll/R68Hc4lANGQcF3wkgMhw8fVitXrlT16tXTI6Ncv37dYSjVunXr6uFYN2zYoF8P5FCqgSgHjNSIIWRbtGihn9sPwxoogdof7GG5QI++F6hyCPfzpDflYIbzJMyfP1/P+/TTT9X+/fvVlClTVGRkpB5a2oDhl8uVK6dWrVqlh19u1KiRnsKBpzINVzgGcG7DhPPcpEmT9POjR4+mDEWOcvjuu+/Uzp079UiVroYiD6brpy/0799fD8G+Zs0ah2vh1atXvT4ejOHIH3jgAX2uWLZsmSpWrFjID2OPcwtGIcQ5E/sE/sZoiz/++KOpy8UV+9H3zFw2gwcP1scS9hlcj1q2bKmKFi2qR7U0c7nA5s2b9fV57Nix+tr71Vdfqbx586pZs2alLGPW87AxEi72DYxS6CxY9xsGpUIYKr/YqaKiovSwzJs2bXI4oWPIbntz5sxRVapU0cvXqFFDLVmyxO36XQWlbty4oU+S+IFVoEABfYLcvXu3Mls5YBhnHKxFihTR5XDXXXfpITTDpRxQgcT3w0kIP7hQBn379k3zQ+P8+fP65J0/f349VGivXr10Zd1M5TB9+nT9o8TVZLb9IdiCUoEqh3A/T3pbDuF+njR8/vnnOjCdO3duPXz3woULHV5HBfjZZ5/Vw7+j0tyxY8eABq39WabhavXq1S7P+cb+g6G3R4wYoUqUKKGDdrhpgcBssF8/syq9ayGukxk5Ho4cOaLatGmj8uTJo3+E43yalJSkQlnv3r31uRLHCc6d2CeMgJSZy8WboJRZy6Zr166qVKlSep/BjS78feDAAWX2cjF8//33OniCc2zVqlX1zSF7Zj0PA26K4tzr/H2Deb+x4J/sa4dFRERERERERESUFnNKERERERERERGR3zEoRUREREREREREfsegFBERERERERER+R2DUkRERERERERE5HcMShERERERERERkd8xKEVERERERERERH7HoBQREREREREREfkdg1JEREREREREROR3DEoREflAbGys9OzZk2VJREREYSMhIUGKFy8uX331ld+326dPHylZsqRYLBZ54YUX0l02KSlJypYtKx999JFfPyMR+QaDUkQUVGbMmKErH5g2bNiQ5nWllK544PWHHnpIzGTNmjX6ex85ciTQH4WIiIiyAAEUXNMbNmwY1OU4efJkKVCggDz22GN+3e64ceN0nbB///4yc+ZMefLJJ+WXX36R0aNHy6VLlxyWzZkzp7z44osyduxYuX79ul8/JxFlHYNSRBSUcufOLf/73//SzF+7dq0cP35ccuXKJcFk79698tlnnwX6YxAREVEIQMsjtLLevHmzHDhwQIIRWiAhKIUWS5GRkX7d9qpVq+Suu+6SUaNGSffu3aV+/fo6KPXaa6+lCUpBr1695Ny5cy7rjkQU3BiUIqKg9OCDD8rcuXPl5s2bDvNR2UDFBM25gwmCZLhTR0REROTO4cOHdYBl0qRJUqxYMa+7xqFOdOPGDb8V7uLFi+Xs2bPy6KOPir/FxcVJoUKFvF4eyz7wwAO6dRURhRYGpYgoKHXr1k3Onz8vK1asSJmHiti8efPk8ccfd/met99+Wxo3biwxMTGSJ08eHbzC8s7QXP7555+XhQsXSs2aNXVAqUaNGrJs2TKH5dBEHMviDibyRaHCEx0dre/GXb161W1OKaMb4s8//6yblKPSmS9fPunYsaOu4NmzWq16W6VLl5a8efNK8+bN5c8///QqT9X+/fulc+fOOkiH1mVlypTRTez/+ecft+9r1qyZ/u7YDraH7d5yyy3y5ptvun0fERERZQ2CUIULF5a2bdvKI4884jIoha76qEegbvPee+9JxYoVdX0F123466+/9HuLFCmir/933HGHLFq0yGEdFy5ckJdeeklq1aol+fPnl4IFC0qbNm1kx44dXn1O1JNQF8G27Z0+fVrXhVDnwGcqVaqUtG/f3iG9ANItvPHGG3oZo27zxx9/eKzbGKkKELhbsmRJSkoHvGfIkCF6mQoVKqTMt9/m/fffr1M/4HsTUejIEegPQETkCiotjRo1kq+//lpXoOCHH37QwRYEXd5///0070ET83bt2skTTzyhA1izZ8+WLl266Dt9qPjZQ6Vl/vz58uyzz+pcCVgfgjvHjh3TQS17uEOICtD48eNl27ZtMm3aNJ30c+LEiR7/8/7zn//oiiean6PihIolAmLffPNNyjLDhg3TwaCHH35YWrVqpSuLePSUFwHfEcslJibq7SAwdeLECf190bQdATR3Ll68KK1bt5ZOnTrp74gA3ssvv6wrr0aZExERkW8hCIVrb1RUlL4JN3XqVNmyZYs0aNAgzbLTp0/X9YGnn35aB4AQhEJw5+6779Y3k4YOHapves2ZM0c6dOgg3377rb4BBocOHdKBJdSFUI85c+aMfPLJJ9K0aVMd3MLNMHfQmqtevXpp5qO+hM+Augfqa2jVhJuIqEPhbxg5cqQOSqHlOybUn9CSyVNLr2rVqukcUoMGDdIBrcGDB+v5qJvgvagXvvvuu1K0aFE9Hzf9DLgZiWAYPrfZ8o4ShTRFRBREpk+frnBq2rJli/rggw9UgQIF1NWrV/VrXbp0Uc2bN9fPy5cvr9q2bevwXmM5w40bN1TNmjXVfffd5zAf64+KilIHDhxImbdjxw49f8qUKSnzRo0apef17t3b4f0dO3ZUMTExDvPweXr06JHme7Rs2VJZrdaU+YMGDVKRkZHq0qVL+u/Tp0+rHDlyqA4dOjisb/To0fr99ut0tn37dr3M3LlzVUY1bdpUv/fLL79MmZeYmKhKliypOnfunOH1ERERkWdbt27V198VK1bov1FHKFOmjBo4cKDDcocPH9bLFSxYUMXFxTm81qJFC1WrVi11/fr1lHlYT+PGjVXlypVT5uH15OTkNOvNlSuXGjNmjNvPmZSUpCwWixo8eLDD/IsXL+rP9dZbb6X7Xnxe1LNQT7OvA73yyise6zYGV/U8bBPvx3dw5eTJk/r1iRMnelw/EQUPdt8joqCF1jvXrl3TLX/i4+P1Y3pd9wBd9uxbAaFV1T333KPvzjlr2bKlQ3P02rVr62btuKvo7JlnnnH4G+tE18LLly97/A64s4nm5fbvTU5OlqNHj+q/f/rpJ50jAi227OHuoydGS6jly5en6U7oDTTlR/JQA+7Y3nnnnS7LgIiIiHzTSqpEiRK6OxugjtC1a1fduhv1A1etkuxbA6FrGpKAo46EuhGSe2NCvQStp9GtH62mAS2rIiJsP/ewbiyDa/9tt93msm5kD9vBfTy09naua6G+gG52qGu5snLlSt2qCXUZ+zrQCy+8INnJ+KwoDyIKHQxKEVHQQiUMwSMkN0dXO1SokD8hPQhaYaQW5FZA83a8H03iXeVXKleunMvKjKsKlvOyRqUnvcpYRt5rBKcqVarksBw+v3NF0Bma4iNfFboTohk7KqMffvihx3xSBjSLt68sGp/Pm+9FREREGYN6DIJPCEghZxJyVmJq2LCh7lqHG1WurvX2sDyCRSNGjND1HPsJqQIA3emMnJXo6la5cmUdoEJdAcvt3LnT67qCrYF5KqwH6QuQUgHBtXvvvVenIECeKYNRt8F27WHbnuo2WWF8Vue6DREFNwaliCiooWUUKj4ff/yxznOU3kgs69ev1/mkEJD66KOPZOnSpTq/Ad7vXKGC9IY2zuqyvnyvN9555x1duXzllVd0q7IBAwbopO3Hjx8P+GcjIiKiVGjhdOrUKR2YQsDGmIzR7VwlPLdvBW4EmgAJzFHPcTUZN7rGjRunb14hcDRr1izdshqvo55grCc9uDmG4I6rG1Vo8bRv3z6daxP1LgTIkAtq+/btAf3vNj6rkW+KiEIDE50TUVBDss5+/frJpk2bHJKDO0NiT1SMUOHCXTz7BKHBrHz58il3Pu3vhqKJvbctlpD8E9Pw4cN1ck8kP0UQDwlGiYiIKDgg6ISBUtCq2RlahC9YsEBfv50DUfZuvfVW/ZgzZ07dmtwdDGCCVlmff/65w3wMhuIpcJMjRw6d5gAtulzBa0hCjgldBm+//XZ9owzBL6Nug/nG5wWMPpyV1tieWkAZnxUBMiIKHQxKEVFQQ+4DdMHDyHUYnc5dqx9UVuzzMeA9GHUmmLVo0UJX/PAdMZSx4YMPPvD4XuS0wjDLeL8BwSnkj8CIfERERBQc0JoZgSeMhOcqFQFGwsPIcosWLdI5ptKDoFazZs30KHrI2VSqVCmH1xH4MXJQoW7k3Pp57ty5OueUc9oAVzAKMnJH2UMOS9QzcCPQPkCFkYyNugeCZQiaTZkyRY+4ZwSTMAJxVmCUQSOo5spvv/2mt4XPTUShg0EpIgp6PXr08LhM27ZtZdKkSdK6dWvdZQ/5FHAnEpUudG8LVsjHMHDgQH13Ed0P8fl37NihuyziLqa7u4LoBvD888/rCm6VKlV0wnQMo4xKKBKjEhERUXBAsAmJyXGtdwU5MRFMQmsqd0EpQP2mSZMm+kZU3759dWsk5KTauHGj7r6PegQ89NBDMmbMGOnVq5c0btxYdu3apddv33rJnfbt2+t6BbrqoZ4BeI4bauhyWL16dX1jDC28sP3HHntML4Pvge6F6N6Hz/Dggw/qrn1G3Saz6tevrx9fffVVvS0EvnDD0ghWoWsiWovHxMRkehtE5H8MShFRWLjvvvt08/QJEyboXAfoCodEnGgtFcxBKcDnRIunzz77TI9Ygzt8P/74o65w2t+JdFanTh2d3Pz777/Xdz2xDsxDpQ+VWyIiIgoOCAbhmm7fKtoeWh/hBhuWQxd+dxAM2rp1q7z22msyY8YMvTxaUNWtW1dGjhyZshzyTV65ckUPGIMUCPXq1ZMlS5bI0KFDvfrMCPggiDRnzhydIgDKli0r3bp100nZEbBCUKpq1ap6GfsbYkghgO+L7oirV6/WydxRt8F3zKwGDRrI66+/rte5bNkynRcLXfYQlELidqwfeUWJKLRYFDPaEhEFHTRNxwg1qNThjiARERGRvyEIhPycyA+V3gApGREbG6u7HyKY5kvoGohRAA8ePOg2JxcRBR+OvkdEFAR5JpwZeRdQcSMiIiIKhEGDBklCQoIeMTBYJSUl6RQOaM3FgBRR6GH3PSKiAEOTetwxRM4FJHbfsGGDTnaK5KDIjUBEREQUCKiXIE9nMENuqWPHjgX6YxBRJjEoRUQUYLVr19Y5GdDsHCPqGcnP0XWPiIiIiIgoXDGnFBERERERERER+R1zShERERERERERkd8xKEVERERERERERH7HoBQREREREREREfkdg1JEREREREREROR3DEoREREREREREZHfMShFRERERERERER+x6AUERERERERERH5HYNSRERERERERETkdwxKERERERERERGR+Nv/A2bAyO0T5/26AAAAAElFTkSuQmCC",
-      "text/plain": [
-       "<Figure size 1200x500 with 2 Axes>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "execution_count": null,
+   "id": "358d8371",
+   "metadata": {},
+   "outputs": [],
    "source": [
-    "max_elev = base_df['Elevation'].max()\n",
-    "target_elev = max_elev + 5.0\n",
+    "# --- Figure: Before vs After depth-varying n and table extension ---\n",
+    "fig, axes = plt.subplots(1, 2, figsize=(13.5, 5.6), sharey=True, constrained_layout=True)\n",
     "\n",
-    "def extend_n_func(depth, base_n):\n",
-    "    \"\"\"Manning's n for extension rows (same exponential decay).\"\"\"\n",
-    "    if depth <= 0:\n",
-    "        return base_n\n",
-    "    return N_ASYMPTOTE + (base_n - N_ASYMPTOTE) * np.exp(-depth / DEPTH_HALF)\n",
-    "\n",
-    "rows_added = HdfMesh.extend_face_property_tables(\n",
-    "    hdf_path=modified_geom_hdf,\n",
-    "    mesh_name=MESH_NAME,\n",
-    "    extension_elevation=target_elev,\n",
-    "    mannings_n_func=extend_n_func,\n",
-    "    elevation_step=0.5,\n",
-    "    face_ids=None,\n",
-    "    pin_tables=True,\n",
+    "orig_max_elev = pre_sample['Elevation'].max()\n",
+    "set_portion = ext_sample[ext_sample['Elevation'] <= orig_max_elev + 0.01]\n",
+    "ext_portion = ext_sample[ext_sample['Elevation'] > orig_max_elev - 0.01]\n",
+    "roughness_xlim = (\n",
+    "    min(float(ext_sample[n_col].min()), N_ASYMPTOTE) - 0.001,\n",
+    "    max(float(original_n), float(ext_sample[n_col].max())) + 0.002,\n",
     ")\n",
     "\n",
-    "print(f\"Extended {len(rows_added)} faces, total rows added: {sum(rows_added.values())}\")\n",
-    "\n",
-    "ext_tables = HdfMesh.get_mesh_face_property_tables(modified_geom_hdf)\n",
-    "ext_df = ext_tables[MESH_NAME]\n",
-    "ext_sample = ext_df[ext_df['Face ID'] == sample_face]\n",
-    "\n",
-    "print(f\"Face {sample_face}: {len(after_sample)} rows -> {len(ext_sample)} rows\")\n",
-    "print(f\"Elevation range: {ext_sample['Elevation'].min():.2f} - {ext_sample['Elevation'].max():.2f} ft\")\n",
-    "\n",
-    "fig, axes = plt.subplots(1, 2, figsize=(12, 5), sharey=True)\n",
-    "\n",
     "ax = axes[0]\n",
-    "orig_max_elev = after_sample['Elevation'].max()\n",
-    "orig_portion = ext_sample[ext_sample['Elevation'] <= orig_max_elev + 0.01]\n",
-    "ext_portion = ext_sample[ext_sample['Elevation'] > orig_max_elev - 0.01]\n",
-    "\n",
-    "ax.plot(orig_portion[n_col], orig_portion['Elevation'], 'b-o', markersize=4,\n",
-    "        label='Depth-varying (preprocessed range)', linewidth=2)\n",
-    "ax.plot(ext_portion[n_col], ext_portion['Elevation'], 'r-s', markersize=3,\n",
-    "        label='Extended range', linewidth=2)\n",
-    "ax.axhline(y=orig_max_elev, color='gray', linestyle=':', alpha=0.7)\n",
-    "ax.axvline(x=N_ASYMPTOTE, color='orange', linestyle='--', alpha=0.5,\n",
-    "           label=f'Asymptote n={N_ASYMPTOTE}')\n",
+    "ax.plot(pre_sample[n_col], pre_sample['Elevation'], color='0.45', linestyle='--', marker='s',\n",
+    "        markersize=4, label=f'Original uniform n={original_n:.3f}', linewidth=1.6, alpha=0.85)\n",
+    "ax.plot(set_portion[n_col], set_portion['Elevation'], color='#1f77b4', marker='o',\n",
+    "        markersize=3.6, label='Existing rows after depth adjustment', linewidth=2.2)\n",
+    "ax.plot(ext_portion[n_col], ext_portion['Elevation'], color='#d62728', marker='^',\n",
+    "        markersize=3.2, label=f'Added extension rows ({len(ext_portion)})', linewidth=2.2)\n",
+    "ax.axhline(y=orig_max_elev, color='gray', linestyle=':', alpha=0.7,\n",
+    "           label='Original table top')\n",
+    "ax.axvline(x=N_ASYMPTOTE, color='orange', linestyle='--', alpha=0.55,\n",
+    "           label=f'Asymptote n={N_ASYMPTOTE:.3f}')\n",
+    "ax.set_xlim(*roughness_xlim)\n",
     "ax.set_xlabel(\"Manning's n\", fontsize=12)\n",
-    "ax.set_ylabel('Elevation (ft)', fontsize=12)\n",
-    "ax.set_title(f\"Face {sample_face}: Manning's n\", fontsize=13)\n",
-    "ax.legend(fontsize=9)\n",
+    "ax.set_ylabel('Elevation (ft NAVD88)', fontsize=12)\n",
+    "ax.set_title(f\"Face {sample_face}: Roughness Table\\nMagnified Manning's n Scale\", fontsize=13)\n",
+    "ax.text(\n",
+    "    0.04, 0.06,\n",
+    "    f\"n range after edit: {ext_sample[n_col].min():.4f}-{ext_sample[n_col].max():.4f}\\n\"\n",
+    "    f\"rows: {len(pre_sample)} -> {len(ext_sample)}\",\n",
+    "    transform=ax.transAxes,\n",
+    "    fontsize=9,\n",
+    "    bbox=dict(boxstyle='round,pad=0.3', facecolor='white', edgecolor='0.75', alpha=0.92),\n",
+    ")\n",
+    "ax.legend(fontsize=8.2, loc='upper right')\n",
     "ax.grid(True, alpha=0.3)\n",
     "\n",
     "ax = axes[1]\n",
-    "ax.plot(orig_portion['Area'], orig_portion['Elevation'], 'b-o', markersize=4,\n",
-    "        label='Preprocessed', linewidth=2)\n",
-    "ax.plot(ext_portion['Area'], ext_portion['Elevation'], 'r-s', markersize=3,\n",
-    "        label='Extended (rectangular)', linewidth=2)\n",
+    "ax.plot(pre_sample['Area'], pre_sample['Elevation'], color='0.35', linestyle='--', marker='s',\n",
+    "        markersize=4, label='Original area', linewidth=1.6)\n",
+    "ax.plot(set_portion['Area'], set_portion['Elevation'], color='#1f77b4', marker='o',\n",
+    "        markersize=4, label='Existing table area', linewidth=2)\n",
+    "ax.plot(ext_portion['Area'], ext_portion['Elevation'], color='#d62728', marker='^',\n",
+    "        markersize=3, label='Extended area', linewidth=2)\n",
     "ax.axhline(y=orig_max_elev, color='gray', linestyle=':', alpha=0.7,\n",
-    "           label=f'Original max elev')\n",
-    "ax.set_xlabel('Area (sq ft)', fontsize=12)\n",
-    "ax.set_title(f'Face {sample_face}: Flow Area', fontsize=13)\n",
-    "ax.legend(fontsize=9)\n",
+    "           label='Original table top')\n",
+    "ax.set_xlabel('Flow Area (sq ft)', fontsize=12)\n",
+    "ax.set_title(f'Face {sample_face}: Area-Elevation Table', fontsize=13)\n",
+    "ax.legend(fontsize=8.5, loc='upper left')\n",
     "ax.grid(True, alpha=0.3)\n",
     "\n",
-    "fig.suptitle('Face Property Table: Depth-Varying + Extended', fontsize=14, y=1.02)\n",
-    "fig.tight_layout()\n",
-    "plt.show()"
+    "fig.suptitle('Face Property Table Before and After Full-Mesh Depth-Varying n', fontsize=14)\n",
+    "plt.show()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "14bcbd8a",
+   "metadata": {},
+   "source": [
+    "## Step 7: Run the Modified Linux Solver from the Edited `.tmp.hdf`\n",
+    "\n",
+    "The Windows solver rebuilds face-property tables at startup, so this notebook does\n",
+    "not call `compute_plan()` after the HDF edits. The modified `.tmp.hdf` is passed\n",
+    "directly to the Linux `RasUnsteady` binary through `RasCmdr.compute_plan_linux()`.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5890bac1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "modified_ras = init_ras_project(modified_path, RAS_VERSION, ras_object=\"new\")\n",
+    "pre_solver_tmp_df = HdfMesh.get_mesh_face_property_tables(modified_tmp_hdf)[MESH_NAME]\n",
+    "pre_solver_sample = pre_solver_tmp_df[pre_solver_tmp_df['Face ID'] == sample_face].copy()\n",
+    "assert len(pre_solver_sample) == len(ext_sample), \"Pre-solver .tmp.hdf should contain extended rows\"\n",
+    "assert pre_solver_sample['Elevation'].max() >= target_elev - ELEVATION_STEP - 0.01\n",
+    "assert pre_solver_sample[n_col].min() < original_n - 0.001, \"Pre-solver .tmp.hdf should contain depth-varying n\"\n",
+    "\n",
+    "print(\"Running modified model with native Linux RasUnsteady from the edited .tmp.hdf...\")\n",
+    "modified_result = RasCmdr.compute_plan_linux(\n",
+    "    PLAN_NUMBER,\n",
+    "    ras_exe_dir=RAS_LINUX_EXE_DIR,\n",
+    "    ras_object=modified_ras,\n",
+    "    timeout_sec=7200,\n",
+    "    num_cores=2,\n",
+    "    retry=False,\n",
+    ")\n",
+    "assert modified_result.success, \"Modified Linux solver run failed\"\n",
+    "modified_ras = init_ras_project(modified_path, RAS_VERSION, ras_object=\"new\")\n",
+    "mod_hdf_path = Path(modified_ras.plan_df.loc[\n",
+    "    modified_ras.plan_df['plan_number'] == PLAN_NUMBER, 'HDF_Results_Path'\n",
+    "].iloc[0])\n",
+    "\n",
+    "modified_messages = read_linux_compute_log(modified_path, PLAN_NUMBER)\n",
+    "modified_errors = blocking_compute_errors(modified_messages)\n",
+    "print(f\"Modified Linux compute log: {len(modified_messages.splitlines()) if modified_messages else 0} lines, \"\n",
+    "      f\"{len(modified_errors)} blocking errors\")\n",
+    "assert not modified_errors, \"Modified compute produced blocking errors\"\n",
+    "assert \"Finished Unsteady Flow Simulation\" in modified_messages, \"Modified Linux solver did not report completion\"\n",
+    "print(\"Modified Linux solver run completed without blocking compute errors\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "17930ccc",
+   "metadata": {},
+   "source": [
+    "## Step 8: Verify Output HDF Tables Persist and Compare Results\n",
+    "\n",
+    "After the Linux solver completes, the `.tmp.hdf` has been renamed to the plan\n",
+    "output HDF. The assertions below confirm the depth-varying/extended face-property\n",
+    "tables were not reverted to uniform `0.06`, then compare baseline and modified\n",
+    "maximum water-surface elevation and depth products.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7b7540be",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from matplotlib.colors import TwoSlopeNorm\n",
+    "\n",
+    "# Step 8 proof: the solver-facing output HDF still contains the edited tables.\n",
+    "post_run_tables = HdfMesh.get_mesh_face_property_tables(mod_hdf_path)\n",
+    "post_run_df = post_run_tables[MESH_NAME]\n",
+    "post_run_sample = post_run_df[post_run_df['Face ID'] == sample_face].copy()\n",
+    "\n",
+    "assert len(post_run_sample) == len(ext_sample), \"Output HDF should preserve extended face table rows\"\n",
+    "assert post_run_sample['Elevation'].max() >= target_elev - ELEVATION_STEP - 0.01\n",
+    "np.testing.assert_allclose(\n",
+    "    post_run_sample[n_col].to_numpy(),\n",
+    "    ext_sample[n_col].to_numpy(),\n",
+    "    rtol=1e-5,\n",
+    "    atol=1e-6,\n",
+    ")\n",
+    "assert post_run_df[n_col].round(6).nunique() > 1, \"Output HDF n values should not be uniform\"\n",
+    "assert post_run_df[n_col].min() < original_n - 0.001, \"Output HDF should contain depth-varying n values\"\n",
+    "print(\n",
+    "    \"Output HDF face tables persisted: \"\n",
+    "    f\"{post_run_df['Face ID'].nunique():,} faces, {len(post_run_df):,} rows, \"\n",
+    "    f\"n range {post_run_df[n_col].min():.4f}-{post_run_df[n_col].max():.4f}\"\n",
+    ")\n",
+    "\n",
+    "base_wse_gdf = HdfResultsMesh.get_mesh_max_ws(base_hdf_path)\n",
+    "mod_wse_gdf = HdfResultsMesh.get_mesh_max_ws(mod_hdf_path)\n",
+    "\n",
+    "wse_col = next(\n",
+    "    c for c in base_wse_gdf.columns\n",
+    "    if c == 'maximum_water_surface' or 'water_surface' in c.lower() or 'water surface' in c.lower()\n",
+    ")\n",
+    "topology = HdfMesh.get_mesh_sloped_topology(base_hdf_path, MESH_NAME)\n",
+    "assert topology and 'cell_min_elev' in topology, 'Expected mesh cell terrain elevations in the plan HDF'\n",
+    "ground_df = pd.DataFrame({\n",
+    "    'cell_id': np.arange(len(topology['cell_min_elev'])),\n",
+    "    'cell_min_elev': topology['cell_min_elev'].astype(float),\n",
+    "})\n",
+    "\n",
+    "base_wse = base_wse_gdf[base_wse_gdf['mesh_name'] == MESH_NAME][['cell_id', wse_col, 'geometry']].copy()\n",
+    "mod_wse = mod_wse_gdf[mod_wse_gdf['mesh_name'] == MESH_NAME][['cell_id', wse_col]].copy()\n",
+    "\n",
+    "map_df = (\n",
+    "    base_wse\n",
+    "    .rename(columns={wse_col: 'baseline_wse'})\n",
+    "    .merge(mod_wse.rename(columns={wse_col: 'modified_wse'}), on='cell_id')\n",
+    "    .merge(ground_df, on='cell_id')\n",
+    ")\n",
+    "map_df['baseline_depth'] = (map_df['baseline_wse'] - map_df['cell_min_elev']).clip(lower=0)\n",
+    "map_df['modified_depth'] = (map_df['modified_wse'] - map_df['cell_min_elev']).clip(lower=0)\n",
+    "map_df['delta_wse'] = map_df['modified_wse'] - map_df['baseline_wse']\n",
+    "map_df['delta_depth'] = map_df['modified_depth'] - map_df['baseline_depth']\n",
+    "valid = (\n",
+    "    np.isfinite(map_df['delta_wse'])\n",
+    "    & np.isfinite(map_df['delta_depth'])\n",
+    "    & (map_df['baseline_wse'] > -100)\n",
+    "    & (map_df['modified_wse'] > -100)\n",
+    ")\n",
+    "map_df = map_df[valid].copy()\n",
+    "\n",
+    "print(f\"Wet cells compared: {len(map_df)}\")\n",
+    "print(f\"Mean delta WSE:     {map_df['delta_wse'].mean():+.4f} ft\")\n",
+    "print(f\"Max delta WSE:      {map_df['delta_wse'].max():+.4f} ft\")\n",
+    "print(f\"Min delta WSE:      {map_df['delta_wse'].min():+.4f} ft\")\n",
+    "print(f\"Mean delta depth:   {map_df['delta_depth'].mean():+.4f} ft\")\n",
+    "\n",
+    "n_changed = int((map_df['delta_wse'].abs() > 0.001).sum())\n",
+    "print(f\"Cells with |delta WSE| > 0.001 ft: {n_changed}/{len(map_df)} ({100*n_changed/max(len(map_df),1):.1f}%)\")\n",
+    "assert n_changed > 0, \"Expected WSE changes from depth-varying Manning's n\"\n",
+    "\n",
+    "wse_abs = max(abs(float(map_df['delta_wse'].min())), abs(float(map_df['delta_wse'].max())), 0.01)\n",
+    "depth_abs = max(abs(float(map_df['delta_depth'].min())), abs(float(map_df['delta_depth'].max())), 0.01)\n",
+    "\n",
+    "fig, axes = plt.subplots(1, 2, figsize=(14, 6.5), constrained_layout=True)\n",
+    "for ax, column, title, label, abs_range in [\n",
+    "    (axes[0], 'delta_wse', 'Maximum WSE Difference', 'Modified - Baseline WSE (ft)', wse_abs),\n",
+    "    (axes[1], 'delta_depth', 'Maximum Depth Difference', 'Modified - Baseline Depth (ft)', depth_abs),\n",
+    "]:\n",
+    "    map_df.plot(\n",
+    "        column=column,\n",
+    "        ax=ax,\n",
+    "        cmap='RdBu_r',\n",
+    "        marker='s',\n",
+    "        markersize=2.6,\n",
+    "        legend=True,\n",
+    "        norm=TwoSlopeNorm(vcenter=0, vmin=-abs_range, vmax=abs_range),\n",
+    "        legend_kwds={'label': label, 'shrink': 0.74},\n",
+    "    )\n",
+    "    ax.set_title(title, fontsize=13)\n",
+    "    ax.set_xlabel('Easting (ft)', fontsize=11)\n",
+    "    ax.set_ylabel('Northing (ft)', fontsize=11)\n",
+    "    ax.set_aspect('equal')\n",
+    "    ax.grid(True, alpha=0.18)\n",
+    "    ax.annotate('N', xy=(0.94, 0.88), xytext=(0.94, 0.74),\n",
+    "                xycoords='axes fraction', textcoords='axes fraction',\n",
+    "                ha='center', va='center', fontsize=11, fontweight='bold',\n",
+    "                arrowprops=dict(arrowstyle='-|>', color='black', lw=1.25))\n",
+    "    xmin, xmax = ax.get_xlim()\n",
+    "    ymin, ymax = ax.get_ylim()\n",
+    "    scale_len = 5000\n",
+    "    x0 = xmin + 0.06 * (xmax - xmin)\n",
+    "    y0 = ymin + 0.06 * (ymax - ymin)\n",
+    "    ax.plot([x0, x0 + scale_len], [y0, y0], color='black', linewidth=2)\n",
+    "    ax.text(x0 + scale_len / 2, y0 + 0.02 * (ymax - ymin), f'{scale_len:,.0f} ft',\n",
+    "            ha='center', va='bottom', fontsize=9)\n",
+    "\n",
+    "fig.suptitle(\"Muncie Stored HDF Result Comparison: Depth-Varying Manning\\'s n minus Baseline\", fontsize=14)\n",
+    "plt.show()\n"
    ]
   },
   {
@@ -2130,57 +876,424 @@
     "tags": []
    },
    "source": [
-    "## Step 7: Limiting Modifications to an Override Region\n",
+    "## Step 9: Polygon Mask API — Selective Face Application\n",
     "\n",
-    "In practice, depth-varying Manning's n is most meaningful in the **channel** â€”\n",
-    "overbank areas may have vegetation or land cover that already captures the\n",
-    "roughness variation you care about. The API supports three spatial filtering\n",
-    "strategies, listed in precedence order:\n",
+    "The primary example applied depth-varying n to the entire mesh. In production\n",
+    "calibration, you may want to apply depth-varying n **only to channel faces** and\n",
+    "leave overbank roughness unchanged. `HdfMesh.extend_face_property_tables()` and\n",
+    "`set_face_mannings_n_values()` accept optional `polygon` or `region_name`\n",
+    "parameters for this spatial filtering.\n",
     "\n",
-    "| Parameter | Source | Use Case |\n",
-    "|-----------|--------|----------|\n",
-    "| `face_ids` | Pre-computed list of face IDs | Full control â€” any selection logic |\n",
-    "| `region_name` | Named calibration region in the geometry HDF | Drawn in RASMapper; recommended for repeatable workflows |\n",
-    "| `polygon` | Any Shapely polygon | Programmatic selection from external GIS data, bank lines, or classification results |\n",
+    "**Precedence**: `face_ids` > `region_name` > `polygon` > None (all faces)\n",
     "\n",
-    "When any of these parameters is passed to `extend_face_property_tables()` or\n",
-    "`set_face_mannings_n_values()`, only the matching faces are modified â€” all\n",
-    "other faces retain their original property tables.\n",
+    "### Channel Polygon Strategies\n",
     "\n",
-    "### Calibration Regions (Recommended)\n",
+    "There are several ways to identify which faces are \"in the channel\":\n",
     "\n",
-    "The simplest approach is to draw a **calibration region** in RASMapper that\n",
-    "covers the channel corridor, then reference it by name:\n",
+    "1. **Calibration Regions** (recommended) — draw a region in RASMapper GUI,\n",
+    "   reference by name via `get_face_ids_in_calibration_region()`\n",
+    "2. **Fluvial/Pluvial Classification** — use `HdfFluvialPluvial` to identify\n",
+    "   fluvial cells from simulation results, then extract the fluvial polygon\n",
+    "3. **Bank Lines** — use `HdfXsec.get_river_bank_lines()` from the geometry\n",
+    "   HDF to construct a channel polygon between left and right banks\n",
+    "4. **External regulatory or GIS polygons** — NFHL floodways, surveyed channel\n",
+    "   polygons, or locally maintained calibration regions\n",
     "\n",
-    "```python\n",
-    "HdfMesh.extend_face_property_tables(\n",
-    "    hdf_path=geom_hdf,\n",
-    "    mesh_name=\"Your 2D Area\",\n",
-    "    extension_elevation=960.0,\n",
-    "    mannings_n_func=my_n_func,\n",
-    "    region_name=\"Main Channel\",   # drawn in RASMapper\n",
+    "We demonstrate the first three strategies below using the Muncie model.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "69c3db76",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-12T12:23:56.515867Z",
+     "iopub.status.busy": "2026-05-12T12:23:56.515468Z",
+     "iopub.status.idle": "2026-05-12T12:23:57.908331Z",
+     "shell.execute_reply": "2026-05-12T12:23:57.907311Z"
+    },
+    "papermill": {
+     "duration": 1.410163,
+     "end_time": "2026-05-12T12:23:57.909117+00:00",
+     "exception": false,
+     "start_time": "2026-05-12T12:23:56.498954+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# --- Strategy A: RASMapper Manning's n calibration region ---\n",
+    "calibration_geom_hdf = baseline_path / f\"{baseline_ras.project_name}.g{CALIBRATION_GEOM_NUMBER}.hdf\"\n",
+    "calibration_regions = HdfLandCover.get_mannings_region_polygons(calibration_geom_hdf)\n",
+    "assert not calibration_regions.empty, \"Expected Muncie g04 to include a RASMapper calibration region\"\n",
+    "\n",
+    "region_names = calibration_regions['Name'].tolist()\n",
+    "assert CALIBRATION_REGION_NAME in region_names, f\"Expected {CALIBRATION_REGION_NAME!r}; available: {region_names}\"\n",
+    "calibration_polygon = calibration_regions.loc[\n",
+    "    calibration_regions['Name'] == CALIBRATION_REGION_NAME, 'geometry'\n",
+    "].iloc[0]\n",
+    "calibration_face_ids = HdfMesh.get_face_ids_in_calibration_region(\n",
+    "    calibration_geom_hdf, MESH_NAME, CALIBRATION_REGION_NAME, method='midpoint'\n",
+    ")\n",
+    "print(f\"Calibration region '{CALIBRATION_REGION_NAME}': {len(calibration_face_ids)} faces\")\n",
+    "assert calibration_face_ids, \"Calibration region should select mesh faces\"\n",
+    "\n",
+    "# --- Strategy B: Fluvial/Pluvial Classification ---\n",
+    "# Run the baseline model first (already done above), then classify cells.\n",
+    "print(\"Generating fluvial/pluvial classification...\")\n",
+    "with contextlib.redirect_stderr(io.StringIO()):\n",
+    "    fp_gdf = HdfFluvialPluvial.generate_fluvial_pluvial_polygons(base_hdf_path)\n",
+    "assert not fp_gdf.empty, \"Expected fluvial/pluvial polygons\"\n",
+    "\n",
+    "print(\"\\nClassification results:\")\n",
+    "for _, row in fp_gdf.iterrows():\n",
+    "    area_acres = row.geometry.area / 43560\n",
+    "    print(f\"  {row['classification']}: {area_acres:.1f} acres\")\n",
+    "\n",
+    "# Extract the fluvial polygon (river corridor)\n",
+    "fluvial_mask = fp_gdf[fp_gdf['classification'] == 'fluvial']\n",
+    "assert not fluvial_mask.empty, \"Expected a fluvial polygon for Muncie\"\n",
+    "fluvial_polygon = fluvial_mask.geometry.iloc[0]\n",
+    "fluvial_acres = fluvial_polygon.area / 43560\n",
+    "print(f\"\\nFluvial polygon: {fluvial_acres:.0f} acres\")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ce4b06b1",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-12T12:23:57.934258Z",
+     "iopub.status.busy": "2026-05-12T12:23:57.934069Z",
+     "iopub.status.idle": "2026-05-12T12:23:58.671600Z",
+     "shell.execute_reply": "2026-05-12T12:23:58.670616Z"
+    },
+    "papermill": {
+     "duration": 0.751381,
+     "end_time": "2026-05-12T12:23:58.672325+00:00",
+     "exception": false,
+     "start_time": "2026-05-12T12:23:57.920944+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# --- Strategy C: Bank Lines from 1D Geometry ---\n",
+    "bank_lines = HdfXsec.get_river_bank_lines(baseline_geom_hdf)\n",
+    "assert bank_lines is not None and not bank_lines.empty, \"Expected bank lines in Muncie geometry\"\n",
+    "print(f\"Bank lines found: {len(bank_lines)} lines\")\n",
+    "for _, row in bank_lines.iterrows():\n",
+    "    length_ft = row.geometry.length\n",
+    "    print(f\"  {row.get('Name', 'bank')}: {length_ft:,.0f} ft ({length_ft/5280:.2f} mi)\")\n",
+    "\n",
+    "# --- Get face IDs within the fluvial polygon ---\n",
+    "faces_gdf = HdfMesh.get_mesh_cell_faces(baseline_geom_hdf)\n",
+    "faces_gdf = faces_gdf[faces_gdf['mesh_name'] == MESH_NAME].copy()\n",
+    "\n",
+    "channel_face_ids = HdfMesh.get_face_ids_in_polygon(\n",
+    "    baseline_geom_hdf, MESH_NAME, fluvial_polygon, method='midpoint'\n",
+    ")\n",
+    "total_faces = base_df['Face ID'].nunique()\n",
+    "print(f\"\\nChannel faces (fluvial polygon): {len(channel_face_ids)} / {total_faces} \"\n",
+    "      f\"({100*len(channel_face_ids)/total_faces:.1f}%)\")\n",
+    "assert 0 < len(channel_face_ids) < total_faces, \"Channel polygon should select a subset of faces\"\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3a37d37f",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-12T12:23:58.699897Z",
+     "iopub.status.busy": "2026-05-12T12:23:58.699708Z",
+     "iopub.status.idle": "2026-05-12T12:23:58.807525Z",
+     "shell.execute_reply": "2026-05-12T12:23:58.806748Z"
+    },
+    "papermill": {
+     "duration": 0.122598,
+     "end_time": "2026-05-12T12:23:58.808384+00:00",
+     "exception": false,
+     "start_time": "2026-05-12T12:23:58.685786+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "\n",
+    "# --- Figure: Channel polygon, calibration region, and modified face locations ---\n",
+    "import matplotlib.patches as mpatches\n",
+    "from matplotlib.collections import PatchCollection\n",
+    "from matplotlib.patches import Polygon as MplPolygon\n",
+    "from shapely.geometry import Polygon, MultiPolygon\n",
+    "\n",
+    "fig, ax = plt.subplots(figsize=(11, 7))\n",
+    "\n",
+    "def polygon_patches(geom):\n",
+    "    geoms = list(geom.geoms) if isinstance(geom, MultiPolygon) else [geom]\n",
+    "    patches = []\n",
+    "    for part in geoms:\n",
+    "        if isinstance(part, Polygon):\n",
+    "            coords = np.array(part.exterior.coords)\n",
+    "            patches.append(MplPolygon(coords[:, :2], closed=True))\n",
+    "    return patches\n",
+    "\n",
+    "# Base mesh context and modified faces.\n",
+    "faces_gdf.plot(ax=ax, color='0.80', linewidth=0.15, alpha=0.35, label='Mesh faces')\n",
+    "channel_faces_gdf = faces_gdf[faces_gdf['face_id'].isin(channel_face_ids)]\n",
+    "channel_faces_gdf.plot(ax=ax, color='#d95f02', linewidth=0.35, alpha=0.85, label='Modified channel faces')\n",
+    "\n",
+    "fluvial_patches = polygon_patches(fluvial_polygon)\n",
+    "ax.add_collection(PatchCollection(\n",
+    "    fluvial_patches, alpha=0.22, facecolor='steelblue', edgecolor='navy', linewidth=1.4,\n",
+    "))\n",
+    "\n",
+    "calibration_patches = polygon_patches(calibration_polygon)\n",
+    "ax.add_collection(PatchCollection(\n",
+    "    calibration_patches, alpha=0.16, facecolor='none', edgecolor='#1b9e77',\n",
+    "    linewidth=2.0, linestyle='--',\n",
+    "))\n",
+    "\n",
+    "for _, row in bank_lines.iterrows():\n",
+    "    coords = np.array(row.geometry.coords)\n",
+    "    ax.plot(coords[:, 0], coords[:, 1], color='black', linewidth=1.3, alpha=0.85)\n",
+    "\n",
+    "legend_elements = [\n",
+    "    mpatches.Patch(facecolor='0.80', edgecolor='0.80', alpha=0.35, label='Mesh faces'),\n",
+    "    mpatches.Patch(facecolor='#d95f02', edgecolor='#d95f02', alpha=0.85,\n",
+    "                   label=f'Modified channel faces ({len(channel_face_ids):,})'),\n",
+    "    mpatches.Patch(facecolor='steelblue', edgecolor='navy', alpha=0.22,\n",
+    "                   label=f'Fluvial zone ({fluvial_acres:.0f} ac)'),\n",
+    "    mpatches.Patch(facecolor='none', edgecolor='#1b9e77', linestyle='--', linewidth=2,\n",
+    "                   label=f'Calibration region: {CALIBRATION_REGION_NAME}'),\n",
+    "]\n",
+    "from matplotlib.lines import Line2D\n",
+    "legend_elements.append(Line2D([0], [0], color='black', linewidth=1.3, label='Bank lines'))\n",
+    "ax.legend(handles=legend_elements, fontsize=9, loc='upper left')\n",
+    "\n",
+    "ax.set_xlabel('Easting (ft)', fontsize=11)\n",
+    "ax.set_ylabel('Northing (ft)', fontsize=11)\n",
+    "ax.set_title('Muncie Channel Delineation and Polygon Mask Face Selection', fontsize=13)\n",
+    "ax.set_aspect('equal')\n",
+    "ax.grid(True, alpha=0.2)\n",
+    "\n",
+    "# North arrow and 5,000 ft scale bar.\n",
+    "ax.annotate('N', xy=(0.95, 0.88), xytext=(0.95, 0.73),\n",
+    "            xycoords='axes fraction', textcoords='axes fraction',\n",
+    "            ha='center', va='center', fontsize=12, fontweight='bold',\n",
+    "            arrowprops=dict(arrowstyle='-|>', color='black', lw=1.4))\n",
+    "xmin, xmax = ax.get_xlim()\n",
+    "ymin, ymax = ax.get_ylim()\n",
+    "scale_len = 5000\n",
+    "x0 = xmin + 0.06 * (xmax - xmin)\n",
+    "y0 = ymin + 0.06 * (ymax - ymin)\n",
+    "ax.plot([x0, x0 + scale_len], [y0, y0], color='black', linewidth=2)\n",
+    "ax.text(x0 + scale_len / 2, y0 + 0.02 * (ymax - ymin), f'{scale_len:,.0f} ft',\n",
+    "        ha='center', va='bottom', fontsize=9)\n",
+    "\n",
+    "fig.tight_layout()\n",
+    "plt.show()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f878b72c",
+   "metadata": {
+    "papermill": {
+     "duration": 0.012882,
+     "end_time": "2026-05-12T12:23:58.834305+00:00",
+     "exception": false,
+     "start_time": "2026-05-12T12:23:58.821423+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Step 10: Apply Depth-Varying n to Channel Faces Only\n",
+    "\n",
+    "This secondary example demonstrates the polygon mask API on a fresh project copy:\n",
+    "face property tables are extended with depth-varying Manning's n **only for\n",
+    "channel faces** identified by the fluvial polygon. Overbank faces retain their\n",
+    "original uniform roughness.\n",
+    "\n",
+    "This uses the `polygon` parameter on `extend_face_property_tables()`:\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d10a821f",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-12T12:23:58.862152Z",
+     "iopub.status.busy": "2026-05-12T12:23:58.861900Z",
+     "iopub.status.idle": "2026-05-12T12:24:37.830157Z",
+     "shell.execute_reply": "2026-05-12T12:24:37.829278Z"
+    },
+    "papermill": {
+     "duration": 38.983645,
+     "end_time": "2026-05-12T12:24:37.830862+00:00",
+     "exception": false,
+     "start_time": "2026-05-12T12:23:58.847217+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# Re-extract a fresh modified project for the selective demo.\n",
+    "selective_path = RasExamples.extract_project(\n",
+    "    PROJECT_NAME, output_path=PROJECT_DIR, suffix=\"414_selective\"\n",
+    ")\n",
+    "selective_ras = init_ras_project(selective_path, RAS_VERSION, ras_object=\"new\")\n",
+    "\n",
+    "# Preprocess only; then edit the selective .tmp.hdf without running the solver.\n",
+    "print(\"Preprocessing selective model to create a fresh .tmp.hdf...\")\n",
+    "selective_preprocess = RasPreprocess.preprocess_plan(\n",
+    "    PLAN_NUMBER,\n",
+    "    ras_object=selective_ras,\n",
+    "    max_wait=300,\n",
+    "    clear_existing=True,\n",
+    ")\n",
+    "assert selective_preprocess.success, selective_preprocess.error\n",
+    "selective_tmp_hdf = Path(selective_preprocess.tmp_hdf_path)\n",
+    "assert selective_tmp_hdf.exists(), f\"Missing selective tmp HDF: {selective_tmp_hdf}\"\n",
+    "\n",
+    "# Read original tables for comparison.\n",
+    "before_tables = HdfMesh.get_mesh_face_property_tables(selective_tmp_hdf)\n",
+    "before_df = before_tables[MESH_NAME]\n",
+    "\n",
+    "# Extend ONLY channel faces with depth-varying n.\n",
+    "rows_added = HdfMesh.extend_face_property_tables(\n",
+    "    hdf_path=selective_tmp_hdf,\n",
+    "    mesh_name=MESH_NAME,\n",
+    "    extension_elevation=target_elev,\n",
+    "    mannings_n_func=extend_n_func,\n",
+    "    elevation_step=0.5,\n",
+    "    polygon=fluvial_polygon,   # Spatial filter from the polygon mask API.\n",
     "    pin_tables=True,\n",
     ")\n",
-    "```\n",
     "\n",
-    "This is preferred because the region persists in the geometry file, is visible\n",
-    "in the GUI, and doesn't depend on simulation results.\n",
+    "print(f\"\\nExtended {len(rows_added)} channel faces (of {before_df['Face ID'].nunique()} total)\")\n",
+    "print(f\"Total rows added: {sum(rows_added.values())}\")\n",
+    "assert rows_added, \"Expected channel faces to be extended\"\n",
+    "assert set(rows_added).issubset(set(channel_face_ids)), \"Extended faces should come from polygon mask\"\n",
     "\n",
-    "### Other Channel Delineation Approaches\n",
+    "# Read back to verify.\n",
+    "after_selective = HdfMesh.get_mesh_face_property_tables(selective_tmp_hdf)\n",
+    "after_sel_df = after_selective[MESH_NAME]\n",
     "\n",
-    "For models where a calibration region isn't already defined, the channel\n",
-    "polygon can be derived programmatically:\n",
+    "# Compare row counts: channel faces should have more rows, overbank unchanged.\n",
+    "channel_set = set(rows_added.keys())\n",
+    "overbank_set = set(before_df['Face ID'].unique()) - channel_set\n",
+    "assert overbank_set, \"Expected overbank faces to remain unmodified\"\n",
     "\n",
-    "- **Bank lines** â€” `HdfXsec.get_river_bank_lines()` extracts 1D bank line\n",
-    "  geometry from the HDF, which can be buffered or connected into a channel polygon.\n",
-    "- **External GIS** â€” FEMA NFHL floodway boundaries, NHD flowlines, or any\n",
-    "  shapefile/GeoJSON polygon can be loaded with GeoPandas and passed as the\n",
-    "  `polygon` parameter.\n",
+    "# Pick representative channel/overbank faces with the richest available tables.\n",
+    "channel_face_example = int(pd.Series(rows_added).sort_values(ascending=False).index[0])\n",
+    "overbank_counts = before_df[before_df['Face ID'].isin(overbank_set)].groupby('Face ID').size()\n",
+    "overbank_face_example = int(overbank_counts.sort_values(ascending=False).index[0])\n",
     "\n",
-    "The Muncie example project is too small to meaningfully demonstrate selective\n",
-    "application â€” the channel dominates the domain, so nearly all faces would be\n",
-    "selected. In a real project with a large overbank area, the difference between\n",
-    "channel-only and full-mesh modification would be significant."
+    "ch_before = before_df[before_df['Face ID'] == channel_face_example]\n",
+    "ch_after = after_sel_df[after_sel_df['Face ID'] == channel_face_example]\n",
+    "print(f\"\\nChannel face {channel_face_example}: {len(ch_before)} -> {len(ch_after)} rows\")\n",
+    "assert len(ch_after) > len(ch_before), \"Channel face should be extended\"\n",
+    "\n",
+    "ob_before = before_df[before_df['Face ID'] == overbank_face_example]\n",
+    "ob_after = after_sel_df[after_sel_df['Face ID'] == overbank_face_example]\n",
+    "print(f\"Overbank face {overbank_face_example}: {len(ob_before)} -> {len(ob_after)} rows (unchanged)\")\n",
+    "assert len(ob_after) == len(ob_before), \"Overbank face should remain unchanged\"\n",
+    "assert np.allclose(ob_after[n_col].to_numpy(), ob_before[n_col].to_numpy())\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "324aa933",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-12T12:24:37.864203Z",
+     "iopub.status.busy": "2026-05-12T12:24:37.863977Z",
+     "iopub.status.idle": "2026-05-12T12:24:38.050596Z",
+     "shell.execute_reply": "2026-05-12T12:24:38.049906Z"
+    },
+    "papermill": {
+     "duration": 0.20531,
+     "end_time": "2026-05-12T12:24:38.051577+00:00",
+     "exception": false,
+     "start_time": "2026-05-12T12:24:37.846267+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "\n",
+    "# --- Figure: Channel face (extended) vs Overbank face (unchanged) ---\n",
+    "fig, axes = plt.subplots(1, 2, figsize=(13.5, 5.4), sharey=True, constrained_layout=True)\n",
+    "selective_xlim = (\n",
+    "    min(float(ch_after[n_col].min()), float(ob_after[n_col].min()), N_ASYMPTOTE) - 0.001,\n",
+    "    max(float(ch_after[n_col].max()), float(ob_after[n_col].max()), original_n) + 0.002,\n",
+    ")\n",
+    "\n",
+    "# Channel face: extended with depth-varying n.\n",
+    "ax = axes[0]\n",
+    "ch_orig_max = ch_before['Elevation'].max()\n",
+    "ch_orig = ch_after[ch_after['Elevation'] <= ch_orig_max + 0.01]\n",
+    "ch_ext = ch_after[ch_after['Elevation'] > ch_orig_max - 0.01]\n",
+    "\n",
+    "ax.plot(ch_before[n_col], ch_before['Elevation'], color='0.45', linestyle='--', marker='s',\n",
+    "        markersize=4, label='Before polygon edit', linewidth=1.6, alpha=0.85)\n",
+    "ax.plot(ch_orig[n_col], ch_orig['Elevation'], color='#1f77b4', marker='o', markersize=3.7,\n",
+    "        label='Channel rows after edit', linewidth=2.1)\n",
+    "ax.plot(ch_ext[n_col], ch_ext['Elevation'], color='#d62728', marker='^', markersize=3.2,\n",
+    "        label=f'Added channel rows ({len(ch_ext)})', linewidth=2.1)\n",
+    "ax.axhline(y=ch_orig_max, color='gray', linestyle=':', alpha=0.6, label='Original table top')\n",
+    "ax.axvline(x=N_ASYMPTOTE, color='orange', linestyle='--', alpha=0.45, label=f'Asymptote n={N_ASYMPTOTE:.3f}')\n",
+    "ax.set_xlim(*selective_xlim)\n",
+    "ax.set_xlabel(\"Manning's n\", fontsize=12)\n",
+    "ax.set_ylabel('Elevation (ft NAVD88)', fontsize=12)\n",
+    "ax.set_title(f'Channel Face {channel_face_example}\\n(Extended)', fontsize=12)\n",
+    "ax.text(\n",
+    "    0.04, 0.06,\n",
+    "    f\"rows: {len(ch_before)} -> {len(ch_after)}\\n\"\n",
+    "    f\"n range: {ch_after[n_col].min():.4f}-{ch_after[n_col].max():.4f}\",\n",
+    "    transform=ax.transAxes,\n",
+    "    fontsize=9,\n",
+    "    bbox=dict(boxstyle='round,pad=0.3', facecolor='white', edgecolor='0.75', alpha=0.92),\n",
+    ")\n",
+    "ax.legend(fontsize=8.1, loc='upper right')\n",
+    "ax.grid(True, alpha=0.3)\n",
+    "\n",
+    "# Overbank face: unchanged.\n",
+    "ax = axes[1]\n",
+    "ob_data = ob_after\n",
+    "ax.plot(ob_before[n_col], ob_before['Elevation'], color='0.45', linestyle='--', marker='s',\n",
+    "        markersize=4, label='Before polygon edit', linewidth=1.6, alpha=0.85)\n",
+    "ax.plot(ob_data[n_col], ob_data['Elevation'], color='#1f77b4', marker='o', markersize=3.7,\n",
+    "        label='After edit (unchanged)', linewidth=2.1)\n",
+    "ax.set_xlim(*selective_xlim)\n",
+    "ax.set_xlabel(\"Manning's n\", fontsize=12)\n",
+    "ax.set_ylabel('Elevation (ft NAVD88)', fontsize=12)\n",
+    "ax.set_title(f'Overbank Face {overbank_face_example}\\n(Not Modified)', fontsize=12)\n",
+    "ax.text(\n",
+    "    0.04, 0.06,\n",
+    "    f\"rows: {len(ob_before)} -> {len(ob_after)}\\n\"\n",
+    "    f\"uniform n={ob_after[n_col].iloc[0]:.3f}\\n\"\n",
+    "    \"vertical line is expected\",\n",
+    "    transform=ax.transAxes,\n",
+    "    fontsize=9,\n",
+    "    bbox=dict(boxstyle='round,pad=0.3', facecolor='white', edgecolor='0.75', alpha=0.92),\n",
+    ")\n",
+    "ax.legend(fontsize=8.1, loc='upper right')\n",
+    "ax.grid(True, alpha=0.3)\n",
+    "\n",
+    "fig.suptitle('Selective Polygon Mask Application: Channel vs Overbank Face Tables', fontsize=14)\n",
+    "plt.show()\n"
    ]
   },
   {
@@ -2199,56 +1312,63 @@
    "source": [
     "## Summary\n",
     "\n",
-    "This notebook demonstrated a complete workflow for depth-varying Manning's n\n",
-    "in HEC-RAS 2D models:\n",
+    "This notebook demonstrated a complete workflow for depth-varying Manning's n in\n",
+    "HEC-RAS 2D models:\n",
     "\n",
     "### What We Showed\n",
     "\n",
-    "1. **Literature basis**: Manning's n decreases with flow depth â€” established by\n",
+    "1. **Literature basis**: Manning's n decreases with flow depth — established by\n",
     "   HEC-15, Limerinos (1970), Jarrett (1984), and Chow (1959)\n",
-    "2. **Geometry preprocessing**: Ran with `force_geompre=True` to generate face\n",
-    "   property tables from the uniform Manning's n in the plain-text geometry\n",
-    "3. **Depth-varying n**: Applied an exponential decay formula to the face property\n",
-    "   tables using `HdfMesh.set_face_mannings_n_values()`\n",
-    "4. **Table extension**: Extended face tables above terrain elevation using\n",
+    "2. **Baseline model**: Ran the original Muncie plan with uniform Manning's n as\n",
+    "   the comparison condition\n",
+    "3. **Two-phase solver workflow**: Used `RasPreprocess.preprocess_plan()` on\n",
+    "   Windows, edited the returned `.tmp.hdf`, and ran `RasCmdr.compute_plan_linux()`\n",
+    "   with HEC-RAS 7.0 Linux `RasUnsteady`\n",
+    "4. **Depth-varying n**: Applied an exponential decay formula to every face\n",
+    "   property table using `HdfMesh.set_face_mannings_n_values()`\n",
+    "5. **Table extension**: Extended face tables above terrain elevation using\n",
     "   `HdfMesh.extend_face_property_tables()` with depth-varying Manning's n\n",
-    "5. **Spatial filtering**: Described how `region_name`, `polygon`, and `face_ids`\n",
-    "   parameters limit modifications to specific faces (e.g., channel only)\n",
+    "6. **Solver persistence proof**: Re-read the output plan HDF after Linux compute\n",
+    "   to confirm the depth-varying tables persisted\n",
+    "7. **Stored result comparison**: Reviewed Maximum WSE and Maximum Depth\n",
+    "   differences from HEC-RAS HDF result products\n",
+    "8. **Selective application**: Used `polygon` and `region_name` workflows to\n",
+    "   identify channel/calibration faces while preserving overbank roughness\n",
+    "9. **Channel delineation**: Demonstrated calibration regions, fluvial/pluvial\n",
+    "   classification, and bank line extraction as channel polygon sources\n",
     "\n",
     "### Key Architecture Points\n",
     "\n",
     "| Workflow | Method |\n",
     "|----------|--------|\n",
-    "| Persist n through compute | Modify `.g##` via `GeomStorage` + `force_geompre=True` |\n",
-    "| Direct HDF modification | `HdfMesh.set_face_mannings_n_values()` (analysis only) |\n",
-    "| Extend tables higher | `HdfMesh.extend_face_property_tables()` |\n",
-    "| Protect from RASMapper | `HdfMesh.pin_property_tables()` (but NOT from preprocessor) |\n",
+    "| Generate solver input tables | `RasPreprocess.preprocess_plan()` |\n",
+    "| Direct solver HDF n modification | `HdfMesh.set_face_mannings_n_values(tmp_hdf, ...)` |\n",
+    "| Extend tables higher | `HdfMesh.extend_face_property_tables(tmp_hdf, ...)` |\n",
+    "| Consume edited tables | `RasCmdr.compute_plan_linux()` with the edited `.tmp.hdf` |\n",
+    "| Protect from RASMapper edits | `HdfMesh.pin_property_tables()` |\n",
     "| Spatial filtering | `polygon=`, `region_name=`, or `face_ids=` parameters |\n",
+    "| Channel identification | Calibration regions, fluvial/pluvial, bank lines, NFHL/GIS polygons |\n",
     "\n",
     "### Adapting for Your Project\n",
     "\n",
     "```python\n",
-    "# 1. Extract your project (or point to your local copy)\n",
     "ras = init_ras_project(\"/path/to/your/project\", \"7.0\")\n",
+    "result = RasPreprocess.preprocess_plan(\"01\", ras_object=ras)\n",
+    "tmp_hdf = result.tmp_hdf_path\n",
     "\n",
-    "# 2. Run with force_geompre to generate face tables\n",
-    "RasCmdr.compute_plan(\"01\", ras_object=ras, force_geompre=True)\n",
-    "ras = init_ras_project(\"/path/to/your/project\", \"7.0\", ras_object=\"new\")\n",
-    "\n",
-    "# 3. Define your depth-varying n function\n",
-    "def my_n_func(depth, base_n):\n",
-    "    if depth <= 0: return base_n\n",
-    "    return 0.035 + (base_n - 0.035) * np.exp(-depth / 1.5)\n",
-    "\n",
-    "# 4. Extend channel faces only (using calibration region)\n",
-    "geom_hdf = Path(ras.geom_df.iloc[0]['file_path']).with_suffix('.hdf')\n",
     "HdfMesh.extend_face_property_tables(\n",
-    "    hdf_path=geom_hdf,\n",
+    "    hdf_path=tmp_hdf,\n",
     "    mesh_name=\"Your 2D Area\",\n",
-    "    extension_elevation=960.0,  # target elevation\n",
+    "    extension_elevation=960.0,\n",
     "    mannings_n_func=my_n_func,\n",
-    "    region_name=\"Channel\",      # drawn in RASMapper\n",
+    "    region_name=\"Channel\",\n",
     "    pin_tables=True,\n",
+    ")\n",
+    "\n",
+    "RasCmdr.compute_plan_linux(\n",
+    "    \"01\",\n",
+    "    ras_exe_dir=\"/mnt/c/Program Files (x86)/HEC/HEC-RAS/7.0/Linux\",\n",
+    "    ras_object=ras,\n",
     ")\n",
     "```\n",
     "\n",
@@ -2258,8 +1378,8 @@
     "- FHWA, 2005. *Design of Roadside Channels with Flexible Linings* (HEC-15). FHWA-NHI-05-114.\n",
     "- Limerinos, J.T., 1970. USGS Water-Supply Paper 1898-B.\n",
     "- Jarrett, R.D., 1984. *J. Hydraulic Engineering*, ASCE, 110(11): 1519-1539.\n",
-    "- [HEC-RAS Technical Reference â€” Energy Loss Coefficients](https://www.hec.usace.army.mil/confluence/rasdocs/ras1dtechref/6.6/basic-data-requirements/geometric-data/energy-loss-coefficients)\n",
-    "- [HEC-RAS 2D â€” Face Property Tables](https://www.hec.usace.army.mil/confluence/rasdocs/r2dum/latest/development-of-a-2d-or-combined-1d-2d-model/creating-hydraulic-property-tables-for-2d-flow-areas)"
+    "- [HEC-RAS Technical Reference — Energy Loss Coefficients](https://www.hec.usace.army.mil/confluence/rasdocs/ras1dtechref/6.6/basic-data-requirements/geometric-data/energy-loss-coefficients)\n",
+    "- [HEC-RAS 2D — Face Property Tables](https://www.hec.usace.army.mil/confluence/rasdocs/r2dum/latest/development-of-a-2d-or-combined-1d-2d-model/creating-hydraulic-property-tables-for-2d-flow-areas)\n"
    ]
   }
  ],
@@ -2279,7 +1399,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.12"
+   "version": "3.14.3"
   },
   "papermill": {
    "default_parameters": {},

--- a/ras_commander/RasCmdr.py
+++ b/ras_commander/RasCmdr.py
@@ -38,6 +38,7 @@ List of Functions in RasCmdr:
 import os
 import subprocess
 import shutil
+import shlex
 from collections import defaultdict
 from pathlib import Path
 from concurrent.futures import ThreadPoolExecutor, as_completed
@@ -1436,13 +1437,30 @@ class RasCmdr:
 
         plan_num_str = RasUtils.normalize_ras_number(plan_number)
 
-        ras_exe_dir = Path(ras_exe_dir)
-        ras_exe = ras_exe_dir / "RasUnsteady"
-        if not ras_exe.exists():
-            raise FileNotFoundError(
-                f"RasUnsteady binary not found at {ras_exe}. "
-                "Ensure HEC-RAS Linux binaries are installed."
+        ras_exe_dir_raw = str(ras_exe_dir)
+        ras_exe_dir_posix = ras_exe_dir_raw.replace("\\", "/").rstrip("/")
+        run_via_wsl = os.name == "nt" and ras_exe_dir_posix.startswith("/mnt/")
+
+        if run_via_wsl:
+            ras_exe = f"{ras_exe_dir_posix}/RasUnsteady"
+            probe = subprocess.run(
+                ["wsl", "test", "-x", ras_exe],
+                capture_output=True,
+                text=True,
             )
+            if probe.returncode != 0:
+                raise FileNotFoundError(
+                    f"RasUnsteady binary not found or not executable in WSL at {ras_exe}. "
+                    "Ensure HEC-RAS Linux binaries are installed and WSL can access them."
+                )
+        else:
+            ras_exe_dir = Path(ras_exe_dir)
+            ras_exe = ras_exe_dir / "RasUnsteady"
+            if not ras_exe.exists():
+                raise FileNotFoundError(
+                    f"RasUnsteady binary not found at {ras_exe}. "
+                    "Ensure HEC-RAS Linux binaries are installed."
+                )
 
         project_dir = Path(ras_obj.project_folder)
         project_name = ras_obj.project_name
@@ -1491,6 +1509,22 @@ class RasCmdr:
                 logger.info(f"Set number of cores to {num_cores} for plan: {plan_num_str}")
             except Exception as e:
                 logger.error(f"Error setting number of cores: {e}")
+
+        if run_via_wsl:
+            return RasCmdr._compute_plan_linux_via_wsl(
+                ras_exe=str(ras_exe),
+                ras_exe_dir=ras_exe_dir_posix,
+                plan_number=plan_num_str,
+                geom_num=geom_num,
+                project_dir=project_dir,
+                project_name=project_name,
+                tmp_hdf=tmp_hdf,
+                timeout_sec=timeout_sec,
+                dos2unix=dos2unix,
+                retry=retry,
+                retry_delay_sec=retry_delay_sec,
+                ras_obj=ras_obj,
+            )
 
         # Build LD_LIBRARY_PATH — auto-detect library subdirectories
         # HEC-RAS Linux versions have varying layouts:
@@ -1642,3 +1676,156 @@ class RasCmdr:
                         pass
 
                 return ComputeResult(success=False, results_df_row=None)
+
+    @staticmethod
+    def _windows_path_to_wsl(path: Union[str, Path]) -> str:
+        """Translate a Windows path to its WSL path using the active distro."""
+        path_arg = str(path).replace("\\", "/")
+        proc = subprocess.run(
+            ["wsl", "wslpath", "-a", path_arg],
+            capture_output=True,
+            text=True,
+        )
+        if proc.returncode != 0:
+            raise RuntimeError(
+                f"wslpath failed for {path}: {proc.stderr.strip() or proc.stdout.strip()}"
+            )
+        return proc.stdout.strip()
+
+    @staticmethod
+    def _compute_plan_linux_via_wsl(
+        ras_exe: str,
+        ras_exe_dir: str,
+        plan_number: str,
+        geom_num: str,
+        project_dir: Path,
+        project_name: str,
+        tmp_hdf: Path,
+        timeout_sec: int,
+        dos2unix: bool,
+        retry: bool,
+        retry_delay_sec: int,
+        ras_obj,
+    ) -> 'ComputeResult':
+        """Run native Linux RasUnsteady from a Windows Python session via WSL."""
+        project_dir_wsl = RasCmdr._windows_path_to_wsl(project_dir)
+        tmp_hdf_wsl = RasCmdr._windows_path_to_wsl(tmp_hdf)
+        log_path = project_dir / f"compute_linux_{plan_number}.log"
+        log_path_wsl = RasCmdr._windows_path_to_wsl(log_path)
+
+        if dos2unix:
+            try:
+                count = RasUtils.dos2unix(project_dir)
+                logger.debug(f"dos2unix converted {count} files")
+            except Exception as e:
+                logger.warning(f"dos2unix failed before WSL execution: {e}")
+
+        project_q = shlex.quote(project_dir_wsl)
+        project_name_q = shlex.quote(project_name)
+        ras_exe_q = shlex.quote(ras_exe)
+        ras_exe_dir_q = shlex.quote(ras_exe_dir)
+        tmp_hdf_q = shlex.quote(tmp_hdf_wsl)
+        log_path_q = shlex.quote(log_path_wsl)
+        geom_arg_q = shlex.quote(f"x{geom_num}")
+
+        cleanup_script = (
+            f"cd {project_q} && "
+            "find . -maxdepth 1 -type l -name 'io.*' -delete"
+        )
+
+        script = fr"""
+set -e
+cd {project_q}
+find . -maxdepth 1 -type l -name 'io.*' -delete
+link_or_copy() {{
+    ln -sfn "\$1" "\$2" 2>/dev/null || cp -f "\$1" "\$2"
+}}
+prefix={project_name_q}.
+link_or_copy {shlex.quote(f'{project_name}.b{plan_number}')} io.b
+link_or_copy {shlex.quote(f'{project_name}.x{geom_num}')} io.X
+link_or_copy {shlex.quote(f'{project_name}.x{geom_num}')} io.x
+for f in {project_name_q}.*; do
+    [ -e "\$f" ] || continue
+    suffix="\${{f#\$prefix}}"
+    [ -e "io.\$suffix" ] || link_or_copy "\$f" "io.\$suffix"
+done
+lib_base=""
+if [ -d {ras_exe_dir_q}/libs ]; then
+    lib_base={ras_exe_dir_q}/libs
+elif [ -d "\$(dirname {ras_exe_dir_q})/libs" ]; then
+    lib_base="\$(dirname {ras_exe_dir_q})/libs"
+fi
+if [ -n "\$lib_base" ]; then
+    ld_path="\$lib_base"
+    for d in "\$lib_base"/*; do
+        [ -d "\$d" ] && ld_path="\$ld_path:\$d"
+    done
+else
+    ld_path={ras_exe_dir_q}
+fi
+LD_LIBRARY_PATH="\$ld_path" {ras_exe_q} {tmp_hdf_q} {geom_arg_q} > {log_path_q} 2>&1
+"""
+
+        max_attempts = 2 if retry else 1
+        for attempt in range(1, max_attempts + 1):
+            logger.info(
+                f"WSL Linux execution attempt {attempt}/{max_attempts} for plan {plan_number}"
+            )
+            proc = subprocess.Popen(
+                ["wsl", "bash", "-lc", script],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+            )
+            try:
+                stdout, stderr = proc.communicate(timeout=timeout_sec)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+                proc.communicate()
+                logger.error(f"Plan {plan_number}: WSL RasUnsteady timeout after {timeout_sec}s")
+                stdout, stderr = "", f"Timeout after {timeout_sec}s"
+                rc = -1
+            else:
+                rc = proc.returncode
+
+            if rc == 0:
+                subprocess.run(
+                    ["wsl", "bash", "-lc", cleanup_script],
+                    capture_output=True,
+                    text=True,
+                )
+                if tmp_hdf.exists():
+                    plan_hdf = RasCmdr._get_hdf_path(plan_number, ras_obj)
+                    shutil.move(str(tmp_hdf), str(plan_hdf))
+                    logger.debug(f"Renamed {tmp_hdf.name} -> {plan_hdf.name}")
+
+                try:
+                    ras_obj.plan_df = ras_obj.get_plan_entries()
+                    ras_obj.update_results_df(plan_numbers=[plan_number])
+                    mask = ras_obj.results_df['plan_number'] == plan_number
+                    results_row = ras_obj.results_df[mask].iloc[0].copy() if mask.any() else None
+                except Exception as e:
+                    logger.debug(f"Could not extract results_df_row: {e}")
+                    results_row = None
+
+                return ComputeResult(success=True, results_df_row=results_row)
+
+            try:
+                tail = log_path.read_text(errors='replace')[-800:] if log_path.exists() else ""
+            except OSError:
+                tail = "(log unreadable)"
+            logger.error(
+                f"Plan {plan_number}: WSL RasUnsteady exited with code {rc}. "
+                f"stdout={stdout.strip()} stderr={stderr.strip()} log tail={tail}"
+            )
+
+            if attempt < max_attempts:
+                logger.info(f"Retrying in {retry_delay_sec}s...")
+                time.sleep(retry_delay_sec)
+
+        subprocess.run(
+            ["wsl", "bash", "-lc", cleanup_script],
+            capture_output=True,
+            text=True,
+        )
+        return ComputeResult(success=False, results_df_row=None)

--- a/ras_commander/hdf/HdfMesh.py
+++ b/ras_commander/hdf/HdfMesh.py
@@ -402,7 +402,7 @@ class HdfMesh:
                             logger.warning(f"Error converting attribute '{name}': {str(e)}")
                     return pd.DataFrame.from_dict(result, orient='index', columns=['Value'])
                 else:
-                    logger.debug("No 2D Flow Area attributes found or invalid dataset.")
+                    logger.info("No 2D Flow Area attributes found or invalid dataset.")
                     return pd.DataFrame()  # Return an empty DataFrame
         except Exception as e:
             logger.error(f"Error reading 2D flow area attributes from {hdf_path}: {str(e)}")
@@ -1382,7 +1382,7 @@ class HdfMesh:
 
         # Create result GeoDataFrame
         if not selected_indices:
-            logger.debug("No faces found along profile line with given thresholds")
+            logger.info("No faces found along profile line with given thresholds")
             result = faces.iloc[0:0].copy()  # Empty GeoDataFrame with same structure
             result['distance_along_profile'] = []
             result['angle_to_profile'] = []
@@ -1686,6 +1686,8 @@ class HdfMesh:
         required_cols = ['Elevation', 'Area', 'Wetted Perimeter', "Manning's n"]
 
         for fid, df in face_tables.items():
+            if int(fid) < 0:
+                raise ValueError(f"Face ID must be non-negative, got {fid}")
             missing = [c for c in required_cols if c not in df.columns]
             if missing:
                 raise ValueError(f"Face {fid} table missing columns: {missing}")
@@ -1697,12 +1699,16 @@ class HdfMesh:
             if info_path not in hdf_file or values_path not in hdf_file:
                 raise KeyError(f"Face property tables not found for mesh '{mesh_name}'")
 
-            old_info = hdf_file[info_path][()]
-            old_values = hdf_file[values_path][()]
+            old_info_ds = hdf_file[info_path]
+            old_values_ds = hdf_file[values_path]
+            old_info = old_info_ds[()]
+            old_values = old_values_ds[()]
             num_faces = old_info.shape[0]
 
-            info_attrs = dict(hdf_file[info_path].attrs)
-            values_attrs = dict(hdf_file[values_path].attrs)
+            info_attrs = dict(old_info_ds.attrs)
+            values_attrs = dict(old_values_ds.attrs)
+            info_create_kwargs = HdfMesh._dataset_create_kwargs(old_info_ds)
+            values_create_kwargs = HdfMesh._dataset_create_kwargs(old_values_ds)
 
             new_face_slices = []
             for face_id in range(num_faces):
@@ -1719,9 +1725,9 @@ class HdfMesh:
                     start, count = old_info[face_id]
                     new_face_slices.append(old_values[start:start + count])
 
-            new_values = np.vstack(new_face_slices).astype(np.float32)
+            new_values = np.vstack(new_face_slices).astype(old_values.dtype, copy=False)
 
-            new_info = np.zeros((num_faces, 2), dtype=np.int32)
+            new_info = np.zeros((num_faces, 2), dtype=old_info.dtype)
             offset = 0
             for i, sl in enumerate(new_face_slices):
                 new_info[i, 0] = offset
@@ -1731,11 +1737,15 @@ class HdfMesh:
             del hdf_file[info_path]
             del hdf_file[values_path]
 
-            ds_info = hdf_file.create_dataset(info_path, data=new_info)
+            ds_info = hdf_file.create_dataset(
+                info_path, data=new_info, **info_create_kwargs
+            )
             for k, v in info_attrs.items():
                 ds_info.attrs[k] = v
 
-            ds_values = hdf_file.create_dataset(values_path, data=new_values)
+            ds_values = hdf_file.create_dataset(
+                values_path, data=new_values, **values_create_kwargs
+            )
             for k, v in values_attrs.items():
                 ds_values.attrs[k] = v
 
@@ -1746,6 +1756,37 @@ class HdfMesh:
             f"Wrote face property tables for {len(face_tables)} faces "
             f"in mesh '{mesh_name}' ({new_values.shape[0]} total rows)"
         )
+
+    @staticmethod
+    def _dataset_create_kwargs(dataset: h5py.Dataset) -> Dict[str, Any]:
+        """
+        Return creation keyword arguments needed to recreate an HDF dataset.
+
+        HEC-RAS geometry and preprocessed plan HDF datasets can use chunking,
+        compression, filters, fill values, and unlimited dimensions. Preserve
+        those properties when rewriting face property tables so solver-facing
+        files keep their original HDF layout.
+        """
+        kwargs: Dict[str, Any] = {}
+
+        if dataset.chunks is not None:
+            kwargs["chunks"] = dataset.chunks
+        if dataset.maxshape is not None:
+            kwargs["maxshape"] = dataset.maxshape
+        if dataset.compression is not None:
+            kwargs["compression"] = dataset.compression
+        if dataset.compression_opts is not None:
+            kwargs["compression_opts"] = dataset.compression_opts
+        if dataset.shuffle:
+            kwargs["shuffle"] = True
+        if dataset.fletcher32:
+            kwargs["fletcher32"] = True
+        if dataset.scaleoffset is not None:
+            kwargs["scaleoffset"] = dataset.scaleoffset
+        if dataset.fillvalue is not None:
+            kwargs["fillvalue"] = dataset.fillvalue
+
+        return kwargs
 
     @staticmethod
     @log_call


### PR DESCRIPTION
## Summary

- Add polygon-mask face selection APIs to `HdfMesh`: `get_face_ids_in_polygon()`, `get_face_ids_in_calibration_region()`, plus `polygon`/`region_name` params on `extend_face_property_tables()` and `set_face_mannings_n_values()`
- Preserve HDF dataset creation properties (chunks, compression, maxshape, dtypes) when rewriting face-property tables in `.tmp.hdf`
- Add Windows-to-WSL support in `compute_plan_linux()` for two-phase execution on Windows machines with WSL
- Rewrite notebook 414 as end-to-end depth-varying Manning's n proof: Windows preprocess, edit `.tmp.hdf`, WSL Linux solve, verify persisted tables, compare baseline vs modified WSE/depth

## Why Linux two-phase?

HEC-RAS Windows solver always regenerates face-property tables at startup (Subroutine RFAMRC_HTAB) regardless of `Run HTab=0`. The Linux `RasUnsteady` binary is a pure Fortran solver with no table regeneration, so editing `.tmp.hdf` after preprocessing and before Linux execution preserves depth-varying Manning's n through the solver run.

## Test plan

- [x] Notebook executes end-to-end without error (5 figures, 0 cell errors)
- [x] Output HDF face-property tables contain depth-varying n (0.045-0.060 range, not uniform 0.06)
- [x] Baseline vs modified WSE comparison shows physically meaningful difference
- [x] Selective polygon mask applies depth-varying n to channel faces only, overbank unchanged
- [x] py_compile, notebook AST parse, API smoke all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)