### PR TITLE
fix(terrain): Type attr, profile precision, rasmap guard in RasTerrainModWriter (CLB-849)

### DIFF
--- a/ras_commander/terrain/RasTerrainModWriter.py
+++ b/ras_commander/terrain/RasTerrainModWriter.py
@@ -867,7 +867,7 @@ class RasTerrainModWriter:
             mod_grp = mods.create_group(name)
 
             # Set type attributes
-            mod_grp.attrs['Type'] = np.bytes_('Levee')
+            mod_grp.attrs['Type'] = np.bytes_(subtype)
             mod_grp.attrs['Subtype'] = np.bytes_(subtype)
             mod_grp.attrs['Priority'] = np.int32(0)
 
@@ -891,6 +891,7 @@ class RasTerrainModWriter:
             )
             mod_grp['Polyline Info'].attrs['Feature Type'] = np.bytes_('Polyline')
 
+            profile_data = np.asarray(profile_data, dtype=np.float64)
             profile_info = np.array([[0, len(profile_data)]], dtype=np.int32)
             RasTerrainModWriter._create_hdf_dataset(
                 mod_grp, 'Profile Info', profile_info
@@ -1791,6 +1792,13 @@ class RasTerrainModWriter:
 
     @staticmethod
     def _read_profile_array(mod_grp) -> np.ndarray:
+        if "Profile" in mod_grp:
+            values = np.asarray(mod_grp["Profile"][:], dtype=np.float64)
+            if "Profile Info" in mod_grp and len(mod_grp["Profile Info"]) > 0:
+                start, count = np.asarray(mod_grp["Profile Info"][0], dtype=np.int64)
+                values = values[start : start + count]
+            return values
+
         if "Profile Values" in mod_grp:
             values = np.asarray(mod_grp["Profile Values"][:], dtype=np.float64)
             if "Profile Info" in mod_grp and len(mod_grp["Profile Info"]) > 0:
@@ -1798,10 +1806,7 @@ class RasTerrainModWriter:
                 values = values[start : start + count]
             return values
 
-        if "Profile" in mod_grp:
-            return np.asarray(mod_grp["Profile"][:], dtype=np.float64)
-
-        raise KeyError(f"Modification profile not found: {mod_grp.name}/Profile Values")
+        raise KeyError(f"Modification profile not found: {mod_grp.name}/Profile")
 
     @staticmethod
     def _read_ground_line_modification(
@@ -2200,6 +2205,11 @@ class RasTerrainModWriter:
             if child.get('Type') == 'ElevationModificationGroup':
                 mod_group = child
                 break
+
+        if mod_group is None:
+            raise RuntimeError(
+                "ElevationModificationGroup not found after rasmap update"
+            )
 
         # Check if modification layer already exists
         for child in mod_group.findall('Layer'):

--- a/tests/test_ras_terrain_mod_writer.py
+++ b/tests/test_ras_terrain_mod_writer.py
@@ -377,6 +377,7 @@ def test_add_channel_modification_keeps_take_lower_mode(tmp_path):
 
     with h5py.File(terrain_hdf, "r") as hdf:
         mod = hdf["Modifications/Pilot Channel"]
+        assert _decode(mod.attrs["Type"]) == "Channel"
         assert _decode(mod.attrs["Subtype"]) == "Channel"
         np.testing.assert_allclose(
             mod["Profile Values"][:],
@@ -388,6 +389,73 @@ def test_add_channel_modification_keeps_take_lower_mode(tmp_path):
     assert layer.find("DefaultModificationType").get("Value") == str(
         MODIFICATION_TAKE_LOWER
     )
+
+
+def test_profile_readback_prefers_float64_profile_for_large_stations(tmp_path):
+    terrain_hdf, rasmap = _write_minimal_terrain(tmp_path)
+    profile_points = np.array(
+        [
+            [500000.123456, 601.1234567],
+            [500250.654321, 601.7654321],
+        ],
+        dtype=np.float64,
+    )
+
+    RasTerrainModWriter.add_high_ground_modification(
+        terrain_hdf,
+        rasmap,
+        name="Precision Levee",
+        polyline_points=np.array(
+            [[500000.1, 300000.2], [500250.6, 300000.3]],
+            dtype=np.float64,
+        ),
+        profile_points=profile_points,
+    )
+
+    with h5py.File(terrain_hdf, "r") as hdf:
+        mod = hdf["Modifications/Precision Levee"]
+        assert mod["Profile Values"].dtype == np.dtype("float32")
+        assert mod["Profile"].dtype == np.dtype("float64")
+        assert not np.allclose(
+            mod["Profile Values"][:], profile_points, rtol=0.0, atol=1e-12
+        )
+        np.testing.assert_allclose(
+            mod["Profile"][:], profile_points, rtol=0.0, atol=1e-12
+        )
+
+    profile = RasTerrainModWriter.get_modification_profile(
+        terrain_hdf, "Precision Levee"
+    )
+    np.testing.assert_allclose(
+        profile[["station", "elevation"]].to_numpy(),
+        profile_points,
+        rtol=0.0,
+        atol=1e-12,
+    )
+
+
+def test_update_rasmap_xml_raises_clear_error_when_group_missing(
+    tmp_path, monkeypatch
+):
+    terrain_hdf, rasmap = _write_minimal_terrain(tmp_path)
+    monkeypatch.setattr(
+        RasTerrainModWriter,
+        "_ensure_modification_group_in_rasmap",
+        staticmethod(lambda *args, **kwargs: None),
+    )
+
+    with pytest.raises(
+        RuntimeError, match="ElevationModificationGroup not found after rasmap update"
+    ):
+        RasTerrainModWriter._update_rasmap_xml(
+            rasmap,
+            terrain_hdf,
+            name="Missing Group",
+            mod_type="GroundLineModificationLayer",
+            default_mod_type=MODIFICATION_TAKE_HIGHER,
+            elev_pt_tolerance=50.0,
+            group_name="Modifications",
+        )
 
 
 def test_sample_modification_surface_applies_take_higher(tmp_path):


### PR DESCRIPTION
## Summary
Fixes **CLB-849** — three structural bugs in `RasTerrainModWriter.py` flagged during QAQC of PR #64/#74 (CLB-324). Notebook 316's BaldEagle example avoids triggering them, but production use would expose all three.

| Bug | Fix |
|---|---|
| **1 (Critical)** — `Type=b'Levee'` hardcoded for all mods | Write `Type` from `subtype` → channel mods get `Type=b'Channel'` |
| **2** — `Profile Values` float32 precision loss on large coords | `_read_profile_array` prefers the float64 `Profile` dataset (sliced by `Profile Info`); `Profile Values` kept float32 for RAS Mapper compat; `Profile` written from float64 data |
| **3** — fragile rasmap re-parse → `AttributeError` on silent write failure | Guard raising `RuntimeError("ElevationModificationGroup not found after rasmap update")` |

**Bug 2 note:** a float64 *write* of `Profile Values` broke RAS Mapper raster readback (it stopped applying the modification), so the read-preference approach was chosen instead — satisfies sub-0.01 ft precision without changing RAS Mapper output format.

## Verification
- Applies cleanly onto current `main`; deliverable isolated from unrelated churn.
- `pytest tests/test_ras_terrain_mod_writer.py` → **13 passed**, including the three new pins (channel `Type`, large-station float64 round-trip, rasmap missing-group error).

Linear: CLB-849

🤖 Generated with [Claude Code](https://claude.com/claude-code)
