### PR TITLE
CLB-868 Repair stale geometry HDF handling

### DIFF
--- a/examples/230_mesh_sensitivity_analysis.ipynb
+++ b/examples/230_mesh_sensitivity_analysis.ipynb
@@ -3,7 +3,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "# 2D Mesh Sensitivity Analysis\n\n## Overview\n\nThis notebook demonstrates **end-to-end 2D mesh sensitivity analysis** using the `GeomMesh` API.\nFor any 2D HEC-RAS model, mesh resolution is a critical modeling choice that directly affects:\n\n- **Accuracy**: Finer meshes resolve terrain and flow features better\n- **Runtime**: Cell count drives computation time (roughly quadratic with cell size reduction)\n- **Stability**: Too-fine meshes near breaklines can cause solver instability\n- **Calibration**: Mesh resolution can affect calibrated Manning's n values\n\n### What This Notebook Does\n\n1. Extracts the **BaldEagleCrkMulti2D** example project (Plan 06, Geometry 09)\n2. Clones the geometry for each sensitivity scenario\n3. Varies mesh parameters systematically:\n   - **Base cell size** (coarse -- fine)\n   - **Breakline spacing** (all breaklines, near and far)\n   - **Selective breakline spacing** (dam breakline only vs. channel breaklines)\n4. Regenerates meshes using `GeomMesh.generate()`\n5. Clones plans pointing to each modified geometry\n6. Executes all plans\n7. Generates WSE stored maps and compares results\n\n### Mesh Parameters Explained\n\n| Parameter | Text File Field | Default | Effect |\n|-----------|----------------|---------|--------|\n| `cell_size` | `Storage Area Point Generation Data=,,X,X` | `None` (auto-detect from HDF `Spacing dx`) | Base grid spacing for seed points |\n| `bl_spacing_near` | `BreakLine CellSize Min=` | `None` (preserve text) | Cell size immediately adjacent to breaklines |\n| `bl_spacing_far` | `BreakLine CellSize Max=` | `None` (preserve text) | Cell size at transition distance from breaklines |\n\n### Cell Size Auto-Detection\n\nWhen `cell_size=None` (the default), `GeomMesh.generate()` reads the model's own spacing from\nthe compiled geometry HDF attribute `Spacing dx`. This ensures headless mesh generation\nreproduces the original model's cell count without requiring the caller to know the spacing.\n\nPass an explicit `cell_size` to override — this is what sensitivity analysis does.\n\n### Reference\n\n- [HEC-RAS 2D User Manual: Section 3.4 - Mesh Generation](https://www.hec.usace.army.mil/software/hec-ras/documentation.aspx)\n- [Brunner (2016) Combined 1D and 2D Modeling with HEC-RAS](https://www.hec.usace.army.mil/publications/)"
+   "source": "# 2D Mesh Sensitivity Analysis\n\n## Overview\n\nThis notebook demonstrates **end-to-end 2D mesh sensitivity analysis** using the `GeomMesh` API.\nFor any 2D HEC-RAS model, mesh resolution is a critical modeling choice that directly affects:\n\n- **Accuracy**: Finer meshes resolve terrain and flow features better\n- **Runtime**: Cell count drives computation time (roughly quadratic with cell size reduction)\n- **Stability**: Too-fine meshes near breaklines can cause solver instability\n- **Calibration**: Mesh resolution can affect calibrated Manning's n values\n\n### What This Notebook Does\n\n1. Extracts the **BaldEagleCrkMulti2D** example project (Plan 06, Geometry 09)\n2. Clones the geometry for each sensitivity scenario\n3. Varies mesh parameters systematically:\n   - **Base cell size** (coarse -- fine)\n   - **Breakline spacing** (all breaklines, near and far)\n   - **Selective breakline spacing** (dam breakline only vs. channel breaklines)\n4. Regenerates meshes using `GeomMesh.generate()`\n5. Clones plans pointing to each modified geometry\n6. Executes all plans\n7. Generates WSE stored maps and compares results\n\n### Mesh Parameters Explained\n\n| Parameter | Text File Field | Default | Effect |\n|-----------|----------------|---------|--------|\n| `cell_size` | `Storage Area Point Generation Data=,,X,X` | `None` (auto-detect from geometry text; HDF fallback) | Base grid spacing for seed points |\n| `bl_spacing_near` | `BreakLine CellSize Min=` | `None` (preserve text) | Cell size immediately adjacent to breaklines |\n| `bl_spacing_far` | `BreakLine CellSize Max=` | `None` (preserve text) | Cell size at transition distance from breaklines |\n\n### Cell Size Auto-Detection\n\nWhen `cell_size=None` (the default), `GeomMesh.generate()` reads the model's own spacing from\nthe geometry text `Storage Area Point Generation Data` first, then falls back to the compiled\ngeometry HDF attribute `Spacing dx` only when the text does not define spacing. This avoids\ntrusting stale HDF metadata after geometry clones.\n\nPass an explicit `cell_size` to override — this is what sensitivity analysis does. If a compiled\ngeometry HDF is content-stale or missing and the geometry is already referenced by a plan, pass\n`recompile_via_rasexe=True` so ras-commander refreshes it through Ras.exe/HTab instead of\ndeleting the HDF.\n\n### Reference\n\n- [HEC-RAS 2D User Manual: Section 3.4 - Mesh Generation](https://www.hec.usace.army.mil/software/hec-ras/documentation.aspx)\n- [Brunner (2016) Combined 1D and 2D Modeling with HEC-RAS](https://www.hec.usace.army.mil/publications/)"
   },
   {
    "cell_type": "markdown",
@@ -462,12 +462,12 @@
     }
    },
    "outputs": [],
