### PR TITLE
feat(unsteady): set_constant_precipitation() testing/commissioning helper (CLB-705)

### DIFF
--- a/ras_commander/RasPrj.py
+++ b/ras_commander/RasPrj.py
@@ -735,6 +735,7 @@ class RasPrj:
                 'Met BC=Precipitation|Mode': r'Met BC=Precipitation\|Mode=(.+)',
                 'Met BC=Evapotranspiration|Mode': r'Met BC=Evapotranspiration\|Mode=(.+)',
                 'Met BC=Precipitation|Expanded View': r'Met BC=Precipitation\|Expanded View=(.+)',
+                'Met BC=Precipitation|Constant Value': r'Met BC=Precipitation\|Constant Value=(.+)',
                 'Met BC=Precipitation|Constant Units': r'Met BC=Precipitation\|Constant Units=(.+)',
                 'Met BC=Precipitation|Gridded Source': r'Met BC=Precipitation\|Gridded Source=(.+)'
             }

--- a/ras_commander/RasUnsteady.py
+++ b/ras_commander/RasUnsteady.py
@@ -42,6 +42,7 @@ List of Functions in RasUnsteady:
 - write_table_to_file()
 - get_met_precipitation_config()
 - set_precipitation_hyetograph()
+- set_constant_precipitation()
 - set_gridded_precipitation()
 - configure_gridded_dss_precipitation()
 - set_meteorological_station()
@@ -3906,6 +3907,161 @@ class RasUnsteady:
             f"{num_values} time steps, interval={interval_str}, "
             f"total depth={total_depth:.4f} inches"
         )
