### PR TITLE
fix(hdf): harden HdfResultsSediment + RasPlan sediment-output per Codex QAQC

### DIFF
--- a/examples/232_weise_2d_sediment_mesh_sensitivity.ipynb
+++ b/examples/232_weise_2d_sediment_mesh_sensitivity.ipynb
@@ -894,7 +894,7 @@
     "## Execute (constant native 1-hour window)\n",
     "\n",
     "The plan's native simulation window (1 hour) is held constant across all meshes, so result\n",
-    "differences are due to resolution alone. We also use\n",
+    "differences across meshes reflect cell-size resolution rather than changes in the flow forcing (numerical-scheme and time-step effects also vary with resolution). We also use\n",
     "`RasPlan.set_sediment_output_variables()` to **request active-layer gradation output**\n",
     "(`d50`/`d10`/`d90`) on each cloned plan -- the stock Weise plan omits it, so without this the\n",
     "`Cell Active Layer Percentile Diameters` datasets would not be written."

--- a/ras_commander/RasPlan.py
+++ b/ras_commander/RasPlan.py
@@ -1484,11 +1484,22 @@ class RasPlan:
         """
         logger = logging.getLogger(__name__)
 
-        plan_file_path = Path(plan_number_or_path)
-        if not plan_file_path.is_file():
+        # Resolve to a plan file path. Accept str/Path (file path) or a plan
+        # number (str/int/float). Avoid calling Path() on a numeric plan number
+        # (Path(1) raises TypeError) by routing non-file inputs to get_plan_path,
+        # which normalizes plan numbers via RasUtils.normalize_ras_number.
+        plan_file_path = None
+        if isinstance(plan_number_or_path, (str, Path)):
+            candidate = Path(plan_number_or_path)
+            if candidate.is_file():
+                plan_file_path = candidate
+            elif isinstance(plan_number_or_path, Path) or '/' in str(plan_number_or_path) or '\\' in str(plan_number_or_path):
+                # An explicit path that does not exist.
+                raise ValueError(f"Plan file not found: {plan_number_or_path}")
+        if plan_file_path is None:
             plan_file_path = RasPlan.get_plan_path(plan_number_or_path, ras_object)
             if plan_file_path is None or not Path(plan_file_path).exists():
-                raise ValueError(f"Plan file not found: {plan_file_path}")
+                raise ValueError(f"Plan file not found for plan number: {plan_number_or_path!r}")
 
         try:
             with open(plan_file_path, 'r', encoding='utf-8', errors='replace') as file:
@@ -1822,11 +1833,22 @@ class RasPlan:
         """
 
         # Get the plan file path
-        plan_file_path = Path(plan_number_or_path)
-        if not plan_file_path.is_file():
+        # Resolve to a plan file path. Accept str/Path (file path) or a plan
+        # number (str/int/float). Avoid calling Path() on a numeric plan number
+        # (Path(1) raises TypeError) by routing non-file inputs to get_plan_path,
+        # which normalizes plan numbers via RasUtils.normalize_ras_number.
+        plan_file_path = None
+        if isinstance(plan_number_or_path, (str, Path)):
+            candidate = Path(plan_number_or_path)
+            if candidate.is_file():
+                plan_file_path = candidate
+            elif isinstance(plan_number_or_path, Path) or '/' in str(plan_number_or_path) or '\\' in str(plan_number_or_path):
+                # An explicit path that does not exist.
+                raise ValueError(f"Plan file not found: {plan_number_or_path}")
+        if plan_file_path is None:
             plan_file_path = RasPlan.get_plan_path(plan_number_or_path, ras_object)
             if plan_file_path is None or not Path(plan_file_path).exists():
-                raise ValueError(f"Plan file not found: {plan_file_path}")
+                raise ValueError(f"Plan file not found for plan number: {plan_number_or_path!r}")
 
         # Format the dates
         formatted_date = f"{start_date.strftime('%d%b%Y').upper()},{start_date.strftime('%H%M')},{end_date.strftime('%d%b%Y').upper()},{end_date.strftime('%H%M')}"
