### PR TITLE
Fix model sources API drift for notebook 958

### DIFF
--- a/ras_commander/sources/base.py
+++ b/ras_commander/sources/base.py
@@ -3,7 +3,7 @@
 from dataclasses import dataclass, field
 from enum import Enum
 from pathlib import Path
-from typing import Dict, List, Optional, Protocol, Union
+from typing import Any, Dict, List, Optional, Protocol, Union
 
 
 class ModelType(str, Enum):
@@ -23,6 +23,7 @@ class SourceStatus(str, Enum):
     AVAILABLE = "available"
     UNAVAILABLE = "unavailable"
     DEPRECATED = "deprecated"
+    REQUIRES_AUTH = "requires_auth"
 
 
 @dataclass
@@ -38,6 +39,12 @@ class ModelMetadata:
     hecras_version: Optional[str] = None
     doi: Optional[str] = None
     url: Optional[str] = None
+    file_size_mb: Optional[float] = None
+    study_date: Optional[str] = None
+    last_modified: Optional[Any] = None
+    projection: Optional[str] = None
+    spatial_extent: Optional[Any] = None
+    effective_date: Optional[str] = None
     tags: List[str] = field(default_factory=list)
     extra: Dict[str, object] = field(default_factory=dict)
 

--- a/ras_commander/sources/federal/__init__.py
+++ b/ras_commander/sources/federal/__init__.py
@@ -4,8 +4,8 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from ras_commander.sources.federal.usgs_sciencebase import UsgsScienceBase
-    from ras_commander.sources.federal.noaa_ras2fim import NoaaRas2fimModels
 
 from .ebfe_models import RasEbfeModels
+from .noaa_ras2fim import NoaaRas2fimModels
 
 __all__ = ['UsgsScienceBase', 'RasEbfeModels', 'NoaaRas2fimModels']