-   "source": "scenario_results = []\n\nfor scenario in SCENARIOS:\n    name = scenario[\"name\"]\n    title = scenario[\"title\"]\n    cell_size = scenario.get(\"cell_size\", 250.0)\n    bl_near = scenario.get(\"bl_spacing_near\")\n    bl_far = scenario.get(\"bl_spacing_far\")\n    bl_by_name = scenario.get(\"bl_by_name\")  # optional per-breakline dict\n\n    print(f\"\\n{'='*60}\")\n    print(f\"Scenario: {title}\")\n    print(f\"  cell_size={cell_size}, bl_near={bl_near}, bl_far={bl_far}\")\n\n    # 1. Clone geometry (copies both .g## text and .g##.hdf)\n    new_geom = RasPlan.clone_geom(template_geom, ras_object=ras)\n    print(f\"  Cloned geometry: g{template_geom} -> g{new_geom}\")\n\n    # Get the new geometry's text file path\n    new_geom_path = Path(\n        ras.geom_df.loc[\n            ras.geom_df['geom_number'] == new_geom, 'full_path'\n        ].values[0]\n    )\n\n    # 2. Apply per-breakline spacing if specified (using the API)\n    if bl_by_name:\n        for bl_name, (near_val, far_val) in bl_by_name.items():\n            GeomMesh.set_breakline_spacing(\n                new_geom_path,\n                near=near_val, far=far_val,\n                breakline_name=bl_name,\n            )\n            print(f\"  Set breakline '{bl_name}': near={near_val}, far={far_val}\")\n\n    # 3. Generate mesh (cell_size and breakline spacing applied internally)\n    mesh_result = GeomMesh.generate(\n        geom_number=new_geom_path,\n        mesh_name=\"BaldEagleCr\",\n        cell_size=cell_size,\n        bl_spacing_near=bl_near,\n        bl_spacing_far=bl_far,\n        max_iterations=8,\n        ras_object=ras,\n    )\n\n    print(f\"  Mesh: status={mesh_result.status}, \"\n          f\"cells={mesh_result.cell_count}, faces={mesh_result.face_count}\")\n    if mesh_result.fixes_applied:\n        print(f\"  Fixes: {mesh_result.fixes_applied}\")\n\n    # 4. Clone plan and assign the new geometry\n    new_plan = RasPlan.clone_plan(\n        TEMPLATE_PLAN,\n        new_plan_shortid=name[:12],\n        geometry=new_geom,\n        num_cores=NUM_CORES,\n        ras_object=ras,\n    )\n    print(f\"  Cloned plan: p{TEMPLATE_PLAN} -> p{new_plan} (geom=g{new_geom})\")\n\n    scenario_results.append({\n        \"name\": name,\n        \"title\": title,\n        \"plan_number\": new_plan,\n        \"geom_number\": new_geom,\n        \"cell_size\": cell_size,\n        \"bl_near\": bl_near,\n        \"bl_far\": bl_far,\n        \"cell_count\": mesh_result.cell_count,\n        \"face_count\": mesh_result.face_count,\n        \"mesh_status\": mesh_result.status,\n        \"fixes\": mesh_result.fixes_applied,\n    })\n\n# Summary table\nscenario_df = pd.DataFrame(scenario_results)\nprint(f\"\\n{'='*60}\")\nprint(\"Scenario Summary:\")\nprint(scenario_df[['name', 'plan_number', 'geom_number', 'cell_size',\n                    'bl_near', 'bl_far', 'cell_count', 'face_count', 'mesh_status'\n                    ]].to_string(index=False))"
+   "source": "scenario_results = []\n\nfor scenario in SCENARIOS:\n    name = scenario[\"name\"]\n    title = scenario[\"title\"]\n    cell_size = scenario.get(\"cell_size\", 250.0)\n    bl_near = scenario.get(\"bl_spacing_near\")\n    bl_far = scenario.get(\"bl_spacing_far\")\n    bl_by_name = scenario.get(\"bl_by_name\")  # optional per-breakline dict\n\n    print(f\"\\n{'='*60}\")\n    print(f\"Scenario: {title}\")\n    print(f\"  cell_size={cell_size}, bl_near={bl_near}, bl_far={bl_far}\")\n\n    # 1. Clone geometry (copies both .g## text and .g##.hdf)\n    new_geom = RasPlan.clone_geom(template_geom, ras_object=ras)\n    print(f\"  Cloned geometry: g{template_geom} -> g{new_geom}\")\n\n    # Get the new geometry's text file path\n    new_geom_path = Path(\n        ras.geom_df.loc[\n            ras.geom_df['geom_number'] == new_geom, 'full_path'\n        ].values[0]\n    )\n\n    # 2. Clone plan and assign the new geometry before mesh generation.\n    # This gives recompile_via_rasexe=True a valid plan-driven HTab path\n    # if the cloned compiled HDF is missing or content-stale.\n    new_plan = RasPlan.clone_plan(\n        TEMPLATE_PLAN,\n        new_plan_shortid=name[:12],\n        geometry=new_geom,\n        num_cores=NUM_CORES,\n        ras_object=ras,\n    )\n    print(f\"  Cloned plan: p{TEMPLATE_PLAN} -> p{new_plan} (geom=g{new_geom})\")\n\n    # 3. Apply per-breakline spacing if specified (using the API)\n    if bl_by_name:\n        for bl_name, (near_val, far_val) in bl_by_name.items():\n            GeomMesh.set_breakline_spacing(\n                new_geom_path,\n                near=near_val, far=far_val,\n                breakline_name=bl_name,\n            )\n            print(f\"  Set breakline '{bl_name}': near={near_val}, far={far_val}\")\n\n    # 4. Generate mesh. Keep the cloned HDF; it is the .NET workspace.\n    # The opt-in Ras.exe path is used only if content checks find the HDF\n    # stale/missing before geometry is read.\n    mesh_result = GeomMesh.generate(\n        geom_number=new_geom_path,\n        mesh_name=\"BaldEagleCr\",\n        cell_size=cell_size,\n        bl_spacing_near=bl_near,\n        bl_spacing_far=bl_far,\n        max_iterations=8,\n        ras_object=ras,\n        recompile_via_rasexe=True,\n    )\n\n    print(f\"  Mesh: status={mesh_result.status}, \"\n          f\"cells={mesh_result.cell_count}, faces={mesh_result.face_count}\")\n    if mesh_result.fixes_applied:\n        print(f\"  Fixes: {mesh_result.fixes_applied}\")\n\n    scenario_results.append({\n        \"name\": name,\n        \"title\": title,\n        \"plan_number\": new_plan,\n        \"geom_number\": new_geom,\n        \"cell_size\": cell_size,\n        \"bl_near\": bl_near,\n        \"bl_far\": bl_far,\n        \"cell_count\": mesh_result.cell_count,\n        \"face_count\": mesh_result.face_count,\n        \"mesh_status\": mesh_result.status,\n        \"fixes\": mesh_result.fixes_applied,\n    })\n\n# Summary table\nscenario_df = pd.DataFrame(scenario_results)\nprint(f\"\\n{'='*60}\")\nprint(\"Scenario Summary:\")\nprint(scenario_df[['name', 'plan_number', 'geom_number', 'cell_size',\n                    'bl_near', 'bl_far', 'cell_count', 'face_count', 'mesh_status'\n                    ]].to_string(index=False))"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "## Mesh Reproduction Validation\n\nBefore executing plans, verify the baseline scenario reproduces the original mesh.\nRegenerateMeshPoints uses the same grid origin as RAS Mapper: same HEC-RAS version and\ncell size produces identical cell centers to machine precision.\n\n### Auto-Detection vs Explicit Cell Size\n\n`GeomMesh.generate()` defaults to `cell_size=None`, which reads `Spacing dx` from the\ncompiled geometry HDF. This produces the same mesh as the original model without the caller\nneeding to know the spacing. In sensitivity analysis (above) we override with explicit values.\n\nThe cell below demonstrates both: auto-detect for reproduction fidelity, then compares\nagainst the explicit baseline scenario."
+   "source": "## Mesh Reproduction Validation\n\nBefore executing plans, verify the baseline scenario reproduces the original mesh.\nRegenerateMeshPoints uses the same grid origin as RAS Mapper: same HEC-RAS version and\ncell size produces identical cell centers to machine precision.\n\n### Auto-Detection vs Explicit Cell Size\n\n`GeomMesh.generate()` defaults to `cell_size=None`, which reads the base spacing from\ngeometry text first and falls back to HDF `Spacing dx` only when text spacing is absent.\nThe scenario loop above creates each plan before mesh generation, so\n`recompile_via_rasexe=True` can refresh a missing or content-stale compiled HDF through\nRas.exe/HTab before geometry is read.\n\nThe cell below demonstrates auto-detect for reproduction fidelity, then compares\nagainst the explicit baseline scenario."
   },
   {
    "cell_type": "code",
@@ -481,7 +481,7 @@
     }
    },
    "outputs": [],
