### PR TITLE
feat(geom): greenfield 2D meshing — Storage Area Is2D detection + generate_computation_points

### DIFF
--- a/ras_commander/geom/GeomMesh.py
+++ b/ras_commander/geom/GeomMesh.py
@@ -3381,6 +3381,137 @@ class GeomMesh:
 
     @staticmethod
     @log_call
+    def generate_computation_points(
+        geom_number: Union[str, Number, Path],
+        mesh_name: Optional[str] = None,
+        mesh_index: int = 0,
+        cell_size: Optional[float] = None,
+        hecras_dir: Optional[Union[str, Path]] = None,
+        ras_object=None,
+    ) -> "MeshResult":
+        """
+        Generate initial 2D computation points for a 2D flow area directly from
+        the authored .g## perimeter text — **no pre-existing compiled .g##.hdf
+        required**.
+
+        This is the greenfield bootstrap for a brand-new 2D flow area. It builds
+        a RasMapperLib perimeter ``Polygon`` from the ``Storage Area Surface
+        Line=`` block and runs ``PointGenerator.GeneratePoints`` (RASMapper's
+        "Generate Computation Points on Regular Interval"), then writes the
+        resulting cell centers into the ``Storage Area 2D Points=`` block of the
+        .g## text. HEC-RAS builds the full Voronoi mesh from those points during
+        geometry preprocessing (e.g. ``RasCmdr.compute_plan(force_geompre=True)``).
+
+        Unlike :meth:`generate`, this does NOT load a compiled HDF and is
+        therefore the path to use *before* any mesh exists. It is
+        breakline-unaware (regular-interval grid clipped to the perimeter); use
+        :meth:`generate` for breakline-aware regeneration once a compiled HDF
+        exists.
+
+        Args:
+            geom_number: Geometry number ("01", 1) or path to .g## text file.
+            mesh_name: Name of the 2D flow area (None -> use mesh_index).
+            mesh_index: 0-based 2D-area index when mesh_name is None.
+            cell_size: Regular-interval spacing in project units. When None, it
+                is read from ``Storage Area Point Generation Data`` in the text.
+            hecras_dir: Override HEC-RAS installation directory (for RasMapperLib).
+            ras_object: Optional RasPrj instance for multi-project support.
+
+        Returns:
+            MeshResult with status, mesh_name, cell_count (= number of generated
+            computation points), and geom_text_path. Points are written to the
+            .g## text; the full mesh is produced by the subsequent HEC-RAS
+            geometry preprocess.
+        """
+        import numpy as np
+        from .GeomStorage import GeomStorage
+
+        _load_dlls(hecras_dir)
+        ns = _imports()
+        geom_path = _resolve_geom_text_path(geom_number, ras_object)
+
+        result = MeshResult(
+            mesh_name=mesh_name or f"<index {mesh_index}>",
+            status="error",
+            geom_text_path=str(geom_path),
+        )
+
+        try:
+            # ── Read the 2D-area perimeter ring from the .g## text ──────────
+            gdf = GeomStorage.get_storage_area_polygons(geom_path, exclude_2d=False)
+            twod = gdf[gdf["is_2d"]] if "is_2d" in gdf.columns else gdf
+            if mesh_name is not None:
+                twod = twod[twod["Name"] == mesh_name]
+            elif 0 <= mesh_index < len(twod):
+                twod = twod.iloc[mesh_index:mesh_index + 1]
+            if len(twod) == 0:
+                result.error_message = (
+                    f"No matching 2D flow area in {geom_path.name} "
+                    f"(mesh_name={mesh_name!r}, mesh_index={mesh_index})"
+                )
+                return result
+            row = twod.iloc[0]
+            area = mesh_name or str(row["Name"])
+            result.mesh_name = area
+            poly = row.geometry
+            if poly is None or not hasattr(poly, "exterior"):
+                result.error_message = f"2D area '{area}' has no perimeter polygon"
+                return result
+            coords = list(poly.exterior.coords)
+
+            # ── Resolve cell size (arg > text point-generation data) ───────
+            if cell_size is None:
+                cell_size = _read_cell_size_from_text(geom_path, mesh_name=area)
+            if cell_size is None or float(cell_size) <= 0:
+                result.error_message = (
+                    "cell_size not provided and not found in 'Storage Area "
+                    "Point Generation Data' of the geometry text"
+                )
+                return result
+            cell_size = float(cell_size)
+
+            # ── Build a RasMapperLib perimeter Polygon from the coords ─────
+            from RasMapperLib import PointMs as _PointMs, Polygon as _Polygon  # type: ignore
+            from RasMapperLib import PointM as _PointM  # type: ignore
+            pts = _PointMs()
+            for x, y in coords:
+                pts.Add(_PointM(float(x), float(y)))
+            perim = _Polygon(pts)
+
+            # ── Generate computation points (float32-safe GeneratePoints) ──
+            seeds = _generate_seeds_safe(perim, cell_size, ns)
+            n_pts = int(seeds.Count)
+            if n_pts <= 0:
+                result.status = "exception"
+                result.error_message = "PointGenerator returned no computation points"
+                return result
+            centers = np.empty((n_pts, 2), dtype=float)
+            for i in range(n_pts):
+                p = seeds.PointM(i)
+                centers[i, 0] = float(p.X)
+                centers[i, 1] = float(p.Y)
+
+            # ── Write points into the .g## text (sole persistent output) ───
+            _patch_text_seeds(geom_path, centers, mesh_name=area)
+
+            result.status = "success"
+            result.cell_count = n_pts
+            logger.info(
+                f"Generated {n_pts} computation points for 2D area '{area}' "
+                f"(cell_size={cell_size:g}) in {geom_path.name}; run HEC-RAS "
+                f"geometry preprocessing to build the mesh."
+            )
+            return result
+        except Exception as exc:  # noqa: BLE001
+            result.status = "exception"
+            result.error_message = f"{type(exc).__name__}: {exc}"
+            logger.error(
+                f"[{result.mesh_name}] generate_computation_points failed: {exc}"
+            )
+            return result
+
+    @staticmethod
+    @log_call
     def generate(
         geom_number: Union[str, Number, Path],
         mesh_name: Optional[str] = None,

--- a/ras_commander/gui/workflows/mesh_regeneration.py
+++ b/ras_commander/gui/workflows/mesh_regeneration.py
@@ -52,42 +52,72 @@ logger = get_logger(__name__)
 # ---------------------------------------------------------------------------
 
 def _get_2d_area_name(geometry_file: Path) -> Optional[str]:
-    """Parse .g## file and return the first 2D flow area name, or None."""
-    pattern = re.compile(r"^2D Flow Area=\s*(.+?)\s*,", re.MULTILINE | re.IGNORECASE)
-    text = geometry_file.read_text(errors="replace")
-    match = pattern.search(text)
-    return match.group(1).strip() if match else None
+    """Return the first 2D flow area name in a .g## file, or None.
+
+    Delegates to GeomStorage, which identifies 2D flow areas by the modern
+    HEC-RAS 6.x/7.0 ``Storage Area Is2D= -1`` representation. (The legacy
+    ``2D Flow Area=`` token this module used historically is not written by
+    current HEC-RAS, so the previous regex matched nothing.)
+    """
+    from ...geom.GeomStorage import GeomStorage
+    try:
+        df = GeomStorage.get_storage_areas(geometry_file, exclude_2d=False)
+    except Exception as e:  # noqa: BLE001
+        logger.warning(f"Could not read storage areas from {Path(geometry_file).name}: {e}")
+        return None
+    if df is None or df.empty or "Is2D" not in df.columns:
+        return None
+    twod = df[df["Is2D"]]
+    if twod.empty:
+        return None
+    return str(twod.iloc[0]["Name"])
 
 
 def _read_perimeter_coords(geometry_file: Path) -> Optional[List[Tuple[float, float]]]:
-    """Read the 2D Flow Area Perimeter coordinates from a .g## file."""
-    text = geometry_file.read_text(errors="replace")
+    """Read the 2D flow area perimeter ring from a .g## file.
 
-    # Match "2D Flow Area Perimeter= N" followed by N lines of "     x,y"
-    pattern = re.compile(
-        r"2D Flow Area Perimeter=\s*(\d+)\s*\n"
-        r"((?:[ \t]*-?[\d.]+\s*,\s*-?[\d.]+[ \t]*\n)*)",
-        re.MULTILINE,
-    )
-    match = pattern.search(text)
-    if not match:
+    Delegates to GeomStorage, which parses the ``Storage Area Surface Line=``
+    16-char fixed-width XY block of the 2D-flagged storage area.
+    """
+    from ...geom.GeomStorage import GeomStorage
+    try:
+        gdf = GeomStorage.get_storage_area_polygons(geometry_file, exclude_2d=False)
+    except Exception as e:  # noqa: BLE001
+        logger.warning(f"Could not read perimeter from {Path(geometry_file).name}: {e}")
         return None
-
-    coord_lines = match.group(2).strip().split("\n")
-    coords = []
-    for line in coord_lines:
-        line = line.strip()
-        if "," in line:
-            parts = line.split(",")
-            coords.append((float(parts[0].strip()), float(parts[1].strip())))
-    return coords
+    if gdf is None or len(gdf) == 0:
+        return None
+    twod = gdf[gdf["is_2d"]] if "is_2d" in gdf.columns else gdf
+    if len(twod) == 0:
+        return None
+    poly = twod.iloc[0].geometry
+    if poly is None:
+        return None
+    return [(float(x), float(y)) for x, y in poly.exterior.coords]
 
 
 def _read_cell_size(geometry_file: Path) -> Optional[float]:
-    """Read the 2D Flow Area Cell Size from a .g## file."""
-    text = geometry_file.read_text(errors="replace")
-    match = re.search(r"2D Flow Area Cell Size=\s*([\d.]+)", text)
-    return float(match.group(1)) if match else None
+    """Read the 2D flow area nominal cell size (point-generation dx) from a .g##.
+
+    Delegates to GeomStorage; the value lives in ``Storage Area Point Generation
+    Data=dx,dy,,`` rather than the legacy ``2D Flow Area Cell Size=`` token.
+    """
+    from ...geom.GeomStorage import GeomStorage
+    try:
+        df = GeomStorage.get_2d_flow_area_settings(geometry_file)
+    except Exception as e:  # noqa: BLE001
+        logger.warning(f"Could not read 2D settings from {Path(geometry_file).name}: {e}")
+        return None
+    if df is None or df.empty:
+        return None
+    pgd = df.iloc[0].get("point_generation_data")
+    if pgd is None:
+        return None
+    try:
+        first = pgd.split(",")[0] if isinstance(pgd, str) else pgd[0]
+        return float(first)
+    except (ValueError, IndexError, TypeError):
+        return None
 
 
 def _write_perimeter_and_cell_size(
@@ -96,52 +126,29 @@ def _write_perimeter_and_cell_size(
     coords: List[Tuple[float, float]],
     cell_size: float,
 ) -> bool:
-    """
-    Write simplified perimeter coordinates and cell size to .g## file.
+    """Write a (simplified) perimeter ring + nominal cell size back to the .g##.
 
-    Creates .bak backup before modifying. Auto-closes polygon.
+    Delegates to ``GeomStorage.set_2d_flow_area_perimeter``, which writes the
+    modern ``Storage Area`` / ``Storage Area Surface Line=`` /
+    ``Storage Area Point Generation Data=`` representation, auto-closes the
+    polygon, and creates a .bak backup.
     """
-    text = geometry_file.read_text(errors="replace")
-
-    # Verify the named area exists
-    area_pat = re.compile(
-        r"2D Flow Area=\s*" + re.escape(area_name) + r"\s*,",
-        re.IGNORECASE,
-    )
-    if not area_pat.search(text):
-        logger.warning(f"2D flow area '{area_name}' not found in {geometry_file.name}")
+    from ...geom.GeomStorage import GeomStorage
+    try:
+        GeomStorage.set_2d_flow_area_perimeter(
+            geom_file=geometry_file,
+            flow_area_name=area_name,
+            coordinates=[(float(x), float(y)) for x, y in coords],
+            point_generation_data=[float(cell_size), float(cell_size)],
+        )
+    except Exception as e:  # noqa: BLE001
+        logger.warning(
+            f"Failed to write perimeter for '{area_name}' in {Path(geometry_file).name}: {e}"
+        )
         return False
-
-    # Backup
-    bak_path = geometry_file.with_suffix(geometry_file.suffix + ".bak")
-    bak_path.write_text(text, encoding="utf-8")
-
-    # Close polygon
-    pts = list(coords)
-    if pts and pts[0] != pts[-1]:
-        pts.append(pts[0])
-
-    coord_lines = "\n".join(f"     {x:.3f},{y:.3f}" for x, y in pts)
-    new_block = f"2D Flow Area Perimeter= {len(pts)}\n{coord_lines}\n"
-
-    # Replace perimeter block
-    perim_pat = re.compile(
-        r"(2D Flow Area Perimeter=\s*\d+\s*\n)"
-        r"((?:[ \t]*-?[\d.]+\s*,\s*-?[\d.]+[ \t]*\n)*)",
-        re.MULTILINE,
-    )
-    updated, n = perim_pat.subn(new_block, text, count=1)
-    if n == 0:
-        # Insert after the area header
-        updated = area_pat.sub(lambda m: m.group(0) + "\n" + new_block, updated, count=1)
-
-    # Update cell size
-    cs_pat = re.compile(r"2D Flow Area Cell Size=\s*[\d.]+")
-    updated = cs_pat.sub(f"2D Flow Area Cell Size= {cell_size:.1f}", updated)
-
-    geometry_file.write_text(updated, encoding="utf-8")
     logger.info(
-        f"Updated {geometry_file.name}: {len(pts)} perimeter points, cell size {cell_size:.1f}"
+        f"Updated {Path(geometry_file).name}: {len(coords)} perimeter points, "
+        f"cell size {cell_size:.1f} (via GeomStorage)"
     )
     return True
 


### PR DESCRIPTION
Two related changes that together let ras-commander build a 2D flow-area mesh **from scratch** (no GUI clicking), validated end-to-end on a HEC-RAS 7.0 workstation.

## 1. fix(gui) — detect 2D flow areas via `Storage Area Is2D` (b2115154)

`MeshRegenerationWorkflow`'s geometry helpers parsed the legacy HEC-RAS 5.x tokens (`2D Flow Area=`, `2D Flow Area Perimeter=`, `2D Flow Area Cell Size=`), which 6.x/7.0 no longer writes — modern geometry uses `Storage Area Is2D=-1` + `Storage Area Surface Line=` + `Storage Area Point Generation Data=`. The four helpers now delegate to `GeomStorage` (the parser the rest of the library uses), so the workflow recognizes any current 2D area instead of raising "No 2D flow area found".

## 2. feat(geom) — `GeomMesh.generate_computation_points` (ebb24288)

`GeomMesh.generate()` can only *regenerate* an existing mesh (loads the perimeter from a compiled HDF via `RegenerateMeshPoints`, gated by `_ensure_hdf`), so it cannot bootstrap a never-meshed 2D area. The new method generates the **initial** computation points directly from the authored `.g##` perimeter text — **no pre-existing compiled `.g##.hdf` required**:

1. read the perimeter ring from `Storage Area Surface Line=` (`GeomStorage.get_storage_area_polygons`)
2. build a RasMapperLib perimeter `Polygon` from those coords
3. run `PointGenerator.GeneratePoints` (RASMapper's "Generate Computation Points on Regular Interval", float32-safe)
4. write the cell centers as `Storage Area 2D Points= N` into the `.g##` text

HEC-RAS then builds the full Voronoi mesh during geometry preprocessing.

## Verified greenfield workflow (HEC-RAS 7.0, blank-geometry template)

```
GeomStorage.set_2d_flow_area_perimeter(... point_generation_data=[None,None,dx,dy])
GeomMesh.generate_computation_points(...)   -> 2574 points (status=success)
RasCmdr.compute_plan(force_geompre=True)    -> ComputeResult(SUCCESS)
=> compiled .g01.hdf with 2784 mesh cells
```

Both changes are pure-Python/pythonnet (no GUI automation). Note: `generate_computation_points` needs Windows + HEC-RAS + RasMapperLib (pythonnet), so like ras-agent's mesh tests it can't run in headless CI; validated manually on a CLB HEC-RAS 7.0 workstation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