+
+    @staticmethod
+    @log_call
+    def set_constant_precipitation(
+        unsteady_file: Union[str, Path],
+        value: float = 1.0,
+        units: str = "in/hr",
+        ras_object: Optional[Any] = None,
+    ) -> None:
+        """
+        Configure constant (spatially and temporally uniform) precipitation.
+
+        .. note::
+            Constant precipitation is a **testing and 2D model-commissioning
+            convenience**, not an engineering-deliverable forcing. Real event
+            modeling uses a time-varying hyetograph
+            (:meth:`set_precipitation_hyetograph`) or a gridded record
+            (:meth:`set_gridded_precipitation` /
+            :meth:`configure_gridded_dss_precipitation`). A uniform rate is
+            useful for rain-on-grid mesh shakedown, where
+            ``depth = rate * duration`` makes the 2D solver mass balance
+            trivially hand-checkable, for numerical / stability sensitivity
+            runs, and for cheap CI smoke-test fixtures.
+
+        Writes the ``Precipitation Mode`` switch and the constant-mode
+        ``Met BC=Precipitation|...`` keys, and updates the
+        ``<unsteady_file>.hdf`` sidecar attributes when it exists.
+
+        Parameters
+        ----------
+        unsteady_file : str or Path
+            Path to the unsteady flow file (.u##) or unsteady number (e.g. "01").
+        value : float, default 1.0
+            Constant precipitation rate (must be finite and >= 0).
+        units : {"in/hr", "mm/hr"}, default "in/hr"
+            Constant precipitation rate units.
+        ras_object : optional
+            Custom RAS object used to resolve an unsteady number.
+
+        Returns
+        -------
+        None
+            Modifies the .u## file in-place and updates the .u##.hdf sidecar
+            when present.
+
+        Raises
+        ------
+        ValueError
+            If ``value`` is not a finite, non-negative real number, or ``units``
+            is not ``"in/hr"`` or ``"mm/hr"``.
+
+        Examples
+        --------
+        >>> # Commission a 2D rain-on-grid mesh with 1 in/hr uniform rain
+        >>> RasUnsteady.set_constant_precipitation("01", value=1.0, units="in/hr")
+
+        See Also
+        --------
+        set_precipitation_hyetograph : Time-varying hyetograph (real events).
+        set_gridded_precipitation : Gridded NetCDF precipitation (real events).
+        configure_gridded_dss_precipitation : Gridded DSS precipitation.
+        """
+        if isinstance(value, bool) or not isinstance(value, numbers.Real):
+            raise ValueError(f"value must be a real number, got {type(value).__name__}")
+        constant_value = float(value)
+        if not np.isfinite(constant_value):
+            raise ValueError(f"value must be finite, got {constant_value!r}")
+        if constant_value < 0:
+            raise ValueError(f"value must be >= 0, got {constant_value!r}")
+        if units not in {"in/hr", "mm/hr"}:
+            raise ValueError("units must be either 'in/hr' or 'mm/hr'")
+
+        unsteady_path = RasUnsteady._resolve_unsteady_file_path(
+            unsteady_file,
+            ras_object=ras_object,
+        )
+        # HEC-RAS writes constant values compactly (e.g. "1", "0.25").
+        formatted_value = f"{constant_value:g}"
+
+        logger.info(
+            "Configuring constant precipitation in %s: value=%s, units=%s",
+            unsteady_path, formatted_value, units,
+        )
+
+        with open(unsteady_path, "r", encoding="utf-8", errors="ignore") as file:
+            lines = file.readlines()
+
+        new_keys = {
+            "Precipitation Mode": "Enable",
+            "Met BC=Precipitation|Mode": "Constant",
+            "Met BC=Precipitation|Constant Value": formatted_value,
+            "Met BC=Precipitation|Constant Units": units,
+        }
+
+        # Update existing keys in place; track those still needing insertion.
+        remaining = dict(new_keys)
+        for i, line in enumerate(lines):
+            for key in list(remaining):
+                if line.startswith(key + "="):
+                    lines[i] = f"{key}={remaining.pop(key)}\n"
+
+        # Insert any missing keys at a stable meteorology location.
+        if remaining:
+            insert_at = RasUnsteady._get_default_met_insert_index(lines)
+            block = [f"{k}={v}\n" for k, v in remaining.items()]
+            lines[insert_at:insert_at] = block
+
+        with open(unsteady_path, "w", encoding="utf-8") as file:
+            file.writelines(lines)
+
+        hdf_path = Path(str(unsteady_path) + ".hdf")
+        if hdf_path.exists():
+            RasUnsteady._update_constant_precipitation_hdf(
+                hdf_path, constant_value, units
+            )
+        else:
+            logger.warning(
+                f"HDF file not found: {hdf_path} - constant precipitation "
+                "attributes not written"
+            )
+
+        ras_obj = ras_object or ras
+        if ras_obj is not None and hasattr(ras_obj, "get_unsteady_entries"):
+            try:
+                ras_obj.unsteady_df = ras_obj.get_unsteady_entries()
+            except Exception as exc:
+                logger.debug(f"unsteady_df refresh skipped: {exc}")
+
+    @staticmethod
+    def _update_constant_precipitation_hdf(
+        hdf_path: Path,
+        value: float,
+        units: str,
+    ) -> None:
+        """Write constant-mode precipitation attributes to an unsteady .u##.hdf."""
+        import h5py
+
+        met_path = "Event Conditions/Meteorology"
+        precip_grp_path = f"{met_path}/Precipitation"
+        logger.info(f"Updating constant precipitation HDF attributes: {hdf_path}")
+        try:
+            with h5py.File(hdf_path, "a") as hdf_file:
+                hdf_file.require_group("Event Conditions")
+                hdf_file.require_group(met_path)
+                precip_grp = hdf_file.require_group(precip_grp_path)
+
+                precip_grp.attrs["Enabled"] = np.uint8(1)
+                precip_grp.attrs["Mode"] = np.bytes_("Constant")
+                precip_grp.attrs["Constant Value"] = np.float64(value)
+                precip_grp.attrs["Constant Units"] = np.bytes_(units)
+
+                RasUnsteady._ensure_meteorology_attributes_dataset(hdf_file, met_path)
+        except Exception as e:
+            logger.error(f"Error updating constant precipitation HDF attributes: {e}")
+            raise
 
     @staticmethod
     def _update_precipitation_hdf(

--- a/tests/test_rasunsteady_constant_precipitation.py
+++ b/tests/test_rasunsteady_constant_precipitation.py
@@ -1,0 +1,137 @@
+"""Tests for RasUnsteady.set_constant_precipitation().
+
+Constant precipitation is a testing/commissioning helper (rain-on-grid mesh
+shakedown, numerical sensitivity, CI fixtures), not an engineering-deliverable
+forcing. These tests cover the .u## text write, the .u##.hdf sidecar update,
+round-trip through get_met_precipitation_config(), insertion into a minimal
+file, and input validation. They require only h5py + numpy (no HEC-RAS/pyjnius).
+"""
+
+from pathlib import Path
+
+import pytest
+
+h5py = pytest.importorskip("h5py")
+np = pytest.importorskip("numpy")
+
+
+def _write_unsteady(path: Path, body: str) -> Path:
+    path.write_text(body, encoding="utf-8")
+    return path
+
+
+def _decode(value):
+    if isinstance(value, bytes):
+        return value.decode("utf-8").rstrip("\x00")
+    if isinstance(value, np.bytes_):
+        return bytes(value).decode("utf-8").rstrip("\x00")
+    if isinstance(value, np.generic):
+        return value.item()
+    return value
+
+
+@pytest.fixture
+def davis_style_unsteady(tmp_path):
+    body = (
+        "Flow Title=Full System Rain w/ Pump\n"
+        "Program Version=6.60\n"
+        "Use Restart= 0 \n"
+        "Precipitation Mode=Disable\n"
+        "Wind Mode=Disable\n"
+        "Met BC=Precipitation|Mode=Hyetograph\n"
+        "Met BC=Evapotranspiration|Mode=Disable\n"
+        "Met BC=Precipitation|Expanded View=-1\n"
+        "Met BC=Precipitation|Constant Value=1\n"
+        "Met BC=Precipitation|Constant Units=in/hr\n"
+        "Met BC=Precipitation|Gridded Source=DSS\n"
+        "Boundary Location=                ,                ,        ,        ,                ,DavisSystem     ,                ,Rainfall                        ,                                \n"
+        "Interval=1HOUR\n"
+        "Precipitation Hydrograph= 2 \n"
+        "    0.00    0.00\n"
+    )
+    unsteady_path = _write_unsteady(tmp_path / "DavisStormSystem.u01", body)
+    with h5py.File(str(unsteady_path) + ".hdf", "w") as hdf:
+        precip = hdf.require_group("Event Conditions/Meteorology/Precipitation")
+        precip.attrs["Enabled"] = np.uint8(0)
+        precip.attrs["Mode"] = np.bytes_("Hyetograph")
+    return unsteady_path
+
+
+def test_set_constant_precipitation_updates_text_and_hdf(davis_style_unsteady):
+    from ras_commander import RasUnsteady
+
+    RasUnsteady.set_constant_precipitation(
+        davis_style_unsteady, value=0.25, units="mm/hr"
+    )
+
+    lines = davis_style_unsteady.read_text(encoding="utf-8").splitlines()
+    assert "Precipitation Mode=Enable" in lines
+    assert "Met BC=Precipitation|Mode=Constant" in lines
+    assert "Met BC=Precipitation|Constant Value=0.25" in lines
+    assert "Met BC=Precipitation|Constant Units=mm/hr" in lines
+
+    with h5py.File(str(davis_style_unsteady) + ".hdf", "r") as hdf:
+        precip = hdf["Event Conditions/Meteorology/Precipitation"]
+        assert _decode(precip.attrs["Enabled"]) == 1
+        assert _decode(precip.attrs["Mode"]) == "Constant"
+        assert _decode(precip.attrs["Constant Value"]) == pytest.approx(0.25)
+        assert _decode(precip.attrs["Constant Units"]) == "mm/hr"
+        # The shared HDF writer also registers the Meteorology attributes index.
+        attrs = hdf["Event Conditions/Meteorology/Attributes"][()]
+        assert _decode(attrs[0]["Variable"]) == "Precipitation"
+
+
+def test_round_trips_through_get_met_precipitation_config(davis_style_unsteady):
+    from ras_commander import RasUnsteady
+
+    RasUnsteady.set_constant_precipitation(davis_style_unsteady)  # defaults: 1.0 in/hr
+
+    config = RasUnsteady.get_met_precipitation_config(davis_style_unsteady)
+    assert config["enabled"] is True
+    assert config["precipitation_mode"] == "Enable"
+    assert config["mode"] == "Constant"
+    assert config["constant_value"] == pytest.approx(1.0)
+    assert config["constant_units"] == "in/hr"
+    assert config["raw"]["Constant Value"] == "1"
+    assert config["hdf_attributes"]["Enabled"] == 1
+    assert config["hdf_attributes"]["Mode"] == "Constant"
+    assert config["hdf_attributes"]["Constant Value"] == pytest.approx(1.0)
+    assert config["hdf_attributes"]["Constant Units"] == "in/hr"
+
+
+def test_inserts_missing_keys_into_minimal_file(tmp_path):
+    from ras_commander import RasUnsteady
+
+    unsteady_path = _write_unsteady(
+        tmp_path / "Minimal.u01",
+        (
+            "Flow Title=Minimal\n"
+            "Program Version=6.60\n"
+            "Boundary Location=                ,                ,        ,        ,                ,Area            ,                ,Rain                            ,                                \n"
+        ),
+    )
+
+    RasUnsteady.set_constant_precipitation(unsteady_path)
+
+    lines = unsteady_path.read_text(encoding="utf-8").splitlines()
+    assert "Precipitation Mode=Enable" in lines
+    assert "Met BC=Precipitation|Mode=Constant" in lines
+    assert "Met BC=Precipitation|Constant Value=1" in lines
+    assert "Met BC=Precipitation|Constant Units=in/hr" in lines
+    # Keys are inserted after the Flow Title line.
+    assert lines.index("Precipitation Mode=Enable") > lines.index("Flow Title=Minimal")
+
+
+def test_validates_inputs(davis_style_unsteady):
+    from ras_commander import RasUnsteady
+
+    with pytest.raises(ValueError, match="units must be"):
+        RasUnsteady.set_constant_precipitation(davis_style_unsteady, units="ft/day")
+
+    with pytest.raises(ValueError, match=">= 0"):
+        RasUnsteady.set_constant_precipitation(davis_style_unsteady, value=-0.1)
+
+    with pytest.raises(ValueError, match="finite"):
+        RasUnsteady.set_constant_precipitation(
+            davis_style_unsteady, value=float("nan")
+        )


### PR DESCRIPTION
@
## Summary

Adds `RasUnsteady.set_constant_precipitation()` to configure spatially- and temporally-uniform precipitation in an unsteady flow file.

Resolves **CLB-705**.

## Hydraulic scoping (important)

Constant precipitation is a **testing / 2D model-commissioning convenience — not an engineering-deliverable forcing.** Real event modeling uses a time-varying hyetograph (`set_precipitation_hyetograph()`) or a gridded record (`set_gridded_precipitation()` / `configure_gridded_dss_precipitation()`). The docstring states this explicitly and cross-references all three.

Legitimate uses of a uniform rate, and why HEC exposes a "Constant" met mode:
- **2D rain-on-grid mesh shakedown** — `depth = rate × duration` makes the solver mass balance trivially hand-checkable before trusting a real storm.
- **Numerical / stability sensitivity runs** — isolates solver behavior (cell size, dt, courant) from storm temporal structure.
- **CI smoke-test fixtures** — cheapest way to generate a valid `.u##` for execution-pipeline regression tests.

## Changes

| File | Change |
|------|--------|
| `ras_commander/RasUnsteady.py` | New `set_constant_precipitation(unsteady_file, value=1.0, units="in/hr")` + private `_update_constant_precipitation_hdf()` + docstring list entry |
| `ras_commander/RasPrj.py` | Add `Met BC=Precipitation|Constant Value` regex (symmetry with existing `Constant Units`) |
| `tests/test_rasunsteady_constant_precipitation.py` | New tests (h5py+numpy only; no HEC-RAS/pyjnius) |

## Scope reconciled against current `main`

The original runner work was never committed (only a stashed diff existed). Rather than apply that diff verbatim — which would have collided with `main` — this PR adds **only the genuinely-new pieces** and reuses existing infrastructure:

- Reuses existing `_resolve_unsteady_file_path()` and existing `_ensure_meteorology_attributes_dataset()`.
- Does **not** re-add `get_met_precipitation_config()`, `_decode_hdf_attr_value()`, or the `__init__.py` geom-import repair — all already on `main`. The stash diff would have duplicated them (re-introducing the duplicate-method bug commit `64ea09bd` fixed).
- Adds a small `_update_constant_precipitation_hdf()` because `main`s `_update_precipitation_hdf()` is the **NetCDF importer** (different signature), not a generic attribute writer.
- Test targets `main`s actual `get_met_precipitation_config()` return shape (`enabled`/`mode`/`constant_value`/`constant_units`/`hdf_attributes`), not the stashs different shape.

## Validation (CLB08, `symphony-dev`)

- `tests/test_rasunsteady_constant_precipitation.py` — **4 passed**
- Full precip/unsteady suite (`-k "precip or unsteady or gridded"`) — **41 passed**, no regressions from the RasPrj regex change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@