### PR TITLE
Fix calibration scoring after worker project refresh loss

### DIFF
--- a/ras_commander/RasCalibrate.py
+++ b/ras_commander/RasCalibrate.py
@@ -792,6 +792,42 @@ def _aggregate_objectives(
     return float(np.mean(finite))
 
 
+def _raise_if_grid_search_unscored(
+    grid_results: pd.DataFrame,
+    metric: str,
+) -> None:
+    """Fail loudly when no calibration permutation has a finite objective."""
+    if grid_results.empty:
+        raise RuntimeError("Calibration grid search produced no result rows.")
+
+    objectives = pd.to_numeric(
+        grid_results.get("overall_objective", pd.Series(dtype=float)),
+        errors="coerce",
+    )
+    if objectives.notna().any():
+        return
+
+    if "status" in grid_results.columns:
+        status_counts = grid_results["status"].fillna("missing").value_counts()
+        status_text = ", ".join(
+            f"{status}={count}" for status, count in status_counts.items()
+        )
+    else:
+        status_text = "status column missing"
+
+    hdf_count = 0
+    if "hdf_path" in grid_results.columns:
+        hdf_count = int(grid_results["hdf_path"].notna().sum())
+
+    raise RuntimeError(
+        "Calibration grid search produced no finite "
+        f"{metric} objective values. Execution status counts: {status_text}. "
+        f"HDF paths present for {hdf_count} of {len(grid_results)} "
+        "permutation(s). Check compute_parallel execution and calibration "
+        "point extraction errors before selecting a best fit."
+    )
+
+
 def _calculate_point_metrics(
     observed: Observation,
     modeled: Union[float, pd.Series],
@@ -1771,10 +1807,12 @@ class RasCalibrate:
                 prefix = f"point_{idx:02d}_{suffix_name}"
                 row[f"{prefix}_modeled"] = point_result["modeled"]
                 row[f"{prefix}_objective"] = point_result["objective"]
+                row[f"{prefix}_error"] = point_result["error"]
 
             augmented_rows.append(row)
 
         augmented_df = pd.DataFrame(augmented_rows)
+        _raise_if_grid_search_unscored(augmented_df, metric_name)
         ascending = metric_name in _LOWER_IS_BETTER
         return augmented_df.sort_values(
             "overall_objective",
@@ -2080,6 +2118,19 @@ class RasCalibrate:
             bounds=bounds,
             options={"maxiter": max_iterations},
         )
+        history_df = pd.DataFrame(iteration_history)
+        history_objectives = pd.to_numeric(
+            history_df.get("raw_objective", pd.Series(dtype=float)),
+            errors="coerce",
+        )
+        if not history_objectives.notna().any():
+            raise RuntimeError(
+                "Calibration optimization produced no finite "
+                f"{metric_name} objective values across "
+                f"{len(history_df)} evaluation(s). Check HEC-RAS execution "
+                "and calibration point extraction errors before selecting a "
+                "best fit."
+            )
 
         best_parameters = {
             parameter_name: float(value)
@@ -2098,6 +2149,14 @@ class RasCalibrate:
             force_geompre=force_geompre,
             ras_object=ras_object,
         )
+        best_objective = best_evaluation.get("overall_objective")
+        if pd.isna(best_objective):
+            raise RuntimeError(
+                "Calibration optimization best evaluation produced no finite "
+                f"{metric_name} objective value. Check HEC-RAS execution and "
+                "calibration point extraction errors before selecting a best "
+                "fit."
+            )
 
         return {
             "metric": metric_name,
@@ -2109,7 +2168,7 @@ class RasCalibrate:
                 for parameter_name, value in zip(parameter_names, x0)
             },
             "best_parameters": best_parameters,
-            "best_objective": best_evaluation.get("overall_objective"),
+            "best_objective": best_objective,
             "nit": getattr(optimization_result, "nit", None),
             "nfev": getattr(optimization_result, "nfev", None),
             "bounds": {

--- a/ras_commander/RasCmdr.py
+++ b/ras_commander/RasCmdr.py
@@ -105,6 +105,104 @@ class RasCmdr:
         return Path(ras_object.project_folder) / f"{ras_object.project_name}.p{plan_num_str}.hdf"
 
     @staticmethod
+    def _plan_entries_with_expected_hdf_paths(
+        plan_entries: Optional[pd.DataFrame],
+        project_folder: Union[str, Path],
+        project_name: str,
+        plan_numbers: List[Union[str, Number]],
+    ) -> pd.DataFrame:
+        """
+        Return plan metadata with expected HDF paths without rereading the .prj.
+        """
+        normalized_plan_numbers = [
+            RasUtils.normalize_ras_number(plan_number)
+            for plan_number in plan_numbers
+        ]
+        project_folder = Path(project_folder)
+
+        if plan_entries is None or plan_entries.empty:
+            cached_plan_entries = pd.DataFrame(
+                {"plan_number": normalized_plan_numbers}
+            )
+        else:
+            cached_plan_entries = plan_entries.copy()
+
+        if "plan_number" not in cached_plan_entries.columns:
+            cached_plan_entries["plan_number"] = normalized_plan_numbers[:len(
+                cached_plan_entries
+            )]
+
+        cached_plan_entries["plan_number"] = cached_plan_entries[
+            "plan_number"
+        ].map(RasUtils.normalize_ras_number)
+
+        for column_name in ("HDF_Results_Path", "full_path"):
+            if column_name not in cached_plan_entries.columns:
+                cached_plan_entries[column_name] = None
+
+        missing_plan_numbers = [
+            plan_number
+            for plan_number in normalized_plan_numbers
+            if plan_number not in set(cached_plan_entries["plan_number"])
+        ]
+        if missing_plan_numbers:
+            cached_plan_entries = pd.concat(
+                [
+                    cached_plan_entries,
+                    pd.DataFrame(
+                        {"plan_number": missing_plan_numbers}
+                    ),
+                ],
+                ignore_index=True,
+            )
+
+        for plan_number in normalized_plan_numbers:
+            plan_mask = cached_plan_entries["plan_number"] == plan_number
+            expected_plan_path = project_folder / f"{project_name}.p{plan_number}"
+            expected_hdf_path = Path(f"{expected_plan_path}.hdf")
+            cached_plan_entries.loc[
+                plan_mask, "full_path"
+            ] = str(expected_plan_path)
+            cached_plan_entries.loc[
+                plan_mask, "HDF_Results_Path"
+            ] = str(expected_hdf_path)
+
+        return cached_plan_entries
+
+    @staticmethod
+    def _update_results_from_cached_plan_entries(
+        ras_object: 'RasPrj',
+        plan_numbers: List[Union[str, Number]],
+        project_folder: Union[str, Path, None] = None,
+        project_name: Optional[str] = None,
+        plan_entries: Optional[pd.DataFrame] = None,
+    ) -> pd.DataFrame:
+        """
+        Update results_df using cached plan metadata when the .prj is unavailable.
+        """
+        normalized_plan_numbers = [
+            RasUtils.normalize_ras_number(plan_number)
+            for plan_number in plan_numbers
+        ]
+        project_folder = Path(project_folder or ras_object.project_folder)
+        project_name = project_name or ras_object.project_name
+        cached_plan_entries = (
+            plan_entries
+            if plan_entries is not None
+            else getattr(ras_object, "plan_df", None)
+        )
+
+        ras_object.plan_df = RasCmdr._plan_entries_with_expected_hdf_paths(
+            cached_plan_entries,
+            project_folder,
+            project_name,
+            normalized_plan_numbers,
+        )
+        return ras_object.update_results_df(
+            plan_numbers=normalized_plan_numbers
+        )
+
+    @staticmethod
     def _normalize_requested_plan_numbers(
         plan_number: Union[str, Number, List[Union[str, Number]], None]
     ) -> Optional[List[str]]:
@@ -739,6 +837,30 @@ class RasCmdr:
                             logger.debug(f"Could not extract results_df_row: {e}")
                 except Exception as e_refresh:
                     logger.warning(f"Error refreshing DataFrames after compute_plan: {e_refresh}")
+                    if _did_execute:
+                        try:
+                            normalized_plan_number = RasUtils.normalize_ras_number(
+                                plan_number
+                            )
+                            RasCmdr._update_results_from_cached_plan_entries(
+                                _ras_obj,
+                                [normalized_plan_number],
+                            )
+                            mask = (
+                                _ras_obj.results_df["plan_number"]
+                                == normalized_plan_number
+                            )
+                            if mask.any():
+                                _results_df_row = (
+                                    _ras_obj.results_df[mask].iloc[0].copy()
+                                )
+                        except Exception as e_results:
+                            logger.warning(
+                                "Could not summarize plan %s after refresh "
+                                "failure: %s",
+                                plan_number,
+                                e_results,
+                            )
 
         return ComputeResult(success=_success, results_df_row=_results_df_row)
 
@@ -863,6 +985,9 @@ class RasCmdr:
 
             - verify is passed through to compute_plan() for each worker execution.
         """
+        execution_results: Dict[str, bool] = {}
+        filtered_plan_numbers: List[str] = []
+
         try:
             ras_obj = ras_object or ras
             ras_obj.check_initialized()
@@ -890,9 +1015,6 @@ class RasCmdr:
                 plan_number
             )
             filtered_plan_numbers = list(filtered_plan_entries["plan_number"])
-
-            # Initialize execution_results dict
-            execution_results: Dict[str, bool] = {}
 
             # Filter out plans with existing results if skip_existing is True
             if skip_existing:
@@ -1072,11 +1194,32 @@ class RasCmdr:
                 logger.info(f"Plan {plan_num}: {status}")
 
             ras_obj = ras_object or ras
-            ras_obj.plan_df = ras_obj.get_plan_entries()
-            ras_obj.geom_df = ras_obj.get_geom_entries()
-            ras_obj.flow_df = ras_obj.get_flow_entries()
-            ras_obj.unsteady_df = ras_obj.get_unsteady_entries()
-            ras_obj.update_results_df(plan_numbers=list(execution_results.keys()))
+            try:
+                ras_obj.plan_df = ras_obj.get_plan_entries()
+                ras_obj.geom_df = ras_obj.get_geom_entries()
+                ras_obj.flow_df = ras_obj.get_flow_entries()
+                ras_obj.unsteady_df = ras_obj.get_unsteady_entries()
+                ras_obj.update_results_df(plan_numbers=list(execution_results.keys()))
+            except Exception as e_refresh:
+                logger.warning(
+                    "Error refreshing DataFrames after compute_parallel: %s. "
+                    "Using cached plan metadata and expected result paths.",
+                    e_refresh,
+                )
+                try:
+                    RasCmdr._update_results_from_cached_plan_entries(
+                        ras_obj,
+                        list(execution_results.keys()),
+                        project_folder=final_dest_folder,
+                        project_name=ras_obj.project_name,
+                        plan_entries=filtered_plan_entries,
+                    )
+                except Exception as e_results:
+                    logger.error(
+                        "Could not summarize parallel results after refresh "
+                        "failure: %s",
+                        e_results,
+                    )
 
             # Extract results_df rows for executed plans
             _results_df = pd.DataFrame()
@@ -1093,7 +1236,9 @@ class RasCmdr:
 
         except Exception as e:
             logger.critical(f"Error in compute_parallel: {str(e)}")
-            return ComputeParallelResult()
+            for plan_num in filtered_plan_numbers:
+                execution_results.setdefault(plan_num, False)
+            return ComputeParallelResult(execution_results=execution_results)
 
     @staticmethod
     @log_call

--- a/ras_commander/RasPermutation.py
+++ b/ras_commander/RasPermutation.py
@@ -763,19 +763,44 @@ class RasPermutation:
 
             summary_df = compute_result.results_df.copy()
             if summary_df.empty:
-                summary_df = batch_ras.update_results_df(plan_numbers=plan_numbers)
-                summary_df = summary_df[
-                    summary_df["plan_number"].isin(plan_numbers)
-                ].copy()
+                try:
+                    summary_df = batch_ras.update_results_df(
+                        plan_numbers=plan_numbers
+                    )
+                    summary_df = summary_df[
+                        summary_df["plan_number"].isin(plan_numbers)
+                    ].copy()
+                except Exception as exc:
+                    logger.warning(
+                        "Could not refresh batch result summaries for %s: %s",
+                        batch_folder,
+                        exc,
+                    )
+                    summary_df = pd.DataFrame()
 
             if summary_df.empty:
                 batch_summary = batch_log_df[
                     ["absolute_perm_id", "plan_number"]
                 ].copy()
-                batch_summary["status"] = "not_run"
+                batch_summary["status"] = batch_summary["plan_number"].map(
+                    lambda plan_num: RasPermutation._derive_status(
+                        pd.Series(dtype="object"),
+                        compute_result.execution_results.get(plan_num),
+                    )
+                )
                 batch_summary["max_wse"] = np.nan
                 batch_summary["runtime_seconds"] = np.nan
-                batch_summary["hdf_path"] = np.nan
+                batch_summary["hdf_path"] = batch_summary["plan_number"].map(
+                    lambda plan_num: str(
+                        batch_folder
+                        / f"{batch_ras.project_name}.p{plan_num}.hdf"
+                    )
+                    if (
+                        batch_folder
+                        / f"{batch_ras.project_name}.p{plan_num}.hdf"
+                    ).exists()
+                    else np.nan
+                )
                 batch_results.append(batch_summary)
                 continue
 

--- a/ras_commander/hdf/HdfResultsQuery.py
+++ b/ras_commander/hdf/HdfResultsQuery.py
@@ -113,6 +113,45 @@ def _project_name_from_plan_hdf(plan_hdf_path: Path) -> str:
     return match.group(1) if match else stem
 
 
+def _resolve_geometry_hdf_from_plan_text(plan_hdf_path: Path) -> Optional[Path]:
+    """Resolve a geometry HDF from the sibling .p## plan text file."""
+    plan_match = re.search(
+        r"\.p(\d{1,2})$",
+        plan_hdf_path.stem,
+        flags=re.IGNORECASE,
+    )
+    if not plan_match:
+        return None
+
+    project_folder = plan_hdf_path.parent
+    project_name = _project_name_from_plan_hdf(plan_hdf_path)
+    plan_number = plan_match.group(1).zfill(2)
+    plan_path = project_folder / f"{project_name}.p{plan_number}"
+    if not plan_path.exists():
+        return None
+
+    try:
+        plan_text = plan_path.read_text(encoding="utf-8", errors="ignore")
+    except Exception as exc:
+        logger.debug("Could not read plan text %s: %s", plan_path, exc)
+        return None
+
+    geom_number = None
+    for line in plan_text.splitlines():
+        if line.strip().startswith("Geom File="):
+            geom_number = _extract_geometry_number(line.split("=", 1)[1])
+            break
+
+    if geom_number is None:
+        return None
+
+    geom_hdf_path = project_folder / f"{project_name}.g{geom_number}.hdf"
+    if geom_hdf_path.exists():
+        return geom_hdf_path
+
+    raise FileNotFoundError(f"Geometry HDF not found: {geom_hdf_path}")
+
+
 def _paths_match(path_a: Any, path_b: Any) -> bool:
     """Compare paths without forcing symlink or UNC resolution."""
     try:
@@ -189,6 +228,10 @@ def _resolve_geometry_hdf(
                 return plan_hdf_path
     except Exception:
         pass
+
+    plan_text_geom_hdf = _resolve_geometry_hdf_from_plan_text(plan_hdf_path)
+    if plan_text_geom_hdf is not None:
+        return plan_text_geom_hdf
 
     _ras = ras_object if ras_object is not None else _get_global_ras()
     plan_df = getattr(_ras, "plan_df", None)

--- a/tests/test_hdf_results_query_geometry_resolution.py
+++ b/tests/test_hdf_results_query_geometry_resolution.py
@@ -1,0 +1,16 @@
+from ras_commander.hdf.HdfResultsQuery import _resolve_geometry_hdf
+
+
+def test_resolve_geometry_hdf_uses_sibling_plan_text_when_prj_metadata_unavailable(
+    tmp_path,
+):
+    plan_hdf = tmp_path / "Project.p07.hdf"
+    plan_hdf.write_bytes(b"not a real hdf")
+    (tmp_path / "Project.p07").write_text(
+        "Plan Title=Generated\nGeom File=g09\n",
+        encoding="utf-8",
+    )
+    geom_hdf = tmp_path / "Project.g09.hdf"
+    geom_hdf.write_bytes(b"geometry")
+
+    assert _resolve_geometry_hdf(plan_hdf) == geom_hdf

--- a/tests/test_rascalibrate_failure_guards.py
+++ b/tests/test_rascalibrate_failure_guards.py
@@ -1,0 +1,95 @@
+import importlib
+
+import pandas as pd
+import pytest
+
+from ras_commander.RasCalibrate import CalibrationPoint, RasCalibrate
+
+
+rascalibrate_module = importlib.import_module("ras_commander.RasCalibrate")
+
+
+def test_grid_search_raises_when_every_permutation_is_unscored(monkeypatch):
+    point = CalibrationPoint(
+        name="target",
+        variable="wse",
+        extraction_method="steady_profile",
+        observed=1.0,
+        river="River",
+        reach="Reach",
+        station="1000",
+    )
+
+    monkeypatch.setattr(
+        rascalibrate_module.RasPermutation,
+        "define_parameters",
+        staticmethod(lambda parameters: pd.DataFrame({"n": [0.04]})),
+    )
+    monkeypatch.setattr(
+        rascalibrate_module.RasPermutation,
+        "generate_plans",
+        staticmethod(
+            lambda *args, **kwargs: {
+                "master_log": "unused.csv",
+                "batch_folders": [],
+            }
+        ),
+    )
+    monkeypatch.setattr(
+        rascalibrate_module.RasPermutation,
+        "execute_and_summarize",
+        staticmethod(
+            lambda *args, **kwargs: pd.DataFrame(
+                [
+                    {
+                        "absolute_perm_id": 1,
+                        "plan_number": "04",
+                        "status": "executed_no_summary",
+                        "hdf_path": "missing.p04.hdf",
+                    }
+                ]
+            )
+        ),
+    )
+
+    with pytest.raises(RuntimeError, match="no finite rmse objective values"):
+        RasCalibrate.grid_search(
+            template_plan="03",
+            parameters={"n": [0.04]},
+            apply_fn=lambda plan_path, row, ras_object=None: None,
+            calibration_points=[point],
+            metric="rmse",
+        )
+
+
+def test_optimize_raises_when_every_evaluation_is_unscored(monkeypatch):
+    point = CalibrationPoint(
+        name="target",
+        variable="wse",
+        extraction_method="steady_profile",
+        observed=1.0,
+        river="River",
+        reach="Reach",
+        station="1000",
+    )
+
+    monkeypatch.setattr(
+        RasCalibrate,
+        "evaluate_single",
+        staticmethod(
+            lambda *args, **kwargs: {
+                "success": False,
+                "overall_objective": float("nan"),
+            }
+        ),
+    )
+
+    with pytest.raises(RuntimeError, match="optimization produced no finite rmse"):
+        RasCalibrate.optimize(
+            plan_number="03",
+            parameter_bounds={"n": (0.02, 0.06)},
+            apply_fn=lambda plan_path, row, ras_object=None: None,
+            calibration_points=[point],
+            metric="rmse",
+            max_iterations=1,
+        )

--- a/tests/test_rascmdr_compute_plan_control_flow.py
+++ b/tests/test_rascmdr_compute_plan_control_flow.py
@@ -4,6 +4,7 @@ import importlib
 from pathlib import Path
 from types import SimpleNamespace
 
+import pandas as pd
 import pytest
 
 from ras_commander.ComputeResults import ComputeResult
@@ -73,6 +74,81 @@ def test_compute_plan_does_not_swallow_keyboard_interrupt():
         RasCmdr.compute_plan("01", ras_object=ras_obj)
 
     assert ras_obj.refresh_calls == ["plan", "geom", "flow", "unsteady"]
+
+
+def test_compute_plan_uses_cached_plan_entries_when_prj_refresh_fails(
+    monkeypatch, tmp_path
+):
+    """A deleted worker .prj should not prevent result-row recovery."""
+    plan_path = tmp_path / "TestProject.p01"
+    hdf_path = tmp_path / "TestProject.p01.hdf"
+    plan_path.write_text("Plan Title=Plan 01\n", encoding="utf-8")
+
+    class MissingPrjAfterRunRas:
+        def __init__(self):
+            self.project_folder = tmp_path
+            self.project_name = "TestProject"
+            self.prj_file = tmp_path / "TestProject.prj"
+            self.ras_exe_path = "Ras.exe"
+            self.plan_df = pd.DataFrame(
+                {
+                    "plan_number": ["01"],
+                    "full_path": [str(plan_path)],
+                    "HDF_Results_Path": [None],
+                }
+            )
+            self.results_df = pd.DataFrame()
+
+        def check_initialized(self):
+            return None
+
+        def get_plan_entries(self):
+            raise FileNotFoundError(self.prj_file)
+
+        def get_geom_entries(self):
+            return pd.DataFrame()
+
+        def get_flow_entries(self):
+            return pd.DataFrame()
+
+        def get_unsteady_entries(self):
+            return pd.DataFrame()
+
+        def update_results_df(self, plan_numbers=None):
+            self.results_df = pd.DataFrame(
+                {
+                    "plan_number": list(plan_numbers),
+                    "HDF_Results_Path": [str(hdf_path)],
+                    "hdf_path": [str(hdf_path)],
+                }
+            )
+            return self.results_df
+
+    def fake_run(*args, **kwargs):
+        hdf_path.write_text("computed\n", encoding="utf-8")
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(
+        rascmdr_module.RasPlan,
+        "get_plan_path",
+        staticmethod(lambda plan_number, ras_object: plan_path),
+    )
+    monkeypatch.setattr(
+        rascmdr_module.BcoMonitor,
+        "enable_detailed_logging",
+        staticmethod(lambda plan_path: None),
+    )
+    monkeypatch.setattr(rascmdr_module.subprocess, "run", fake_run)
+
+    result = RasCmdr.compute_plan(
+        "01",
+        force_rerun=True,
+        ras_object=MissingPrjAfterRunRas(),
+    )
+
+    assert result.success is True
+    assert result.results_df_row["plan_number"] == "01"
+    assert result.results_df_row["hdf_path"] == str(hdf_path)
 
 
 def test_windows_path_to_wsl_decodes_utf8(monkeypatch):

--- a/tests/test_rascmdr_plan_number_normalization.py
+++ b/tests/test_rascmdr_plan_number_normalization.py
@@ -20,6 +20,7 @@ class FakeRasProject:
         self.project_name = "TestProject"
         self.ras_exe_path = Path("C:/HEC-RAS/6.6/Ras.exe")
         self._plan_numbers = list(plan_numbers or self.DEFAULT_PLAN_NUMBERS)
+        self.raise_on_get_plan_entries = False
         self.project_folder = (
             Path(project_folder) if project_folder is not None else Path.cwd()
         )
@@ -40,6 +41,8 @@ class FakeRasProject:
         self.plan_df = self.get_plan_entries()
 
     def get_plan_entries(self):
+        if self.raise_on_get_plan_entries:
+            raise FileNotFoundError(self.prj_file)
         return pd.DataFrame(
             {
                 "plan_number": self._plan_numbers,
@@ -59,10 +62,16 @@ class FakeRasProject:
 
     def update_results_df(self, plan_numbers=None):
         plan_numbers = [] if plan_numbers is None else list(plan_numbers)
+        hdf_paths = [
+            str(self.project_folder / f"{self.project_name}.p{plan_number}.hdf")
+            for plan_number in plan_numbers
+        ]
         self.results_df = pd.DataFrame(
             {
                 "plan_number": plan_numbers,
                 "status": ["done"] * len(plan_numbers),
+                "HDF_Results_Path": hdf_paths,
+                "hdf_path": hdf_paths,
             }
         )
 
@@ -284,6 +293,44 @@ def test_compute_parallel_dest_folder_keeps_fresh_outputs_when_workers_share_sta
     assert (dest_folder / "TestProject.p02.hdf").read_text(encoding="utf-8") == (
         "fresh hdf 02\n"
     )
+
+
+def test_compute_parallel_uses_cached_plan_entries_when_prj_refresh_fails(
+    monkeypatch, tmp_path
+):
+    project_folder = tmp_path / "parallel-project"
+    project_folder.mkdir()
+    _seed_parallel_project(project_folder)
+    ras_object = FakeRasProject(
+        project_folder=project_folder,
+        plan_numbers=["01"],
+    )
+    ras_object.raise_on_get_plan_entries = True
+
+    def fake_compute_plan(plan_number, **kwargs):
+        worker_folder = Path(kwargs["ras_object"].project_folder)
+        (worker_folder / f"TestProject.p{plan_number}.hdf").write_text(
+            f"fresh hdf {plan_number}\n",
+            encoding="utf-8",
+        )
+        return ComputeResult(success=True)
+
+    monkeypatch.setattr(rascmdr_module, "RasPrj", FakeRasProject)
+    monkeypatch.setattr(rascmdr_module, "init_ras_project", fake_init_ras_project)
+    monkeypatch.setattr(rascmdr_module.time, "sleep", lambda _: None)
+    monkeypatch.setattr(RasCmdr, "compute_plan", staticmethod(fake_compute_plan))
+
+    result = RasCmdr.compute_parallel(
+        plan_number=["01"],
+        max_workers=1,
+        ras_object=ras_object,
+    )
+
+    assert result.execution_results == {"01": True}
+    assert result.results_df["plan_number"].tolist() == ["01"]
+    assert result.results_df["hdf_path"].tolist() == [
+        str(project_folder / "TestProject.p01.hdf")
+    ]
 
 
 def test_filter_plan_entries_none_returns_all_plans():


### PR DESCRIPTION
## Summary
- Preserve cached per-plan metadata in compute_plan/compute_parallel when post-run project refresh fails because HEC-RAS deleted or replaced a worker .prj file.
- Keep calibration and permutation scoring from collapsing to silent all-NaN results by carrying clear execution status and raising when no finite objective was scored.
- Add plan-text geometry HDF fallback for result extraction when project metadata is unavailable.

## Validation
- `conda run -n symphony-dev python -m pytest tests/test_rascmdr_compute_plan_control_flow.py tests/test_rascmdr_plan_number_normalization.py tests/test_rascalibrate_failure_guards.py tests/test_hdf_results_query_geometry_resolution.py` -> 18 passed
- `examples/220_calibration_workflow.ipynb` executed through `run_notebook_visible.py` with local `PYTHONPATH` -> passed; produced finite RMSE scores
- Extracted notebook figures reviewed by subagent -> both passed

Artifacts: H:/Symphony/ras-commander/CLB-877/