### PR TITLE
feat(linux): native HEC-RAS 5.0.7 support in compute_plan_linux (CLB-886)

### DIFF
--- a/ras_commander/RasCmdr.py
+++ b/ras_commander/RasCmdr.py
@@ -1546,9 +1546,21 @@ class RasCmdr:
             - {project}.p{plan_num}.tmp.hdf — preprocessed plan HDF
             - {project}.b{plan_num} — boundary conditions file
             - {project}.x{geom_num} — cross-section preprocessor file
+            - {project}.c{geom_num} — computed-geometry file (5.0.7 layout only)
 
-        Compatible with HEC-RAS Linux versions 6.3.1, 6.4, 6.5, 6.6, 6.7.
-        Auto-detects library subdirectory layout (libs/, libs/mkl/, libs/rhel_8/).
+        Supported native Linux install layouts (auto-detected from ``ras_exe_dir``):
+
+        * **canonical (6.3.1-7.0)** — ``RasUnsteady`` at the install root with a
+          sibling ``libs/`` tree (``libs/``, ``libs/mkl/``, ``libs/rhel_8/``).
+          Invoked as ``RasUnsteady {proj}.p{plan}.tmp.hdf x{geom}``.
+        * **bin_ras (5.0.7)** — ``bin_ras/rasUnsteady64`` with libraries colocated
+          in ``bin_ras/`` (no ``libs/`` tree). Invoked as
+          ``rasUnsteady64 {proj}.c{geom} b{plan}`` and additionally requires the
+          ``.c{geom}`` computed-geometry file. (CLB-886)
+
+        Detection and binary resolution mirror
+        :meth:`RasUtils._scan_native_linux_ras` (root ``RasUnsteady`` →
+        ``bin_ras/{rasUnsteady64,RasUnsteady,rasUnsteady}``).
 
         The Linux RasUnsteady binary uses Fortran I/O conventions that require
         files to be accessible with a base name of "io" (e.g., io.b, io.X).
@@ -1556,8 +1568,9 @@ class RasCmdr:
 
         Args:
             plan_number (Union[str, Number]): Plan number to execute (e.g., "01").
-            ras_exe_dir (Union[str, Path]): Directory containing the RasUnsteady
-                binary and sibling libs/ directory.
+            ras_exe_dir (Union[str, Path]): HEC-RAS Linux install directory. For the
+                canonical layout this holds ``RasUnsteady`` + ``libs/``; for the
+                5.0.7 layout it holds ``bin_ras/rasUnsteady64`` + its libraries.
             ras_object: Optional RAS project object. If None, uses global ras.
             timeout_sec (int): Maximum execution time in seconds (default 14400 = 4 hours).
             dos2unix (bool): Convert CRLF→LF in text files before execution (default True).
@@ -1604,11 +1617,12 @@ class RasCmdr:
                 )
         else:
             ras_exe_dir = Path(ras_exe_dir)
-            ras_exe = ras_exe_dir / "RasUnsteady"
+            layout = RasCmdr._resolve_linux_layout(ras_exe_dir)
+            ras_exe = layout["ras_exe"]
             if not ras_exe.exists():
                 raise FileNotFoundError(
-                    f"RasUnsteady binary not found at {ras_exe}. "
-                    "Ensure HEC-RAS Linux binaries are installed."
+                    f"Linux RasUnsteady binary not found under {ras_exe_dir} "
+                    f"(looked for {ras_exe}). Ensure HEC-RAS Linux binaries are installed."
                 )
 
         project_dir = Path(ras_obj.project_folder)
@@ -1647,6 +1661,10 @@ class RasCmdr:
         tmp_hdf = project_dir / f"{project_name}.p{plan_num_str}.tmp.hdf"
         b_file = project_dir / f"{project_name}.b{plan_num_str}"
         x_file = project_dir / f"{project_name}.x{geom_num}"
