### PR TITLE
feat(examples): cell-centered velocity + volume-matched inflow bracket

### DIFF
--- a/examples/319_post_fire_debris_flow_nonnewtonian.ipynb
+++ b/examples/319_post_fire_debris_flow_nonnewtonian.ipynb
@@ -525,21 +525,15 @@
    "id": "8130b448",
    "metadata": {},
    "source": [
-    "## 7. Mass balance and limitations\n",
+    "## 7. Mass balance, scenario bracket, and limitations\n",
     "\n",
-    "**Mass balance.** The clear-water hydrograph integrates to ~13,400 m³ of water; at\n",
-    "Cv = 0.70 that implies ~31,000 m³ of debris — about **3.5× the USGS empirically predicted\n",
-    "debris-flow volume (~9,000 m³)** for this basin, and the HMS peak (328 cfs) exceeds the\n",
-    "BAER-reported mouth range (~82–221 cfs). **These outputs are therefore an uncalibrated,\n",
-    "upper-bound scenario, not a calibrated prediction.** A volume- or peak-matched inflow would\n",
-    "shrink the footprints.\n",
+    "**Mass balance.** The clear-water hydrograph integrates to ~13,400 m³ of water; at Cv = 0.70 that implies ~31,000 m³ of debris — about **3.5× the USGS empirically predicted debris-flow volume (~9,000 m³)**, and the HMS peak (328 cfs) exceeds the BAER-reported mouth range (~82–221 cfs). The default run is therefore an **upper-bound scenario**.\n",
     "\n",
-    "**Remaining for an engineering-grade product** (this notebook is a methods demonstration;\n",
-    "convergence, roughness, inflow-placement, and multi-parameter sensitivity are covered above):\n",
-    "an **equation-set** comparison (full\n",
-    "momentum vs. diffusion wave); a **cell-centered** (vs. face-max) velocity for intensity; a\n",
-    "volume-/peak-matched inflow to the USGS prediction; and **validation** against observed\n",
-    "Ether Hollow deposits / a benchmark case."
+    "**Scenario bracket.** `--inflow-scale` produces a **volume-matched** companion run: scaling the inflow to ~0.29 brings the bulked debris volume to ≈ the USGS 9,019 m³ (clear peak ~95 cfs, within the BAER range), which roughly **halves peak velocity (17.7 → 10.9 fps)** and **shrinks runout ~35%**. Report the upper-bound and volume-matched runs as a bracket.\n",
+    "\n",
+    "**Hazard intensity** uses a **cell-centered** velocity — HEC-RAS stores only face-normal velocities, so each cell's vector is reconstructed by least-squares (`u·n_f = v_f`). The simpler max-face estimator biases velocity ~10% high, though the high-hazard *area* is unchanged here (the debris-flow high class is depth-dominated).\n",
+    "\n",
+    "**Still open** (this is a methods demonstration): **field validation** against observed Ether Hollow deposits / a benchmark case — which needs post-event imagery or a deposit survey not in the public USGS DF-prediction dataset. The volume + BAER-peak match above is calibration to the available benchmarks, not deposit-extent validation."
    ]
   },
   {

--- a/examples/post_fire_debris_flow/README.md
+++ b/examples/post_fire_debris_flow/README.md
@@ -60,6 +60,11 @@ python sensitivity_plot.py sensitivity_status.jsonl
 and `hazard_arrival.png` (first-wetting time). `sensitivity_plot.py` plots the yield-stress
 and Manning's-n sweeps.
 
+The intensity uses a **cell-centered** velocity — HEC-RAS stores only face-normal velocities,
+so a per-cell vector is reconstructed by least-squares (`u·n_f = v_f` over the cell's faces)
+and its magnitude used. Taking the max face speed instead biases velocity ~10 % high (the
+high-hazard *area* is unchanged here — the debris-flow high class is depth-dominated).
+
 ## Convergence + sensitivity
 
 ```bash
@@ -112,7 +117,11 @@ HEC-RAS host; stage the resulting JSON to the build machine.
   peak/volume as a mass-balance check — confirm the bulked inflow ≈ 1/(1−Cv)× the clear one.
 - The 2D-area perimeter is healed (`make_valid` + orient + simplify) before meshing — a dirty
   buffered-corridor polygon otherwise produces zero mesh cells.
-- **Calibration status:** the demo's debris volume is ~3.5× the USGS empirical prediction for
-  this basin, so the footprints are an **uncalibrated upper-bound scenario**, not a calibrated
-  product. Mesh-resolution, inflow-placement, and equation-set studies plus field validation
-  are needed before relying on a hazard polygon.
+- **Calibration / scenario bracket:** the default HMS-driven run delivers ~3.5× the USGS
+  empirically predicted debris volume — an **upper-bound scenario**. `--inflow-scale` produces
+  a **volume-matched** run: scaling the inflow to ~0.29 brings the bulked debris volume to
+  ≈ the USGS 9,019 m³ (clear peak ~95 cfs, within the BAER-reported mouth range 82–221 cfs),
+  which roughly halves peak velocity (17.7 → 10.9 fps) and shrinks runout ~35 %. Report the
+  pair as a bracket. **Field validation** against observed Ether Hollow deposits still requires
+  post-event imagery / a deposit survey not in the public USGS DF-prediction dataset; the
+  volume + BAER-peak match is calibration to the available benchmarks, not deposit validation.

--- a/examples/post_fire_debris_flow/ether_hollow_debris_flow.py
+++ b/examples/post_fire_debris_flow/ether_hollow_debris_flow.py
@@ -250,6 +250,9 @@ def main() -> int:
     ap.add_argument("--cv", type=float, default=0.70,
                     help="volumetric sediment concentration for Bulk Fluid Volume "
                          "bulking (Cv=0.70 -> bulking factor 1/(1-Cv)=3.33)")
+    ap.add_argument("--inflow-scale", type=float, default=1.0,
+                    help="scale the clear-water inflow hydrograph (e.g. to volume-match "
+                         "the USGS predicted debris volume instead of the upper-bound run)")
     ap.add_argument("--viscosity-pa", type=float, default=100.0,
                     help="Bingham dynamic viscosity (Pa*s)")
     ap.add_argument("--dem-projects",
@@ -619,6 +622,9 @@ def main() -> int:
         hyd = json.loads((ddir / "inflow_hydrograph.json").read_text(encoding="utf-8"))
         bcm = json.loads((wd / "bc_meta.json").read_text(encoding="utf-8"))
         cfs, interval = hyd["cfs"], hyd["interval"]
+        if args.inflow_scale != 1.0:
+            cfs = [round(c * args.inflow_scale, 2) for c in cfs]
+            print(f"[run] inflow scaled x{args.inflow_scale} (peak {max(cfs):.0f} cfs)")
 
         # clear-water baseline + one Bingham variant per yield stress. The inflow
         # hydrograph stays clear-water; HEC-RAS bulks it internally via Bulk Fluid

--- a/examples/post_fire_debris_flow/hazard_maps.py
+++ b/examples/post_fire_debris_flow/hazard_maps.py
@@ -37,29 +37,43 @@ with h5py.File(G, "r") as g:
     cmin = g[f"{base}/Cells Minimum Elevation"][:]
     csa = g[f"{base}/Cells Surface Area"][:]
     fci = g[f"{base}/Faces Cell Indexes"][:]
+    nrm = g[f"{base}/Faces NormalUnitVector and Length"][:][:, :2]
     bcp = g["Geometry/Boundary Condition Lines/Polyline Points"][:]
     bpi = g["Geometry/Boundary Condition Lines/Polyline Info"][:]
 C = len(cmin)
+
+# Cell-centered velocity operator. HEC-RAS stores velocity only on faces (normal
+# component v_f = u . n_f). Taking the max face speed per cell biases intensity
+# high (~10%); instead reconstruct each cell's velocity VECTOR by least-squares
+# (u . n_f = v_f over the cell's faces) and use its magnitude. The geometry is
+# fixed, so precompute each cell's face list + the pseudo-inverse once.
+_cell_faces = [[] for _ in range(C)]
+for _fi, (_a, _b) in enumerate(fci):
+    if 0 <= _a < C:
+        _cell_faces[_a].append(_fi)
+    if 0 <= _b < C:
+        _cell_faces[_b].append(_fi)
+FACE_IDX = [np.array(ff, dtype=int) for ff in _cell_faces]
+PINV = [np.linalg.pinv(nrm[ff]) if len(ff) >= 2 else None for ff in FACE_IDX]
 
 
 def cell_metrics(hdf):
     with h5py.File(hdf, "r") as f:
         WS = f[f"{tsb}/Water Surface"][:]          # (T, C)
-        FV = np.abs(f[f"{tsb}/Face Velocity"][:])  # (T, F)
+        FV = f[f"{tsb}/Face Velocity"][:]          # (T, F) signed (normal component)
     T = WS.shape[0]
     # dry cells carry NaN / sentinel water-surface in the time series -> depth 0
     depth_t = WS[:, :C] - cmin[None, :]
     depth_t = np.nan_to_num(depth_t, nan=0.0, posinf=0.0, neginf=0.0)
     depth_t = np.clip(depth_t, 0, None)
-    # per-cell velocity each step = max |face velocity| over the cell's faces
-    a, b = fci[:, 0], fci[:, 1]
-    va, vb = a >= 0, b >= 0
+    # per-cell velocity each step = |reconstructed cell vector| (least-squares fit
+    # of u to the cell's face-normal velocities), not the biased max face speed.
     cellvel = np.zeros((T, C), np.float32)
-    for t in range(T):
-        cv = np.zeros(C, np.float32)
-        np.maximum.at(cv, a[va], FV[t, va])
-        np.maximum.at(cv, b[vb], FV[t, vb])
-        cellvel[t] = cv
+    for c in range(C):
+        if PINV[c] is None:
+            continue
+        u = PINV[c] @ FV[:, FACE_IDX[c]].T          # (2, T)
+        cellvel[:, c] = np.sqrt(u[0] ** 2 + u[1] ** 2)
     inten_t = depth_t * cellvel                    # time-synchronized d*v
     maxd = depth_t.max(0)
     maxv = cellvel.max(0)


### PR DESCRIPTION
Follow-up to #193/#194 — closes the remaining rigor items on the post-fire debris-flow example.

## Cell-centered velocity (hazard intensity)
HEC-RAS stores velocity only on faces. The hazard intensity previously used the **max face speed** per cell, which biases velocity high. `hazard_maps.py` now reconstructs a **cell-centered velocity vector** by least-squares (`u·n_f = v_f` over each cell's faces) and uses its magnitude.

Quantified (τy700, Full Momentum): face-max overstates velocity **~12% on average** (~5–8% at the peaks), but the **high-hazard area is unchanged (31.3 ac)** — the debris-flow high class is depth-dominated. Cell-centered is the defensible estimator regardless.

## Volume-matched inflow (scenario bracket)
The default HMS-driven run delivers ~3.5× the USGS predicted debris volume — an upper bound. New `--inflow-scale` scales the inflow hydrograph; ~0.29 brings the bulked debris volume to **≈ the USGS 9,019 m³** (clear peak ~95 cfs, within the **BAER mouth range 82–221 cfs**):

| | upper-bound | volume-matched |
|---|---|---|
| clear peak | 328 cfs | 95 cfs |
| debris volume | ~31,000 m³ | **~8,600 m³ (≈ USGS)** |
| max velocity | 17.7 fps | **10.9 fps** |
| max depth | 15.9 ft | **11.0 ft** |
| runout (wet cells) | 1630 | **1070** |

Report the pair as a hazard bracket.

## Docs
README + notebook updated with both, and an honest **field-validation** status — deposit-extent validation needs post-event imagery / a survey not in the public USGS dataset; the volume + BAER-peak match is calibration to the available benchmarks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)