### PR TITLE
Fix notebook 901 AORC cleanup isolation

### DIFF
--- a/examples/901_aorc_precipitation_catalog.ipynb
+++ b/examples/901_aorc_precipitation_catalog.ipynb
@@ -35,7 +35,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "cell-1",
    "metadata": {},
    "outputs": [],
@@ -46,19 +46,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "cell-2",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "📦 PIP PACKAGE MODE: Loading installed ras-commander\n",
-      "✓ Loaded: c:\\Users\\billk_clb\\anaconda3\\envs\\rascmdr_piptest\\Lib\\site-packages\\ras_commander\\__init__.py\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# =============================================================================\n",
     "# DEVELOPMENT MODE TOGGLE\n",
@@ -76,7 +67,7 @@
     "    print(\"📦 PIP PACKAGE MODE: Loading installed ras-commander\")\n",
     "\n",
     "# Import ras-commander\n",
-    "from ras_commander import init_ras_project, RasExamples, RasPlan, RasUnsteady, RasCmdr\n",
+    "from ras_commander import init_ras_project, RasExamples, RasPlan, RasUnsteady, RasCmdr, RasUtils\n",
     "from ras_commander.precip import PrecipAorc\n",
     "from ras_commander.hdf.HdfProject import HdfProject\n",
     "\n",
@@ -110,7 +101,22 @@
    "id": "08a9fd8a",
    "metadata": {},
    "outputs": [],
-   "source": "# =============================================================================\n# PARAMETERS - Edit these to customize the notebook\n# =============================================================================\nfrom pathlib import Path\n\n# Project Configuration\nPROJECT_NAME = \"Muncie\"           # Example project to extract\nRAS_VERSION = \"7.0\"               # HEC-RAS version (6.3, 6.5, 6.6, etc.)\nSUFFIX = \"901\"                    # Notebook identifier for project folder\n\n# AORC Settings\nONLINE = True                     # Enable network requests\n\nprint(f\"Project: {PROJECT_NAME}, Version: {RAS_VERSION}\")"
+   "source": [
+    "# =============================================================================\n",
+    "# PARAMETERS - Edit these to customize the notebook\n",
+    "# =============================================================================\n",
+    "from pathlib import Path\n",
+    "\n",
+    "# Project Configuration\n",
+    "PROJECT_NAME = \"BaldEagleCrkMulti2D\"  # Example project to extract\n",
+    "RAS_VERSION = \"7.0\"               # HEC-RAS version (6.3, 6.5, 6.6, etc.)\n",
+    "SUFFIX = \"901\"                    # Notebook identifier for project folder\n",
+    "\n",
+    "# AORC Settings\n",
+    "ONLINE = True                     # Enable network requests\n",
+    "\n",
+    "print(f\"Project: {PROJECT_NAME}, Version: {RAS_VERSION}\")"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -149,8 +155,8 @@
    "source": [
     "## Step 1: Extract Example Project and Create Working Copy\n",
     "\n",
-    "We extract the BaldEagleCrkMulti2D example and create a labeled copy for our AORC analysis.\n",
-    "**Note**: Existing AORC folders are deleted to ensure repeatability."
+    "We extract the example project into a notebook-specific work root and create a labeled copy for our AORC analysis.\n",
+    "**Note**: Existing notebook 901 AORC folders are removed with retry cleanup to ensure repeatability without touching notebook 900 worker folders."
    ]
   },
   {
@@ -166,41 +172,35 @@
     "NUM_CORES = 2  # Cores per HEC-RAS instance\n",
     "MAX_WORKERS = 3  # Parallel worker processes\n",
     "\n",
-    "# Clean up stale worker directories from prior notebook runs (e.g. notebook 900)\n",
-    "# These can hold file locks that cause PermissionError during extraction\n",
-    "import time\n",
-    "examples_dir = Path(ras_commander.__file__).parent.parent / \"examples\" / \"example_projects\"\n",
-    "if examples_dir.exists():\n",
-    "    stale_dirs = list(examples_dir.glob(\"*AllWorkers*\"))\n",
-    "    if stale_dirs:\n",
-    "        print(f\"Cleaning {len(stale_dirs)} stale worker directories...\")\n",
-    "        for d in stale_dirs:\n",
-    "            shutil.rmtree(d, ignore_errors=True)\n",
-    "            print(f\"  Removed: {d.name}\")\n",
-    "    else:\n",
-    "        print(\"No stale worker directories found.\")\n",
+    "# Keep this notebook isolated from notebook 900 parallel worker folders.\n",
+    "notebook_work_root = Path.cwd() / \"working\" / \"example_projects_901_aorc_catalog\"\n",
+    "notebook_work_root.mkdir(parents=True, exist_ok=True)\n",
+    "print(f\"Notebook work root: {notebook_work_root}\")\n",
     "\n",
-    "# Extract base example project (with PermissionError retry)\n",
-    "try:\n",
-    "    base_project = RasExamples.extract_project(PROJECT_NAME, suffix=SUFFIX)\n",
-    "except PermissionError:\n",
-    "    print(\"PermissionError during extraction -- retrying after short delay...\")\n",
-    "    time.sleep(3)\n",
-    "    base_project = RasExamples.extract_project(PROJECT_NAME, suffix=SUFFIX)\n",
+    "# Extract base example project into the notebook-specific work root.\n",
+    "base_project = RasExamples.extract_project(\n",
+    "    PROJECT_NAME,\n",
+    "    output_path=notebook_work_root,\n",
+    "    suffix=SUFFIX,\n",
+    ")\n",
     "print(f\"Base project extracted to: {base_project}\")\n",
     "\n",
     "# Clean up any existing AORC folders (for repeatability)\n",
     "print(\"\\nCleaning up existing AORC folders...\")\n",
-    "aorc_pattern = base_project.parent / \"BaldEagleCrkMulti2D_AORC_*\"\n",
-    "existing_folders = list(base_project.parent.glob(\"BaldEagleCrkMulti2D_AORC_*\"))\n",
+    "aorc_pattern = f\"{PROJECT_NAME}_AORC_*_{SUFFIX}*\"\n",
+    "existing_folders = list(base_project.parent.glob(aorc_pattern))\n",
+    "removed_folders = 0\n",
     "for folder in existing_folders:\n",
     "    if folder.is_dir():\n",
     "        print(f\"  Removing: {folder.name}\")\n",
-    "        shutil.rmtree(folder)\n",
-    "print(f\"  Removed {len(existing_folders)} existing folders\")\n",
+    "        if RasUtils.remove_with_retry(folder, ras_object=None):\n",
+    "            removed_folders += 1\n",
+    "        else:\n",
+    "            raise PermissionError(f\"Unable to remove stale notebook 901 folder: {folder}\")\n",
+    "print(f\"  Removed {removed_folders} existing folders\")\n",
     "\n",
     "# Create labeled working copy (include SUFFIX for concurrent testing)\n",
-    "working_folder = base_project.parent / f\"BaldEagleCrkMulti2D_AORC_{YEAR}_{SUFFIX}\"\n",
+    "working_folder = base_project.parent / f\"{PROJECT_NAME}_AORC_{YEAR}_{SUFFIX}\"\n",
     "print(f\"\\nCreating working copy: {working_folder}\")\n",
     "shutil.copytree(base_project, working_folder)\n",
     "\n",
@@ -224,53 +224,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "id": "cell-6",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2025-12-17 22:05:09 - ras_commander.hdf.HdfProject - INFO - Using existing Path object HDF file: C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\BaldEagleDamBrk.g09.hdf\n",
-      "2025-12-17 22:05:09 - ras_commander.hdf.HdfProject - INFO - Final validated file path: C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\BaldEagleDamBrk.g09.hdf\n",
-      "2025-12-17 22:05:09 - ras_commander.hdf.HdfProject - INFO - Using existing Path object HDF file: C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\BaldEagleDamBrk.g09.hdf\n",
-      "2025-12-17 22:05:09 - ras_commander.hdf.HdfProject - INFO - Final validated file path: C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\BaldEagleDamBrk.g09.hdf\n",
-      "2025-12-17 22:05:09 - ras_commander.hdf.HdfMesh - INFO - Using existing Path object HDF file: C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\BaldEagleDamBrk.g09.hdf\n",
-      "2025-12-17 22:05:09 - ras_commander.hdf.HdfMesh - INFO - Final validated file path: C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\BaldEagleDamBrk.g09.hdf\n",
-      "2025-12-17 22:05:09 - ras_commander.hdf.HdfMesh - INFO - Using existing Path object HDF file: C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\BaldEagleDamBrk.g09.hdf\n",
-      "2025-12-17 22:05:09 - ras_commander.hdf.HdfMesh - INFO - Final validated file path: C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\BaldEagleDamBrk.g09.hdf\n",
-      "2025-12-17 22:05:09 - ras_commander.hdf.HdfBase - INFO - Using HDF file from h5py.File object: C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\BaldEagleDamBrk.g09.hdf\n",
-      "2025-12-17 22:05:09 - ras_commander.hdf.HdfBase - INFO - Final validated file path: C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\BaldEagleDamBrk.g09.hdf\n",
-      "2025-12-17 22:05:09 - ras_commander.hdf.HdfBase - INFO - Found projection in HDF file: C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\BaldEagleDamBrk.g09.hdf\n",
-      "2025-12-17 22:05:09 - ras_commander.hdf.HdfBase - INFO - Converted WKT to EPSG:2271 from HDF file BaldEagleDamBrk.g09.hdf\n",
-      "2025-12-17 22:05:09 - ras_commander.hdf.HdfProject - INFO - Found 1 2D flow areas\n",
-      "2025-12-17 22:05:09 - ras_commander.hdf.HdfXsec - ERROR - Error processing cross-section data: \"Unable to synchronously open object (object 'Polyline Info' doesn't exist)\"\n",
-      "2025-12-17 22:05:09 - ras_commander.hdf.HdfXsec - INFO - Using existing Path object HDF file: C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\BaldEagleDamBrk.g09.hdf\n",
-      "2025-12-17 22:05:09 - ras_commander.hdf.HdfXsec - INFO - Final validated file path: C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\BaldEagleDamBrk.g09.hdf\n",
-      "2025-12-17 22:05:09 - ras_commander.hdf.HdfXsec - WARNING - No river centerlines found in geometry file\n",
-      "2025-12-17 22:05:09 - ras_commander.hdf.HdfProject - INFO - Original extent: (1965981.77, 289578.11, 2084790.14, 371007.58)\n",
-      "2025-12-17 22:05:09 - ras_commander.hdf.HdfProject - INFO - Buffered extent (50.0% x, 50.0% y): (1936279.68, 269220.75, 2114492.23, 391364.95)\n",
-      "2025-12-17 22:05:09 - ras_commander.hdf.HdfProject - INFO - WGS84 bounds: W=-77.867158, S=40.904353, E=-77.219156, N=41.240758\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Template plan 06 uses geometry: g09\n",
-      "Geometry HDF: C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\BaldEagleDamBrk.g09.hdf\n",
-      "Exists: True\n",
-      "\n",
-      "Project Bounds (WGS84 with 50% buffer):\n",
-      "  West:  -77.8672\n",
-      "  South: 40.9044\n",
-      "  East:  -77.2192\n",
-      "  North: 41.2408\n",
-      "  Size:  0.6480 x 0.3364 degrees\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Get geometry HDF path from template plan\n",
     "# The 'Geom File' column contains just the number (e.g., \"09\"),\n",
@@ -319,50 +276,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "id": "cell-8",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2025-12-17 22:05:10 - ras_commander.precip.PrecipAorc - INFO - Generating storm catalog for 2020\n",
-      "2025-12-17 22:05:10 - ras_commander.precip.PrecipAorc - INFO -   Bounds: W=-77.8672, S=40.9044, E=-77.2192, N=41.2408\n",
-      "2025-12-17 22:05:10 - ras_commander.precip.PrecipAorc - INFO -   Parameters: inter_event=8.0h, min_depth=0.75in, buffer=48h\n",
-      "2025-12-17 22:05:10 - ras_commander.precip.PrecipAorc - INFO - Connecting to AWS S3...\n",
-      "2025-12-17 22:05:10 - ras_commander.precip.PrecipAorc - INFO - Loading s3://noaa-nws-aorc-v1-1-1km/2020.zarr...\n",
-      "2025-12-17 22:05:11 - ras_commander.precip.PrecipAorc - INFO - Loading spatial subset...\n",
-      "2025-12-17 22:05:12 - ras_commander.precip.PrecipAorc - INFO - Loaded 8784 hourly timesteps\n",
-      "2025-12-17 22:05:12 - ras_commander.precip.PrecipAorc - INFO - Identified 137 raw events\n",
-      "2025-12-17 22:05:12 - ras_commander.precip.PrecipAorc - INFO - Storm catalog complete: 12 storms\n",
-      "2025-12-17 22:05:12 - ras_commander.precip.PrecipAorc - INFO -   Total depth range: 0.76 - 2.72 inches\n",
-      "2025-12-17 22:05:12 - ras_commander.precip.PrecipAorc - INFO -   Largest storm: 2020-12-24 12:00:00 (2.72 in)\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "Storm Catalog: 12 events for 2020\n",
-      "==========================================================================================\n",
-      " storm_id          start_time            end_time  total_depth_in  peak_intensity_in_hr  duration_hours  rank\n",
-      "        1 2020-02-07 09:00:00 2020-02-07 17:00:00           1.023                 0.287               9     9\n",
-      "        2 2020-03-19 01:00:00 2020-03-19 10:00:00           0.763                 0.209              10    12\n",
-      "        3 2020-03-28 08:00:00 2020-03-29 11:00:00           1.530                 0.156              28     6\n",
-      "        4 2020-04-17 17:00:00 2020-04-18 08:00:00           0.777                 0.093              16    11\n",
-      "        5 2020-04-30 04:00:00 2020-05-01 00:00:00           2.115                 0.203              21     2\n",
-      "        6 2020-05-28 12:00:00 2020-05-30 01:00:00           1.188                 0.284              38     8\n",
-      "        7 2020-06-03 06:00:00 2020-06-03 22:00:00           0.846                 0.360              17    10\n",
-      "        8 2020-09-29 11:00:00 2020-09-30 08:00:00           1.278                 0.177              22     7\n",
-      "        9 2020-10-29 07:00:00 2020-10-30 18:00:00           1.735                 0.127              36     5\n",
-      "       10 2020-11-11 12:00:00 2020-11-11 22:00:00           1.989                 0.448              11     3\n",
-      "       11 2020-12-16 17:00:00 2020-12-17 09:00:00           1.834                 0.174              17     4\n",
-      "       12 2020-12-24 12:00:00 2020-12-25 12:00:00           2.720                 0.202              25     1\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Generate storm catalog\n",
     "storm_catalog = PrecipAorc.get_storm_catalog(\n",
@@ -391,329 +308,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "id": "cell-10",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2025-12-17 22:05:12 - ras_commander.precip.PrecipAorc - INFO - Downloading AORC data:\n",
-      "2025-12-17 22:05:12 - ras_commander.precip.PrecipAorc - INFO -   Bounds: W=-77.8672, S=40.9044, E=-77.2192, N=41.2408\n",
-      "2025-12-17 22:05:12 - ras_commander.precip.PrecipAorc - INFO -   Time range: 2020-02-05 09:00:00 to 2020-02-09 17:00:00\n",
-      "2025-12-17 22:05:12 - ras_commander.precip.PrecipAorc - INFO -   Variable: APCP_surface\n",
-      "2025-12-17 22:05:12 - ras_commander.precip.PrecipAorc - INFO - Connecting to AWS S3...\n",
-      "2025-12-17 22:05:12 - ras_commander.precip.PrecipAorc - INFO -   Loading year 2020 from s3://noaa-nws-aorc-v1-1-1km/2020.zarr\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Storm catalog exported to: C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\Precipitation\\storm_catalog.csv\n",
-      "\n",
-      "Downloading AORC precipitation data for 12 storms...\n",
-      "======================================================================\n",
-      "  Storm  1: Feb 07 - Downloading...\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2025-12-17 22:05:13 - ras_commander.precip.PrecipAorc - INFO -     Loaded Frozen({'time': 120, 'latitude': 40, 'longitude': 77})\n",
-      "2025-12-17 22:05:13 - ras_commander.precip.PrecipAorc - INFO - Combining datasets...\n",
-      "2025-12-17 22:05:13 - ras_commander.precip.PrecipAorc - INFO - Reprojecting to EPSG:5070 at 2000.0m resolution...\n",
-      "2025-12-17 22:05:13 - ras_commander.precip.PrecipAorc - INFO - Reprojected grid shape: (120, 24, 30)\n",
-      "2025-12-17 22:05:13 - ras_commander.precip.PrecipAorc - INFO - Writing to NetCDF: C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\Precipitation\\storm_20200207.nc\n",
-      "2025-12-17 22:05:13 - ras_commander.precip.PrecipAorc - INFO - Download complete: C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\Precipitation\\storm_20200207.nc (0.2 MB)\n",
-      "2025-12-17 22:05:13 - ras_commander.precip.PrecipAorc - INFO - Downloading AORC data:\n",
-      "2025-12-17 22:05:13 - ras_commander.precip.PrecipAorc - INFO -   Bounds: W=-77.8672, S=40.9044, E=-77.2192, N=41.2408\n",
-      "2025-12-17 22:05:13 - ras_commander.precip.PrecipAorc - INFO -   Time range: 2020-03-17 01:00:00 to 2020-03-21 10:00:00\n",
-      "2025-12-17 22:05:13 - ras_commander.precip.PrecipAorc - INFO -   Variable: APCP_surface\n",
-      "2025-12-17 22:05:13 - ras_commander.precip.PrecipAorc - INFO - Connecting to AWS S3...\n",
-      "2025-12-17 22:05:13 - ras_commander.precip.PrecipAorc - INFO -   Loading year 2020 from s3://noaa-nws-aorc-v1-1-1km/2020.zarr\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  Storm  2: Mar 19 - Downloading...\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2025-12-17 22:05:13 - ras_commander.precip.PrecipAorc - INFO -     Loaded Frozen({'time': 120, 'latitude': 40, 'longitude': 77})\n",
-      "2025-12-17 22:05:13 - ras_commander.precip.PrecipAorc - INFO - Combining datasets...\n",
-      "2025-12-17 22:05:13 - ras_commander.precip.PrecipAorc - INFO - Reprojecting to EPSG:5070 at 2000.0m resolution...\n",
-      "2025-12-17 22:05:13 - ras_commander.precip.PrecipAorc - INFO - Reprojected grid shape: (120, 24, 30)\n",
-      "2025-12-17 22:05:13 - ras_commander.precip.PrecipAorc - INFO - Writing to NetCDF: C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\Precipitation\\storm_20200319.nc\n",
-      "2025-12-17 22:05:13 - ras_commander.precip.PrecipAorc - INFO - Download complete: C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\Precipitation\\storm_20200319.nc (0.2 MB)\n",
-      "2025-12-17 22:05:13 - ras_commander.precip.PrecipAorc - INFO - Downloading AORC data:\n",
-      "2025-12-17 22:05:13 - ras_commander.precip.PrecipAorc - INFO -   Bounds: W=-77.8672, S=40.9044, E=-77.2192, N=41.2408\n",
-      "2025-12-17 22:05:13 - ras_commander.precip.PrecipAorc - INFO -   Time range: 2020-03-26 08:00:00 to 2020-03-31 11:00:00\n",
-      "2025-12-17 22:05:13 - ras_commander.precip.PrecipAorc - INFO -   Variable: APCP_surface\n",
-      "2025-12-17 22:05:13 - ras_commander.precip.PrecipAorc - INFO - Connecting to AWS S3...\n",
-      "2025-12-17 22:05:13 - ras_commander.precip.PrecipAorc - INFO -   Loading year 2020 from s3://noaa-nws-aorc-v1-1-1km/2020.zarr\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  Storm  3: Mar 28 - Downloading...\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2025-12-17 22:05:14 - ras_commander.precip.PrecipAorc - INFO -     Loaded Frozen({'time': 144, 'latitude': 40, 'longitude': 77})\n",
-      "2025-12-17 22:05:14 - ras_commander.precip.PrecipAorc - INFO - Combining datasets...\n",
-      "2025-12-17 22:05:14 - ras_commander.precip.PrecipAorc - INFO - Reprojecting to EPSG:5070 at 2000.0m resolution...\n",
-      "2025-12-17 22:05:14 - ras_commander.precip.PrecipAorc - INFO - Reprojected grid shape: (144, 24, 30)\n",
-      "2025-12-17 22:05:14 - ras_commander.precip.PrecipAorc - INFO - Writing to NetCDF: C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\Precipitation\\storm_20200328.nc\n",
-      "2025-12-17 22:05:14 - ras_commander.precip.PrecipAorc - INFO - Download complete: C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\Precipitation\\storm_20200328.nc (0.2 MB)\n",
-      "2025-12-17 22:05:14 - ras_commander.precip.PrecipAorc - INFO - Downloading AORC data:\n",
-      "2025-12-17 22:05:14 - ras_commander.precip.PrecipAorc - INFO -   Bounds: W=-77.8672, S=40.9044, E=-77.2192, N=41.2408\n",
-      "2025-12-17 22:05:14 - ras_commander.precip.PrecipAorc - INFO -   Time range: 2020-04-15 17:00:00 to 2020-04-20 08:00:00\n",
-      "2025-12-17 22:05:14 - ras_commander.precip.PrecipAorc - INFO -   Variable: APCP_surface\n",
-      "2025-12-17 22:05:14 - ras_commander.precip.PrecipAorc - INFO - Connecting to AWS S3...\n",
-      "2025-12-17 22:05:14 - ras_commander.precip.PrecipAorc - INFO -   Loading year 2020 from s3://noaa-nws-aorc-v1-1-1km/2020.zarr\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  Storm  4: Apr 17 - Downloading...\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2025-12-17 22:05:14 - ras_commander.precip.PrecipAorc - INFO -     Loaded Frozen({'time': 144, 'latitude': 40, 'longitude': 77})\n",
-      "2025-12-17 22:05:14 - ras_commander.precip.PrecipAorc - INFO - Combining datasets...\n",
-      "2025-12-17 22:05:14 - ras_commander.precip.PrecipAorc - INFO - Reprojecting to EPSG:5070 at 2000.0m resolution...\n",
-      "2025-12-17 22:05:14 - ras_commander.precip.PrecipAorc - INFO - Reprojected grid shape: (144, 24, 30)\n",
-      "2025-12-17 22:05:14 - ras_commander.precip.PrecipAorc - INFO - Writing to NetCDF: C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\Precipitation\\storm_20200417.nc\n",
-      "2025-12-17 22:05:14 - ras_commander.precip.PrecipAorc - INFO - Download complete: C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\Precipitation\\storm_20200417.nc (0.2 MB)\n",
-      "2025-12-17 22:05:14 - ras_commander.precip.PrecipAorc - INFO - Downloading AORC data:\n",
-      "2025-12-17 22:05:14 - ras_commander.precip.PrecipAorc - INFO -   Bounds: W=-77.8672, S=40.9044, E=-77.2192, N=41.2408\n",
-      "2025-12-17 22:05:14 - ras_commander.precip.PrecipAorc - INFO -   Time range: 2020-04-28 04:00:00 to 2020-05-03 00:00:00\n",
-      "2025-12-17 22:05:14 - ras_commander.precip.PrecipAorc - INFO -   Variable: APCP_surface\n",
-      "2025-12-17 22:05:14 - ras_commander.precip.PrecipAorc - INFO - Connecting to AWS S3...\n",
-      "2025-12-17 22:05:14 - ras_commander.precip.PrecipAorc - INFO -   Loading year 2020 from s3://noaa-nws-aorc-v1-1-1km/2020.zarr\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  Storm  5: Apr 30 - Downloading...\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2025-12-17 22:05:15 - ras_commander.precip.PrecipAorc - INFO -     Loaded Frozen({'time': 144, 'latitude': 40, 'longitude': 77})\n",
-      "2025-12-17 22:05:15 - ras_commander.precip.PrecipAorc - INFO - Combining datasets...\n",
-      "2025-12-17 22:05:15 - ras_commander.precip.PrecipAorc - INFO - Reprojecting to EPSG:5070 at 2000.0m resolution...\n",
-      "2025-12-17 22:05:15 - ras_commander.precip.PrecipAorc - INFO - Reprojected grid shape: (144, 24, 30)\n",
-      "2025-12-17 22:05:15 - ras_commander.precip.PrecipAorc - INFO - Writing to NetCDF: C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\Precipitation\\storm_20200430.nc\n",
-      "2025-12-17 22:05:15 - ras_commander.precip.PrecipAorc - INFO - Download complete: C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\Precipitation\\storm_20200430.nc (0.2 MB)\n",
-      "2025-12-17 22:05:15 - ras_commander.precip.PrecipAorc - INFO - Downloading AORC data:\n",
-      "2025-12-17 22:05:15 - ras_commander.precip.PrecipAorc - INFO -   Bounds: W=-77.8672, S=40.9044, E=-77.2192, N=41.2408\n",
-      "2025-12-17 22:05:15 - ras_commander.precip.PrecipAorc - INFO -   Time range: 2020-05-26 12:00:00 to 2020-06-01 01:00:00\n",
-      "2025-12-17 22:05:15 - ras_commander.precip.PrecipAorc - INFO -   Variable: APCP_surface\n",
-      "2025-12-17 22:05:15 - ras_commander.precip.PrecipAorc - INFO - Connecting to AWS S3...\n",
-      "2025-12-17 22:05:15 - ras_commander.precip.PrecipAorc - INFO -   Loading year 2020 from s3://noaa-nws-aorc-v1-1-1km/2020.zarr\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  Storm  6: May 28 - Downloading...\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2025-12-17 22:05:15 - ras_commander.precip.PrecipAorc - INFO -     Loaded Frozen({'time': 168, 'latitude': 40, 'longitude': 77})\n",
-      "2025-12-17 22:05:15 - ras_commander.precip.PrecipAorc - INFO - Combining datasets...\n",
-      "2025-12-17 22:05:15 - ras_commander.precip.PrecipAorc - INFO - Reprojecting to EPSG:5070 at 2000.0m resolution...\n",
-      "2025-12-17 22:05:15 - ras_commander.precip.PrecipAorc - INFO - Reprojected grid shape: (168, 24, 30)\n",
-      "2025-12-17 22:05:15 - ras_commander.precip.PrecipAorc - INFO - Writing to NetCDF: C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\Precipitation\\storm_20200528.nc\n",
-      "2025-12-17 22:05:15 - ras_commander.precip.PrecipAorc - INFO - Download complete: C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\Precipitation\\storm_20200528.nc (0.3 MB)\n",
-      "2025-12-17 22:05:15 - ras_commander.precip.PrecipAorc - INFO - Downloading AORC data:\n",
-      "2025-12-17 22:05:15 - ras_commander.precip.PrecipAorc - INFO -   Bounds: W=-77.8672, S=40.9044, E=-77.2192, N=41.2408\n",
-      "2025-12-17 22:05:15 - ras_commander.precip.PrecipAorc - INFO -   Time range: 2020-06-01 06:00:00 to 2020-06-05 22:00:00\n",
-      "2025-12-17 22:05:15 - ras_commander.precip.PrecipAorc - INFO -   Variable: APCP_surface\n",
-      "2025-12-17 22:05:15 - ras_commander.precip.PrecipAorc - INFO - Connecting to AWS S3...\n",
-      "2025-12-17 22:05:15 - ras_commander.precip.PrecipAorc - INFO -   Loading year 2020 from s3://noaa-nws-aorc-v1-1-1km/2020.zarr\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  Storm  7: Jun 03 - Downloading...\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2025-12-17 22:05:15 - ras_commander.precip.PrecipAorc - INFO -     Loaded Frozen({'time': 120, 'latitude': 40, 'longitude': 77})\n",
-      "2025-12-17 22:05:15 - ras_commander.precip.PrecipAorc - INFO - Combining datasets...\n",
-      "2025-12-17 22:05:15 - ras_commander.precip.PrecipAorc - INFO - Reprojecting to EPSG:5070 at 2000.0m resolution...\n",
-      "2025-12-17 22:05:15 - ras_commander.precip.PrecipAorc - INFO - Reprojected grid shape: (120, 24, 30)\n",
-      "2025-12-17 22:05:15 - ras_commander.precip.PrecipAorc - INFO - Writing to NetCDF: C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\Precipitation\\storm_20200603.nc\n",
-      "2025-12-17 22:05:15 - ras_commander.precip.PrecipAorc - INFO - Download complete: C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\Precipitation\\storm_20200603.nc (0.2 MB)\n",
-      "2025-12-17 22:05:15 - ras_commander.precip.PrecipAorc - INFO - Downloading AORC data:\n",
-      "2025-12-17 22:05:15 - ras_commander.precip.PrecipAorc - INFO -   Bounds: W=-77.8672, S=40.9044, E=-77.2192, N=41.2408\n",
-      "2025-12-17 22:05:15 - ras_commander.precip.PrecipAorc - INFO -   Time range: 2020-09-27 11:00:00 to 2020-10-02 08:00:00\n",
-      "2025-12-17 22:05:15 - ras_commander.precip.PrecipAorc - INFO -   Variable: APCP_surface\n",
-      "2025-12-17 22:05:15 - ras_commander.precip.PrecipAorc - INFO - Connecting to AWS S3...\n",
-      "2025-12-17 22:05:15 - ras_commander.precip.PrecipAorc - INFO -   Loading year 2020 from s3://noaa-nws-aorc-v1-1-1km/2020.zarr\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  Storm  8: Sep 29 - Downloading...\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2025-12-17 22:05:16 - ras_commander.precip.PrecipAorc - INFO -     Loaded Frozen({'time': 144, 'latitude': 40, 'longitude': 77})\n",
-      "2025-12-17 22:05:16 - ras_commander.precip.PrecipAorc - INFO - Combining datasets...\n",
-      "2025-12-17 22:05:16 - ras_commander.precip.PrecipAorc - INFO - Reprojecting to EPSG:5070 at 2000.0m resolution...\n",
-      "2025-12-17 22:05:16 - ras_commander.precip.PrecipAorc - INFO - Reprojected grid shape: (144, 24, 30)\n",
-      "2025-12-17 22:05:16 - ras_commander.precip.PrecipAorc - INFO - Writing to NetCDF: C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\Precipitation\\storm_20200929.nc\n",
-      "2025-12-17 22:05:16 - ras_commander.precip.PrecipAorc - INFO - Download complete: C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\Precipitation\\storm_20200929.nc (0.2 MB)\n",
-      "2025-12-17 22:05:16 - ras_commander.precip.PrecipAorc - INFO - Downloading AORC data:\n",
-      "2025-12-17 22:05:16 - ras_commander.precip.PrecipAorc - INFO -   Bounds: W=-77.8672, S=40.9044, E=-77.2192, N=41.2408\n",
-      "2025-12-17 22:05:16 - ras_commander.precip.PrecipAorc - INFO -   Time range: 2020-10-27 07:00:00 to 2020-11-01 18:00:00\n",
-      "2025-12-17 22:05:16 - ras_commander.precip.PrecipAorc - INFO -   Variable: APCP_surface\n",
-      "2025-12-17 22:05:16 - ras_commander.precip.PrecipAorc - INFO - Connecting to AWS S3...\n",
-      "2025-12-17 22:05:16 - ras_commander.precip.PrecipAorc - INFO -   Loading year 2020 from s3://noaa-nws-aorc-v1-1-1km/2020.zarr\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  Storm  9: Oct 29 - Downloading...\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2025-12-17 22:05:16 - ras_commander.precip.PrecipAorc - INFO -     Loaded Frozen({'time': 144, 'latitude': 40, 'longitude': 77})\n",
-      "2025-12-17 22:05:16 - ras_commander.precip.PrecipAorc - INFO - Combining datasets...\n",
-      "2025-12-17 22:05:16 - ras_commander.precip.PrecipAorc - INFO - Reprojecting to EPSG:5070 at 2000.0m resolution...\n",
-      "2025-12-17 22:05:16 - ras_commander.precip.PrecipAorc - INFO - Reprojected grid shape: (144, 24, 30)\n",
-      "2025-12-17 22:05:16 - ras_commander.precip.PrecipAorc - INFO - Writing to NetCDF: C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\Precipitation\\storm_20201029.nc\n",
-      "2025-12-17 22:05:16 - ras_commander.precip.PrecipAorc - INFO - Download complete: C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\Precipitation\\storm_20201029.nc (0.2 MB)\n",
-      "2025-12-17 22:05:16 - ras_commander.precip.PrecipAorc - INFO - Downloading AORC data:\n",
-      "2025-12-17 22:05:16 - ras_commander.precip.PrecipAorc - INFO -   Bounds: W=-77.8672, S=40.9044, E=-77.2192, N=41.2408\n",
-      "2025-12-17 22:05:16 - ras_commander.precip.PrecipAorc - INFO -   Time range: 2020-11-09 12:00:00 to 2020-11-13 22:00:00\n",
-      "2025-12-17 22:05:16 - ras_commander.precip.PrecipAorc - INFO -   Variable: APCP_surface\n",
-      "2025-12-17 22:05:16 - ras_commander.precip.PrecipAorc - INFO - Connecting to AWS S3...\n",
-      "2025-12-17 22:05:16 - ras_commander.precip.PrecipAorc - INFO -   Loading year 2020 from s3://noaa-nws-aorc-v1-1-1km/2020.zarr\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  Storm 10: Nov 11 - Downloading...\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2025-12-17 22:05:17 - ras_commander.precip.PrecipAorc - INFO -     Loaded Frozen({'time': 120, 'latitude': 40, 'longitude': 77})\n",
-      "2025-12-17 22:05:17 - ras_commander.precip.PrecipAorc - INFO - Combining datasets...\n",
-      "2025-12-17 22:05:17 - ras_commander.precip.PrecipAorc - INFO - Reprojecting to EPSG:5070 at 2000.0m resolution...\n",
-      "2025-12-17 22:05:17 - ras_commander.precip.PrecipAorc - INFO - Reprojected grid shape: (120, 24, 30)\n",
-      "2025-12-17 22:05:17 - ras_commander.precip.PrecipAorc - INFO - Writing to NetCDF: C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\Precipitation\\storm_20201111.nc\n",
-      "2025-12-17 22:05:17 - ras_commander.precip.PrecipAorc - INFO - Download complete: C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\Precipitation\\storm_20201111.nc (0.2 MB)\n",
-      "2025-12-17 22:05:17 - ras_commander.precip.PrecipAorc - INFO - Downloading AORC data:\n",
-      "2025-12-17 22:05:17 - ras_commander.precip.PrecipAorc - INFO -   Bounds: W=-77.8672, S=40.9044, E=-77.2192, N=41.2408\n",
-      "2025-12-17 22:05:17 - ras_commander.precip.PrecipAorc - INFO -   Time range: 2020-12-14 17:00:00 to 2020-12-19 09:00:00\n",
-      "2025-12-17 22:05:17 - ras_commander.precip.PrecipAorc - INFO -   Variable: APCP_surface\n",
-      "2025-12-17 22:05:17 - ras_commander.precip.PrecipAorc - INFO - Connecting to AWS S3...\n",
-      "2025-12-17 22:05:17 - ras_commander.precip.PrecipAorc - INFO -   Loading year 2020 from s3://noaa-nws-aorc-v1-1-1km/2020.zarr\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  Storm 11: Dec 16 - Downloading...\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2025-12-17 22:05:17 - ras_commander.precip.PrecipAorc - INFO -     Loaded Frozen({'time': 144, 'latitude': 40, 'longitude': 77})\n",
-      "2025-12-17 22:05:17 - ras_commander.precip.PrecipAorc - INFO - Combining datasets...\n",
-      "2025-12-17 22:05:17 - ras_commander.precip.PrecipAorc - INFO - Reprojecting to EPSG:5070 at 2000.0m resolution...\n",
-      "2025-12-17 22:05:17 - ras_commander.precip.PrecipAorc - INFO - Reprojected grid shape: (144, 24, 30)\n",
-      "2025-12-17 22:05:17 - ras_commander.precip.PrecipAorc - INFO - Writing to NetCDF: C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\Precipitation\\storm_20201216.nc\n",
-      "2025-12-17 22:05:17 - ras_commander.precip.PrecipAorc - INFO - Download complete: C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\Precipitation\\storm_20201216.nc (0.2 MB)\n",
-      "2025-12-17 22:05:17 - ras_commander.precip.PrecipAorc - INFO - Downloading AORC data:\n",
-      "2025-12-17 22:05:17 - ras_commander.precip.PrecipAorc - INFO -   Bounds: W=-77.8672, S=40.9044, E=-77.2192, N=41.2408\n",
-      "2025-12-17 22:05:17 - ras_commander.precip.PrecipAorc - INFO -   Time range: 2020-12-22 12:00:00 to 2020-12-27 12:00:00\n",
-      "2025-12-17 22:05:17 - ras_commander.precip.PrecipAorc - INFO -   Variable: APCP_surface\n",
-      "2025-12-17 22:05:17 - ras_commander.precip.PrecipAorc - INFO - Connecting to AWS S3...\n",
-      "2025-12-17 22:05:17 - ras_commander.precip.PrecipAorc - INFO -   Loading year 2020 from s3://noaa-nws-aorc-v1-1-1km/2020.zarr\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  Storm 12: Dec 24 - Downloading...\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2025-12-17 22:05:17 - ras_commander.precip.PrecipAorc - INFO -     Loaded Frozen({'time': 144, 'latitude': 40, 'longitude': 77})\n",
-      "2025-12-17 22:05:17 - ras_commander.precip.PrecipAorc - INFO - Combining datasets...\n",
-      "2025-12-17 22:05:17 - ras_commander.precip.PrecipAorc - INFO - Reprojecting to EPSG:5070 at 2000.0m resolution...\n",
-      "2025-12-17 22:05:17 - ras_commander.precip.PrecipAorc - INFO - Reprojected grid shape: (144, 24, 30)\n",
-      "2025-12-17 22:05:17 - ras_commander.precip.PrecipAorc - INFO - Writing to NetCDF: C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\Precipitation\\storm_20201224.nc\n",
-      "2025-12-17 22:05:17 - ras_commander.precip.PrecipAorc - INFO - Download complete: C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\Precipitation\\storm_20201224.nc (0.2 MB)\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "Downloaded 12 precipitation files to C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\Precipitation\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Create precipitation folder structure\n",
     "precip_folder = ras.project_folder / \"Precipitation\"\n",
@@ -756,33 +354,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "id": "cell-11",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Generating hyetograph plots for 12 storms...\n",
-      "======================================================================\n",
-      "  Storm  1: Feb 07 - Saved to storm_20200207_hyetograph.png\n",
-      "  Storm  2: Mar 19 - Saved to storm_20200319_hyetograph.png\n",
-      "  Storm  3: Mar 28 - Saved to storm_20200328_hyetograph.png\n",
-      "  Storm  4: Apr 17 - Saved to storm_20200417_hyetograph.png\n",
-      "  Storm  5: Apr 30 - Saved to storm_20200430_hyetograph.png\n",
-      "  Storm  6: May 28 - Saved to storm_20200528_hyetograph.png\n",
-      "  Storm  7: Jun 03 - Saved to storm_20200603_hyetograph.png\n",
-      "  Storm  8: Sep 29 - Saved to storm_20200929_hyetograph.png\n",
-      "  Storm  9: Oct 29 - Saved to storm_20201029_hyetograph.png\n",
-      "  Storm 10: Nov 11 - Saved to storm_20201111_hyetograph.png\n",
-      "  Storm 11: Dec 16 - Saved to storm_20201216_hyetograph.png\n",
-      "  Storm 12: Dec 24 - Saved to storm_20201224_hyetograph.png\n",
-      "\n",
-      "Hyetographs saved to: C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\Precipitation\\hyetographs\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Generate and save individual hyetograph plots for each storm\n",
     "print(f\"Generating hyetograph plots for {len(storm_catalog)} storms...\")\n",
@@ -835,28 +410,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "id": "cell-12",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Summary plot saved to: C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\Precipitation\\storm_catalog_summary.png\n"
-     ]
-    },
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAABW0AAAPZCAYAAABqHAjqAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjMsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvZiW1igAAAAlwSFlzAAAPYQAAD2EBqD+naQAA61RJREFUeJzs3Qd4FNX38PGTUBJa6L0j0jtIly4oSBMUlI4gCAiCiILSVEBQmoIUaSIgCAIqKkpHBOlNmoB0qdJrKPs+5/7e3f9usqkkmdnk+3meMbvT9s7s7Ho5e+ZcP4fD4RAAAAAAAAAAgC34W90AAAAAAAAAAMD/IWgLAAAAAAAAADZC0BYAAAAAAAAAbISgLQAAAAAAAADYCEFbAAAAAAAAALARgrYAAAAAAAAAYCMEbQEAAAAAAADARgjaAgAAAAAAAICNELQFAAAAAAAAABshaAsAAAAPefLkET8/PzMNGTLE6uYAAAAACQ5BWwAAEGnz58+XevXqSebMmSVJkiSSOnVqyZs3r9SoUUN69eolv/76a6htnME/nWbNmiUJgcPhkJ9//lnatGkjBQoUkKCgIHO+9LzVrl1bRo4cKWfPnn3s10mI59bdn3/+Ka+88ooJMgcGBkqKFCkkZ86c8tRTT8mrr74qU6ZMsbqJiEF//PGHDB482HyG8ufPLylTppRkyZLJE088IR06dJDdu3eHue3Vq1fl/fffl2LFipnrRD+TZcuWlVGjRsndu3ctfS0AAABv/Bz6rwoAAIAItG3bVr7++utw12ncuLEsXbrUY54GFJ1mzpwp7du3l/js1KlTJpC4YcOGcNdr167dYwdaY+vcahD0xIkT5rEGruyYbTtt2jR57bXXTIA8LPqjggbQED8UKlRIDh06FObyxIkTy+zZs+Xll1/2mP/PP/9IrVq1XNd0SKVLl5YVK1ZI+vTpLXktAAAAbxJ7nQsAAOBm+fLlHgFbzRrTjFvNPrt48aLs2LFDNm3aJHZy48YNSZUqVZy+5vnz56V69epy7Ngx1zzNRG7UqJHJsr1y5YrJDo0ooIvwXb58WXr27OkK2ObIkUOaN28umTJlMu/7X3/9JevXr7e6mT7t4cOHcu/ePUmePLnYjWZSa3a/ZrGuWbNG1q1bZ+Y/ePDABPKfe+45SZMmjZn36NEjadmypSuImi5dOrOOZrxqJvadO3dk586d0rVrV1m4cKGlrwUAAOBBM20BAADC07t3b42OmSl//vyOBw8ehFrn2rVrjg0bNrieV69e3bWNtyl37twe258+fdrRt29fR7FixRwpUqRwBAQEmHVatWrl2Lx5c6jXGzx4sMe+Ll265OjWrZsje/bsDn9/f8fYsWPNerrMuZ5u8/PPPzsqVqzoSJYsmVn3vffecwQHB5t1J06c6ChUqJB57bx58zqGDRvmePToUaTPU8uWLT2O8fXXX3fcv38/1Hp///23Y86cOa7n//zzj6NXr16OqlWrOnLkyOFInjy5I2nSpI5s2bI5nn/+eccPP/zgsX1Uzu306dMdL774ojmu9OnTOxInTuxIlSqVo2TJko5+/fo5Ll68GKp9Ic9ZSNu2bXO0adPGkSdPHnOu9P0qWrSoo0+fPo5Tp055PTd79uwxx6KvrdOzzz7r2LlzZ6j3MTK+//57j+M9fvx4qHX0vP/6668e89asWeOx3bFjxyJ13CG3O3jwoGPQoEGOXLlymevoqaeecvzyyy9m3QsXLjg6duzoyJAhgyMwMNBRpUoVx/r160O1z31/M2fOdMyePdu8J7rNE0884RgzZozrOD788ENzrvWa0Pdx6tSpofanbdTXLV26tCNLlixmXW2b7qt9+/bm/IfUrl07Vxv0mjpx4oSjdevWjkyZMjn8/Pwcn376qfksOdcJeT5VuXLlXMu7du3qiE1vvfWWY/fu3eEeh07un5effvrJY9lvv/3mWqbn0X3Z/v37LXktAAAAbwjaAgCACL3xxhuuYIMGo44cORLhNlEJLK5bt86RNm3aMNfVwNHo0aM99u8e7NM2aTDLfRtvQVsNaGkwKuT+NRDjfozu08CBAyN1jv7991+PfZcqVcrx8OHDSG37448/hnuudBo6dGi0zm3ZsmXDXVcD12fOnIl00FbPq3sgL+SUOnVqE0B0t3XrVkfKlClDrasBymeeeSbKQdvvvvvOYz8axI2MmAraejunek7mz59vgv0hl2lgO2SQLqL9Oa+9xo0be12mwXh3GmQM733WIO6KFSvCDEA++eSTJtjrvs2SJUscDRo0cD3X4L87/bHBff0tW7Y4rBDy87No0SLXsi5durjmBwUFefwI899//3ls9/HHH9vqtQAAQMJGeQQAABChMmXKuB5funTJDK5VqlQpc+uwlkqoWbOmGazH3euvvy7PP/+8vP322655LVq0kHLlyrnqjSqtOfrCCy+Y0gFKB/vRgX508J5vvvnG3Gqstx337dvXvJaWHwhJ26RTnTp1pEqVKqZkg5YjCElvTS5atKh5PS35sHXrVjP/q6++ctWb1DbrgGuHDx8288aPH28GFUqaNGm450hvnXavr6o1a/39Izfmq9bH1POp5yZjxozm2G/dumUGQ9L9qg8//NAMrpU9e/ZIn1ulJQMaNmxoBlDS27UTJUokZ86ckQULFsh///1nHn/00UfyxRdfRNhOLTnQp08f13HmypXL1PS8efOmqal7+/ZtuXbtmjRr1kyOHDkiadOmNet27NjRrOOk2+TLl0++/fZbU98zqvRcaT1fZzu0lrLur2LFiuZaffrpp8216V7zNyZt377dnG99zQkTJpiSDM5b45UOQJchQwb5/PPPzW30WmZAr6PJkyeHub9KlSrJM888Y94XZy1Vfc+VXvPVqlWTL7/8Us6dO2fm6aBWel6d9PZ9Xa948eLmfdbPkb6/P/30kxw4cECCg4NNSYn9+/d7bYPzetfPRsmSJc3nTq+jN954w+xDff/99+Zzpsem3G/x18+VnnMrHDx40PVYP3P6PeG0Z88ej1Il7teEnic9Rr1mQ65rh9cCAAAJnNVRYwAAYH96i7b7bdDeJr21f9euXaG2DXkbeEiauem+jpYvcDp//rxHhqZmHXrLtNXpzTff9Np29+xJLQ+gZRzUoUOHPLbXW8Jv3rxpli1fvtxjmbdby0MaNWqUxzbO2+WjQtuk2Zqff/65uTX9k08+MaUSnPvUW+ijcm6dbt265Vi5cqW5RVtvu9f9umdw5suXL1IZp+7baIkDfX+c9H3zlum8adMmj/nvvPOOa5vLly97ZFhHNtNW6fsd3vWoGa8LFy6MlUzbTp06uZb179/fY1n37t29lssoU6aMx2u5b1OkSBFXiQ4tQeC+TEsmOMuRTJ482WPZ9evXPfapmd1aSmTWrFmOcePGmfdZS1a4b3Py5Mkwb/XXbULSbNECBQq41nHPeHfPEA6ZCR9XDhw44HENaSkIdwULFnQte/rpp0Ntr+VInMvr1atnm9cCAAAg0xYAAEQqE3T16tUyYsQImTFjhhlwKyQdXEszBfft22eyRSPLfQAz3U4H9nHPEtXnzoy+8AY702zYiGjGqWaxqjx58ngsa9CggclWVJqV6s6ZBRxbjh8/Lq1atZKNGzeGu97p06ejvO8xY8bI4MGDPTJdo7tf9/P/7LPPmvfHSd8nff80y9m57ptvvinbtm3z2Efbtm1djzUTV7NkZ82aJdE5riJFipgMVr3mQtLB4F566SVZtWqVyQSPSa1bt3Y9Dnkd6Ws6uV9H4V1Duk2SJEm87k8zXzU7OuT+nPt0DranGcudOnWSkydPhtt2fa9z5swZar6+F927dw81X7NFe/ToYbJ01bRp00y2tZ5fzRBW2nb3cxKW69evy9SpU0PN1wzUzp07S1TpNabXj/PcaqZxeBnj7pnw4c2z+rUAAABU5O7ZAwAACZ4Gh4YPHy5nz56Vv/76S6ZPn25KADiDRkoDdl9//XWU9nv58mXXY28lDdznhRX40tu106dPH+FrZcuWzfU4ZLkD92UapHant75HRMsWhHUbdUSaNGkSYcBW6W32UbF06VJ56623wg3YKr11PrbeKy1/4S5LlizhPo8sDSZqoE+vxVOnTplSCxokzp07t0eQbOzYsWHuI2QQLbLnNzrXUXjX0ONel//++6+5hiIK2IZ3jBoQDrl/p/bt27s+51pqQct26Pl2/8HDPYAf3vWjJT1CTsOGDZOo0jIStWrVcv1IUL9+ffn5559NWQh37t8LWsYiJPd5zrIPVr4WAACAE0FbAAAQ5WCZ1q/UepqaIam1Gd1rtzprY0aW1np08pbB6z5PswG9cWbIRsSZzehNWAGryNJsTvcalrNnz45UsFfrl+7evdv1/JVXXjHZkLqtBhWjkrXsLdjklDJlSvntt9/kzp07Zr8TJ06M8v6i816lSZPGY50LFy54PHfWaH0cOXLkkBdffNEEaP/++28pXLiw1+sxZI1hPRfuWaDejikurqPH3d+PP/5o6gk7jR492gTL9X32loUc1c+QBmw1cOuk2bbu9Wy1BnVc0iCv1kW+e/euef7aa6+ZervJkycPtW6JEiVcjzU72D1Qr0FYfd+dtB6wla8FAADgjqAtAACIkA7UNWXKFI+gg3uwxz0YFjJI5x50cg8sOVWuXNkjsPHLL794BPjcn7uvazdZs2b1uDVeBz3r1auXPHz4MNS6GkicO3eueayDRblr3ry5ydrVAPDatWtd2X3eRHRu3fetg2Zp+YrAwEATEF60aFGUj9H9/OtAbu4BWH2f3NvqXNc5OJqTDi7nno2rAbCo0tvytRyGZth6Oyd6jN6ux5DX5p9//ul6rKU/fPX29ZDXkAZRnYPRuWfEPg4tkeD8UULfQ2dpBM2u1szTyNDSD3qOQ05aHiQyNCNcg8f63ut22p6PP/7YfDeFFdxu1KiR67F+f61cudL1PORnQMsfWPFaAAAA3lDTFgAAREizxoYOHWpuP69ataqUKlXKZF1qsEiDEQ8ePPCodepOA5A6Er0zA1C30duKS5cuLbVr1zYlFj788ENX4KlZs2Ymi1drz86bN891a78GTfT17UwzPTUQ6DzeCRMmmGCm1tLV4JbeHr5582b5/fffTW1XrWObP39+E/R2ZuVqoHfXrl3mfMycOTPc14vo3BYsWNDUOlWaEa0Zg5qFqm1yD1hGVu/evU2QVYNYeqv3U089ZTKD9T3SWsdOem3o+6oqVqxosgr37t1rnut7rddTrly5TEAxOvWC9bU1A1LLdZQtW1YqVKhgyghoNqQerwbMvV2PhQoVMlmjztvUu3XrJsuWLTPZvuHVS7Y7fZ/dabkCrTGs73l0gvPeFChQQOrWrSu//vqrR4mFNm3aPHaWemTpd4O+X05VqlQx9X4//fRTj/X0BwPnjwb16tUz1+nWrVvN85YtW0qXLl3MtTJp0iSPH0v0+rDitQAAALyyeiQ0AABgf4MHD/YYZT6sqXPnzqG27d27t9d1u3fv7lpn3bp1jjRp0oS5X39/f8enn34aZpty584dZtt1mXM93cad+2u4Lzt27JjHsjVr1kT6XB0/ftxRqVKlCM9Vu3btXNt07drV6zq1a9d2ZM+ePcz2R3RuDx8+7EiVKlWo5YkTJ3a0atXKY15kz9nYsWPN+xHWcaVOnTrU+dq6dasjZcqUodYNCAhw1KpVy/U8b968kTrHuv/IXI9lypRxXL9+3WPb999/3+u65cqVc2TKlMnrcYd8Pb0+nGbOnBnmsvCuUfdtdB9hXXvuy8JqR3BwsKN48eJhXmdhXcvuy6pXrx7heV+2bFmo/e/bt88RV9yvy/CmkNfs0aNHw922VKlSjkuXLln2WgAAAN5QHgEAAERIM1w1Y08zE8uXL2+yJDWjUwdN0mxPvS34u+++8zoyvGZEavao1h3VTDVvqlWrZgaU0kGztF6u1ovUfevraDaqDtKly3yBDoSlAzVpnVFnJq2WkNBsRB2sqU6dOqae7KhRo1zbfP755/LBBx+YbbW+qR63DtCk+wgvizGic6uvvX79epMhqedU69rqqPerVq0y7YjutaDZwpphqe3V90mvBc3g1UxczaitUaOGxzZaIkHfQ80A1TbopJnA2rYnn3wyzPIFYdHMRj2G9957z7yWHqdmZuu50sGg9HoaN26ceU33gfKUnmfN0M2bN68513oM/fv3l3Xr1oUaWMpX6HGsXr3a3M6vxx8QECDFihUzn8chQ4bE2OtoGQQ9106a4VykSBGxOy0NotnrAwYMMNepvs/6mdSM9JEjR5os68gMZGi31wIAAPGbn0ZurW4EAAAA4i+tD6oB1ZADgWlZBQ0uOks8dO7c2WvgH/ah5Sa0RIKaPHmyuf0fAAAAMY+atgAAAIhV+/fvN9nYmnmsmZlp06Y1g09p0M8ZsNWAbvfu3a1uKrw4ePCgnDlzxtRB/u2331xZ0fp+AgAAIHYQtAUAAECsO3XqlHz88cdel2mJBR2oqWTJknHeLkRM37evvvoqVGkOLXMBAACA2EHQFgAAALEqZ86cpt7t2rVr5eTJk3Lt2jUJDAw0dWW1Jq3WSi5UqJDVzUQEtFau1rTV9/LVV1+1ujkAAADxGjVtAQAAAAAAAMBGPEeDAAAAAAAAAABYiqAtAAAAAAAAANgIQVsAABDjKlWqJH5+fqYGpo46D8Q3WotXr3Gd2rdvH+evr6/pfH1tC+L+vb5z545kzJjRzM+TJ4/cu3fP0nYCAID4haAtAACIUUuWLJE///zTPH7llVcke/bsHsu//PJL6dixoxQvXlwSJ07sCoZo0CMsy5cvl3feeUeefvppM3hV8uTJJUWKFGbwqh49esixY8di9ZgIkEXP/fv3ZezYsdKqVSspWLCg+Pv7R3geZ82a5VonoknXjYqffvpJXnjhBcmVK5cZCC1p0qSSOXNmqVWrlkycOFGCg4Nj6MhhRbBbv0Oc+x4yZIjEtmTJkkn37t3N4xMnTsikSZNi/TUBAEDCkdjqBgAAgPhl8ODBrse9evUKtfztt9+Wa9euRWmfTZo08ZrFdujQITPNnDnTBOQIqNrLrVu3pE+fPrG2fw3ORdb7778vw4YNCzX/woULZlqzZo18++23smrVKvNjQkRef/11ef75583jYsWKRbHliC80aKvX1YMHD2T48OHmutA7DAAAAB4XQVsAABBjNm7cKHv37jWPNbOyVKlSodZJlCiRFC5cWMqVK2fW3bVrV6T2rVma1apVk8qVK5t9LFu2THbu3GmW3b59W9q1a2cybnW9+OL69esSFBQkvixJkiRStGhR835rQDSirOinnnpKPvnkE6/LFixYINu2bXPtt06dOpFqw/nz52XEiBGu51mzZjXXiwbX5s2bJ4cPHzbz169fL7/99pvUr18/wn22aNEiUq+N+E3LI2imtl43Fy9elMWLF8vLL79sdbMAAEB84AAAAIghnTp1cmj3QqcBAwZ4Xef27duux+3atXOtnzt37jD326VLF8fRo0c95j18+NBRs2ZN1/Y67dmzJ1LtvH//vmPs2LGOihUrOlKnTu1IlCiRI126dI4iRYo42rRp4/jmm2/MejNnzvTYv7dpzZo1rv0+ePDAMX36dEetWrUc6dOndyROnNjst0aNGo6pU6ea13V37NixUPuaNm2ao3Tp0o7AwEBHyZIlzXqDBw/2OE///vuvo23btuY1UqVK5Xj++ecdhw4dMutu377dUa9ePUfKlCkdadKkcTRv3txx8uTJUOfg+++/N+tlypTJtFP3ky9fPkfjxo0dw4cPN+f3cT169Mhx9+5d1/Pq1au7jkMfR8XNmzcdadOmdW2v105kbdq0yeM8L1q0yLVs27ZtHstmzZoVqX26H4t7W7y9p3o9lS9f3pEsWbJw3xN14MABR7du3RyFCxd2pEiRwmyTN29eR4sWLRxbt271+tnRtly8eNHx+uuvO7JmzepImjSpo1ChQuaa80bfk88//9zx9NNPm3OaJEkSR5YsWUy7Nm7c6HUb/Szo6zivaz2OAgUKOF566SXHxIkTIzxf7tdwWJOeO/fviTFjxjgqV65sXkvbqNfqc88951iwYIHHvt3PRViT0+LFix2tW7d2FC9e3OxP96vnWc939+7dPdoQ0XvtpOfZubxOnToRngsAAIDIIGgLAABiTK5cuVzBi2XLlkW4fmSDtmHRwJN7YEYDcJERUZCnQoUKUQ7aalCxWrVq4a5btWpVx40bN8IM8GkQzf25t6CtBoHz5MkTat8ZM2Z0LFmyxBEQEBBq2ZNPPum4c+eO63Ujc1zu68eUxwnajhs3zrWtn5+fY+/evZHeVgOaGsh0bt++fXvHpUuXzHvx3nvvueZroNxb0O5xgrb6nns7vyHfE6UBe/d2hpz0hwZv13DBggW9XhM66Y8I7i5cuOAoVapUmK/h7+9vznVUAq6ZM2eO0aDt2bNnHUWLFg133WbNmrl+BIlK0Fa3C2+9oKCgUD/+RBS01WvRuVw/f+4/VAAAAEQX5REAAECMOHnypJmc9Hb42Hbw4EHX41SpUpmBySJy8+ZNmTNnjut5s2bNpEyZMqbOrg4mtG7dulC36rvflp8vXz5Tt9LpiSeeMH979uxpbq93qlu3rlSqVMkMyvbrr7+aeRs2bDDrzZgxw2vbfv/9d8mdO7dpkw62prVWQ7p8+bIZtV7rBWvN2GnTppn5emt206ZNJWXKlGZwNj2WRYsWmWV6+//SpUulZcuW5rn7gEl6jFqbVWtynjp1SjZv3iwHDhwQO9G26YBmTs8991yU6shmyJDBlEfo27evRu/MAGYhBzF78sknzWBk4Q2IFx36nus5rlevnqmb+8cff3h9T/Q6ee211+TRo0fmudbVffHFF801ffr0aTMYX1i0rrMOrKbXpQ6Ope+vXiNq1KhRZuA/pzZt2rhKkuhnRgcLzJEjh2mXvoa+fu/evc3nt0qVKqGuFy1JobWj9drT60WPz/la4dHPg16buq9//vnHzNPXcC8zkS5dOvNXB67bt2+fa37z5s2lSJEismLFCtm0aZOZ991335kasoMGDTLnUK8HfX7lyhWz/JlnnjGvGVKaNGnMfC3RkjZtWjMYnZbP0AEU9ftLS5LooIc///yzRJbuSwdG1HOitbe3bNliBk0EAAB4LNEO9wIAALhZvXq1K9tMswUj43EybdevX29ubXZuP2TIkEhtd/nyZY+sunv37oW6pf+ff/4Js53eMkQ1a1NLLDjX0VvG3elz5zJdT9f3lpWpt8FfuXIlwizFOXPmuJZVqlTJY9nChQtdx5EtWzbX/D59+ri2KVGihGu+lg4ISdsVE+URYirTdt68eWGWpIgKzUTWMhAhsyu1BMGgQYNMtnR0jiW8TFstixAcHGyW6V+9Jd/be/LCCy94ZLvq9e1Or9NTp065nofMLl26dKnXrGSdrl+/bubv3r3bY75+Zt3Vr1/ftaxp06au+fo5cc7XLNiQQpYuic55c9q5c6dHG/v16+dRfsT9etesc/frVL9DnMv0MxMWfR/0/GoWsmYvf/LJJ44OHTp4ZMs637PItFnlz5/ftY5msgMAADwuMm0BAECM0ExPJ81gi00//PCDyRC8f/++ea6ZdgMHDozUtto2HRhLM/k0qy5v3rwmE1IzLYsXLy61a9c286JCM+sePnzoeq6DXLnT599++615rOvp+pot6m0kes0EDI9mYLpnJ2pmqDP7UAfn0mxb5efnZ47j33//Nc+dGYhKswD37NnjykjUjGA9fs1m1MHe9DzYyaeffup6rNmZmukZVePGjTOZtnr+NaOzQ4cOJjv166+/NhmWH3zwgfz0009mMD3NvowpnTp1Mu+L0r/6njgzqN3fE81YddKs3JCZmtomzYj1Jlu2bNK4cWPXcx0E0J2+jmbVOrN8nXQArbDoeXDStui5UZrRWqFCBXO96OeoZs2akj9/fokpzmvZ22dJByBs3bq1ax3NOtcsY810jay5c+fKm2++KZcuXQpzHc2W1eU6YF1kpU+fXo4cORLquxAAACC6CNoCAACforfJa/DNeRu53vo9depU8ff3j/Q+5s2bZ0Z4379/vwlqfv/9965luh8tPTBmzJhI70+DR+4yZ84c7nP3YJ27yJR3yJQpkwncOrkHGHWZBrac3Ndzni+lt5HrLeq//PKLKReht53r5FS9enUTpNNbvq22evVq2bFjh+t5v379orwPDVD36dPHlEZQeiu8BqedQVUteaHLtm/fLrNnzzbzYkrIcgsBAQFe3xP3ayiqPxqE9xrurxPyOg2Pe+BRSxq89NJLpoTDf//9F6p0gC775ptvovQZjO3Pkjd6HbVt29bjvIcXuI0K57UFAAAQUwjaAgCAGKF1Q6MTSIkszZB84403POprDh061NS0jKoSJUqYTNu9e/eaQI7WF9W/GsTUgI4Ghhs2bGiyCCPDWYvTSWtkhvc8rEzkyARJnVmb3rgHacMTFBRkAm9aK1UDcX///bcJYGsw8/bt26aur9ZC1fNrNa0p7F4/+IUXXojyPrSWrHtQTTOr3QOeeu06g5TOeq8xJeT7pRnQYV1DzgzcY8eOxdpruNPsYq2BG5GcOXOa7FbNJNUscf286GdHf+zQesOaRf7ss8+a7OXH5e2zpFms7s/dRSWrf+HCha6ArZ4j/fFGP+f6udPPQ4MGDWIk2JwxY8Zo7wcAAMCJoC0AAIgRmq3oFBwcbAJQmvkZE7SMgWbzOQf00uxSHcxLByyKDg3MlSpVypQBcC8FULJkSVfZAA3iOoO27kExDWqGVL58eZPh6iyR8NVXX0n9+vVdy/W5k66n61vpr7/+MrfQ6+32OsiTk2YYf/bZZ+axe3arDtrlHpCLq6xCbaf7AFyaLeueSezu+PHjHhmqGqh1llFwL12htm7d6sq01e3cb5WPTBAzNlStWlUWL15sHv/222+mlIFzIDClwVENWGbPnj3ar1G5cmWP5xqsdh9Uz0l/0HD/4WX37t3mc6JlENxLIWhJBi1V4rxeIhO0jeizFLKN+tkZOXKk6310H0RQA7zupSAi2rdmCTulTp3afKc4s4Od5UuiQ9vlLEMS8rsQAAAgugjaAgCAGKEZixpQOnPmjCuIo9l3Iemt+c6stG3btrnma5BIyx44vffee64sOg1eaQDPSfd79uxZj1qnSuvEap3NiFSsWNHUAdVanfpXM081MOUM2Cr32rLugTK9hV6Dm5p9qMHjnj17mkzA9u3by/Tp010BoKtXr5pasZrJ6gw2K7092z1z0Ap6njVjUuv36nFoZqAGnWbOnOlaJ6LaulF5LaejR496PHZfFvK9DDlPA4zRzeTUcg/uNFtX96VlBLSmrXsQWuvJWuHtt9+WpUuXmkxQDQLqDwYaVNSg5Llz58w11KNHD1OPNbr0RwmtYewshaH70+zysmXLmuDliRMnTC3bAwcOyODBg00gWWkN5WvXrpk26WdBg6X6/rmXSYjs9eL+WdISHO+++655b3XSz5C2Ua/LVatWmXU041tLeejnWoPZ7jVv9XPoXpJB9+2sK6s/NGgAXmv5aoa21np2D/Dq51MzazVIrPWEdd/RpefLGSTW7wSrf5QBAADxxGMPZQYAAOBlRPtBgwZ5Xcd9hPfwpmPHjrm2icz6URm1XUeHD28/efPmdVy9etVjRHt/f/9Q66VIkcK1zs2bNx3VqlULd79VqlRx3Lhxw7WNHqP78jVr1nht7+DBg13r6PkL65yHXBbWqPf16tULt52BgYGOLVu2uNbX8+q+PCoi+96FdPr0aUeSJElcy4cMGRLu60R0Lnv16hVhGzp06BDp4wrr3EbUjrC2U9OmTXMkTZo0zPaNHTvW6/uu+3SnrxnWZ+n8+fOOUqVKRXgu9JpzKliwYLjrpkuXznH8+PFInbfvv//e6z6KFi3qWufs2bOOIkWKhPuazZo1c9y/f99j3+PHj/e6boMGDczy//77z5EtWzav67ifz5DnLLz3TE2dOtW1vHbt2pE6DwAAABF5/NECAAAA/j8dFMxp0aJFYldaF1czLbW2rWaZai3YlClTmuc60NXmzZvN7dNOWkpBB1oqU6aMBAYGet2n1sXU7MBp06aZjETNRtT9arawZnpOmTJF1q5da17HaprVqVmKmnGs2YmaHahZp3pbd7t27UwWrnvdV2etVRVXWYTjx4+X+/fvm8eaMdm9e/fH2t+4cePMrfyacallIfSY9Xb6rFmzmoxLzY7WkhtWevXVV03pDi1ZoIPSJU+e3Lwvmg2tZSycma+PQ0uW6PWtn4FatWqZDFctOaHXr75m69atZe7cueYacRoxYoR07drVZORmyZLFnDdtm67frVs3k32eO3fuSL1+o0aNZMKECVK4cGGPQfTc6WtoCYvRo0ebbHX9LOpnST+rmmU/f/588/0SsoazXiNDhgwx17G3+s76mdSsWs201ux6va70OteyFJrlG13u33Xu34EAAACPw08jt4+1BwAAADfFihUzNTGVlhtwrxkL36T1efU2er0VXQO6GrwDIGYAOy2xojWHNQB+6tSpMH/YAQAAiAoybQEAQIwaOnSoR7YkfJvWV9VBsdRrr71GwBZwM3HiRBOwVQMGDCBgCwAAYgyZtgAAIMbpbfd6C7be/nzs2DGTiQbfpIPF6S3kmkX4999/uwaHAxK6O3fuSK5cueTSpUvmr34+tJwFAABATCBoCwAAAAAAAAA2QnkEAAAAAAAAALARgrYAAAAAAAAAYCMEbQEAAAAAAADARgjaAgAAAAAAAICNELQFAAAAAAAAABshaAsAAAAAAAAANkLQFgAAAAAAAABshKAtAAAAAAAAANgIQVsAAAAAAAAAsBGCtgAAAAAAAABgIwRtASAC7du3lzx58kRr2yFDhoifn5/ElRo1apgpoTp+/Lg537NmzbK6KQAAAD7X502ZMqUkdPQnAdgFQVsAtqMdJO0oOafAwEApUKCA9OjRQ86fPy++bvjw4bJ06dJob79//34TDNYOpR1oQNv9/QprikzH94svvqCDDAAAEjRf7As7ExUuXboU5W3//fdfs/2uXbvErn7++WfTRgCIS4nj9NUAIAo++OADyZs3r9y9e1c2bNggkyZNMh2mv/76S5InTx5n7fjyyy/l0aNH0dr2/fffl3fffTdU0LZ58+bSpEmTaAdthw4dajJqQ2YA//bbbxLXxo0bJzdv3nQ91/fom2++kbFjx0qGDBlc8ytXrhypoK1uo5keAAAACZld+sKxTYO22rfVfm2pUqWsbo7kzp1b7ty5I0mSJHHN0/M+ceJEArcA4hRBWwC29dxzz0m5cuXM406dOkn69OllzJgx8v3338vLL7/sdZtbt25JihQpYrQd7h22qEqcOLGZ4krSpEklroUMPp87d84EbXV+dMtKAAAAJHTR6Qvj8TmzmwHAapRHAOAzatWqZf4eO3bMo+7W0aNHpX79+pIqVSpp1aqVWaaZsZoBWrRoUdPpypw5s3Tp0kWuXLkSar+//PKLVK9e3WwfFBQkTz31lMybNy/MmrbOOleffvqpySbVX+OTJUtm9qGZD+HVtNXHGlj+6quvXLe8ObNKT5w4Id26dZOCBQua/WnH/MUXX/Qog6C3y+k8VbNmTdc+1q5dG2ZN2wsXLsirr75qzoGei5IlS5rXd+d+TFOnTpUnnnhCAgICzLnYunWrPK4HDx7Ihx9+6Nqvns8BAwbIvXv3XOvovH379sm6detcx+U8lsuXL0vfvn2lePHi5j3X90n/IbN79+4IX1uDyB06dJAcOXKY186aNas0btzYNuUlAAAAotMXVnPmzJGyZcuavmO6dOmkZcuWcurUKY/tfv/9d9N/zJUrl+kL5cyZU3r37m2ySSOiJQsyZsxo+mTud1ZFhm5TrFgxc5eY9ls1Ozh79uwyatQo1zrah9X+ptL+mreyWps3b5Znn31WUqdObfahfe4//vjDa5/7yJEjpm+dJk0as77u8/bt2x7rrlixQqpWrWrW0X6l9r21XxpWTVvdn2bZKveyFQ6Hw/RftV8ZkmZH6+vrvz8AILrItAXgMzQ4qzSY6R4MrFevnul4acDReauYdpC0o6UdtZ49e5rO7YQJE2Tnzp2mk+fMntV1OnbsaIK7/fv3N503XWf58uXyyiuvhNue2bNny40bN6R79+6mYzZ+/HjTmd67d68JkHrz9ddfm0yJ8uXLy2uvvWbmaSBTaXB048aNprOtAUbtMOptcNrh1c6uHlu1atXM8Xz22Wemc1m4cGGzrfNvSNoZ1+21A6t10PQWu4ULF5rO59WrV6VXr14e62uwWo9Jz592RrVT/cILL8g///zzWBnHeswaKNayEG+99ZbpfI8YMUIOHDggS5YsMetokP2NN94wnef33nvPzHOeR319rQOs/+DQY9B6blOmTDGddj032bJlC/O1mzVrZoLBum/tWGsQWzvrJ0+eJBMYAAD4bF942LBhMnDgQHnppZdMX+vixYvy+eefm/6i9me1X6u076eBy9dff91su2XLFrPe6dOnzbKwaN9U+9ma7avZvRoYjipNmNCAq/YntZ2LFi2Sd955x/wQrz/Aax9Wy0AMGjTI9I2ffvppj7Jaq1evNutpYHrw4MHi7+8vM2fONH1uDUZrn9qdvob2FbWfuWPHDpk2bZpkypRJRo4caZZrn/D555+XEiVKmNfVILb2k0MGgd1pv1hLOGj/UfvyTtpXbt26tekva4KBBs2dfvzxR7l+/bpZDgDR5gAAm5k5c6ZDv55WrlzpuHjxouPUqVOO+fPnO9KnT+9IliyZ4/Tp02a9du3amfXeffddj+1///13M3/u3Lke85cvX+4x/+rVq45UqVI5KlSo4Lhz547Huo8ePXI91tfJnTu36/mxY8fMftzbojZv3mzm9+7d2zVv8ODBZp67FClSmH2GdPv27VDzNm3aZLafPXu2a97ChQvNvDVr1oRav3r16mZyGjdunFl3zpw5rnnBwcGOSpUqOVKmTOm4fv26xzHpOb58+bJr3e+//97M//HHHx2R9cknn5htdJ9q165d5nmnTp081uvbt6+Zv3r1ate8okWLerTf6e7du46HDx96zNP9BwQEOD744AOPebpPvYbUlStXzHNtEwAAQHzpCx8/ftyRKFEix7Bhwzy23bt3ryNx4sQe8731MUeMGOHw8/NznDhxwjVP+6faT1UbNmxwBAUFORo0aGD6YRFx9nm1vU7apwvZj713754jS5YsjmbNmrnmbd261aP/5t4ff/LJJx316tXz6Jvr8eTNm9fxzDPPhHr9jh07euyjadOm5rw5jR07NlQ7QwrZn1Tdu3cP1adXhw4dMvMnTZrkMb9Ro0aOPHnyeLQbAKKK8ggAbKtOnTrmdiy9hUuzTzUDU7My9bYqd5o14E4zBvR2pGeeecaMYOuc9Bd63ceaNWvMevpruWaV6kBhIetWuZc0CIvWbHVvi/7SX6FCBTNQQXS4Zy/cv39f/vvvP8mfP7/JktBMgejQtmTJksWj7plmzGq2rt7ipqUI3LVo0ULSpk3reu7MdtBM1+hyno8+ffp4zNeMW/XTTz9FuA/NgtDMCvXw4UNzbpy3s4V3bvScap1fvfXOW2kMAAAAX+wLL1682JQD08xS9/6u9vuefPJJV383ZB9Ty3TpeprJqrf3a0ZuSLqtZtjWrl3bvI72w6JL2+yebar9Mu0zR6ZvqaUZDh8+bO5+076f8xj1GLRt69evDzVYcNeuXT2ea19Wt9WsV+XMPtbM4egONOyuQIECpv8/d+5c1zzNutXya1q2LTL/pgCAsFAeAYBtae0o7QjpQF56m7wG6JyBOyddpqUE3Gnn7tq1a+ZWKG/09nj3W8y01lZ0aIc4JG3vt99+G639aSkDvZVLb/k6c+aM6Ug76fFEh9bJ1XaGPG/Ocgq63J3WOnPnDOA+TsBTX0NfXwPQ7vQfFdpxDtkGb7RTreUnvvjiC1PqQgO3Tu7lMkLSf2To7XAaINZrqGLFiuaWuLZt25rXBwAA8MW+sPZ3ta/orT+q3MtaaUkoLT/www8/hOrThexjasmvBg0amGQH7dM+7oC62k8PGbjU/uWePXsi3FaPUbVr1y7MdbT97gkH4fVldUwETVDQkglaTkITNzT4q6UbtIRXyP5yZGm/UsuQaZ9Wx7rQBBJNwGjTpk209gcATgRtAdiW/grvHDE3MhmY7gE+Ddi6/+LtTjMW7EhrrmrA9s0335RKlSqZbGHt5GpmRUxkAkRGokSJvM53DyBH1+NkGgwfPtzUbNP6wzqgmdYM0/ddz1VE50bXadiwoamJ++uvv5r9aHBca6SVLl062m0CAACITeH1hbX/o30rzej01n/TDFelP3Tr3Wea/am1ZAsVKiQpUqQwCQI6xkHIfpT2rXWAX81E1TEe9Mduq/qWzrZ98sknUqpUKa/rOI8zsq+nWceaoavZxHq3lx7jggULTI3c3377Lcztw6N9dR3YTf/toWNO6OBw+r5pkB0AHgdBWwDxjg7stXLlSqlSpUq4AyY4BwD766+/QmWBRobz1393f//9d4SDW4UVvNSBGTSTYPTo0R7ZDjpgWGS290Z/7ddMBu30uge3Dx486Foe2/Q19PX1fLkPmKaDiemxubchvHOjow5Pnz7dY75unyFDhgjboO+1ZtvqpO3Qjr+eZ+1UAwAA+Brt22ggUgfd0mzcsOgAudo/1QFhNSPUScuEeaN9MQ0+Nm7c2AwAq0FhHdQ2NoXV/3P21TVDVktFxBTtE2uGrU5jxowxyQE6CK4GcsN6nfD635pMoNnJet60JIIOaqYD7ALA46KmLYB4R2t7aVaBZmSG9ODBA1cQtG7dupIqVSqTdanB0aj++q+Zm5ql4KQj8W7evNmMcBsezW4IGYhV+st+yNfVkX3dSwE4t1fe9hGSZkqcO3fOZBC4nwPdr2YmVK9eXWKbtkGF7LxqJ1lpJzc650ZvPXM//97oSMkh31v9B4C+7/fu3YvG0QAAAFhPb+nX/tHQoUND9ZH0udZxVc7MUfd19LGWnQqL1p3VWrZPPfWUuVtJ+7ixKay+rZZo0H7bp59+asZiCOnixYtRfi3NOA7JmcUbXt8wov63lkLYv3+/vP322+aca/YtADwuMm0BxDsaiOzSpYsJxuoABhqc1bpemmGpgT7tpGrdKv3VfuzYsaamlXZKdZADrXu1e/duE+zTjITwaHZu1apVzUBo2snToKTWV+3Xr1+422kHVDOBNWiZLVs2kyGhAxjo7Wdff/21KYtQpEgR2bRpk1kvZM1W7VhqZ1BrtWodL72NTW/p8lbD97XXXpMpU6aY29+2b99usoA1a9WZAaDBy9hWsmRJk0E8depU09HV90c7/3p+dTA3zaB1PzeTJk2Sjz76yJxfPSY9Nj03H3zwgXTo0MEMnKFZI5rNkC9fvnBfWzNLNItCA/l6TrUumw7goVm+dKYBAICv0mCm9pf69+8vx48fN30q7ddp7X/t62gfsG/fvqYcgq6rj/XHbu3/fvfddxGOV6B3qy1btsz0wzQhQQevje44EJE5Fh3nYPLkyeYYNECqfWPtI2v9WX39okWLmn6gDsKmx6FZsXosP/74Y5ReS/uTWh5Bkwb0bi8d60LHTNDau9qvD4v2UZUO5quDtIUMzOr+tM+u/9bQ9oY1tgYARAVBWwDxknb6tHOlAUutLaXBOg1Y6ui1WjbB6dVXXzWdqo8//thk5mpwVzu3WpcqInqLmd5epcFP7fBp3bEJEyZI1qxZw91Og7XakX7//ffN4GMa0NSOqQaTtQOowUjNDtV2atBWO4budAAtPT4NSmv7NRNXO67eOofa4V67dq0ZaEGDpDpyrtbX0tq5GsiNK9rh1gDrrFmzzD8k9Bj0HxmDBw/2WE8HydBBHEaNGiU3btwwAV79x4K+hzpS8Lx580zWcJkyZUwdMj2u8Ohoyy+//LKsWrXKBMT1OtD3VwfWaNasWSwfNQAAQOzRfpCWRtAkBM24dfZ9NGGhUaNG5rn2bTWwqcFG7TsGBgZK06ZNzcBZ+sN6eDQoquMBVKtWzdTF/f3336NVUiwi2kbtp2rfsGvXruauMO2ratBWSzNoIoP207WfrRm32o/UvrMmaUSVnhcNcs+YMUMuXbpkymxpf1PPnyZOhJfZrONPzJ8/35TX0mxl96CtZifrIGcaAGYAMgAxxc8RE6PLAEACoh097UTqoAiatQAAAAAgYdOkDx1/QUuTJU+e3OrmAIgHqGkLAAAAAAAQTXqXnGbg6p1cBGwBxBTKIwAAAAAAAESRlkjTcmY6ZoQO/tarVy+rmwQgHiFoCwAAAAAAEEX79++XVq1ambElPvvsMzNgMADEFGraAgAAAAAAAICNUNMWAAAAAAAAAGyEoC0AAAAAAAAA2EiCq2n76NEj+ffffyVVqlTi5+dndXMAAADghVbwunHjhmTLlk38/RNungF9VwAAgITZd01wQVvt9ObMmdPqZgAAACASTp06JTly5JCEir4rAABAwuy7JrigrWYpOE9iUFCQ1c0BAACAF9evXzfBSmffLaGi7woAAJAw+64JLmjrvK1MO710fAEAAOwtoZcEoO8KAACQMPuuCbdAGAAAAAAAAADYEEFbAAAAAAAAALARgrYAAAAAAAAAYCMEbQEAAHzI3bt3pUmTJlKgQAEpWbKkPPPMM3LkyJFQ6/36669SqlQp15QtWzYpU6aMWfbvv/9KvXr1pGDBglKiRAlp1qyZXLx40YKjAQAAAOANQVsAAAAf89prr8mhQ4dk9+7d0rhxY+nUqVOodTQou2vXLtekAdtWrVqZZYkSJZKBAweafezZs0fy5csnb7/9tgVHAgAAAMAbgrYAAAA+JDAwUOrXr+8ambZixYpy/PjxcLfRzNpVq1ZJmzZtzPPMmTNL1apVXcsrVKgQ4T4AAAAAxB2CtgAAAD5s/PjxJts2PLNmzTKB3kyZMoVa9vDhQ5kwYUKE+wAAAAAQdxLH4WsBAAAgBg0fPtzUs9Us2rA4HA6ZMWOGfPbZZ16XdevWTdKmTSu9evWK5dYCAAAAiCyCtgAAAD7o008/lcWLF8vKlSslefLkYa63bt06M3iZ1rgNqWfPnnLq1ClZunSp+PtzAxYAAABgFwRtAQAAfMyYMWPkm2++MQHbNGnShLvu9OnTpX379mbwsZABW83S1YBt0qRJY7nFAAAAAKLCz6H3xSUg169fl9SpU8u1a9ckKCjI6uYAAABEyenTpyVnzpySL18+SZUqlZkXEBAgmzdvlkGDBkm2bNmka9euZr72d/T53r17zfpOf/zxhxmIrFChQmZblTdvXlmyZInYBX22/+E8AAAAJMw+G0FbAAAA2A59tv/hPAAAACTMPhvFywAAAAAAAADARgjaAgAAAAAAAICNELQFAAAAAAAAABshaAsAAAAAAAAANpLY6gYAAADg//SYtkHsakKnqlY3AQAAILQ55cSWWm+zugXwYWTaAgAAAAAAAICNELQFAAAAAAAAABshaAsAAAAAAAAANkLQFgAAAAAAAABshKAtAAAAAAAAANgIQVsAAAAAAAAAsBGCtgAAAAAAAABgIwRtAQAAAAAAAMBGCNoCAAAAAAAAgI0QtAUAAAAAAAAAGyFoCwAAAAAAAAA2QtAWAAAAAAAAAGyEoC0AAAAAAAAA2AhBWwAAAAAAAACwEYK2AAAAAAAAAGAjBG0BAAAAAAAAwEYI2gIAAAAAAACAjRC0BQAAAAAAAAAbIWgLAAAAAAAAADZC0BYAAAAAAAAAbISgLQAAAAAAAADYCEFbAAAAAAAAALARgrYAAAAAAAAAYCMEbQEAAAAAAADARiwN2o4YMUKeeuopSZUqlWTKlEmaNGkihw4dCnebWbNmiZ+fn8cUGBgYZ20GAAAAAAAAgHgbtF23bp10795d/vzzT1mxYoXcv39f6tatK7du3Qp3u6CgIDl79qxrOnHiRJy1GQAAAAAAAABiU2Kx0PLly0Nl0WrG7fbt26VatWphbqfZtVmyZImDFgIAAAAAAABAAgrahnTt2jXzN126dOGud/PmTcmdO7c8evRIypQpI8OHD5eiRYt6XffevXtmcrp+/br5q9vqBAAAYCd+4hC7isu+E/00AAAAJGS2Cdpqx/zNN9+UKlWqSLFixcJcr2DBgjJjxgwpUaKECfJ++umnUrlyZdm3b5/kyJHDa93coUOHhpp/8eJFuXv3bowfBwAAwONIn/S+2NWFCxfi7LVu3LgRZ68FAAAA2I1tgrZa2/avv/6SDRs2hLtepUqVzOSkAdvChQvLlClT5MMPPwy1fv/+/aVPnz4embY5c+aUjBkzmtq4AAAAdvJf8GGxKy1jFVcYaBYAAAAJmS2Ctj169JBly5bJ+vXrvWbLhidJkiRSunRpOXLkiNflAQEBZgrJ39/fTAAAAHbiED+xq7jsO9FPAwAAQEJmaW/Y4XCYgO2SJUtk9erVkjdv3ijv4+HDh7J3717JmjVrrLQRAAAAAAAAABJMpq2WRJg3b558//33kipVKjl37pyZnzp1akmWLJl53LZtW8mePbupTas++OADqVixouTPn1+uXr0qn3zyiZw4cUI6depk5aEAAAAAAAAAgO9n2k6aNMkMJlajRg2TKeucFixY4Frn5MmTcvbsWdfzK1euSOfOnU0d2/r165satRs3bpQiRYpYdBQAAABIKCZOnCh58uQxNXcrVKggW7ZsidR28+fPFz8/P2nSpEmstxEAAAC+L7HV5REisnbtWo/nY8eONRMAAAAQlzSxQAe4nTx5sgnYjhs3TurVqyeHDh0Kd5C248ePS9++feXpp5+O0/YCAADAdzHCAwAAABAJY8aMMXd8dejQwdzlpcHb5MmTy4wZM8Idf6FVq1YydOhQyZcvX5y2FwAAAL6LoC0AAAAQgeDgYNm+fbvUqVPHNc/f398837RpU5jb6XgMmoX76quvxlFLAQAAEB9YWh4BAAAA8AWXLl0yWbOZM2f2mK/PDx486HWbDRs2yPTp02XXrl2Rfp179+6ZyUnHb1CPHj0yEwAA8MZPbIn/dycYj2LhvSZoCwAAAMSwGzduSJs2beTLL7+UDBkyRHq7ESNGmFIKIV28eFHu3r0bw60EACCeSJRfbOnCBatbgDjs+8U0grYAAABABDTwmihRIjl//rzHfH2eJUuWUOsfPXrUDEDWsGHDUBkYiRMnNoOXPfHEE6G269+/vxnszD3TNmfOnJIxY0YJCgqK4aMCACCeeHhEbCmcgUoRvwQGBsb4PgnaAgAAABFImjSplC1bVlatWiVNmjRxBWH1eY8ePUKtX6hQIdm7d6/HvPfff99kYYwfP94EYr0JCAgwU0haP1cnAADgjUNsif93Jxj+sfBeE7QFAAAAIkEzYNu1ayflypWT8uXLy7hx4+TWrVvSoUMHs7xt27aSPXt2U+JAsy2KFSvmsX2aNGnM35DzAQAAgJAI2gIAAACR0KJFC1NbdtCgQXLu3DkpVaqULF++3DU42cmTJ8mGBQAAQIwgaAsAAABEkpZC8FYOQa1duzbcbWfNmhVLrQIAAEB8QyoAAAAAAAAAANgIQVsAAAAAAAAAsBGCtgAAAAAAAABgIwRtAQAAAAAAAMBGCNoCAAAAAAAAgI0QtAUAAAAAAAAAGyFoCwAAAAAAAAA2QtAWAAAAAAAAAGyEoC0AAAAAAAAA2AhBWwAAAAAAAACwEYK2AAAAAAAAAGAjBG0BAAAAAAAAwEYI2gIAAAAAAACAjRC0BQAAAAAAAAAbIWgLAAAAAAAAADZC0BYAAAAAAAAAbISgLQAAAAAAAADYCEFbAAAAAAAAALARgrYAAAAAAAAAYCMEbQEAAAAAAADARgjaAgAAAAAAAICNELQFAAAAAAAAABshaAsAAAAAAAAANkLQFoBl7t69K02aNJECBQpIyZIl5ZlnnpEjR46EWu/mzZtSr149yZAhg6RJk8Zj2d69e6VatWpSqFAhKVasmHTs2FHu3LkTh0cBAAAAAAAQswjaArDUa6+9JocOHZLdu3dL48aNpVOnTqHWSZIkibzzzjuycuXKUMsCAwNlwoQJcvDgQbOPW7duyciRI+Oo9QAAAAAAADGPoC0Ay2jAtX79+uLn52eeV6xYUY4fPx5qvYCAAKlVq1aoLFv15JNPSokSJczjRIkSyVNPPeV1HwAAAAAAAL4isdUNAACn8ePHm2zb6NIs22nTpsmIESNitF0AAAAAYtmccmJLrbdZ3QIACRRBWwC2MHz4cFPPdtWqVdHaPjg4WFq0aCF169aVpk2bxnj7AAAAAAAA4gpBWwCW+/TTT2Xx4sWmZm3y5MmjvP39+/dNwDZr1qwmWxcAAAAAAMCXEbQFYKkxY8bIN998YwK23mrWRuTBgwfSsmVLSZcunUydOtVVHxcAAAAAAMBXMRAZAMucPn1a3nrrLbl69arUrFlTSpUqJRUqVDDLBg0aJJMnT3atq4ONVapUSa5fvy45cuSQNm3amPkLFiwwWbrbtm2T0qVLm310797dsmMCAAAAAAB4XGTaArCMBl8dDofXZR988IHH8z179nhdr1WrVmYCAAAAAACIL8i0BQAAAAAAAAAbIWgLAAAAAAAAADZC0BYAAAAAAAAAbISgLQAAAAAAAADYCAORAYhVPaZtEDua0Kmq1U0AAAAAAADwikxbAAAAAAAAALARgrYAAAAAAAAAYCMEbQEAAAAAAADARgjaAgCAKOvZs6fkyZNH/Pz8ZNeuXV7XefTokfTt21eKFSsmhQoVkldffVWCg4Ndyz/55BOzrEiRItK0aVO5evVqHB4BAAAAANgXQVsAABBlzZs3lw0bNkju3LnDXGf69OmyY8cOMx04cED8/f1l/PjxZtmKFStk5syZsmnTJtm/f7+ULVtW3nvvvTg8AgAAAACwL4K2AAAgyqpVqyY5cuQId53du3dLnTp1JGnSpCYj97nnnpOvv/7ataxq1aqSKlUq87x+/fquZQAAAACQ0BG0BQAAsUKzZ3/44Qe5fv263L9/X7799ls5fvy4a9nKlSvl3Llz4nA4ZO7cuXLjxg25fPmy1c0GAAAAAMsRtAUAALGiffv28uyzz0r16tXNVKBAAUmcOLFZVrNmTVPv9vnnn5eKFStKxowZzXzncgAAAABIyAjaAgCAWKElEYYMGSI7d+6UjRs3mgHHihYt6lrerVs32bZtm2zevFlq1Khhyi0EBQVZ2mYAAAAAsAOCtgAAIFbcvXtXrly5Yh5funRJPv74Y+nXr59r+dmzZ83f27dvy6BBgzyWAQAAAEBCZmnQdsSIEfLUU0+ZQUgyZcokTZo0kUOHDkW43cKFC6VQoUISGBgoxYsXl59//jlO2gsAAP6nS5cuJjP29OnTUq9ePcmfP7+Z36lTJ1PHVl27dk0qV65ssmuffvpp6dq1qzRs2NC1j7p165plJUuWNIOS9ejRw7LjAQAAAAA7sbRw3Lp166R79+4mcPvgwQMZMGCA+Qfc/v37JUWKFF630dsrX375ZRPw1Tp48+bNM8HeHTt2SLFixeL8GAAASIimTJnidf60adNcjzNnziwHDhwIcx979+6NlbYBAAAAgK+zNGi7fPlyj+ezZs0yGbfbt2+XatWqed1m/PjxZlCTt99+2zz/8MMPZcWKFTJhwgSZPHlynLQbAAAAAAAAAGKLrYZo1tsoVbp06cJcZ9OmTdKnTx+PeXpb5tKlS72uf+/ePTM5Xb9+3fx99OiRmQDELj9xiB3x+QdgV3b93ozr706+pwEAAJCQ2SZoqx3zN998U6pUqRJumYNz586Z2y3d6XOd742WURg6dGio+RcvXjQDpACIXemT3hc7unDhgtVNAACf+t6M6+/OGzduxNlrAQAAAHZjm6Ct1rb966+/ZMOGDTG63/79+3tk5mqmbc6cOSVjxowSFBQUo68FILT/gg+LHWkpFgCwI7t+b8b1d6cOOAsAAAAkVLYI2upo0cuWLZP169ebkajDkyVLFjl//rzHPH2u870JCAgwU0j+/v5mAhC7HOIndsTnHwhfj2kx+yNqTJnQqarEd3b93ozr706+pwEAAJCQWdobdjgcJmC7ZMkSWb16teTNmzfCbSpVqiSrVq3ymKcDkel8AAAAAAAAAPB1ia0uiTBv3jz5/vvvJVWqVK66tKlTp5ZkyZKZx23btpXs2bOb2rSqV69eUr16dRk9erQ0aNBA5s+fL9u2bZOpU6daeSgAAAAAAAAA4PuZtpMmTZJr165JjRo1JGvWrK5pwYIFrnVOnjwpZ8+edT2vXLmyCfRqkLZkyZKyaNEiWbp0abiDlwEAAAAAAACAr0hsdXmEiKxduzbUvBdffNFMAAAAAAAAABDf2GIgMgAAACA2HDt2TH7//Xc5ceKE3L59WzJmzCilS5c24yEEBgZa3TwAAADAK4K2AAAAiHfmzp0r48ePN2MfZM6cWbJly2bGTLh8+bIcPXrUBGxbtWol77zzjuTOndvq5gIAAAAxF7S9d++eBAQEPM4uAAAAgBilmbRJkyaV9u3by3fffSc5c+YM1YfdtGmTGdC2XLly8sUXX1B6CwAAAL47ENkvv/wi7dq1k3z58kmSJEkkefLkEhQUJNWrV5dhw4bJv//+G3stBQAAiAE9e/aUPHnyiJ+fn+zatcvrOo8ePZI+ffpIkSJFpESJElKzZk05cuSI63b7smXLSqlSpcxAqBrsu3LlShwfBcLz8ccfy+bNm6Vbt26hArZKkw50INzJkyfLwYMHTd8WAAAA8Lmg7ZIlS6RAgQLSsWNHSZw4sbmNbPHixfLrr7/KtGnTTNB25cqVpsPbtWtXuXjxYuy3HAAAIBqaN28uGzZsCPeW+B9++EH++OMP2b17t+zZs0dq164tAwYMMMv0NnvdXgO+f/31l3k+ZMiQODwCRKRevXrm74MHD2T27Nly/vz5MNdNnz69CcIDAAAAPlceYdSoUTJ27Fh57rnnxN8/dJz3pZdeMn/PnDkjn3/+ucyZM0d69+4d860FAAB4TNWqVYtwHc3C1Vvo7969a36wvn79uuTIkcMscy8N9fDhQ7l165akTJkyVtuM6NH3ThMKDhw4YHVTAAAAgJgP2mrNr8jInj27uR0NAADAlzVs2FDWrFkjWbJkkVSpUpk+zrp161zLg4ODpXz58nLixAlTPkEzc2FP+j5pVjSDjQEAACDe1rT1RjNMtCNMLTcAABBfbNu2zZQ+0LuItGa/lkfQjE0nHeRK+z96232hQoVkypQplrYXYdO6tlqfeMKECSYRQctduE8AAACAz2baunvzzTelePHi8uqrr5qArdaz3bhxoxmUbNmyZWZQBwAAAF+mdVBr1aoladKkMc91INa6deuGWk+Dtx06dJDOnTtLv379LGgpItKyZUvXAHTu5S8cDof5q/1ZAAAAwOeDtosWLZLWrVubxz/++KMZQVlH3f3666/lvffeM4N2AAAA+DIdXPXnn3+Wvn37msCs/jBdrFgxs0xLImTMmNH8YP3o0SNZuHChKZEAe9K+KgAAABDvg7aXLl0y9d2U/mPmxRdflAIFCkjHjh1l/PjxsdFGAACAGNOlSxf56aef5Ny5c1KvXj1Ts/bIkSPSqVMnadSokZm6d+9uBq8qWbKkJEmSxPR9Jk+ebLbXW+r1h2qlQdsyZcrIZ599ZvFRISzUsgUAAECCCNpmzpxZ9u/fL1mzZpXly5fLpEmTzPzbt29LokSJYqONAAAAMSas+rPTpk1zPQ4ICJAvv/wyzEHKdILvOHz4sBlY7sKFCybQ7m7QoEGWtQsAAACIsaCt1m176aWXTNBW64DVqVPHzN+8ebMZiAMAAACwCw2+v/7665IhQwaTMa39Vyd9TNAWAAAAduQf1Q2GDBliMlFee+01U79WM1GUZtm+++67sdFGAAAAIFo++ugjGTZsmCmHsWvXLtm5c6dr2rFjR5T3N3HiRMmTJ48EBgZKhQoVZMuWLWGuu3jxYilXrpwZ0C5FihRSqlQpMw4EAAAAEOOZtqp58+bm7927d13zdFRlAAAAwE6uXLlixmCICQsWLJA+ffqY+sYasB03bpypi3zo0CHJlClTqPXTpUtn6h/r3WjOAe30rjVdV7cDAAAAYizT9uHDh/Lhhx9K9uzZJWXKlPLPP/+Y+QMHDpTp06dHdXcAAABArNGA7W+//RYj+xozZox07tzZBF6LFCligrfJkyeXGTNmeF2/Ro0a0rRpUylcuLA88cQT0qtXLylRooRs2LAhRtoDAACA+CvKmbZ6e9lXX30lo0aNMp1Wp2LFiplsg1dffTWm2wgAQLzTs2dP+eGHH+TEiRPmNm29bTqkmTNnyvjx413PT58+LdWqVTO3XLtr3769+X+zZhTqbdgQ6THNnkGxCZ2qWt2EBOGzzz5zPc6fP79JLvjzzz+lePHikiRJklCfxcgIDg6W7du3S//+/V3z/P39zfgOmzZtinB7h8Mhq1evNlm5I0eODHO9e/fumcnp+vXr5q8OoBZyEDUAiF/+r+a4rfDd6yO4fmCt2OinRTloO3v2bJk6darUrl1bunbt6ppfsmRJOXjwYEy3DwCAeElLDfXr10+qVg07iKfZfDq5/0DaqlUrj3U0gBsyCAUkdGPHjvV4rneHrVu3zkzudCCyyAZtL126ZO44y5w5s8d8fR5eH/jatWvmDjUNxOoYEF988YU888wzYa4/YsQIGTp0aKj5Fy9e9ChNBgDxTqL8YksXLljdAkQG1w8sduPGDeuDtmfOnDEZC94iyvfv34+pdgEAEK9pxmxUbN68WS5cuCCNGjVyzTt//rwMHz5c1qxZYwYJBfA/x44dE7tIlSqVGQDt5s2bsmrVKlMTN1++fKZ0gjeayavruGfa5syZUzJmzChBQUFx2HIAiGMPj4gtealZDhvi+oHFdJBay4O2Wr/r999/l9y5c3vMX7RokZQuXTom2wYAAP4/rRvfpk0bj6xaLVOk5Yo0KAQg9A8jjRs3Nj90PPnkk4+9vwwZMphMWf2xxJ0+z5IlS5jbaQkFZ8KDlkE5cOCAyaYNK2gbEBBgJm/70QkA4i+H2BLfvT6C6wfWio1+WpSDtoMGDZJ27dqZjFvNrtXbMrU2l5ZN0BFxAQBAzLp165bMnz/f1OR00szaXLlySa1atSxtG2BXOs6C1o0eMmSI5MiRwwRvdapcubIpixBVSZMmlbJly5ps2SZNmph52hfW5z169Ij0fnQb95q1AAAAgDdRDgNrxsKPP/4oK1eulBQpUpggrmYM6Lzw6nMBAIDoWbhwoRQtWtTc7eKkJRG+//57yZMnj5mUjkqvg5oBEJNk8N1335latKNHj5arV6/Kiy++aLJiO3bsKEuXLpU7d+5EaZ9atuDLL780A/9p//f11183P6o4a0+3bdvWY6AyzahdsWKF/PPPP2Z9bcfXX38trVu3jvHjBQAAQPwS5Uxb9fTTT5sOKAAAiJvSCJo16G7u3LkezzVzcM+ePZImTZo4bh1gb1pqoH79+maaMmWKqQ+tGbgDBw6UV155xWSra6C1SpUqEe6rRYsWZkAwTVo4d+6cKXewfPly1+BkJ0+e9Lg1TgO63bp1k9OnT0uyZMmkUKFCMmfOHLMfAAAAIMaDtio4ONgMiKK3eLnTWzUBAED4unTpIj/99JMJ/NSrV8/UpT1y5Ih06tTJdRu30hJEOojRzz//bHWTgXihQoUKZho2bJgcPXrUBHDPnj0b6e21FEJY5RDWrl3r8fyjjz4yEwAAABDrQdvDhw+bW8o2btzoMd/hcJgsn4cPH0a5EQAAJDSa8eeN1qp1V7BgQblx40aE+9P/DwOIWsKBDuzXu3dvS9sFAAAAxEjQtn379pI4cWIz6FjWrFmjNZADAAAAEBdIOAAAAECCCNrqLZrbt283NbkAAAAAOyPhAAAAAAkiaKsjV+sovAAAAIDdkXAAAACAeBu0vX79uuvxyJEjpV+/fjJ8+HApXry4qQXmLigoKOZbCQAAAEQDCQfRMKec2FbrbVa3AAAAwD5B2zRp0njcSqY1wGrXru2xDnXBAAD4Pz2mbRA7mtCpqtVNAOIUCQcAAACIt0HbNWvWxH5LAAAAgBhWp04d85eEAwDxHlnyAJDwgrbVq1eP/ZYAAAAAMYzkAwAAACSIgchmzpwpKVOmlBdffNFj/sKFC+X27dvSrl27mGwfAAAAEG0kHwAAACBBBG1HjBghU6ZMCTU/U6ZM8tprrxG0BQAAgKX27NkjxYoVE39/f/M4PCVKlIizdgEAAACxFrQ9efKk5M2bN9T83Llzm2UAAACAlUqVKiXnzp0zSQX6WGvXag3bkKhpCwAAgHgTtNXOr2Ys5MmTx2P+7t27JX369DHZNgAAACDKjh07JhkzZnQ9BgAAAOJ90Pbll1+Wnj17SqpUqaRatWpm3rp166RXr17SsmXL2GgjAAAAEGl6B5i3xwAAAICv8I/qBh9++KFUqFBBateuLcmSJTNT3bp1pVatWjJ8+PDYaSUAAAAQSX/++Wek19WBdPft2xer7QEAAABiPWibNGlSWbBggRw8eFDmzp0rixcvlqNHj8qMGTPMMgAAAMBKbdq0kXr16snChQvl1q1bXtfZv3+/DBgwQJ544gnZvn17nLcRAAAAiNHyCE4FChQwEwAAAGAnGpCdNGmSvP/++/LKK6+YPmu2bNkkMDBQrly5YpIPbt68KU2bNpXffvtNihcvbnWTAQAAgMcL2uoIu7NmzZJVq1bJhQsX5NGjRx7LV69eHdVdAgAAADEmSZIkZgwGnbZt2yYbNmyQEydOyJ07d6RkyZLSu3dvqVmzpqRLl87qpgIAAAAxE7TVAcc0aNugQQMpVqyY+Pn5RXUXAAAAQJwoV66cmQAAAIB4HbSdP3++fPvtt1K/fv3YaREAAAAAAAAAJGDRGogsf/78sdMaAAAAAAAAAEjgohy0feutt2T8+PHicDhip0VAHNN6d3ny5DGlPnbt2uV1nbVr10qyZMmkVKlSrknr4qlNmza55hUtWlS6dOki9+7di+OjAAAAAAAAQIItj6ADOaxZs0Z++eUXE6DSgR7cLV68OCbbB8S65s2bS79+/aRq1arhrlewYEGvQV0d0GTr1q3ms6AD8zVr1ky++OILM8gJAAAAAAAAEOtB2zRp0kjTpk2j/EKAXVWrVu2xtk+ePLnrcXBwsMnAZYA+AADs4Z9//pF8+fJZ3QwAAAAgdoO2M2fOjOomQLxw9OhRKVOmjCRKlEg6dOgg3bp1cy07fvy4NG7c2KzToEEDj2UAAMA6OhZD9erV5dVXXzV31wQGBlrdJAAAACDma9oCCZEGa0+fPi07duyQJUuWyOTJk+Xbb791LdeauLt375Zz586ZeraUCQEAwB70/90lSpSQPn36SJYsWUzt+S1btljdLAAAAODxg7YasLpy5Yp5XLp0afM8rAmIj4KCgiR16tTmcY4cOeTll1+W33//PdR6KVOmlJYtW8rcuXMtaCUAAAhJBwrVQXT//fdfmTFjhpw9e9bUsS9WrJiMGTNGLl68aHUTAQAAgOiVR9DbvgMCAszjJk2aRGYTIF7Rf+BlzpxZ/P395caNG7Js2TJzm6U6cuSI5M6d2wxEpjVtNRNXM3oAAIB9JE6cWF544QVTxkgHDO3fv7/07dtXBgwYIC+99JKMHDlSsmbNanUzAQAAgMgHbQcPHuz1MRAf6G2SP/30kyltUK9ePUmVKpUJxHbq1EkaNWpkpu+++04mTZpk/sH34MEDefHFF01dW7V69Wr57LPPTK1bXVa7dm0ZOHCg1YcFAADcbNu2zWTazp8/X1KkSGECtvoDrJY/Gjp0qElSoGwCAAAAfCpo63A4xM/PL/ZbA1hgypQpXudPmzbN9bhHjx5m8ua1114zEwAAsB8tgaAD6R46dEjq168vs2fPNn/17hmVN29emTVrlqlPDwAAAPhUTduiRYuarAS99Ts8hw8fltdff10+/vjjmGofAAAAEG16p8wrr7wiJ06ckKVLl8rzzz/vCtg6ZcqUSaZPn25ZGwEAAIBoZdp+/vnn8s4770i3bt3kmWeekXLlykm2bNkkMDDQDFC2f/9+2bBhg+zbt89kI2rgFgAAALDaihUrJFeuXKECtXon2alTp8yypEmTSrt27SxrIwAAABCtoK3W6NQ6YBqYXbBggcydO9dkK9y5c0cyZMggpUuXlrZt20qrVq0kbdq0kdklAAAAEOueeOIJM6CoZtO6u3z5simN8PDhQ8vaBgAAADxW0NapatWqZoop69evl08++US2b99uOtNLliyRJk2ahLn+2rVrpWbNmqHm67ZZsmSJsXYBAAAgftCMWm9u3rxp7hoDAAAAfD5oG9Nu3bolJUuWlI4dO8oLL7wQ6e10IImgoCDX85CZE4C7HtM2iB1N6BRzP4AAAABPffr0MX91MN1BgwZJ8uTJXcs0u3bz5s1SqlQpC1sIAAAA2DRo+9xzz5kpqjRImyZNmlhpEwAAAHzfzp07XZm2e/fuNXVrnfSxJg707dvXwhYCAAAANg3aRpdmRdy7d0+KFSsmQ4YMkSpVqljdJAAAANjImjVrzN8OHTrI+PHjPe7SAgAAAOzOp4K2WbNmlcmTJ0u5cuVM0HbatGlSo0YNc3tbmTJlvG6j6+nkdP36dfP30aNHZkL85yfea9lZLaFcf5x/JFS+fu3Tfuvab9e2x/V3Z0y91syZM2NkPwAAAEBc8qmgbcGCBc3kVLlyZTl69KiMHTtWvv76a6/bjBgxQoYOHRpq/sWLF+Xu3bux2l7YQ/qk98WOLly4IAkB5x8Jla9f+7Tfuvbbte1x/d1548aNaG+rYyXMmjXLZNdGNG7C4sWLo/06AAAAgK2Ctpr5cOTIEdNxD5kFUa1aNYlL5cuXlw0bwh5oqn///q6BKJyZtjlz5pSMGTNym1wC8V/wYbGjhDKAHucfCZWvX/u037r227Xtcf3dGRgYGO1tU6dObQYgcz4GAAAA4n3Q9s8//5RXXnlFTpw4YQZ2cKedYx2NNy7t2rXLlE0IS0BAgJlC8vf3NxPiP4f87x9tdpNQrj/OPxIqX7/2ab917bdr2+P6u/NxXsu9JALlEQAAAJAggrZdu3Y1NWV/+uknEyx1ZjFEx82bN03GrtOxY8dMEDZdunSSK1cukyV75swZmT17tlk+btw4yZs3rxQtWtSUNtCatqtXr5bffvst2m0AAABA/HXnzh2TaJA8eXLzXBMPlixZIkWKFJG6deta3TwAAAAgZoK2hw8flkWLFkn+/PnlcW3btk1q1qzpeu4sY9CuXTtTh+zs2bNy8uRJ1/Lg4GB56623TCBXO94lSpSQlStXeuwDAAAAcGrcuLGpa6uJB1evXjWltZImTSqXLl2SMWPGyOuvv251EwEAAIDHD9pWqFDBZMfGRNC2Ro0aoUosuNPArbt+/fqZCQAAAIiMHTt2mEFrlSYeZMmSRXbu3CnfffedDBo0iKAtAAAAfDdou2fPHtfjN954w2S7njt3TooXLy5JkiTxWFezXwEAAAA7uH37tqRKlco81pJamnWr9XIrVqxoSiUAAAAAPhu0LVWqlKld654V27FjR9dj5zIrBiIDAAAAwqJ3hy1dulSaNm0qv/76q/Tu3dvMv3DhggQFBVndPAAAACD6QVsdIAwAAADwNVoC4ZVXXjHB2tq1a0ulSpVcWbelS5e2unkAAABA9IO2uXPndj1ev369VK5cWRIn9tz0wYMHsnHjRo91AQAAACs1b95cqlataga4LVmypGu+BnA1+xYAAACIFwOR1axZ03R6M2XK5DH/2rVrZhnlEQAAAGAnOviYTu7Kly9vWXsAAACAGA/aOmvXhvTff/9JihQporo7AAAAINbcunVLPv74Y1m1apWpY/vo0SOP5f/8849lbQMAAAAeO2irI+0qDdi2b99eAgICXMs0u3bPnj2mbAIAAABgF506dZJ169ZJmzZtJGvWrF6TDwAAAACfDdqmTp3alWmbKlUqSZYsmWtZ0qRJpWLFitK5c+fYaSUAAAAQDb/88ov89NNPUqVKFaubAgAAAMR80HbmzJnmb548eaRv376UQgAAAIDtpU2bVtKlS2d1MwAAAIAo8Y/a6iKDBw82AVutCfb777+bSR8DAAAAdvPhhx/KoEGD5Pbt21Y3BQAAAIi9gchu3Lgh3bp1k/nz55tatipRokTSokULmThxoquMAgAAAGC10aNHy9GjRyVz5szmjrEkSZJ4LN+xY4dlbQMAAABiLGirgzns3LlTli1bJpUqVTLzNm3aJL169ZIuXbqYYC4AALGtZ8+e8sMPP8iJEyfM/5dKlSoVap3Vq1fLu+++Kzdv3jSDDzVo0MCMIu/v/78bTUaOHClfffWVqc0eGBgon332mZQvX96CowEQW5o0aWJ1EwAAAIDYD9pqsPbXX3+VqlWruubVq1dPvvzyS3n22Wej3gIAAKKhefPm0q9fP4//H3mrZak/JubLl0/u3r0rderUkdmzZ0v79u1l165d8sUXX8i+ffskZcqUMmfOHOnRo4ds2bIlTo8DQOzS0l4AAABAvA/apk+f3msJBJ2n/zgGACAuVKtWLcJ1Spcu7XqsmbSajXv8+HHzXDNv79+/L7du3TJB26tXr0qOHDlitc0ArKGf70WLFpkyCW+//bYZmEzLImjJhOzZs1vdPAAAAODxg7bvv/++9OnTR77++mvJkiWLmXfu3DnTAR44cGBUdwcAQJzQ/1dp0EbvGFElS5aU3r17S968eU0AJyAgQNavX291MwHEsD179pgse00w0B9tOnfubD7zixcvlpMnT5rsewAAAMDng7aTJk2SI0eOSK5cucyktMOr/9i9ePGiTJkyxbUuAzsAAOzg+vXr0rBhQ1NOoVy5cmbesWPHTNBG/5+WLVs2mTBhghlUc8OGDVY3F0AM0mQDLYkyatQoSZUqlWt+/fr15ZVXXrG0bQAAAECMBW0ZzAEA4Etu3Lhhaq43btzYBG+cvvvuOylevLgJ2KoOHTrIG2+8IcHBwWZgMgDxw9atWz2SCpy0LIJm4AMAAADxImjLYA4AAF9x8+ZNE7DVScv7uNPByWbOnGnW0Zq2WjahQIECBGyBeEbvBtNs+5D+/vtvyZgxoyVtAgAAACLiL9EczGHatGnSv39/uXz5sqsUwpkzZ6KzOwAAoqxLly5m4LDTp09LvXr1JH/+/GZ+p06d5IcffjCPx48fL1u2bDFlEHQQMp2GDRtmljVt2lQaNWpkyiVofVtdd968eZYeE4CYp5/zDz74wAw86ByEUEt7vfPOO9KsWTOrmwcAAADETKYtgzkAAOzA2+3OSn9UdHrvvffM5I0GbkaMGGEmAPHX6NGjpXnz5pIpUya5c+eOVK9e3ZRFqFSpkutHHAAAAMDng7YM5gAAAABfoYkGK1askD/++EN2795tSqKUKVPGJCEAAAAA8SZoy2AOAAAA8BV6F1iLFi2kSpUqZnLSQQfnz58vbdu2tbR9AAAAQIzUtGUwBwAAAPiKDh06yLVr10LNv3HjhlkGAAAAxItMW+dgDt9++615zmAOABKqnj17mgGvTpw4ITt37jSDXIWktb+1pIwuz5s3r+zatcu17NGjR9KvXz9Zvny5PHjwwGSATZo0SZImTRrHR2JPPaZtEDua0Kmq1U0AEAUOh8P0V0PSQQy1dAIAAAAQLzJtdTAHrQXmPpiDjtit9W0ZzAFAQqID22zYsEFy584d5jpBQUHy0Ucfybx580Itmz59uuzYscNMBw4cEH9/fxk/fnwstxoAEobSpUub2rUasK1du7Z57JxKliwpTz/9NHVtAQAAEH8ybZ2DOWigYs+ePQzmACDBqlatWoTrpEuXTqpWrSpr164NtUwHxNHvTmdm7XPPPSdDhgyRt99+O1baCwAJSZMmTcxfvcOhXr16kjJlStcy/d7NkycPd4nFV3PKiS213mZ1CwAAQHwO2jppEEInAED0lC1b1gzs2KNHD0mWLJkpO6PlFAAAj2/w4MHmrwZndSCywMBAq5sEAAAAxE7QVusvzpo1SxYvXmwCC3q7mdZo1FuE27Rp47VeGADAO611q/VwtcyMBm016/a3336zulkAEK+0a9fO/A0ODpYLFy6Y/qy7XLlyWdQyAAAAIAZq2uogDjoIWadOneTMmTNSvHhxKVq0qAk4aOChadOmkd0VAOD/D+So5RB0kLKNGzdKkSJFzPcqACDmHD582NSv1R/HtAa5JhzopBm4+jeqJk6caLbVzN0KFSrIli1bwlz3yy+/NK+dNm1aM+mPc+GtDwAAAEQ501YzbNevXy+rVq2SmjVreixbvXq1qRs2e/Zsadu2bWR3CQAJ2t27d82AjvoP+UuXLsnHH38sH374odXNAoB4RZMLEidOLMuWLZOsWbM+1p1hCxYskD59+sjkyZNNwHbcuHGmXu6hQ4fMIL0haT3zl19+WSpXrmyCvCNHjpS6devKvn37JHv27I95ZAAAAIjPIh20/eabb2TAgAGhAraqVq1a8u6778rcuXMJ2gJIMLp06SI//fSTnDt3zvyjPVWqVHLkyBFzR4LemaDT7du3pUCBAnLv3j25du2a5MiRw5STGTFihHleo0YN8ff3N7fr9urVSxo2bGj1YQFAvKIDkW3fvl0KFSr02PsaM2aMdO7cWTp06GCea/BW/z8wY8YM0xcOSfvG7qZNmybfffedSYKgzwzYFAPZAUDU8L1pfdB2z549MmrUqDCX66jnn332WUy1CwBsTwcR80b/Ue6UPHlyOX36tNf1MmfOLAcOHIi19gEAxJSe0bsZHpfWxNXgb//+/V3z9Ec3LXmwadOmSO1Df8i7f/++pEuXLsx19Ec+nZyuX79u/uqPeyHr8cYeG49TEalzYNP2x9n7h8fjy9ePTdvu6+3ns+sjuH6sw7lXsdFPi3TQ9vLlyybAEBZdduXKlZhqFwAAAPDYtCRBv379ZPjw4WZMhiRJkngsDwoKitR+NPD78OHDUP1hfX7w4MFI7eOdd96RbNmymUBvWPROjKFDh4aaf/HiRVNWJ04kyi+2deGC77Y/Mm2H9Xz5+rFr2329/Xx2fQPXj3U498aNGzfEsqCtdlK1HlhYEiVKJA8ePIipdgEAAACPzRkgrV27dqhBdrW+rfZx44LWLZ8/f76pc6v1bcOimbxaN9c90zZnzpySMWPGSAeYH9vDI2JbXmoH+0z7I9N2WM+Xrx+7tt3X289n1zdw/ViHc2+E17+L9aCtdmx1IIeAgACvy91v4wIAAADsYM2aNTGynwwZMpgkhfPnz3vM1+dZsmQJd9tPP/3UBG1XrlwpJUqUCHdd7Wt7629rKQad4oZDbCtS58Cm7Y+z9w+Px5evH5u23dfbz2fXR3D9WIdzr2KjnxbpoG27du0iXIcBFQAAAGAn1atXj5H9JE2aVMqWLWsGEWvSpImrdpk+79GjR5jb6ZgQw4YNk19//VXKlbPpQB0AAACwnUgHbWfOnBm7LQEAG+oxbYPY0YROVa1uAgDYmg6iGxkRZb6607IFmsigwdfy5cvLuHHj5NatW9KhQwdXAkP27NlNXVpnPd1BgwbJvHnzJE+ePHLu3DkzP2XKlGYCAAAAHjtoCwAAAPiKUqVKmZq1WuIrLFGtaduiRQszIJgGYjUAq6+xfPly1+BkJ0+e9Lg1btKkSRIcHCzNmzf32M/gwYNlyJAh0TouAAAAJAwEbQEAABDvHDt2LFb2q6UQwiqHoIOMuTt+/HistAEAAADxH0FbAAAAxDu5c+e2ugkAAABAtCWEYewAAAAAAAAAwGcQtAUAAAAAAAAAXyuP8MMPP0R6h40aNXqc9gAAAAAAAABAghapoG2TJk0itbOojsALAAAAAAAAAIhGeYRHjx5FaiJgCwAAADv55ptvwlz29ttvx2lbAAAAgMiipq0N9OzZU/LkyWMylXft2hXmetOnT5cnn3xSnnjiCencubPcv3/fzF+9erWUL19eihQpIkWLFpV+/fqZIDoAAEBC9/rrr8svv/wSan7v3r1lzpw5lrQJAAAAiJHyCCHdunVL1q1bJydPnpTg4OBQAUhETfPmzU2gtWrVqmGuc+zYMRk4cKDs2LFDMmfOLI0bN5apU6dK9+7dJW3atDJ//nzJly+f3L17V+rUqSOzZ8+W9u3bx+lxAAAA2M3cuXPl5ZdflmXLlrn6Wm+88YYsXrxY1qxZY3XzAAAAgJgJ2u7cuVPq168vt2/fNsHbdOnSyaVLlyR58uSSKVMmgrbRUK1atQjXWbRokRnkLUuWLOZ5165dZfjw4SZoW7p0add6gYGBUqpUKTl+/HisthkAAMAXNGjQQL744gvTj1qxYoW5c+n77783AdsCBQpY3TwAAAAgZoK2eitZw4YNZfLkyZI6dWr5888/JUmSJNK6dWvp1atXVHeHSNKs5ty5c7ueazkFnRfSuXPnTIBXs0kAAAAg8sorr8jVq1elSpUqkjFjRnPHWP78+a1uFgAAABBzQVutuTplyhTx9/eXRIkSyb1798xt+aNGjZJ27drJCy+8ENVdIoZcv37dBNS11EK5cuWsbg4AAIAl+vTp43W+BmzLlCljMm+dxowZE4ctAwAAAGIpaKtZtRqwVVoOQbM9CxcubLJuT506FdXdIZJy5colR48edT3X8gc6z+nGjRvy7LPPmlq3Yf1DBQAAICHQcl7eaHat/sjtXK6DwAIAAADxImir9VO3bt0qTz75pFSvXl0GDRpkatp+/fXXUqxYsdhpJaRZs2Zm8IwhQ4aYgci0PEXLli3Nsps3b5qArU7vv/++1U0FAACwFAOMAQDi3Byb3u3aepvVLQAQTf9LmY0CHfwqa9as5vGwYcMkbdq08vrrr8vFixdN2QREXZcuXSRHjhxy+vRpqVevnqvGWqdOneSHH34wj7UExdChQ00tNl2ut/fpdmr8+PGyZcsWMwqyDkKmk743AAAAAAAAABJApq17rVQtj7B8+fKYblOCE1awe9q0aR7PO3fubKaQ3nvvPTMBAAAgtG3btsm3335rynoFBwd7LNMfvQEAACxj1yxtRaa2b2Xa1qpVy4y+G5LWB9NlAAAAgF3Mnz9fKleuLAcOHJAlS5bI/fv3Zd++fbJ69WozJgMAAAAQL4K2a9euDZWhoO7evSu///57TLULAAAAeGxa2mvs2LHy448/StKkSU1ZqYMHD8pLL73kMagrAAAA4JNB2z179phJ7d+/3/VcJx2Bd/r06ZI9e/Yovfj69eulYcOGki1bNjN679KlSyMVNC5TpowEBASY2q6zZs2K0msCAAAg4Th69Kg0aNDAPNag7a1bt0y/s3fv3jJ16lSrmwcAAAA8Xk1bHdxKO7g6eSuDkCxZMvn8888lKrTTXLJkSenYsaO88MILEa5/7Ngx0+nu2rWrzJ07V1atWmUG69KB0XQALwAAAMCdDpp748YN81gTDP766y8pXry4Kfd1+/Ztq5sHAAAAPF7QVgOmDodD8uXLJ1u2bJGMGTO6lmnWgg5KlihRIomK5557zkyRNXnyZMmbN6+MHj3aPC9cuLBs2LDB3PJm56Btj2kbxK4mdKpqdRMAAABiTbVq1WTFihUmUPviiy9Kr169TD1bnVe7dm2rmwcAAAA8XtA2d+7c5u+jR4/EKps2bZI6dep4zNNg7ZtvvmlZmwAAAGBfEyZMMGMvqPfee0+SJEkiGzdulGbNmsn7779vdfMAAACAxwvahqwNNm7cODMKrypSpIjJWnjiiSckNp07d04yZ87sMU+fX79+Xe7cuWNKNIR07949Mznpus7gc1wFoP3EIXZlZRA+rtj1/CeEcx8fzr+vt9+X+fq5p/2xIyG0365tj+vvnph6rXTp0rke+/v7y7vvvhsj+wUAAABsFbT99ddfpVGjRqbGbZUqVcy8P/74Q4oWLWpG5X3mmWfETkaMGCFDhw4NNf/ixYuurIvYlj7pfbGrCxcuSHxn1/OfEM59fDj/vt5+X+br5572x46E0H67tj2uv3ucdWhjgiYczJw50/wdP368Kev1yy+/SK5cuUwfFgAAAPD5oK1mJ+houx9//HGo+e+8806sBm2zZMki58+f95inz4OCgrxm2ar+/ftLnz59PDJtc+bMaWry6nZx4b/gw2JX+o+W+M6u5z8hnPv4cP59vf2+zNfPPe2PHQmh/XZte1x/9wQGBsbIftatW2fGUNBkg/Xr18uwYcPMcezevVumT58uixYtipHXAQAAACwN2mpJhG+//TbU/I4dO5qSCbGpUqVK8vPPP3vM00EkdH5YAgICzBSS3h6nU1xwiJ/YVVydAyvZ9fwnhHMfH86/r7ffl/n6uaf9sSMhtN+ubY/r756Yei1NLPjoo4/Mj/ipUqVyza9Vq5apdwsAAADYUZR7w5qhumvXrlDzdV5Usy9u3rxptnPu79ixY+bxyZMnXVmybdu2da3ftWtX+eeff6Rfv35y8OBB+eKLL0wAWTN/AQAAgJD27t0rTZs2DTVf+62XLl2ypE0AAABAjGXafvDBB9K3b1/p3LmzvPbaayZ4WrlyZVdN25EjR3qUIYiMbdu2Sc2aNV3Pndu3a9dOZs2aJWfPnnUFcFXevHnlp59+MkFarUeWI0cOmTZtmtSrVy9KrwsAAICEIU2aNKZPqf1Idzt37pTs2bNb1i4AAAAgRoK2OpiXZroOHDjQ3Fo2evRokwmrsmXLJkOGDJGePXtKVNSoUUMcjrBHSNbArbdttJMNAAAARKRly5Zm3IWFCxeKn5+fPHr0yCQcaDKC+x1dAAAAgE8GbZ3BVe3saqarTs5Rfd3rgwEAAAB2MXz4cOnevbsZiPbhw4dSpEgR8/eVV16R999/3+rmAQAAAI8/EJkGbN0RrAUAAICdJU2aVL788ksZNGiQqW+rYyqULl1annzySaubBng3p5zYUuttVrcAAIAEJUpB2wIFCoQK3IZ0+fLlx20TACCOHD582NQR18F4UqdObcrSFC1a1GMdvZVYbyNevny5JE6cWNKnT28CIPnz55fjx4/LE088IcWLF3et/91335l5AGAl/e765JNP5IcffpDg4GCpXbu2DB48WJIlS2Z10wAAAICYDdpqXVv9Rz0AIH7o0qWLGVyyffv2smjRIvN369atHutowEPrP+7evVuSJEkiH330kQwYMEC+/fZb110Xu3btsugIAMC7YcOGmTEX6tSpYwK1OojthQsXZMaMGVY3DQAAAIjZoK0O5JApU6aobAIAsCkNXmzbtk1+++0387xZs2bSo0cPOXLkiMmiddI7LO7duyd37941mbbXr1+XHDlyWNhyAIjY7Nmz5YsvvjA/TqmVK1dKgwYNZNq0aeLv72918wAAAICYCdpGVBYBAOBbTp06JVmzZjWBWOf3fK5cueTkyZMeQduGDRvKmjVrJEuWLCarNnv27LJu3TrX8lu3bslTTz1lBvZp0qSJvPfee5IoUSJLjgkAnPS7rH79+q7nmnGr33P//vsvPzwBAADA9iKdZuBwOGK3JQAAW9Js3L/++kvOnDljgh1aF7Jr165mmQZ9db6WVNAstt9//11Gjx5tdZMBQB48eCCBgYEe87TEy/379y1rEwAAABDjmbY6mAMAIP7ImTOnnD171gQ2NNtWf5zTzDTNtg15i3GtWrUkTZo05rkOXFa3bl3zOCAgwFU2J126dNKxY0eZN2+e9OvXz4IjAoD/o99pWqdbv6ectMyL/uiUIkUK17zFixdb1EIAAAAgbBT0AoAESoOtZcqUkTlz5pjn3333nbll2L00gsqXL5+sXr3ajL6uli1bJsWKFXPVxXVmrWndWw1+lC5dOs6PBQBC0h+Y9HtOB9F1Tq1bt5Zs2bJ5zAMAAAB8fiAyAED8MmXKFJOJNnz4cAkKCpKZM2ea+Z06dZJGjRqZqXv37nLgwAEpWbKkubVYa9tOnjzZrLdhwwYZNGiQqWGrGbuakas1bQHAas7vMwAAAMAXEbQFgASsYMGCsmnTplDzdXR1J721+Msvv/S6/QsvvGAmAAAAAAAQcyiPAPi4w4cPS+XKlaVAgQLy1FNPyb59+7xmG5UqVco1ZciQwSPQNnLkSClSpIhZVrFiRdmyZUscHwUAAAAAAACcCNoCPq5Lly7y2muvyd9//y3vvPOOudU9pA4dOsiuXbtck97e3qpVK7NMn3/xxRcmUKuPe/ToYSYAAAAAAABYg6AtbJPtqaPWN2zY0NyurVmfn3/+eRwfhe/RQaC2bdtmBlZRzZo1k1OnTsmRI0fC3Gbz5s1mO61Vqvz8/MxAUrdu3TLPr169agajAgAAAAAAgDWoaYsYzfbULM9FixaZv1u3bg2V7amTk44+78z2dDgc0rRpU3n33XflxRdfNPPOnz8fx0fhezRAmzVrVkmcOLErAJsrVy4TAM+fP7/XbaZPny5t2rQxA0opHVyqd+/ekjdvXkmXLp2pX7p+/fo4PQ4AAAAAAAD8H4K2iLFsz99++82V7am312u2Z1iBw5DZnqtWrTLBQmfAVmXOnDmOjiDh0Gza+fPny59//umad+zYMVm8eLF5v7JlyyYTJkyQFi1ayIYNGyxtKx5fj2n2fQ8ndKpqdRMAAAAAALAtyiMgVrM9wxIy23P//v2SMWNGadmypZQuXdpk3f7zzz9xdgy+KmfOnHL27Fl58OCBK2NZz7uef28WLlwoRYsWNeUnnL777jspXry4CdgqzYb+448/JDg4OI6OAgAAAAAAAO4I2sKybM9XX33VNU+DjqtXr5aBAwfKzp07pV69evLSSy9Z2k5fkClTJilTpozMmTPHFYDVerThlUZwP+8qX758Jkh78+ZN83zZsmWmNnHSpEnj4AgAAAAAAAAQEuUREKPZnpptG51sT11XM2x1vtIs3G7dupkBspzZuPBuypQppobw8OHDJSgoyAz4pjp16mTKTzhLUBw6dEh27dolP//8s8f2mtWs9YfLlStnSlSkSJFC5s2bZ8mxAAAAAAAAgKAtYjjbU4OH0cn2fO6556Rfv35y5swZyZ49uwksFi5cmIBtJBQsWFA2bdoUav60adNCrXfjxo1Q62k5ixEjRpgJAAAAAAAA1iNoC1tke2p25+TJk6VBgwYmUzd16tSmhAIAAAAAAACQ0BC0hS2yPVXdunXNBAAAAAAAACRkDEQGAAAAAAAAADZC0BYAAAAAAAAAbITyCIDN9Zi2QexoQqeqVjcBAAAAAAAgXiJoCwAAAAAAkJDNKSe21Hqb1S0ALEPQFj6b6anI9gQAAAAAAEB8Q01bAAAAAAAAALARgrYAAAAAAAAAYCMEbQEAAAAAAADARgjaAgAAAAAAAICNELQFAAAAAAAAABshaAsAAAAAAAAANkLQFgAAAAAAAABshKAtAAAAAAAAANgIQVsAAAAAAAAAsBGCtgAAAAAAAABgIwRtAQAAAAAAAMBGCNoCAAAAAAAAgI0QtAUAAAAAAAAAGyFoCwAAAAAAAAA2QtAWAAAAAAAAAGyEoC0AAAAQSRMnTpQ8efJIYGCgVKhQQbZs2RLmuvv27ZNmzZqZ9f38/GTcuHFx2lYAAAD4LoK2AAAAQCQsWLBA+vTpI4MHD5YdO3ZIyZIlpV69enLhwgWv69++fVvy5csnH3/8sWTJkiXO2wsAAADfRdAWAAAAiIQxY8ZI586dpUOHDlKkSBGZPHmyJE+eXGbMmOF1/aeeeko++eQTadmypQQEBMR5ewEAAOC7CNoCAAAAEQgODpbt27dLnTp1XPP8/f3N802bNlnaNgAAAMQ/ia1uAAAAAGB3ly5dkocPH0rmzJk95uvzgwcPxtjr3Lt3z0xO169fN38fPXpkprjhJ7YVqXNg0/ZH+v3z9fb7Ol8+/zZtu6+3P8F8dml/rPDla9/X2/8obv+/FRv9NIK2AAAAgE2MGDFChg4dGmr+xYsX5e7du3HTiET5xbbCqB/sE+2PTNvjQ/t9nS+ff7u23dfbn1A+u7Q/dvjyte/r7b8Qt//funHjRozvk6AtAAAAEIEMGTJIokSJ5Pz58x7z9XlMDjLWv39/M9iZe6Ztzpw5JWPGjBIUFCRx4uERsa1MmXy3/ZFpe3xov6/z5fNv17b7evsTymeX9scOX772fb39meL2/1uBgYExvk+CtgAAAEAEkiZNKmXLlpVVq1ZJkyZNXLfB6fMePXrE2OvogGXeBi3T+rk6xQ2H2FakzoFN2x/p98/X2+/rfPn827Ttvt7+BPPZpf2xwpevfV9vv3/c/n8rNvppBG0BAACASNAM2Hbt2km5cuWkfPnyMm7cOLl165Z06NDBLG/btq1kz57dlDhwDl62f/9+1+MzZ87Irl27JGXKlJI/v01vJQQAAIAtELQFAAAAIqFFixamtuygQYPk3LlzUqpUKVm+fLlrcLKTJ096ZFn8+++/Urp0adfzTz/91EzVq1eXtWvXWnIMAAAA8A0EbQEAAIBI0lIIYZVDCBmIzZMnjzgcNr1lEIgtc8qJLbXeZnULAACIkoRSmAgAAAAAAAAAfAJBWwAAAAAAAACwEYK2AAAAAAAAAGAjBG0BAAAAAAAAwEZsEbSdOHGiGaghMDBQKlSoIFu2bAlz3VmzZomfn5/HpNsBAAAAAAAAQHxgedB2wYIF0qdPHxk8eLDs2LFDSpYsKfXq1ZMLFy6EuU1QUJCcPXvWNZ04cSJO2wwAAAAAAAAA8TZoO2bMGOncubN06NBBihQpIpMnT5bkyZPLjBkzwtxGs2uzZMnimjJnzhynbQYAAAAAAACA2JJYLBQcHCzbt2+X/v37u+b5+/tLnTp1ZNOmTWFud/PmTcmdO7c8evRIypQpI8OHD5eiRYt6XffevXtmcrp+/br5q9vqFBf8xCF2FZlzQPtjR2SvP9ofOxJC++3adl9vf0K4dhTtjx2+fO2ruOo7xfVrAQAAAHZjadD20qVL8vDhw1CZsvr84MGDXrcpWLCgycItUaKEXLt2TT799FOpXLmy7Nu3T3LkyBFq/REjRsjQoUNDzb948aLcvXtX4kL6pPfFrsIrQ+FE+61ru6L9sSMhtN+ubff19ieEa0fR/tjhy9d+VM5/TLhx40acvRYAAABgN5YGbaOjUqVKZnLSgG3hwoVlypQp8uGHH4ZaX7N4tWaue6Ztzpw5JWPGjKY2blz4L/iw2FWmTJkiXIf2W9d2RftjR0Jov13b7uvtTwjXjqL9scOXr/2onP+YwECzAAAASMgsDdpmyJBBEiVKJOfPn/eYr8+1Vm1kJEmSREqXLi1HjhzxujwgIMBMIWkZBp3igkP8xK4icw5of+yI7PVH+2NHQmi/Xdvu6+1PCNeOov2xw5evfRVXfae4fi0AAADAbiztDSdNmlTKli0rq1at8qhfps/ds2nDo+UV9u7dK1mzZo3FlgIAAAAAAABAAimPoKUL2rVrJ+XKlZPy5cvLuHHj5NatW9KhQwezvG3btpI9e3ZTm1Z98MEHUrFiRcmfP79cvXpVPvnkEzlx4oR06tTJ4iMBAAAAAAAAgHgQtG3RooUZFGzQoEFy7tw5KVWqlCxfvtw1ONnJkyc9bo+7cuWKdO7c2aybNm1ak6m7ceNGKVKkiIVHAQAAAAAAAADxJGirevToYSZv1q5d6/F87NixZgIAAAAAAACA+IgRHgAAAAAAAADARgjaAgAAAAAAAICNELQFAAAAAAAAABshaAsAAAAAAAAANkLQFgAAAAAAAABshKAtAAAAAAAAANgIQVsAAAAAAAAAsBGCtgAAAAAAAABgIwRtAQAAAAAAAMBGCNoCAAAAAAAAgI0QtAUAAAAAAAAAGyFoCwAAAAAAAAA2QtAWAAAAAAAAAGyEoC0AAAAAAAAA2AhBWwAAAAAAAACwEYK2AAAAAAAAAGAjBG0BAAAAAAAAwEYI2gIAAAAAAACAjRC0BQAAAAAAAAAbIWgLAAAAAAAAADZC0BYAAAAAAAAAbISgLQAAAAAAAADYCEFbAAAAAAAAALARgrYAAAAAAAAAYCMEbQEAAAAAAADARgjaAgAAAAAAAICNELQFAAAAAAAAABshaAsAAAAAAAAANkLQFgAAAAAAAABshKAtAAAAAAAAANgIQVsAAAAAAAAAsBGCtgAAAAAAAABgIwRtAQAAAAAAAMBGCNoCAAAAAAAAgI0QtAUAAAAAAAAAGyFoCwAAAAAAAAA2QtAWAAAAAAAAAGyEoC0AAAAAAAAA2AhBWwAAAAAAAACwEYK2AAAAAAAAAGAjBG0BAAAAAAAAwEYI2gIAAAAAAACAjRC0BQAAAAAAAAAbIWgLAAAAAAAAADZC0BYAAAAAAAAAbISgLQAAAAAAAADYCEFbAAAAAAAAALARgrYAAAAAAAAAYCMEbQEAAAAAAADARgjaAgAAAAAAAICNELQFAAAAAAAAABshaAsAAAAAAAAANkLQFgAAAAAAAABshKAtAAAAAAAAANgIQVsAAAAAAAAAsBGCtgAAAAAAAABgI7YI2k6cOFHy5MkjgYGBUqFCBdmyZUu46y9cuFAKFSpk1i9evLj8/PPPcdZWAAAAJFz0WwEAAJAggrYLFiyQPn36yODBg2XHjh1SsmRJqVevnly4cMHr+hs3bpSXX35ZXn31Vdm5c6c0adLETH/99Vectx0AAAAJB/1WAAAAJJig7ZgxY6Rz587SoUMHKVKkiEyePFmSJ08uM2bM8Lr++PHj5dlnn5W3335bChcuLB9++KGUKVNGJkyYEOdtBwAAQMJBvxUAAABxJbFYKDg4WLZv3y79+/d3zfP395c6derIpk2bvG6j8zXDwZ1mOCxdutTr+vfu3TOT07Vr18zfq1evyqNHjyQu3L9zU+xKz0NEaL91bVe0P3YkhPbbte2+3v6EcO0o2h87fPnaj8r5jwnXr183fx0Oh9hBXPRb7dJ3lTtx9DrREZlr0K7tj+znh/bHjoTQfru23dfbnxCuHUX7Y4cvX/u+3v6rcddvjbW+q8NCZ86c0SNxbNy40WP+22+/7ShfvrzXbZIkSeKYN2+ex7yJEyc6MmXK5HX9wYMHm9dgYmJiYmJiYmLyvenUqVMOO4iLfqui78rExMTExMTE5LtTTPZdLc20jQuaDeGe4aAZCpcvX5b06dOLn5+fpW1LaPRXh5w5c8qpU6ckKCjI6uYkOJx/a3H+rcO5txbn3zq+fu41S+HGjRuSLVs2SUjou9qHr3+GfB3n3zqce2tx/q3F+beOr597Ryz0XS0N2mbIkEESJUok58+f95ivz7NkyeJ1G50flfUDAgLM5C5NmjSP3XZEn374fPEDGF9w/q3F+bcO595anH/r+PK5T506tdhFXPRbFX1X+/Hlz1B8wPm3DufeWpx/a3H+rePL5z51DPddLR2ILGnSpFK2bFlZtWqVRzaBPq9UqZLXbXS++/pqxYoVYa4PAAAAPC76rQAAAIhLlpdH0Nu/2rVrJ+XKlZPy5cvLuHHj5NatW2ZUXtW2bVvJnj27jBgxwjzv1auXVK9eXUaPHi0NGjSQ+fPny7Zt22Tq1KkWHwkAAADiM/qtAAAASDBB2xYtWsjFixdl0KBBcu7cOSlVqpQsX75cMmfObJafPHnSjMzrVLlyZZk3b568//77MmDAAHnyySfNCLzFihWz8CgQGXqr3+DBg0Pd8oe4wfm3FuffOpx7a3H+rcO5j3n0WxMWPkPW4vxbh3NvLc6/tTj/1uHch+ano5F5mQ8AAAAAAAAAsIClNW0BAAAAAAAAAJ4I2gIAAAAAAACAjRC0BQAAAAAAAAAbIWgLAAAAAAAAADZC0BaxbsSIEfLUU09JqlSpJFOmTNKkSRM5dOiQ1c1KkD7++GPx8/OTN9980+qmJBhnzpyR1q1bS/r06SVZsmRSvHhx2bZtm9XNShAePnwoAwcOlLx585pz/8QTT8iHH34ojL8ZO9avXy8NGzaUbNmyme+ZpUuXeizX8z5o0CDJmjWreT/q1Kkjhw8ftqy9CeXc379/X9555x3z3ZMiRQqzTtu2beXff/+1tM2AndF3tQ/6rnGPvqt16LvGHfqt1qLvGnkEbRHr1q1bJ927d5c///xTVqxYYT6EdevWlVu3blndtARl69atMmXKFClRooTVTUkwrly5IlWqVJEkSZLIL7/8Ivv375fRo0dL2rRprW5agjBy5EiZNGmSTJgwQQ4cOGCejxo1Sj7//HOrmxYv6Xd6yZIlZeLEiV6X67n/7LPPZPLkybJ582bTCatXr57cvXs3ztuakM797du3ZceOHeYfgfp38eLFJvjUqFEjS9oK+AL6rvZA3zXu0Xe1Fn3XuEO/1Vr0XSPPz8HPNohjFy9eNFkL2iGuVq2a1c1JEG7evCllypSRL774Qj766CMpVaqUjBs3zupmxXvvvvuu/PHHH/L7779b3ZQE6fnnn5fMmTPL9OnTXfOaNWtmfi2fM2eOpW2L7/QX8yVLlpjsNKVdDf2V/K233pK+ffuaedeuXTPvz6xZs6Rly5YWtzj+nvuwAiHly5eXEydOSK5cueK0fYAvou8a9+i7WoO+q7Xou1qDfqu16LuGj0xbxDn9wlPp0qWzuikJhmaLNGjQwNzWgbjzww8/SLly5eTFF180/9grXbq0fPnll1Y3K8GoXLmyrFq1Sv7++2/zfPfu3bJhwwZ57rnnrG5agnPs2DE5d+6cx3dQ6tSppUKFCrJp0yZL25ZQ/z+sHeQ0adJY3RTAJ9B3jXv0Xa1B39Va9F3tgX6r/VxLwH3XxFY3AAnLo0ePTE0qve2mWLFiVjcnQZg/f765rUB/nULc+ueff8wtTn369JEBAwaY96Bnz56SNGlSadeundXNSxDZItevX5dChQpJokSJTJ2wYcOGSatWraxuWoKjHV+lGQru9LlzGeKG3tandcJefvllCQoKsro5gO3Rd4179F2tQ9/VWvRd7YF+q73cTeB9V4K2iPNfzf/66y/ziyFi36lTp6RXr16mHltgYKDVzUmQ/9DTbIXhw4eb55qtoNe/1kai4xv7vv32W5k7d67MmzdPihYtKrt27TL/8NbbnTj/SIi0LudLL71kbvvTf5QDiBh917hF39Va9F2tRd8V8HSfvivlERB3evToIcuWLZM1a9ZIjhw5rG5OgrB9+3a5cOGCqQmWOHFiM2k9Ni2qro/111vEHh1ttEiRIh7zChcuLCdPnrSsTQnJ22+/bTIWtO6Ujj7apk0b6d27txkVHHErS5Ys5u/58+c95utz5zLETadXa4FpMCQhZioAUUXfNe7Rd7UWfVdr0Xe1B/qt9kDf9X8I2iLW6a8i2unV4tKrV6+WvHnzWt2kBKN27dqyd+9e8yutc9Jfz/UWG32st90g9uitlDrSpTutUZU7d27L2pSQ6Mij/v6e/5vTa16zSBC39HtfO7lap81Jb//T0XgrVapkadsSUqf38OHDsnLlSkmfPr3VTQJsjb6rdei7Wou+q7Xou9oD/Vbr0Xf9P5RHQJzcVqa3eHz//feSKlUqVx0YLeatI2Ei9uj5Dll/LUWKFOZLj7pssU9/GdcBBfQWM/2fzpYtW2Tq1KlmQuxr2LChqQOmI4zqLWY7d+6UMWPGSMeOHa1uWrwd6fvIkSMegzjoP7B14B59D/T2Ph0B/MknnzSd4YEDB5rb/cIbKRaPf+41a6p58+amPqRmDGqWmvP/w7pc6xQC8ETf1Tr0Xa1F39Va9F3jDv1Wa9F3jQIHEMv0MvM2zZw50+qmJUjVq1d39OrVy+pmJBg//vijo1ixYo6AgABHoUKFHFOnTrW6SQnG9evXzbWeK1cuR2BgoCNfvnyO9957z3Hv3j2rmxYvrVmzxut3fbt27czyR48eOQYOHOjInDmz+TzUrl3bcejQIaubHe/P/bFjx8L8/7BuByA0+q72Qt81btF3tQ5917hDv9Va9F0jz0//E5UgLwAAAAAAAAAg9lDTFgAAAAAAAABshKAtAAAAAAAAANgIQVsAAAAAAAAAsBGCtgAAAAAAAABgIwRtAQAAAAAAAMBGCNoCAAAAAAAAgI0QtAUAAAAAAAAAGyFoCwAAAAAAAAA2QtAWAGLYxYsX5fXXX5dcuXJJQECAZMmSRerVqyd//PGHax0/Pz9ZunSp2MmQIUOkVKlSHs+1nTolTpxYMmTIINWqVZNx48bJvXv3LG0rAAAAYgZ9VwCwp8RWNwAA4ptmzZpJcHCwfPXVV5IvXz45f/68rFq1Sv77778Yf6379+9LkiRJJLYULVpUVq5cKY8ePTLtX7t2rXz00Ufy9ddfm8epUqWKtdcGAABA7KPvCgD2RKYtAMSgq1evyu+//y4jR46UmjVrSu7cuaV8+fLSv39/adSokVknT5485m/Tpk1NJoDzuZo0aZI88cQTkjRpUilYsKDpYLrT9XUd3VeKFClk2LBhriyDGTNmmAyJlClTSrdu3eThw4cyatQoky2RKVMms25UaZaCbp8tWzYpXry4vPHGG7Ju3Tr566+/zDECAADAd9F3BQD7ImgLADFIO5066e1jYd2GtXXrVvN35syZcvbsWdfzJUuWSK9eveStt94yHcsuXbpIhw4dZM2aNR7ba0dXO8179+6Vjh07mnlHjx6VX375RZYvXy7ffPONTJ8+XRo0aCCnT582HVXtpL7//vuyefPmxz7GQoUKyXPPPSeLFy9+7H0BAADAOvRdAcC+CNoCQAzSX/dnzZplbi9LkyaNVKlSRQYMGCB79uxxrZMxY0bzV5drJoDz+aeffirt27c3mQYFChSQPn36yAsvvGDmu3vllVdMh1hvX9PsBKW3gGm2QpEiRaRhw4YmU+LQoUOmhpdmPej6+jdkJ/pxOr/Hjx+PkX0BAADAGvRdAcC+CNoCQCzUBfv333/lhx9+kGeffdbUzypTpozpEIfnwIEDpqPsTp/rfHflypULta3epuZeoytz5symE+zv7+8x78KFCxITHA6Hud0NAAAAvo2+KwDYE0FbAIgFgYGB8swzz8jAgQNl48aNJgth8ODBMbJvrQcWUsgBHbRT6m2eZjXEBO2M582bN0b2BQAAAGvRdwUA+yFoCwBxQDMHbt265XqunVIdbMFd4cKF5Y8//vCYp891Wzs5ePCgqT+mWRkAAACIf+i7AoD1ElvdAACIT/777z958cUXzSALJUqUMLd9bdu2zYyE27hxY49bwlatWmVuIQsICJC0adPK22+/LS+99JKULl1a6tSpIz/++KMZMGHlypWWHc+DBw/k3LlzJstBj01vl/voo4/MiL/aXgAAAPgu+q4AYF8EbQEgBunouxUqVJCxY8eaUXHv378vOXPmlM6dO5tBHZxGjx5tBmv48ssvJXv27GZghCZNmsj48ePN4A06Eq/ewqWj9NaoUcOy49m3b59kzZpVEiVKJKlTpzaZE/3795fXX3/ddNgBAADgu+i7AoB9+Tm0IjcAAAAAAAAAwBaoaQsAAAAAAAAANkLQFgAAAAAAAABshKAtAAAAAAAAANgIQVsAAAAAAAAAsBGCtgAAAAAAAABgIwRtAQAAAAAAAMBGCNoCAAAAAAAAgI0QtAUAAAAAAAAAGyFoCwAAAAAAAAA2QtAWAAAAAAAAAGyEoC0AAAAAAAAA2AhBWwAAAAAAAACwEYK2AAAAAAAAAGAjBG0BAAAAAAAAwEYI2gIAAAAAAACAjRC0BQAAAAAAAAAbIWgLAAAAAAAAADZC0BYAAAAAAAAAbISgLQAg1q1du1b8/PzMXwAAAMBp1qxZpp94/PhxW/RR27dvL3ny5InztgBASARtAcQ7e/fulebNm0vu3LklMDBQsmfPLs8884x8/vnnHusNHz5cli5dKr5CO7LaqXROSZIkkQwZMkjlypVlwIABcvLkSaubKF988YXpeAMAACDh9l1r1Kjh0W8NaxoyZIjVTQUA2/JzOBwOqxsBADFl48aNUrNmTcmVK5e0a9dOsmTJIqdOnZI///xTjh49KkeOHHGtmzJlStNB9pUgowZt8+bNKy+//LLUr19fHj16JFeuXJGtW7fK4sWLTcd3+vTp0rJlS8vaWKxYMRNIDplRq20NDg6WpEmTir8/vxcCAADE577rihUr5Pz5867n2l/97LPPTKJB4cKFXfNLlCghRYsWlfv370tAQIDpz8Yl7bPq+V+zZo0JNCtti/ZdtT0AYKXElr46AMSwYcOGSerUqU3HME2aNB7LLly4EOuvf+vWLUmRIkWsvkaZMmWkdevWHvNOnDghdevWNZ197QiXLFnysV9Hf9O7e/euJEuW7LH3pYFazRwBAABA/O+7aqawO+0HatBW5zuDo+4SJUokdqF3swGAHZDuBCBe0YwE/bU+ZKdXZcqUyfVYf8XXTupXX33luj1L61c57dy5U5577jkJCgoyWQ21a9c2GQ/e6m+tW7dOunXrZvafI0cOs0w7o5p1umfPHqlevbokT55c8ufPL4sWLTLLdZsKFSqYgGjBggVl5cqVj3XcejudtkezWUeNGuWar7ecectY8FY7TGt3Pf/88/Lrr79KuXLlTNumTJlils2cOVNq1apljlGzDooUKSKTJk3y2Kduv2/fPnNsznPq7JSHVdN24cKFUrZsWfNamqGrwegzZ854rKPvi74HOr9Jkybmccb/1959gElV3Y3jP0u3AAJSIyqKig0sELtiD/GlqElEjYL6FzWWCFaiIhANqLHmNVheaywYe0msqGAXNLaoRBTFguJroSmgMP/nnN+z++7CUoSZnbs7n8/zXGfn3rv3fud4dzjzne89p3XrcOqpp4aFCxeuUrsBABRTqfZdV7RfGvuO5f3SLbfcsqIvGe8yi89jMjj2JePrX9y7776bKpNbtmyZ9ovHeeCBB5Ybz+Jj2pYPUfbnP/85XHPNNWHDDTdM/eEePXqkZHu+zguwOElboE6JyctXXnklvPXWW8vc729/+1vqbO2yyy7p57gcc8wxaVtMPMb1r7/+ejj99NPDOeecE6ZOnZo6sy+99NISx4qd3rfffjsMGzYsnHnmmRXr49AFsbMZO7gxkRrPF4cuuOOOO9JjHOJg9OjRqQMeO3azZ89epde+ww47pE5kvB1tZU2ePDkNvxCrIC6//PKw1VZbpfUxQRvbNt7SdvHFF4eOHTum133llVdW/O5ll12WOv5dunSpaNOzzjprmR303/zmN6myYtSoUeHoo49OHfCdd945fPvtt1X2jcnZfffdN7Rq1Sp1mOOHiRhH7DgDANRWpdx3XZ44NMQhhxwSevfunfqKMb7486233hoGDx6cvuwfMWJESnzHPmUc0qBcbJPtt98+vPPOO+k1xn5jrCiOBQD33nvvSsVz2223hYsuuii1+3nnnZeSuQcccEAaTqGQ5wVKWBzTFqCueOyxx3L169dPyw477JA7/fTTc48++mhuwYIFS+y7xhpr5AYMGLDE+n79+uUaNWqUe//99yvWffbZZ7mmTZvmdt1114p1N9xwQxwTPLfzzjvnfvzxxyrH2G233dK22267rWLdu+++m9bVq1cv9+KLL1asj/HF9fF4yzJ16tS030UXXbTUffr27Zv2mTlzZnp+7rnnpueLK489HrPceuutl9Y98sgjS+z/3XffLbFu3333zW2wwQZV1m2++ebptS/uqaeeSseOj1H8/9GmTZvcFltskfv+++8r9nvooYfSfsOGDatYF/8fxXUjR46scsytt946t+222y61LQAAsq4u910ru/POO6v0BVe0X/r8888vcd7VVlst99FHH1Wsv/rqq5c49p577pnbcsstc/PmzatYt2jRotyOO+6Y22ijjZbaR41iG8fzL94Hb9WqVe7rr7+uWH///fen9Q8++OBPPi/AilBpC9QpsUL0hRdeCH369EnVBrFKIFZoxll4V+S2pFjR+dhjj6VvwzfYYIOK9e3bt0/f9D/77LNh1qxZVX4nVohWNw5XvDWt8qRg8VayeOtbHHM2VjCUK//5gw8+WOnXXfmc0cpWPsSJzmJ7La7yuLYzZ84M//u//5uqXWPM8flPNWnSpDROW6z0qDzW7X777Zcqdf/xj38s8TvHHntsleexoiQfbQYAUCyl3nddljgcV7yTbPHzxiG74sRtS4vn66+/Dk8++WSqvo194thvjctXX32V2va9995bYjiuFXHQQQeFFi1aVOmL1sR5gdIlaQvUOXF8qXibfbyF6uWXXw5Dhw5NHad4G1e8FWxZvvzyy/Ddd9+lTuriYoc13nYVZ/RdPNFZnThUwOLjycaJJuLQAouvi2K8q2rOnDnpsWnTpiv1+0t7Lc8991zYa6+90u1dsfMex5SNQyVEK5O0jROnRdW1c0zalm8vFxO78ZyVxU5zPtoMAKCYSrnvuiyVE7OVz7u8eOKwCnFC3ThMROw/Vl7OPffclZ7kbfF4yhO4hT4vULoaFDsAgEJp1KhR6gTHZeONNw5HHHFEmviqvNOUL5WrUFdkFtylrY+dvFUVx0OLk0rESSii6iYhi5Y2gVd1ryWOExYns4jJ1EsuuSR1lGPb/vOf/wyXXnpplfHDCiVLMwoDABRCKfZdl2Vl4ynvm8ZJa6u7gyyKk6zlK55CnxcoXZK2QEmIs7ZG06dPr1hXXUIzfhMeZ8uNE3JVNxNsvXr1lvh2PyvirXUxwRonZVi8AiBO7FV5VuLFK1mX5cEHHwzz589Pt+hVrjB46qmnlth3aUni6ibdiGI7x1vcKovryrcDAJSiUui7Fkr5MBENGzZMd4rV9fMCdZfhEYA6JSYSq/vWP1aFRpVvHYu3+sdk5uLfoO+zzz7h/vvvTzPClvviiy/SjLE777xzRRVrlsQk7MCBA1OFxmmnnVaxfsMNN0yPEyZMqFgXZ/y96aabfnJVQeV2jUMi3HDDDUvsW12bLu2DSKwIvuqqq1JCuNzDDz+cZtuNY9sCANR1pdp3LaTYx+zZs2e4+uqrqyS9Kw8pUZfOC9RdKm2BOuXEE09M43rtv//+6Xb+BQsWhOeffz7ccccdYf3110+3mZXbdtttwxNPPJFu+e/QoUMa3ytOZHDeeeeFxx9/PHVy40RZDRo0SJ2vmFyMk0MU26uvvhpuueWWdAtW7LhPnDgx3H333an64m9/+1vo2rVrxb6xEx+rY4866qiUzI0d++uvvz5VZUybNm2FzhePEZPBvXv3Dsccc0waN/faa69NHdPFO6SxTceMGZPaMN7+FfdZvJK2vALhggsuSP8/4oRmBx98cPpwcfnll6f/T4MHD85DSwEAZFsp9F2L4corr0ztseWWW6aJ12IVbOxrxjvTPvnkkzTpW106L1A3SdoCdcqf//znNPZXrE645pprUsc3Ji1jB/bss8+uMkRA7PAOGjQorf/+++/DgAEDUsd38803D88880yaBGLUqFEpORrXx0Rp5Zlzi+X2229PS+yQx8qJjTbaKJx88snh2GOPXWKChJgcvffee9Prj5MitGvXLu0bh02o/CFgWWKFx1133ZXaKY7RFY9x3HHHpcTvkUceWWXfYcOGparf+AEhTqARE7LVJW2jWBkcb+cbPXp0OOOMM1L1SPzAEpO5lf8/AQDUVaXQdy2GzTbbLEyaNCmMGDEi3HjjjeGrr75KxQRbb7116q/WtfMCdVNZrtCjhwMAAAAAsMKMaQsAAAAAkCGStgAAAAAAGSJpCwAAAACQIZK2AAAAAAAZImkLAAAAAJAhkrYAAAAAABnSIJSYRYsWhc8++yw0bdo0lJWVFTscAACqkcvlwuzZs0OHDh1CvXqlW2eg7woAUJp915JL2sZOb8eOHYsdBgAAK+Djjz8O66yzTihV+q4AAKXZdy25pG2sUihvxGbNmhU7HAAAqjFr1qyUrCzvu5WqQvRdY/Xul19+GVq3bl3SVcz5pE3zT5sWhnbNP21aGNo1/7RpYdt0zpw5ee+7llzStvy2stjplbQFAMi2Uh8SoBB91/gBY968eel4PrTlhzbNP21aGNo1/7RpYWjX/NOmNdOm+ey7+r8EAAAAAJAhkrYAAAAAABkiaQsAAAAAkCGStgAAAAAAGSJpCwAAAACQIZK2AAAAAAAZImkLAAAAAJAhkrYAAAAAABkiaQsAAAAAkCGStgAAAAAAGSJpCwAAAACQIZK2AAAAAAAZImkLAAAAAJAhkrYAAAAAABnSoNgBAAAAAADZNWzsxFBbjOzfI9QFkrYAy9D9mu4hiyYNmlTsEAAAAIACMTwCAAAAAECGSNoCAAAAAGSIpC0AAAAAQIZI2gIAwEqYMGFC6N27d+jQoUMoKysL9913X8W2H374IZxxxhlhyy23DGussUba5/DDDw+fffZZUWMGAKB2kLQFAICVMHfu3NCtW7dw5ZVXLrHtu+++C6+++mo455xz0uM999wTJk+eHPr06VOUWAEAqF0aFDsAAACojXr16pWW6jRv3jw8/vjjVdb993//d/j5z38epk2bFtZdd90aihIAgNpI0hYAAGrAzJkz0zAKa6211lL3mT9/flrKzZo1q4aiAwAgSwyPAAAABTZv3rw0xu3BBx8cmjVrttT9Ro0alap0y5eOHTvWaJwAAGSDpC0AABRQnJTsN7/5TcjlcmHMmDHL3Hfo0KGpIrd8+fjjj2ssTgAAssPwCAAAUOCE7UcffRSefPLJZVbZRo0bN04LAAClTdIWAAAKmLB97733wlNPPRVatWpV7JAAAKglJG0BAGAlzJkzJ0yZMqXi+dSpU8Nrr70WWrZsGdq3bx9+9atfhVdffTU89NBDYeHCheHzzz9P+8XtjRo1KmLkAABknaQtAACshEmTJoXdd9+94vmQIUPS44ABA8Lw4cPDAw88kJ5vtdVWVX4vVt327NmzhqMFAKA2kbQFAICVEBOvcXKxpVnWNgAAWJZ6y9wKAAAAAECNkrQFAAAAAMgQwyMAAAAAAEs1sn+PYodQclTaAgAAAABkiEpbACiA7td0D1k0adCkYocAAADAcqi0BQAAAADIEElbAAAAAIAMkbQFAAAAAMgQSVsAAAAAgAzJVNJ2zJgxoWvXrqFZs2Zp2WGHHcLDDz9csb1nz56hrKysynLssccWNWYAAAAAgHxqEDJknXXWCaNHjw4bbbRRyOVy4aabbgp9+/YN//rXv8Lmm2+e9jn66KPDyJEjK35n9dVXL2LEAAAAAAB1OGnbu3fvKs/PP//8VH374osvViRtY5K2Xbt2RYoQAAAAAKCEhkeobOHChWHs2LFh7ty5aZiEcrfeemtYe+21wxZbbBGGDh0avvvuu6LGCQAAAABQZyttozfffDMlaefNmxfWXHPNcO+994bNNtssbTvkkEPCeuutFzp06BDeeOONcMYZZ4TJkyeHe+65Z6nHmz9/flrKzZo1Kz0uWrQoLQDLUhbKQhZ5/8o+1w6sGtcqAAClLHNJ20022SS89tprYebMmeGuu+4KAwYMCOPHj0+J20GDBlXst+WWW4b27duHPffcM7z//vthww03rPZ4o0aNCiNGjFhi/ZdffpkSwwDL0rlR55BFM2bMKHYILIdrB1bN7Nmzix0CAECdNGzsxBo/58j+PWr8nLVd5pK2jRo1Cp07/78Puttuu22YOHFiuPzyy8PVV1+9xL7bbbddepwyZcpSk7ZxCIUhQ4ZUqbTt2LFjaN26dWjWrFnBXgdQN0xZMCVkUZs2bYodAsvh2oFV06RJk2KHAAAARZO5pG11t8ZVHt6gsliRG8WK26Vp3LhxWhZXr169tAAsSy7kQhZ5/8o+1w6sGtcqAAClLFNJ21gV26tXr7DuuuumW+Juu+228PTTT4dHH300DYEQn//yl78MrVq1SmPaDh48OOy6666ha9euxQ4dAAAAAKDuJW3jOHuHH354mD59emjevHlKxsaE7d577x0+/vjj8MQTT4TLLrsszJ07Nw1xcOCBB4azzz672GEDAAAAANTNpO1111231G0xSRsnJAMAAAAAqMsMFgYAAAAAkCGStgAAAAAAGSJpCwAAAACQIZK2AAAAAAAZImkLAAAAAJAhkrYAAAAAABkiaQsAAAAAkCGStgAAAAAAGSJpCwAAAACQIZK2AAAAAAAZImkLAAAAAJAhkrYAAAAAABnSoNgBAAAAAAA1Y2T/HsUOgRWg0hYAAAAAIEMkbQEAAAAAMkTSFgAAAAAgQyRtAQAAAAAyRNIWAAAAACBDJG0BAAAAADJE0hYAAAAAIEMkbQEAAAAAMkTSFgAAAAAgQyRtAQAAAAAyRNIWAAAAACBDGhQ7AAAAAAAolmFjJ+btWCP798jbsShtKm0BAAAAADJE0hYAAAAAIEMkbQEAAAAAMkTSFgAAAAAgQyRtAQBgJUyYMCH07t07dOjQIZSVlYX77ruvyvZcLheGDRsW2rdvH1ZbbbWw1157hffee69o8QIAUHtI2gIAwEqYO3du6NatW7jyyiur3X7hhReGK664Ilx11VXhpZdeCmussUbYd999w7x582o8VgAAapcGxQ4AAABqo169eqWlOrHK9rLLLgtnn3126Nu3b1p38803h7Zt26aK3P79+9dwtAAA1CYqbQEAIM+mTp0aPv/88zQkQrnmzZuH7bbbLrzwwgtL/b358+eHWbNmVVkAACg9krYAAJBnMWEbxcrayuLz8m3VGTVqVEruli8dO3YseKwAAGSPpC0AAGTE0KFDw8yZMyuWjz/+uNghAQBQBJK2AACQZ+3atUuPX3zxRZX18Xn5tuo0btw4NGvWrMoCAEDpkbQFAIA869SpU0rOjhs3rmJdHJ/2pZdeCjvssENRYwMAIPsaFDsAAACojebMmROmTJlSZfKx1157LbRs2TKsu+664eSTTw7nnXde2GijjVIS95xzzgkdOnQI/fr1K2rcAABkX6YqbceMGRO6du1acStYrEJ4+OGHK7bPmzcvHH/88aFVq1ZhzTXXDAceeOASt5wBAEBNmDRpUth6663TEg0ZMiT9PGzYsPT89NNPDyeeeGIYNGhQ6NGjR0ryPvLII6FJkyZFjhwAgKzLVKXtOuusE0aPHp2qEXK5XLjppptC3759w7/+9a+w+eabh8GDB4d//OMf4c4770yz6Z5wwgnhgAMOCM8991yxQwcAoMT07Nkz9VmXpqysLIwcOTItAABQa5O2vXv3rvL8/PPPT9W3L774YkroXnfddeG2224Le+yxR9p+ww03hE033TRt33777YsUNQAAAABAHU3aVrZw4cJUUTt37tw0TMIrr7wSfvjhh7DXXntV7NOlS5c0XtgLL7yw1KTt/Pnz01J5Aoho0aJFaQFYlrJQFrLI+1f2uXZg1bhWAQAoZZlL2r755pspSRvHr43j1t57771hs802S5M6NGrUKKy11lpV9m/btm34/PPPl3q8UaNGhREjRiyx/ssvv0znAFiWzo06hyyaMWNGsUNgOVw7sGpmz55d7BAAAKBoMpe03WSTTVKCdubMmeGuu+4KAwYMCOPHj1/p4w0dOjRNClG50rZjx46hdevWabIzgGWZsuD/ZgXPkjZt2hQ7BJbDtQOrxmRdAEBNGdm/R7FDgOwnbWM1befO/686adtttw0TJ04Ml19+eTjooIPCggULwrffflul2vaLL74I7dq1W+rxGjdunJbF1atXLy0Ay5ILS59gppi8f2WfawdWjWsVAIBSVq82jGcWx6SNCdyGDRuGcePGVWybPHlymDZtWhpOAQAAAACgLshUpW0cyqBXr15pcrE4jtltt90Wnn766fDoo4+G5s2bh6OOOioNddCyZcs0tMGJJ56YErZLm4QMAAAAAKC2aZC1yVEOP/zwMH369JSk7dq1a0rY7r333mn7pZdemm6VO/DAA1P17b777hv++te/FjtsAAAAAIC6mbS97rrrljshxZVXXpkWAAAAAIC6KPNj2gIAAAAAlBJJWwAAAACADJG0BQAAAADIEElbAAAAAIAMkbQFAAAAAMgQSVsAAAAAgAxpUOwAAAAAAGB5ho2dGErNyP49ih0CRaLSFgAAAAAgQyRtAQAAAAAyRNIWAAAAACBDJG0BAAAAADJE0hYAAAAAIEMaFDsAKLTu13QPWTRp0KRihwAAAABABqm0BQAAAADIEElbAAAAAIAMkbQFAAAAAMgQSVsAAAAAgAyRtAUAAAAAyBBJWwAAAACADJG0BQAAAADIEElbAAAAAIAMkbQFAAAAAMgQSVsAAAAAgAyRtAUAAAAAyJAGxQ4AAAAAAJZnZP8exQ4BaoxKWwAAAACADJG0BQAAAADIEElbAAAAAIAMkbQFAAAAAMgQSVsAAAAAgAyRtAUAAAAAyBBJWwAAAACADJG0BQAAAADIEElbAAAAAIAMaZCPg8yfPz+89NJL4aOPPgrfffddaN26ddh6661Dp06d8nF4AAAAAICSsUpJ2+eeey5cfvnl4cEHHww//PBDaN68eVhttdXC119/nRK5G2ywQRg0aFA49thjQ9OmTfMXNQAAAABAHbXSSds+ffqEV199NRxyyCHhscceC927d08J23IffPBBeOaZZ8Ltt98eLrnkknDzzTeHvffeO19xAwAAALAMw8ZODFk0sn+PYocAdXdM2/322y9MnTo1XHjhhWGXXXapkrCNYpXtgAEDwiOPPBLGjRsX6tVb/qlGjRoVevTokapy27RpE/r16xcmT55cZZ+ePXuGsrKyKkus5AUAAAAAKOmk7THHHBMaNmy4QvtuttlmYc8991zufuPHjw/HH398ePHFF8Pjjz+ehlzYZ599wty5c6vsd/TRR4fp06dXLDFxDAAAAABQF+RlIrKPP/44Vbyus8466fnLL78cbrvttpSsjWParqhYlVvZjTfemCpuX3nllbDrrrtWrF999dVDu3bt8hE6AAAAAEDdS9rGcW1jcvawww4Ln3/+eRq7dvPNNw+33nprej5s2LCVOu7MmTPTY8uWLausj8e95ZZbUuK2d+/e4ZxzzkmJ3OrECdHiUm7WrFnpcdGiRWmh7isLZSGLXH+1g+uHleXagVVTV67VhQsXhuHDh6e+a+wXd+jQIQwcODCcffbZqegBAAAKlrR96623ws9//vP089///vewxRZbhOeeey5NUBbHm12ZpG3sqJ988slhp512SsernCBeb731Uof3jTfeCGeccUYa9/aee+5Z6ji5I0aMWGL9l19+GebNm/eT46L26dyoc8iiGTNmFDsEVoDrh5Xl2mFlDX5kcMiqS39xaY2da/bs2aEuuOCCC8KYMWPCTTfdlIoaJk2aFI444ojQvHnzcNJJJxU7PAAA6nLSNo4927hx4/TzE088Efr06ZN+7tKlSxpzdmXEsW1jMvjZZ5+tsr7ycAtbbrllaN++fRov9/333w8bbrjhEscZOnRoGDJkSJVK244dO4bWrVuHZs2arVRs1C5TFkwJWRSH/iD7XD+sLNcOde3aqenrp0mTJqEueP7550Pfvn3TJL7R+uuvH26//fY0nBgAABQ0aRurBq666qrUGY0TiP3xj39M6z/77LPQqlWrn3y8E044ITz00ENhwoQJFePkLs12222XHqdMmVJt0jYmk8sTypXVq1cvLdR9uZALWeT6qx1cP6ws1w517dqp6eunrlyrO+64Y7jmmmvCf/7zn7DxxhuH119/PRUlXHLJJcUODQCAup60jbd97b///uGiiy4KAwYMCN26dUvrH3jggYphE1ZELpcLJ554Yrj33nvD008/HTp16rTc33nttdfSY6y4BQCALDnzzDPTnV7xDrT69eunMW7PP//8cOihh/6k+RgAACgtq5y0jYnWDTbYIEybNi38+OOPoUWLFlWGMljaBGFLGxLhtttuC/fff39o2rRpmqwhimN+rbbaamkIhLj9l7/8ZargjWPaDh48OOy6666ha9euq/pSAAAgr+J8D3ES3diHjXenxYKDOG9DnJ8hFjus6HwMAACUlnr5SNp27tw5JVgrJ2zLx+z6KWOfxUkaZs6cGXr27JkqZ8uXO+64I21v1KhRGjN3n332SdUKp5xySjjwwAPDgw8+uKovAwAA8u60005L1bb9+/dP8zEcdthhqeggJmerE+djiP3h8uXjjz+u8ZgBAKgDlbZxvLGNNtoofPXVV+lxVRPAyxInEBs/fvwqnQMAAGrKd999t8T4vHGYhEWLFlW7/9LmYwAAoLTkZYaH0aNHpyqCt956Kx+HAwCAOqF3795pDNt//OMf4cMPP0xzN8RJyOJ8EAAAUNCJyA4//PBURRAnIItDGMTxZyv7+uuv83EaAACoVf7yl7+Ec845J/zud78LM2bMSGPZHnPMMWHYsGHFDg0AgLqetL3sssvycRgAAKhT4uS6sa+svwwAQI0nbaub+RYAAAAAgCIlbadNm7bM7euuu24+TgMAAAAAUOflJWm7/vrrh7KysqVuX7hwYT5OAwAAAABQ5+Ulafuvf/2ryvMffvghrYsz48bZcgEAAACoWSP79yh2CEAxk7bdunVbYl337t3T7LgXXXRROOCAA/JxGgAAAACAOq9eIQ++ySabhIkTJxbyFAAAAAAAdUpeKm1nzZpV5XkulwvTp08Pw4cPDxtttFE+TgEAAAAAUBLykrRda621lpiILCZuO3bsGMaOHZuPUwAAAAAAlIS8JG2feuqpKs/r1asXWrduHTp37hwaNMjLKQAAAAAASkJeMqq77bZbPg4DAAAAAFDy8jYR2fvvvx9OPPHEsNdee6XlpJNOSusAACAL5s6dG4YNGxa22GKLsOaaa4amTZuGrl27hpEjR4bvvvuu2OEBAEB+K20fffTR0KdPn7DVVluFnXbaKa177rnnwuabbx4efPDBsPfee+fjNAAAsFIWLFiQ7g576623Qq9evULv3r3THAzvvPNOOP/888PDDz8cJkyYEBo2bFjsUAEAID9J2zPPPDMMHjw4jB49eon1Z5xxhqQtAABFNWbMmPDJJ5+E119/PWyyySZVtr377ruhZ8+e4aqrrkp3jgEAQJ0YHiFWKBx11FFLrD/yyCPD22+/nY9TAADASrvnnnvCOeecs0TCNurSpUs466yzwl133VWU2AAAoCBJ29atW4fXXnttifVxXZs2bfJxCgAAWGmxkCBW0y7N7rvvrtgAAIC6NTzC0UcfHQYNGhQ++OCDsOOOO1aMaXvBBReEIUOG5OMUAACw0r799tvQqlWrpW6P22bOnFmjMQGrbtjYiTV+zpH9e9T4OQEoPXlJ2sZbzeLsuxdffHEYOnRoWtehQ4cwfPjwcNJJJ+XjFAAAsNIWLVoU6tevv9Tt9erVCwsXLqzRmAAAoKBJ27KysjQRWVxmz56d1sUkLgAAZEEulwt77rlnaNCg+u7vjz/+WOMxAQBAQZO2lUnWAgCQNeeee+5y9znwwANrJBYAAKiRpO0XX3wRTj311DBu3LgwY8aMVMlQmVvNAPipul/TPWTRpEGTih0CUKCkLQAA1Kmk7cCBA8O0adPS2Lbt27dPwyUAAAAAAFCkpO2zzz4bnnnmmbDVVlvl43AAAJBXW2+99QoVFrz66qs1Eg8AABQ8aduxY8clhkQAAICs6NevX7FDAACAmk3aXnbZZeHMM88MV199dVh//fXzcUgAAMgbY9oCAFASSdsWLVpUucVs7ty5YcMNNwyrr756aNiwYZV9v/7661WLEgAAAACgRDRYlepaAAAAAAAykrQdMGBAfiMBAAAAACDUW9lfjMMhFHJ/AAAAAIBStNJJ286dO4fRo0eH6dOnL3WfXC4XHn/88dCrV69wxRVXrOypAAAAAABKxkoPj/D000+HP/zhD2H48OGhW7duoXv37qFDhw6hSZMm4Ztvvglvv/12eOGFF0KDBg3C0KFDwzHHHJPfyIFaofs13UMWTRo0qdghAFAkEydODE899VSYMWNGWLRoUZVtl1xySdHiAgCAVU7abrLJJuHuu+8O06ZNC3feeWd45plnwvPPPx++//77sPbaa4ett946XHvttanKtn79+it7GgAAyJs//elP4eyzz0592bZt24aysrKKbZV/BgCAWpm0LbfuuuuGU045JS0AAJBll19+ebj++uvDwIEDix0KAADkf0xbAACoberVqxd22mmnYocBAACFrbQFAIDaYvDgweHKK68Ml112WbFDAfJgZP8exQ4BAOp+pe2oUaNCjx49QtOmTUObNm1Cv379wuTJk6vsM2/evHD88ceHVq1ahTXXXDMceOCB4YsvvihazAAA1B6nnnpq6l9uuOGGoXfv3uGAAw6osgAAQBZkKmk7fvz4lJB98cUXw+OPPx5++OGHsM8++4S5c+dWqY548MEH0+Rncf/PPvtMBxsAgBVy0kknhaeeeipsvPHGqQigefPmVRYAAMiCTA2P8Mgjj1R5fuONN6aK21deeSXsuuuuYebMmeG6664Lt912W9hjjz3SPjfccEPYdNNNU6J3++23L1LkAADUBjfddFO4++67w3777VfsUAAAoPBJ22+//Ta8/PLLYcaMGWHRokVVth1++OErdcyYpI1atmyZHmPyNlbf7rXXXhX7dOnSJay77rrhhRdeqDZpO3/+/LSUmzVrVnqMMS4eJ3VTWSgLWVQq119tb//aHn9tVtvbvrbHT/Fk9dqp6eunUOeK/co4NAIAANT5pG0cruDQQw8Nc+bMCc2aNQtlZf/3YSP+vDJJ29hRP/nkk9PsvltssUVa9/nnn4dGjRqFtdZaq8q+bdu2TduWNk7uiBEjllj/5ZdfpvFxqfs6N+ocsih+wVEKanv71/b4a7Pa3va1PX6KJ6vXTk1fP7Nnzy7IcYcPHx7OPffcdLfW6quvXpBzAABAJpK2p5xySjjyyCPDn/70p7x1fuPYtm+99VZ49tlnV+k4Q4cODUOGDKlSaduxY8fQunXrlGCm7puyYErIojj0Rymo7e1f2+OvzWp729f2+CmerF47NX39NGnSpCDHveKKK8L777+fvvRff/31Q8OGDatsf/XVVwtyXgAAqPGk7aeffpomdchXwvaEE04IDz30UJgwYUJYZ511Kta3a9cuLFiwIA3FULna9osvvkjbqtO4ceO0LK5evXppoe7LhVzIolK5/mp7+9f2+Guz2t72tT1+iier105NXz+FOle/fv0KclwAAMhc0nbfffcNkyZNChtssMEqHSeXy4UTTzwx3HvvveHpp58OnTp1qrJ92223TdUQ48aNCwceeGBaN3ny5DBt2rSwww47rNK5AQCo23788cc0dFe8Q6xyYQAAANTJpG2cffe0004Lb7/9dthyyy2XuM2sT58+Kzwkwm233Rbuv//+0LRp04pxaps3bx5WW2219HjUUUel4Q7iJBJxeIOY5I0J2+omIQMAgHINGjQIF1100UpPkgsAALUqaXv00Uenx5EjRy6xLVYzLFy4cIWOM2bMmPTYs2fPKuvjRBEDBw5MP1966aXpdrlYaTt//vxU5fvXv/41D68CAIC6bo899gjjx49P49kCAECdTtouWrQoH4dJwyOsyKQUV155ZVoAAOCn6NWrVzjzzDPDm2++mYbeWmONNVbqDjEAAMh80hYAAGqD3/3ud+nxkksuWaU7xIDCGv73SaF5vflh5qJp8a8zlKKR/XsUOwQAiihv0/LG28x69+4dOnfunJZYpfDMM8/k6/AAAJCXO8SWtkjYAgBQp5K2t9xyS9hrr73C6quvHk466aS0xInD9txzzzSxGAAAAAAANZi0Pf/888OFF14Y7rjjjoqkbfx59OjR4Y9//GM+TgEAAHnhDjEAAEoiafvBBx+kju/iYgd46tSp+TgFAADUyjvEPv300/Db3/42tGrVKp1ryy23DJMmTSrIuQAAqBvyMhFZx44dw7hx41KlQmVPPPFE2gYAAFlQfofY4MGDK9bFxG2cmCzeIXbIIYfk9XzffPNN2GmnncLuu+8eHn744dC6devw3nvvhRYtWuT1PAAA1C15SdqecsopqbP72muvhR133DGte+6558KNN94YLr/88nycAgAACnqH2B/+8Ie8n++CCy5IRQw33HBDxbpOnTrl/TwAANQteRke4bjjjgtjx44Nb775Zjj55JPT8tZbb6VxbY855ph8nAIAAPJ2h9jiCnWH2AMPPBC6d+8efv3rX4c2bdqErbfeOlx77bV5Pw8AAHVLXipto/333z8tAACQVTV9h1is7B0zZkwYMmRIquSdOHFiOn+jRo3CgAEDlth//vz5aSk3a9asvMcEAEAJJW0BACDr4h1i7dq1CxdffHH4+9//ntZtuumm6Q6xvn375v18ixYtSpW2f/rTn9LzWGkb70i76qqrqk3ajho1KowYMSLvcQAAUCJJ25YtW4b//Oc/Ye21104TKZSVlS1136+//nplTwMAAHlVk3eItW/fPmy22WZV1sUk8d13313t/kOHDk1VuZUrbU3sCwBQelY6aXvppZeGpk2bVvy8rKQtAABkwQYbbJCGKGjVqlWV9d9++23YZptt0nAG+bTTTjuFyZMnV1kXCx/WW2+9avdv3LhxWgAAKG0rnbStfDvXwIED8xUPAAAUzIcffhgWLly4xPo4juynn36a9/MNHjw4jZ0bh0f4zW9+E15++eVwzTXXpAUAAAo6pm39+vXD9OnT04y4lX311VdpXXUdYwAAqCkPPPBAxc+PPvpoaN68ecXz2FcdN25cWH/99fN+3h49eoR77703DXswcuTI0KlTp3DZZZeFQw89NO/nAgCg7shL0jaXy1W7PlYsxJlxAQCgmPr165ce45Bei08A1rBhw5SwjZOTFcJ//dd/pQUAAGokaXvFFVdUdH7/53/+J6y55ppVKhYmTJgQunTpsiqnAACAVbZo0aL0GCtd45i2cTJdAACok0nbOAFZeaXtVVddlYZJKBcrbGPFQlwPAABZMHXq1GKHAAAAhU3alnd6d99993DPPfeEFi1arMrhAACgIF544YU030LlYQpuvvnmcO6554a5c+em4RP+8pe/hMaNGxc1TgAAyNuYtk899ZTWBAAgs+IkYD179qxI2r755pvhqKOOCgMHDgybbrppuOiii0KHDh3C8OHDix0qEEIY/pvuYcaMGWli63r16hU7HAConUnb6JNPPkmz8k6bNi0sWLCgyrZLLrkkX6cBAICf7LXXXgt//OMfK56PHTs2bLfdduHaa69Nzzt27JiqbiVtAQCoM0nbcePGhT59+oQNNtggvPvuu2GLLbYIH374YRrrdptttsnHKQAAYKV98803oW3bthXPx48fH3r16lXxvEePHuHjjz8uUnQAAFBVXu4zGTp0aDj11FPTbWZNmjQJd999d+r07rbbbuHXv/51Pk4BAAArLSZsy+djiHeFvfrqq2H77bev2D579uzQsGHDIkYIAAB5rrR95513wu233/7/DtigQfj+++/DmmuumcYO69u3bzjuuOPycRoAfoLu13QPWTVp0KRih0Adl9Xr37VfPL/85S/DmWeeGS644IJw3333hdVXXz3ssssuFdvfeOONsOGGGxY1RgAAyGul7RprrFExjm379u3D+++/X7Htf//3f/NxCgAAWGlxPNtYXBDvBIvj2MalUaNGFduvv/76sM8++xQ1RgAAyGulbby17Nlnn00z78YqhlNOOSUNlXDPPfdUue0MAACKYe211w4TJkwIM2fOTHeE1a9fv8r2O++8M60HAIA6k7S95JJLwpw5c9LPI0aMSD/fcccdYaONNkrbAAAgC5o3b17t+pYtW9Z4LAAAULCk7cKFC8Mnn3wSunbtWjFUwlVXXbWqhwUAAAAAKEmrPKZtvLUsjv/1zTff5CciAAAAAIASlpeJyLbYYovwwQcf5ONQAAAAAAAlLS9J2/POOy+ceuqp4aGHHgrTp08Ps2bNqrIAAAAAAFCDE5H98pe/TI99+vQJZWVlFetzuVx6Hse9BQAAoGYMGzsxZMnI/j2KHQIAlF7S9qmnnsrHYQAAAAAASl5ekra77bZbPg4DVKP7Nd1DFk0aNKnYIQAAAADUSXlJ2k6YMGGZ23fdddd8nAYAAAAAoM7LS9K2Z8+eS6yrPLatMW0BAAAAAFZMvZAH33zzTZVlxowZ4ZFHHgk9evQIjz32WD5OAQAAAABQEvJSadu8efMl1u29996hUaNGYciQIeGVV17Jx2kAAAAAAOq8vFTaLk3btm3D5MmTf9LYuL179w4dOnRIwyvcd999VbYPHDgwra+8/OIXvyhA5AAAAAAAtbjS9o033qjyPJfLhenTp4fRo0eHrbbaaoWPM3fu3NCtW7dw5JFHhgMOOKDafWKS9oYbbqh43rhx41WIHAAAAACgDiZtY2I2Vr3GZG1l22+/fbj++utX+Di9evVKy7LEJG27du1WOlYAAAAAgDqftJ06dWqV5/Xq1QutW7cOTZo0Cfn29NNPhzZt2oQWLVqEPfbYI5x33nmhVatWS91//vz5aSk3a9as9Lho0aK0UPeVhbKQRSt6/Ym/MEoh/qzGXtvjL4Vrpy6oze2f1dhr+voplWsVAAAKlrRdb731Qk2IQyPEYRM6deoU3n///fCHP/whVea+8MILoX79+tX+zqhRo8KIESOWWP/ll1+GefPm1UDUFFvnRp1DFs2YMWOF9hN/YZRC/FmNvbbHXwrXTl1Qm9s/q7HX9PUze/bsGjsXAADUuaRtrIK48cYbwz333BM+/PDDNExCTKr+6le/Cocddlh6ni/9+/ev+HnLLbcMXbt2DRtuuGGqvt1zzz2r/Z2hQ4eGIUOGVKm07dixY6oEbtasWd5iI7umLJgSsihWjK8I8RdGKcSf1dhre/ylcO3UBbW5/bMae01fP4W4YwsAAEoiaRvHsO3Tp0/45z//mSYQi4nUuO6dd94JAwcOTInc++67LxTKBhtsENZee+0wZcqUpSZt4xi41U1WFodwiAt1Xy5UHWs5K1b0+hN/YZRC/FmNvbbHXwrXTl1Qm9s/q7HX9PVTKtcqAADkPWkbK2wnTJgQxo0bF3bfffcq25588snQr1+/cPPNN4fDDz88FMInn3wSvvrqq9C+ffuCHB8AAAAAoKatUgnD7bffnsaVXTxhG8VJws4888xw6623rvDx5syZE1577bW0lE9wFn+eNm1a2nbaaaeFF198MQ3DEBPFffv2DZ07dw777rvvqrwMAAAAAIC6kbR944030uRgSxMnCXv99ddX+HiTJk0KW2+9dVqiOBZt/HnYsGFporF4vjgcw8YbbxyOOuqosO2224Znnnmm2uEPAAAAAABKbniEr7/+OrRt23ap2+O2b775ZoWP17NnzzQm7tI8+uijPzlGAAAAAICSSdouXLgwNGiw9EPE6tgff/xxVU4BAADATzSyf49ihwAAFCtpG6tiBw4cuNThCebPn78qhwcAAAAAKDmrlLQdMGDAcvc5/PDDV+UUAAAAAAAlZZWStjfccEP+IgEAAAAAINQrdgAAAAAAAPwfSVsAAAAAgAyRtAUAAAAAyBBJWwAAAACADJG0BQAAAADIEElbAAAAAIAMkbQFAAAAAMgQSVsAAAAAgAxpUOwAAAAAStWwsRNr7Fwj+/eosXMBAKtGpS0AAAAAQIZI2gIAAAAAZIikLQAAAABAhkjaAgBADRg9enQoKysLJ598crFDAQAg4yRtAQCgwCZOnBiuvvrq0LVr12KHAgBALSBpCwAABTRnzpxw6KGHhmuvvTa0aNGi2OEAAFALSNoCAEABHX/88WG//fYLe+21V7FDAQCglmhQ7AAAAKCuGjt2bHj11VfT8AgrYv78+WkpN2vWrAJGBwBAVqm0BQCAAvj444/D73//+3DrrbeGJk2arNDvjBo1KjRv3rxi6dixY8HjBAAgeyRtAQCgAF555ZUwY8aMsM0224QGDRqkZfz48eGKK65IPy9cuHCJ3xk6dGiYOXNmxRITvwAAlB7DIwAAQAHsueee4c0336yy7ogjjghdunQJZ5xxRqhfv/4Sv9O4ceO0AABQ2iRtAQCgAJo2bRq22GKLKuvWWGON0KpVqyXWAwBAZYZHAAAAAADIEJW2AABQQ55++ulihwAAQC2g0hYAAAAAIEMkbQEAAAAAMkTSFgAAAAAgQ4xpCwAAUCQj+/codggAQAaptAUAAAAAyBCVtgDAErpf0z1k0aRBk4odAgAAQMGptAUAAAAAyBBJWwAAAACADJG0BQAAAADIEElbAAAAAIAMyVTSdsKECaF3796hQ4cOoaysLNx3331VtudyuTBs2LDQvn37sNpqq4W99torvPfee0WLFwAAAACgTidt586dG7p16xauvPLKardfeOGF4YorrghXXXVVeOmll8Iaa6wR9t133zBv3rwajxUAAAAAoBAahAzp1atXWqoTq2wvu+yycPbZZ4e+ffumdTfffHNo27Ztqsjt379/DUcLAAAAAFDHK22XZerUqeHzzz9PQyKUa968edhuu+3CCy+8UNTYAAAAAADqZKXtssSEbRQrayuLz8u3VWf+/PlpKTdr1qz0uGjRorRQ95WFspBFK3r9ib8wSiH+rMZe2+MvhWsnEn9h1OZrP6rJvpN+GgAApazWJG1X1qhRo8KIESOWWP/ll18aC3cFDX5kcMiqS39x6XL36dyoc8iiGTNmrNB+4i+MUog/q7HX9vhL4dqJxF8Ytfna/yntnw+zZ8+usXNRmoaNnZjHo+VC83rzw8xF09JXL4U2sn+Pgp8DACiuWpO0bdeuXXr84osvQvv27SvWx+dbbbXVUn9v6NChYciQIVUqbTt27Bhat24dmjVrVuCo64YpC6aErGrTpk2tjX9FYo/EXxilEH9WY6/t8ZfCtROJvzBq87X/U9o/H5o0aVJj5wIAgKypNUnbTp06pcTtuHHjKpK0MQH70ksvheOOO26pv9e4ceO0LK5evXppYflyIReyakX+H2Y1/hW9/sRfGKUQf1Zjr+3xl8K1E4m/MGrztR/VZN9JPw0AgFKWqaTtnDlzwpQpU6pMPvbaa6+Fli1bhnXXXTecfPLJ4bzzzgsbbbRRSuKec845oUOHDqFfv35FjRsAAAAAoE4mbSdNmhR23333iuflwxoMGDAg3HjjjeH0008Pc+fODYMGDQrffvtt2HnnncMjjzzi9jkAAAAAoM7IVNK2Z8+eIZdb+i2BZWVlYeTIkWkBAAAAAKiLDBYGAAAAAJAhkrYAAAAAABkiaQsAAAAAkCGZGtO2rup+TfeQVZMGTSp2CAAAAABAJSptAQAAAAAyRNIWAAAAACBDJG0BAAAAADJE0hYAAAAAIEMkbQEAAAAAMkTSFgAAAAAgQyRtAQAAAAAyRNIWAAAAACBDGhQ7AAAAgJo2sn+PvB1r0aJFYcaMGaFNmzahXj11MQDAqtOjAAAAAADIEElbAAAAAIAMkbQFAAAAAMgQSVsAAAAAgAyRtAUAAAAAyBBJWwAAAACADJG0BQAAAADIEElbAAAAAIAMkbQFAAAAAMgQSVsAAAAAgAyRtAUAAAAAyJAGxQ4AAADgpxo2duIqH2Nk/x55iQUAIN9U2gIAAAAAZIikLQAAAABAhkjaAgAAAABkiKQtAAAAAECGSNoCAECBjBo1KvTo0SM0bdo0tGnTJvTr1y9Mnjy52GEBAJBxkrYAAFAg48ePD8cff3x48cUXw+OPPx5++OGHsM8++4S5c+cWOzQAADKsQbEDAACAuuqRRx6p8vzGG29MFbevvPJK2HXXXYsWFwAA2SZpCwAANWTmzJnpsWXLltVunz9/flrKzZo1q8ZiAwAgOwyPAAAANWDRokXh5JNPDjvttFPYYostljoGbvPmzSuWjh071nicAAAUn6QtAADUgDi27VtvvRXGjh271H2GDh2aqnHLl48//rhGYwQAIBsMjwAAAAV2wgknhIceeihMmDAhrLPOOkvdr3HjxmkBAKC0SdoCAECB5HK5cOKJJ4Z77703PP3006FTp07FDgkAgFqg1g2PMHz48FBWVlZl6dKlS7HDAgCAaodEuOWWW8Jtt90WmjZtGj7//PO0fP/998UODQCADKuVlbabb755eOKJJyqeN2hQK18GAAB13JgxY9Jjz549q6y/4YYbwsCBA4sUFQAAWVcrs50xSduuXbtihwEAAMsdHgEAAOr88AjRe++9Fzp06BA22GCDcOihh4Zp06YVOyQAAAAAgNKstN1uu+3CjTfeGDbZZJMwffr0MGLEiLDLLruEt956K40Ttrj58+enpdysWbPS46JFi9JSE8pCWciqFWkD8RfGil5/4i+MUog/q7HX9vhL4dqJxF8Ytfnaj2qq71TT5wIAgKypdUnbXr16VfzctWvXlMRdb731wt///vdw1FFHLbH/qFGjUmJ3cV9++WWYN29eqAmdG3UOWTVjxozl7iP+4sUeib8wSiH+rMZe2+MvhWsnEn9h1OZr/6e0fz7Mnj27xs5F7TSyf49ihwAAUDC1Lmm7uLXWWitsvPHGYcqUKdVuHzp0aBgyZEiVStuOHTuG1q1bh2bNmtVIjFMWVB9bFrRp02a5+4i/eLFH4i+MUog/q7HX9vhL4dqJxF8Ytfna/yntnw9NmjSpsXMBAEDW1Pqk7Zw5c8L7778fDjvssGq3N27cOC2Lq1evXlpqQi5kdwKKFWkD8RfGil5/4i+MUog/q7HX9vhL4dqJxF8Ytfnaj2qq71TT5wIAgKypdb3hU089NYwfPz58+OGH4fnnnw/7779/qF+/fjj44IOLHRoAAAAAQOlV2n7yyScpQfvVV1+lIQ523nnn8OKLL6afAQAAAABqu1qXtB07dmyxQwAAAAAAKJhaNzwCAAAAAEBdJmkLAAAAAJAhkrYAAAAAABkiaQsAAAAAkCGStgAAAAAAGSJpCwAAAACQIQ2KHQAAALBs59/1Smi8+po/+fdG9u9RkHgAACgslbYAAAAAABkiaQsAAAAAkCGStgAAAAAAGSJpCwAAAACQIZK2AAAAAAAZImkLAAAAAJAhkrYAAAAAABkiaQsAAAAAkCGStgAAAAAAGSJpCwAAAACQIZK2AAAAAAAZImkLAAAAAJAhkrYAAAAAABkiaQsAAAAAkCGStgAAAAAAGSJpCwAAAACQIZK2AAAAAAAZ0qDYAQAAAMt21q+2Dc2aNSt2GAAA1BCVtgAAAAAAGSJpCwAAAACQIZK2AAAAAAAZImkLAAAAAJAhkrYAAAAAABkiaQsAAAAAkCGStgAAAAAAGSJpCwAAAACQIZK2AAAAAAAZImkLAAAAAJAhkrYAAAAAABkiaQsAAAAAkCG1Nml75ZVXhvXXXz80adIkbLfdduHll18udkgAAAAAAKWZtL3jjjvCkCFDwrnnnhteffXV0K1bt7DvvvuGGTNmFDs0AAAAAIDSS9pecskl4eijjw5HHHFE2GyzzcJVV10VVl999XD99dcXOzQAAAAAgNJK2i5YsCC88sorYa+99qpYV69evfT8hRdeKGpsAAAAAACrqkGoZf73f/83LFy4MLRt27bK+vj83XffXWL/+fPnp6XczJkz0+O3334bFi1aVAMRh7Do+5o5z8qI7bA84i9e7JH4C6MU4s9q7LU9/lK4diLxF0ZtvvZ/Svvnw6xZs9JjLpcLpaz89Ze3Rz7EPvDs2bPT3BCx+IFVp03zT5sWhnbNP21aGNo1/7RpYdt0zpw5ee+7luVqWU/4s88+Cz/72c/C888/H3bYYYeK9aeffnoYP358eOmll6rsP3z48DBixIgiRAoAwKr6+OOPwzrrrBNK1SeffBI6duxY7DAAAKjhvmutq7Rde+21Q/369cMXX3xRZX183q5duyX2Hzp0aJq0rHIW/Ouvvw6tWrUKZWVlNRIzoaJCJH7oiBdws2bNih1OydH+xaX9i0fbF5f2L57a3vaxriBWLnTo0CGUsvj64//Dpk2b5q3vWtuvjSzSpvmnTQtDu+afNi0M7Zp/2rSwbRr7avnuu9a6pG2jRo3CtttuG8aNGxf69etXkYiNz0844YQl9m/cuHFaKltrrbVqLF6WFN8cvEEUj/YvLu1fPNq+uLR/8dTmtm/evHkodfH2xUJVGtfmayOrtGn+adPC0K75p00LQ7vmnzYtXJvmu+9a65K2UaycHTBgQOjevXv4+c9/Hi677LIwd+7ccMQRRxQ7NAAAAACA0kvaHnTQQeHLL78Mw4YNC59//nnYaqutwiOPPLLE5GQAAAAAALVNrUzaRnEohOqGQyC74jAV55577hLDVVAztH9xaf/i0fbFpf2LR9uzNK6N/NOm+adNC0O75p82LQztmn/atPa1aVkuzvIAAAAAAEAm1Ct2AAAAAAAA/B9JWwAAAACADJG0BQAAAADIEElbCm7UqFGhR48eoWnTpqFNmzahX79+YfLkycUOqySNHj06lJWVhZNPPrnYoZSMTz/9NPz2t78NrVq1CquttlrYcsstw6RJk4odVklYuHBhOOecc0KnTp1S22+44Ybhj3/8YzCUe2FMmDAh9O7dO3To0CG9z9x3331Vtsd2HzZsWGjfvn36/7HXXnuF9957r2jxlkrb//DDD+GMM85I7z1rrLFG2ufwww8Pn332WVFjpvCGDx+erofKS5cuXSq2z5s3Lxx//PHp36c111wzHHjggeGLL74oasx18X3t66+/Doceemho1qxZWGuttcJRRx0V5syZE0rZ8tp14MCBS1y7v/jFL6rso11/+uetFfmbnzZtWthvv/3C6quvno5z2mmnhR9//DGUohVp0549ey5xrR577LFV9tGmVY0ZMyZ07do1/e3GZYcddggPP/xwxXbXaf7b1HVamDxKTV2rkrYU3Pjx49PF/OKLL4bHH388fYDcZ599wty5c4sdWkmZOHFiuPrqq9MbOjXjm2++CTvttFNo2LBh+ofz7bffDhdffHFo0aJFsUMrCRdccEHqxPz3f/93eOedd9LzCy+8MPzlL38pdmh1UnxP79atW7jyyiur3R7b/oorrghXXXVVeOmll1ICcd99900dHgrX9t9991149dVX0xcY8fGee+5JHzr79OlTlFipWZtvvnmYPn16xfLss89WbBs8eHB48MEHw5133pn6ajGRf8ABBxQ13rr4vhYTi//+979TH/ihhx5KCctBgwaFUra8do1ikrbytXv77bdX2a5df/rnreX9zccvu2NyYcGCBeH5558PN910U7jxxhvTFxOlaEU/wx599NFVrtX4vlBOmy5pnXXWSQmwV155JRWy7LHHHqFv377p7zlynea/TSPXaf7zKDV2reaghs2YMSOWueXGjx9f7FBKxuzZs3MbbbRR7vHHH8/ttttuud///vfFDqkknHHGGbmdd9652GGUrP322y935JFHVll3wAEH5A499NCixVQq4nv8vffeW/F80aJFuXbt2uUuuuiiinXffvttrnHjxrnbb7+9SFGWRttX5+WXX077ffTRRzUWFzXv3HPPzXXr1q3abfHvr2HDhrk777yzYt0777yTrosXXnihBqOs2+9rb7/9dvq9iRMnVuzz8MMP58rKynKffvppDb+C2vOeNWDAgFzfvn2X+jva9ad/3lqRv/l//vOfuXr16uU+//zzin3GjBmTa9asWW7+/Pm5UlfdZ9jlfa7SpiumRYsWuf/5n/9xnRagTSPXaf7zKDV5raq0pcbNnDkzPbZs2bLYoZSM+C1x/JYn3rZHzXnggQdC9+7dw69//et0O8TWW28drr322mKHVTJ23HHHMG7cuPCf//wnPX/99ddTlVmvXr2KHVrJmTp1avj888+rvAc1b948bLfdduGFF14oamyl+u9wvMUr3lJM3RZv1Y+3oG+wwQapMjHephfFapxYNVb5bzIOnbDuuuv6m8zj+1p8jH9nsS9QLu5fr169VJnL0j399NOp77TJJpuE4447Lnz11VcV27TrT/+8tSJ/8/ExDqXTtm3bin1i5fisWbOqVOyVqqV9hr311lvD2muvHbbYYoswdOjQdIdLOW26bLEScezYsal6Od7S7zrNf5uWc53mN49Sk9dqg5WMHVbKokWL0jgg8Zbx+IZB4cU37XhLbCzrp2Z98MEH6fb8IUOGhD/84Q/p/8FJJ50UGjVqFAYMGFDs8Oq8M888M/2jGP8BrV+/furEnH/++SlxQc2KiY2ocqel/Hn5NmpGvG07jnF78MEHp3HPqLti8jDehheTXvFWyBEjRoRddtklvPXWW+nvLv5btHji3t9kft/X4mNMPFbWoEGDlPTRzmGZQyPEW0zjmPTvv/9+6kPFL1zjB+D477l2/emft1bkbz4+Vnc9l28rZUv7DHvIIYeE9dZbL3059sYbb6R/X+MQRHEookibVu/NN99MCcXYJ4ljgd57771hs802C6+99prrNM9tGrlO859Hqcn3VElbavybivhhofKYahTOxx9/HH7/+9+ncZiaNGlS7HBKsoMXq0D+9Kc/peex0jZe/3HsO0nbwvv73/+evlW+7bbb0riOsSMYO9yxw6L9KUWxIuA3v/lNmjwpfqFE3Vb5roI4DltM4sYPbfG9MU6aBVnVv3//ip9jlVK8fuNkorH6ds899yxqbLWBz1s116aVx1GO12qclDBeo/HLhnjNUr34ZWLsl8fq5bvuuiv1y+OYoOS/TWPi1nVau/MohkegxpxwwglpooCnnnoqDZZN4cWy/RkzZoRtttkmVSDEJb55x0kz4s+x8pDCif8gln/DWW7TTTetuD2Vwoqzc8Zq2/jhL3ZQDjvssDRgfJwNmJrVrl279Lj4jKrxefk2aiZh+9FHH6UOqCrb0hOrQTbeeOMwZcqU9HcXJ8b49ttvq+zjbzK/72vxMfbDKouzRn/99dfa+SeIw3vE23rjtRtp15/+eWtF/ubjY3XXc/m2UvVTPsPGL8eiyteqNl1SrFDs3Llz2HbbbVO/PE5MePnll7tOC9Cm1XGdrnoeJVbM1tS1KmlLwcWKnviPXSzRf/LJJ9OtTtSM+A1avFUifutWvsTKz3h7ePw53mJG4cRbqOKtJ5XF8VVjpROFF8dqiuPbVRav+VgBTc2K7/uxcxLHGC4Xh66IYw9WHm+LwiZs4/imTzzxRGjVqlWxQ6II5syZk6pq4heK8UNdw4YNq/xNxn+v4peK/ibz974WH+MHuvjhr1zsC8d/h8o/NLN8n3zySRrTNl67kXb96Z+3VuRvPj7Gzw2VE+LlX/ItXoRQClbmM2z8fBVVvla16fLFv9358+e7TgvQptVxna56HiX+XGPX6ipMpAYr5Ljjjss1b9489/TTT+emT59esXz33XfFDq0kLW/2SPInztDeoEGD3Pnnn5977733crfeemtu9dVXz91yyy3FDq0kxNmnf/azn+Ueeuih3NSpU3P33HNPbu21186dfvrpxQ6tzs6u+q9//SstsXtxySWXpJ8/+uijtH306NG5tdZaK3f//ffn3njjjTQzeKdOnXLff/99sUOv022/YMGCXJ8+fXLrrLNO7rXXXqvy73Cpzwhc151yyimp7xXf/5577rncXnvtld4D4wzo0bHHHptbd911c08++WRu0qRJuR122CEt5Pd97Re/+EVu6623zr300ku5Z599Ns1CffDBB+dK2bLaNW479dRT0+zb8dp94okncttss01qt3nz5lUcQ7v+9M9by/ub//HHH3NbbLFFbp999kn/XjzyyCO51q1b54YOHZorRctr0ylTpuRGjhyZ2jJeq/F9YIMNNsjtuuuuFcfQpks688wzc+PHj09tFt834/OysrLcY489lra7TvPbpq7TwuVRaupalbSl4GJnrLrlhhtuKHZoJUnStmY9+OCD6c26cePGuS5duuSuueaaYodUMmbNmpWu9fiPaZMmTVIH5ayzzpKoKpCnnnqq2vf6mDyPFi1alDvnnHNybdu2TX8Pe+65Z27y5MnFDrvOt33soC/t3+H4e9RdBx10UK59+/a5Ro0apS+w4vP44a1cTCz+7ne/y7Vo0SJ9obj//vunhAT5fV/76quvUjJxzTXXzDVr1ix3xBFHpMRkKVtWu8aEWPyAGz/YNmzYMLfeeuvljj766Nznn39e5Rja9ad/3lqRv/kPP/ww16tXr9xqq62WvuSJX/788MMPuVK0vDadNm1aSny1bNky/f137tw5d9ppp+VmzpxZ5TjatKojjzwy/V3Hf5vi33l83yxP2Eau0/y2qeu0cHmUmrpWy+J/VrwuFwAAAACAQjKmLQAAAABAhkjaAgAAAABkiKQtAAAAAECGSNoCAAAAAGSIpC0AAAAAQIZI2gIAAAAAZIikLQAAAABAhkjaAgAAAABkiKQtAAAAsITnnnsubLnllqFhw4ahX79+Ieuuu+66sM8++4QsOvPMM8OJJ55Y7DCAWkTSFiDPvvzyy3DccceFddddNzRu3Di0a9cu7LvvvqnTW66srCzcd999IUuGDx8ettpqqyrPY5xxadCgQVh77bXDrrvuGi677LIwf/78osYKAFDbDRw4sKKvFZOibdu2DXvvvXe4/vrrw6JFi0IWDBkyJPUPp06dGm688cYq22J/cPPNNw+DBg1a4vdOP/300KlTpzB79uwai3XevHnhnHPOCeeee27FumuvvTbssssuoUWLFmnZa6+9wssvv1zl93K5XBg2bFho3759WG211dI+7733XsX2Dz/8MBx11FHp9cTtG264YTrHggULqhznjTfeSOdq0qRJ6NixY7jwwgurbD/11FPDTTfdFD744IOCtQFQt0jaAuTZgQceGP71r3+lTtl//vOf8MADD4SePXuGr776Ku/n+uGHH0IhxY749OnTw7Rp08JTTz0Vfv3rX4dRo0aFHXfcsUY74QAAddEvfvGL1NeKicGHH3447L777uH3v/99+K//+q/w448/Fju88P7774c99tgjrLPOOmGttdaqsi0WJ9x8880pmfvoo49WrH/xxRfDpZdemtY3bdo0r/HEBOvS2uWuu+4KzZo1CzvttFPFuqeffjocfPDBqR/7wgsvpGRqrMT99NNPK/aJydUrrrgiXHXVVeGll14Ka6yxRiq4iEng6N13301J9Kuvvjr8+9//Tq8t7vuHP/yh4hizZs1Kx11vvfXCK6+8Ei666KJUAHHNNddU7BMLIOJxx4wZk9c2AeqwHAB588033+TiW+vTTz+91H3WW2+9tE/5Ep+X++tf/5rbYIMNcg0bNsxtvPHGuZtvvrnK78b94z69e/fOrb766rlzzz03Ld26dctdd911uY4dO+bWWGON3HHHHZf78ccfcxdccEGubdu2udatW+fOO++8ZcZefpylPS/3zjvv5Bo1apQ766yzfmLrAABQbsCAAbm+ffsusX7cuHGpz3fttddWrLv44otzW2yxRer/rbPOOqmvN3v27LRtzpw5uaZNm+buvPPOKse599570/6zZs2q9vzz5s3LnXjiiamf2Lhx49xOO+2Ue/nll9O2qVOnVumvxuWGG26o9jjDhw/P/exnP0v94O+//z7XpUuX3ODBg9O2Z555JrfzzjvnmjRpkuKO54vxlot93W233Ta35pprpj7rwQcfnPviiy8qtj/11FPp3P/85z9z22yzTeojx3XV2W+//XKnnnrqMts89o9jW910003p+aJFi3Lt2rXLXXTRRRX7fPvtt6k9br/99qUe58ILL8x16tSp4nnsn7do0SI3f/78inVnnHFGbpNNNqnye/G8sR0AVoRKW4A8WnPNNdMShz5Y2hACEydOTI833HBDqqwof37vvfemyopTTjklvPXWW+GYY44JRxxxRKoMqCx+a7///vuHN998Mxx55JEVVRCxOuORRx4Jt99+exrPa7/99guffPJJGD9+fLjgggvC2WefnaoHVlWXLl1Cr169wj333LPKxwIAoKpY2dqtW7cqfa169eqlatBY6Rnv5nryySfTEARRrAzt379/6ltWFp//6le/Wmq1a/z9u+++Ox3v1VdfDZ07d06VoF9//XWqSI391Fi5GofGij8fdNBB1R7nrLPOSsOBnXTSSam/GYd7+NOf/pT6p7GSON6FFocOuOOOO8Kzzz4bTjjhhCp3jf3xj38Mr7/+euo/x4rjOGxEdePBjh49Orzzzjuha9eu1cYRj929e/dltu13332XztmyZcv0PA778Pnnn6chEco1b948bLfddqkyd2lmzpxZcYwo7huHEWvUqFHFutiWkydPDt98803Fup///Oepfx5fJ8ByrVBqF4AVdtddd6Vv2mNFwY477pgbOnRo7vXXX6+yT3z7jdUPlcV9jz766Crrfv3rX+d++ctfVvm9k08+uco+sSJ28SqKfffdN7f++uvnFi5cWLEuftM/atSoVa60La8cWG211ZbRCgAArEylbXTQQQflNt1006X+bqyqbdWqVcXzl156KVe/fv3cZ599lp7HatUGDRos9e6vWO0aq1ZvvfXWinULFizIdejQIVWRlmvevPlSK2wr+/e//536vvFurIkTJ6Z1Rx11VG7QoEFV9ouVt/Xq1UsVudWJvxv7u+VVxOWVtvfdd98K3e02YcKEZe4XK5TjXW3l53/uuefS75W3W+U++G9+85tqj/Hee+/lmjVrlrvmmmsq1u29995LvNbYJvHYb7/9dsW6mTNnLveuPIByKm0B8ixWE3z22WdpLNtYXRDH0tpmm22WmLxhcbFyoPIYXFF8HtdXVl0Fwfrrr1+liiJOZLHZZpulqozK62bMmBHyIeaPYxUFAAD5t3hf64knngh77rln+NnPfpb6fIcddliaLyFWjpZXcMa5CGLVbHTLLbek8VVj9Wd1YhVsrDit3PeMk6HF4yze91wRsd8Z+8BxIrXyvmqsno393/I70eISq0/j+LCxwjWK47/27t07TeAbX9duu+2W1sf5FCpbXgXt999/nx7jJGBLEyt1x44dm+5uW9Z+yxLHwo39+zjPw9FHH/2Tfz9OZBaV/38DWBZJW4ACiB3B2GmNM9g+//zz6TavyjPZrop4C9ziYie7svJZiBdfl6+ZiGNnPs6gCwBA/lXua8Vb6ePEZHFYgDicQUx0XnnllWnbggULKn7n//v//r+KIoE4NEIcZqsmv2Rv0KBBWsrNmTMnDff12muvVSwxkfvee++FDTfcMMydOzclceMQDLfeemsaMiwmVBd/XUvr/1bWqlWr9ForD0VQ2Z///OeUtH3ssceqDK8Qh3WIvvjiiyr7x+fl28rFoow4UVyckLfyBGPlx6nuGJXPEcWhJ6LWrVsv8/UARJK2ADUgVh/Ejmm5mFBduHBhlX023XTT8Nxzz1VZF5/H382SOINuHDs3VlMAAJBfcbzaOHdBeV8rJmnjF+8XX3xx2H777cPGG2+cEoiL++1vfxs++uijNPbt22+/HQYMGLDUc8SkaRx/tXLfM1bexsRpvvqe8U6zGEccK3fxJZ479iljtXBMpu6yyy5p3oSVvSssHi/GHc+3uAsvvDCNmxv7r4tX7MbEeEyqjhs3rmLdrFmz0jwQO+ywQ5UK2549e4Ztt902JcQr380WxX0nTJiQ2rDc448/HjbZZJPQokWLinVx3or4OSBWRQMsj6QtQB7FjmecPCLekhYnXIi3ft15552ps9i3b98qwxnEzmGc+KC8IuC0005L1RFjxoxJFQiXXHJJmoDi1FNPLdrr+fHHH1OM8YNB/PDwl7/8Jd22ttVWW6V4AQBYeXHi2tjXiknBOBlYnMAr9hljZe3hhx+e9olJzpgMjP2wDz74IPztb38LV1111RLHisnBAw44IPXR9tlnn7DOOuss9byxcvW4445L+8ZkZkx2xtv94237Rx11VF5e2xlnnJHuOIsTj8Uq29i/vf/++ysmIotDIsRka/nrikOLxeTqyopVu3EyssriZLzxzrfrr78+9b9jW8clVgFHsTr35JNPDuedd146f+zvxnbv0KFD6NevX5WEbYw3Vux++eWXFccpd8ghh6TXEtsuThYXJ127/PLLw5AhQ6rE88wzz6QEdfkwCQDL8n/3LgCwyuJYXXG22UsvvbRirLA4+27sBP/hD3+o2C9WSsRO3LXXXpvGJou3vcWOYezcxc7g73//+/TNf/wmP3YSiyV2Otu3bx/q16+fZtKNFQxDhw5NnfzGjRsXLS4AgLogJkxjXysOKxCTrt26dUuVsrFKtryaM66LX+bHBGTsh8VxakeNGlWR1K0sJg1vu+22cOSRRy733LHCNVbwxvFxZ8+enapQH3300SqVoasiDkMwfvz4cNZZZ6VEZRynN1b4HnTQQRVDBMSChdhHjq85VubGfnCfPn1W6nzxtcfXMHPmzNRvjWIxRBxq4Ve/+lWVfeOwZcOHD08/n3766emOuEGDBoVvv/027Lzzzun/S/m4t7FidsqUKWlZPBH+/+YJDul8ceiF448/PlXjrr322mHYsGHpmJXFMXXLzwuwPGVxNrLl7gUAAABkWqzCHTx4cLpLKlZ+lpo4QVhM/sbkdtY8/PDD4ZRTTkl341Ue+xdgaQyPAAAAALVYHNYg3uUVq2fj5F+lmLCNLrroonTnWxbFat54F52ELbCiVNoCAABALRZvuT///PPT0Alx3NisJi4BWHGStgAAAAAAGWJ4BAAAAACADJG0BQAAAADIEElbAAAAAIAMkbQFAAAAAMgQSVsAAAAAgAyRtAUAAAAAyBBJWwAAAACADJG0BQAAAADIEElbAAAAAICQHf8/acWc9bSUmPwAAAAASUVORK5CYII=",
-      "text/plain": [
-       "<Figure size 1400x1000 with 4 Axes>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Create storm catalog summary plot\n",
     "fig, axes = plt.subplots(2, 2, figsize=(14, 10))\n",
@@ -913,334 +470,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "id": "cell-13",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2025-12-17 22:05:23 - ras_commander.precip.PrecipAorc - INFO - Creating storm plans from template plan 06 (unsteady 03)\n",
-      "2025-12-17 22:05:23 - ras_commander.precip.PrecipAorc - INFO -   Precipitation folder: C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\Precipitation\n",
-      "2025-12-17 22:05:23 - ras_commander.precip.PrecipAorc - INFO -   Processing 12 storms\n",
-      "2025-12-17 22:05:23 - ras_commander.precip.PrecipAorc - INFO - Storm 1: 2020-02-07 (1.02 in)\n",
-      "2025-12-17 22:05:23 - ras_commander.precip.PrecipAorc - INFO -   Cloning unsteady file...\n",
-      "2025-12-17 22:05:23 - ras_commander.RasUtils - INFO - File cloned from C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\BaldEagleDamBrk.u03 to C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\BaldEagleDamBrk.u04\n",
-      "2025-12-17 22:05:23 - ras_commander.RasUtils - INFO - Successfully updated file: C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\BaldEagleDamBrk.u04\n",
-      "2025-12-17 22:05:23 - ras_commander.RasUtils - INFO - Project file updated with new Unsteady entry: 04\n",
-      "2025-12-17 22:05:23 - ras_commander.rasmap - INFO - Successfully parsed RASMapper file: C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\BaldEagleDamBrk.rasmap\n",
-      "2025-12-17 22:05:23 - ras_commander.precip.PrecipAorc - INFO -   Configuring gridded precipitation...\n",
-      "2025-12-17 22:05:23 - ras_commander.RasUnsteady - INFO - Configuring gridded precipitation in C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\BaldEagleDamBrk.u04\n",
-      "2025-12-17 22:05:23 - ras_commander.RasUnsteady - INFO -   NetCDF file: .\\Precipitation\\storm_20200207.nc\n",
-      "2025-12-17 22:05:23 - ras_commander.RasUnsteady - INFO -   Interpolation: Bilinear\n",
-      "2025-12-17 22:05:23 - ras_commander.RasUnsteady - INFO - Successfully configured gridded precipitation in C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\BaldEagleDamBrk.u04\n",
-      "2025-12-17 22:05:23 - ras_commander.RasUnsteady - INFO - Updating precipitation in HDF: C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\BaldEagleDamBrk.u04.hdf\n",
-      "2025-12-17 22:05:23 - ras_commander.RasUnsteady - INFO -   NetCDF: 120 timesteps, 24x30 grid\n",
-      "2025-12-17 22:05:23 - ras_commander.RasUnsteady - INFO -   Imported 120 timesteps, 720 cells (cumulative)\n",
-      "2025-12-17 22:05:23 - ras_commander.RasUnsteady - INFO -   Precip range: 0.0 - 41.2 mm\n",
-      "2025-12-17 22:05:23 - ras_commander.precip.PrecipAorc - INFO -   Cloning plan file...\n",
-      "2025-12-17 22:05:23 - ras_commander.RasUtils - INFO - File cloned from C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\BaldEagleDamBrk.p06 to C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\BaldEagleDamBrk.p07\n",
-      "2025-12-17 22:05:23 - ras_commander.RasUtils - INFO - Successfully updated file: C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\BaldEagleDamBrk.p07\n",
-      "2025-12-17 22:05:23 - ras_commander.RasUtils - INFO - Project file updated with new Plan entry: 07\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Creating HEC-RAS plans for 12 storms...\n",
-      "======================================================================\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2025-12-17 22:05:23 - ras_commander.rasmap - INFO - Successfully parsed RASMapper file: C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\BaldEagleDamBrk.rasmap\n",
-      "2025-12-17 22:05:24 - ras_commander.RasPlan - INFO - Updated simulation date in plan file: C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\BaldEagleDamBrk.p07\n",
-      "2025-12-17 22:05:24 - ras_commander.precip.PrecipAorc - INFO -   Enabled HDF time series output\n",
-      "2025-12-17 22:05:24 - ras_commander.precip.PrecipAorc - INFO -   Created plan 07 with unsteady 04\n",
-      "2025-12-17 22:05:24 - ras_commander.precip.PrecipAorc - INFO - Storm 2: 2020-03-19 (0.76 in)\n",
-      "2025-12-17 22:05:24 - ras_commander.precip.PrecipAorc - INFO -   Cloning unsteady file...\n",
-      "2025-12-17 22:05:24 - ras_commander.RasUtils - INFO - File cloned from C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\BaldEagleDamBrk.u03 to C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\BaldEagleDamBrk.u05\n",
-      "2025-12-17 22:05:24 - ras_commander.RasUtils - INFO - Successfully updated file: C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\BaldEagleDamBrk.u05\n",
-      "2025-12-17 22:05:24 - ras_commander.RasUtils - INFO - Project file updated with new Unsteady entry: 05\n",
-      "2025-12-17 22:05:24 - ras_commander.rasmap - INFO - Successfully parsed RASMapper file: C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\BaldEagleDamBrk.rasmap\n",
-      "2025-12-17 22:05:24 - ras_commander.precip.PrecipAorc - INFO -   Configuring gridded precipitation...\n",
-      "2025-12-17 22:05:24 - ras_commander.RasUnsteady - INFO - Configuring gridded precipitation in C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\BaldEagleDamBrk.u05\n",
-      "2025-12-17 22:05:24 - ras_commander.RasUnsteady - INFO -   NetCDF file: .\\Precipitation\\storm_20200319.nc\n",
-      "2025-12-17 22:05:24 - ras_commander.RasUnsteady - INFO -   Interpolation: Bilinear\n",
-      "2025-12-17 22:05:24 - ras_commander.RasUnsteady - INFO - Successfully configured gridded precipitation in C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\BaldEagleDamBrk.u05\n",
-      "2025-12-17 22:05:24 - ras_commander.RasUnsteady - INFO - Updating precipitation in HDF: C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\BaldEagleDamBrk.u05.hdf\n",
-      "2025-12-17 22:05:24 - ras_commander.RasUnsteady - INFO -   NetCDF: 120 timesteps, 24x30 grid\n",
-      "2025-12-17 22:05:24 - ras_commander.RasUnsteady - INFO -   Imported 120 timesteps, 720 cells (cumulative)\n",
-      "2025-12-17 22:05:24 - ras_commander.RasUnsteady - INFO -   Precip range: 0.0 - 45.9 mm\n",
-      "2025-12-17 22:05:24 - ras_commander.precip.PrecipAorc - INFO -   Cloning plan file...\n",
-      "2025-12-17 22:05:24 - ras_commander.RasUtils - INFO - File cloned from C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\BaldEagleDamBrk.p06 to C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\BaldEagleDamBrk.p08\n",
-      "2025-12-17 22:05:24 - ras_commander.RasUtils - INFO - Successfully updated file: C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\BaldEagleDamBrk.p08\n",
-      "2025-12-17 22:05:24 - ras_commander.RasUtils - INFO - Project file updated with new Plan entry: 08\n",
-      "2025-12-17 22:05:24 - ras_commander.rasmap - INFO - Successfully parsed RASMapper file: C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\BaldEagleDamBrk.rasmap\n",
-      "2025-12-17 22:05:24 - ras_commander.RasPlan - INFO - Updated simulation date in plan file: C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\BaldEagleDamBrk.p08\n",
-      "2025-12-17 22:05:24 - ras_commander.precip.PrecipAorc - INFO -   Enabled HDF time series output\n",
-      "2025-12-17 22:05:24 - ras_commander.precip.PrecipAorc - INFO -   Created plan 08 with unsteady 05\n",
-      "2025-12-17 22:05:24 - ras_commander.precip.PrecipAorc - INFO - Storm 3: 2020-03-28 (1.53 in)\n",
-      "2025-12-17 22:05:24 - ras_commander.precip.PrecipAorc - INFO -   Cloning unsteady file...\n",
-      "2025-12-17 22:05:24 - ras_commander.RasUtils - INFO - File cloned from C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\BaldEagleDamBrk.u03 to C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\BaldEagleDamBrk.u06\n",
-      "2025-12-17 22:05:24 - ras_commander.RasUtils - INFO - Successfully updated file: C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\BaldEagleDamBrk.u06\n",
-      "2025-12-17 22:05:24 - ras_commander.RasUtils - INFO - Project file updated with new Unsteady entry: 06\n",
-      "2025-12-17 22:05:24 - ras_commander.rasmap - INFO - Successfully parsed RASMapper file: C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\BaldEagleDamBrk.rasmap\n",
-      "2025-12-17 22:05:24 - ras_commander.precip.PrecipAorc - INFO -   Configuring gridded precipitation...\n",
-      "2025-12-17 22:05:24 - ras_commander.RasUnsteady - INFO - Configuring gridded precipitation in C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\BaldEagleDamBrk.u06\n",
-      "2025-12-17 22:05:24 - ras_commander.RasUnsteady - INFO -   NetCDF file: .\\Precipitation\\storm_20200328.nc\n",
-      "2025-12-17 22:05:24 - ras_commander.RasUnsteady - INFO -   Interpolation: Bilinear\n",
-      "2025-12-17 22:05:24 - ras_commander.RasUnsteady - INFO - Successfully configured gridded precipitation in C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\BaldEagleDamBrk.u06\n",
-      "2025-12-17 22:05:24 - ras_commander.RasUnsteady - INFO - Updating precipitation in HDF: C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\BaldEagleDamBrk.u06.hdf\n",
-      "2025-12-17 22:05:24 - ras_commander.RasUnsteady - INFO -   NetCDF: 144 timesteps, 24x30 grid\n",
-      "2025-12-17 22:05:24 - ras_commander.RasUnsteady - INFO -   Imported 144 timesteps, 720 cells (cumulative)\n",
-      "2025-12-17 22:05:24 - ras_commander.RasUnsteady - INFO -   Precip range: 0.0 - 62.8 mm\n",
-      "2025-12-17 22:05:24 - ras_commander.precip.PrecipAorc - INFO -   Cloning plan file...\n",
-      "2025-12-17 22:05:24 - ras_commander.RasUtils - INFO - File cloned from C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\BaldEagleDamBrk.p06 to C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\BaldEagleDamBrk.p09\n",
-      "2025-12-17 22:05:24 - ras_commander.RasUtils - INFO - Successfully updated file: C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\BaldEagleDamBrk.p09\n",
-      "2025-12-17 22:05:24 - ras_commander.RasUtils - INFO - Project file updated with new Plan entry: 09\n",
-      "2025-12-17 22:05:24 - ras_commander.rasmap - INFO - Successfully parsed RASMapper file: C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\BaldEagleDamBrk.rasmap\n",
-      "2025-12-17 22:05:24 - ras_commander.RasPlan - INFO - Updated simulation date in plan file: C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\BaldEagleDamBrk.p09\n",
-      "2025-12-17 22:05:24 - ras_commander.precip.PrecipAorc - INFO -   Enabled HDF time series output\n",
-      "2025-12-17 22:05:24 - ras_commander.precip.PrecipAorc - INFO -   Created plan 09 with unsteady 06\n",
-      "2025-12-17 22:05:24 - ras_commander.precip.PrecipAorc - INFO - Storm 4: 2020-04-17 (0.78 in)\n",
-      "2025-12-17 22:05:24 - ras_commander.precip.PrecipAorc - INFO -   Cloning unsteady file...\n",
-      "2025-12-17 22:05:24 - ras_commander.RasUtils - INFO - File cloned from C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\BaldEagleDamBrk.u03 to C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\BaldEagleDamBrk.u14\n",
-      "2025-12-17 22:05:24 - ras_commander.RasUtils - INFO - Successfully updated file: C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\BaldEagleDamBrk.u14\n",
-      "2025-12-17 22:05:24 - ras_commander.RasUtils - INFO - Project file updated with new Unsteady entry: 14\n",
-      "2025-12-17 22:05:24 - ras_commander.rasmap - INFO - Successfully parsed RASMapper file: C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\BaldEagleDamBrk.rasmap\n",
-      "2025-12-17 22:05:24 - ras_commander.precip.PrecipAorc - INFO -   Configuring gridded precipitation...\n",
-      "2025-12-17 22:05:24 - ras_commander.RasUnsteady - INFO - Configuring gridded precipitation in C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\BaldEagleDamBrk.u14\n",
-      "2025-12-17 22:05:24 - ras_commander.RasUnsteady - INFO -   NetCDF file: .\\Precipitation\\storm_20200417.nc\n",
-      "2025-12-17 22:05:24 - ras_commander.RasUnsteady - INFO -   Interpolation: Bilinear\n",
-      "2025-12-17 22:05:24 - ras_commander.RasUnsteady - INFO - Successfully configured gridded precipitation in C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\BaldEagleDamBrk.u14\n",
-      "2025-12-17 22:05:24 - ras_commander.RasUnsteady - INFO - Updating precipitation in HDF: C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\BaldEagleDamBrk.u14.hdf\n",
-      "2025-12-17 22:05:24 - ras_commander.RasUnsteady - INFO -   NetCDF: 144 timesteps, 24x30 grid\n",
-      "2025-12-17 22:05:24 - ras_commander.RasUnsteady - INFO -   Imported 144 timesteps, 720 cells (cumulative)\n",
-      "2025-12-17 22:05:24 - ras_commander.RasUnsteady - INFO -   Precip range: 0.0 - 30.2 mm\n",
-      "2025-12-17 22:05:24 - ras_commander.precip.PrecipAorc - INFO -   Cloning plan file...\n",
-      "2025-12-17 22:05:24 - ras_commander.RasUtils - INFO - File cloned from C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\BaldEagleDamBrk.p06 to C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\BaldEagleDamBrk.p10\n",
-      "2025-12-17 22:05:24 - ras_commander.RasUtils - INFO - Successfully updated file: C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\BaldEagleDamBrk.p10\n",
-      "2025-12-17 22:05:24 - ras_commander.RasUtils - INFO - Project file updated with new Plan entry: 10\n",
-      "2025-12-17 22:05:24 - ras_commander.rasmap - INFO - Successfully parsed RASMapper file: C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\BaldEagleDamBrk.rasmap\n",
-      "2025-12-17 22:05:24 - ras_commander.RasPlan - INFO - Updated simulation date in plan file: C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\BaldEagleDamBrk.p10\n",
-      "2025-12-17 22:05:25 - ras_commander.precip.PrecipAorc - INFO -   Enabled HDF time series output\n",
-      "2025-12-17 22:05:25 - ras_commander.precip.PrecipAorc - INFO -   Created plan 10 with unsteady 14\n",
-      "2025-12-17 22:05:25 - ras_commander.precip.PrecipAorc - INFO - Storm 5: 2020-04-30 (2.12 in)\n",
-      "2025-12-17 22:05:25 - ras_commander.precip.PrecipAorc - INFO -   Cloning unsteady file...\n",
-      "2025-12-17 22:05:25 - ras_commander.RasUtils - INFO - File cloned from C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\BaldEagleDamBrk.u03 to C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\BaldEagleDamBrk.u15\n",
-      "2025-12-17 22:05:25 - ras_commander.RasUtils - INFO - Successfully updated file: C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\BaldEagleDamBrk.u15\n",
-      "2025-12-17 22:05:25 - ras_commander.RasUtils - INFO - Project file updated with new Unsteady entry: 15\n",
-      "2025-12-17 22:05:25 - ras_commander.rasmap - INFO - Successfully parsed RASMapper file: C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\BaldEagleDamBrk.rasmap\n",
-      "2025-12-17 22:05:25 - ras_commander.precip.PrecipAorc - INFO -   Configuring gridded precipitation...\n",
-      "2025-12-17 22:05:25 - ras_commander.RasUnsteady - INFO - Configuring gridded precipitation in C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\BaldEagleDamBrk.u15\n",
-      "2025-12-17 22:05:25 - ras_commander.RasUnsteady - INFO -   NetCDF file: .\\Precipitation\\storm_20200430.nc\n",
-      "2025-12-17 22:05:25 - ras_commander.RasUnsteady - INFO -   Interpolation: Bilinear\n",
-      "2025-12-17 22:05:25 - ras_commander.RasUnsteady - INFO - Successfully configured gridded precipitation in C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\BaldEagleDamBrk.u15\n",
-      "2025-12-17 22:05:25 - ras_commander.RasUnsteady - INFO - Updating precipitation in HDF: C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\BaldEagleDamBrk.u15.hdf\n",
-      "2025-12-17 22:05:25 - ras_commander.RasUnsteady - INFO -   NetCDF: 144 timesteps, 24x30 grid\n",
-      "2025-12-17 22:05:25 - ras_commander.RasUnsteady - INFO -   Imported 144 timesteps, 720 cells (cumulative)\n",
-      "2025-12-17 22:05:25 - ras_commander.RasUnsteady - INFO -   Precip range: 0.0 - 69.2 mm\n",
-      "2025-12-17 22:05:25 - ras_commander.precip.PrecipAorc - INFO -   Cloning plan file...\n",
-      "2025-12-17 22:05:25 - ras_commander.RasUtils - INFO - File cloned from C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\BaldEagleDamBrk.p06 to C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\BaldEagleDamBrk.p11\n",
-      "2025-12-17 22:05:25 - ras_commander.RasUtils - INFO - Successfully updated file: C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\BaldEagleDamBrk.p11\n",
-      "2025-12-17 22:05:25 - ras_commander.RasUtils - INFO - Project file updated with new Plan entry: 11\n",
-      "2025-12-17 22:05:25 - ras_commander.rasmap - INFO - Successfully parsed RASMapper file: C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\BaldEagleDamBrk.rasmap\n",
-      "2025-12-17 22:05:25 - ras_commander.RasPlan - INFO - Updated simulation date in plan file: C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\BaldEagleDamBrk.p11\n",
-      "2025-12-17 22:05:25 - ras_commander.precip.PrecipAorc - INFO -   Enabled HDF time series output\n",
-      "2025-12-17 22:05:25 - ras_commander.precip.PrecipAorc - INFO -   Created plan 11 with unsteady 15\n",
-      "2025-12-17 22:05:25 - ras_commander.precip.PrecipAorc - INFO - Storm 6: 2020-05-28 (1.19 in)\n",
-      "2025-12-17 22:05:25 - ras_commander.precip.PrecipAorc - INFO -   Cloning unsteady file...\n",
-      "2025-12-17 22:05:25 - ras_commander.RasUtils - INFO - File cloned from C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\BaldEagleDamBrk.u03 to C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\BaldEagleDamBrk.u16\n",
-      "2025-12-17 22:05:25 - ras_commander.RasUtils - INFO - Successfully updated file: C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\BaldEagleDamBrk.u16\n",
-      "2025-12-17 22:05:25 - ras_commander.RasUtils - INFO - Project file updated with new Unsteady entry: 16\n",
-      "2025-12-17 22:05:25 - ras_commander.rasmap - INFO - Successfully parsed RASMapper file: C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\BaldEagleDamBrk.rasmap\n",
-      "2025-12-17 22:05:25 - ras_commander.precip.PrecipAorc - INFO -   Configuring gridded precipitation...\n",
-      "2025-12-17 22:05:25 - ras_commander.RasUnsteady - INFO - Configuring gridded precipitation in C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\BaldEagleDamBrk.u16\n",
-      "2025-12-17 22:05:25 - ras_commander.RasUnsteady - INFO -   NetCDF file: .\\Precipitation\\storm_20200528.nc\n",
-      "2025-12-17 22:05:25 - ras_commander.RasUnsteady - INFO -   Interpolation: Bilinear\n",
-      "2025-12-17 22:05:25 - ras_commander.RasUnsteady - INFO - Successfully configured gridded precipitation in C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\BaldEagleDamBrk.u16\n",
-      "2025-12-17 22:05:25 - ras_commander.RasUnsteady - INFO - Updating precipitation in HDF: C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\BaldEagleDamBrk.u16.hdf\n",
-      "2025-12-17 22:05:25 - ras_commander.RasUnsteady - INFO -   NetCDF: 168 timesteps, 24x30 grid\n",
-      "2025-12-17 22:05:25 - ras_commander.RasUnsteady - INFO -   Imported 168 timesteps, 720 cells (cumulative)\n",
-      "2025-12-17 22:05:25 - ras_commander.RasUnsteady - INFO -   Precip range: 0.0 - 61.2 mm\n",
-      "2025-12-17 22:05:25 - ras_commander.precip.PrecipAorc - INFO -   Cloning plan file...\n",
-      "2025-12-17 22:05:25 - ras_commander.RasUtils - INFO - File cloned from C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\BaldEagleDamBrk.p06 to C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\BaldEagleDamBrk.p12\n",
-      "2025-12-17 22:05:25 - ras_commander.RasUtils - INFO - Successfully updated file: C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\BaldEagleDamBrk.p12\n",
-      "2025-12-17 22:05:25 - ras_commander.RasUtils - INFO - Project file updated with new Plan entry: 12\n",
-      "2025-12-17 22:05:25 - ras_commander.rasmap - INFO - Successfully parsed RASMapper file: C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\BaldEagleDamBrk.rasmap\n",
-      "2025-12-17 22:05:25 - ras_commander.RasPlan - INFO - Updated simulation date in plan file: C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\BaldEagleDamBrk.p12\n",
-      "2025-12-17 22:05:25 - ras_commander.precip.PrecipAorc - INFO -   Enabled HDF time series output\n",
-      "2025-12-17 22:05:25 - ras_commander.precip.PrecipAorc - INFO -   Created plan 12 with unsteady 16\n",
-      "2025-12-17 22:05:25 - ras_commander.precip.PrecipAorc - INFO - Storm 7: 2020-06-03 (0.85 in)\n",
-      "2025-12-17 22:05:25 - ras_commander.precip.PrecipAorc - INFO -   Cloning unsteady file...\n",
-      "2025-12-17 22:05:25 - ras_commander.RasUtils - INFO - File cloned from C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\BaldEagleDamBrk.u03 to C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\BaldEagleDamBrk.u17\n",
-      "2025-12-17 22:05:25 - ras_commander.RasUtils - INFO - Successfully updated file: C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\BaldEagleDamBrk.u17\n",
-      "2025-12-17 22:05:25 - ras_commander.RasUtils - INFO - Project file updated with new Unsteady entry: 17\n",
-      "2025-12-17 22:05:25 - ras_commander.rasmap - INFO - Successfully parsed RASMapper file: C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\BaldEagleDamBrk.rasmap\n",
-      "2025-12-17 22:05:25 - ras_commander.precip.PrecipAorc - INFO -   Configuring gridded precipitation...\n",
-      "2025-12-17 22:05:25 - ras_commander.RasUnsteady - INFO - Configuring gridded precipitation in C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\BaldEagleDamBrk.u17\n",
-      "2025-12-17 22:05:25 - ras_commander.RasUnsteady - INFO -   NetCDF file: .\\Precipitation\\storm_20200603.nc\n",
-      "2025-12-17 22:05:25 - ras_commander.RasUnsteady - INFO -   Interpolation: Bilinear\n",
-      "2025-12-17 22:05:25 - ras_commander.RasUnsteady - INFO - Successfully configured gridded precipitation in C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\BaldEagleDamBrk.u17\n",
-      "2025-12-17 22:05:25 - ras_commander.RasUnsteady - INFO - Updating precipitation in HDF: C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\BaldEagleDamBrk.u17.hdf\n",
-      "2025-12-17 22:05:25 - ras_commander.RasUnsteady - INFO -   NetCDF: 120 timesteps, 24x30 grid\n",
-      "2025-12-17 22:05:25 - ras_commander.RasUnsteady - INFO -   Imported 120 timesteps, 720 cells (cumulative)\n",
-      "2025-12-17 22:05:25 - ras_commander.RasUnsteady - INFO -   Precip range: 0.0 - 47.1 mm\n",
-      "2025-12-17 22:05:25 - ras_commander.precip.PrecipAorc - INFO -   Cloning plan file...\n",
-      "2025-12-17 22:05:25 - ras_commander.RasUtils - INFO - File cloned from C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\BaldEagleDamBrk.p06 to C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\BaldEagleDamBrk.p14\n",
-      "2025-12-17 22:05:25 - ras_commander.RasUtils - INFO - Successfully updated file: C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\BaldEagleDamBrk.p14\n",
-      "2025-12-17 22:05:25 - ras_commander.RasUtils - INFO - Project file updated with new Plan entry: 14\n",
-      "2025-12-17 22:05:25 - ras_commander.rasmap - INFO - Successfully parsed RASMapper file: C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\BaldEagleDamBrk.rasmap\n",
-      "2025-12-17 22:05:25 - ras_commander.RasPlan - INFO - Updated simulation date in plan file: C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\BaldEagleDamBrk.p14\n",
-      "2025-12-17 22:05:25 - ras_commander.precip.PrecipAorc - INFO -   Enabled HDF time series output\n",
-      "2025-12-17 22:05:25 - ras_commander.precip.PrecipAorc - INFO -   Created plan 14 with unsteady 17\n",
-      "2025-12-17 22:05:25 - ras_commander.precip.PrecipAorc - INFO - Storm 8: 2020-09-29 (1.28 in)\n",
-      "2025-12-17 22:05:25 - ras_commander.precip.PrecipAorc - INFO -   Cloning unsteady file...\n",
-      "2025-12-17 22:05:25 - ras_commander.RasUtils - INFO - File cloned from C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\BaldEagleDamBrk.u03 to C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\BaldEagleDamBrk.u18\n",
-      "2025-12-17 22:05:25 - ras_commander.RasUtils - INFO - Successfully updated file: C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\BaldEagleDamBrk.u18\n",
-      "2025-12-17 22:05:25 - ras_commander.RasUtils - INFO - Project file updated with new Unsteady entry: 18\n",
-      "2025-12-17 22:05:26 - ras_commander.rasmap - INFO - Successfully parsed RASMapper file: C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\BaldEagleDamBrk.rasmap\n",
-      "2025-12-17 22:05:26 - ras_commander.precip.PrecipAorc - INFO -   Configuring gridded precipitation...\n",
-      "2025-12-17 22:05:26 - ras_commander.RasUnsteady - INFO - Configuring gridded precipitation in C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\BaldEagleDamBrk.u18\n",
-      "2025-12-17 22:05:26 - ras_commander.RasUnsteady - INFO -   NetCDF file: .\\Precipitation\\storm_20200929.nc\n",
-      "2025-12-17 22:05:26 - ras_commander.RasUnsteady - INFO -   Interpolation: Bilinear\n",
-      "2025-12-17 22:05:26 - ras_commander.RasUnsteady - INFO - Successfully configured gridded precipitation in C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\BaldEagleDamBrk.u18\n",
-      "2025-12-17 22:05:26 - ras_commander.RasUnsteady - INFO - Updating precipitation in HDF: C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\BaldEagleDamBrk.u18.hdf\n",
-      "2025-12-17 22:05:26 - ras_commander.RasUnsteady - INFO -   NetCDF: 144 timesteps, 24x30 grid\n",
-      "2025-12-17 22:05:26 - ras_commander.RasUnsteady - INFO -   Imported 144 timesteps, 720 cells (cumulative)\n",
-      "2025-12-17 22:05:26 - ras_commander.RasUnsteady - INFO -   Precip range: 0.0 - 39.5 mm\n",
-      "2025-12-17 22:05:26 - ras_commander.precip.PrecipAorc - INFO -   Cloning plan file...\n",
-      "2025-12-17 22:05:26 - ras_commander.RasUtils - INFO - File cloned from C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\BaldEagleDamBrk.p06 to C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\BaldEagleDamBrk.p16\n",
-      "2025-12-17 22:05:26 - ras_commander.RasUtils - INFO - Successfully updated file: C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\BaldEagleDamBrk.p16\n",
-      "2025-12-17 22:05:26 - ras_commander.RasUtils - INFO - Project file updated with new Plan entry: 16\n",
-      "2025-12-17 22:05:26 - ras_commander.rasmap - INFO - Successfully parsed RASMapper file: C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\BaldEagleDamBrk.rasmap\n",
-      "2025-12-17 22:05:26 - ras_commander.RasPlan - INFO - Updated simulation date in plan file: C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\BaldEagleDamBrk.p16\n",
-      "2025-12-17 22:05:26 - ras_commander.precip.PrecipAorc - INFO -   Enabled HDF time series output\n",
-      "2025-12-17 22:05:26 - ras_commander.precip.PrecipAorc - INFO -   Created plan 16 with unsteady 18\n",
-      "2025-12-17 22:05:26 - ras_commander.precip.PrecipAorc - INFO - Storm 9: 2020-10-29 (1.74 in)\n",
-      "2025-12-17 22:05:26 - ras_commander.precip.PrecipAorc - INFO -   Cloning unsteady file...\n",
-      "2025-12-17 22:05:26 - ras_commander.RasUtils - INFO - File cloned from C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\BaldEagleDamBrk.u03 to C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\BaldEagleDamBrk.u19\n",
-      "2025-12-17 22:05:26 - ras_commander.RasUtils - INFO - Successfully updated file: C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\BaldEagleDamBrk.u19\n",
-      "2025-12-17 22:05:26 - ras_commander.RasUtils - INFO - Project file updated with new Unsteady entry: 19\n",
-      "2025-12-17 22:05:26 - ras_commander.rasmap - INFO - Successfully parsed RASMapper file: C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\BaldEagleDamBrk.rasmap\n",
-      "2025-12-17 22:05:26 - ras_commander.precip.PrecipAorc - INFO -   Configuring gridded precipitation...\n",
-      "2025-12-17 22:05:26 - ras_commander.RasUnsteady - INFO - Configuring gridded precipitation in C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\BaldEagleDamBrk.u19\n",
-      "2025-12-17 22:05:26 - ras_commander.RasUnsteady - INFO -   NetCDF file: .\\Precipitation\\storm_20201029.nc\n",
-      "2025-12-17 22:05:26 - ras_commander.RasUnsteady - INFO -   Interpolation: Bilinear\n",
-      "2025-12-17 22:05:26 - ras_commander.RasUnsteady - INFO - Successfully configured gridded precipitation in C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\BaldEagleDamBrk.u19\n",
-      "2025-12-17 22:05:26 - ras_commander.RasUnsteady - INFO - Updating precipitation in HDF: C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\BaldEagleDamBrk.u19.hdf\n",
-      "2025-12-17 22:05:26 - ras_commander.RasUnsteady - INFO -   NetCDF: 144 timesteps, 24x30 grid\n",
-      "2025-12-17 22:05:26 - ras_commander.RasUnsteady - INFO -   Imported 144 timesteps, 720 cells (cumulative)\n",
-      "2025-12-17 22:05:26 - ras_commander.RasUnsteady - INFO -   Precip range: 0.0 - 60.8 mm\n",
-      "2025-12-17 22:05:26 - ras_commander.precip.PrecipAorc - INFO -   Cloning plan file...\n",
-      "2025-12-17 22:05:26 - ras_commander.RasUtils - INFO - File cloned from C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\BaldEagleDamBrk.p06 to C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\BaldEagleDamBrk.p20\n",
-      "2025-12-17 22:05:26 - ras_commander.RasUtils - INFO - Successfully updated file: C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\BaldEagleDamBrk.p20\n",
-      "2025-12-17 22:05:26 - ras_commander.RasUtils - INFO - Project file updated with new Plan entry: 20\n",
-      "2025-12-17 22:05:26 - ras_commander.rasmap - INFO - Successfully parsed RASMapper file: C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\BaldEagleDamBrk.rasmap\n",
-      "2025-12-17 22:05:26 - ras_commander.RasPlan - INFO - Updated simulation date in plan file: C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\BaldEagleDamBrk.p20\n",
-      "2025-12-17 22:05:26 - ras_commander.precip.PrecipAorc - INFO -   Enabled HDF time series output\n",
-      "2025-12-17 22:05:26 - ras_commander.precip.PrecipAorc - INFO -   Created plan 20 with unsteady 19\n",
-      "2025-12-17 22:05:26 - ras_commander.precip.PrecipAorc - INFO - Storm 10: 2020-11-11 (1.99 in)\n",
-      "2025-12-17 22:05:26 - ras_commander.precip.PrecipAorc - INFO -   Cloning unsteady file...\n",
-      "2025-12-17 22:05:26 - ras_commander.RasUtils - INFO - File cloned from C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\BaldEagleDamBrk.u03 to C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\BaldEagleDamBrk.u20\n",
-      "2025-12-17 22:05:26 - ras_commander.RasUtils - INFO - Successfully updated file: C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\BaldEagleDamBrk.u20\n",
-      "2025-12-17 22:05:26 - ras_commander.RasUtils - INFO - Project file updated with new Unsteady entry: 20\n",
-      "2025-12-17 22:05:26 - ras_commander.rasmap - INFO - Successfully parsed RASMapper file: C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\BaldEagleDamBrk.rasmap\n",
-      "2025-12-17 22:05:26 - ras_commander.precip.PrecipAorc - INFO -   Configuring gridded precipitation...\n",
-      "2025-12-17 22:05:26 - ras_commander.RasUnsteady - INFO - Configuring gridded precipitation in C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\BaldEagleDamBrk.u20\n",
-      "2025-12-17 22:05:26 - ras_commander.RasUnsteady - INFO -   NetCDF file: .\\Precipitation\\storm_20201111.nc\n",
-      "2025-12-17 22:05:26 - ras_commander.RasUnsteady - INFO -   Interpolation: Bilinear\n",
-      "2025-12-17 22:05:26 - ras_commander.RasUnsteady - INFO - Successfully configured gridded precipitation in C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\BaldEagleDamBrk.u20\n",
-      "2025-12-17 22:05:26 - ras_commander.RasUnsteady - INFO - Updating precipitation in HDF: C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\BaldEagleDamBrk.u20.hdf\n",
-      "2025-12-17 22:05:26 - ras_commander.RasUnsteady - INFO -   NetCDF: 120 timesteps, 24x30 grid\n",
-      "2025-12-17 22:05:26 - ras_commander.RasUnsteady - INFO -   Imported 120 timesteps, 720 cells (cumulative)\n",
-      "2025-12-17 22:05:26 - ras_commander.RasUnsteady - INFO -   Precip range: 0.0 - 77.9 mm\n",
-      "2025-12-17 22:05:26 - ras_commander.precip.PrecipAorc - INFO -   Cloning plan file...\n",
-      "2025-12-17 22:05:26 - ras_commander.RasUtils - INFO - File cloned from C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\BaldEagleDamBrk.p06 to C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\BaldEagleDamBrk.p21\n",
-      "2025-12-17 22:05:26 - ras_commander.RasUtils - INFO - Successfully updated file: C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\BaldEagleDamBrk.p21\n",
-      "2025-12-17 22:05:26 - ras_commander.RasUtils - INFO - Project file updated with new Plan entry: 21\n",
-      "2025-12-17 22:05:26 - ras_commander.rasmap - INFO - Successfully parsed RASMapper file: C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\BaldEagleDamBrk.rasmap\n",
-      "2025-12-17 22:05:26 - ras_commander.RasPlan - INFO - Updated simulation date in plan file: C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\BaldEagleDamBrk.p21\n",
-      "2025-12-17 22:05:27 - ras_commander.precip.PrecipAorc - INFO -   Enabled HDF time series output\n",
-      "2025-12-17 22:05:27 - ras_commander.precip.PrecipAorc - INFO -   Created plan 21 with unsteady 20\n",
-      "2025-12-17 22:05:27 - ras_commander.precip.PrecipAorc - INFO - Storm 11: 2020-12-16 (1.83 in)\n",
-      "2025-12-17 22:05:27 - ras_commander.precip.PrecipAorc - INFO -   Cloning unsteady file...\n",
-      "2025-12-17 22:05:27 - ras_commander.RasUtils - INFO - File cloned from C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\BaldEagleDamBrk.u03 to C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\BaldEagleDamBrk.u21\n",
-      "2025-12-17 22:05:27 - ras_commander.RasUtils - INFO - Successfully updated file: C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\BaldEagleDamBrk.u21\n",
-      "2025-12-17 22:05:27 - ras_commander.RasUtils - INFO - Project file updated with new Unsteady entry: 21\n",
-      "2025-12-17 22:05:27 - ras_commander.rasmap - INFO - Successfully parsed RASMapper file: C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\BaldEagleDamBrk.rasmap\n",
-      "2025-12-17 22:05:27 - ras_commander.precip.PrecipAorc - INFO -   Configuring gridded precipitation...\n",
-      "2025-12-17 22:05:27 - ras_commander.RasUnsteady - INFO - Configuring gridded precipitation in C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\BaldEagleDamBrk.u21\n",
-      "2025-12-17 22:05:27 - ras_commander.RasUnsteady - INFO -   NetCDF file: .\\Precipitation\\storm_20201216.nc\n",
-      "2025-12-17 22:05:27 - ras_commander.RasUnsteady - INFO -   Interpolation: Bilinear\n",
-      "2025-12-17 22:05:27 - ras_commander.RasUnsteady - INFO - Successfully configured gridded precipitation in C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\BaldEagleDamBrk.u21\n",
-      "2025-12-17 22:05:27 - ras_commander.RasUnsteady - INFO - Updating precipitation in HDF: C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\BaldEagleDamBrk.u21.hdf\n",
-      "2025-12-17 22:05:27 - ras_commander.RasUnsteady - INFO -   NetCDF: 144 timesteps, 24x30 grid\n",
-      "2025-12-17 22:05:27 - ras_commander.RasUnsteady - INFO -   Imported 144 timesteps, 720 cells (cumulative)\n",
-      "2025-12-17 22:05:27 - ras_commander.RasUnsteady - INFO -   Precip range: 0.0 - 63.2 mm\n",
-      "2025-12-17 22:05:27 - ras_commander.precip.PrecipAorc - INFO -   Cloning plan file...\n",
-      "2025-12-17 22:05:27 - ras_commander.RasUtils - INFO - File cloned from C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\BaldEagleDamBrk.p06 to C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\BaldEagleDamBrk.p22\n",
-      "2025-12-17 22:05:27 - ras_commander.RasUtils - INFO - Successfully updated file: C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\BaldEagleDamBrk.p22\n",
-      "2025-12-17 22:05:27 - ras_commander.RasUtils - INFO - Project file updated with new Plan entry: 22\n",
-      "2025-12-17 22:05:27 - ras_commander.rasmap - INFO - Successfully parsed RASMapper file: C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\BaldEagleDamBrk.rasmap\n",
-      "2025-12-17 22:05:27 - ras_commander.RasPlan - INFO - Updated simulation date in plan file: C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\BaldEagleDamBrk.p22\n",
-      "2025-12-17 22:05:27 - ras_commander.precip.PrecipAorc - INFO -   Enabled HDF time series output\n",
-      "2025-12-17 22:05:27 - ras_commander.precip.PrecipAorc - INFO -   Created plan 22 with unsteady 21\n",
-      "2025-12-17 22:05:27 - ras_commander.precip.PrecipAorc - INFO - Storm 12: 2020-12-24 (2.72 in)\n",
-      "2025-12-17 22:05:27 - ras_commander.precip.PrecipAorc - INFO -   Cloning unsteady file...\n",
-      "2025-12-17 22:05:27 - ras_commander.RasUtils - INFO - File cloned from C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\BaldEagleDamBrk.u03 to C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\BaldEagleDamBrk.u22\n",
-      "2025-12-17 22:05:27 - ras_commander.RasUtils - INFO - Successfully updated file: C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\BaldEagleDamBrk.u22\n",
-      "2025-12-17 22:05:27 - ras_commander.RasUtils - INFO - Project file updated with new Unsteady entry: 22\n",
-      "2025-12-17 22:05:27 - ras_commander.rasmap - INFO - Successfully parsed RASMapper file: C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\BaldEagleDamBrk.rasmap\n",
-      "2025-12-17 22:05:27 - ras_commander.precip.PrecipAorc - INFO -   Configuring gridded precipitation...\n",
-      "2025-12-17 22:05:27 - ras_commander.RasUnsteady - INFO - Configuring gridded precipitation in C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\BaldEagleDamBrk.u22\n",
-      "2025-12-17 22:05:27 - ras_commander.RasUnsteady - INFO -   NetCDF file: .\\Precipitation\\storm_20201224.nc\n",
-      "2025-12-17 22:05:27 - ras_commander.RasUnsteady - INFO -   Interpolation: Bilinear\n",
-      "2025-12-17 22:05:27 - ras_commander.RasUnsteady - INFO - Successfully configured gridded precipitation in C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\BaldEagleDamBrk.u22\n",
-      "2025-12-17 22:05:27 - ras_commander.RasUnsteady - INFO - Updating precipitation in HDF: C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\BaldEagleDamBrk.u22.hdf\n",
-      "2025-12-17 22:05:27 - ras_commander.RasUnsteady - INFO -   NetCDF: 144 timesteps, 24x30 grid\n",
-      "2025-12-17 22:05:27 - ras_commander.RasUnsteady - INFO -   Imported 144 timesteps, 720 cells (cumulative)\n",
-      "2025-12-17 22:05:27 - ras_commander.RasUnsteady - INFO -   Precip range: 0.0 - 89.5 mm\n",
-      "2025-12-17 22:05:27 - ras_commander.precip.PrecipAorc - INFO -   Cloning plan file...\n",
-      "2025-12-17 22:05:27 - ras_commander.RasUtils - INFO - File cloned from C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\BaldEagleDamBrk.p06 to C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\BaldEagleDamBrk.p23\n",
-      "2025-12-17 22:05:27 - ras_commander.RasUtils - INFO - Successfully updated file: C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\BaldEagleDamBrk.p23\n",
-      "2025-12-17 22:05:27 - ras_commander.RasUtils - INFO - Project file updated with new Plan entry: 23\n",
-      "2025-12-17 22:05:27 - ras_commander.rasmap - INFO - Successfully parsed RASMapper file: C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\BaldEagleDamBrk.rasmap\n",
-      "2025-12-17 22:05:27 - ras_commander.RasPlan - INFO - Updated simulation date in plan file: C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\BaldEagleDamBrk.p23\n",
-      "2025-12-17 22:05:27 - ras_commander.precip.PrecipAorc - INFO -   Enabled HDF time series output\n",
-      "2025-12-17 22:05:27 - ras_commander.precip.PrecipAorc - INFO -   Created plan 23 with unsteady 22\n",
-      "2025-12-17 22:05:27 - ras_commander.precip.PrecipAorc - INFO - Storm plan creation complete: 12/12 successful\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "Plan Creation Results:\n",
-      " storm_id          start_time  total_depth_in plan_number  status\n",
-      "        1 2020-02-07 09:00:00           1.023          07 success\n",
-      "        2 2020-03-19 01:00:00           0.763          08 success\n",
-      "        3 2020-03-28 08:00:00           1.530          09 success\n",
-      "        4 2020-04-17 17:00:00           0.777          10 success\n",
-      "        5 2020-04-30 04:00:00           2.115          11 success\n",
-      "        6 2020-05-28 12:00:00           1.188          12 success\n",
-      "        7 2020-06-03 06:00:00           0.846          14 success\n",
-      "        8 2020-09-29 11:00:00           1.278          16 success\n",
-      "        9 2020-10-29 07:00:00           1.735          20 success\n",
-      "       10 2020-11-11 12:00:00           1.989          21 success\n",
-      "       11 2020-12-16 17:00:00           1.834          22 success\n",
-      "       12 2020-12-24 12:00:00           2.720          23 success\n",
-      "\n",
-      "Total plans in project: 23\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Create storm plans with precipitation data written to HDF\n",
     "print(f\"Creating HEC-RAS plans for {len(storm_catalog)} storms...\")\n",
@@ -1278,20 +511,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "id": "cell-15",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Plans to execute: ['07', '08', '09', '10', '11', '12', '14', '16', '20', '21', '22', '23']\n",
-      "Execution config: 2 cores x 3 workers\n",
-      "======================================================================\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Get list of storm plan numbers\n",
     "storm_plan_numbers = results[results['status'] == 'success']['plan_number'].tolist()\n",
@@ -1302,174 +525,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "id": "cell-16",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2025-12-17 22:05:27 - ras_commander.RasCmdr - INFO - Filtered plans to execute: ['07', '08', '09', '10', '11', '12', '14', '16', '20', '21', '22', '23']\n",
-      "2025-12-17 22:05:27 - ras_commander.RasCmdr - INFO - Adjusted max_workers to 3 based on the number of plans to compute: 12\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Starting parallel execution of 12 plans...\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2025-12-17 22:05:28 - ras_commander.RasCmdr - INFO - Created worker folder: C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020 [Worker 1]\n",
-      "2025-12-17 22:05:28 - ras_commander.rasmap - INFO - Successfully parsed RASMapper file: C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020 [Worker 1]\\BaldEagleDamBrk.rasmap\n",
-      "2025-12-17 22:05:28 - ras_commander.RasCmdr - INFO - Created worker folder: C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020 [Worker 2]\n",
-      "2025-12-17 22:05:29 - ras_commander.rasmap - INFO - Successfully parsed RASMapper file: C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020 [Worker 2]\\BaldEagleDamBrk.rasmap\n",
-      "2025-12-17 22:05:29 - ras_commander.RasCmdr - INFO - Created worker folder: C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020 [Worker 3]\n",
-      "2025-12-17 22:05:29 - ras_commander.rasmap - INFO - Successfully parsed RASMapper file: C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020 [Worker 3]\\BaldEagleDamBrk.rasmap\n",
-      "2025-12-17 22:05:29 - ras_commander.RasCmdr - INFO - Using ras_object with project folder: C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020 [Worker 1]\n",
-      "2025-12-17 22:05:29 - ras_commander.RasCmdr - INFO - Using ras_object with project folder: C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020 [Worker 2]\n",
-      "2025-12-17 22:05:29 - ras_commander.RasCmdr - INFO - Using ras_object with project folder: C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020 [Worker 3]\n",
-      "2025-12-17 22:05:29 - ras_commander.RasUtils - INFO - Using provided plan file path: C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020 [Worker 1]\\BaldEagleDamBrk.p07\n",
-      "2025-12-17 22:05:29 - ras_commander.RasUtils - INFO - Using provided plan file path: C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020 [Worker 2]\\BaldEagleDamBrk.p08\n",
-      "2025-12-17 22:05:29 - ras_commander.RasUtils - INFO - Successfully updated file: C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020 [Worker 1]\\BaldEagleDamBrk.p07\n",
-      "2025-12-17 22:05:29 - ras_commander.RasUtils - INFO - Successfully updated file: C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020 [Worker 2]\\BaldEagleDamBrk.p08\n",
-      "2025-12-17 22:05:30 - ras_commander.RasUtils - INFO - Using provided plan file path: C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020 [Worker 3]\\BaldEagleDamBrk.p09\n",
-      "2025-12-17 22:05:30 - ras_commander.RasUtils - INFO - Successfully updated file: C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020 [Worker 3]\\BaldEagleDamBrk.p09\n",
-      "2025-12-17 22:05:30 - ras_commander.RasCmdr - INFO - Set number of cores to 2 for plan: 08\n",
-      "2025-12-17 22:05:30 - ras_commander.RasCmdr - INFO - Running HEC-RAS from the Command Line:\n",
-      "2025-12-17 22:05:30 - ras_commander.RasCmdr - INFO - Set number of cores to 2 for plan: 07\n",
-      "2025-12-17 22:05:30 - ras_commander.RasCmdr - INFO - Running HEC-RAS from the Command Line:\n",
-      "2025-12-17 22:05:30 - ras_commander.RasCmdr - INFO - Running command: \"C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.6\\Ras.exe\" -c \"C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020 [Worker 2]\\BaldEagleDamBrk.prj\" \"C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020 [Worker 2]\\BaldEagleDamBrk.p08\"\n",
-      "2025-12-17 22:05:30 - ras_commander.RasCmdr - INFO - Set number of cores to 2 for plan: 09\n",
-      "2025-12-17 22:05:30 - ras_commander.RasCmdr - INFO - Running command: \"C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.6\\Ras.exe\" -c \"C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020 [Worker 1]\\BaldEagleDamBrk.prj\" \"C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020 [Worker 1]\\BaldEagleDamBrk.p07\"\n",
-      "2025-12-17 22:05:30 - ras_commander.RasCmdr - INFO - Running HEC-RAS from the Command Line:\n",
-      "2025-12-17 22:05:30 - ras_commander.RasCmdr - INFO - Running command: \"C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.6\\Ras.exe\" -c \"C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020 [Worker 3]\\BaldEagleDamBrk.prj\" \"C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020 [Worker 3]\\BaldEagleDamBrk.p09\"\n",
-      "2025-12-17 22:18:46 - ras_commander.RasCmdr - INFO - HEC-RAS execution completed for plan: 07\n",
-      "2025-12-17 22:18:46 - ras_commander.RasCmdr - INFO - Total run time for plan 07: 796.55 seconds\n",
-      "2025-12-17 22:18:46 - ras_commander.RasCmdr - INFO - Using ras_object with project folder: C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020 [Worker 1]\n",
-      "2025-12-17 22:18:46 - ras_commander.RasCmdr - INFO - Plan 07 executed in worker 1: Successful\n",
-      "2025-12-17 22:18:46 - ras_commander.RasUtils - INFO - Using provided plan file path: C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020 [Worker 1]\\BaldEagleDamBrk.p10\n",
-      "2025-12-17 22:18:46 - ras_commander.RasUtils - INFO - Successfully updated file: C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020 [Worker 1]\\BaldEagleDamBrk.p10\n",
-      "2025-12-17 22:18:46 - ras_commander.RasCmdr - INFO - Set number of cores to 2 for plan: 10\n",
-      "2025-12-17 22:18:46 - ras_commander.RasCmdr - INFO - Running HEC-RAS from the Command Line:\n",
-      "2025-12-17 22:18:46 - ras_commander.RasCmdr - INFO - Running command: \"C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.6\\Ras.exe\" -c \"C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020 [Worker 1]\\BaldEagleDamBrk.prj\" \"C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020 [Worker 1]\\BaldEagleDamBrk.p10\"\n",
-      "2025-12-17 22:19:56 - ras_commander.RasCmdr - INFO - HEC-RAS execution completed for plan: 08\n",
-      "2025-12-17 22:19:56 - ras_commander.RasCmdr - INFO - Total run time for plan 08: 866.38 seconds\n",
-      "2025-12-17 22:19:56 - ras_commander.RasCmdr - INFO - Using ras_object with project folder: C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020 [Worker 2]\n",
-      "2025-12-17 22:19:56 - ras_commander.RasCmdr - INFO - Plan 08 executed in worker 2: Successful\n",
-      "2025-12-17 22:19:56 - ras_commander.RasUtils - INFO - Using provided plan file path: C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020 [Worker 2]\\BaldEagleDamBrk.p11\n",
-      "2025-12-17 22:19:56 - ras_commander.RasUtils - INFO - Successfully updated file: C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020 [Worker 2]\\BaldEagleDamBrk.p11\n",
-      "2025-12-17 22:19:56 - ras_commander.RasCmdr - INFO - Set number of cores to 2 for plan: 11\n",
-      "2025-12-17 22:19:56 - ras_commander.RasCmdr - INFO - Running HEC-RAS from the Command Line:\n",
-      "2025-12-17 22:19:56 - ras_commander.RasCmdr - INFO - Running command: \"C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.6\\Ras.exe\" -c \"C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020 [Worker 2]\\BaldEagleDamBrk.prj\" \"C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020 [Worker 2]\\BaldEagleDamBrk.p11\"\n",
-      "2025-12-17 22:22:01 - ras_commander.RasCmdr - INFO - HEC-RAS execution completed for plan: 09\n",
-      "2025-12-17 22:22:01 - ras_commander.RasCmdr - INFO - Total run time for plan 09: 991.30 seconds\n",
-      "2025-12-17 22:22:01 - ras_commander.RasCmdr - INFO - Using ras_object with project folder: C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020 [Worker 3]\n",
-      "2025-12-17 22:22:01 - ras_commander.RasCmdr - INFO - Plan 09 executed in worker 3: Successful\n",
-      "2025-12-17 22:22:01 - ras_commander.RasUtils - INFO - Using provided plan file path: C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020 [Worker 3]\\BaldEagleDamBrk.p12\n",
-      "2025-12-17 22:22:01 - ras_commander.RasUtils - INFO - Successfully updated file: C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020 [Worker 3]\\BaldEagleDamBrk.p12\n",
-      "2025-12-17 22:22:01 - ras_commander.RasCmdr - INFO - Set number of cores to 2 for plan: 12\n",
-      "2025-12-17 22:22:01 - ras_commander.RasCmdr - INFO - Running HEC-RAS from the Command Line:\n",
-      "2025-12-17 22:22:01 - ras_commander.RasCmdr - INFO - Running command: \"C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.6\\Ras.exe\" -c \"C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020 [Worker 3]\\BaldEagleDamBrk.prj\" \"C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020 [Worker 3]\\BaldEagleDamBrk.p12\"\n",
-      "2025-12-17 22:31:42 - ras_commander.RasCmdr - INFO - HEC-RAS execution completed for plan: 10\n",
-      "2025-12-17 22:31:42 - ras_commander.RasCmdr - INFO - Total run time for plan 10: 775.36 seconds\n",
-      "2025-12-17 22:31:42 - ras_commander.RasCmdr - INFO - Using ras_object with project folder: C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020 [Worker 1]\n",
-      "2025-12-17 22:31:42 - ras_commander.RasCmdr - INFO - Plan 10 executed in worker 1: Successful\n",
-      "2025-12-17 22:31:42 - ras_commander.RasUtils - INFO - Using provided plan file path: C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020 [Worker 1]\\BaldEagleDamBrk.p14\n",
-      "2025-12-17 22:31:42 - ras_commander.RasUtils - INFO - Successfully updated file: C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020 [Worker 1]\\BaldEagleDamBrk.p14\n",
-      "2025-12-17 22:31:42 - ras_commander.RasCmdr - INFO - Set number of cores to 2 for plan: 14\n",
-      "2025-12-17 22:31:42 - ras_commander.RasCmdr - INFO - Running HEC-RAS from the Command Line:\n",
-      "2025-12-17 22:31:42 - ras_commander.RasCmdr - INFO - Running command: \"C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.6\\Ras.exe\" -c \"C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020 [Worker 1]\\BaldEagleDamBrk.prj\" \"C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020 [Worker 1]\\BaldEagleDamBrk.p14\"\n",
-      "2025-12-17 22:33:48 - ras_commander.RasCmdr - INFO - HEC-RAS execution completed for plan: 11\n",
-      "2025-12-17 22:33:48 - ras_commander.RasCmdr - INFO - Total run time for plan 11: 832.09 seconds\n",
-      "2025-12-17 22:33:48 - ras_commander.RasCmdr - INFO - Using ras_object with project folder: C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020 [Worker 2]\n",
-      "2025-12-17 22:33:48 - ras_commander.RasCmdr - INFO - Plan 11 executed in worker 2: Successful\n",
-      "2025-12-17 22:33:48 - ras_commander.RasUtils - INFO - Using provided plan file path: C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020 [Worker 2]\\BaldEagleDamBrk.p16\n",
-      "2025-12-17 22:33:48 - ras_commander.RasUtils - INFO - Successfully updated file: C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020 [Worker 2]\\BaldEagleDamBrk.p16\n",
-      "2025-12-17 22:33:48 - ras_commander.RasCmdr - INFO - Set number of cores to 2 for plan: 16\n",
-      "2025-12-17 22:33:48 - ras_commander.RasCmdr - INFO - Running HEC-RAS from the Command Line:\n",
-      "2025-12-17 22:33:48 - ras_commander.RasCmdr - INFO - Running command: \"C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.6\\Ras.exe\" -c \"C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020 [Worker 2]\\BaldEagleDamBrk.prj\" \"C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020 [Worker 2]\\BaldEagleDamBrk.p16\"\n",
-      "2025-12-17 22:40:18 - ras_commander.RasCmdr - INFO - HEC-RAS execution completed for plan: 12\n",
-      "2025-12-17 22:40:18 - ras_commander.RasCmdr - INFO - Total run time for plan 12: 1097.28 seconds\n",
-      "2025-12-17 22:40:18 - ras_commander.RasCmdr - INFO - Using ras_object with project folder: C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020 [Worker 3]\n",
-      "2025-12-17 22:40:18 - ras_commander.RasCmdr - INFO - Plan 12 executed in worker 3: Successful\n",
-      "2025-12-17 22:40:18 - ras_commander.RasUtils - INFO - Using provided plan file path: C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020 [Worker 3]\\BaldEagleDamBrk.p20\n",
-      "2025-12-17 22:40:18 - ras_commander.RasUtils - INFO - Successfully updated file: C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020 [Worker 3]\\BaldEagleDamBrk.p20\n",
-      "2025-12-17 22:40:18 - ras_commander.RasCmdr - INFO - Set number of cores to 2 for plan: 20\n",
-      "2025-12-17 22:40:18 - ras_commander.RasCmdr - INFO - Running HEC-RAS from the Command Line:\n",
-      "2025-12-17 22:40:18 - ras_commander.RasCmdr - INFO - Running command: \"C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.6\\Ras.exe\" -c \"C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020 [Worker 3]\\BaldEagleDamBrk.prj\" \"C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020 [Worker 3]\\BaldEagleDamBrk.p20\"\n",
-      "2025-12-17 22:47:24 - ras_commander.RasCmdr - INFO - HEC-RAS execution completed for plan: 14\n",
-      "2025-12-17 22:47:24 - ras_commander.RasCmdr - INFO - Total run time for plan 14: 942.27 seconds\n",
-      "2025-12-17 22:47:25 - ras_commander.RasCmdr - INFO - Using ras_object with project folder: C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020 [Worker 1]\n",
-      "2025-12-17 22:47:25 - ras_commander.RasCmdr - INFO - Plan 14 executed in worker 1: Successful\n",
-      "2025-12-17 22:47:25 - ras_commander.RasUtils - INFO - Using provided plan file path: C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020 [Worker 1]\\BaldEagleDamBrk.p21\n",
-      "2025-12-17 22:47:25 - ras_commander.RasUtils - INFO - Successfully updated file: C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020 [Worker 1]\\BaldEagleDamBrk.p21\n",
-      "2025-12-17 22:47:25 - ras_commander.RasCmdr - INFO - Set number of cores to 2 for plan: 21\n",
-      "2025-12-17 22:47:25 - ras_commander.RasCmdr - INFO - Running HEC-RAS from the Command Line:\n",
-      "2025-12-17 22:47:25 - ras_commander.RasCmdr - INFO - Running command: \"C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.6\\Ras.exe\" -c \"C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020 [Worker 1]\\BaldEagleDamBrk.prj\" \"C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020 [Worker 1]\\BaldEagleDamBrk.p21\"\n",
-      "2025-12-17 22:50:49 - ras_commander.RasCmdr - INFO - HEC-RAS execution completed for plan: 16\n",
-      "2025-12-17 22:50:49 - ras_commander.RasCmdr - INFO - Total run time for plan 16: 1020.38 seconds\n",
-      "2025-12-17 22:50:49 - ras_commander.RasCmdr - INFO - Using ras_object with project folder: C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020 [Worker 2]\n",
-      "2025-12-17 22:50:49 - ras_commander.RasCmdr - INFO - Plan 16 executed in worker 2: Successful\n",
-      "2025-12-17 22:50:49 - ras_commander.RasUtils - INFO - Using provided plan file path: C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020 [Worker 2]\\BaldEagleDamBrk.p22\n",
-      "2025-12-17 22:50:49 - ras_commander.RasUtils - INFO - Successfully updated file: C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020 [Worker 2]\\BaldEagleDamBrk.p22\n",
-      "2025-12-17 22:50:49 - ras_commander.RasCmdr - INFO - Set number of cores to 2 for plan: 22\n",
-      "2025-12-17 22:50:49 - ras_commander.RasCmdr - INFO - Running HEC-RAS from the Command Line:\n",
-      "2025-12-17 22:50:49 - ras_commander.RasCmdr - INFO - Running command: \"C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.6\\Ras.exe\" -c \"C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020 [Worker 2]\\BaldEagleDamBrk.prj\" \"C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020 [Worker 2]\\BaldEagleDamBrk.p22\"\n",
-      "2025-12-17 22:57:51 - ras_commander.RasCmdr - INFO - HEC-RAS execution completed for plan: 20\n",
-      "2025-12-17 22:57:51 - ras_commander.RasCmdr - INFO - Total run time for plan 20: 1053.01 seconds\n",
-      "2025-12-17 22:57:51 - ras_commander.RasCmdr - INFO - Using ras_object with project folder: C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020 [Worker 3]\n",
-      "2025-12-17 22:57:51 - ras_commander.RasCmdr - INFO - Plan 20 executed in worker 3: Successful\n",
-      "2025-12-17 22:57:51 - ras_commander.RasUtils - INFO - Using provided plan file path: C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020 [Worker 3]\\BaldEagleDamBrk.p23\n",
-      "2025-12-17 22:57:51 - ras_commander.RasUtils - INFO - Successfully updated file: C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020 [Worker 3]\\BaldEagleDamBrk.p23\n",
-      "2025-12-17 22:57:51 - ras_commander.RasCmdr - INFO - Set number of cores to 2 for plan: 23\n",
-      "2025-12-17 22:57:51 - ras_commander.RasCmdr - INFO - Running HEC-RAS from the Command Line:\n",
-      "2025-12-17 22:57:51 - ras_commander.RasCmdr - INFO - Running command: \"C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.6\\Ras.exe\" -c \"C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020 [Worker 3]\\BaldEagleDamBrk.prj\" \"C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020 [Worker 3]\\BaldEagleDamBrk.p23\"\n",
-      "2025-12-17 22:58:40 - ras_commander.RasCmdr - INFO - HEC-RAS execution completed for plan: 21\n",
-      "2025-12-17 22:58:40 - ras_commander.RasCmdr - INFO - Total run time for plan 21: 674.75 seconds\n",
-      "2025-12-17 22:58:40 - ras_commander.RasCmdr - INFO - Plan 21 executed in worker 1: Successful\n",
-      "2025-12-17 23:02:37 - ras_commander.RasCmdr - INFO - HEC-RAS execution completed for plan: 22\n",
-      "2025-12-17 23:02:37 - ras_commander.RasCmdr - INFO - Total run time for plan 22: 707.57 seconds\n",
-      "2025-12-17 23:02:37 - ras_commander.RasCmdr - INFO - Plan 22 executed in worker 2: Successful\n",
-      "2025-12-17 23:09:24 - ras_commander.RasCmdr - INFO - HEC-RAS execution completed for plan: 23\n",
-      "2025-12-17 23:09:24 - ras_commander.RasCmdr - INFO - Total run time for plan 23: 692.16 seconds\n",
-      "2025-12-17 23:09:24 - ras_commander.RasCmdr - INFO - Plan 23 executed in worker 3: Successful\n",
-      "2025-12-17 23:09:24 - ras_commander.RasCmdr - INFO - Final destination for computed results: C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020 [Computed]\n",
-      "2025-12-17 23:11:55 - ras_commander.rasmap - INFO - Successfully parsed RASMapper file: C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020 [Computed]\\BaldEagleDamBrk.rasmap\n",
-      "2025-12-17 23:11:55 - ras_commander.RasCmdr - INFO - \n",
-      "Execution Results:\n",
-      "2025-12-17 23:11:55 - ras_commander.RasCmdr - INFO - Plan 07: Successful\n",
-      "2025-12-17 23:11:55 - ras_commander.RasCmdr - INFO - Plan 08: Successful\n",
-      "2025-12-17 23:11:55 - ras_commander.RasCmdr - INFO - Plan 09: Successful\n",
-      "2025-12-17 23:11:55 - ras_commander.RasCmdr - INFO - Plan 10: Successful\n",
-      "2025-12-17 23:11:55 - ras_commander.RasCmdr - INFO - Plan 11: Successful\n",
-      "2025-12-17 23:11:55 - ras_commander.RasCmdr - INFO - Plan 12: Successful\n",
-      "2025-12-17 23:11:55 - ras_commander.RasCmdr - INFO - Plan 14: Successful\n",
-      "2025-12-17 23:11:55 - ras_commander.RasCmdr - INFO - Plan 16: Successful\n",
-      "2025-12-17 23:11:55 - ras_commander.RasCmdr - INFO - Plan 20: Successful\n",
-      "2025-12-17 23:11:55 - ras_commander.RasCmdr - INFO - Plan 21: Successful\n",
-      "2025-12-17 23:11:55 - ras_commander.RasCmdr - INFO - Plan 22: Successful\n",
-      "2025-12-17 23:11:55 - ras_commander.RasCmdr - INFO - Plan 23: Successful\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "Execution complete in 66.5 minutes\n",
-      "  Successful: 12\n",
-      "  Failed: 0\n",
-      "\n",
-      "Results copied to: C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020 [Computed]\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Execute plans in parallel\n",
     "import time\n",
@@ -1509,35 +568,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": null,
    "id": "cell-18",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Warning: Computed folder not found\n",
-      "\n",
-      "Storm Execution Results\n",
-      "================================================================================\n",
-      "Storm  1 (Feb 07): Plan 07 - OK - 6609.5 MB\n",
-      "Storm  2 (Mar 19): Plan 08 - OK - 6898.7 MB\n",
-      "Storm  3 (Mar 28): Plan 09 - OK - 9728.2 MB\n",
-      "Storm  4 (Apr 17): Plan 10 - OK - 6553.5 MB\n",
-      "Storm  5 (Apr 30): Plan 11 - OK - 7938.8 MB\n",
-      "Storm  6 (May 28): Plan 12 - OK - 9764.3 MB\n",
-      "Storm  7 (Jun 03): Plan 14 - OK - 7177.6 MB\n",
-      "Storm  8 (Sep 29): Plan 16 - OK - 7073.5 MB\n",
-      "Storm  9 (Oct 29): Plan 20 - OK - 10036.5 MB\n",
-      "Storm 10 (Nov 11): Plan 21 - OK - 6230.5 MB\n",
-      "Storm 11 (Dec 16): Plan 22 - OK - 6915.7 MB\n",
-      "Storm 12 (Dec 24): Plan 23 - OK - 9077.6 MB\n",
-      "\n",
-      "Completed: 12 of 12 storms\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Results are already in original folder (v0.88.1+) - no re-initialization needed\n",
     "\n",
@@ -1591,29 +625,24 @@
   },
   {
    "cell_type": "code",
-   "id": "6rekji93qh8",
-   "source": "# Display results summary from results_df\n# Shows execution status, completion, errors/warnings, and runtime for all plans\n_summary_cols = ['plan_number', 'plan_title', 'completed', 'has_errors', 'has_warnings', 'runtime_complete_process_hours']\n_avail = [c for c in _summary_cols if c in ras.results_df.columns]\nras.results_df[_avail]",
-   "metadata": {},
    "execution_count": null,
-   "outputs": []
+   "id": "6rekji93qh8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Display results summary from results_df\n",
+    "# Shows execution status, completion, errors/warnings, and runtime for all plans\n",
+    "_summary_cols = ['plan_number', 'plan_title', 'completed', 'has_errors', 'has_warnings', 'runtime_complete_process_hours']\n",
+    "_avail = [c for c in _summary_cols if c in ras.results_df.columns]\n",
+    "ras.results_df[_avail]"
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": null,
    "id": "cell-19",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAABW0AAAHvCAYAAAAvoP1zAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjMsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvZiW1igAAAAlwSFlzAAAPYQAAD2EBqD+naQAAogZJREFUeJzs3Qm8lPP////XaU/atZJElhalhVSokJItsvOpaCFZkjXSKqHdVrKULTshRFok0aYoLUREO5X2/frfnu/v/5rfzJylc+qcM9d1zuN+u02dmblm5jXXXDPzmtf1vl7vJM/zPAMAAAAAAAAABEKeRAcAAAAAAAAAAPh/KNoCAAAAAAAAQIBQtAUAAAAAAACAAKFoCwAAAAAAAAABQtEWAAAAAAAAAAKEoi0AAAAAAAAABAhFWwAAAAAAAAAIEIq2AAAAAAAAABAgFG0BAAAAAAAAIEAo2gIAAORCSUlJkdPYsWMtaKZNmxYT4x9//JHlj6nHiH5MxYDs0b59+8h6b9q0aaLDAQAASDiKtgAABFTNmjVjCkgVKlSwffv2HfR2v/32m913331Wr149K1WqlBUoUMCOOuooa9SokfXp08fWrVuX4u10XfTj+SfdvmzZstakSRMbMWKE7dq1K83H/+mnn+zOO++0OnXquMfPnz+/lSxZ0s444wwXl65PLz3fUaNGuccuXbp05L6qVq1qzZs3d/f33XffWW4vvC1ZssQ6depkJ554ohUuXNgKFSpkRx99tHsN/ve//9mQIUNs7969lpvllO0ivpjtn/LmzWslSpSwunXr2gMPPGBr1661nCIsBd0ff/zRBg4caBdeeKGdfPLJVrx4cStYsKBVqlTJrr76aps+fXqqt9Xn6pNPPuk+t4sVK2ZFihRx3wE9e/a0//77L6GPBQAAEsQDAACBM3v2bE9f0/GnTz75JM3bDRw40MubN2+Kt/VPRxxxhPfaa68lu23v3r3TvJ1/Ouecc7x9+/Ylu/3OnTu9zp07H/T2lStXTtc62LNnj3fuuece9P7uuuuumNutWLEi5vqpU6d6Odlnn33mFShQ4KDradOmTTG3GzRoUOS0aNEiL2j0ukXHr9f1cKRnu/jvv/9i1svKlSu9oK+X1E7ly5cPZPypadeuXST2Jk2apPu6IGnRosVBX5cnnngi2e3++ecfr06dOqne5rjjjvN+//33hD0WAABIjHyJKhYDAIDUpXa4ui6/+OKLU7zuiSeesB49ekTOa0Tqtddea8ccc4wtX77c3nrrLdu5c6ft2LHD2rZt60ZlXXXVVanG8NBDD7mRexqx9/rrr9v69evd5RrB9emnn9qll14aWXb//v1udNcnn3wSuUwjv6644go3KlYjuzTC9ssvv0z3OnjppZdsypQpkfMaYXf22We7UaRr1qyxOXPmuFNQaB3s3r3bjjjiiGx9zI4dO9qePXvceY1G1uug0XZ6nZcuXepeL/+1i3bvvfdmW5xhoVGHYVsv11xzjdWvX9+2bNli48ePt4ULF7rL9b4dNmyYDR06NNEh5jo1atSw888/370f9RkV/bmoz9XLLrvMjY71de7c2ebPn+/+1kj5W265xX3OvfDCC/bvv/+6UeL6LNdRBXny5EnYYwEAgGyWoGIxAABIxa5du7ySJUtGRj6ddNJJkb81olIjpeL98ccfXv78+SPLHXvssd7ff/8ds8xPP/3kFS1aNLJMmTJlvK1bt6Y60jZ6ZOPnn38ec51G9EYbNWpUzPUNGzb0NmzYkCzOjRs3esOGDUvXerj88ssj99e0adMUl1m3bp03Z86cyHmN4k1r5Fn8KL1ly5Z5t956q1vHhQsXdqcTTzzRjRhesmRJsseLH/H3559/ejfeeKNXtmxZLykpyfvwww/dctGPOWbMGO/VV1/1ateu7RUqVMg74YQTvKFDh7rl9u7d6/Xv39+NbtNre8opp3ijR4/20uvHH3+Meaxp06YlW+bAgQPe5MmT3XYVLT5Gn/6Ovm7z5s3eHXfc4UZuapS2XotZs2a5ZX/77TevTZs2XokSJbwjjzzSjf5buHBhhkbMRr9m2gbTc7v58+d7Xbp08c444wyvYsWKbr0WLFjQbfdXX321980336T6GGltF+kZjfvee+95rVq18sqVK+fec3ru2t4HDx7sbd++Pdny8ev5yy+/dOuwSJEibp21bNkyQyOd49dL9Gun1yp61LVej5RMnz7du+aaa7xKlSq55fW5cOaZZ3rPPPOMG+EeT58dN9xwg1uPWl7rW7dt1qyZ9+CDD8Z81qQ1Kjat1zSl28Vviymd/Ndo27ZtXt++fd0oUq3XfPnyuc84ve86duzoPsOyWr9+/dy6jderV6+YmJ966qnIdT///HPMddHvf20r0ddpVH0iHgsAACQGRVsAAALm7bffjvnx/N1338UUZKN/hKdWcH3xxRdTvO8ePXrELDd27NhU7yO6oKKiTfR1L7zwQsz9qtjoX6eCzqpVqw57PVxyySWR+zz55JNdgfZgMlK0feedd1ysqS2rIuCbb74Zc//RhSUVd1XIjL5NSkXbevXqpXj/jzzyiHfZZZeleN1LL72UrnU0b968mNuNGDEi3es3vUXblOLXevvoo4+8UqVKJbuudOnS3vr167O0aPv000+n+TqrgB79nDKjaKuWICoIp3U/1apV81avXp3qem7cuLGL7WDr7FCLthL9mqjQGu+hhx5K8zmcffbZrgAaXehTsT6t20QXRBNVtFUhPK3lVKROFO3IiI5FBX6fdoBFX/fvv//G7HApVqxY5DrtYArSYwEAgKxFewQAAALcGkGTCp155pnu8NfPP/88cv0dd9wRc5tvvvkm5nxqbQ90KLUmr4m+Xbt27VKNRTUnHWY9aNCgyGU6pDa6RcPq1avdYfi+Fi1aWMWKFe1w6bn7h/ouW7bMtXnQYeD+6bzzznOTbUV7+OGH3eG9jz32WOSyW2+91U444QT3t9oGiNpFaIIutTMQHVqs9aCJjl555RX7559/3HW6TJP1aIKveL/++qv7Xy0gateubX/++adrCRFv3rx51rBhQzdx2ttvv+2ei/Tv39/9r0nWzjnnHHd4sj95lCYJuvnmmw+6jk455RT3eqjthdx1112uTYYmndP6a9y4sTtpkqpDpUOpNcnZkUceac8884yb0EztLnTYdb58+ey2225z7RlefPFFt7wOsVZriwcffNCyilp76H1x2mmnuddOsWkCpcmTJ7tDxLXd3nPPPW571/pJ73aRFt32nXfeiZzX419wwQVuErh3333XXaa/b7jhhpi2HtG+/fZb95ppm1mwYIF99tlnmbbO1B5Bnw0bN26MXKZWGdHUIiV6Hei9qu1DkxNqu9+2bZv7TLj77rtt9OjRbhldrlYbovfgjTfe6Cau+vvvv23RokX2/fffW1Y5/fTT3WeP3jdz5851lx1//PHWpUuXyDJ6DbXe/YnldEi/2r+cdNJJ7n28YsWKhE86F/35KJqU0Rc9MaM+PzR5o0+fR1WqVHGTjsUvG4THAgAAWSyLi8IAACADNEoveiIxTYYkOrw+eoSURr5G0wg//zodrp0aTUYVfT86zDsjE5HpUPRJkyalOWnaAw88kCnrQod6pzVCUiMWL7roomQjN9NziLsmL/Ovz5MnT8wh/fpbl6U00Vn0aECdhg8fnmLs0ctUr149csj5F198EXOdDt32J3WLbzGxZcuWdK0nxZDWa6bD+J999tlDHmn76KOPRq677rrrYq7zt0/R4fX+5VdccUWWjrSNbg/x+uuvuxHGikWxRt8m+vDx9GwXqS2zf//+mBGsaocQPRnf/fffH3M7tW9IaT2rpUD06xo9IVT0Ojvcicg0Mjb6tUnp8dq2bRtznUae+9eptYA/CvPOO+9MtS2K3/JEp6wYaZue6+SHH36IXK/PQo0ajabXSi1kEmHNmjVelSpVIvGppURqE4pp+4h31llnxRxxEJTHAgAAWY+RtgAABMhrr73mJpfyRz5ppKC0bt3aTRajEY4yZsyYbJ9gSKMqu3Xr5ka4ZgeNBJs1a5b169fPxo0bZ5s3b465XvUwTYj222+/udGgWj/ppUl2fBpJW7Nmzch5/a3L/EnOopeNponeunbtetDH0mjH/Pnzu7+PO+64mOs04tIfBeuP+vRt2rTJihYtetD71+hajRTVCNvZs2cnu16jKBWnJkhr3769ZZRGVvri448eyan4/VGXij0r/fDDD2405c8//5zmchoNmhk0Ojp6BKvWSfToZY3I1uhon7YZjQKOp9Hd0a+pRoP6k0Jl5jq7/PLL3UjiaBotq9G9vldffdWdUrJv3z63LbVs2dJN/vfUU0+5y3v27Gkff/yxGy2sya0aNGjgrj+ckdyZoVq1am7EtUYsa9StJj+sU6eOW7+1atVyRypUrlw5Xfc1ePDgFC8/lAnqfvnlF2vVqpUb7SvVq1ePGa0d7/9q/Ae/LNGPBQAAsgdFWwAAAtoaQYe4+4dtq9Bz0UUX2fvvv+/Ov/HGG65IpEKqVKhQwRUrRMVNHSpdrFixZPevQ/ij6Xap0czjOgz9gw8+cIfMqpBz//33u+JP7969I8vFtyiIPzz3cJQrV86effZZVzRSwUmFJB3q/NFHH0VaG+jxdJi5CqDpFV2A02Ok9Li+1IppKlL66z8t0a0iChQokOp18fd14MABSy89d502bNjgCoY6aR3524SoyH8oRdtDiT+t2OMLQ/7rmF5qBaH2HGvWrDnoshm97/RsLyltM/HnU9tm4oveen8dyusdTTt21J5j5syZNmHChMjng9bPV1995Xb++DFlpCinbUmuvPJKV7B8+umn3fr0ty+fiqHaeVKjRo1Mf63TSztsVKC86aabbOXKlfb777+7U/R2q7Yw3bt3P+h93XfffZlStNXnlN6T/ragli76nDrqqKNillOx2bd169Zk9xN9WfxtE/FYAAAg++TJxscCAABp0KjS6CKb+l+q4OKf/IKtrF+/PtIPUzTaLdp7772X4mPEj7yKv1009THt1atXslGD6omp0a3RhTuNvPN98cUX6SqoZYRG8mn0q3pZqr/lpEmTUuwvm17RvRw1EjVe9GUaUZsS9fVMD3+UbUrSU/TNiDJlytill17qClQahaoRhoe6jjIrfvUYjeb33xXtXEhp/adl+vTpMduXeteqwKgC4fbt2y0rRG8vEh9z/PnUtpn4dekXVA+HRsP26NHD9X++5ZZbIperr+7rr78eOV+iRImY22k7Ub/Y1E7qiezTeT1Hfeao+K9RvH7BXjuC1Nc4pdc7+rU+nG0wPc4991w3ylQj5NUf+oEHHoh8vqnnsoqx6mWdXTvf1O/YL6JecsklrrCq92c8jQT2qS+zRgtHF/L9kbNy6qmnJvSxAABA9qJoCwBAAEfZZnR5jaCMLghpkqv4wqmKeJpIKnokVZs2bQ76OJrIadiwYZHzKoA8+uijyQ7R96mFgyZCix+dKCosDB8+PF3PT8UhtUXwW0JE08RT0aILUvGFMX8SpWgaxRw9UVj0YfaaXEmXpbRs0GgSOE1Kl9LoZhUE1RIhtaJddol/3OiJq1Rczugh2dGFJtHEX/6owLQOB0/PdpEatQKILtyqGOq3MfEn64qWqG3m8ccfj5kMT61F/Di1kyF654vWo963GkEafdLOGk045o+cVSFPo/d1vxdeeKGbpGzkyJExnyVqV5HS6622En5bExUJNWr+UES/dim9bvqM0A4vFYw1yrRjx45uXXz99deR9aGipD/JVlq0PaZ0Sg8tp0nvNOJXE/aJ3p/jx49PdSePiqzRdGRD9A6w6NGvmvwvEY8FAAASg/YIAAAEgIoOmtndp1m8o2f99i1cuNAWL17s/tah0JodXQUrHXatAo1G3Mkff/zherNee+21rgCjEWZvvvlmZOSbCnrPPfdcsuJnapo2beoKUToE2y9a9enTJ9InUoUe9br8/PPPI6OE1T5Ah+zqfz0/zUb+5ZdfWtmyZV1v3IPR8hpFqdYQ55xzjhv5pZYPKkZrtG30KNzmzZtHzmuEmYo8fiFDhQ0Va3SZnoeKOurxqsKTDtdWMadJkyauL6nWiwpw/qHqOqw6PX1rE0UFdBXPdNLr7bfUUKFOr0H0iGSNyEwEjcLWa+gXhDQqU9vu2rVrU+0XfLACajT1l1WLAG3z6gmdmvRsF6lRMVDFykceecSdV9xnnXWWG+Gognl0sbhZs2auXUEiqGCq7VWj4UXve71Xrr/+endeo01V5BZtHxp5qUKeRgariKv+ujNmzHBtU/TZIbq92qFoHZ144onuOo1o1udJ9OP6Tj/99JiR1Ootq88yPd6qVasO6XlFt2DRDhW/j7Pen3feeacrDKuHqwrNeiyNAtbOJj0XFYtTijMrKJboYrbiOfbYY5P1H9d71X8/Km7tPPOPpNBzUwFaLR+ef/75yG30vLS9JeKxAABAgmTDZGcAAOAg3nzzzZhZ1V9//fUUl5s8eXLMcsOHD4+5/rHHHvPy5s170JnlX3311WT33bt371RndpcJEybEXN+lS5eY67dv3+516NDhoDPbV65cOV3rJHrG+LROAwYMSHbbyy+/PMVlBw0aFFnmnXfe8QoVKpTq/RYsWNC9LhmZxd4XfT9jxoyJXK51mtp1U6dOTXP9pyT+/lI7HXfccd6qVavSFaP+jr4urW0kveumZ8+eKcZVv359r2zZspHzuv/0rI+WLVumeH/x20z080rPdhG/PhWDb9++fd5VV12V5nquVq1autfzwdZZauLXS/x9rl+/3r3H/etr1KjhHThwIHJ9jx49MvQeHThw4EGXf+qppyLL79y50zvxxBNTXK5Vq1apvqZprYv58+d7efLkSXZ/RYoUcdevWbPmoDGeccYZ3t69e72spLjT837Uc432zz//eKeddlqar8dvv/2WsMcCAACJQXsEAAACILrVgQ7nTW1SLY3ii57MKL6lgkba6pBkjVDVCDfdl/qO6tDuM8880/WoVT9azWKfUZoILXoE4csvvxzTgkGH4r/44otutN7tt9/ultXINo2EVRwagacRexMnTkzX4z3xxBNuRO/NN9/s+tlqxLAmbtJJ60CjK9W3UxOmxVNPS42c1QRR8T1VfWrhoMnN1J9Ts81rtJlOGhmskcN6Hv5ow6DSyDqNYFQ7DI021ihUjZrUOte6b9CggRuBrecZPWlYdlMMGv2pEeQa2aoR2tpWdfi6RkRmlEYKarS2Rn1qtKVeP93/Sy+9lObt0rNdpEbrVCNq3333XWvVqpUbMa73lrZtrWf1fVU/1USuZ39EsdoD+NT648MPP4yc13rSNqMRyno99H7Sa6LRrBpdqesnT54cWb5169buc0P9kfW+0/tcz1vrXp8JGmGvw/J9eg/p9ldffbXbBnVe60cxpDbJ18GorYNG9qrPru4vnrZ5jTq97rrr3GhSfd7p9dLIfI2g1vtDMWV2D+nMognCdBSDWjroc1vtDfS+0HPR55vev8cff3zoHgsAAByeJFVuD/M+AAAAAAAAAACZhJG2AAAAAAAAABAgFG0BAAAAAAAAIEAo2gIAAAAAAABAgFC0BQAAAAAAAIAAoWgLAAAAAAAAAAFC0RYAAAAAAAAAAoSiLQAAAAAAAAAECEVbAAAAAAAAAAgQirYAAAAAAAAAECAUbQEAAAAAAAAgQCjaAgAAAAAAAECAULQFAAAAAAAAgAChaAsAAAAAAAAAAULRFgAAAAAAAAAChKItAAAAAAAAAAQIRVsAAAAAAAAACBCKtgAAAAAAAAAQIBRtAQAAAAAAACBAKNoCAAAAAAAAQIBQtAUAAAAAAACAAKFoCwAAAAAAAAABQtEWAAAAAAAAAAKEoi0AAAAAAAAABAhFWwBZbuzYsZaUlGR//PFHhm87bdo0d1v9nx369OnjHi83O+6446x9+/aZdn/vvPOOlSpVyrZt25Zp94nwOvPMM+3+++9PdBgAAIQyr0p0XpvduTnSp2nTpu7k0+8uvU76HQYgvCjaIldbuHChXXnllVa5cmUrVKiQHX300da8eXN7+umnY5Z77LHHbPz48RYW/pe0f8qbN68de+yxdvnll9uCBQss7MaNG2fDhw8/5Nvv2LHDJbFBSTaVyEe/Xqmd0pPwf/bZZ+65BcX+/futd+/edscdd9iRRx6Z6HAQAA888IA9++yztnbt2kSHAgBAlv+OCKvnnnsukAU/z/Pstddes3POOcdKlChhRxxxhJ166qnWr18/2759+yHf7+LFi10OfSiDTLJj/ab2+6B8+fJZGieAxEry9KkH5EIzZ860Zs2auWJmu3bt3BfeX3/9Zd9//7399ttvtnz58siyKjYpKQti4pISJRtVqlSx6667zlq1auUKZ0uWLLGRI0fa7t273XM87bTTsi0ePf7evXutYMGCGd7bf+DAAduzZ48VKFDA8uT5v/1MF198sS1atOiQk6p//vnHypQp44qJ8QXOffv2uZOS7+zy3XffuW3Ot2LFCuvVq5d17tzZzj777MjlJ5xwgjVs2DDN+7r99ttdQexwPto1IkR76jNje9fOjiuuuMK9t/RjBtB7WttCp06d3A8sAABy8u8I5d7KYfPnz5/tcSrP7du37yHlhTVr1rSjjjoq2SCHlHLz7PxNcf3117ujuJQjK8dU0fabb75xgzqqV69uX331lZUrVy7D9/3ee+/ZVVddZVOnTo0ZsZpVUlu/qdFvKO0UaNu2bczlhQsXtjZt2rjXRPS6RP8eHDNmTMJGegM4fPky4T6AUBowYIAVL17c5syZ4/bSRlu/fn2WP772BBcpUiRLH6Nu3bp24403Rs43btzYLr30Ule8ff7557MtLo301elQKBnMzgJqvnz53Ck7qRAbXYydO3euK9rqsujXL4yUKGq7y8yCbXa8d5B19J7WTrBXX33V/ZDM7e1IAAA5+3eEBi3kJNmdm0d78sknXcH23nvvtUGDBkUu10CHq6++2lq3bu0KlJ9//rnlRCeddFKqvw38Yi2AnIX2CMi1tBe8Ro0ayRItKVu2bORvFRRUJHrllVdSPEx9/vz5duGFF1qxYsXciNzzzjvP7WVPqafr119/bbfddpu7/2OOOcZdpz252tP6008/WZMmTdze4qpVq7q9vaLbNGjQwO1FPfnkk93e40N17rnnRkZyHiwuUcKjvdgqkBUtWtQuuugi+/nnn5Pd79KlS12ipNGrfpwPP/xwsucfPTJWozk1YvbLL790o36V/Gnv+AcffJBm3yytr08//dT+/PPPyOuh+xLtYVaxs169ei6RVtyKX3vMfYpBcYpfMNLJH3GbUu8vjbzt37+/G+mqxFuP99BDD7mRE9H85zRjxgw744wz3HM6/vjjXXEqM7z77rvuuWkda8+8krZVq1ZFrtd2qVG2En3YlG/w4MHWqFEjK126tLsP3Ze/naVFo6S1rk488UT3nHT7s846yyZNmpTm7Xbt2mUTJ060888/P9l1O3futDvvvNM9D21b2pmg5xL9WkS/HjpkTSMrSpYs6R7b9/rrr0fWifrmXnvttW6kS7xZs2ZZy5Yt3Xah95jea99++23MMv5jaXSM1qU+G7T8TTfd5FpqZIa33nrLxavnrM8MHc43YsSIZDGkty+03qN6Lv79nX766W6kSfxz14h7rTu9J2rVqhXzmP57WIVUrUO9xvXr17ePP/44w9uBWh5ofelzRO+VChUq2GWXXZYsbo0U0Xs4J7RrAQDkPun9HZFST1v/O135onIh5aW6n1tuucXlsps3b3ajKfW9rZP6wEePlE2tp2x6e5hqh7p+EyhOfVcr/9aAjviYlfPrN4KfT/qjT1N7/IPlqaL1oN9LulwFVv2t568irEbRpkW5owq1KlwOHDgw2fWXXHKJG/Ws3DP6t1h8bpnS66J1plG2ohHU/nP2n2N6f7ekN49La/1mVk/b1GRWzgcgezDSFrmW+k/psHQdZq+iaWrUM6ljx46uCKe9uKLinejLVkVBFUuUUOmwJ41g1RemX2yNpsKoEhMVFqN7Lm3atMklAio4KWFQ4qS/33jjDevWrZvdeuutrmClREVfsipKqUiTUf4h+PriPVhcet5KfFq0aGFPPPGEK1opLn1hq1DtF0pVbNY60HPX+tHlepxPPvnEjUJIy6+//mrXXHONe356LCWRev5KtlTUSYmKwf/995/9/fffNmzYMHeZ3yt1y5Yt9uKLL7q2EDr0euvWrfbSSy+55zB79myXZOl56nl06dLF9fjVYVWiQlZq9PqraK91f88997gimJJFtZz48MMPY5ZVwU/LdejQwT2nl19+2SWESmKV3B8qJXsqhqkop8det26dK7yp8KjXw0/2V69e7RIqvX7xtLyKozfccIP7UaACotb3hAkTXEE+NUpA9Zj++0DrWaOBf/jhh1RfJ5k3b557HI34jqd1opES//vf/9zEVHq/pBWD4lTiqP7S/g8XbV+PPPKI22Gg2DZs2OD6yKnHmb9OZMqUKW7Hil4DtcTQCBH/B4sOp9Nziqb70+Fkes56jtqm9MNG7wOftkEltAejRNffPvW6aNvUjh3/vrQN6TW866677FC2iZtvvtltVz169HDPV89b7x99XviPqc8WFU/1GDp8U4+p19x/TH2O+aOhH3zwQVfY1WujH1Pvv/++e5+kdzvQ4Xm6P/Uw1meBRhsphpUrV0Y+M0Svhei516lTJ8PPHQCAMPyOSIu+K/W9rOKYioyjR4923+VqvaC2C8p5NFeB8n89Rvxh8YdKebByB+WEOrpMObt+C6jtQdeuXd0ymjvCn4/AH4iRVsuB9OSpPhVnlZvrd5IGFGhAypAhQ9zvK+XnqVGRW7+ZlL+kdlSc1pFyPOU5yi/TS7mjCuhPPfWUG5hRrVo1d7n//6H+bklNRtdv9IAItXmLpt+E6R3NnZk5H4Bsop62QG705Zdfennz5nWnhg0bevfff7/3xRdfeHv27Em2bJEiRbx27dolu7x169ZegQIFvN9++y1y2erVq72iRYt655xzTuSyMWPGqMrknXXWWd6+ffti7qNJkybuunHjxkUuW7p0qbssT5483vfffx+5XPHpct1fWlasWOGW69u3r7dhwwZv7dq13rRp07w6deq4y99///0049q6datXokQJr1OnTjH3q/spXrx4zOV6nnq+f/75Z8yyBw4cSPb8FZevcuXKMbHIf//951WoUMHF6Zs6dapbTv/7LrroInf7eHoOu3fvjrls06ZNXrly5bybb745cpnWie6zd+/eye5Dl0V/NC5YsMCd79ixY8xy9957r7t8ypQpyZ7T9OnTI5etX7/eK1iwoHfPPfd46TVnzpyY11nbZNmyZb2aNWt6O3fujCw3YcIEt1yvXr0il3Xt2jUm/mg7duyIOa/71X2ee+65MZfreURv77Vr13brPKNefPFFF8vChQtjLp83b567vFu3bjGXt2/fPtnr4r8e1113Xcyyf/zxh3vvDhgwIOZyPVa+fPkil2s7PPHEE70WLVrEbJNaF1WqVPGaN2+e7LGitxW5/PLLvdKlS6f4vj3YKXo93nXXXV6xYsWSfQaktf2l9h7avHmze981aNAgZpvwn7PocfQc9XrqfZDSMnLeeed5p556qrdr166Y6xs1auTWXXq3Az2GYhw0aJCXHvrs7NKlS7qWBQAgrL8j4vMq/zs9PjfR/SQlJXm33npr5DJ9lx9zzDEu70grN47O/6N/J6SUV8Tng6JYjj/++JjLatSoEfO4qT1+RvJUrQdd1q9fv5j7VO5fr149Ly3Dhw93t/3www9TXWbjxo1umSuuuCJyWWo5f/zr8u6776a4XjPyuyW9eVxa6zc1qeWa/uut+4q+v5S2h8zK+QBkH9ojINfSXkLtIdde5h9//NH1SNJeX+15jD9EJCXaS6xDZLRnUofA+zSiTaPctDdYeyWjafRnSr1dtZdVI2t9ai+gPdLauxs9Wtf/+/fff0/Xc9SoQo0s1V58jf7VCFiN8PNHl6YWl0bG6dAsjQrU3lz/pGUUg99uQCMbp0+f7kb7aURAtPT0qaxYsWJkj65oxLL2kGuP/KHMLK/4/H5OGi2wceNG19pAh/1oz/Ch0AgH6d69e8zlGnEratUQTYdKRU8epvWv1zO9r1lKtGdbIxY1CiK6h5hGpp5yyinJYkiNDlfzaaSCRosq1oOtG22L2jOvEQYZ8e+//7r/dWhfNI1IED2faBpxkBqNaoimw9H0GmtUbPQ2qm1dI3L9bVSH3ytuvScVj7+cRpRrxKu2X91PWo+ldaTbRr+fNSJE75ODnTQCP3o96nEz49Ay3YdGkmuURHxfOf+9p/eRWqFotH784Zv+MnqPaCSy1qPuz18/er76PNS68w9tPNh2oO1L7z8dSqjt62C0XcSPFgEAIDf8jhAdlRWdLyvHVm1Ol0fntspjDyePTCsfVC6o72K1WtJj6Hx25Kkp5VoHe47KUyStow396+J/g2WGzP7dcijUcio+19R2lx6ZmfMByD60R0CupkN4VPzRIdxKuHSouw651+HtKvaoAJcaFSzVMkAFuXgqtqoQpDYG0YfE65DrlKj/Y3yRU700K1WqlOwySU9BRNSuQIft6HBwffkqlpQOn4mPy/+C9nvgxlOSIn5ydaiHhal3b/zzVp8qUc8nFeAySm0MVFBTv6bow9dTW/cHo76bWn+KNZpi0zrV9dHii9d+cSq9r1lqMUhK25qSYe0gSA8dKvboo4+6bTu6H+/BCuz9+vVzSaJeG73W6g2rtgZptZSIFj9jsb9O41+T+HV8sG1U96sCbUr8GZr9bVmHsaVGP1CiC8vxr6F/nV5Df9v3D+/PCP2Y0SFoatWgH3UXXHCBS5y1Pg+11Ula7730LKN2HlqPajOhU0r0Q0zxHmw70GeLdgpph4YO8dNhiWrNoB80Kb2X9bhMQgYAyI2/I1LKN/w8P6X8/3DyyHhqWaCBHSo6x/fsV07kx5FVeaoKu/78EhnJlf2CrF+8PdTC7qHKit8tGaXfjCnNFZEemZnzAcg+FG2B/3+2TSVeOunLST2Z1ExfCU1mit6zHS2l0bdpXR5fBEuNClrp+WKPj8sfeai+qCklIKn1kUo0TUqlXqka/Xzfffe5PqRah+rJ5BewDlV6i0uH+5plFfVu1WgQ9ex67rnn3IhwFTbVjyt+4qp4uo3W30cffeRGl6vHq36UjBo1yvW6So3fO1lJePQEd4cipW1Ur4km4kpt9Lq/nKgfnHoap8RfNiOvoUYr6EdaeuL2f/xoe9SPuC+++MLFrZPWv4qa2tmQ1nZ2sMk5DpW/fjQBSGojNfxienq2A43q1UQg48ePd89TPwr0/tPIjvjetRrNr4lKAADIjb8jMpL/R+cgh5Mr6HtcRxqpmDp06FBXIFb8OrJM3+nxRx9lhdSe98H4/WU1n4Zy/ZToOjlYwTyrcqvszuMSmfMByB7BrLwACaRDkGTNmjVpfgFrD7FmoV+2bFmy6zTKUyMJ4/eUh4U/0ZqKTGkVff22EJqE4XD2+Eav319++cX9Hz1pUXoTovfee8/FpFEP0cvEJ80ZGd2niSaU5GjEZvRkBJpgQUUnXZ/V/MfQthY/+lmXRceQ2nPT5AIa2aBCWvRoaxUN00MzzOpHiE7btm1zyZwmKUgrcdMPAtEh+qeeemqydarLo0fKanvIyDaqbUcjcP1RDqktJxohe6gjE1KiFiOaPO1gNMI3ehZn/TBSUVMnrQONvtXkhSpuKlH2R/Vq24puaRA/ott/XnrvpTZCOXqZ1J67/x5WAT896yc924EeV6NtddL7RsVyjX7XThWfDr9T0Tv6PQUAQE78HZHZonOFaPG5Qko06ZiOtlILh+iRvn5bqUPJlzOSpx4OTYas3EiDDTR5V0rF31dffdX9ryN9otdX/LpSDhL/Gh3s+abnd0t687j0PF5my4qcD0DWo6ctci0lJymNfvR7mEYf4qOZNeO/7JUo6PBm7YHUITHRxTwlE0os/EOpw0Z7XxW7Zq2NbjEQ3RrCL1zrC/zll192s8NndGTp6tWr3aFkPvWfUrKlIk9ahxjp9Uip55afvEU/9qxZs9zhX9FUbJf41zQlrVq1iszyGk2jE/x+XdnxA0AFdO3djm5roJGaS5YsiYlB60ZS2l6VHEbv6dd2qxGR6e1NGz0yVYXC6FhSohYCKlKq11k0f+++RvxGe/rppy0jRVM9J824HL+t6bwfs2JQEVGzEyvhTG1bzqhD6Wkbvx61Y8c/zMxfl36hVb12feqD64/E9emzR4f+aRSrZhKOf/5St25dV9TWthu/PfjLaLtSv2sVjlP6gRm9fg62HegQy/hY9HwUZ/y2Mm/ePPd/o0aNkj0mAAA56XdEZlMRVDlQdK6QUl6VkpRyZeXUKe3ET+n3z+HmqYdD+btGiaoQrKJtPPXO1Y5y5Zlq0RSdi8Svq9GjRycb/ZpaDp2R3y3pzeMysn4zS2bmfACyDyNtkWtp0iMVGdRQXiMCtcd15syZ9vbbb7u9pdqr6FPh56uvvnKFOjWhVyFEkwWoP6gKMyrQasSc2gboi1BfaJqQIKxUsB05cqTrXaTCjyZJU4FWhVklRI0bN7ZnnnnGLfvUU0+556/l1ENX60bFQC2nQ8HTohGSmmxhzpw5rgemir8qeh9s9KdeD71OmhxMh6IpkdDIRe1V1yhbvaZKEDWSUwmkDpGKLtjpkHVdpvtQDNqTrH5NKfX+rF27thstqeROiZUmapg9e7ZLvnRoVrNmzSyraY+4eoVqm9Tja4I4racRI0a4bfXuu++OWTdy5513uqRVybleP60Pbb/qSaVJudSz6tlnn3UJmH8oWWq0rpTk6b61rlSE1ajm22+/Pc3baWSviot676g3VnSMbdq0ccVEJYVKrDVq1R+tkJ6RB0qK9f7r0aOH2970Wqg4qNdcCbW2RSX2KozqkC71kVVPZ61D9erSSE/94NK2rlEnGXUoPW01MkFtFTQKRe0iNOpChWol+/6IU60vjXzR+0ItPvT66X3hv/98iluHqek+9R7Qa6rRHeqpp881bZ967nof672hx9BzV1sMHQmgySU06lq0Heg9rNHQmpRQIzG0fWlnx99//+3uMz3bgV4/HXKpPr1aVp+Hei10X9ETLYo+N/U841smAACQ035HZDa1XdKcFcohlDMpJ9K8BcrtDkZ5hn/Uzy233OLy4xdeeMEV9OILefq+Vx6hfEv5opZJab6LjOSph0sTsGriLz2e8hTlk8rr1TdXR/Qon4ovkCpX0sRnWlYTyCmvUQ4U36JJuZLyLt23Ctk6Mk3PV887vb9b0pvHZWT9ZqbMyvkAZCMPyKU+//xz7+abb/ZOOeUU78gjj/QKFCjgVa1a1bvjjju8devWxSy7dOlS75xzzvEKFy6s3dJeu3btItf98MMPXosWLdx9HHHEEV6zZs28mTNnxtx+zJgx7nZz5sxJFkeTJk28GjVqJLu8cuXK3kUXXZTsct1P165d03xuK1ascMsNGjQozeXSikumTp3qnlvx4sW9QoUKeSeccILXvn17b+7cuTHLLVq0yLv88su9EiVKuOVOPvlk75FHHkn2OIor/vl98cUXXq1atbyCBQu61+Ldd99NFoNuq/9927Zt866//nr3eLpO9yUHDhzwHnvsMXde91enTh1vwoQJ7vXyl/HpNapXr5573XUfvXv3dpfr//iPxr1793p9+/b1qlSp4uXPn9+rVKmS16NHD2/Xrl3pes30GuuUXno9FIPWW7S3337bPSc9t1KlSnk33HCD9/fff8css2/fPrcNlylTxktKSop5Li+99JJ34oknRta17j+l56vnEb2NP/roo94ZZ5zh1rfeA7rtgAEDvD179hz0uXzwwQcujpUrV8Zcvn37drcd63novdO6dWtv2bJlLpbHH388spwf34YNG1K8//fff98766yzvCJFiriTYtP96r6izZ8/37viiiu80qVLu+ev53j11Vd7kydPPuhjpbT9Hor33nvPu+CCC7yyZcu67e7YY4/1brnlFm/NmjUxy82bN89r0KBBZJmhQ4emGsPHH3/sNWrUyL0uxYoVc6/Tm2++GbPMjBkzvObNm3tFixZ160jvt6effjpmmd9++81r27atV758ebeNH3300d7FF1/sYk7vdvDPP/+4da/L9Tj63NDzeOedd2Iea//+/V6FChW8nj17Htb6BAAgDL8j4vOq1PLv1PIQ3Vbfq9G0TJs2bdxvj5IlS7p8Qvl4fP6YUp6n3EG5gHL24447znviiSe8l19+OVmesXbtWpfXKn/QdX4um1Junt48NaXnklqcqVEeoefYuHFjl/voeei3lHJ1/UZIafkHHnjAO+qoo9z60m+b5cuXJ3td5IUXXvCOP/54L2/evDHPMb2/WzKSx6W2flNzsN+A8b83/N+D8b8nMiPnA5B9kvRPdhaJAUC0510jWzUyADmXDj3T3nqNvuzfv3+ay2pktkZeaqTEDTfckG0xInupJYdGBmuCC438BQAACDJ+twBIFHraAgCyjA4LU2sEHY4V3aJi586dyZZVuwQd0q8+yci5dNihDq+jYAsAAAAAqaOnLQAgS11zzTXuFE09nzUZlXoCq/epJqvQSb1oK1WqlLBYkfXiJwYEAAAAACRH0RYAkO0aNWrkJqNSywSNwNWkDX369ElxNmAAAAAAAHIbetoCAAAAAAAAQIDQ0xYAAAAAAAAAAoSiLQAAAAAAAAAESK7raXvgwAFbvXq1FS1a1JKSkhIdDgAAQK6nbl1bt261ihUrWp48jCnIbOS/AAAA4ct9c13RVgkrM5MDAAAEz19//WXHHHNMosPIcch/AQAAwpf75rqirUYY+CumWLFiiQ4HAAAg19uyZYsrKvp5GjIX+S8AAED4ct9cV7T1DwlTwkrSCgAAEBwcup81yH8BAADCl/vSNAwAAAAAAAAAAoSiLQAAAAAAAAAECEVbAAAAAAAAAAgQirYAAAAAAAAAECAUbQEAAAAAAAAgQCjaAgAAAAAAAECAULQFAAAAAAAAgAChaAsAAAAAAAAAAULRFgAAAAAAAAAChKItAAAAAAAAAAQIRVsAAAAAAAAACBCKtgAAAECc6dOn2yWXXGIVK1a0pKQkGz9+fMz1nudZr169rEKFCla4cGE7//zz7ddff41ZZuPGjXbDDTdYsWLFrESJEtahQwfbtm1bzDI//fSTnX322VaoUCGrVKmSPfnkk8lieffdd+2UU05xy5x66qn22WefZdGzBgAAQFBQtAUAAADibN++3WrXrm3PPvtsiteruPrUU0/ZqFGjbNasWVakSBFr0aKF7dq1K7KMCrY///yzTZo0ySZMmOAKwZ07d45cv2XLFrvggguscuXKNm/ePBs0aJD16dPHRo8eHVlm5syZdt1117mC7/z5861169butGjRoixeAwAAAEikJE/DBHIRJcfFixe3//77z416AAAAQGIFPT/TSNsPP/zQFUtF6bNG4N5zzz127733ussUe7ly5Wzs2LF27bXX2pIlS6x69eo2Z84cq1+/vltm4sSJ1qpVK/v777/d7UeOHGkPP/ywrV271goUKOCWefDBB92o3qVLl7rz11xzjSsgq+jrO/PMM+20005zBeOcsH4BAAByky3pzM3yZWtUAAAAiFF/9P8V9IJmbue5iQ4hsFasWOEKrWqJ4FPi3aBBA/vuu+9c0Vb/qyWCX7AVLZ8nTx43Mvfyyy93y5xzzjmRgq1otO4TTzxhmzZtspIlS7plunfvHvP4Wia+XUO03bt3u1P0DwM5cOCAOwEAkBkavNjAgmhWx1mJDgFIU3rzMYq2AAAAQAaoYCsaWRtN5/3r9H/ZsmVjrs+XL5+VKlUqZpkqVaokuw//OhVt9X9aj5OSgQMHWt++fZNdvmHDhpj2DQAAHI6qBapaEK1fvz7RIQBp2rp1q6UHRVsAAAAgB+nRo0fM6FyNtNUkZ2XKlKE9AgAg0yzfs9yCKH6nKRA0mlw2PSjaAgAAABlQvnx59/+6deusQoUKkct1Xr1m/WXiR/rs27fPNm7cGLm9/tdtovnnD7aMf31KChYs6E7x1JpBJwAAMoNnwZwiie86BF16t1G2ZAAAACAD1NJARdPJkyfHjGZVr9qGDRu68/p/8+bNNm/evMgyU6ZMcT3M1PvWX2b69Om2d+/eyDKTJk2yk08+2bVG8JeJfhx/Gf9xAAAAkDNRtAUAAADibNu2zRYsWOBO/uRj+nvlypWWlJRk3bp1s0cffdQ+/vhjW7hwobVt29YqVqxorVu3dstXq1bNWrZsaZ06dbLZs2fbt99+a7fffrubpEzLyfXXX+8mIevQoYP9/PPP9vbbb9uIESNiWhvcddddNnHiRBsyZIgtXbrU+vTpY3PnznX3BQAAgJyL9ggAAABAHBVGmzVrFjnvF1LbtWtnY8eOtfvvv9+2b99unTt3diNqzzrrLFdcje5R9sYbb7ji6nnnnecOg2vTpo099dRTkeuLFy9uX375pXXt2tXq1atnRx11lPXq1cvdp69Ro0Y2btw469mzpz300EN24okn2vjx461mzZrZti4AAACQ/ZI8zwtmE5IsokPXlCD/999/TMQAAAASrv7o+hZEczvPzbbHIj/LWqxfAEBWIIcBsjY3oz0CAAAAAAAAAAQI7REAAAAAAMjFGDEJAMFD0RYAAAAAcgAKbwAA5By0RwAAAAAAAACAAKFoCwAAAAAAAAABQtEWAAAAAAAAAAKEoi0AAAAAAAAABAhFWwAAAAAAAAAIEIq2AAAAAAAAABAgFG0BAAAAAAAAIEAo2gIAAAAAAABAgFC0BQAAAAAAAIAAoWgLAAAAAAAAAAFC0RYAAAAAAAAAAiShRduBAwfa6aefbkWLFrWyZcta69atbdmyZWneZuzYsZaUlBRzKlSoULbFDAAAAAAAAAA5tmj79ddfW9euXe3777+3SZMm2d69e+2CCy6w7du3p3m7YsWK2Zo1ayKnP//8M9tiBgAAAAAAAICslM8SaOLEiclG0WrE7bx58+ycc85J9XYaXVu+fPlsiBAAAAAAAAAAclHRNt5///3n/i9VqlSay23bts0qV65sBw4csLp169pjjz1mNWrUSHHZ3bt3u5Nvy5Yt7n/dVicAAIBESrIkC6LszJPIyQAAAICAFm2VrHfr1s0aN25sNWvWTHW5k08+2V5++WWrVauWK/IOHjzYGjVqZD///LMdc8wxKfbN7du3b7LLN2zYYLt27cr05wEAAJARVQtUtSBav359tj3W1q1bs+2xAAAAgDAITNFWvW0XLVpkM2bMSHO5hg0bupNPBdtq1arZ888/b/3790+2fI8ePax79+4xI20rVapkZcqUcb1xAQAAEmn5nuUWRGpZlV2YVBYAAAAIYNH29ttvtwkTJtj06dNTHC2blvz581udOnVs+fKUf/AULFjQneLlyZPHnQAAABLJM8+CKDvzJHIyAAAAIFZCM2TP81zB9sMPP7QpU6ZYlSpVMnwf+/fvt4ULF1qFChWyJEYAAAAAAAAAyDUjbdUSYdy4cfbRRx9Z0aJFbe3ate7y4sWLW+HChd3fbdu2taOPPtr1ppV+/frZmWeeaVWrVrXNmzfboEGD7M8//7SOHTsm8qkAAAAAAAAAQPiLtiNHjnT/N23aNObyMWPGWPv27d3fK1eujDlkbtOmTdapUydX4C1ZsqTVq1fPZs6cadWrV8/m6AEAAAAAAACkV/3R9S2I5naea0GTL9HtEQ5m2rRpMeeHDRvmTgAAAAAAAACQEzHrAwAAAAAAAAAECEVbAAAAAAAAAAgQirYAAAAAAAAAECAUbQEAAAAAAAAgQCjaAgAAAAAAAECAULQFAAAAAAAAgAChaAsAAAAAAAAAAULRFgAAAAAAAAAChKItAAAAAAAAAAQIRVsAAAAAAAAACBCKtgAAAAAAAAAQIBRtAQAAAAAAACBAKNoCAAAAAAAAQIBQtAUAAAAAAACAAKFoCwAAAAAAAAABQtEWAAAAAAAAAAKEoi0AAAAAAAAABAhFWwAAAAAAAAAIEIq2AAAAAAAAABAgFG0BAAAAAAAAIEAo2gIAAAAAAABAgFC0BQAAAAAAAIAAoWgLAAAAAAAAAAFC0RYAAAAAAAAAAoSiLQAAAAAAAAAECEVbAAAAAAAAAAgQirYAAAAAAAAAECAUbQEAAAAAAAAgQCjaAgAAAAAAAECAULQFAAAAMmj//v32yCOPWJUqVaxw4cJ2wgknWP/+/c3zvMgy+rtXr15WoUIFt8z5559vv/76a8z9bNy40W644QYrVqyYlShRwjp06GDbtm2LWeann36ys88+2woVKmSVKlWyJ598MtueJwAAABKDoi0AAACQQU888YSNHDnSnnnmGVuyZIk7r2Lq008/HVlG55966ikbNWqUzZo1y4oUKWItWrSwXbt2RZZRwfbnn3+2SZMm2YQJE2z69OnWuXPnyPVbtmyxCy64wCpXrmzz5s2zQYMGWZ8+fWz06NHZ/pwBAACQffJl42MBAAAAOcLMmTPtsssus4suusidP+644+zNN9+02bNnR0bZDh8+3Hr27OmWk1dffdXKlStn48ePt2uvvdYVeydOnGhz5syx+vXru2VU9G3VqpUNHjzYKlasaG+88Ybt2bPHXn75ZStQoIDVqFHDFixYYEOHDo0p7gIAACBnYaQtAAAAkEGNGjWyyZMn2y+//OLO//jjjzZjxgy78MIL3fkVK1bY2rVrXUsEX/Hixa1Bgwb23XffufP6Xy0R/IKtaPk8efK4kbn+Muecc44r2Po0WnfZsmW2adOmbHu+AAAACPBI282bN9uHH35o33zzjf3555+2Y8cOK1OmjNWpU8clj0peAQAAgJzuwQcfdK0LTjnlFMubN6/rcTtgwADX7kBUsBWNrI2m8/51+r9s2bIx1+fLl89KlSoVs4z65sbfh39dyZIlk8W2e/dud/IpTjlw4IA7IedKsiQLIra74GPbwaFgu8GhYLuxdD9Wuoq2q1evdpMo6PAsHaZ1xhln2GmnneYmVNDkCVOnTnWHcKnXVu/eve2aa6453PgBAACAwHrnnXdcbjxu3LhIy4Ju3bq5XLldu3YJjW3gwIHWt2/fZJdv2LAhpp8ucp6qBapaEK1fvz7RIeAg2HZwKNhucCjYbsy2bt2aeUVbjaRV8qnJD6pXr57iMjt37nT9udS766+//rJ77703YxEDAAAAIXHfffe50bbqTSunnnqqOxJNBVPlzeXLl3eXr1u3zipUqBC5nc5r8INomfgfCPv27XODIvzb63/dJpp/3l8mXo8ePax79+4xI20rVarkjpArVqxYJq0BBNHyPcstiOJHlCN42HZwKNhucCjYbswKFSqUeUXbxYsXW+nSpdNcRqNur7vuOnf6999/0xclAAAAEEJqE6bes9HUJsE/3E0tDVRUVd9bv0ir4ql61Xbp0sWdb9iwoWs/poER9erVc5dNmTLF3Yd63/rLPPzww7Z3717Lnz+/u2zSpEl28sknp9gaQQoWLOhO8RRvfMzIWTzzLIhyw3ZXf/T/600dJHM7z03Xcmw7OBRsNzgUbDeW7sdK11IHK9ge7vIAAABAmFxyySWuh+2nn35qf/zxh5v3YejQoXb55Ze765OSkly7hEcffdQ+/vhjW7hwobVt29a1T2jdurVbplq1atayZUvr1KmTzZ4927799lu7/fbb3ehdLSfXX3+9m4SsQ4cO9vPPP9vbb79tI0aMiBlJCwAAgJwnw2XkV155xSWnvvvvv9/NeqtJyHRIGAAAAJDTPf3003bllVfabbfd5oqvag12yy23WP/+/WPy5DvuuMM6d+5sp59+um3bts0mTpwYc0ic+uJqMrPzzjvPWrVqZWeddZaNHj06cn3x4sXtyy+/tBUrVrjRuPfcc4+ba0L3CQAAgJwrXe0Roj322GM2cuRI9/d3331nzz77rA0bNswmTJhgd999t33wwQdZEScAAAAQGEWLFnVzOeiUGo227devnzulplSpUm4ys7TUqlXLvvnmm8OKFwAAADm8aKtJxqpW/b+Z3jTxWJs2bdye/saNG1vTpk2zIkYAIRT2vl4AAAAAAAChaY9w5JFHRiYa06FazZs3d3/rMK+dO3dmfoQAAAAAAAAAkItkeKStirQdO3a0OnXq2C+//OJ6b4kmRjjuuOOyIkYAAAAAAAAAyDUyPNJWPWwbNmxoGzZssPfff99Kly7tLp83b55dd911WREjAAAAAAAAAOQaGR5pW6JECXvmmWeSXd63b9/MigkAAAAAAAAAcq0Mj7QVzV574403WqNGjWzVqlXustdee81mzJiR2fEBAAAAAAAAQK6S4aKtWiK0aNHCChcubD/88IPt3r3bXf7ff//ZY489lhUxAgAAAAAAAECukeGi7aOPPmqjRo2yF154wfLnzx+5vHHjxq6ICwAAAAAAAADIxqLtsmXL7Jxzzkl2efHixW3z5s2HEQoAAAAAAAAAIMNF2/Lly9vy5cuTXa5+tscff3xmxQUAAAAAAAAAuVKGi7adOnWyu+66y2bNmmVJSUm2evVqe+ONN+zee++1Ll26ZOi+Bg4caKeffroVLVrUypYta61bt3YjeQ/m3XfftVNOOcUKFSpkp556qn322WcZfRoAAAAAAAAAkDOKtg8++KBdf/31dt5559m2bdtcq4SOHTvaLbfcYnfccUeG7uvrr7+2rl272vfff2+TJk2yvXv32gUXXGDbt29P9TYzZ8606667zjp06GDz5893hV6dFi1alNGnAgAAAAAAAACBky+jN9Do2ocfftjuu+8+1yZBhdvq1avbkUcemeEHnzhxYsz5sWPHuhG38+bNS7FvrowYMcJatmzpHl/69+/vCr7PPPOMmyANAAAAAAAAAHJV0dZXoEABV6zNTP/995/7v1SpUqku891331n37t1jLmvRooWNHz8+xeV3797tTr4tW7a4/w8cOOBOALJGkiVZEPG+BxA0fF7y2QwAAAAcdtFWrQsef/xxmzx5sq1fvz5Zkv3777/bodD9dOvWzRo3bmw1a9ZMdbm1a9dauXLlYi7TeV2eWt/cvn37Jrt8w4YNtmvXrkOKFcDBVS1Q1YJIn1sAECR8Xppt3bo12x4LAAAAyJFFW/WvVS/a//3vf1ahQgXXLiEzqLet+tLOmDHDMlOPHj1iRuZqpG2lSpWsTJkyVqxYsUx9LAD/z/I9yy2I1IIFQHINXmxgQTSr4yzL6fi8NDe5LAAAAIDDKNp+/vnn9umnn7oRsZnl9ttvtwkTJtj06dPtmGOOSXPZ8uXL27p162Iu03ldnpKCBQu6U7w8efK4E4Cs4ZlnQcT7HkgZ79nEYd3njtcZAAAAyIgMZ8glS5ZMs+dsRnie5wq2H374oU2ZMsWqVKly0Ns0bNjQtWaIponIdDkAAAAAAAAA5Lqibf/+/a1Xr162Y8eOTGmJ8Prrr9u4ceOsaNGiri+tTjt37ows07ZtW9fiwHfXXXfZxIkTbciQIbZ06VLr06ePzZ071xV/AQAAAAAAACBXtEeoU6dOTO/a5cuXu8m/jjvuOMufP3/Msj/88EO6H3zkyJHu/6ZNm8ZcPmbMGGvfvr37e+XKlTGHzDVq1MgVeXv27GkPPfSQnXjiiTZ+/Pg0Jy8DAAAAAAAAgBxVtG3dunWWPLjaIxzMtGnTkl121VVXuRMAAAAAAAAA5Mqibe/evbM+EgAAAAAAgAyoP7q+BdHcznMTHQKA3FC0jTZnzhw7cOCANWjQIObyWbNmWd68ea1+/WB+YAIAACDnU2utP//8082/UKZMGatRo4YVLFgw0WEBAAAAWTsRmSYP++uvv5JdvmrVKncdAAAAkJ3++OMPe+CBB6xy5cpWpUoVa9KkiV144YVuMEHx4sWtefPm9u6777qBBwAAAECOHGm7ePFiq1u3boqTlek6AAAAILvceeed9sorr1iLFi3s0UcftTPOOMMqVqxohQsXto0bN9qiRYvsm2++sV69elnfvn3dhLenn356osMGACCw7R1o7QCEtGirw8vWrVtnxx9/fMzla9assXz5Mnx3AAAAwCErUqSI/f7771a6dOlk15UtW9bOPfdcd9IcDRMnTnRHjFG0BQAAQNBluMp6wQUXWI8ePeyjjz5yh5vJ5s2b7aGHHnKHngEAAADZZeDAgeletmXLllkaCwAAAJCwou3gwYPtnHPOcT3D1BJBFixYYOXKlbPXXnst0wIDAAAADseePXvc6cgjj0x0KAAAAEDWTkR29NFH208//WRPPvmkVa9e3erVq2cjRoywhQsXWqVKlTJ6dwAAAMBhU6/aO+64w9544w13XkeGFS1aNDIR2b///pvoEAEAAIB0y3eovcM6d+58KDcFAAAAMtWAAQPcqXHjxjZu3DibMWOGjR8/3vr162d58uSxp556ynr27GkjR45MdKgAAAA5cgI7YRK7ABRtf/31V5s6daqtX7/eDhw4EHOdZuYFAAAAssvYsWPtpZdesuuuu87mzp1rDRo0sHfeecfatGnjrq9Zs6bdeuutiQ4TIcEPYQAAEMqi7QsvvGBdunSxo446ysqXL29JSUmR6/Q3RVsAAABkp5UrV9pZZ53l/q5fv77ly5fPFWp9tWrVsjVr1iQwQgAAACCLi7aPPvqoO/zsgQceyOhNAQAAgEy3d+9eK1iwYOR8gQIFLH/+/JHzKuLu378/QdEBAAAA2VC03bRpk1111VWH8FAAAABA1li8eLGtXbvW/e15ni1dutS2bdvmzv/zzz8Jjg4AAADI4qKtCrZffvklfcEAAEAg0H8Sct5557lire/iiy+OtO/S5dEtvQAAAIAcV7StWrWqPfLII/b999/bqaeeGnPomdx5552ZGR8AAACQphUrViQ6BAAAACCxRdvRo0fbkUceaV9//bU7RdMIBoq2AAAAyE6VK1dOdAgAAABAYou2jGQAAABAkKxcuTJdyx177LFZHgsAAACQkKItAAAAECRVqlSJ/O33tY3uYev3tN2/f39C4gMAAACypGjbvXt369+/vxUpUsT9nZahQ4dmOAgAAADgUKkge8wxx1j79u3tkksusXz5GJeQaEwQCAAAcHjSldHOnz/f9u7dG/k7NczKCwAAgOz2999/2yuvvGJjxoyxUaNG2Y033mgdOnSwatWqJTo0AAAAIOuKtlOnTk3xbwAAACDRypcvbw888IA7zZgxwxVvGzRoYNWrV3fFW53y5MmT6DABHAQjtAEA+H/IXgEAAJBjnHXWWfbSSy/Zr7/+akcccYTdeuuttnnz5kSHBQAAAGR+0VbJrg47S4+3337b3njjjYxFAQAAAGSCmTNnWseOHe2kk06ybdu22bPPPmslSpRIdFgAAABA5rdHKFOmjNWoUcMaN27sJneoX7++VaxY0QoVKmSbNm2yxYsXu0PR3nrrLXf56NGjMxYFAAAAcIjWrFljr776qmuLoNz0hhtusG+//dZq1qyZ6NAAAACArCva9u/f326//XZ78cUX7bnnnnNF2mhFixa1888/3xVrW7ZseWiRAAAAAIfg2GOPtaOPPtratWtnl156qeXPn98OHDhgP/30U8xytWrVSliMAAAAQKYXbaVcuXL28MMPu5NGMKxcudJ27txpRx11lJ1wwgmWlJSUoQcGACAnYfIUIHH279/vclMNNHj00UfdZZ7nxSyjXFXLAQAAADmqaButZMmS7gQAAAAk2ooVKxIdAgAAAJD4oi0AAAAQFJUrV050CAAAAECmypO5dwcAAABkH7VFyIhVq1ZlWSwAAABAZqFoCwAAgNA6/fTT7ZZbbrE5c+akusx///1nL7zwgtWsWdPef//9bI0PAAAAOBS0RwAAAEBoLV682AYMGGDNmze3QoUKWb169axixYrub02eq+t//vlnq1u3rj355JPWqlWrRIcMAAAAHBRFWwAAAIRW6dKlbejQoa5w++mnn9qMGTPszz//tJ07d9pRRx1lN9xwg7Vo0cKNsgUAAJD6o+tbEM3tPDfRISDMRdt169bZvffea5MnT7b169eb53kx1+/fvz8z4wMAAAAOqnDhwnbllVe6EwAAAJDrirbt27d3Ez488sgjVqFCBUtKSsqayAAAAAAAAAAgF8rwRGQ65OyNN96wLl26WOvWre2yyy6LOQEAAAC5wapVq+zGG290LRo00vfUU0+1uXP/32GNOiKtV69ebqCDrj///PPt119/jbmPjRs3uhYOxYoVsxIlSliHDh1s27ZtMcv89NNPdvbZZ7s+vZUqVXK9eQEAAJCzZbhoq0QxviUCAAAAkJtokrPGjRtb/vz57fPPP3cTng0ZMsRKliwZWUbF1aeeespGjRpls2bNsiJFirj+urt27Yoso4KtJkqbNGmSTZgwwaZPn26dO3eOXL9lyxa74IILrHLlyjZv3jwbNGiQ9enTx0aPHp3tzxkAAAABbo8wfPhwe/DBB+3555+34447LmuiAgAAAALsiSeecIMZxowZE7msSpUqkb81yEF5c8+ePSNHo7366qtWrlw5Gz9+vF177bW2ZMkSmzhxos2ZM8fq1/+/CVGefvppa9WqlQ0ePNgqVqzojnDbs2ePvfzyy1agQAGrUaOGLViwwE2+Fl3cBQAAQC4v2l5zzTW2Y8cOO+GEE+yII45wowviD/ECAAAAcrKPP/7YjZq96qqr7Ouvv7ajjz7abrvtNuvUqZO7fsWKFbZ27VrXEsFXvHhxa9CggX333XeuaKv/1RLBL9iKls+TJ48bmXv55Ze7Zc455xxXsPXpcVU01mjf6JG9vt27d7tT9GhdOXDggDtlhyQL5rwX6Xn+xJ750rvdhTn+MMce9vjDHHtQ4w9z7MJ2kzi5Yd1n52Md0khbAAAAIIhee+01145ARVMVPNVWQPmrRsFm5vwLv//+u40cOdK6d+9uDz30kBste+edd7riart27VzBVjSyNprO+9fp/7Jly8Zcny9fPitVqlTMMtEjeKPvU9elVLQdOHCg9e3bN9nlGzZsiGnNkJWqFqhqQbR+/fqDLkPsiYk97PGHOfawxx/m2IMaf5hjF7abxMkN6z4zbN26NWuKtkpCAQAAgKBREVUTf3Xr1s0GDBhg+/fvd5drNKsKt5lZtNUICY2Qfeyxx9z5OnXq2KJFi1zBONH5co8ePVwxOXqkrVo5lClTxk14lh2W71luQRRfJE8JsScm9rDHH+bYwx5/mGMPavxhjl3YbhInN6z7zKDJZbOkaCtKgNWLS324RL21Lr30UsubN++h3B0AAABw2NQP9oUXXrDWrVvb448/HrlcxdV77703Ux+rQoUKVr169ZjLqlWrZu+//777u3z58u7/devWuWV9On/aaadFlokf1bFv3z7Xbsy/vf7XbaL55/1l4hUsWNCd4qntgk7ZwbNgTlycnudP7JkvvdtdmOMPc+xhjz/MsQc1/jDHLmw3iZMb1n12PlaGI1q+fLlLSNu2bWsffPCBO914442ucPvbb78dSqwAAADAYVNLBI14jacC5vbt2zP1sRo3bmzLli2LueyXX35x7RhELQ1UVJ08eXLMiFf1qm3YsKE7r/83b95s8+bNiywzZcoUN4pXvW/9ZaZPn2579+6NLDNp0iQ7+eSTU2yNAAAAgJwhw0Vb9erSJGR//fWX/fDDD+60cuVKl5jqOgAAACARlI8uWLAg2eUTJ050gw4y0913323ff/+9a4+gQQ3jxo2z0aNHW9euXd31SUlJrk3Do48+6iYtW7hwoRv0ULFiRTcSWBRTy5Yt3eRls2fPtm+//dZuv/12N0mZlpPrr7/e9cnt0KGD/fzzz/b222/biBEjYtofAAAAIOfJcHsEzY6rBFUTJPhKly7tDkHTiAMAAAAgEVTIVNFUk215nucKoW+++aabmOvFF1/M1Mc6/fTT7cMPP3T9Y/v16+cKxuqbe8MNN0SWuf/++90I386dO7sRtWeddZYrIEf3MXvjjTdcofa8885zh8q1adPGnnrqqcj1xYsXty+//NI9r3r16tlRRx3l+vbqPgEAAJBzZbhoq8PLUprlbNu2bW4UAAAAAJAIHTt2tMKFC1vPnj1tx44dbpSqRqxqZKpGr2a2iy++2J1So9G2KujqlBoNhNAo3bTUqlXLvvnmm8OKFQAAADm8PYISU+3ZVz8ujWDQSSNvb731VjcZGQAAAJAoGun666+/ugEFa9eutb///tu1FgAAAABydNFWh2upp60mRdChXTqpLULVqlXdKAYAAAAgETSiVRN5yRFHHGFly5Z1f6tFQVqjXQEAAIDQt0coUaKEffTRR24Ew9KlSyOTKKhoCwAAACRKnz59LH/+/K6HbfREXRp127dvX9cLFgAAAMiRRVvfiSee6E4AAABAULz66qtu0q6FCxfa888/z5wLAAAAyLlFW41U6N+/vxUpUiRm1EJKhg4dmu4Hnz59ug0aNMjmzZtna9ascTPwtm7dOtXlp02bZs2aNUt2uW5bvnz5dD8uAAAAciblipp74ZJLLrGmTZva+PHjEx0SAAAAkDVF2/nz59vevXsjf2cW9RerXbu23XzzzXbFFVek+3bLli2zYsWKRc77/cqAePVH17cgmtt5bqJDAAAgx0lKSnL/a/4FTZR79dVXW7169WzUqFGJDg0AAADI/KLt1KlTU/z7cF144YXulFEq0qq3LgAAAODzPC/yt3bwf/bZZ9atW7c0j+QCAAAAgihPRm+gUbFbt25NcdSsrssOp512mlWoUMGaN29u3377bbY8JgAAAIJtzJgxVrx48cj5PHny2FNPPWWjR4+2tm3bJjQ2AAAAIEsnInvllVfs8ccft6JFi8ZcvnPnTjfxw8svv2xZRYVaHd5Wv3592717t7344ouuV5n6ltWtWzfF22g5nXxbtmxx/x84cMCdkLMl2f8dJhk0uWHbY90jtwn7Nh/m+MMce06IP0iP1a5duxQvv+mmm9wJAAAAyHFFWxU7dciZThppW6hQoch1+/fvd4efZXVv2ZNPPtmdfI0aNbLffvvNhg0bZq+99lqKtxk4cKD17ds32eUbNmywXbt2ZWm8SLyqBapaEK1fv95yOtY9cpuwb/Nhjj/MseeE+DNDSkdxpZdG0nbu3Nnlpvo7rX63d9xxxyE/DgAAABDIoq16yCrZ1emkk05Kdr0uT6k4mtXOOOMMmzFjRqrX9+jRw7p37x5TfK5UqZKVKVMmZjIz5EzL9yy3IMoNk+ex7pHbhH2bD3P8YY49J8SfGaIHA2SUdt7fcMMN7j70d2oo2gIAACBHFm01AZlG2Z577rn2/vvvW6lSpSLXFShQwCpXrmwVK1a07LZgwQLXNiE1BQsWdKd46nGmE3I2z/7fhCRBkhu2PdY9cpuwb/Nhjj/MseeE+BP9WCtWrEjxbwAAACBXFG2bNGkSSYY1UjUzEvlt27bZ8uX/b3SJ7ltFWBWEjz32WDdKdtWqVa5XrgwfPtyqVKliNWrUcK0N1NN2ypQp9uWXXx52LAAAAMhZ9u3b53LGI488MtGhAAAAAFk7EZlG1MqOHTts5cqVtmfPnpjra9Wqle77mjt3rjVr1ixy3m9joEkkxo4da2vWrHGP4dNj3XPPPa6Qe8QRR7jH+uqrr2LuAwAAALnLJ598Yv/++6+1b98+ctmAAQOsf//+rnCrI8XefvttK1myZELjBAAAALKsaKsJvDT77ueff57i9ZqULL2aNm3qWi6kRoXbaPfff787AQAAAL6hQ4falVdeGTk/c+ZM69Wrl/Xr18+qVatmDz/8sCvgajkAAAAgDDLc46Bbt262efNmmzVrlhUuXNgmTpxor7zyip144on28ccfZ02UAAAAQCp+/vlna9SoUeT8e++9Z82bN3fF2iuuuMKGDBniRuMCAAAAOXakrXrIfvTRR1a/fn3X11btEpQUFytWzAYOHGgXXXRR1kQKAAAApGDr1q1WunTpyPkZM2bYVVddFTmv+RBWr16doOgAAACAbBhpu337ditbtqz7W33B1C5BTj31VPvhhx8OIQQAAADg0B199NG2ZMmSyES3P/74Y8zIW/W71XwIAAAAQI4t2p588sm2bNky93ft2rXt+eefdxODjRo1yipUqJAVMQIAAACp0qhatfB67bXXrFOnTla+fHk788wzYya/VQ4LAAAA5Nj2CHfddZetWbPG/d27d29r2bKlvfHGG1agQIFkE4cBAAAAWU2TjmkQwZ133ukKtq+//rrlzZs3cv2bb75pl1xySUJjBAAAALK0aHvjjTdG/q5Xr579+eeftnTpUjv22GPtqKOOyujdAQAAAIdFk+O++uqrqV4/derUbI0HAAAAyPb2CP369bMdO3ZEzqs/WN26da1IkSLuOgAAAAAAAABANhZt+/bt6yZ4iKdCrq4DAAAAAAAAAGRj0dbzPEtKSkp2uWbpLVWq1GGEAgAAAAAAAABId0/bkiVLumKtTieddFJM4Xb//v1u9O2tt96aVXECAAAAAAAAQK6Q7qLt8OHD3Sjbm2++2bVBKF68eOS6AgUK2HHHHWcNGzbMqjgBAACAdNu1a5cVKlQo0WEAAAAAWVu0bdeunfu/SpUq1qhRI8ufP/+hPSIAAACQBQ4cOGADBgywUaNG2bp16+yXX36x448/3h555BE3wKBDhw6JDhEAAADIvJ62W7Zsifxdp04d27lzp7sspRMAAACQCI8++qiNHTvWnnzySXckmK9mzZr24osvJjQ2AAAAINNH2qqf7Zo1a6xs2bJWokSJFCci8ycoU39bAAAAILu9+uqrNnr0aDvvvPNi5lqoXbu2LV26NKGxAQAAAJletJ0yZYqVKlXK/T116tQMPQAAAACQHVatWmVVq1ZNsW3C3r17ExITAAAAkGVF2yZNmqT4NwAAABAU1atXt2+++cYqV64cc/l7773nWnwBAAAAOW4ismibNm2yl156yZYsWRJJkG+66abIaFwAAAAgu/Xq1ctNnqsRtxpd+8EHH9iyZctc24QJEyYkOjwAAAAgcyciizZ9+nQ3++5TTz3lirc66e8qVaq46wAAAIBEuOyyy+yTTz6xr776yooUKeKKuBpkoMuaN2+e6PAAAACArBtp27VrV7vmmmts5MiRljdvXneZJh+77bbb3HULFy7M6F0CAAAAmeLss8+2SZMmJToMAAAAIHtH2i5fvtzuueeeSMFW9Hf37t3ddQAAAAAAAACAbBxpW7duXXeY2cknnxxzuS6rXbv2YYQCAAAAZEzJkiUtKSkpXctu3Lgxy+MBAAAAElK0vfPOO+2uu+5yo2rPPPNMd9n3339vzz77rD3++OP2008/RZatVatWpgQJAMgd6o+ub0E0t/PcRIcAIBXDhw9PdAgAAABA4ou21113nfv//vvvT/E6jXTwPM/9r163AAAAQFZp165dokMAAAAAEl+0XbFiReZHAQAAAByCLVu2WLFixSJ/p8VfDgAAAMhxRdvKlStnTSQAAADAIfS0XbNmjZUtW9ZKlCiRYn9bjgIDAABAjizafvzxx3bhhRda/vz53d9pufTSSzMrNgAAACBNU6ZMsVKlSrm/p06dmuhwAAAAgOwr2rZu3drWrl3rRjDo79QwggEAAADZqUmTJta2bVs3Ka7+lh9//NGqV6/uBhwAAAAAYZQnPQsdOHDAFWz9v1M7UbAFAABAdnvjjTds586dkfNnn322/fXXXwmNCQAAAMjyoi0AAAAQVOpZm9Z5AAAAIMcXbe+880576qmnkl3+zDPPWLdu3TIrLgAAAAAAAADIldLV0zba+++/n+JkZI0aNbLHH3/chg8fnlmxAQAAAOmyePFiNweDP9J26dKltm3btphlatWqlaDoAAAAgCwu2v77779WvHjxZJcXK1bM/vnnn4zeHQAETv3R9S2I5naem+gQACCwzjvvvJi2CBdffHFkolxdzoS5AAAAyNFF26pVq9rEiRPt9ttvj7n8888/t+OPPz4zYwMAAAAOasWKFYkOAQAAAEhs0bZ79+6uYLthwwY799xz3WWTJ0+2IUOG0BoBAAAA2a5y5cqJDgEAAABIbNH25ptvtt27d9uAAQOsf//+7rLjjjvORo4caW3bts3c6AAAAAAAAAAgl8lw0Va6dOniThptW7hwYTvyyCMzPzIAAAAAAAAAyIXyHMqN9u3bZ1999ZV98MEHkQkfVq9enWyGXgAAAAAAAABAFo+0/fPPP61ly5a2cuVK1yahefPmVrRoUXviiSfc+VGjRmX0LgEAAAAAAAAAhzrS9q677rL69evbpk2bXGsE3+WXX+4mJAMAAACy05QpU9yRYAAAAECuLdp+88031rNnTytQoEDM5ZqMbNWqVZkZGwAAAHBQOvJr48aNkfNnnnkmeSkAAAByV9H2wIEDtn///mSX//33365NAgAAAJCd/DkWfD///LNr25WdHn/8cUtKSrJu3bpFLtu1a5d17drVSpcu7SbubdOmja1bty7mdmo5dtFFF9kRRxxhZcuWtfvuuy/ZqOFp06ZZ3bp1rWDBgla1alUbO3Zstj0vAAAAJEaGi7YXXHCBDR8+PHJeyakmIOvdu7e1atUqs+MDAAAAAm3OnDn2/PPPW61atWIuv/vuu+2TTz6xd999177++ms3ce8VV1wRuV4DIVSw3bNnj82cOdNeeeUVV5Dt1atXZJkVK1a4ZZo1a2YLFixwReGOHTvaF198ka3PEQAAAAEv2g4ePNi+/fZbq169uhs9cP3110daI2gyMgAAACA7aRCBTqmdz0oavHDDDTfYCy+8YCVLloxc/t9//9lLL71kQ4cOtXPPPdfq1atnY8aMccXZ77//3i3z5Zdf2uLFi+3111+30047zS688ELr37+/Pfvss66QK5rkt0qVKjZkyBCrVq2a3X777XbllVfasGHDsuX5AQAAIDHyZfQGlSpVsh9//NHefvtt978S1Q4dOrhkNXpiMgAAACC72iOcd955li/f/6W2O3bssEsuuSTZHAw//PBDpj+22h9oJOz5559vjz76aOTyefPm2d69e93lvlNOOcWOPfZY++6771zfXf1/6qmnWrly5SLLtGjRwrp06eJaPNSpU8ctE30f/jLRbRjiqTVEdHuILVu2RNqc6ZQdkix7iuYZlZ7nT+yZL73bXZjjD3PsYY8/zLEHNf4wxy5sN4mTG9Z9dj5Whoq2SjyVbE6YMMEVaXUCAAAAEkltuqJddtll2fK4b731lisEqz1CvLVr17qicYkSJWIuV4FW1/nLRBds/ev969JaRoXYnTt3pjhoYuDAgda3b99kl2/YsMEdKZcdqhaoakG0fv36gy5D7ImJPezxhzn2sMcf5tiDGn+YYxe2m8TJDes+M2zdujXzi7b58+fPtkQPAAAAOJSibXb466+/7K677rJJkyZZoUKFLEh69Ohh3bt3j5xXgVdHy5UpU8aKFSuWLTEs37PcgkiTvR0MsScm9rDHH+bYwx5/mGMPavxhjl3YbhInN6z7zJDe3DHfoRwCpt61L774YuQQNAAAACAI/vnnH/vjjz9cT1vNu1C6dOkseRy1P9CIjLp168ZMLDZ9+nR75pln3ERh6ku7efPmmNG269ats/Lly7u/9f/s2bNj7lfX+9f5//uXRS+j4mtqrckKFizoTvHy5MnjTtnBM8+CKD3Pn9gzX3q3uzDHH+bYwx5/mGMPavxhjl3YbhInN6z77HysDFdddfjX5MmT3cQJ6sFVpEiRmOs/+OCDjN4lAAAAcFjUA1a9YDVhbrQmTZrYyJEj7eSTT87Ux1MP3YULF8ZcdtNNN7lWYg888IAb2aqj1JQ3t2nTxl2/bNkyW7lypTVs2NCd1/8DBgxwxV9/dIdG7qogq0l//WU+++yzmMfRMv59AAAAIGfKcNFWIwX8xBMAAABINPV9VXFWh/8PHTrUFU41OdnixYvthRdesLPPPtsWLVqUqYe9FS1a1GrWrBlzmQYzaGSvf7km61WbglKlSrlC7B133OGKrZqETC644AJXnP3f//5nTz75pHsePXv2dEe2+SNlb731Vjdy9/7777ebb77ZpkyZYu+88459+umnmfZcAAAAkAOKtmPGjMmaSAAAAIBDMGzYMKtcubIbZRvdI6xly5Zu9O1ZZ53lltEEXdkdlw5/04CH3bt3W4sWLey5556LXJ83b143wa9iVDFXRd927dpZv379IstUqVLFFWjvvvtuGzFihB1zzDGuTZnuCwAAADlXuhs2HDhwwPWybdy4sZ1++un24IMPuhlrD4d6fl1yySVWsWJF13ds/PjxB73NtGnTXO8wjT6oWrWqjR079rBiAAAAQLipXYBaEqQ0qYP6vt53332ux2xWU546fPjwyHnF8+yzz9rGjRtt+/btro2Y36vWp2Kz2h/s2LHDNmzYYIMHD042b0TTpk1t/vz5rvD722+/Wfv27bP8uQAAACAkI23Vb6tPnz52/vnnu+RXe/rVf+vll18+5AdX8lq7dm13qNcVV1xx0OVXrFhhF110kTtM7I033nA9wjp27GgVKlQI9GiD+qPrWxDN7Tw30SEAAAActt9//z1mQrB49evXd8sAAAAAOa5o++qrr7rDuW655RZ3/quvvnIFVB2edagzrF144YXulF6jRo1yh4gNGTLEna9WrZrNmDHDHXoW5KItAAAAss7WrVtdz9i0+s9u27YtW2MCAAAAsqVoq5luW7VqFTmvEbdqabB69WrXWys7fPfdd+5xo6lY261bt1Rvo8PIdPJt2bIl0u5Bp+yQZEkWRNn1/BOJdZ84YV73YY497MK87sMce9jjD3PsOSH+oDyWCrcptUfw8z9NTAYAAADkuKLtvn37kiXC+fPnt71791p20Yy65cqVi7lM55WIq7+u2jbE04QTffv2TXa5eobt2rXLskPVAlUtiNTeIqdj3SdOmNd9mGMPuzCv+zDHHvb4wxx7Tog/M6jgejhUkD3ppJPSvF6DDQAAAIAcV7RVsqtJDzQBmE9FT/WX1Uy3Pk2wECQ9evSw7t27R86rwFupUiUrU6ZMmofRZable5ZbEJUtW9ZyOtZ94oR53Yc59rAL87oPc+xhjz/MseeE+DNDaiNk02vq1KmZFgsAAAAQqqJtu3btkl124403WnbSbLvr1q2LuUznVXxNaZStqMgcXWj2qQ/vofbizSjPgnk4XnY9/0Ri3SdOmNd9mGMPuzCv+zDHHvb4wxx7Tog/CI/VpEmTTIsFAAAACFXRdsyYMZZoDRs2tM8++yzmskmTJrnLAQAAkDv5cxYcTHYdZQUAAABkW9E2K2gW3+XL/98hgStWrLAFCxZYqVKl7Nhjj3WtDVatWmWvvvqqu16tGJ555hm7//777eabb7YpU6bYO++8Y59++mkCnwUAAAASqUSJEmn2rPV72u7fvz9b4wIAAABCWbSdO3euNWvWLHLe7z2rVgxjx461NWvW2MqVKyPXV6lSxRVo7777bhsxYoQdc8wx9uKLL1qLFi0SEj8AAAASL7qnrQq0rVq1cjni0UcfndC4AAAAgFAWbZs2beoS69SocJvSbebPn5/FkQEAACAs4nva5s2b184880w7/vjjExYTAAAAcDhy/qw2AAAAAAAAABAiFG0BAAAAAAAAIGztET7++ON03+Gll156OPEAAAAAhy2tickAAACAHFG0bd26dbrujFl5AQAAkN2uuOKKmPO7du2yW2+91YoUKRJz+QcffJDNkQEAAABZWLQ9cODAId49AAAAkLWKFy8ec/7GG29MWCwAAABAthVtAQAAgKAaM2ZMokMAAAAAEl+03b59u3399de2cuVK27NnT8x1d955Z2bFBgAAAAAAAAC5ToaLtvPnz7dWrVrZjh07XPG2VKlS9s8//9gRRxxhZcuWpWgLAAAAAAAAAIchT0ZvcPfdd9sll1ximzZtssKFC9v3339vf/75p9WrV88GDx58OLEAAAAAAAAAQK6X4aLtggUL7J577rE8efJY3rx5bffu3VapUiV78skn7aGHHsqaKAEAAAAAAAAgl8hw0TZ//vyuYCtqh6C+tv6svX/99VfmRwgAAAAAAAAAuUiGe9rWqVPH5syZYyeeeKI1adLEevXq5Xravvbaa1azZs2siRIAAAAAAAAAcokMF20fe+wx27p1q/t7wIAB1rZtW+vSpYsr4r700ktZESMAIAPqj65vQTS389xEhwAAAAAAQM4s2tav//+KAWqPMHHixMyOCQAAAAAAAAByrQz3tD333HNt8+bNyS7fsmWLuw4AAAAAAAAAkI1F22nTptmePXuSXb5r1y775ptvDiMUAAAAAAAAAEC62yP89NNPkb8XL15sa9eujZzfv3+/a5Nw9NFHZ36EAAAAAAAAAJCLpLtoe9ppp1lSUpI7pdQGoXDhwvb0009ndnwAAAAAAAAAkKuku2i7YsUK8zzPjj/+eJs9e7aVKVMmcl2BAgXcpGR58+bNqjgBAAAAAAAAIFdId9G2cuXK7v8DBw5kZTwAAAAAAAAAkKulu2gb7bfffrPhw4fbkiVL3Pnq1avbXXfdZSeccEJmxwfkWvVH17cgmtt5bqJDAAAAAAAAyNHyZPQGX3zxhSvSqkVCrVq13GnWrFlWo0YNmzRpUtZECQAAAAAAAAC5RIZH2j744IN299132+OPP57s8gceeMCaN2+emfEhABjxCQAAAAAAAAR4pK1aInTo0CHZ5TfffLMtXrw4s+ICAAAAAAAAgFwpw0XbMmXK2IIFC5JdrsvKli2bWXEBAAAAAAAAQK6U7vYI/fr1s3vvvdc6depknTt3tt9//90aNWrkrvv222/tiSeesO7du2dlrAAAAAAAAACQ46W7aNu3b1+79dZb7ZFHHrGiRYvakCFDrEePHu66ihUrWp8+fezOO+/MylgBAAAAAAAAIMdLd9HW8zz3f1JSkpuITKetW7e6y1TEBQAAAAAAAABkY9HWL9hGo1gLAAAAAAAAAAks2p500knJCrfxNm7ceLgxAQAAAAAAAECulaGirfraFi9ePOuiAQAAAAAAAIBcLkNF22uvvdbKli2bddEAAAAAAAAAQC6XJ70LHqwtAgAAAAAAAAAgG4u2nudlwsMBAAAAAAAAADKlPcKBAwfSuygAAAAAAAAAIKtH2gIAAAAAAAAAsh5FWwAAAAAAAAAIEIq2AAAAAAAAABAgFG0BAAAAAAAAIEAo2gIAAAAAAABAgFC0BQAAAAAAAIAAoWgLAAAAAAAAAAFC0RYAAAAAAAAAAoSiLQAAAAAAAAAECEVbAAAAIIMGDhxop59+uhUtWtTKli1rrVu3tmXLlsUss2vXLuvatauVLl3ajjzySGvTpo2tW7cuZpmVK1faRRddZEcccYS7n/vuu8/27dsXs8y0adOsbt26VrBgQatataqNHTs2W54jAAAAEoeiLQAAAJBBX3/9tSvIfv/99zZp0iTbu3evXXDBBbZ9+/bIMnfffbd98skn9u6777rlV69ebVdccUXk+v3797uC7Z49e2zmzJn2yiuvuIJsr169IsusWLHCLdOsWTNbsGCBdevWzTp27GhffPFFtj9nAAAAZJ982fhYAAAAQI4wceLEmPMqtmqk7Lx58+ycc86x//77z1566SUbN26cnXvuuW6ZMWPGWLVq1Vyh98wzz7Qvv/zSFi9ebF999ZWVK1fOTjvtNOvfv7898MAD1qdPHytQoICNGjXKqlSpYkOGDHH3odvPmDHDhg0bZi1atEjIcwcAAEDWY6QtAAAAcJhUpJVSpUq5/1W81ejb888/P7LMKaecYscee6x999137rz+P/XUU13B1qdC7JYtW+znn3+OLBN9H/4y/n0AAAAgZ2KkLQAAAHAYDhw44NoWNG7c2GrWrOkuW7t2rRspW6JEiZhlVaDVdf4y0QVb/3r/urSWUWF3586dVrhw4WTx7N692518WtaPU6fskGRJFkTpef7EnvnSu92FOf4wxx72+MMce1DjD3PswnaTOLlh3WfnYwWiaPvss8/aoEGDXFJau3Zte/rpp+2MM85IcVkdenbTTTfFXKZJGTTRAwAAAJDd1Nt20aJFrm1BUCZJ69u3b7LLN2zYkG05c9UCVS2I1q9ff9BliD0xsYc9/jDHHvb4wxx7UOMPc+zCdpM4uWHdZ4atW7eGo2j79ttvW/fu3V2/rgYNGtjw4cPdIV+afVd9wVJSrFixmNl5k5KCWaUHAABAznb77bfbhAkTbPr06XbMMcdELi9fvrybYGzz5s0xo23XrVvnrvOXmT17dsz96Xr/Ov9//7LoZZQPpzTKVnr06OHy6+iRtpUqVbIyZcq422WH5XuWWxCl9vsiGrEnJvawxx/m2MMef5hjD2r8YY5d2G4SJzes+8xQqFChcBRthw4dap06dYqMnlXx9tNPP7WXX37ZHnzwwRRvoyKtn8gCAAAA2c3zPLvjjjvsww8/tGnTprnJwqLVq1fP8ufPb5MnT7Y2bdq4yzToYOXKldawYUN3Xv8PGDDAjezwfyhMmjTJFVarV68eWeazzz6LuW8t499HSnQUmk7x8uTJ407ZwTPPgig9z5/YM196t7swxx/m2MMef5hjD2r8YY5d2G4SJzes++x8rIRORKbRB5qkIXpyBQWu82lNrrBt2zarXLmyGzFw2WWXRSZqAAAAALKrJcLrr79u48aNs6JFi7o2Xzqpz6wUL17cOnTo4Ea8Tp061eW8GqSgYuuZZ57plrngggtccfZ///uf/fjjj/bFF19Yz5493X37Rddbb73Vfv/9d7v//vtt6dKl9txzz9k777xjd999d0KfPwAAALJWQkfa/vPPP7Z///4UJ1dQUpqSk08+2Y3CrVWrlpuld/DgwdaoUSNXuI0+JM3HRAypo8F14uT02MMef5hjD3v8xJ752G4SJzes+zA+VmYZOXKk+79p06Yxl48ZM8bat2/v/h42bJgbkKCRtspH1QJMRVdf3rx5XWuFLl26uGJukSJFrF27dtavX7/IMhrBq6PQVKQdMWKEy3dffPFFd18AAADIuRLeHiGjlNBGHw6mgm21atXs+eeft/79+ydbnokYUkeD68TJ6bGHPf4wxx72+Ik987HdJE5uWPfZPRlD0NojpKdfmSbc1Sk1Onosvv1BPBWG58+ff0hxAgAAIJwSWrQ96qij3AiDlCZXSG/PWvUKq1Onji1fnnIjYyZiSB0NrhMnp8ce9vjDHHvY4yf2zMd2kzi5Yd1n92QMAAAAQG6R0KJtgQIF3CQNmqChdevWkcPjdF4z8aaH2issXLjQWrVqleL1TMSQOhpcJ05Ojz3s8Yc59rDHT+yZj+0mcXLDug/jYwEAAABhkPD2CBoFq95d9evXtzPOOMOGDx9u27dvdxM1SNu2be3oo492bQ5EPb40eUPVqlVt8+bNNmjQIPvzzz+tY8eOCX4mAAAAAAAAAJADirbXXHON6y/bq1cvN+PuaaedZhMnToxMTrZy5cqY0RebNm2yTp06uWVLlizpRurOnDnTzbwLAAAAAAAAAGGX8KKtqBVCau0Qpk2bFnNes/DqBAAAAAAAAAA5EQ3EAAAAAAAAACBAKNoCAAAAAAAAQIBQtAUAAAAAAACAAKFoCwAAAAAAAAABQtEWAAAAAAAAAAKEoi0AAAAAAAAABAhFWwAAAAAAAAAIEIq2AAAAAAAAABAgFG0BAAAAAAAAIEAo2gIAAAAAAABAgFC0BQAAAAAAAIAAoWgLAAAAAAAAAAFC0RYAAAAAAAAAAoSiLQAAAAAAAAAECEVbAAAAAAAAAAgQirYAAAAAAAAAECAUbQEAAAAAAAAgQCjaAgAAAAAAAECAULQFAAAAAAAAgAChaAsAAAAAAAAAAULRFgAAAAAAAAAChKItAAAAAAAAAAQIRVsAAAAAAAAACBCKtgAAAAAAAAAQIBRtAQAAAAAAACBAKNoCAAAAAAAAQIBQtAUAAAAAAACAAKFoCwAAAAAAAAABQtEWAAAAAAAAAAKEoi0AAAAAAAAABAhFWwAAAAAAAAAIEIq2AAAAAAAAABAgFG0BAAAAAAAAIEAo2gIAAAAAAABAgFC0BQAAAAAAAIAAoWgLAAAAAAAAAAFC0RYAAAAAAAAAAoSiLQAAAAAAAAAECEVbAAAAAAAAAAgQirYAAAAAAAAAECAUbQEAAAAAAAAgQCjaAgAAAAAAAECAULQFAAAAAAAAgAChaAsAAAAAAAAAAULRFgAAAAAAAAAChKItAAAAAAAAAAQIRVsAAAAAAAAACBCKtgAAAAAAAAAQIBRtAQAAAAAAACBAKNoCAAAAAAAAQIAEomj77LPP2nHHHWeFChWyBg0a2OzZs9Nc/t1337VTTjnFLX/qqafaZ599lm2xAgAAAEHPlwEAABBuCS/avv3229a9e3fr3bu3/fDDD1a7dm1r0aKFrV+/PsXlZ86cadddd5116NDB5s+fb61bt3anRYsWZXvsAAAAQNDyZQAAAIRfwou2Q4cOtU6dOtlNN91k1atXt1GjRtkRRxxhL7/8corLjxgxwlq2bGn33XefVatWzfr3729169a1Z555JttjBwAAAIKWLwMAACD88iXywffs2WPz5s2zHj16RC7LkyePnX/++fbdd9+leBtdrpEG0TTSYPz48Skuv3v3bnfy/ffff+7/zZs324EDByw7HNiZPY+TUVoHOT1+Ys98bDeJw7pPnJwee9jjD3PsOSH+zLBlyxb3v+d52faYYXEo+TL5b+79TAlz7GGPP8yxhz3+MMce1PjDHLuw3SROblj32Zr7egm0atUqRefNnDkz5vL77rvPO+OMM1K8Tf78+b1x48bFXPbss896ZcuWTXH53r17u8fgxIkTJ06cOHHiFOzTX3/9lYmZZs5wKPky+S8nTpw4ceLEiZOFPvdN6Ejb7KBRCdEjczW6YOPGjVa6dGlLSkqyMFElvlKlSvbXX39ZsWLFLGzCHD+xJ06Y4w9z7GGPn9gTJ8zxhzn2sMevUQZbt261ihUrJjqUHIH8NxiIPXHCHH+YYw97/MSeOGGOP8yxhz3+Lbkg901o0faoo46yvHnz2rp162Iu1/ny5cuneBtdnpHlCxYs6E7RSpQoYWGmjTFsG2ROiZ/YEyfM8Yc59rDHT+yJE+b4wxx7mOMvXrx4okMIpEPJl8l/g4XYEyfM8Yc59rDHT+yJE+b4wxx72OMvloNz34RORFagQAGrV6+eTZ48OWYkgM43bNgwxdvo8ujlZdKkSakuDwAAAITVoeTLAAAACL+Et0fQoVvt2rWz+vXr2xlnnGHDhw+37du3u9lxpW3btnb00UfbwIED3fm77rrLmjRpYkOGDLGLLrrI3nrrLZs7d66NHj06wc8EAAAAyP58GQAAADlPwou211xzjW3YsMF69epla9eutdNOO80mTpxo5cqVc9evXLnSzZDra9SokY0bN8569uxpDz30kJ144ok2fvx4q1mzpuV0Osytd+/eyQ53C4swx0/siRPm+MMce9jjJ/bECXP8YY49J8SPQ8+Xc7Iwb9fEnjhhjj/MsYc9fmJPnDDHH+bYwx5/wRDHnl5Jmo0s0UEAAAAAAAAAAALQ0xYAAAAAAAAAEIuiLQAAAAAAAAAECEVbAAAAAAAAAAgQirYAAAAAAAAAECAUbQEAAAAAAAAgQCja5kBbt25NdAgIoY0bNyY6BAAAgAwj98WhIv8FAAQZRdsc5plnnrFRo0a5vw8cOJDocHKVzZs3244dO2zfvn0WNsOGDbOHHnrI9uzZY57nJTqcXCXM241iDmPcwOH6999/Ex0CgP8fuW/ihDmHEfLfxAj7dkP+i9yI3Ddxkjy+oXKM++67z4YMGWLHHnus/fLLL1agQAELi6efftp+++03W7x4sbVr185OP/10O+mkk1wClZSUZEH35JNP2rRp09xzuOGGG+yWW26xcuXKWRh0797dhg8fbqVKlbJff/3VSpYsGZr1Li+//LL98ccftnr1auvUqZNVrVrVSpcubWEQ5u3m2WeftXnz5tnSpUvtjjvusMsuu8yOOOIIC4uwf+b8999/tn37dqtYsWLkMhUr8uQJ/r5Y/dDJly9faNZ1vP79+7v136VLFzvhhBMsTD788EOrVKmS1a9fP9GhAJbbc9+wfxeFOYcJe/5L7ps4Yc5/w/x5E/bcN+z5L7lvYoVjC8dB3X333fbiiy/aG2+8YcWKFYuMOAiDHj16WL9+/VyyUaJECXv88cetY8eONnv2bPeBFvT9CopfPxguv/xyO//8823MmDG2bNkyC8t2M3bsWJsyZYodd9xx7nWQsHyR3H///e60ZMkS++GHH1zi1KdPH5eMBF2Yt5sHHnjABgwYYMccc4yVKVPGfYGvWLHCXRf092tO+Mzp3bu3XXrppVa7dm23/YwYMcLFrKQ16KPM9GNH2862bdtCsa7jPfjgg25k1llnnWXly5ePuS7oz+Wtt96yNm3a2FNPPWVz5sxJdDhArs59w/5dFOYcJuz5L7lv4oQ5/w3z503Yc9+w57/kvgGgkbYIt27dunmlSpXyFi1a5M43b97cu+CCC7wwmD59ule9enXvhx9+iFz21FNPeUlJSd4JJ5zgTZs2zQsyxXfiiSd68+bNi1zWtGlT76OPPvK2bNnibd++3QvydlOiRAnvxx9/dOc7duzonXHGGd6OHTvc+QMHDnhBNnfuXK9q1ared999F7ls+PDhXuPGjb02bdpE3g9BFObtZujQod7RRx/tzZ8/P3JZ7dq1valTp3p79uzxgi7snzmPPvqoV65cOe+9997zvvjiC+/666/3ypcv73Xu3Dnyng3qe3fw4MFuPZ966qnek08+6W3dujXQ8cabPHmy+8z5/vvv3fm///7bW7BgQcz7eP/+/V5QPf/8896RRx7pPmtuvPFGb86cOTHXBzl2ICflvmH/LgpzDhP2/JfcN3HCnP+G+fMm7Llv2PNfct9goGgbcq+//rr7EPATD9EXef78+b13333XC7oJEyZ41apV81auXOnt3bvXXfb77797jRo18i655BKvWbNm3h9//OEF1aeffuq+7H755Rd3Xl/alStX9po0aeJVqlTJJVDffvutFzRKkIoVKxaz3fz6669uu3n22We9MJg1a5ZXsmTJmAREXnvtNe+ss87ybrnlFm/dunVeEIV1u1m9erXXpUsX74033ohcpiT7+OOP91q1auXVqFHD6969u/fTTz95QRXWzxwldkqUFOfHH38cuVzbuH5EFC5c2LvuuusCmwAquTv99NO9YcOGuW2ofv363uOPPx5JXMOQNOk79bzzznN/64eDno/er9r+9d7duXNnoJ+Lfsx37drVbT9169Z1P3r++usv9xr47wUgDMKe+4b5uyjMOUxOyH/JfRMj7PlvWD9vwp775oT8l9w3GGiPEHLqBfTnn39arVq13PB0nU488URr2rSpffHFF7Z///5AHzKgvjRqaq1DBfLmzesu0+FK+vuqq66y5cuX26JFiyyo/HWrmD/77DM77bTT3CEzOkypV69e7vUYOnRo4Gam1eElOhzJ3270PKpUqWJt27a1jz/+2P755x8Luvz587s+ZKtWrXLn/QkBbrzxRrv22mttwoQJtnDhwkAeuhHW7aZChQp2880327nnnuvO6/NF25AOEdNn0TXXXGPffvut67W2d+9eCyJ91oTxM0eHUukQsPXr18dMflG2bFlr0KCB3XTTTe5QyVdeeSWQ23zlypXd4WytW7e25557zs444wx777333OFiei303KJjDuL3lvoHbtq0yb0GPXv2tPbt27vnoB5xurxx48aRQ/WCSLF9+eWX1rx5c3eIpw7pvPPOO91h5TrsDQiLsOe+Yc9/w5rD5IT8l9w3McKe/5L7Jk7Y819y34BIdNUYmWPfvn0x57W3WHuflixZ4s4HbQ9U9N4YDVfX3jLtHb766qu9vHnzuj3Joj04OvQhiM/Bd99997k4r7rqKu+UU07xNmzYELluxIgRXtmyZd1ewqBI6xCet99+2203M2bMCPQ691166aXeSSedFBlVEL3HTNvVZZdd5gVV2LablCxevNjtNd60aVPksrvvvts79thjvf/++y+hsaXlnHPOCeVnzvr1690hSrfddltkm9chY9rbvWzZMnd48DXXXOMFlb833n+v6nn4Iw62bdvmLtfe76Ctd59G0Chexa2RKdHb+OzZs72TTz7Ze//9972g5gi7d+92h49rdI2fJxQoUMAdrup/5gNhErbcNyflv2HMYXJK/kvum3hhzH/JfRMnzPkvuW8w5Et00RgZp1EEmi30qKOOslNOOcWNLtCeMu2Z0R4pnbTH+PXXX3d7LLUnR3tmg0Bxa8ZH7Y3RnkjFNXXqVLv99ttt7dq1bm+I9vTpee3Zs8ddr72wQZkc4Pvvv3d74TXDbPXq1d3/mgVVz0V7cbS3uGDBgpHl9Tw0wYH2yAZl3ae1LVx99dVub2Xfvn1t/PjxgZoNVSMgNDO09oxpL6X20GsCA+31vvDCC937Qu8Jn16f6L2yiRTm7eaDDz5we+D92LVHVfR5U61aNff5ovemPyOqRqzUq1fPChcubEGgSUb++usvt92ceuqpboblr7/+2rp27Wrr1q0L/GdONI3oeOGFF6xVq1b21VdfuXWs1+aTTz5xs/9ed911bpKDrVu3uveuP5oi0fxZcgsVKuTO+9uKJgXQ3u7333/fxapRcldeeaXddtttbpKVoNF2oe173LhxbuSEtimfLtfz2rFjhwWR1q9Oei00S7peD33uNGzY0MX8/PPPu+9lnQeCKMy5b9jz3zDnMGHPf8l9EyfM+S+5bzDkhPyX3DcgEl01Rsbcf//9XpkyZVxPjuLFi3sNGzZ0eyZT2oOvZbX3w9+Dk2j9+vVzfX+im+fH9xKJPq/+QeoR9PLLL3tB8NBDD7m9etrbp72Tmshg48aNkevVK0W9mdSr6d9//3Xxq+F4hw4dvCCu+9T25j3zzDMxPaeC4IEHHnD9c9RzqUKFCl67du0ivYC0B7BmzZpuj/2UKVO85cuXe6tWrXJ70B555JFEhx7q7UYjIo466ijv3HPP9apUqeK2Cz0fX3z/orVr13r16tXzHn74YS8IHnzwQbdu/c9L9b1aunRpaD5zRo8e7d1xxx3exRdf7L311luRESk///yzm3hEk0j8+eefMe9z7QUPAo1a0oQpBxshp21Iz1HbvPZ8X3TRRV4QTJw4MeYz0N/WtadeE9aon2bfvn1jRoJo2//kk0+8IG03eh2iP280Eki9vTTaRp+jfo8yvU9GjhyZwKiBnJn7hj3/DXMOE/b8l9w3ccKc/5L7JlaY819y3+CiaBsimi1RMydqBkjRzH333HOPmz2xd+/eyT6IdciG3lyvvPKKl2gail60aFH3BahDGPzDMVI6vG3z5s1uJk4lIkH5EH7sscdcwqQG+ZrhdPz48V6hQoW8SZMmxSynRumlS5d2X5RKpi6//PLIdYk65CGtdZ9STNp+9OUR/YMokfTloHXvz1r5wQcfuFl/16xZE1lGX+g69EEfvnqe2naC8OUX5u1Gh4zos8WfUVYTFChZ0uGDt956a7JkVYfI1KpVyx2250vkYT6anbVixYruh5q2aX1u6rUYN25csmWD+JmjH2uKVz90zj77bDeBhCYaSYk+Q5V0a/1H/6hIFB22pu+eli1bxswuG89PBhcuXOiW1+QA8dclQp8+fVw82s41QU38d5WSVz03/ZDTIYV6rXSoavS2H6TtRpM2+ZSk6rnddNNNMTN1R38vAEES5tw37PlvmHOYsOe/5L6J227CnP+S+yZWmPNfct9go2gbAv4H/0svveTVrl075s2sDyv1Q1EPoKFDh8a8wdQ/JQh7PhSjeuc88cQT7gtQe4E1Q2hqyZP2pOnNF723NZE/4PUDQX2AtLcvOpYWLVpEviSi91jq9Rg0aFDMD4ZExZ/Rde8/j6B8iGl2XPXn+vDDDyOXqeePXg+NptGXY3QfHT1HzU6rH3mJXvdh3m78URAaWRD95bZjxw6X+Clx1XvUpy/GBg0auC/DIMSuvcT6IaPPzOhY2rZt67Vv3z7Z8kH7zHnhhRfcj7A5c+ZELtMPTv3AiacfRHqtlHRr73KifzDo/ahRA0r6lNwpprRGHGgmY/2o1kioIKz7d955xyV7GpmiGXK1Zz46efXfs/rhrPeCklVt99GjaxIVf3q2G41o0qgsfxRi/HYS1Nl/kfuEPfcNe/4b9hwmzPkvuW9iv4fCmv+S+ya22B/m/Jfcd78XdBRtQ2DRokXu/wkTJrg9f/EfANrLp0Mh1CRaX5YpSdTGqEbt8vnnn3vz5893f2uPpA6XiU+eoukQnyC8kXQ4ifZk64NXzc6j6QNBX4QH+5II27qPluh1r/WqpPWff/5xl+m89qjqi+V///uf+6LTXj4dBhGk+MO83fjbhT5njjzySLf9RNMPYo1e0WQL0T8Qog89TOR2o7iVVChBVUIavZ61B/bCCy+MuSz6B14Q4leDf01u0b9/f5ckqYG+fPXVV27bj57MQPSjQnuQ9cMnCPF/9tln3g033ODesxpdc/7558ckrilt84MHDw5M4vTqq6+6HzA6BFWHTNWpUycmeVX88aPjoiUq/oxuN0DQhTn3DXv+G+YcJuz5L7lv4rabMOe/5L6Jzx/DnP+S+wYfRduAUyKq4dzae6APY72JdFiYeohE0we0+nS88cYbXtBi1x7j+Dd1SsnTihUrYvYqJ3qPmRI9xf/bb7/FzJTo721SvyP1Ton+AtFhDmFd9x999FHC4k1t3f/4448xlw8cONDt0daPNdH/2pOmhESCMOtmWLcbbR/aS6/Y9WUnOsxOh+z4CWD0j0p9FukwrHiJeg2i41eCFJ1c+H+rD9a1114buVzJyTfffBNzP4nchkaNGuX6dI0ZMyZZXDqvwwijP/v9WP0kJZGJ04svvhiJ2Z+hVZRU+4lr9F7wXbt2JbuPRCaszz33XKRHWnQ/r6effjqSvEZf7q/zIHzmpHe7iY81CLEDOS33DXv+G9YcJifkv+S+iRHm/JfcN/H5Y5jzX3Lf8MiT6InQkLbatWtbly5dbMKECVa+fHm79dZb3WyVL774opuR06dZLY8//nj7/fffLWixaxbWXbt2uZn7NEOfZt08/fTT3SyEP/74ow0ZMsTefvttO//8891MkNESOYOlZmjV+n711VfdrJqKX/QcRM9j27Zt7u9///3XzTz4+eefW1jX/UcffWRBoXWv+DWrph+/PPjggzZt2jQrV66cO6//NWuuP1NoEGY8Det2o/g0G/dDDz1kY8eOdbOBdurUyWbNmmWjRo2yJUuWRJbVLMyaQfTvv/9Odj+Jeg38+LWNDB8+3K3b6OtEMxZHr/tGjRq5mZmjJXIbeuONN+yBBx6w9u3b21lnneUu87cfzYir7cmP77///rOBAwfapk2brECBAsmea3bTDNbdu3ePzCbrz/7cpk0b917W+1izci9YsMBtN5oF+88//4y5j0TFLm+99ZabyVe0Hfnxa2b3Dh062MyZM23EiBG2YsUKW7lypbVu3drNSB6Ez5z0bjc6abt57LHHbPPmzYGIHchpuW/Y89+w5jA5If8l902MMOe/5L6Jzx/DnP+S+4YHRdsQ0Jtbydz69eutc+fO7o3fp08fGzx4sP30009umT/++MO9ifRlErTY9aW8ZcsW9ybRl3Z08vTuu+/a7Nmz7brrrrNq1arZSy+9ZEHSoEED++yzz2zr1q0x8Yu+APVFqC+OJk2aWKlSpey+++6zoAj7uo+PX0mUFCpUKLKMvkRWrVplNWrUsCAJ83bTrFkzl1QoubjssstcIqgfzk888YRNnjzZLaMfyIsXL3Y/loPmvPPOszVr1kQSIiUg0cme1r2S1qZNm1rZsmXtySefTHDE/y/JGDZsmG3fvt0mTZrkzmu78WM/8sgjrVixYla6dGmXdNSrV8+9RiVLlgxE7M8995yVKFEi8jmiH5P+dVdccYXddtttbt3ffffd7v1RpEgR98Mn0fwYhw4d6v7+6quv3Hn/s1K6du1qHTt2dD/gHn74Yfdjc8+ePQn/vj2c7UavFRBkYc59w56DhTmHCfu6J/dNnDDnv+S+2S/M+S+5bwgleqgvYqXUFF/UiyZ6RlANCddMm2qsf+aZZ7rDfaIbcSfanj17YmJPbWZBHeKj2f7UAyYoPWkOFr9/uEnPnj29K6+80k2Q0bx588DEH/34YVz36YlfPWp0uIb61eg1COL7N2zbTXTs7dq1c43ooxvUa3IDzU6snmrHH398IGaaTe3zUvHrczF+3asXWbNmzbzq1au7Q5aCsu6jZ/K96qqrvNtuuy3Zc9Rhb5qxdcmSJW6iA70e8cskkg73Un/J6Mk4FFf0utUhejqEL/owvSCv+/j4HnnkERe/JrdJ6fpECfN2A+Sk3Dfs+W+Yc9/4GMK27sl9Eyds+S+5b+wyiRbm/JfcNzwo2gaMZqeMnq3S73uiXkFKTDU7aHTfJjWh1yyiQZh1U33Honu5+F8kfuwTJ05M9lwbNmzoTkH4EEhv/P6XoGbc1IeYPjASHb8a4i9fvjy06z698StGvT/UeF6xRyetiYpfM1crqYuPIwzbzWOPPeYSaf/x/f/VRP/cc891zeijZzlVj6DRo0fH9N5L5HazadMmNyNoPE2EofgVazQ/aQpa4hE/gUrJkiVjtimZN2+emxhDPZqik48gxa/egKVKlXI9suLp/a0E6vLLLw9c7H4cqa17JXiaYKVSpUqBeN9mJPYwbDdAmHPfsOe/Yc59w57/kvsmbrsJc/5L7hu8+MOY/5L7hgtF2wAZPny4G1GgmXBvvPHGmOvU1F17Z2699dY07yNRG+OAAQO8M844wytbtqxrlu/PeJpa7P5eDn0YBOGNlNH4/Qbj2quZ6Pg18kRfxorPbyYepnWf0fj9mVo102Wi47/zzjvdl4I/u2a0oG83mhSiXLlyroG+EsDo7UOjOXr06OFm+vW3l5T2TCZyu+nbt6/XuHFjN/JBP2I0kYj/PPSjzI8/2pQpU9xkNkGIX7GoEPHll1+6eON/TGgW1+iJFzSTep48eQKx7aQ0G6sfi4ooLVq0cHu3o3388cdu8pf45RNByZx+gEXP+Oz/WE5p3YsmOjr77LMTHn9GYw/SdgPktNw37PlvmHPfsOe/5L6J227CnP+S+yY2/jDnv+S++70wo2gbENoDqUN1Bg0a5PXu3dvtkbnmmmtiltGHQEp7ExJNsZcvX9577bXXvM8//9wdrta5c+eYZTT7ZlqxJ/KNFPb4n3/+ee+EE07wjjjiCJcoaY9wdIKhD66gxh7m+O+++263B0+HYKQWR2p7ABMdu5K8Y445xvv222/d+S1btnh//fWXG8nhHx6pkTc6HOyZZ57xgqZ///7u83LcuHEuAdShatp+7r//fu/vv/+O7PVOK/5Ebvf33nuv+5GsQ9X0o02jUt58883I9UpmNWvrjBkzYm4XhFFlOkxKh5RG/9CJptmgVYDxt/nomYyDsO4Vv37sHHvssV7+/PndthRN21P0ug9S/BmNPUjbDZDTct+w549hjj3s+WOYYw9z7hv2/JfcN/H5Y1jzX3Lf/V7YUbQNgLfeess76aSTvJkzZ8bs2VAPjtWrV8e8eQYOHOi1b9/eW7dunRcEL730kustFr3nQ3v5hgwZ4vZka4+Uv1dKe0KCFPvhxB+Efih+DNpjqS9C9bkqVKiQd91113m7d+92cfp7wYO23YQ9/sGDB7uEY+rUqe78tGnTvLvuusslIDfffLMbNeEnf0Hbbvz+Vv6IJiWwGmGjL0P9gND27x8qqS889R5TAh4U+kzUiKz3338/5nIdvqNeY9qW/L2tGpEStPg/+OAD90NZnzkakaIkr2XLlm7kxLBhwyLLdevWzSUp6tkUL1HJx9NPP+1+IOTNm9f9yFT8KdH7Vc/RH7WVUvKXCP369XM/GKZPn+62Cf3w0Z74yZMnxyzXvXv3mHUfvb4T9R4+1Nij5YSkFTlHmHPfsOe/Yc59w54/hjn2sOe+Yc5/yX0Tm8OEOf8l993v5QT/N6UjEkazOy5dutTNale3bt3IjHiaXVCzQGqWTX8mQjnzzDPtxx9/tCVLlrjz/vKJotlNb7nlFhe/7/3337enn37azcJZq1Yte/vttyOxa8ZfPd8gxH448Wt2wkTH78+QWLNmTfvyyy/txBNPtIkTJ9oHH3xgV199tYv9o48+imxPQVv3YY5/5cqVdvLJJ9uvv/5qr732mt144432zz//uNlMNcvmOeec496n/kzAQdpuZN26dW42WcXYpUsXu/zyy+311193Myl//fXXNmTIEDcjZ/369d2Mxf5zCULsO3fudJ+NRx99tDuvGVmldu3ablvS+9f/fDzttNMCF79mHj722GPdNq2ZTRXzyJEj7aSTTnIzWr/yyituOc3UWr16dXdZfOz+bMzZHff06dOtd+/eNmXKFPee1ayy+gz1+TPOasbls88+221Hen38769E0vty/PjxNmbMGBebZgy/5JJL3Dau97H/fSwPPPBAzLr3P6vi/w5D7IneboCcmPuGPf8Nc+4b9vwxzLGHPfcNc/5L7pu4HCbM+S+5r+Wc3DfRVWP832Eks2bNipzXXspVq1Z5Rx99dEyD+uheQhqJEN8LJlH8PXvaC6MG6Oqxo8NOdPiA9mYed9xx3tatWwMZe06IX3tfNVpFk3OI9sJqL5QOM9QefF8QYw9z/Nojr73b2gOow5CiZ3DVnuOzzjorcl4jEYIUuw6H1OzDapjfqVOnmD2omlxCIw70GeTv5axYsWKqe5Wzm9az9qZqVIpPIzo0akjrt2nTpjGzieswmiDE769jTRChde+PJPP3AP/xxx9uxmWNPNBnj/bOazZazcQcBIppzJgx7pBN+f77792kC5qcIKV1q2U10iO+P1aiKO5zzjknppehaFvRyI7oERF6TR566CH3WgRBmGMHcmruG/b8Mcyxhz1/DHPsYc59w5z/kvsmTpjz3zDnj2GOPStQtE0QfTlrZkqdli1bFrnc//Lbtm2bO1xDjZdFw+x16Il67+hDQF+U+juRsetQgejEWv2YXn/99Zi4lHgULFjQNY+WRMce9vj92HV4j2Lzvwz1hadDTdSXqUyZMl6rVq3cYRxKvP3nmOjYwx6/H/uIESMiSYcSpq5du3obN26MSUJ0aJKeh5KRIMWuGLSOFaeSax3mpi9E/3A2UYxKRtQ436fb+s8xkfFrBtzffvvNHdKmxFo/GnS4WLFixSKH62kZHe4WPRN5ouOP9tNPP7ltW9uOz99ulJjoR5vfD0uH+ejHkWZKDwJ/RndfdOLqb9s6PHL27Nlum6pXr56b6CMo/Pdt9HetZlPWDwSfthtdp0Q8SOs+zLEDOSH3zSn5Yxhjzyn5Y5hjD2PuG/b8l9w3ODlMmPPfMOePYY49s1G0TQD1ndEbXXvFihQp4j54e/bsGfkS14eYNkDtIdNIhH///derUaOGd/rpp0fuI1F7Lf3YmzVrFhO7z//y85/LZ5995p155pmRL3BJ5B7XMMefUuwPP/xwpJfLlVde6bYZv1eTvlCUlGhvcqJjD3v88bGfdtpprm+RrF27NrKcv90oUdKy/iiVoMWupEmjO3SZJpSYOHFiJHnSD+natWt7c+bMidyH+qwlSnz8Gg2kCVSUwCoJ18iI6Pfno48+6iZn0Gvhvx6JjF+N8f1RG/GzRqeU0CnR04iE6EQ3ekbvRMaeUk8rP3FVjy+NmlPBxU+mNDFG9PsjKPHrfz/5U9yaSVr0XatRK/76D+K6D0PsQE7LfXNi/hiW2HNa/hjm2MOU+4Y9/yX3TWwOE+b8N8z5Y5hjz2oUbbPZ119/7Wat9Cde0N4ZfTDXrVvX69ixY2Q57Q3URqhDlfRBFoTh3mnF3qFDh2TLq/m8ZvPr0qWLFwRhjj+12JVcKD4d7lOuXDk3IkWTR/gJiD+ZQaKFOf60Yr/llluSLa8vaW03/hdKEGPXZ4omiFCSoR9mWkajJoYPH+4OZWvTpo0XBPHxay/qPffc49bv7bffHrOsthklSTVr1oz5MZpImvFUCaoS7Q0bNkQuVyKtmdJ13ZNPPhkZCaFEpXLlyq7RfhBma00p9pRoFukSJUq45Vu0aBG5PJGTj6Q3fs1Urx/Oem9oRmMVlMKy7oMYO5DTct+cmj+GIfacnD+GOfag575hz3/JfRObw4Q5/w1z/hjm2LMDRdtspqH/2hOj/ig+HQagGVv1YezvodEHtL7I4z8EErkxpjd2Xaa9aEoIL7roosiyiZ49NMzxpxW7ko4bbrjBHUYTvVc1eltJ9IdYmOM/2HajLxfR9drTpz350X2lgrjdaAZgJa76gtTIJvUdO++887wLLrgg0ico6NuN1rP/ntVzULKnflk6vDAI617bs/qPde7c2cuXL5/7sRCdhOhQK42W0CGoOlRP61/LR8cf1Njj6TBOHa7Xtm3bQGw76Ynf3zZUtNAPOI1+Ov/88xMef5hjB3Ji7puT88egx56T88cwxx703Dfs+S+5b+KEOf8Nc/4Y5tizSw6ZTi08KlSo4GZ0XLhwoTuvwnnx4sXdLIQXXnihffXVV7ZgwQLLnz+/FSlSxFq3bu1mFfVnJkzkDHgHi33SpEn2ww8/2ObNm23+/PnWuHFjmzBhQiT2RMw8mFPiTyt2zfT7xx9/WOXKla1AgQKR20RvK4meOTHM8afnPetvN999952bGfWTTz4J9HbTqVMna9GihYtz9erVNnz4cPc5oxmLhw0bFok9yNtNq1atIp+XRxxxhO3YscOuuuoq+/TTTxO+7vft2+dmlW3evLk9//zzNm7cODeT7JNPPmkbNmxwyxQsWNC6du1q3377rV188cVutl/NZBwdf9Bi1yzR8bSsXo9TTjklMvtvIred9Mbvr99t27a5uI8//nj3HZDI+MMcO5BTc9+cnD8GPfacnD+GOfag575hz3/JfRMjzPlvmPPHMMeerbKtPIzI4SPak6B+HNprFk0TMGiEgWarFH+WwqDsPThY7NrT5Pc6im46H4TYwx5/erabAQMGeEEV5vgzst1EXx+W7cb/vImW6BESGYlfM+TGC8K6V7zqPeZ788033egxHTp4sBllEx1/WrFH7/nW4ZwyefLkwMSekfjlk08+caOdghJ/mGMHcmLum9PzxyDHntPzxzDHHuTcN+z5L7lv4oQ5/w1z/hjm2LMLRdsE+O6777wCBQq4vjQ6FCxa69atIw3qg7gxZjT2IHz55ZT4DxZ7UHoZ5cT4c/J2Ex970IR5u/G3Bf8zPDoJ0WFvmvRCh/n8/PPPXthi1wzY6sMXPQt5kL6r0rPuFX/0DPZBij/MsQM5LffNbXlAkGIPex6Qk2MP+3YT5Pw3zNtN2HPfsOe/Yc4fwxx7VqNomyAfffSR+zDWbKGapVL9jNRIvEqVKq4ZelhjHzFihBd0YY4/zLGHPX7es4kT9vijZ/N96623vLx587rEQ6MlLr30Ui+ssWum4qDLqes+6LEDOe17NOzfRWGOPezx59TYec9mrTDHnhNymDDnv2Fe92GOPSsl6Z/sbcgA38yZM+3GG2+0I4880nbu3Gn58uWzE044IdJLKsjCHHvY4w9z7GGPn9gTJ+zx66vW7zM2dOhQu/fee10fsrfffjvZ9UET5tjDHn+YYwdy4md5mOMPc+xhj5/YEyfM8Yc59pyQw4Q5fmLPWSjaJtiqVatc4/8VK1ZYuXLl7Oqrrw5NQ+Uwxx72+MMce9jjJ/bECXv8smTJErvgggvcpB3vvfdeqOIPc+xhjz/MsQM57bM8zPGHOfawx0/siRPm+MMce07JYcIcP7HnDBRtAyjMG2OYYw97/GGOPezxE3vihCl+fd2+9dZb9u6779oHH3wQqvjDHHvY4w9z7EB6hX2bDnP8YY497PETe+KEOf4wxR72HCbM8RN7zkHRFgCAbLJv3z53eFsYk48wxx72+MMcOwAAyL3CnsOEOX5izxko2gIAkM3C3I8pzLGHPf4wxw4AAHKvsOcwYY6f2MONoi0AAAAAAAAABEjuHWMMAAAAAAAAAAFE0RYAAAAAAAAAAoSiLQAAAAAAAAAECEVbAAAAAAAAAAgQirYAAAAAAAAAECAUbQEAAAAAAAAgQCjaAkA227Bhg3Xp0sWOPfZYK1iwoJUvX95atGhh3377rbs+KSnJxo8fn+gwAQAAgMNG7gsAhybfId4OAHCI2rRpY3v27LFXXnnFjj/+eFu3bp1NnjzZ/v3330x9nL1791r+/Pkz9T4BAACAjCD3BYBDw0hbAMhGmzdvtm+++caeeOIJa9asmVWuXNnOOOMM69Gjh1166aV23HHHueUuv/xyN+rAPy8jR460E044wQoUKGAnn3yyvfbaazH3reW1jO6nSJEiNmDAAOvTp4+ddtpp9vLLL7vRDUceeaTddttttn//fnvyySfdSIeyZcu6ZQEAAIDMRO4LAIeOoi0AZCMljjrpELDdu3cnu37OnDnu/zFjxtiaNWsi5z/88EO766677J577rFFixbZLbfcYjfddJNNnTo15vZKVJX0Lly40G6++WZ32W+//Waff/65TZw40d5880176aWX7KKLLrK///7bvv76a5dE9+zZ02bNmpUt6wAAAAC5A7kvABy6JM/zvMO4PQAgg95//33r1KmT7dy50+rWrWtNmjSxa6+91mrVqhUZNaBEtXXr1pHbNG7c2GrUqGGjR4+OXHb11Vfb9u3b7dNPP43crlu3bjZs2LCYRHbQoEG2du1aK1q0qLusZcuWtmzZMpfQ5snzf/vuTjnlFGvfvr09+OCD2bYeAAAAkPOR+wLAoWGkLQAkoK/X6tWr7eOPP3ZJ5LRp01wCO3bs2FRvs2TJEpe8RtN5XR6tfv36yW6rw8z8pFXKlStn1atXjySt/mXr168/zGcGAAAAxCL3BYBDQ9EWABKgUKFC1rx5c3vkkUds5syZbk9/7969D/t+1c8rXvyEDBqVkNJlBw4cOOzHBwAAAOKR+wJAxlG0BYAA0N5/He4lSio1WUK0atWq2bfffhtzmc7rdgAAAECYkPsCwMHlS8cyAIBM8u+//9pVV13lJkpQHy8dujV37lw3m+1ll10WOaRr8uTJ7hCwggULWsmSJe2+++5zfbzq1Klj559/vn3yySf2wQcf2FdffZXopwQAAACkiNwXAA4dRVsAyEaaPbdBgwZuwgRNhrB3716rVKmSm5zhoYcecssMGTLEunfvbi+88IIdffTR9scff7iJGUaMGGGDBw92M+lWqVLFzbLbtGnTRD8lAAAAIEXkvgBw6JI8z/MO4/YAAAAAAAAAgExET1sAAAAAAAAACBCKtgAAAAAAAAAQIBRtAQAAAAAAACBAKNoCAAAAAAAAQIBQtAUAAAAAAACAAKFoCwAAAAAAAAABQtEWAAAAAAAA/187dkwAAACAMMj+qa2xA2IAhEhbAAAAAIAQaQsAAAAAECJtAQAAAABCpC0AAAAAQIi0BQAAAABYxwEZG9lJIDh2wgAAAABJRU5ErkJggg==",
-      "text/plain": [
-       "<Figure size 1400x500 with 2 Axes>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Summary visualization\n",
     "if storm_results:\n",
@@ -1624,6 +653,11 @@
     "    storm_dates = [r['start_time'].strftime('%m/%d') for r in storm_results]\n",
     "    precip_totals = [r['total_depth_in'] for r in storm_results]\n",
     "    colors = ['green' if r['exec_success'] else 'red' for r in storm_results]\n",
+    "    from matplotlib.patches import Patch\n",
+    "    status_legend = [\n",
+    "        Patch(facecolor='green', alpha=0.8, label='Successful'),\n",
+    "        Patch(facecolor='red', alpha=0.8, label='Failed'),\n",
+    "    ]\n",
     "    \n",
     "    bars = ax1.bar(range(len(storm_results)), precip_totals, color=colors, alpha=0.8)\n",
     "    ax1.set_xlabel('Storm')\n",
@@ -1631,6 +665,7 @@
     "    ax1.set_title('Storm Precipitation Totals (green=success)')\n",
     "    ax1.set_xticks(range(len(storm_results)))\n",
     "    ax1.set_xticklabels(storm_dates, rotation=45)\n",
+    "    ax1.legend(handles=status_legend, title='Execution status', fontsize=9)\n",
     "    ax1.grid(True, alpha=0.3, axis='y')\n",
     "    \n",
     "    # HDF sizes\n",
@@ -1661,36 +696,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": null,
    "id": "cell-21",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Precipitation Data Export Summary\n",
-      "Location: C:\\GH\\ras-commander\\examples\\example_projects_400_aorc_precipitation_catalog\\BaldEagleCrkMulti2D_AORC_2020\\Precipitation\n",
-      "======================================================================\n",
-      "\n",
-      "Exported Files:\n",
-      "  Storm Catalog CSV:    1 file(s)\n",
-      "  NetCDF Precip Files:  12 file(s)\n",
-      "  Hyetograph PNGs:      12 file(s)\n",
-      "  Summary Plot:         1 file(s)\n",
-      "\n",
-      "Total Size: 3.4 MB\n",
-      "\n",
-      "Folder Structure:\n",
-      "  Precipitation/\n",
-      "    storm_catalog.csv\n",
-      "    storm_catalog_summary.png\n",
-      "    storm_YYYYMMDD.nc  (x12)\n",
-      "    hyetographs/\n",
-      "      storm_YYYYMMDD_hyetograph.png  (x12)\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# List all exported files\n",
     "print(f\"Precipitation Data Export Summary\")\n",
@@ -1765,25 +774,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": null,
    "id": "cell-24",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Set PROCESS_ALL_YEARS = True to process all AORC years (1979-2024)\n",
-      "Warning: This will take many hours and create ~50 project folders!\n",
-      "\n",
-      "Each year will include:\n",
-      "  - Precipitation/storm_catalog.csv\n",
-      "  - Precipitation/storm_catalog_summary.png\n",
-      "  - Precipitation/storm_YYYYMMDD.nc (per storm)\n",
-      "  - Precipitation/hyetographs/storm_YYYYMMDD_hyetograph.png (per storm)\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# OPTIONAL: Process all AORC years\n",
     "# Set PROCESS_ALL_YEARS = True to run\n",
@@ -1800,14 +794,18 @@
     "    print(f\"Configuration: {NUM_CORES} cores x {MAX_WORKERS} workers per year\")\n",
     "    print(\"=\"*80)\n",
     "\n",
-    "    # Clean up ALL existing AORC folders first\n",
+    "    # Clean up this notebook's existing AORC folders first\n",
     "    print(\"\\nCleaning up existing AORC folders...\")\n",
-    "    existing_folders = list(base_project.parent.glob(\"BaldEagleCrkMulti2D_AORC_*\"))\n",
+    "    existing_folders = list(base_project.parent.glob(f\"{PROJECT_NAME}_AORC_*_{SUFFIX}*\"))\n",
+    "    removed_folders = 0\n",
     "    for folder in existing_folders:\n",
     "        if folder.is_dir():\n",
     "            print(f\"  Removing: {folder.name}\")\n",
-    "            shutil.rmtree(folder)\n",
-    "    print(f\"  Removed {len(existing_folders)} existing folders\")\n",
+    "            if RasUtils.remove_with_retry(folder, ras_object=None):\n",
+    "                removed_folders += 1\n",
+    "            else:\n",
+    "                raise PermissionError(f\"Unable to remove stale notebook 901 folder: {folder}\")\n",
+    "    print(f\"  Removed {removed_folders} existing folders\")\n",
     "\n",
     "    all_year_results = {}\n",
     "\n",
@@ -1818,7 +816,7 @@
     "            print(f\"{'='*80}\")\n",
     "\n",
     "            # Create year-specific working folder\n",
-    "            year_folder = base_project.parent / f\"BaldEagleCrkMulti2D_AORC_{year}\"\n",
+    "            year_folder = base_project.parent / f\"{PROJECT_NAME}_AORC_{year}_{SUFFIX}\"\n",
     "            print(f\"  Creating: {year_folder.name}\")\n",
     "            shutil.copytree(base_project, year_folder)\n",
     "\n",

--- a/ras_commander/RasCmdr.py
+++ b/ras_commander/RasCmdr.py
@@ -873,7 +873,8 @@ class RasCmdr:
                 dest_folder_path = Path(dest_folder)
                 if dest_folder_path.exists():
                     if overwrite_dest:
-                        shutil.rmtree(dest_folder_path)
+                        if not RasUtils.remove_with_retry(dest_folder_path, ras_object=None):
+                            raise PermissionError(f"Unable to remove destination folder: {dest_folder_path}")
                         logger.info(f"Destination folder '{dest_folder_path}' exists. Overwriting as per overwrite_dest=True.")
                     elif any(dest_folder_path.iterdir()):
                         error_msg = f"Destination folder '{dest_folder_path}' exists and is not empty. Use overwrite_dest=True to overwrite."
@@ -936,7 +937,8 @@ class RasCmdr:
             for worker_id in range(1, max_workers + 1):
                 worker_folder = project_folder.parent / f"{project_folder.name} [Worker {worker_id}]"
                 if worker_folder.exists():
-                    shutil.rmtree(worker_folder)
+                    if not RasUtils.remove_with_retry(worker_folder, ras_object=None):
+                        raise PermissionError(f"Unable to remove existing worker folder: {worker_folder}")
                     logger.info(f"Removed existing worker folder: {worker_folder}")
                 shutil.copytree(project_folder, worker_folder, ignore=RasUtils.ignore_windows_reserved)
                 logger.info(f"Created worker folder: {worker_folder}")
@@ -1038,7 +1040,8 @@ class RasCmdr:
                             
                             # Try to remove the worker folder
                             if worker_folder.exists():
-                                shutil.rmtree(worker_folder)
+                                if not RasUtils.remove_with_retry(worker_folder, ras_object=None):
+                                    raise PermissionError(f"Unable to remove worker folder: {worker_folder}")
                             break  # If successful, break the retry loop
                             
                         except PermissionError as pe:

--- a/ras_commander/RasExamples.py
+++ b/ras_commander/RasExamples.py
@@ -52,6 +52,7 @@ import re
 from tqdm import tqdm
 from ras_commander import get_logger
 from ras_commander.LoggingConfig import log_call
+from ras_commander.RasUtils import RasUtils
 
 logger = get_logger(__name__)
 
@@ -258,7 +259,8 @@ class RasExamples:
             if final_folder_path.exists():
                 logger.debug(f"Folder '{folder_name}' already exists. Deleting existing folder...")
                 try:
-                    shutil.rmtree(final_folder_path)
+                    if not RasUtils.remove_with_retry(final_folder_path, ras_object=None):
+                        raise PermissionError(f"Unable to remove existing folder: {final_folder_path}")
                     logger.debug(f"Existing folder '{folder_name}' has been deleted.")
                 except Exception as e:
                     raise RuntimeError(

--- a/ras_commander/RasUtils.py
+++ b/ras_commander/RasUtils.py
@@ -515,7 +515,9 @@ class RasUtils:
         max_attempts (int): Maximum number of removal attempts.
         initial_delay (float): Initial delay between attempts in seconds.
         is_folder (bool): If True, the path is treated as a folder; if False, it's treated as a file.
-        ras_object (RasPrj, optional): RAS object to use. If None, uses the default ras object.
+        ras_object (RasPrj, optional): Accepted for backward compatibility. The
+            cleanup does not require an initialized RAS project, so it can be used
+            before project extraction or during worker-folder cleanup.
 
         Returns:
         bool: True if the file or folder was successfully removed, False otherwise.
@@ -524,10 +526,6 @@ class RasUtils:
         >>> success = RasUtils.remove_with_retry(Path("temp_folder"), is_folder=True)
         >>> print(f"Removal successful: {success}")
         """
-        
-        ras_obj = ras_object or ras
-        ras_obj.check_initialized()
-
         path = Path(path)
         for attempt in range(1, max_attempts + 1):
             try:

--- a/tests/test_rasutils_cleanup.py
+++ b/tests/test_rasutils_cleanup.py
@@ -1,0 +1,48 @@
+from pathlib import Path
+import shutil
+import zipfile
+
+import pandas as pd
+
+from ras_commander.RasExamples import RasExamples
+from ras_commander.RasUtils import RasUtils
+
+
+def test_remove_with_retry_does_not_require_initialized_project(tmp_path):
+    stale_worker = tmp_path / "AORC_900 [Worker 1]"
+    stale_worker.mkdir()
+    (stale_worker / "locked-after-hecras.txt").write_text("released", encoding="utf-8")
+
+    assert RasUtils.remove_with_retry(stale_worker, ras_object=None)
+    assert not stale_worker.exists()
+
+
+def test_extract_project_reuses_retry_cleanup_for_existing_folder(tmp_path, monkeypatch):
+    zip_path = tmp_path / "Example_Projects_7_0.zip"
+    with zipfile.ZipFile(zip_path, "w") as zip_ref:
+        zip_ref.writestr("Category/FakeProject/FakeProject.prj", "Proj Title=FakeProject\n")
+
+    existing_folder = tmp_path / "FakeProject_901"
+    existing_folder.mkdir()
+    (existing_folder / "old.prj").write_text("old", encoding="utf-8")
+
+    removed_paths = []
+
+    def fake_remove(path: Path, **kwargs) -> bool:
+        removed_paths.append(Path(path))
+        shutil.rmtree(path)
+        return True
+
+    monkeypatch.setattr(
+        RasExamples,
+        "_folder_df",
+        pd.DataFrame([{"Category": "Category", "Project": "FakeProject"}]),
+    )
+    monkeypatch.setattr(RasExamples, "_zip_file_path", zip_path)
+    monkeypatch.setattr(RasUtils, "remove_with_retry", staticmethod(fake_remove))
+
+    extracted = RasExamples.extract_project("FakeProject", output_path=tmp_path, suffix="901")
+
+    assert extracted == existing_folder
+    assert removed_paths == [existing_folder]
+    assert (existing_folder / "FakeProject.prj").exists()


### PR DESCRIPTION
## Summary
- route notebook 901 setup into a notebook-specific working directory and suffix-scoped AORC cleanup
- reuse retry cleanup for existing extracted projects and parallel worker folders on Windows
- clear stale executed notebook outputs and add focused cleanup regression tests

## Validation
- conda run -n symphony-dev --no-capture-output python -m pytest tests/test_rasutils_cleanup.py -q
- recorded notebook 901 structural check
- recorded setup preflight preserving simulated notebook 900 worker folder
- run_notebook_visible.py smoke notebook execution with extracted figure visual review

Artifacts: H:/Symphony/ras-commander/CLB-873/