@@ -1889,11 +1911,22 @@ class RasPlan:
         Raises:
             ValueError: If the plan file is not found.
         """
-        plan_file_path = Path(plan_number_or_path)
-        if not plan_file_path.is_file():
+        # Resolve to a plan file path. Accept str/Path (file path) or a plan
+        # number (str/int/float). Avoid calling Path() on a numeric plan number
+        # (Path(1) raises TypeError) by routing non-file inputs to get_plan_path,
+        # which normalizes plan numbers via RasUtils.normalize_ras_number.
+        plan_file_path = None
+        if isinstance(plan_number_or_path, (str, Path)):
+            candidate = Path(plan_number_or_path)
+            if candidate.is_file():
+                plan_file_path = candidate
+            elif isinstance(plan_number_or_path, Path) or '/' in str(plan_number_or_path) or '\\' in str(plan_number_or_path):
+                # An explicit path that does not exist.
+                raise ValueError(f"Plan file not found: {plan_number_or_path}")
+        if plan_file_path is None:
             plan_file_path = RasPlan.get_plan_path(plan_number_or_path, ras_object)
             if plan_file_path is None or not Path(plan_file_path).exists():
-                raise ValueError(f"Plan file not found: {plan_file_path}")
+                raise ValueError(f"Plan file not found for plan number: {plan_number_or_path!r}")
 
         output_level = None
         variables = []
@@ -1948,11 +1981,22 @@ class RasPlan:
         if not variables:
             raise ValueError("variables must be a non-empty list of output tokens.")
 
-        plan_file_path = Path(plan_number_or_path)
-        if not plan_file_path.is_file():
+        # Resolve to a plan file path. Accept str/Path (file path) or a plan
+        # number (str/int/float). Avoid calling Path() on a numeric plan number
+        # (Path(1) raises TypeError) by routing non-file inputs to get_plan_path,
+        # which normalizes plan numbers via RasUtils.normalize_ras_number.
+        plan_file_path = None
+        if isinstance(plan_number_or_path, (str, Path)):
+            candidate = Path(plan_number_or_path)
+            if candidate.is_file():
+                plan_file_path = candidate
+            elif isinstance(plan_number_or_path, Path) or '/' in str(plan_number_or_path) or '\\' in str(plan_number_or_path):
+                # An explicit path that does not exist.
+                raise ValueError(f"Plan file not found: {plan_number_or_path}")
+        if plan_file_path is None:
             plan_file_path = RasPlan.get_plan_path(plan_number_or_path, ras_object)
             if plan_file_path is None or not Path(plan_file_path).exists():
-                raise ValueError(f"Plan file not found: {plan_file_path}")
+                raise ValueError(f"Plan file not found for plan number: {plan_number_or_path!r}")
 
         with open(plan_file_path, 'r', encoding='utf-8', errors='replace') as file:
             lines = file.readlines()

--- a/ras_commander/hdf/HdfResultsSediment.py
+++ b/ras_commander/hdf/HdfResultsSediment.py
@@ -30,7 +30,7 @@ prefixed plan numbers, paths, or open HDF handles.
 """
 
 from pathlib import Path
-from typing import Any, List, Optional, Union
+from typing import Any, List, Optional
 
 import numpy as np
 import pandas as pd
@@ -173,19 +173,41 @@ class HdfResultsSediment:
             if ds_path not in f:
                 raise ValueError(f"Dataset '{dataset}' not found for area '{area}'.")
             arr = f[ds_path]
-            row = arr[time_index] if arr.ndim == 2 else arr[0]
+            row = HdfResultsSediment._select_time_row(arr, time_index, dataset, area)
             sa, cc, crs = HdfResultsSediment._cell_geometry(f, area)
             length_unit = HdfResultsSediment._length_unit(f)
 
