### PR TITLE
Packaging: include sources.state + remote.docker in wheel; bump 0.98.0

### DIFF
--- a/ras_commander/remote/docker/__init__.py
+++ b/ras_commander/remote/docker/__init__.py
@@ -1,0 +1,1 @@
+"""Docker-based remote execution helpers."""

--- a/ras_commander/sources/state/__init__.py
+++ b/ras_commander/sources/state/__init__.py
@@ -1,0 +1,1 @@
+"""State-level model source downloaders (CO CHAMP, IN DNR, MN DNR)."""

--- a/setup.py
+++ b/setup.py
@@ -34,8 +34,8 @@ class CustomBuildPy(build_py):
 
 setup(
     name="ras-commander",
-    version="0.97.0",
-    packages=find_packages(),
+    version="0.98.0",
+    packages=find_packages(include=['ras_commander', 'ras_commander.*']),
     include_package_data=True,
     package_data={
         "ras_commander": [


### PR DESCRIPTION
Fixes a real wheel-omission bug (the class reported in #139/#142, which I had wrongly closed as redundant). Two dirs had .py modules but no `__init__.py`, so `find_packages()` dropped them from built wheels -> ModuleNotFoundError on installed packages:
- `ras_commander/sources/state/` (co_champ, in_dnr, mn_dnr)
- `ras_commander/remote/docker/` (setup_docker)

Adds the two `__init__.py` files + scopes `find_packages(include=['ras_commander','ras_commander.*'])`. Bumps 0.97.0 -> 0.98.0. **Verified:** the 0.98.0 wheel now contains both subpackages.