-   "source": "import h5py\nfrom scipy.spatial import cKDTree\n\n# ── Auto-detect demonstration ──────────────────────────────────────────────\n# Clone a fresh geometry and generate with cell_size=None (auto-detect)\nauto_geom = RasPlan.clone_geom(template_geom, ras_object=ras)\nauto_geom_path = Path(\n    ras.geom_df.loc[\n        ras.geom_df[\"geom_number\"] == auto_geom, \"full_path\"\n    ].values[0]\n)\n\nauto_result = GeomMesh.generate(\n    geom_number=auto_geom_path,\n    mesh_name=\"BaldEagleCr\",\n    cell_size=None,  # auto-detect from HDF Spacing dx\n    max_iterations=8,\n    ras_object=ras,\n)\nprint(f\"Auto-detect result: {auto_result.cell_count:,} cells \"\n      f\"(cell_size read from HDF Spacing dx)\")\n\n# Read original and auto-detect cell centers\norig_hdf = Path(str(template_geom_path) + \".hdf\")\nauto_hdf = Path(str(auto_geom_path) + \".hdf\")\n\nwith h5py.File(str(orig_hdf), \"r\") as f:\n    orig_cc = f[\"Geometry/2D Flow Areas/BaldEagleCr/Cells Center Coordinate\"][:]\n\nwith h5py.File(str(auto_hdf), \"r\") as f:\n    auto_cc = f[\"Geometry/2D Flow Areas/BaldEagleCr/Cells Center Coordinate\"][:]\n\n# Also read the text seed count written by generate()\nauto_text = auto_geom_path.read_text(encoding=\"utf-8\", errors=\"replace\")\nauto_text_seeds = None\nfor line in auto_text.splitlines():\n    if line.startswith(\"Storage Area 2D Points=\"):\n        auto_text_seeds = int(line.split(\"=\", 1)[1].strip())\n        break\n\nprint(f\"\\nOriginal g{template_geom} HDF cells: {orig_cc.shape[0]:,}\")\nprint(f\"Auto-detect regenerated:        {auto_cc.shape[0]:,}\")\nif auto_text_seeds is not None:\n    print(f\"Auto-detect text seed count:    {auto_text_seeds:,}\")\n\n# Spatial comparison\ntree = cKDTree(orig_cc)\ndists, _ = tree.query(auto_cc)\nprint()\nprint(\"Cell center distances (auto-detect vs original):\")\nprint(f\"  Max:    {dists.max():.6f} ft\")\nprint(f\"  Mean:   {dists.mean():.6f} ft\")\nprint(f\"  Median: {np.median(dists):.6f} ft\")\nexact = np.sum(dists < 0.01)\nprint(f\"  Exact matches (<0.01 ft): {exact:,} / {len(dists):,}\")\n\nif orig_cc.shape[0] == auto_cc.shape[0] and dists.max() < 0.01:\n    print(\"\\nEXACT MATCH: Auto-detected cell size reproduces original mesh perfectly\")\nelif orig_cc.shape[0] == auto_cc.shape[0]:\n    print(f\"\\nSame count, {np.sum(dists >= 0.01):,} cells shifted (cross-version delta)\")\nelse:\n    pct = 100 * min(orig_cc.shape[0], auto_cc.shape[0]) / max(orig_cc.shape[0], auto_cc.shape[0])\n    print(f\"\\nCell count delta: {abs(orig_cc.shape[0] - auto_cc.shape[0]):,} \"\n          f\"({pct:.1f}% overlap, cross-version mesh difference)\")\n\n# ── Compare with explicit baseline scenario ────────────────────────────────\nbaseline = next(s for s in scenario_results if s[\"name\"] == \"baseline_250\")\nprint(f\"\\nExplicit baseline_250 cells: {baseline['cell_count']:,}\")\nprint(f\"Auto-detect cells:           {auto_result.cell_count:,}\")\nif baseline[\"cell_count\"] == auto_result.cell_count:\n    print(\"MATCH: Explicit cell_size=250 and auto-detect produce identical meshes\")"
+   "source": "import h5py\nfrom scipy.spatial import cKDTree\n\n# Auto-detect demonstration\n# Clone a fresh geometry and attach it to a plan before generate(). This lets\n# recompile_via_rasexe=True refresh a missing/stale HDF through Ras.exe if the\n# content check ever requires it.\nauto_geom = RasPlan.clone_geom(template_geom, ras_object=ras)\nauto_geom_path = Path(\n    ras.geom_df.loc[\n        ras.geom_df[\"geom_number\"] == auto_geom, \"full_path\"\n    ].values[0]\n)\nauto_plan = RasPlan.clone_plan(\n    TEMPLATE_PLAN,\n    new_plan_shortid=\"auto_detect\",\n    geometry=auto_geom,\n    num_cores=NUM_CORES,\n    ras_object=ras,\n)\nprint(f\"Auto-detect plan: p{auto_plan} (geom=g{auto_geom})\")\n\nauto_result = GeomMesh.generate(\n    geom_number=auto_geom_path,\n    mesh_name=\"BaldEagleCr\",\n    cell_size=None,  # auto-detect from geometry text, HDF fallback\n    max_iterations=8,\n    ras_object=ras,\n    recompile_via_rasexe=True,\n)\nprint(f\"Auto-detect result: {auto_result.cell_count:,} cells \"\n      f\"(cell_size read from geometry text/HDF fallback)\")\n\n# Read original and auto-detect cell centers\norig_hdf = Path(str(template_geom_path) + \".hdf\")\nauto_hdf = Path(str(auto_geom_path) + \".hdf\")\n\nwith h5py.File(str(orig_hdf), \"r\") as f:\n    orig_cc = f[\"Geometry/2D Flow Areas/BaldEagleCr/Cells Center Coordinate\"][:]\n\nwith h5py.File(str(auto_hdf), \"r\") as f:\n    auto_cc = f[\"Geometry/2D Flow Areas/BaldEagleCr/Cells Center Coordinate\"][:]\n\n# Also read the text seed count written by generate()\nauto_text = auto_geom_path.read_text(encoding=\"utf-8\", errors=\"replace\")\nauto_text_seeds = None\nfor line in auto_text.splitlines():\n    if line.startswith(\"Storage Area 2D Points=\"):\n        auto_text_seeds = int(line.split(\"=\", 1)[1].strip())\n        break\n\nprint(f\"\\nOriginal g{template_geom} HDF cells: {orig_cc.shape[0]:,}\")\nprint(f\"Auto-detect regenerated:        {auto_cc.shape[0]:,}\")\nif auto_text_seeds is not None:\n    print(f\"Auto-detect text seed count:    {auto_text_seeds:,}\")\n\n# Spatial comparison\ntree = cKDTree(orig_cc)\ndists, _ = tree.query(auto_cc)\nprint()\nprint(\"Cell center distances (auto-detect vs original):\")\nprint(f\"  Max:    {dists.max():.6f} ft\")\nprint(f\"  Mean:   {dists.mean():.6f} ft\")\nprint(f\"  Median: {np.median(dists):.6f} ft\")\nexact = np.sum(dists < 0.01)\nprint(f\"  Exact matches (<0.01 ft): {exact:,} / {len(dists):,}\")\n\nif orig_cc.shape[0] == auto_cc.shape[0] and dists.max() < 0.01:\n    print(\"\\nEXACT MATCH: Auto-detected cell size reproduces original mesh perfectly\")\nelif orig_cc.shape[0] == auto_cc.shape[0]:\n    print(f\"\\nSame count, {np.sum(dists >= 0.01):,} cells shifted (cross-version delta)\")\nelse:\n    pct = 100 * min(orig_cc.shape[0], auto_cc.shape[0]) / max(orig_cc.shape[0], auto_cc.shape[0])\n    print(f\"\\nCell count delta: {abs(orig_cc.shape[0] - auto_cc.shape[0]):,} \"\n          f\"({pct:.1f}% overlap, cross-version mesh difference)\")\n\n# Compare with explicit baseline scenario\nbaseline = next(s for s in scenario_results if s[\"name\"] == \"baseline_250\")\nprint(f\"\\nExplicit baseline_250 cells: {baseline['cell_count']:,}\")\nprint(f\"Auto-detect cells:           {auto_result.cell_count:,}\")\nif baseline[\"cell_count\"] == auto_result.cell_count:\n    print(\"MATCH: Explicit cell_size=250 and auto-detect produce identical meshes\")"
   },
   {
    "cell_type": "code",
@@ -898,57 +898,7 @@
      ]
     }
    ],
-   "source": [
-    "# â”€â”€ Side-by-side WSE maps â”€â”€\n",
-    "n = len(wse_data)\n",
-    "if n == 0:\n",
-    "    print(\"No WSE data to plot.\")\n",
-    "else:\n",
-    "    ncols = min(3, n)\n",
-    "    nrows = (n + ncols - 1) // ncols\n",
-    "    fig, axes = plt.subplots(nrows, ncols, figsize=(7 * ncols, 6 * nrows))\n",
-    "    if n == 1:\n",
-    "        axes = [axes]\n",
-    "    else:\n",
-    "        axes = axes.flatten()\n",
-    "\n",
-    "    # Common color scale across all scenarios\n",
-    "    all_valid = np.concatenate(\n",
-    "        [d[\"data\"][~np.isnan(d[\"data\"])].ravel() for d in wse_data.values()]\n",
-    "    )\n",
-    "    vmin, vmax = np.percentile(all_valid, [2, 98])\n",
-    "\n",
-    "    for ax, (name, d) in zip(axes, wse_data.items()):\n",
-    "        title_row = next(s for s in scenario_results if s['name'] == name)\n",
-    "        im = ax.imshow(\n",
-    "            d[\"data\"],\n",
-    "            extent=[\n",
-    "                d[\"bounds\"].left, d[\"bounds\"].right,\n",
-    "                d[\"bounds\"].bottom, d[\"bounds\"].top,\n",
-    "            ],\n",
-    "            vmin=vmin, vmax=vmax,\n",
-    "            cmap=\"Blues\",\n",
-    "            origin=\"upper\",\n",
-    "        )\n",
-    "        ax.set_title(\n",
-    "            f\"{title_row['title']}\\n\"\n",
-    "            f\"cells={title_row['cell_count']:,}  faces={title_row['face_count']:,}\",\n",
-    "            fontsize=10,\n",
-    "        )\n",
-    "        ax.set_xlabel(\"Easting\")\n",
-    "        ax.set_ylabel(\"Northing\")\n",
-    "\n",
-    "    # Hide unused axes\n",
-    "    for ax in axes[n:]:\n",
-    "        ax.set_visible(False)\n",
-    "\n",
-    "    fig.colorbar(im, ax=axes[:n], label=\"Max WSE (ft)\", shrink=0.8)\n",
-    "    fig.suptitle(\"Maximum Water Surface Elevation by Mesh Scenario\", fontsize=14, y=1.02)\n",
-    "    plt.tight_layout()\n",
-    "    plt.savefig(Path(project_folder) / \"wse_comparison.png\", dpi=150, bbox_inches=\"tight\")\n",
-    "    plt.show()\n",
-    "    print(f\"Saved: {Path(project_folder) / 'wse_comparison.png'}\")"
-   ]
+   "source": "# Side-by-side WSE maps\nn = len(wse_data)\nif n == 0:\n    print(\"No WSE data to plot.\")\nelse:\n    ncols = min(3, n)\n    nrows = (n + ncols - 1) // ncols\n    fig, axes = plt.subplots(nrows, ncols, figsize=(7 * ncols, 6 * nrows))\n    if n == 1:\n        axes = [axes]\n    else:\n        axes = axes.flatten()\n\n    # Common color scale across all scenarios\n    all_valid = np.concatenate(\n        [d[\"data\"][~np.isnan(d[\"data\"])].ravel() for d in wse_data.values()]\n    )\n    vmin, vmax = np.percentile(all_valid, [2, 98])\n\n    for ax, (name, d) in zip(axes, wse_data.items()):\n        title_row = next(s for s in scenario_results if s['name'] == name)\n        im = ax.imshow(\n            d[\"data\"],\n            extent=[\n                d[\"bounds\"].left, d[\"bounds\"].right,\n                d[\"bounds\"].bottom, d[\"bounds\"].top,\n            ],\n            vmin=vmin, vmax=vmax,\n            cmap=\"Blues\",\n            origin=\"upper\",\n        )\n        ax.set_title(\n            f\"{title_row['title']}\\n\"\n            f\"cells={title_row['cell_count']:,}  faces={title_row['face_count']:,}\",\n            fontsize=10,\n        )\n        ax.set_xlabel(\"Easting (ft)\")\n        ax.set_ylabel(\"Northing (ft)\")\n\n    # Hide unused axes\n    for ax in axes[n:]:\n        ax.set_visible(False)\n\n    fig.colorbar(im, ax=axes[:n], label=\"Max WSE (ft)\", shrink=0.8)\n    fig.suptitle(\"Maximum Water Surface Elevation by Mesh Scenario\", fontsize=14, y=1.02)\n    plt.tight_layout()\n    plt.savefig(Path(project_folder) / \"wse_comparison.png\", dpi=150, bbox_inches=\"tight\")\n    plt.show()\n    print(f\"Saved: {Path(project_folder) / 'wse_comparison.png'}\")"
   },
   {
    "cell_type": "markdown",
@@ -1103,58 +1053,7 @@
      "output_type": "display_data"
     }
    ],