--- a/ras_commander/sources/federal/noaa_ras2fim.py
+++ b/ras_commander/sources/federal/noaa_ras2fim.py
@@ -1,0 +1,196 @@
+"""NOAA OWP ras2fim model-source catalog adapter.
+
+The public notebook examples use this source as a lightweight catalog entry for
+ras2fim HEC-RAS-derived flood-inundation products. The source data are stored in
+the NOAA/ESIP S3 bucket and typically require AWS credentials, so this adapter
+keeps a small built-in registry available without making boto3 a package
+dependency or attempting large downloads implicitly.
+"""
+
+from pathlib import Path
+from typing import Dict, List, Optional, Union
+
+from ras_commander.LoggingConfig import log_call
+from ras_commander.sources.base import (
+    DownloadResult,
+    ModelMetadata,
+    ModelType,
+    SourceStatus,
+)
+
+NOAA_RAS2FIM_BUCKET = "noaa-nws-owp-fim"
+NOAA_RAS2FIM_PREFIX = "ras2fim"
+
+
+class NoaaRas2fimModels:
+    """Catalog-only adapter for NOAA OWP ras2fim model products."""
+
+    SOURCE_NAME = "NOAA ras2fim"
+    SOURCE_TYPE = "federal"
+
+    _MODEL_REGISTRY: Dict[str, Dict[str, object]] = {
+        "03100204": {
+            "name": "NOAA ras2fim HUC 03100204",
+            "location": "03100204",
+            "description": (
+                "NOAA OWP ras2fim flood-inundation model products for HUC8 "
+                "03100204."
+            ),
+            "tags": ["noaa", "owp", "ras2fim", "fim", "huc8"],
+        },
+        "12090301": {
+            "name": "NOAA ras2fim HUC 12090301",
+            "location": "12090301",
+            "description": (
+                "NOAA OWP ras2fim flood-inundation model products for HUC8 "
+                "12090301."
+            ),
+            "tags": ["noaa", "owp", "ras2fim", "fim", "huc8"],
+        },
+        "12040102": {
+            "name": "NOAA ras2fim HUC 12040102",
+            "location": "12040102",
+            "description": (
+                "NOAA OWP ras2fim flood-inundation model products for HUC8 "
+                "12040102."
+            ),
+            "tags": ["noaa", "owp", "ras2fim", "fim", "huc8"],
+        },
+        "08070202": {
+            "name": "NOAA ras2fim HUC 08070202",
+            "location": "08070202",
+            "description": (
+                "NOAA OWP ras2fim flood-inundation model products for HUC8 "
+                "08070202."
+            ),
+            "tags": ["noaa", "owp", "ras2fim", "fim", "huc8"],
+        },
+        "11010011": {
+            "name": "NOAA ras2fim HUC 11010011",
+            "location": "11010011",
+            "description": (
+                "NOAA OWP ras2fim flood-inundation model products for HUC8 "
+                "11010011."
+            ),
+            "tags": ["noaa", "owp", "ras2fim", "fim", "huc8"],
+        },
+    }
+
+    @property
+    def source_name(self) -> str:
+        """Human-readable source name."""
+        return self.SOURCE_NAME
+
+    @property
+    def source_type(self) -> str:
+        """Source category."""
+        return self.SOURCE_TYPE
+
+    @staticmethod
+    @log_call
+    def get_source_status() -> SourceStatus:
+        """
+        Return source availability.
+
+        ras2fim products are generally stored behind the ESIP credentialed S3
+        workflow, but the built-in catalog is available without credentials.
+        """
+        return SourceStatus.REQUIRES_AUTH
+
+    @staticmethod
+    @log_call
+    def list_models(
+        location: Optional[str] = None,
+        model_type: Optional[ModelType] = None,
+        hecras_version: Optional[str] = None,
+        tags: Optional[List[str]] = None,
+        limit: Optional[int] = None,
+        **kwargs,
+    ) -> List[ModelMetadata]:
+        """Return built-in NOAA ras2fim catalog metadata."""
+        results: List[ModelMetadata] = []
+        for huc8, info in NoaaRas2fimModels._MODEL_REGISTRY.items():
+            metadata = NoaaRas2fimModels._metadata_from_registry(huc8, info)
+
+            if location and location.lower() not in metadata.location.lower():
+                continue
+            if model_type and metadata.model_type != model_type:
+                continue
+            if hecras_version and metadata.hecras_version != hecras_version:
+                continue
+            if tags and not all(tag in metadata.tags for tag in tags):
+                continue
+
+            results.append(metadata)
+            if limit and len(results) >= limit:
+                break
+
+        return results
+
+    @staticmethod
+    @log_call
+    def list_catalog_models(**kwargs) -> List[ModelMetadata]:
+        """Return catalog metadata for ModelCatalog integration."""
+        return NoaaRas2fimModels.list_models(**kwargs)
+
+    @staticmethod
+    @log_call
+    def download_model(
+        model_id: str,
+        output_folder: Union[str, Path],
+        extract: bool = True,
+        overwrite: bool = False,
+        credentials: Optional[dict] = None,
+        **kwargs,
+    ) -> DownloadResult:
+        """
+        Report that NOAA ras2fim download is credentialed and not automatic.
+
+        The source is intentionally catalog-only in ras-commander examples to
+        avoid accidental large S3 transfers from the ras2fim archive.
+        """
+        metadata = NoaaRas2fimModels._find_metadata(model_id)
+        return DownloadResult(
+            success=False,
+            model_path=None,
+            message=(
+                "NOAA ras2fim downloads require the ESIP/AWS credentialed S3 "
+                "workflow and are not performed automatically by this catalog "
+                "adapter."
+            ),
+            metadata=metadata,
+            extracted=False,
+        )
+
+    @staticmethod
+    def _metadata_from_registry(
+        huc8: str,
+        info: Dict[str, object],
+    ) -> ModelMetadata:
+        s3_prefix = f"{NOAA_RAS2FIM_PREFIX}/{huc8}/"
+        return ModelMetadata(
+            source_name=NoaaRas2fimModels.SOURCE_NAME,
+            source_id=huc8,
+            name=str(info["name"]),
+            description=str(info.get("description", "")),
+            location=str(info.get("location", huc8)),
+            model_type=ModelType.STEADY_1D,
+            url=f"s3://{NOAA_RAS2FIM_BUCKET}/{s3_prefix}",
+            tags=list(info.get("tags", [])),
+            extra={
+                "bucket": NOAA_RAS2FIM_BUCKET,
+                "s3_prefix": s3_prefix,
+                "catalog_only": True,
+            },
+        )
+
+    @staticmethod
+    def _find_metadata(model_id: str) -> Optional[ModelMetadata]:
+        key = str(model_id).strip()
+        info = NoaaRas2fimModels._MODEL_REGISTRY.get(key)
+        if info is None:
+            return None
+        return NoaaRas2fimModels._metadata_from_registry(key, info)
+
+
+__all__ = ["NoaaRas2fimModels"]