+        # 5.0.7 (bin_ras/rasUnsteady64) additionally consumes the computed-geometry
+        # ".c{geom}" binary file and is invoked as `rasUnsteady64 {proj}.c{geom} b{plan}`
+        # rather than the 6.x/7.0 `RasUnsteady {tmp.hdf} x{geom}` convention (CLB-886).
+        c_file = project_dir / f"{project_name}.c{geom_num}"
 
         missing = []
         if not tmp_hdf.exists():
@@ -1655,10 +1673,13 @@ class RasCmdr:
             missing.append(f".b{plan_num_str}")
         if not x_file.exists():
             missing.append(f".x{geom_num}")
+        if layout["needs_c_file"] and not c_file.exists():
+            missing.append(f".c{geom_num}")
 
         if missing:
             raise FileNotFoundError(
-                f"Missing prerequisite files for Linux execution: {', '.join(missing)}. "
+                f"Missing prerequisite files for Linux execution ({layout['label']} layout): "
+                f"{', '.join(missing)}. "
                 f"Run RasPreprocess.preprocess_plan() on Windows first (Phase 1). "
                 f"See examples/510_linux_execution.ipynb for the complete workflow."
             )
@@ -1687,24 +1708,11 @@ class RasCmdr:
                 ras_obj=ras_obj,
             )
 
-        # Build LD_LIBRARY_PATH — auto-detect library subdirectories
-        # HEC-RAS Linux versions have varying layouts:
+        # Build LD_LIBRARY_PATH — auto-detect library locations per layout:
+        #   5.0.7:     libs live alongside the binary in bin_ras/
         #   6.3.1-6.5: libs/, libs/mkl/
         #   6.6-6.7:   libs/, libs/mkl/, libs/rhel_8/
-        lib_base = ras_exe_dir / "libs"
-        if not lib_base.exists():
-            lib_base = ras_exe_dir.parent / "libs"
-        ld_path_parts = []
-        if lib_base.exists():
-            ld_path_parts.append(str(lib_base))
-            for subdir in sorted(lib_base.iterdir()):
-                if subdir.is_dir():
-                    ld_path_parts.append(str(subdir))
-                    logger.debug(f"Added library path: {subdir}")
-        else:
-            logger.warning(f"No libs/ directory found near {ras_exe_dir}")
-            ld_path_parts.append(str(ras_exe_dir))
-        ld_path = ":".join(ld_path_parts)
+        ld_path = RasCmdr._build_linux_ld_path(ras_exe_dir, layout)
         logger.info(f"LD_LIBRARY_PATH: {ld_path}")
 
         # dos2unix text files
@@ -1761,9 +1769,16 @@ class RasCmdr:
 
             try:
                 start_time = time.time()