-   "source": [
-    "fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(14, 5))\n",
-    "\n",
-    "# Bar chart: cell count by scenario\n",
-    "names = [s['title'] for s in scenario_results]\n",
-    "cells = [s['cell_count'] for s in scenario_results]\n",
-    "faces = [s['face_count'] for s in scenario_results]\n",
-    "\n",
-    "x = np.arange(len(names))\n",
-    "width = 0.35\n",
-    "\n",
-    "ax1.bar(x - width/2, cells, width, label='Cells', color='steelblue')\n",
-    "ax1.bar(x + width/2, faces, width, label='Faces', color='coral')\n",
-    "ax1.set_xticks(x)\n",
-    "ax1.set_xticklabels(names, rotation=45, ha='right', fontsize=9)\n",
-    "ax1.set_ylabel('Count')\n",
-    "ax1.set_title('Mesh Density by Scenario')\n",
-    "ax1.legend()\n",
-    "ax1.grid(axis='y', alpha=0.3)\n",
-    "\n",
-    "for i, (c, f) in enumerate(zip(cells, faces)):\n",
-    "    ax1.text(i - width/2, c + max(cells) * 0.01, f'{c:,}',\n",
-    "             ha='center', va='bottom', fontsize=8)\n",
-    "\n",
-    "# Scatter: cell_size vs cell_count for the cell-size group\n",
-    "cell_size_scenarios = [s for s in scenario_results if s.get('bl_near') is None]\n",
-    "if len(cell_size_scenarios) >= 2:\n",
-    "    cs = [s['cell_size'] for s in cell_size_scenarios]\n",
-    "    cc = [s['cell_count'] for s in cell_size_scenarios]\n",
-    "    ax2.scatter(cs, cc, s=100, c='steelblue', zorder=3)\n",
-    "    for s in cell_size_scenarios:\n",
-    "        ax2.annotate(s['title'], (s['cell_size'], s['cell_count']),\n",
-    "                     textcoords='offset points', xytext=(10, 5), fontsize=9)\n",
-    "\n",
-    "    # Theoretical inverse-square fit\n",
-    "    cs_arr = np.array(cs, dtype=float)\n",
-    "    cc_arr = np.array(cc, dtype=float)\n",
-    "    k = np.mean(cc_arr * cs_arr**2)\n",
-    "    cs_fit = np.linspace(min(cs) * 0.8, max(cs) * 1.2, 50)\n",
-    "    ax2.plot(cs_fit, k / cs_fit**2, '--', color='gray', alpha=0.6,\n",
-    "             label=r'$\\sim 1/\\Delta x^2$ trend')\n",
-    "    ax2.legend()\n",
-    "\n",
-    "ax2.set_xlabel('Cell Size (ft)')\n",
-    "ax2.set_ylabel('Cell Count')\n",
-    "ax2.set_title('Cell Size vs. Mesh Density')\n",
-    "ax2.grid(alpha=0.3)\n",
-    "\n",
-    "plt.tight_layout()\n",
-    "plt.savefig(Path(project_folder) / \"mesh_density_comparison.png\", dpi=150, bbox_inches=\"tight\")\n",
-    "plt.show()"
-   ]
+   "source": "fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(14, 5))\n\n# Bar chart: cell count by scenario\nnames = [s['title'] for s in scenario_results]\ncells = [s['cell_count'] for s in scenario_results]\nfaces = [s['face_count'] for s in scenario_results]\n\nx = np.arange(len(names))\nwidth = 0.35\n\nax1.bar(x - width/2, cells, width, label='Cells', color='steelblue')\nax1.bar(x + width/2, faces, width, label='Faces', color='coral')\nax1.set_xticks(x)\nax1.set_xticklabels(names, rotation=45, ha='right', fontsize=9)\nax1.set_xlabel('Mesh Scenario')\nax1.set_ylabel('Count')\nax1.set_title('Mesh Density by Scenario')\nax1.legend()\nax1.grid(axis='y', alpha=0.3)\n\nfor i, (c, f) in enumerate(zip(cells, faces)):\n    ax1.text(i - width/2, c + max(cells) * 0.01, f'{c:,}',\n             ha='center', va='bottom', fontsize=8)\n\n# Scatter: cell_size vs cell_count for the cell-size group\ncell_size_scenarios = [s for s in scenario_results if s.get('bl_near') is None]\nif len(cell_size_scenarios) >= 2:\n    cs = [s['cell_size'] for s in cell_size_scenarios]\n    cc = [s['cell_count'] for s in cell_size_scenarios]\n    ax2.scatter(cs, cc, s=100, c='steelblue', zorder=3)\n    for s in cell_size_scenarios:\n        ax2.annotate(s['title'], (s['cell_size'], s['cell_count']),\n                     textcoords='offset points', xytext=(10, 5), fontsize=9)\n\n    # Theoretical inverse-square fit\n    cs_arr = np.array(cs, dtype=float)\n    cc_arr = np.array(cc, dtype=float)\n    k = np.mean(cc_arr * cs_arr**2)\n    cs_fit = np.linspace(min(cs) * 0.8, max(cs) * 1.2, 50)\n    ax2.plot(cs_fit, k / cs_fit**2, '--', color='gray', alpha=0.6,\n             label=r'$\\sim 1/\\Delta x^2$ trend')\n    ax2.legend()\n\nax2.set_xlabel('Cell Size (ft)')\nax2.set_ylabel('Cell Count')\nax2.set_title('Cell Size vs. Mesh Density')\nax2.grid(alpha=0.3)\n\nplt.tight_layout()\nplt.savefig(Path(project_folder) / \"mesh_density_comparison.png\", dpi=150, bbox_inches=\"tight\")\nplt.show()"
   },
   {
    "cell_type": "markdown",
@@ -1226,7 +1125,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "## Conclusion\n\nThis notebook demonstrated the complete mesh sensitivity workflow:\n\n1. **Geometry cloning** (`RasPlan.clone_geom`) creates independent copies for each scenario\n2. **Mesh generation** (`GeomMesh.generate`) handles cell sizing, breakline spacing, and fix loops\n3. **Plan cloning** (`RasPlan.clone_plan`) with `geometry=` parameter points each plan at its mesh variant\n4. **Parallel execution** (`RasCmdr.compute_parallel`) runs all scenarios efficiently\n5. **Stored maps** (`RasProcess.store_maps`) produces comparable WSE/depth GeoTIFFs\n\n### Cell Size Auto-Detection\n\n`GeomMesh.generate(cell_size=None)` (the default) reads the model's own `Spacing dx` from\nthe compiled geometry HDF. This is the recommended approach for **mesh reproduction** — it\nproduces the same mesh the model was built with. For **sensitivity analysis**, pass explicit\n`cell_size` values to override, as shown in this notebook.\n\n### Key Observations\n\n- Cell count scales roughly as `1/cell_size^2` (halving cell size quadruples cells)\n- Breakline spacing primarily affects local resolution near structures, not global cell count\n- **Mesh-dependent structure connections**: Changing mesh resolution changes terrain-averaged cell\n  elevations, which can invalidate gate/weir connections (gate elev < cell elev). This is a real\n  modeling constraint — always verify structure connections after mesh changes.\n- The fix loop handles mesh quality issues automatically, but check `fixes_applied` for warnings\n\n### Next Steps\n\n- Use a geometry **without internal structures** for clean WSE comparison across all mesh sizes\n- Add per-breakline scenarios (e.g., refine dam breakline only)\n- Extract time-series at specific locations using `HdfResultsMesh.get_mesh_cells_timeseries()`\n- Plot runtime vs. cell count to quantify the accuracy/performance tradeoff\n- Combine with Manning's n sensitivity for multi-parameter analysis"
+   "source": "## Conclusion\n\nThis notebook demonstrated the complete mesh sensitivity workflow:\n\n1. **Geometry cloning** (`RasPlan.clone_geom`) creates independent copies for each scenario\n2. **Mesh generation** (`GeomMesh.generate`) handles cell sizing, breakline spacing, and fix loops\n3. **Plan cloning** (`RasPlan.clone_plan`) with `geometry=` parameter points each plan at its mesh variant\n4. **Parallel execution** (`RasCmdr.compute_parallel`) runs all scenarios efficiently\n5. **Stored maps** (`RasProcess.store_maps`) produces comparable WSE/depth GeoTIFFs\n\n### Cell Size Auto-Detection\n\n`GeomMesh.generate(cell_size=None)` (the default) reads the model's own base spacing from\ngeometry text first, then falls back to compiled HDF `Spacing dx` only when needed. For\n**sensitivity analysis**, pass explicit `cell_size` values to override, as shown in this\nnotebook. Use `recompile_via_rasexe=True` after assigning a plan when a missing or\ncontent-stale compiled HDF must be rebuilt through Ras.exe before geometry is read.\n\n### Key Observations\n\n- Cell count scales roughly as `1/cell_size^2` (halving cell size quadruples cells)\n- Breakline spacing primarily affects local resolution near structures, not global cell count\n- **Mesh-dependent structure connections**: Changing mesh resolution changes terrain-averaged cell\n  elevations, which can invalidate gate/weir connections (gate elev < cell elev). This is a real\n  modeling constraint — always verify structure connections after mesh changes.\n- The fix loop handles mesh quality issues automatically, but check `fixes_applied` for warnings\n\n### Next Steps\n\n- Use a geometry **without internal structures** for clean WSE comparison across all mesh sizes\n- Add per-breakline scenarios (e.g., refine dam breakline only)\n- Extract time-series at specific locations using `HdfResultsMesh.get_mesh_cells_timeseries()`\n- Plot runtime vs. cell count to quantify the accuracy/performance tradeoff\n- Combine with Manning's n sensitivity for multi-parameter analysis"
   },
   {
    "cell_type": "markdown",
@@ -1471,9 +1370,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "RasCmdr",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "rascmdr"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {

--- a/examples/_test_230.py
+++ b/examples/_test_230.py
@@ -193,33 +193,9 @@ for scenario in SCENARIOS:
         ].values[0]
     )
 