--- a/tests/test_model_sources_api.py
+++ b/tests/test_model_sources_api.py
@@ -1,0 +1,67 @@
+from ras_commander.sources.base import ModelMetadata, ModelType, SourceStatus
+from ras_commander.sources.catalog import ModelCatalog
+from ras_commander.sources.federal.noaa_ras2fim import NoaaRas2fimModels
+from ras_commander.sources.state.co_champ import _parse_champ_item
+
+
+def test_model_metadata_accepts_source_optional_fields():
+    metadata = ModelMetadata(
+        source_name="test",
+        source_id="model-1",
+        name="Model 1",
+        file_size_mb=12.5,
+        study_date="2024-01-02",
+        last_modified="2024-01-03T04:05:06Z",
+        projection="EPSG:4326",
+        spatial_extent={"xmin": -90.0, "ymin": 30.0, "xmax": -89.0, "ymax": 31.0},
+        effective_date="2024-01-04",
+    )
+
+    assert metadata.file_size_mb == 12.5
+    assert metadata.study_date == "2024-01-02"
+    assert metadata.last_modified == "2024-01-03T04:05:06Z"
+    assert metadata.projection == "EPSG:4326"
+    assert metadata.spatial_extent["xmin"] == -90.0
+    assert metadata.effective_date == "2024-01-04"
+
+
+def test_source_status_requires_auth_member_exists():
+    assert SourceStatus.REQUIRES_AUTH.value == "requires_auth"
+
+
+def test_colorado_champ_metadata_file_size_regression():
+    metadata = _parse_champ_item(
+        "12345678-1234-1234-1234-123456789abc",
+        {
+            "title": "Example HEC-RAS 2D Study",
+            "description": {"html": "HEC-RAS 6.0 two-dimensional model"},
+            "file": {"fileSizeBytes": 10 * 1024 * 1024},
+        },
+    )
+
+    assert metadata.file_size_mb == 10.0
+    assert metadata.model_type == ModelType.UNSTEADY_2D
+
+
+def test_noaa_ras2fim_imports_and_lists_catalog_models():
+    from ras_commander.sources.federal import NoaaRas2fimModels as FederalNoaaRas2fim
+
+    assert FederalNoaaRas2fim is NoaaRas2fimModels
+    models = NoaaRas2fimModels.list_models(limit=2)
+
+    assert len(models) == 2
+    assert all(model.source_name == "NOAA ras2fim" for model in models)
+    assert all(model.model_type == ModelType.STEADY_1D for model in models)
+    assert all(model.url.startswith("s3://noaa-nws-owp-fim/") for model in models)
+
+
+def test_noaa_ras2fim_catalog_registration_searches_models():
+    catalog = ModelCatalog()
+    source = NoaaRas2fimModels()
+
+    catalog.register_source(source)
+    models = catalog.search_models(sources=[source.source_name], limit_per_source=1)
+
+    assert catalog._source_status[source.source_name] == SourceStatus.REQUIRES_AUTH
+    assert len(models) == 1
+    assert models[0].source_name == source.source_name


### PR DESCRIPTION
## Summary
- expand ModelMetadata with optional source/catalog fields used by adapters
- add SourceStatus.REQUIRES_AUTH
- restore NOAA ras2fim as a catalog-only federal source adapter
- add regression tests for metadata kwargs, CHAMP file_size_mb, NOAA imports/listing/catalog registration

## Validation
- conda run -n symphony-dev python -m pytest tests/test_model_sources_api.py -q
- conda run -n symphony-dev python working\\CLB-879\\notebook_958_api_drift_smoke.py

Artifacts: H:/Symphony/ras-commander/CLB-879/