### PR TITLE
Migrate notebook 430 to HEC-RAS 7.0 (CLB-878, reconciled onto main)

### DIFF
--- a/examples/430_1d_channel_capacity_analysis.ipynb
+++ b/examples/430_1d_channel_capacity_analysis.ipynb
@@ -107,7 +107,7 @@
    "source": [
     "## Setup: BLE Model Preparation\n",
     "\n",
-    "We use a FEMA Base Level Engineering (BLE) reach model — SHILOH BRANCH from the Lower Colorado-Cummins study (HUC 12090301). BLE models are steady-state with 7 flow profiles representing different AEP events.\n",
+    "We use a FEMA Base Level Engineering (BLE) reach model \u2014 SHILOH BRANCH from the Lower Colorado-Cummins study (HUC 12090301). BLE models are steady-state with 7 flow profiles representing different AEP events.\n",
     "\n",
     "`RasEbfeModels.organize_model(\"lower-colorado-cummins\")` handles downloading the 290.7 MB BLE archive from S3 and organizing the selected reach into the shared delivery workspace. Since BLE models were built with HEC-RAS 4.x, we re-run with HEC-RAS 6.5 to generate HDF output files needed for analysis.\n",
     "\n",
@@ -116,7 +116,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {
     "execution": {
      "iopub.execute_input": "2026-05-18T02:16:43.998818Z",
@@ -125,18 +125,7 @@
      "shell.execute_reply": "2026-05-18T02:16:44.010791Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Reach: Rabbs Creek-Colorado River / SHILOH BRANCH\n",
-      "Storm order: ['10P', '4P', '2P', '1P', '0.2P']\n",
-      "eBFE workspace configured: True\n",
-      "Validation matrix: VALIDATION_MATRIX.md\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# =============================================================================\n",
     "# Parameters\n",
@@ -146,8 +135,10 @@
     "BLE_RIVER = \"Rabbs Creek-Colorado River\"\n",
     "BLE_REACH_NAME = \"SHILOH BRANCH\"\n",
     "\n",
-    "# HEC-RAS version for re-running (generates HDF)\n",
-    "RAS_VERSION = \"6.5\"\n",
+    "# HEC-RAS version for re-running. Version 7.0 migrates this steady 1D BLE model\n",
+    "# and writes the geometry/results HDF files used by the analysis below.\n",
+    "RAS_VERSION = \"7.0\"\n",
+    "RAS_PROGRAM_VERSION = \"7.00\"\n",
     "\n",
     "# BLE profile name to standard AEP mapping\n",
     "# Only 5 of the 7 profiles are standard AEP events;\n",
@@ -646,7 +637,7 @@
     "\n",
     "`extract_steady_profile_wse()` reads individual steady-state profiles from a single\n",
     "plan HDF. Unlike `extract_max_wse()` (which collapses profiles to max), this method\n",
-    "preserves each profile as a separate column — essential for capacity analysis.\n",
+    "preserves each profile as a separate column \u2014 essential for capacity analysis.\n",
     "\n",
     "The BLE model has 7 profiles. We map 5 standard AEP events "
    ]


### PR DESCRIPTION
Reconciles CLB-878 (compute BLE channel capacity with RAS 7) onto current main. The original PR #153 conflicted with main's #166 (CLB-750) rework of notebook 430. This applies only the essential change — `RAS_VERSION` 6.5 → 7.0 — preserving #166's cached-HDF reuse and EBFE workspace handling. #153's plan-patch regex refactor was intentionally dropped (conflicts with #166's cache-reuse; main's existing patch produces Program Version=7.00 with RAS_VERSION="7.0"). Supersedes #153.