-    # 2. Apply per-breakline spacing if specified
-    if bl_by_name:
-        set_breakline_spacing_by_name(new_geom_path, bl_by_name)
-
-    # 3. Delete the cloned HDF so generate() recompiles from modified text
-    cloned_hdf = new_geom_path.with_suffix(new_geom_path.suffix + '.hdf')
-    if cloned_hdf.exists():
-        cloned_hdf.unlink()
-        print(f"  Removed stale HDF: {cloned_hdf.name}")
-
-    # 4. Generate mesh (cell_size and breakline spacing applied internally)
-    mesh_result = GeomMesh.generate(
-        geom_number=new_geom_path,
-        mesh_name="BaldEagleCr",
-        cell_size=cell_size,
-        bl_spacing_near=bl_near,
-        bl_spacing_far=bl_far,
-        max_iterations=8,
-        ras_object=ras,
-    )
-
-    print(f"  Mesh: status={mesh_result.status}, "
-          f"cells={mesh_result.cell_count}, faces={mesh_result.face_count}")
-    if mesh_result.fixes_applied:
-        print(f"  Fixes: {mesh_result.fixes_applied}")
-
-    # 5. Clone plan and assign the new geometry
+    # 2. Clone plan and assign the new geometry before mesh generation.
+    # If the compiled geometry HDF is missing or stale, generate() can now
+    # refresh it through Ras.exe/HTab using this plan reference.
     new_plan = RasPlan.clone_plan(
         TEMPLATE_PLAN,
         new_plan_shortid=name[:12],
@@ -228,6 +204,29 @@ for scenario in SCENARIOS:
         ras_object=ras,
     )
     print(f"  Cloned plan: p{TEMPLATE_PLAN} -> p{new_plan} (geom=g{new_geom})")