-        n = min(len(row), len(sa), len(cc))
+        values = np.asarray(row, dtype=float)
+        sa = np.asarray(sa, dtype=float)
+        # Per-cell results must align 1:1 with the geometry cells; a mismatch
+        # would otherwise yield silently truncated (wrong) values/volumes.
+        if not (len(values) == len(sa) == len(cc)):
+            raise ValueError(
+                f"Cell array length mismatch in area '{area}': {dataset}={len(values)}, "
+                f"Cells Surface Area={len(sa)}, Cells Center Coordinate={len(cc)}.")
         return {
             "area": area,
-            "values": np.asarray(row[:n], dtype=float),
-            "surface_area": np.asarray(sa[:n], dtype=float),
-            "centers": cc[:n],
+            "values": values,
+            "surface_area": sa,
+            "centers": cc,
             "crs": crs,
             "length_unit": length_unit,
         }
+
+    @staticmethod
+    def _select_time_row(arr, time_index, dataset, area):
+        """Select a single per-cell row from a Sediment Bed dataset.
+
+        Handles the normal ``(n_time, n_cell)`` layout and a 1-D ``(n_cell,)``
+        single-snapshot layout; raises a clear error on any other rank.
+        """
+        if arr.ndim == 2:
+            return arr[time_index]
+        if arr.ndim == 1:
+            return arr[:]
+        raise ValueError(
+            f"Unexpected rank {arr.ndim} for dataset '{dataset}' in area '{area}' "
+            "(expected (n_time, n_cell) or (n_cell,)).")
 
     @staticmethod
     def _build_cell_gdf(GeoDataFrame, Point, data, value_col, units):
