### PR TITLE
docs(examples): record nb113 runtime expectation

### DIFF
--- a/examples/113_parallel_execution.ipynb
+++ b/examples/113_parallel_execution.ipynb
@@ -68,6 +68,7 @@
     "3. **HEC-RAS 6.3+**: **REQUIRED** for plan execution\n",
     "4. **Disk Space**: ~5 GB (multiple worker folders + results)\n",
     "5. **CPU Cores**: 2+ recommended for efficient parallelization (since core scaling is nonlinear)\n",
+    "6. **Notebook Timeout**: full verification of the Bald Eagle 2D plan set is long-running; use a 4-hour nbconvert cell timeout for automated execution\n",
     "\n",
     "### What You'll Learn\n",
     "\n",
@@ -118,7 +119,9 @@
     "\n",
     "Example: 4 plans, each taking 10 minutes\n",
     "- Sequential: 40 minutes total\n",
-    "- Parallel (4+ cores): ~10-12 minutes total"
+    "- Parallel (4+ cores): ~10-12 minutes total\n",
+    "\n",
+    "For this notebook's `BaldEagleCrkMulti2D` verification project, the full notebook completed on CLB01 in 11,483.68 seconds (3 hr 11 min 24 sec) with `--ExecutePreprocessor.timeout=14400`. The all-plans parallel cell was the longest section at 10,270.30 seconds (2 hr 51 min 10 sec), dominated by plan 01 at 9,833.71 seconds. A 60-minute cell timeout is expected to stop the real 2D run before completion."
    ]
   },
   {
@@ -342,7 +345,7 @@
    "source": [
     "## Step 2: Parallel Execution of All Plans\n",
     "\n",
-    "Let's execute all plans in the project in parallel. We'll use 3 workers, with 2 cores per worker. This approach is good when you have multiple plans that are independent of each other and you want to complete them as quickly as possible."
+    "Let's execute all plans in the project in parallel. We'll use 4 workers, with 1 core per worker. This section runs the complete 2D plan set and can take nearly 3 hours on CLB01-class hardware; use a 4-hour cell timeout when executing the notebook through nbconvert. This approach is good when you have multiple plans that are independent of each other and you want to complete them as quickly as possible."
    ]
   },
   {
@@ -359,7 +362,7 @@
    "outputs": [],
    "source": [
     "print(\"Executing all plans in parallel...\")\n",
-    "print(\"This may take several minutes...\")\n",
+    "print(\"This full 2D plan set can take hours; use a 4-hour cell timeout for automated verification.\")\n",
     "\n",
     "# Create compute folder if it doesn't exist\n",
     "compute_folder.mkdir(parents=True, exist_ok=True)\n",
@@ -565,7 +568,7 @@
    "outputs": [],
    "source": [
     "print(\"Executing specific plans in parallel...\")\n",
-    "print(\"This may take several minutes...\")\n",
+    "print(\"This subset usually runs faster than the all-plans batch, but it can still take several minutes.\")\n",
     "\n",
     "# Create specific compute folder if it doesn't exist\n",
     "specific_compute_folder.mkdir(parents=True, exist_ok=True)\n",
@@ -647,7 +650,7 @@
    "outputs": [],
    "source": [
     "print(\"Executing plans with dynamic worker allocation...\")\n",
-    "print(\"This may take several minutes...\")\n",
+    "print(\"This subset usually runs faster than the all-plans batch, but it can still take several minutes.\")\n",
     "\n",
     "# Create dynamic compute folder if it doesn't exist\n",
     "dynamic_compute_folder.mkdir(parents=True, exist_ok=True)\n",


### PR DESCRIPTION
## Summary
- documents the verified runtime for `examples/113_parallel_execution.ipynb`
- notes that full Bald Eagle 2D verification needs a 4-hour nbconvert cell timeout
- corrects the all-plans worker/core description and runtime print messages

## Verification
- `run_notebook_visible.py --timeout 14400` completed successfully in 11,483.68 seconds (3 hr 11 min 24 sec)
- all-plans parallel cell completed in 10,270.30 seconds (2 hr 51 min 10 sec), with plan 01 at 9,833.71 seconds
- post-edit notebook source audit passed with no stored outputs/errors
- figure extraction produced one runtime comparison figure; visual review reported no blocking findings

Artifacts: H:/Symphony/ras-commander/CLB-880/