+
+    # 3. Apply per-breakline spacing if specified
+    if bl_by_name:
+        set_breakline_spacing_by_name(new_geom_path, bl_by_name)
+
+    # 4. Generate mesh. Keep the cloned HDF; it is the .NET workspace.
+    # recompile_via_rasexe=True is an opt-in recovery path for content-stale
+    # or missing HDFs and never relies on deleting the HDF.
+    mesh_result = GeomMesh.generate(
+        geom_number=new_geom_path,
+        mesh_name="BaldEagleCr",
+        cell_size=cell_size,
+        bl_spacing_near=bl_near,
+        bl_spacing_far=bl_far,
+        max_iterations=8,
+        ras_object=ras,
+        recompile_via_rasexe=True,
+    )
+
+    print(f"  Mesh: status={mesh_result.status}, "
+          f"cells={mesh_result.cell_count}, faces={mesh_result.face_count}")
+    if mesh_result.fixes_applied:
+        print(f"  Fixes: {mesh_result.fixes_applied}")
 
     scenario_results.append({
         "name": name,

--- a/ras_commander/geom/GeomMesh.py
+++ b/ras_commander/geom/GeomMesh.py
@@ -62,7 +62,7 @@ import sys
 from dataclasses import dataclass, field
 from numbers import Number
 from pathlib import Path
-from typing import List, Optional, Tuple, Union
+from typing import Any, List, Optional, Tuple, Union
 
 from ..Decorators import log_call
 from .._gdal_runtime import (
@@ -1117,6 +1117,171 @@ def _sync_breakline_spacing_text_to_hdf(
         )
 
 
+def _parse_optional_float(value: str | None) -> float | None:
+    """Parse a geometry numeric field, returning None for blanks."""
+    if value is None:
+        return None
+    stripped = value.strip()
+    if not stripped:
+        return None
+    try:
+        return float(stripped)
+    except ValueError:
+        return None
+
+
+def _decode_hdf_text(value: Any) -> str:
+    """Decode an HDF scalar/string value to text."""
+    if isinstance(value, bytes):
+        return value.decode("utf-8", errors="replace").strip()
+    if hasattr(value, "decode"):
+        try:
+            return value.decode("utf-8", errors="replace").strip()
+        except Exception:
+            pass
+    return str(value).strip()
+
+
+def _read_mesh_metadata_from_text(
+    geom_text_path: Path,
+) -> dict[str, dict[str, float | int | None]]:
+    """Read per-2D-area mesh seed count and spacing from geometry text."""
+    text = geom_text_path.read_text(encoding="utf-8", errors="replace")
+    metadata: dict[str, dict[str, float | int | None]] = {}
+    current_area: str | None = None
+
+    for line in text.splitlines():
+        if line.startswith("Storage Area="):
+            current_area = line.split("=", 1)[1].split(",", 1)[0].strip()
+            metadata.setdefault(
+                current_area,
+                {
+                    "seed_count": None,
+                    "spacing_dx": None,
+                    "spacing_dy": None,
+                },
+            )
+            continue
+
+        if current_area is None:
+            continue
+
+        if line.startswith("Storage Area Point Generation Data="):
+            parts = line.split("=", 1)[1].split(",")
+            spacing_dx = _parse_optional_float(parts[2] if len(parts) > 2 else None)
+            spacing_dy = _parse_optional_float(parts[3] if len(parts) > 3 else None)
+            metadata[current_area]["spacing_dx"] = spacing_dx
+            metadata[current_area]["spacing_dy"] = spacing_dy
+            continue
+
+        if line.startswith("Storage Area 2D Points="):
+            try:
+                metadata[current_area]["seed_count"] = int(
+                    line.split("=", 1)[1].strip()
+                )
+            except (IndexError, ValueError):
+                metadata[current_area]["seed_count"] = None
+
+    return metadata
+
+
+def _read_mesh_metadata_from_hdf(
+    hdf_path: Path,
+) -> dict[str, dict[str, float | int | str | None]]:
+    """Read per-2D-area mesh cell count and spacing from compiled geometry HDF."""
+    import h5py
+
+    metadata: dict[str, dict[str, float | int | str | None]] = {}
+    attrs_key = "Geometry/2D Flow Areas/Attributes"
+    flow_areas_key = "Geometry/2D Flow Areas"
+
+    with h5py.File(str(hdf_path), "r") as hf:
+        if attrs_key in hf:
+            data = hf[attrs_key][:]
+            dtype_names = data.dtype.names or ()
+            for i in range(len(data)):
+                if "Name" in dtype_names:
+                    area_name = _decode_hdf_text(data["Name"][i])
+                else:
+                    area_name = f"<index {i}>"
+                if not area_name:
+                    continue
+
+                row = metadata.setdefault(
+                    area_name,
+                    {
+                        "cell_count": None,
+                        "cell_count_source": None,
+                        "spacing_dx": None,
+                        "spacing_dy": None,
+                    },
+                )
+                if "Cell Count" in dtype_names:
+                    try:
+                        row["cell_count"] = int(data["Cell Count"][i])
+                        row["cell_count_source"] = "Attributes/Cell Count"
+                    except (TypeError, ValueError):
+                        pass
+                if "Spacing dx" in dtype_names:
+                    try:
+                        row["spacing_dx"] = float(data["Spacing dx"][i])
+                    except (TypeError, ValueError):
+                        pass
+                if "Spacing dy" in dtype_names:
+                    try:
+                        row["spacing_dy"] = float(data["Spacing dy"][i])
+                    except (TypeError, ValueError):
+                        pass
+
+        if flow_areas_key in hf:
+            for area_name in hf[flow_areas_key].keys():
+                if area_name == "Attributes":
+                    continue
+                row = metadata.setdefault(
+                    area_name,
+                    {
+                        "cell_count": None,
+                        "cell_count_source": None,
+                        "spacing_dx": None,
+                        "spacing_dy": None,
+                    },
+                )
+                if row.get("cell_count") is None:
+                    cells_key = f"{flow_areas_key}/{area_name}/Cells Center Coordinate"
+                    if cells_key in hf:
+                        row["cell_count"] = int(hf[cells_key].shape[0])
+                        row["cell_count_source"] = "Cells Center Coordinate"
+
+    return metadata
+
+
+def _read_cell_size_from_text(
+    geom_text_path: Path,
+    mesh_name: str | None = None,
+    mesh_index: int = 0,
+) -> float | None:
+    """Read base mesh cell size from geometry text point-generation data."""
+    metadata = _read_mesh_metadata_from_text(geom_text_path)
+    if mesh_name is not None:
+        area = metadata.get(mesh_name)
+        if area is None:
+            return None
+        dx = area.get("spacing_dx")
+        return float(dx) if isinstance(dx, (int, float)) and dx > 0 else None
+
+    areas = list(metadata.values())
+    if 0 <= mesh_index < len(areas):
+        dx = areas[mesh_index].get("spacing_dx")
+        if isinstance(dx, (int, float)) and dx > 0:
+            return float(dx)
+
+    for area in areas:
+        dx = area.get("spacing_dx")
+        if isinstance(dx, (int, float)) and dx > 0:
+            return float(dx)
+    return None
+
+
 def _read_cell_size_from_hdf(
     hdf_path: Path, mesh_name: str | None = None
 ) -> float:
@@ -1459,11 +1624,215 @@ def _geometry_hdf_unavailable_message(
     )
 
 
+def _normalize_component_number(value: Any) -> str | None:
+    """Normalize a RAS component number, accepting values like g09 or 9.0."""
+    if value is None:
+        return None
+    raw = str(value).strip()
+    if not raw or raw.lower() in {"nan", "none"}:
+        return None
+    if raw[0].lower() in {"g", "p", "f", "u", "c"}:
+        raw = raw[1:]
+    try:
+        from ..RasUtils import RasUtils
+        return RasUtils.normalize_ras_number(raw)
+    except Exception:
+        digits = raw.split(".", 1)[0]
+        return digits.zfill(2) if digits.isdigit() else None
+
+
+def _geometry_number_from_path(
+    geom_text_path: Path,
+    ras_object=None,
+) -> str | None:
+    """Resolve a geometry number from a geometry text path and project metadata."""
+    suffix = geom_text_path.suffix
+    if len(suffix) > 2 and suffix[1].lower() == "g":
+        normalized = _normalize_component_number(suffix[2:])
+        if normalized is not None:
+            return normalized
+
+    ras_obj = ras_object
+    if ras_obj is not None and getattr(ras_obj, "geom_df", None) is not None:
+        try:
+            for _, row in ras_obj.geom_df.iterrows():
+                row_path = row.get("full_path")
+                if row_path is not None and _paths_equivalent(row_path, geom_text_path):
+                    return _normalize_component_number(row.get("geom_number"))
+        except Exception:
+            pass
+    return None
+
+
+def _find_plan_for_geometry(
+    geom_text_path: Path,
+    ras_object=None,
+) -> str:
+    """Find a plan number that references a geometry text file."""
+    if ras_object is None:
+        from ..RasPrj import ras as ras_object
+
+    try:
+        ras_object.check_initialized()
+    except Exception as exc:
+        raise RuntimeError(
+            "recompile_via_rasexe=True requires an initialized RasPrj object "
+            "so ras-commander can find a plan that references the geometry."
+        ) from exc
+
+    geom_number = _geometry_number_from_path(geom_text_path, ras_object=ras_object)
+    try:
+        plan_df = ras_object.get_plan_entries()
+    except Exception as exc:
+        raise RuntimeError(
+            "Could not read plan entries needed for geometry HDF recompilation."
+        ) from exc
+
+    for _, row in plan_df.iterrows():
+        plan_number = _normalize_component_number(row.get("plan_number"))
+        if plan_number is None:
+            continue
+
+        geom_path = row.get("Geom Path")
+        if geom_path is not None and _paths_equivalent(geom_path, geom_text_path):
+            return plan_number
+
+        for column_name in ("geometry_number", "geom_number", "Geom File"):
+            if column_name not in row:
+                continue
+            row_geom_number = _normalize_component_number(row.get(column_name))
+            if (
+                geom_number is not None
+                and row_geom_number is not None
+                and row_geom_number == geom_number
+            ):
+                return plan_number
+
+    raise RuntimeError(
+        "recompile_via_rasexe=True could not find a plan referencing "
+        f"{geom_text_path.name}. Clone or assign a plan to this geometry before "
+        "requesting Ras.exe recompilation."
+    )
+
+
+def _recompile_geometry_hdf_via_rasexe(
+    geom_text_path: Path,
+    hdf_path: Path,
+    *,
+    ras_object=None,
+) -> Path:
+    """Refresh a compiled geometry HDF from text through HEC-RAS/Ras.exe."""
+    plan_number = _find_plan_for_geometry(geom_text_path, ras_object=ras_object)
+    from .GeomPreprocessor import GeomPreprocessor
+
+    logger.info(
+        f"Refreshing compiled geometry HDF for {geom_text_path.name} "
+        f"through Ras.exe using plan p{plan_number}"
+    )
+    preprocess_result = GeomPreprocessor.run_geometry_preprocessor(
+        plan_number,
+        ras_object=ras_object,
+        clear_geompre=True,
+        force=True,
+        geometry_only=True,
+    )
+    if not preprocess_result.success:
+        raise RuntimeError(
+            "Ras.exe geometry preprocessing failed while refreshing "
+            f"{hdf_path.name}: {preprocess_result.error or preprocess_result.first_error_line}"
+        )
+    if not hdf_path.exists():
+        raise RuntimeError(
+            "Ras.exe geometry preprocessing completed but did not create "
+            f"{hdf_path}"
+        )
+    return hdf_path
+
+
+def _mesh_metadata_is_meaningful(
+    area: dict[str, float | int | None],
+) -> bool:
+    seed_count = area.get("seed_count")
+    spacing_dx = area.get("spacing_dx")
+    spacing_dy = area.get("spacing_dy")
+    return (
+        (isinstance(seed_count, int) and seed_count > 0)
+        or (isinstance(spacing_dx, (int, float)) and spacing_dx > 0)
+        or (isinstance(spacing_dy, (int, float)) and spacing_dy > 0)
+    )
+
+
+def _mesh_hdf_consistency_issues(
+    geom_text_path: Path,
+    hdf_path: Path,
+    *,
+    mesh_name: str | None = None,
+) -> list[str]:
+    """Return content mismatches between geometry text seeds and HDF metadata."""
+    text_metadata = _read_mesh_metadata_from_text(geom_text_path)
+    if mesh_name is not None:
+        text_metadata = {
+            name: area
+            for name, area in text_metadata.items()
+            if name == mesh_name
+        }
+    if not text_metadata:
+        return []
+
+    hdf_metadata = _read_mesh_metadata_from_hdf(hdf_path)
+    issues: list[str] = []
+
+    for area_name, text_area in text_metadata.items():
+        if not _mesh_metadata_is_meaningful(text_area):
+            continue
+
+        hdf_area = hdf_metadata.get(area_name)
+        if hdf_area is None:
+            issues.append(f"{area_name}: missing from compiled HDF")
+            continue
+
+        text_seed_count = text_area.get("seed_count")
+        hdf_cell_count = hdf_area.get("cell_count")
+        hdf_count_source = hdf_area.get("cell_count_source")
+        if (
+            isinstance(text_seed_count, int)
+            and isinstance(hdf_cell_count, int)
+            and hdf_count_source == "Attributes/Cell Count"
+            and text_seed_count != hdf_cell_count
+        ):
+            issues.append(
+                f"{area_name}: text Storage Area 2D Points={text_seed_count} "
+                f"but HDF Cell Count={hdf_cell_count}"
+            )
+
+        for axis in ("dx", "dy"):
+            text_spacing = text_area.get(f"spacing_{axis}")
+            hdf_spacing = hdf_area.get(f"spacing_{axis}")
+            if not isinstance(text_spacing, (int, float)) or text_spacing <= 0:
+                continue
+            if not isinstance(hdf_spacing, (int, float)) or hdf_spacing <= 0:
+                issues.append(
+                    f"{area_name}: text Spacing {axis}={text_spacing:g} "
+                    "but HDF spacing is missing"
+                )
+                continue
+            if abs(float(text_spacing) - float(hdf_spacing)) > 0.001:
+                issues.append(
+                    f"{area_name}: text Spacing {axis}={text_spacing:g} "
+                    f"but HDF Spacing {axis}={float(hdf_spacing):g}"
+                )
+
+    return issues
+
+
 def _ensure_hdf(
     geom_text_path: Path,
     hecras_dir=None,
     *,
     require_current: bool = True,
+    ras_object=None,
+    mesh_name: str | None = None,
+    recompile_via_rasexe: bool = False,
 ) -> Path:
     """Return an existing compiled HDF for *geom_text_path*.
 
@@ -1473,15 +1842,48 @@ def _ensure_hdf(
     """
     hdf_path = geom_text_path.with_suffix(geom_text_path.suffix + ".hdf")
     if not hdf_path.exists():
+        if recompile_via_rasexe:
+            _recompile_geometry_hdf_via_rasexe(
+                geom_text_path,
+                hdf_path,
+                ras_object=ras_object,
+            )
+            if hdf_path.exists():
+                return hdf_path
         raise RuntimeError(
             _geometry_hdf_unavailable_message(geom_text_path, hdf_path, "missing")
         )
-    # 2-second tolerance: file copy/extraction can leave text slightly newer
-    if geom_text_path.stat().st_mtime - hdf_path.stat().st_mtime > 2.0:
+
+    try:
+        consistency_issues = _mesh_hdf_consistency_issues(
+            geom_text_path,
+            hdf_path,
+            mesh_name=mesh_name,
+        )
+    except Exception as exc:
+        consistency_issues = [f"unreadable; {exc}"]
+
+    if consistency_issues:
+        reason = "stale; " + "; ".join(consistency_issues)
+        if recompile_via_rasexe:
+            _recompile_geometry_hdf_via_rasexe(
+                geom_text_path,
+                hdf_path,
+                ras_object=ras_object,
+            )
+            consistency_issues = _mesh_hdf_consistency_issues(
+                geom_text_path,
+                hdf_path,
+                mesh_name=mesh_name,
+            )
+            if not consistency_issues:
+                return hdf_path
+            reason = "stale after Ras.exe refresh; " + "; ".join(consistency_issues)
+
         message = _geometry_hdf_unavailable_message(
             geom_text_path,
             hdf_path,
-            f"stale; {geom_text_path.name} is newer than {hdf_path.name}",
+            reason,
         )
         if require_current:
             raise RuntimeError(message)
@@ -1526,6 +1928,7 @@ def _resolve_geom_hdf_path(
         geom_text_path,
         hecras_dir=hecras_dir,
         require_current=require_current,
+        ras_object=ras_object,
     )
 
 
@@ -1845,7 +2248,11 @@ class GeomMesh:
         import h5py
 
         geom_text_path = _resolve_geom_text_path(geom_number, ras_object)
-        hdf_path = _ensure_hdf(geom_text_path, hecras_dir=hecras_dir)
+        hdf_path = _ensure_hdf(
+            geom_text_path,
+            hecras_dir=hecras_dir,
+            ras_object=ras_object,
+        )
 
         rr_key = "Geometry/2D Flow Area Refinement Regions/Attributes"
         result = []
@@ -1902,7 +2309,11 @@ class GeomMesh:
             raise ValueError("Provide region_fid or old_name, not both.")
 
         geom_text_path = _resolve_geom_text_path(geom_number, ras_object)
-        hdf_path = _ensure_hdf(geom_text_path, hecras_dir=hecras_dir)
+        hdf_path = _ensure_hdf(
+            geom_text_path,
+            hecras_dir=hecras_dir,
+            ras_object=ras_object,
+        )
 
         rr_key = "Geometry/2D Flow Area Refinement Regions/Attributes"
         with h5py.File(str(hdf_path), "r+") as hf:
@@ -1974,7 +2385,11 @@ class GeomMesh:
         import h5py
 
         geom_text_path = _resolve_geom_text_path(geom_number, ras_object)
-        hdf_path = _ensure_hdf(geom_text_path, hecras_dir=hecras_dir)
+        hdf_path = _ensure_hdf(
+            geom_text_path,
+            hecras_dir=hecras_dir,
+            ras_object=ras_object,
+        )
 
         rr_key = "Geometry/2D Flow Area Refinement Regions/Attributes"
         result = []
@@ -2059,7 +2474,11 @@ class GeomMesh:
             spacing_dy = spacing_dx
 
         geom_text_path = _resolve_geom_text_path(geom_number, ras_object)
-        hdf_path = _ensure_hdf(geom_text_path, hecras_dir=hecras_dir)
+        hdf_path = _ensure_hdf(
+            geom_text_path,
+            hecras_dir=hecras_dir,
+            ras_object=ras_object,
+        )
 
         rr_key = "Geometry/2D Flow Area Refinement Regions/Attributes"
         with h5py.File(str(hdf_path), "r+") as hf:
@@ -2196,7 +2615,11 @@ class GeomMesh:
             coords = np.vstack([coords, coords[:1]])
 
         geom_text_path = _resolve_geom_text_path(geom_number, ras_object)
-        hdf_path = _ensure_hdf(geom_text_path, hecras_dir=hecras_dir)
+        hdf_path = _ensure_hdf(
+            geom_text_path,
+            hecras_dir=hecras_dir,
+            ras_object=ras_object,
+        )
 
         rr_group_key = "Geometry/2D Flow Area Refinement Regions"
         attr_key = f"{rr_group_key}/Attributes"
@@ -2484,7 +2907,11 @@ class GeomMesh:
 
         _load_dlls(hecras_dir)
 
-        hdf_path = _ensure_hdf(geom_text_path, hecras_dir=hecras_dir)
+        hdf_path = _ensure_hdf(
+            geom_text_path,
+            hecras_dir=hecras_dir,
+            ras_object=ras_object,
+        )
 
         ns = _imports()
         geom = ns["RASGeometry"](str(hdf_path))
@@ -2546,6 +2973,7 @@ class GeomMesh:
         bl_spacing_near: Optional[float] = None,
         bl_spacing_far: Optional[float] = None,
         ras_object=None,
+        recompile_via_rasexe: bool = False,
         _require_current_hdf: bool = True,
     ) -> MeshResult:
         """
@@ -2556,7 +2984,8 @@ class GeomMesh:
         center extraction. ras-commander does not generate .g##.hdf from text.
 
         Workflow:
-            1. Validate an existing current compiled .g##.hdf workspace.
+            1. Validate an existing content-current compiled .g##.hdf
+               workspace, optionally refreshing it through HEC-RAS/Ras.exe.
             2. Read per-breakline spacing from .g01 text (preserve existing)
             3. Sync text spacing -> HDF (RegenerateMeshPoints reads HDF)
             4. Load .NET geometry -> perimeter, breaklines
@@ -2576,9 +3005,10 @@ class GeomMesh:
             mesh_name: Name of 2D flow area (None = use mesh_index).
             mesh_index: 0-based index if mesh_name not provided.
             cell_size: Base grid spacing in project units.  When ``None``
-                (default), the value is read from the compiled geometry
-                HDF (``Spacing dx``).  Falls back to 100.0 if the HDF
-                attribute is missing or zero.
+                (default), the value is read from geometry text
+                ``Storage Area Point Generation Data`` first, then from the
+                compiled HDF (``Spacing dx``) only as a fallback.  This avoids
+                trusting byte-copied stale HDF metadata after geometry clones.
             bl_spacing: Legacy alias that applies the same positive value to both
                 near and far breakline spacing when explicit values are omitted.
             near_repeats: Number of offset seed rows on each side of breaklines.
@@ -2594,6 +3024,9 @@ class GeomMesh:
             bl_spacing_far: Optional override for far spacing in project units.
                 If omitted, existing per-breakline values are preserved.
             ras_object: Optional RasPrj instance for multi-project support.
+            recompile_via_rasexe: If True, refresh a missing or content-stale
+                compiled geometry HDF through ``GeomPreprocessor``/Ras.exe.
+                The geometry must be referenced by a plan in *ras_object*.
 
         Returns:
             MeshResult with status, cell_count, face_count, fixes_applied, and
@@ -2640,14 +3073,27 @@ class GeomMesh:
                 text_path,
                 hecras_dir=hecras_dir,
                 require_current=_require_current_hdf,
+                ras_object=ras_object,
+                mesh_name=mesh_name,
+                recompile_via_rasexe=recompile_via_rasexe,
             )
 
-            # ── Step 1a: Auto-detect cell size from HDF if not provided ──
+            # ── Step 1a: Auto-detect cell size from text if not provided ──
             if not cell_size_provided:
-                cell_size = _read_cell_size_from_hdf(hdf_path, mesh_name)
-                logger.info(
-                    f"Auto-detected cell size {cell_size} from HDF Spacing dx"
+                cell_size = _read_cell_size_from_text(
+                    text_path,
+                    mesh_name=mesh_name,
+                    mesh_index=mesh_index,
                 )
+                if cell_size is not None:
+                    logger.info(
+                        f"Auto-detected cell size {cell_size} from geometry text"
+                    )
+                else:
+                    cell_size = _read_cell_size_from_hdf(hdf_path, mesh_name)
+                    logger.info(
+                        f"Auto-detected cell size {cell_size} from HDF Spacing dx"
+                    )
 
             # Only modify .g01 text breakline properties if explicitly provided.
             # Otherwise the geometry's existing per-breakline values are
@@ -3018,6 +3464,7 @@ class GeomMesh:
         max_iterations: int = 8,
         hecras_dir: Optional[Union[str, Path]] = None,
         ras_object: Optional['RasPrj'] = None,
+        recompile_via_rasexe: bool = False,
     ) -> List[MeshResult]:
         """Generate/repair all 2D mesh areas in a geometry file.
 
@@ -3028,7 +3475,8 @@ class GeomMesh:
             geom_number: Geometry number (e.g. ``"01"`` or ``1``),
                 or a direct path to a ``.g##`` text file.
             cell_size: Default mesh cell size.  When ``None`` (default),
-                each mesh area reads its spacing from the compiled HDF.
+                each mesh area reads its spacing from geometry text first,
+                then from the compiled HDF as a fallback.
             bl_spacing: Shorthand — sets both near and far breakline spacing.
             bl_spacing_near: Breakline near-spacing override.
             bl_spacing_far: Breakline far-spacing override.
@@ -3038,6 +3486,8 @@ class GeomMesh:
             max_iterations: Maximum fix-loop iterations per mesh area.
             hecras_dir: Override path to the HEC-RAS installation directory.
             ras_object: Optional RasPrj instance for multi-project support.
+            recompile_via_rasexe: If True, refresh a missing or content-stale
+                compiled geometry HDF through ``GeomPreprocessor``/Ras.exe.
 
         Returns:
             List of MeshResult, one per 2D flow area.
@@ -3049,6 +3499,8 @@ class GeomMesh:
             text_path,
             hecras_dir=hecras_dir,
             require_current=True,
+            ras_object=ras_object,
+            recompile_via_rasexe=recompile_via_rasexe,
         )
         geom = ns["RASGeometry"](str(hdf_path))
         d2fa = geom.D2FlowArea
@@ -3069,6 +3521,7 @@ class GeomMesh:
                 max_iterations=max_iterations,
                 hecras_dir=hecras_dir,
                 ras_object=ras_object,
+                recompile_via_rasexe=recompile_via_rasexe,
                 _require_current_hdf=False,
             )
             results.append(r)