@@ -301,35 +323,37 @@ class HdfResultsSediment:
         """
         cols = ["mesh_name", "length_unit", "n_cells", "net_bed_volume",
                 "erosion_volume", "deposition_volume", "max_scour", "max_deposition"]
-        rows = []
         with h5py.File(hdf_path, 'r') as f:
             grp = f.get(_BED_BLOCK)
             if grp is None:
                 return pd.DataFrame(columns=cols)
-            length_unit = HdfResultsSediment._length_unit(f)
-            areas = [mesh_name] if mesh_name is not None else list(grp.keys())
-            for area in areas:
-                ds_path = f"{_BED_BLOCK}/{area}/Cell Bed Change"
-                if ds_path not in f:
-                    continue
-                bc = f[ds_path][time_index]
-                sa, _, _ = HdfResultsSediment._cell_geometry(f, area)
-                n = min(len(bc), len(sa))
-                bc = np.asarray(bc[:n], dtype=float)
-                sa = np.asarray(sa[:n], dtype=float)
-                vol = bc * sa  # native^3 per cell
-                wet = sa > 0  # exclude zero-area perimeter/ghost cells
-                bc_wet = bc[wet]
-                rows.append({
-                    "mesh_name": area,
-                    "length_unit": length_unit,
-                    "n_cells": int(wet.sum()),
-                    "net_bed_volume": float(np.nansum(vol)),
-                    "erosion_volume": float(np.nansum(vol[vol < 0])),
-                    "deposition_volume": float(np.nansum(vol[vol > 0])),
-                    "max_scour": float(np.nanmin(bc_wet)) if bc_wet.size else np.nan,
-                    "max_deposition": float(np.nanmax(bc_wet)) if bc_wet.size else np.nan,
-                })
+            # An explicit mesh_name is validated (raises on a bad name); otherwise
+            # summarize every sediment area. _resolve_area is called again inside
+            # _read_cell_dataset for the actual read.
+            if mesh_name is not None:
+                areas = [HdfResultsSediment._resolve_area(f, mesh_name)]
+            else:
+                areas = list(grp.keys())
+
+        rows = []
+        for area in areas:
+            # Reuse the shared reader: ndim handling + strict length validation.
+            data = HdfResultsSediment._read_cell_dataset(
+                hdf_path, area, "Cell Bed Change", time_index)
+            bc, sa = data["values"], data["surface_area"]
+            vol = bc * sa  # native^3 per cell
+            wet = sa > 0   # exclude zero-area perimeter/ghost cells
+            bc_wet = bc[wet]
+            rows.append({
+                "mesh_name": area,
+                "length_unit": data["length_unit"],
+                "n_cells": int(wet.sum()),
+                "net_bed_volume": float(np.nansum(vol)),
+                "erosion_volume": float(np.nansum(vol[vol < 0])),
+                "deposition_volume": float(np.nansum(vol[vol > 0])),
+                "max_scour": float(np.nanmin(bc_wet)) if bc_wet.size else np.nan,
+                "max_deposition": float(np.nanmax(bc_wet)) if bc_wet.size else np.nan,
+            })
         return pd.DataFrame(rows, columns=cols)
 
     # ------------------------------------------------------------------ #
@@ -352,8 +376,14 @@ class HdfResultsSediment:
         with h5py.File(hdf_path, 'r') as f:
             area = HdfResultsSediment._resolve_area(f, mesh_name)
             bc = f[f"{_BED_BLOCK}/{area}/Cell Bed Change"][:]
-            t = HdfResultsSediment._read_time_vector(f, bc.shape[0])
             length_unit = HdfResultsSediment._length_unit(f)
+            # Tolerate a 1-D single-snapshot dataset by promoting to (1, n_cell).
+            if bc.ndim == 1:
+                bc = bc[np.newaxis, :]
+            elif bc.ndim != 2:
+                raise ValueError(
+                    f"Unexpected rank {bc.ndim} for 'Cell Bed Change' in area '{area}'.")
+            t = HdfResultsSediment._read_time_vector(f, bc.shape[0])
         da = xr.DataArray(
             bc,
             dims=("time", "cell_id"),

--- a/tests/test_hdf_results_sediment.py
+++ b/tests/test_hdf_results_sediment.py
@@ -155,3 +155,110 @@ class TestTimeseries:
         assert da.shape == (2, 5)
         assert da.attrs["units"] == "ft"
         assert list(da.coords["time"].values) == [0.0, 1.0]
+
+    def test_timeseries_si_units(self, si_hdf):
+        # SI model -> timeseries units must be 'm', not hardcoded 'ft'
+        da = HdfResultsSediment.get_cell_bed_change_timeseries(si_hdf)
+        assert da.attrs["units"] == "m"
+
+
+class TestTimeIndexAndPercentiles:
+    def test_time_index_selects_row(self, us_hdf):
+        # time_index=0 is the all-zero first snapshot; default -1 is the active one
+        first = HdfResultsSediment.get_cell_bed_change(us_hdf, time_index=0)
+        assert first["bed_change"].tolist() == [0.0, 0.0, 0.0, 0.0, 0.0]
+        last = HdfResultsSediment.get_cell_bed_change(us_hdf, time_index=-1)
+        assert last["bed_change"].tolist() == [-1.0, 2.0, 5.0, -0.5, 9.0]
+
+    @pytest.mark.parametrize("pct", ["D10", "D50", "D90"])
+    def test_each_percentile(self, tmp_path, pct):
+        # write a model that requests all three percentiles
+        p = tmp_path / f"Grain_{pct}.p01.hdf"
+        with h5py.File(p, "w") as f:
+            f.attrs["Units System"] = np.bytes_("US Customary")
+            g = f.create_group("Geometry")
+            g.attrs["SI Units"] = np.bytes_("False")
+            ga = g.create_group("2D Flow Areas/A")
+            ga.create_dataset("Cells Surface Area", data=np.ones(3, dtype="f4"))
+            ga.create_dataset("Cells Center Coordinate", data=np.zeros((3, 2), dtype="f8"))
+            b = f.create_group(f"{_BED}/A")
+            b.create_dataset("Cell Bed Change", data=np.zeros((1, 3), dtype="f4"))
+            for q in ("D10", "D50", "D90"):
+                b.create_dataset(f"Cell Active Layer Percentile Diameters - {q}",
+                                 data=np.full((1, 3), 1.0, dtype="f4"))
+        gdf = HdfResultsSediment.get_active_layer_grain_class(str(p), pct)
+        assert f"{pct.lower()}_mm" in gdf.columns
+
+
+class TestMultiArea:
+    @pytest.fixture
+    def two_area_hdf(self, tmp_path):
+        p = tmp_path / "Multi.p01.hdf"
+        with h5py.File(p, "w") as f:
+            f.attrs["Units System"] = np.bytes_("US Customary")
+            g = f.create_group("Geometry")
+            g.attrs["SI Units"] = np.bytes_("False")
+            for area, n, bc in [("A", 3, -1.0), ("B", 2, 2.0)]:
+                ga = g.create_group(f"2D Flow Areas/{area}")
+                ga.create_dataset("Cells Surface Area", data=np.full(n, 10.0, dtype="f4"))
+                ga.create_dataset("Cells Center Coordinate", data=np.zeros((n, 2), dtype="f8"))
+                b = f.create_group(f"{_BED}/{area}")
+                b.create_dataset("Cell Bed Change", data=np.full((1, n), bc, dtype="f4"))
+        return str(p)
+
+    def test_areas_listed(self, two_area_hdf):
+        assert set(HdfResultsSediment.get_sediment_mesh_areas(two_area_hdf)) == {"A", "B"}
+
+    def test_volumes_one_row_per_area(self, two_area_hdf):
+        df = HdfResultsSediment.get_bed_change_volumes(two_area_hdf)
+        assert len(df) == 2
+
+    def test_mesh_name_selects_one(self, two_area_hdf):
+        df = HdfResultsSediment.get_bed_change_volumes(two_area_hdf, mesh_name="B")
+        assert len(df) == 1 and df.iloc[0]["mesh_name"] == "B"
+
+    def test_ambiguous_area_raises(self, two_area_hdf):
+        # multiple areas with no mesh_name -> per-cell getters must raise
+        with pytest.raises(ValueError, match="Multiple sediment 2D areas"):
+            HdfResultsSediment.get_cell_bed_change(two_area_hdf)
+
+
+class TestErrorContracts:
+    def test_bad_mesh_name_raises_per_cell(self, us_hdf):
+        with pytest.raises(ValueError, match="not found"):
+            HdfResultsSediment.get_cell_bed_change(us_hdf, mesh_name="NOPE")
+
+    def test_bad_mesh_name_raises_volumes(self, us_hdf):
+        # previously returned an empty DataFrame; must now raise
+        with pytest.raises(ValueError, match="not found"):
+            HdfResultsSediment.get_bed_change_volumes(us_hdf, mesh_name="NOPE")
+
+    def test_length_mismatch_raises(self, tmp_path):
+        p = tmp_path / "Mismatch.p01.hdf"
+        with h5py.File(p, "w") as f:
+            f.attrs["Units System"] = np.bytes_("US Customary")
+            g = f.create_group("Geometry")
+            g.attrs["SI Units"] = np.bytes_("False")
+            ga = g.create_group("2D Flow Areas/A")
+            ga.create_dataset("Cells Surface Area", data=np.ones(2, dtype="f4"))      # 2 cells
+            ga.create_dataset("Cells Center Coordinate", data=np.zeros((2, 2), dtype="f8"))
+            b = f.create_group(f"{_BED}/A")
+            b.create_dataset("Cell Bed Change", data=np.ones((1, 4), dtype="f4"))      # 4 cells
+        with pytest.raises(ValueError, match="length mismatch"):
+            HdfResultsSediment.get_bed_change_volumes(str(p))
+
+    def test_one_d_dataset_handled(self, tmp_path):
+        p = tmp_path / "OneD.p01.hdf"
+        with h5py.File(p, "w") as f:
+            f.attrs["Units System"] = np.bytes_("US Customary")
+            g = f.create_group("Geometry")
+            g.attrs["SI Units"] = np.bytes_("False")
+            ga = g.create_group("2D Flow Areas/A")
+            ga.create_dataset("Cells Surface Area", data=np.ones(3, dtype="f4"))
+            ga.create_dataset("Cells Center Coordinate", data=np.zeros((3, 2), dtype="f8"))
+            b = f.create_group(f"{_BED}/A")
+            b.create_dataset("Cell Bed Change", data=np.array([1.0, 2.0, 3.0], dtype="f4"))  # 1-D
+        gdf = HdfResultsSediment.get_cell_bed_change(str(p))
+        assert gdf["bed_change"].tolist() == [1.0, 2.0, 3.0]
+        ts = HdfResultsSediment.get_cell_bed_change_timeseries(str(p))
+        assert ts.shape == (1, 3)

--- a/tests/test_rasplan_sediment_output_variables.py
+++ b/tests/test_rasplan_sediment_output_variables.py
@@ -101,9 +101,18 @@ def test_missing_level_raises(tmp_path):
         RasPlan.set_sediment_output_variables(p, ["2D Cell d50 Active"])
 
 
-def test_missing_file_raises(tmp_path):
-    # A non-existent path falls through to plan-number resolution (get_plan_path),
-    # which raises when there is no initialized project -- consistent with the
-    # other RasPlan plan-file editors (e.g. update_simulation_date).
-    with pytest.raises((ValueError, RuntimeError)):
+def test_missing_explicit_path_raises_valueerror(tmp_path):
+    # An explicit (Path) plan path that does not exist raises a clean ValueError,
+    # without requiring an initialized project.
+    with pytest.raises(ValueError, match="not found"):
         RasPlan.get_sediment_output_variables(tmp_path / "nope.p01")
+
+
+def test_numeric_plan_number_does_not_typeerror():
+    # int/float plan numbers must route to get_plan_path (which normalizes them),
+    # not crash at Path(int). Regression test for the QAQC MAJOR finding.
+    for value in (1, 1.0):
+        with pytest.raises(Exception) as excinfo:
+            RasPlan.get_sediment_output_variables(value)
+        assert not isinstance(excinfo.value, TypeError), (
+            f"numeric plan number {value!r} should not raise TypeError")


### PR DESCRIPTION
## Summary

Follow-up to #188. An independent Codex QAQC (gpt-5.2-codex) of the merged sediment feature surfaced four MAJOR correctness/robustness gaps; all are fixed here, each confirmed by a new regression test. No public API shape changes.

## MAJOR findings fixed

| # | Problem | Fix |
|---|---------|-----|
| **1** | `RasPlan.get/set_sediment_output_variables` called `Path(plan_number_or_path)` first → `TypeError` on `int`/`float` plan numbers (despite the `Number` contract) | Route non-file inputs through `get_plan_path` (which normalizes plan numbers); raise a clear `ValueError` for missing explicit paths |
| **2** | A 1-D `(n_cell,)` sediment dataset hit `arr[0]` → scalar → `len()` crash | `_select_time_row` handles 2-D `(time, cell)` and 1-D `(cell,)`; timeseries promotes 1-D to `(1, n_cell)` |
| **3** | `n = min(len(...))` silently truncated on array/geometry length mismatch → plausible-but-wrong volumes | Raise `ValueError` on mismatch (matches `HdfResultsQuery`'s validate-don't-truncate approach) |
| **4** | `get_bed_change_volumes(mesh_name="typo")` silently returned an empty DataFrame | Validate explicit `mesh_name` via `_resolve_area` (raises); reuse `_read_cell_dataset` so it inherits the ndim/length guards |

## Also

- Tests: **+14** cases (numeric-plan-number regression that exposes MAJOR-1, missing-path `ValueError`, bad `mesh_name`, length mismatch, 1-D dataset, **SI timeseries units**, multi-area, `time_index`, D10/D90). 33 pass.
- Tightened the previously too-loose `test_missing_file_raises` (it had masked MAJOR-1).
- Dropped an unused `Union` import; softened an overstated causality phrase in notebook 232.

## Verification
- All four MAJORs re-checked against the fixed code: `int` plan number → `RuntimeError` (not `TypeError`); bad name / mismatch → `ValueError`; 1-D dataset → handled.
- 33/33 unit tests pass on a clean `origin/main` checkout (no HEC-RAS required).

Codex also explicitly verified correct and unchanged here: SI/US unit detection, ghost-cell exclusion, the `get_projection(open-handle)` safety, decorator stacking, the `RasPlan` append/replace/dedupe logic, and the ft³→ac-ft (230) / m³ (232) conventions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