+                # Argument convention differs by layout (CLB-886):
+                #   5.0.7:    rasUnsteady64 {proj}.c{geom} b{plan}   (cwd-relative basenames)
+                #   6.x/7.0:  RasUnsteady   {proj}.p{plan}.tmp.hdf x{geom}
+                if layout["needs_c_file"]:
+                    ras_args = [c_file.name, f"b{plan_num_str}"]
+                else:
+                    ras_args = [str(tmp_hdf), f"x{geom_num}"]
                 with open(log_path, "w") as log_fh:
                     proc = subprocess.Popen(
-                        [str(ras_exe), str(tmp_hdf), f"x{geom_num}"],
+                        [str(ras_exe), *ras_args],
                         stdout=log_fh,
                         stderr=subprocess.STDOUT,
                         env=env,
@@ -1852,6 +1867,86 @@ class RasCmdr:
                         pass
 
                 return ComputeResult(success=False, results_df_row=None)
+
+    @staticmethod
+    def _resolve_linux_layout(ras_exe_dir: Path) -> dict:
+        """Detect the HEC-RAS Linux install layout and return its execution adapter (CLB-886).
+
+        Two native layouts are supported:
+
+        * **canonical (6.3.1-7.0)** — ``RasUnsteady`` at the install root, with a
+          sibling ``libs/`` (plus ``libs/mkl/``, ``libs/rhel_8/``). Invoked as
+          ``RasUnsteady {proj}.p{plan}.tmp.hdf x{geom}``.
+        * **bin_ras (5.0.7)** — ``bin_ras/rasUnsteady64`` with the shared libraries
+          alongside the binary in ``bin_ras/`` (no ``libs/`` tree). Invoked as
+          ``rasUnsteady64 {proj}.c{geom} b{plan}`` and additionally requires the
+          computed-geometry ``.c{geom}`` file.
+
+        Resolution prefers a root ``RasUnsteady`` (canonical) and otherwise falls
+        back to ``bin_ras/rasUnsteady64`` / ``bin_ras/RasUnsteady`` — mirroring the
+        binary names :meth:`RasUtils._scan_native_linux_ras` recognizes.
+
+        Returns:
+            dict: ``ras_exe`` (Path), ``needs_c_file`` (bool), ``lib_dirs``
+            (list[Path] explicit lib dirs, or ``[]`` to auto-detect ``libs/``),
+            and ``label`` (str).
+        """
+        ras_exe_dir = Path(ras_exe_dir)
+        # Canonical layout: RasUnsteady at the install root.
+        root_exe = ras_exe_dir / "RasUnsteady"
+        if root_exe.exists():
+            return {
+                "ras_exe": root_exe,
+                "needs_c_file": False,
+                "lib_dirs": [],          # auto-detect libs/ tree
+                "label": "canonical",
+            }
+        # bin_ras layout (5.0.7): rasUnsteady64 (or RasUnsteady) under bin_ras/,
+        # libraries colocated in the same bin_ras/ directory.
+        bin_ras = ras_exe_dir / "bin_ras"
+        for binname in ("rasUnsteady64", "RasUnsteady", "rasUnsteady"):
+            cand = bin_ras / binname
+            if cand.exists():
+                return {
+                    "ras_exe": cand,
+                    "needs_c_file": True,
+                    "lib_dirs": [bin_ras],
+                    "label": "bin_ras (5.0.7)",
+                }
+        # Nothing matched — return the canonical guess so the caller raises a
+        # clear FileNotFoundError pointing at the expected location.
+        return {
+            "ras_exe": root_exe,
+            "needs_c_file": False,
+            "lib_dirs": [],
+            "label": "canonical",
+        }
+
+    @staticmethod
+    def _build_linux_ld_path(ras_exe_dir: Path, layout: dict) -> str:
+        """Build LD_LIBRARY_PATH for a Linux RasUnsteady run, per layout (CLB-886)."""
+        ras_exe_dir = Path(ras_exe_dir)
+        ld_path_parts = []
+        # Explicit lib dirs (e.g. 5.0.7 bin_ras/) take precedence.
+        for d in layout.get("lib_dirs") or []:
+            if Path(d).exists():
+                ld_path_parts.append(str(d))
+        if ld_path_parts:
+            return ":".join(ld_path_parts)
+        # Canonical: auto-detect a libs/ tree next to the binary.
+        lib_base = ras_exe_dir / "libs"
+        if not lib_base.exists():
+            lib_base = ras_exe_dir.parent / "libs"
+        if lib_base.exists():
+            ld_path_parts.append(str(lib_base))
+            for subdir in sorted(lib_base.iterdir()):
+                if subdir.is_dir():
+                    ld_path_parts.append(str(subdir))
+                    logger.debug(f"Added library path: {subdir}")
+        else:
+            logger.warning(f"No libs/ directory found near {ras_exe_dir}")
+            ld_path_parts.append(str(ras_exe_dir))
+        return ":".join(ld_path_parts)
 
     @staticmethod
     def _validate_linux_solve(log_path, result_hdf, plan_num_str: str):

--- a/tests/test_linux_layout_adapter.py
+++ b/tests/test_linux_layout_adapter.py
@@ -72,6 +72,10 @@ def test_resolve_layout_missing_returns_canonical_guess(tmp_path):
     assert lay["ras_exe"] == root / "RasUnsteady"
 
 
+@pytest.mark.skipif(
+    os.name == "nt",
+    reason="LD_LIBRARY_PATH is ':'-separated; Windows drive-letter colons break the split assertion",
+)
 def test_build_ld_path_canonical(tmp_path):
     root = _make_canonical(tmp_path / "6.6")
     lay = RasCmdr._resolve_linux_layout(root)

--- a/tests/test_linux_layout_adapter.py
+++ b/tests/test_linux_layout_adapter.py
@@ -1,0 +1,89 @@
+"""Unit tests for the Linux install-layout adapter in compute_plan_linux (CLB-886)."""
+import os
+import pytest
+
+from ras_commander.RasCmdr import RasCmdr
+
+
+def _make_canonical(root):
+    """6.x/7.0 layout: RasUnsteady at root + libs/ tree."""
+    root.mkdir(parents=True, exist_ok=True)
+    (root / "RasUnsteady").write_text("#!/bin/sh\n")
+    libs = root / "libs"
+    libs.mkdir(exist_ok=True)
+    (libs / "libimf.so").write_text("x")
+    (libs / "mkl").mkdir(exist_ok=True)
+    (libs / "rhel_8").mkdir(exist_ok=True)
+    return root
+
+
+def _make_bin_ras(root, binname="rasUnsteady64"):
+    """5.0.7 layout: bin_ras/rasUnsteady64 with libs colocated, no libs/ tree."""
+    root.mkdir(parents=True, exist_ok=True)
+    b = root / "bin_ras"
+    b.mkdir(exist_ok=True)
+    (b / binname).write_text("#!/bin/sh\n")
+    (b / "libgfortran.so.3").write_text("x")
+    (b / "libmkl_core.so").write_text("x")
+    return root
+
+
+def test_resolve_layout_canonical(tmp_path):
+    root = _make_canonical(tmp_path / "6.6")
+    lay = RasCmdr._resolve_linux_layout(root)
+    assert lay["label"] == "canonical"
+    assert lay["needs_c_file"] is False
+    assert lay["ras_exe"] == root / "RasUnsteady"
+    assert lay["lib_dirs"] == []
+
+
+def test_resolve_layout_bin_ras(tmp_path):
+    root = _make_bin_ras(tmp_path / "5.0.7")
+    lay = RasCmdr._resolve_linux_layout(root)
+    assert lay["label"].startswith("bin_ras")
+    assert lay["needs_c_file"] is True
+    assert lay["ras_exe"] == root / "bin_ras" / "rasUnsteady64"
+    assert lay["lib_dirs"] == [root / "bin_ras"]
+
+
+def test_resolve_layout_bin_ras_capitalized(tmp_path):
+    root = _make_bin_ras(tmp_path / "5.0.7b", binname="RasUnsteady")
+    lay = RasCmdr._resolve_linux_layout(root)
+    assert lay["needs_c_file"] is True
+    assert lay["ras_exe"].name == "RasUnsteady"
+    assert lay["ras_exe"].parent.name == "bin_ras"
+
+
+def test_resolve_layout_prefers_root_over_bin_ras(tmp_path):
+    """If both a root RasUnsteady and bin_ras exist, canonical wins."""
+    root = _make_canonical(tmp_path / "both")
+    _make_bin_ras(root)
+    lay = RasCmdr._resolve_linux_layout(root)
+    assert lay["label"] == "canonical"
+    assert lay["needs_c_file"] is False
+
+
+def test_resolve_layout_missing_returns_canonical_guess(tmp_path):
+    """Empty dir -> canonical guess so the caller raises a clear FileNotFoundError."""
+    root = tmp_path / "empty"
+    root.mkdir()
+    lay = RasCmdr._resolve_linux_layout(root)
+    assert lay["label"] == "canonical"
+    assert lay["ras_exe"] == root / "RasUnsteady"
+
+
+def test_build_ld_path_canonical(tmp_path):
+    root = _make_canonical(tmp_path / "6.6")
+    lay = RasCmdr._resolve_linux_layout(root)
+    ld = RasCmdr._build_linux_ld_path(root, lay)
+    parts = ld.split(":")
+    assert str(root / "libs") in parts
+    assert str(root / "libs" / "mkl") in parts
+    assert str(root / "libs" / "rhel_8") in parts
+
+
+def test_build_ld_path_bin_ras(tmp_path):
+    root = _make_bin_ras(tmp_path / "5.0.7")
+    lay = RasCmdr._resolve_linux_layout(root)
+    ld = RasCmdr._build_linux_ld_path(root, lay)
+    assert ld == str(root / "bin_ras")


### PR DESCRIPTION
## Summary

Makes HEC-RAS **5.0.7** run natively through `RasCmdr.compute_plan_linux()` — the same call
that already runs 6.6/7.0 — with no manual shim. Previously 5.0.7 failed because the method
assumed the canonical 6.x/7.0 layout (`RasUnsteady` at the install root, args
`<tmp.hdf> x<geom>`, `libs/` tree).

## What changed

A small install-layout adapter, plus three branch points in `compute_plan_linux`:

- **`_resolve_linux_layout(ras_exe_dir)`** — detects the layout and returns the binary path,
  whether a `.c{geom}` prerequisite is needed, the lib dirs, and a label:
  - **canonical (6.3.1-7.0)** → `RasUnsteady` at root, `libs/` auto-detect
  - **bin_ras (5.0.7)** → `bin_ras/{rasUnsteady64,RasUnsteady,rasUnsteady}`, libs colocated in `bin_ras/`
  - Binary names mirror `RasUtils._scan_native_linux_ras`; a root `RasUnsteady` wins if both exist.
- **`_build_linux_ld_path(ras_exe_dir, layout)`** — bin_ras → the `bin_ras` dir; canonical →
  `libs/` + `libs/mkl/` + `libs/rhel_8/` (unchanged behavior).
- **`compute_plan_linux`** branches the binary path, the prerequisite check (5.0.7 additionally
  requires `{proj}.c{geom}`), and the argument convention:
  - 5.0.7: `rasUnsteady64 {proj}.c{geom} b{plan}`
  - 6.x/7.0: `RasUnsteady {proj}.p{plan}.tmp.hdf x{geom}`

The CLB-882 success validation (`_validate_linux_solve`: log error markers + `/Results/Unsteady`)
applies to both layouts. **6.6/7.0 behavior is identical to before** (the canonical branch is the
prior code path).

## Invocation pinned down on real binaries (CLB07)

5.0.7's `bin_ras/rasUnsteady64` is invoked `rasUnsteady64 {proj}.c{geom} b{plan}` and requires
`.c{geom}`, `.b{plan}`, `.x{geom}` and the `.tmp.hdf`; it writes results into the `.tmp.hdf`
in place (same as 6.x). The extra input vs 6.x is the computed-geometry `.c{geom}` binary file.

## Verification

End-to-end on CLB07 (real solves):
- **5.0.7** via `compute_plan_linux(ras_exe_dir="/opt/hecras/5.0.7")` → `success=True`, valid
  `/Results/Unsteady` (no manual shim)
- **6.6** → `success=True`, valid result HDF — **no regression**

Tests: `tests/test_linux_layout_adapter.py` (7 tests, layout detection + ld-path for both
layouts, root-wins precedence, empty-dir guard). Full Linux suite green:
layout-adapter + `test_linux_robustness` + `test_geom_preprocess_linux` +
`test_rascmdr_compute_plan_control_flow` → **26 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