--- a/tests/test_geom_mesh.py
+++ b/tests/test_geom_mesh.py
@@ -327,7 +327,18 @@ def _mock_generate_success(monkeypatch, geom_text_path: Path, *, has_breaklines:
     """
     captured = {}
     hdf_path = geom_text_path.with_suffix(geom_text_path.suffix + ".hdf")
-    hdf_path.write_text("compiled", encoding="utf-8")
+    _write_mesh_hdf(
+        hdf_path,
+        [
+            {
+                "name": "MainArea",
+                "spacing_dx": 50.0,
+                "spacing_dy": 50.0,
+                "cell_count": 0,
+                "dataset_count": 2,
+            }
+        ],
+    )
     hdf_mtime = geom_text_path.stat().st_mtime + 1.0
     os.utime(hdf_path, (hdf_mtime, hdf_mtime))
 
@@ -415,6 +426,35 @@ def _mock_generate_success(monkeypatch, geom_text_path: Path, *, has_breaklines:
     )
     captured["geom"] = mock_geom_obj
     return captured
+
+
+def _write_mesh_hdf(hdf_path: Path, areas):
+    """Write minimal HEC-RAS geometry HDF mesh metadata for tests."""
+    hdf_path.parent.mkdir(parents=True, exist_ok=True)
+    dtype = np.dtype(
+        [
+            ("Name", "S64"),
+            ("Spacing dx", "<f4"),
+            ("Spacing dy", "<f4"),
+            ("Cell Count", "<i4"),
+        ]
+    )
+    records = []
+    with h5py.File(str(hdf_path), "w") as hf:
+        flow_areas = hf.create_group("Geometry/2D Flow Areas")
+        for area in areas:
+            name = area["name"]
+            spacing_dx = float(area.get("spacing_dx", 0.0))
+            spacing_dy = float(area.get("spacing_dy", spacing_dx))
+            cell_count = int(area.get("cell_count", 0))
+            dataset_count = int(area.get("dataset_count", cell_count))
+            records.append((name.encode("utf-8"), spacing_dx, spacing_dy, cell_count))
+            area_group = flow_areas.create_group(name)
+            area_group.create_dataset(
+                "Cells Center Coordinate",
+                data=np.zeros((max(dataset_count, 0), 2), dtype=np.float64),
+            )
+        flow_areas.create_dataset("Attributes", data=np.array(records, dtype=dtype))
 
 
 def _install_fake_rasmapper_scripting(monkeypatch):
@@ -597,15 +637,94 @@ class TestGeometryHdfAvailability:
         with pytest.raises(RuntimeError, match="Compiled geometry HDF is missing"):
             _ensure_hdf(breakline_geom_text)
 
-    def test_ensure_hdf_rejects_stale_compiled_geometry(self, breakline_geom_text):
+    def test_ensure_hdf_rejects_stale_compiled_geometry_content(self, breakline_geom_text):
         hdf_path = breakline_geom_text.with_suffix(breakline_geom_text.suffix + ".hdf")
-        hdf_path.write_text("compiled", encoding="utf-8")
-        text_mtime = breakline_geom_text.stat().st_mtime + 10.0
-        os.utime(hdf_path, (text_mtime - 5.0, text_mtime - 5.0))
-        os.utime(breakline_geom_text, (text_mtime, text_mtime))
+        _write_mesh_hdf(
+            hdf_path,
+            [
+                {
+                    "name": "MainArea",
+                    "spacing_dx": 100.0,
+                    "spacing_dy": 100.0,
+                    "cell_count": 0,
+                }
+            ],
+        )
+        shared_mtime = breakline_geom_text.stat().st_mtime
+        os.utime(hdf_path, (shared_mtime, shared_mtime))
 
-        with pytest.raises(RuntimeError, match="is newer than"):
+        with pytest.raises(RuntimeError, match="text Spacing dx=50"):
             _ensure_hdf(breakline_geom_text)
+
+    def test_ensure_hdf_rejects_stale_compiled_geometry_cell_count(
+        self, storage_area_geom_text
+    ):
+        hdf_path = storage_area_geom_text.with_suffix(storage_area_geom_text.suffix + ".hdf")
+        _write_mesh_hdf(
+            hdf_path,
+            [
+                {
+                    "name": "MainArea",
+                    "spacing_dx": 25.0,
+                    "spacing_dy": 25.0,
+                    "cell_count": 2,
+                }
+            ],
+        )
+
+        with pytest.raises(RuntimeError, match="Storage Area 2D Points=3"):
+            _ensure_hdf(storage_area_geom_text)
+
+    def test_ensure_hdf_accepts_matching_content(self, breakline_geom_text):
+        hdf_path = breakline_geom_text.with_suffix(breakline_geom_text.suffix + ".hdf")
+        _write_mesh_hdf(
+            hdf_path,
+            [
+                {
+                    "name": "MainArea",
+                    "spacing_dx": 50.0,
+                    "spacing_dy": 50.0,
+                    "cell_count": 0,
+                }
+            ],
+        )
+
+        assert _ensure_hdf(breakline_geom_text) == hdf_path
+
+    def test_ensure_hdf_recompiles_missing_geometry_when_opted_in(
+        self, monkeypatch, breakline_geom_text
+    ):
+        hdf_path = breakline_geom_text.with_suffix(breakline_geom_text.suffix + ".hdf")
+        calls = []
+
+        def fake_recompile(geom_text_path, compiled_hdf_path, *, ras_object=None):
+            calls.append((geom_text_path, compiled_hdf_path, ras_object))
+            _write_mesh_hdf(
+                compiled_hdf_path,
+                [
+                    {
+                        "name": "MainArea",
+                        "spacing_dx": 50.0,
+                        "spacing_dy": 50.0,
+                        "cell_count": 0,
+                    }
+                ],
+            )
+            return compiled_hdf_path
+
+        monkeypatch.setattr(
+            geom_mesh_module,
+            "_recompile_geometry_hdf_via_rasexe",
+            fake_recompile,
+        )
+        ras_object = object()
+
+        assert _ensure_hdf(
+            breakline_geom_text,
+            ras_object=ras_object,
+            recompile_via_rasexe=True,
+        ) == hdf_path
+        assert calls == [(breakline_geom_text, hdf_path, ras_object)]
 
 
 class TestGeometryAssociation:
@@ -801,10 +920,10 @@ class TestGenerate:
         assert result.ok
         assert result.geom_hdf_path
         assert Path(result.geom_hdf_path).exists()
-        assert captured["cell_size"] == pytest.approx(100.0)
+        assert captured["cell_size"] == pytest.approx(50.0)
 
         text = breakline_geom_text.read_text(encoding="utf-8")
-        assert "Storage Area Point Generation Data=,,100.000000,100.000000" in text
+        assert "Storage Area Point Generation Data=,,50.000000,50.000000" in text
         assert "BreakLine CellSize Min=50.000000" in text
         assert "BreakLine CellSize Max=200.000000" in text
         assert "Storage Area 2D Points= 2 " in text


### PR DESCRIPTION
## Summary
- Add content-based stale geometry HDF checks for 2D mesh cell count and spacing metadata.
- Add opt-in `GeomMesh.generate(..., recompile_via_rasexe=True)` path that rebuilds compiled geometry HDFs through ras-commander's geometry preprocessor.
- Update notebook 230 and its helper script to use the Ras.exe recompile path instead of deleting compiled HDFs.

## Validation
- `pytest tests/test_geom_mesh.py -q` -> 78 passed, 1 skipped.
- Visible execution of `examples/230_mesh_sensitivity_analysis.ipynb` passed.
- Extracted and reviewed notebook figures; all passed visual QA after axis/unit fixes.
- Validated executed notebook scenario geometry HDF cell counts against text seeds.

Artifacts: H:/Symphony/ras-commander/CLB-868/