### PR TITLE
docs: examples index table (with runtimes), Pages auto-deploy off, drop CLB banner link

### DIFF
--- a/.claude/scripts/generate_examples_index.py
+++ b/.claude/scripts/generate_examples_index.py
@@ -1,0 +1,292 @@
+#!/usr/bin/env python3
+"""
+Generate the table-based "Example Notebooks" index page for the docs.
+
+This script regenerates ``docs/examples/index.md`` as a set of per-section
+markdown tables (one row per example notebook). For each notebook it emits:
+
+* Notebook  - display title linked to the rendered docs page
+              (``../notebooks/<name>.md`` which mkdocs serves at /notebooks/<name>/)
+* Source    - link to the source ``.ipynb`` on GitHub
+* Runtime   - total cell-execution wall time summed from the notebook's
+              per-cell ``metadata.execution`` timestamps, or ``N/A`` when the
+              notebook was committed without execution outputs.
+
+It is meant to run during the docs build, AFTER
+``.claude/scripts/prepare_notebooks_for_docs.py`` (which converts the
+notebooks to markdown). It only uses the Python standard library
+(json, re, pathlib, datetime) so it runs under a bare ``python3`` with no
+extra dependencies.
+
+The notebook list is sourced directly from disk
+(``sorted(examples_dir.glob("*.ipynb"))``) -- NOT from the mkdocs.yml nav.
+The published site builds from ``main``, where the Example Notebooks nav block
+is collapsed to a single "Overview" entry and any populated nav (on a feature
+branch) references notebooks that do not exist on ``main``. Sourcing from disk
+guarantees the table reflects exactly the notebooks that ship with the build:
+every ``.ipynb`` present, with no phantom rows.
+
+Per-notebook display titles come from the notebook's first markdown ``# `` H1;
+if absent, the filename is prettified (numeric prefix dropped, underscores ->
+spaces, Title Case). Sections are grouped by the leading integer in the
+filename prefix, bucketed into ``100s``/``200s``/.../``900s``.
+
+Usage:
+    python .claude/scripts/generate_examples_index.py
+"""
+
+import json
+import re
+import sys
+from datetime import datetime
+from pathlib import Path
+from typing import List, Optional, Tuple
+
+GITHUB_BLOB_BASE = "https://github.com/gpt-cmdr/ras-commander/blob/main/examples"
+
+
+# ---------------------------------------------------------------------------
+# Title derivation
+# ---------------------------------------------------------------------------
+
+def _load_notebook(notebook_path: Path) -> Optional[dict]:
+    try:
+        with notebook_path.open(encoding="utf-8") as fh:
+            return json.load(fh)
+    except (OSError, json.JSONDecodeError, UnicodeDecodeError):
+        return None
+
+
+def _cell_source_lines(cell: dict) -> List[str]:
+    """Return a notebook cell's source as a list of text lines.
+
+    nbformat stores ``source`` either as a single string or a list of strings.
+    """
+    source = cell.get("source", "")
+    if isinstance(source, list):
+        text = "".join(source)
+    else:
+        text = source
+    return text.splitlines()
+
+
+def prettify_filename(name: str) -> str:
+    """Fallback title from a notebook basename (no extension).
+
+    Drops a leading numeric prefix (e.g. ``116`` or ``911a``), replaces
+    underscores with spaces, and Title-Cases the result. Deterministic.
+    """
+    stem = re.sub(r"^\d+[a-zA-Z]?_", "", name)
+    stem = stem.replace("_", " ").strip()
+    if not stem:
+        stem = name.replace("_", " ").strip()
+    return stem.title()
+
+
+def derive_title(notebook_path: Path, nb: Optional[dict]) -> str:
+    """Title = first markdown cell's first ``# `` H1, else prettified filename."""
+    name = notebook_path.stem
+    if nb is not None:
+        for cell in nb.get("cells", []):
+            if cell.get("cell_type") != "markdown":
+                continue
+            for line in _cell_source_lines(cell):
+                stripped = line.strip()
+                if stripped.startswith("# "):
+                    return stripped[1:].strip()
+            # First markdown cell had no H1; keep scanning later markdown cells
+            # in case the title lives further down (still deterministic).
+    return prettify_filename(name)
+
+
+# ---------------------------------------------------------------------------
+# Section grouping
+# ---------------------------------------------------------------------------
+
+def section_for(name: str) -> Tuple[int, str]:
+    """Return ``(sort_key, label)`` section bucket for a notebook basename.
+
+    The leading run of digits in the filename prefix (e.g. ``911a_...`` -> 911,
+    ``116_...`` -> 116) is bucketed by hundreds into ``100s``..``900s``. Names
+    without a numeric prefix fall into a trailing "Other" bucket.
+    """
+    m = re.match(r"^(\d+)", name)
+    if not m:
+        return (10_000, "Other")
+    n = int(m.group(1))
+    bucket = (n // 100) * 100
+    return (bucket, f"{bucket}s")
+
+
+# ---------------------------------------------------------------------------
+# Runtime calculation (stdlib json only)
+# ---------------------------------------------------------------------------
+
+def _parse_ts(ts: str) -> Optional[datetime]:
+    try:
+        return datetime.fromisoformat(ts.replace("Z", "+00:00"))
+    except (ValueError, AttributeError):
+        return None
+
+
+def compute_runtime_seconds(nb: Optional[dict]) -> Optional[float]:
+    """Sum per-cell execution wall time for a parsed notebook.
+
+    Returns total seconds across all code cells that carry a parseable
+    ``metadata.execution`` block, or ``None`` when no code cell has execution
+    timing (-> rendered as ``N/A``).
+    """
+    if nb is None:
+        return None
+
+    total = 0.0
+    found_any = False
+    for cell in nb.get("cells", []):
+        if cell.get("cell_type") != "code":
+            continue
+        execution = cell.get("metadata", {}).get("execution")
+        if not execution:
+            continue
+        start_raw = execution.get("iopub.execute_input") or execution.get(
+            "iopub.status.busy"
+        )
+        end_raw = execution.get("iopub.status.idle") or execution.get(
+            "shell.execute_reply"
+        )
+        start = _parse_ts(start_raw) if start_raw else None
+        end = _parse_ts(end_raw) if end_raw else None
+        if start is None or end is None:
+            continue
+        found_any = True
+        duration = (end - start).total_seconds()
+        if duration < 0:
+            duration = 0.0
+        total += duration
+
+    if not found_any:
+        return None
+    return total
+
+
+def format_runtime(seconds: Optional[float]) -> str:
+    """Human-readable runtime: ``N s`` / ``N.N min`` / ``N.N h`` / ``N/A``."""
+    if seconds is None:
+        return "N/A"
+    if seconds < 60:
+        return f"{int(round(seconds))} s"
+    if seconds < 3600:
+        return f"{seconds / 60:.1f} min"
+    return f"{seconds / 3600:.1f} h"
+
+
+# ---------------------------------------------------------------------------
+# Page rendering
+# ---------------------------------------------------------------------------
+
+def build_index_markdown(examples_dir: Path) -> Tuple[str, int, int]:
+    """Build the index.md content from notebooks on disk.
+
+    Returns ``(markdown, total_rows, rows_with_runtime)``.
+    """
+    notebooks = sorted(examples_dir.glob("*.ipynb"))
+
+    grouped: dict = {}
+    section_order: List[Tuple[int, str]] = []
+
+    total_rows = 0
+    rows_with_runtime = 0
+
+    for nb_path in notebooks:
+        name = nb_path.stem
+        nb = _load_notebook(nb_path)
+        title = derive_title(nb_path, nb)
+        seconds = compute_runtime_seconds(nb)
+        runtime = format_runtime(seconds)
+        if seconds is not None:
+            rows_with_runtime += 1
+        total_rows += 1
+
+        sort_key, label = section_for(name)
+        key = (sort_key, label)
+        if key not in grouped:
+            grouped[key] = []
+            section_order.append(key)
+
+        notebook_link = f"[{title}](../notebooks/{name}.md)"
+        source_link = f"[.ipynb]({GITHUB_BLOB_BASE}/{name}.ipynb)"
+        grouped[key].append((name, f"| {notebook_link} | {source_link} | {runtime} |"))
+
+    # Ascending by bucket; within a group sort by filename.
+    section_order.sort(key=lambda k: k[0])
+
+    section_blocks: List[str] = []
+    for key in section_order:
+        rows = [row for _name, row in sorted(grouped[key], key=lambda r: r[0])]
+        block = [
+            f"## {key[1]}",
+            "",
+            "| Notebook | Source | Runtime |",
+            "| --- | --- | --- |",
+        ]
+        block.extend(rows)
+        section_blocks.append("\n".join(block))
+
+    intro = (
+        "# Example Notebooks\n\n"
+        "These are the canonical, runnable examples for ras-commander. Each row "
+        "links to the rendered documentation page and to the source `.ipynb` on "
+        "GitHub. **Runtime** is the summed cell-execution wall time captured the "
+        "last time the notebook was executed (`N/A` means the notebook was "
+        "committed without execution outputs).\n\n"
+    )
+
+    summary = (
+        f"*{total_rows} notebooks indexed - {rows_with_runtime} with runtime "
+        f"data, {total_rows - rows_with_runtime} without.*\n"
+    )
+
+    markdown = intro + summary + "\n" + "\n\n".join(section_blocks) + "\n"
+    return markdown, total_rows, rows_with_runtime
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+def main() -> int:
+    script_dir = Path(__file__).resolve().parent  # .claude/scripts/
+    repo_root = script_dir.parent.parent  # repo root
+
+    examples_dir = repo_root / "examples"
+    output_path = repo_root / "docs" / "examples" / "index.md"
+
+    print("=" * 60)
+    print("Generating Example Notebooks index page")
+    print("=" * 60)
+    print(f"examples: {examples_dir}")
+    print(f"output:   {output_path}")
+    print()
+
+    if not examples_dir.is_dir():
+        print(f"ERROR: examples directory not found at {examples_dir}")
+        return 1
+
+    markdown, total_rows, with_runtime = build_index_markdown(examples_dir)
+    if total_rows == 0:
+        print("ERROR: no notebooks found on disk.")
+        return 1
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(markdown, encoding="utf-8")
+
+    print(f"Wrote {output_path}")
+    print(f"  Rows:            {total_rows}")
+    print(f"  With runtime:    {with_runtime}")
+    print(f"  Without runtime: {total_rows - with_runtime}")
+    print()
+    print("Done.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/docs-validate.yml
+++ b/.github/workflows/docs-validate.yml
@@ -56,6 +56,10 @@ jobs:
           cp examples/README.md docs/notebooks/ || true
           cp examples/AGENTS.md docs/notebooks/ || true
 
+      - name: Generate examples index table
+        run: |
+          python .claude/scripts/generate_examples_index.py
+
       - name: Generate cognitive infrastructure docs
         run: |
           python .claude/scripts/generate_cognitive_docs.py

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,17 +1,21 @@
-name: Deploy Documentation
+name: Deploy Documentation (GitHub Pages — fallback)
 
+# Primary hosting is the self-hosted site at rascommander.info (CT 210), rebuilt by a
+# GitHub webhook on push to main. This GitHub Pages deploy is kept as a manual fallback
+# only — the automatic push trigger is disabled to avoid double-publishing. Run it from the
+# Actions tab (workflow_dispatch) if the self-hosted site is ever unavailable.
 on:
-  push:
-    branches:
-      - main
-    paths:
-      - 'docs/**'
-      - 'examples/**'  # Trigger on notebook changes
-      - 'ras_commander/**'
-      - '.claude/**'
-      - 'mkdocs.yml'
-      - '.github/workflows/docs.yml'
-  workflow_dispatch:  # Allow manual trigger
+  # push:            # DISABLED at rascommander.info cutover (2026-06-10). Re-enable to
+  #   branches:      # restore GitHub Pages as an auto-deploy target.
+  #     - main
+  #   paths:
+  #     - 'docs/**'
+  #     - 'examples/**'
+  #     - 'ras_commander/**'
+  #     - '.claude/**'
+  #     - 'mkdocs.yml'
+  #     - '.github/workflows/docs.yml'
+  workflow_dispatch:  # Manual trigger only
 
 permissions:
   contents: write  # Needed for gh-pages deployment

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -1,199 +1,167 @@
 # Example Notebooks
 
-The repository currently ships **115 canonical notebooks** under `examples/`.
-This page tracks the live notebook inventory in git. Executed copies such as
-`*_executed.ipynb`, extracted HEC-RAS projects, and local test helpers are
-intentionally excluded.
+These are the canonical, runnable examples for ras-commander. Each row links to the rendered documentation page and to the source `.ipynb` on GitHub. **Runtime** is the summed cell-execution wall time captured the last time the notebook was executed (`N/A` means the notebook was committed without execution outputs).
 
-!!! note
-    Rendered per-notebook markdown pages are generated during documentation
-    builds. The canonical source of truth is the `examples/` tree itself.
+*117 notebooks indexed - 64 with runtime data, 53 without.*
 
-## Running Examples Locally
+## 100s
 
-```bash
-git clone https://github.com/gpt-cmdr/ras-commander.git
-cd ras-commander
-pip install -e .
-pip install jupyter rasterio pyproj
-jupyter notebook examples/
-```
+| Notebook | Source | Runtime |
+| --- | --- | --- |
+| [Using RasExamples](../notebooks/100_using_ras_examples.md) | [.ipynb](https://github.com/gpt-cmdr/ras-commander/blob/main/examples/100_using_ras_examples.ipynb) | 1.3 min |
+| [Project Initialization](../notebooks/101_project_initialization.md) | [.ipynb](https://github.com/gpt-cmdr/ras-commander/blob/main/examples/101_project_initialization.ipynb) | 4 s |
+| [Multiple Project Operations](../notebooks/102_multiple_project_operations.md) | [.ipynb](https://github.com/gpt-cmdr/ras-commander/blob/main/examples/102_multiple_project_operations.ipynb) | 2.2 min |
+| [Plan and Geometry Operations](../notebooks/103_plan_and_geometry_operations.md) | [.ipynb](https://github.com/gpt-cmdr/ras-commander/blob/main/examples/103_plan_and_geometry_operations.ipynb) | 1.7 min |
+| [Plan Parameter Operations](../notebooks/104_plan_parameter_operations.md) | [.ipynb](https://github.com/gpt-cmdr/ras-commander/blob/main/examples/104_plan_parameter_operations.ipynb) | 17.1 min |
+| [Single Plan Execution](../notebooks/110_single_plan_execution.md) | [.ipynb](https://github.com/gpt-cmdr/ras-commander/blob/main/examples/110_single_plan_execution.ipynb) | 1.8 min |
+| [Executing Plan Sets](../notebooks/111_executing_plan_sets.md) | [.ipynb](https://github.com/gpt-cmdr/ras-commander/blob/main/examples/111_executing_plan_sets.ipynb) | 3.0 min |
+| [Sequential Plan Execution](../notebooks/112_sequential_plan_execution.md) | [.ipynb](https://github.com/gpt-cmdr/ras-commander/blob/main/examples/112_sequential_plan_execution.ipynb) | 3.3 min |
+| [Parallel Execution](../notebooks/113_parallel_execution.md) | [.ipynb](https://github.com/gpt-cmdr/ras-commander/blob/main/examples/113_parallel_execution.ipynb) | 3.3 h |
+| [Parameter Permutation Sweeps with RasPermutation](../notebooks/114_parameter_permutation.md) | [.ipynb](https://github.com/gpt-cmdr/ras-commander/blob/main/examples/114_parameter_permutation.ipynb) | 2.3 min |
+| [Real-Time Execution Monitoring with Callbacks](../notebooks/115_real_time_execution_monitoring.md) | [.ipynb](https://github.com/gpt-cmdr/ras-commander/blob/main/examples/115_real_time_execution_monitoring.ipynb) | N/A |
+| [HDF Output Options Read Benchmark](../notebooks/116_hdf_output_options_benchmark.md) | [.ipynb](https://github.com/gpt-cmdr/ras-commander/blob/main/examples/116_hdf_output_options_benchmark.ipynb) | 25.6 min |
+| [Win32COM Automation](../notebooks/120_automating_ras_with_win32com.md) | [.ipynb](https://github.com/gpt-cmdr/ras-commander/blob/main/examples/120_automating_ras_with_win32com.ipynb) | N/A |
+| [HECRASController Profiles](../notebooks/121_legacy_hecrascontroller_and_rascontrol.md) | [.ipynb](https://github.com/gpt-cmdr/ras-commander/blob/main/examples/121_legacy_hecrascontroller_and_rascontrol.ipynb) | 12.7 min |
+| [RASMapper Spatial Review](../notebooks/122_rasmapper_spatial_review.md) | [.ipynb](https://github.com/gpt-cmdr/ras-commander/blob/main/examples/122_rasmapper_spatial_review.ipynb) | 55 s |
+| [RASMapper Geometry Layer Updates](../notebooks/123_rasmapper_geometry_layer_updates.md) | [.ipynb](https://github.com/gpt-cmdr/ras-commander/blob/main/examples/123_rasmapper_geometry_layer_updates.ipynb) | 9.8 min |
+| [RASMapper Bank Lines](../notebooks/124_rasmapper_bank_lines.md) | [.ipynb](https://github.com/gpt-cmdr/ras-commander/blob/main/examples/124_rasmapper_bank_lines.ipynb) | N/A |
+| [Using results_df for Plan Results Summary](../notebooks/150_results_dataframe.md) | [.ipynb](https://github.com/gpt-cmdr/ras-commander/blob/main/examples/150_results_dataframe.ipynb) | N/A |
 
-## Notebook Families
+## 200s
 
-| Family | Current focus |
-|--------|---------------|
-| `100s` | project initialization, execution control, parameter sweeps, RASMapper review, bank-line generation, results summaries |
-| `200s` | plaintext geometry parsing, structures, XS interpolation, connections, bridges, levees, steady flow authoring, floodway encroachment, calibration, mesh generation |
-| `300s` | unsteady files, DSS workflows, HMS-to-RAS matching, reference-line generation, 2D floodway encroachment, 2D computation options, terrain modifications, boundary visualization |
-| `400s` | 1D and 2D HDF extraction, reference-line queries, breach results, velocity profiles, channel-capacity analysis |
-| `500s` | remote execution, Linux execution, ModPuls result extraction |
-| `600s` | floodplain mapping, fluvial-pluvial analysis, map-layer validation |
-| `700s` | sensitivity testing, benchmarking, Atlas 14, design storms, and gridded precipitation workflows |
-| `800s` | RasCheck and structure-validation QA workflows |
-| `900s` | AORC, USGS, real-time forecasting, STOFS-3D, terrain creation, and terrain modification |
-| `950s` | FEMA eBFE/BLE delivery organization and validation |
-| `960s` | cloud-native geometry and results export |
+| Notebook | Source | Runtime |
+| --- | --- | --- |
+| [1D Geometry File Parsing](../notebooks/201_1d_plaintext_geometry.md) | [.ipynb](https://github.com/gpt-cmdr/ras-commander/blob/main/examples/201_1d_plaintext_geometry.ipynb) | 24 s |
+| [2D Geometry File Parsing](../notebooks/202_2d_plaintext_geometry.md) | [.ipynb](https://github.com/gpt-cmdr/ras-commander/blob/main/examples/202_2d_plaintext_geometry.ipynb) | 1.7 min |
+| [HTAB Parameter Optimization for Model Stability](../notebooks/203_htab_parameter_optimization.md) | [.ipynb](https://github.com/gpt-cmdr/ras-commander/blob/main/examples/203_htab_parameter_optimization.ipynb) | N/A |
+| [Extract Cross Section XYZ Coordinates from Plain Text Geometry](../notebooks/205_extract_xs_xyz_from_geometry.md) | [.ipynb](https://github.com/gpt-cmdr/ras-commander/blob/main/examples/205_extract_xs_xyz_from_geometry.ipynb) | N/A |
+| [Structures and Metadata from Geometry Files](../notebooks/206_structures_and_metadata.md) | [.ipynb](https://github.com/gpt-cmdr/ras-commander/blob/main/examples/206_structures_and_metadata.ipynb) | N/A |
+| [Reference Lines and Points for 2D Calibration](../notebooks/207_reference_lines_and_points.md) | [.ipynb](https://github.com/gpt-cmdr/ras-commander/blob/main/examples/207_reference_lines_and_points.ipynb) | N/A |
+| [Bridge Method Comparison](../notebooks/208_bridge_method_comparison.md) | [.ipynb](https://github.com/gpt-cmdr/ras-commander/blob/main/examples/208_bridge_method_comparison.ipynb) | 1.7 min |
+| [Culvert Authoring](../notebooks/209_culvert_authoring.md) | [.ipynb](https://github.com/gpt-cmdr/ras-commander/blob/main/examples/209_culvert_authoring.ipynb) | 4 s |
+| [Cross-Section Interpolation Settings](../notebooks/210_xs_interpolation_settings.md) | [.ipynb](https://github.com/gpt-cmdr/ras-commander/blob/main/examples/210_xs_interpolation_settings.ipynb) | 18 s |
+| [Final Manning's N and Infiltration Analysis](../notebooks/211_final_mannings_and_infiltration.md) | [.ipynb](https://github.com/gpt-cmdr/ras-commander/blob/main/examples/211_final_mannings_and_infiltration.ipynb) | 3 s |
+| [NLCD Land Cover Layer Authoring for RASMapper](../notebooks/212_landcover_mannings_n_write.md) | [.ipynb](https://github.com/gpt-cmdr/ras-commander/blob/main/examples/212_landcover_mannings_n_write.ipynb) | N/A |
+| [Land Classification Polygon Authoring](../notebooks/213_land_classification_polygon_authoring.md) | [.ipynb](https://github.com/gpt-cmdr/ras-commander/blob/main/examples/213_land_classification_polygon_authoring.ipynb) | 21 s |
+| [SA/2D Connection Authoring](../notebooks/214_connection_authoring.md) | [.ipynb](https://github.com/gpt-cmdr/ras-commander/blob/main/examples/214_connection_authoring.ipynb) | N/A |
+| [SA/2D Bridge Connection Authoring](../notebooks/215_sa2d_bridge_connection_authoring.md) | [.ipynb](https://github.com/gpt-cmdr/ras-commander/blob/main/examples/215_sa2d_bridge_connection_authoring.ipynb) | N/A |
+| [1D Bridge Authoring](../notebooks/216_1d_bridge_authoring.md) | [.ipynb](https://github.com/gpt-cmdr/ras-commander/blob/main/examples/216_1d_bridge_authoring.ipynb) | N/A |
+| [1D Cross-Section Levee Authoring](../notebooks/217_1d_levee_authoring.md) | [.ipynb](https://github.com/gpt-cmdr/ras-commander/blob/main/examples/217_1d_levee_authoring.ipynb) | 2.4 min |
+| [Infiltration Base Override Authoring](../notebooks/218_infiltration_base_override_authoring.md) | [.ipynb](https://github.com/gpt-cmdr/ras-commander/blob/main/examples/218_infiltration_base_override_authoring.ipynb) | N/A |
+| [219 - 1D Bridge Cross-Section Plotting with Deck/Pier Overlay](../notebooks/219_1d_bridge_xs_plotting.md) | [.ipynb](https://github.com/gpt-cmdr/ras-commander/blob/main/examples/219_1d_bridge_xs_plotting.ipynb) | 5 s |
+| [Manning's n Calibration with RasCalibrate](../notebooks/220_calibration_workflow.md) | [.ipynb](https://github.com/gpt-cmdr/ras-commander/blob/main/examples/220_calibration_workflow.ipynb) | 1.5 h |
+| [1D Manning's N Calibration Workflow](../notebooks/221_calibration_1d_workflow.md) | [.ipynb](https://github.com/gpt-cmdr/ras-commander/blob/main/examples/221_calibration_1d_workflow.ipynb) | 36.6 min |
+| [Steady Flow Calibration](../notebooks/222_steady_flow_calibration.md) | [.ipynb](https://github.com/gpt-cmdr/ras-commander/blob/main/examples/222_steady_flow_calibration.ipynb) | N/A |
+| [Steady Floodway Encroachment](../notebooks/223_steady_floodway_encroachment.md) | [.ipynb](https://github.com/gpt-cmdr/ras-commander/blob/main/examples/223_steady_floodway_encroachment.ipynb) | 17 s |
+| [Steady Flow Authoring](../notebooks/224_steady_flow_authoring.md) | [.ipynb](https://github.com/gpt-cmdr/ras-commander/blob/main/examples/224_steady_flow_authoring.ipynb) | N/A |
+| [Fixing Blocked Obstruction Overlaps with RasFixit](../notebooks/225_fixit_blocked_obstructions.md) | [.ipynb](https://github.com/gpt-cmdr/ras-commander/blob/main/examples/225_fixit_blocked_obstructions.ipynb) | 7 s |
+| [2D Mesh Cell-Size Sensitivity for Sediment Transport](../notebooks/230_mesh_sensitivity_analysis.md) | [.ipynb](https://github.com/gpt-cmdr/ras-commander/blob/main/examples/230_mesh_sensitivity_analysis.ipynb) | 6.9 min |
+| [Pipe Network Mesh Generation](../notebooks/231_pipe_network_mesh_generation.md) | [.ipynb](https://github.com/gpt-cmdr/ras-commander/blob/main/examples/231_pipe_network_mesh_generation.ipynb) | 10 s |
+| [2D Mesh Cell-Size Sensitivity for Sediment Transport - Second Case: Weise Flume](../notebooks/232_weise_2d_sediment_mesh_sensitivity.md) | [.ipynb](https://github.com/gpt-cmdr/ras-commander/blob/main/examples/232_weise_2d_sediment_mesh_sensitivity.ipynb) | 16.7 min |
 
-## Drift-Sensitive Notebooks
+## 300s
 
-These notebooks are tied closely to docs, source adapters, or recurring QAQC
-sweeps.
+| Notebook | Source | Runtime |
+| --- | --- | --- |
+| [Unsteady Flow Operations](../notebooks/300_unsteady_flow_operations.md) | [.ipynb](https://github.com/gpt-cmdr/ras-commander/blob/main/examples/300_unsteady_flow_operations.ipynb) | 26 s |
+| [Flow Hydrograph Optimization](../notebooks/301_flow_hydrograph_optimization.md) | [.ipynb](https://github.com/gpt-cmdr/ras-commander/blob/main/examples/301_flow_hydrograph_optimization.ipynb) | 1.0 min |
+| [DSS Boundary Extraction](../notebooks/310_dss_boundary_extraction.md) | [.ipynb](https://github.com/gpt-cmdr/ras-commander/blob/main/examples/310_dss_boundary_extraction.ipynb) | 7 s |
+| [2D Floodway Encroachment](../notebooks/311_2d_floodway_encroachment.md) | [.ipynb](https://github.com/gpt-cmdr/ras-commander/blob/main/examples/311_2d_floodway_encroachment.ipynb) | 1.2 min |
+| [Boundary DataFrame Enhancement: QMult, QMin, and DSS Path Parsing](../notebooks/312_boundary_df_qmult_dss_paths.md) | [.ipynb](https://github.com/gpt-cmdr/ras-commander/blob/main/examples/312_boundary_df_qmult_dss_paths.ipynb) | N/A |
+| [HMS-to-RAS Boundary Condition Matching](../notebooks/313_hms_to_ras_boundary_matching.md) | [.ipynb](https://github.com/gpt-cmdr/ras-commander/blob/main/examples/313_hms_to_ras_boundary_matching.ipynb) | N/A |
+| [Breakline-Derived Reference Lines And USGS Gauge Points](../notebooks/314_reference_line_generation.md) | [.ipynb](https://github.com/gpt-cmdr/ras-commander/blob/main/examples/314_reference_line_generation.ipynb) | N/A |
+| [2D Computation Options](../notebooks/315_2d_computation_options.md) | [.ipynb](https://github.com/gpt-cmdr/ras-commander/blob/main/examples/315_2d_computation_options.ipynb) | 2.4 min |
+| [Terrain Modifications: High-Ground and Polygon Writer Validation](../notebooks/316_terrain_modifications.md) | [.ipynb](https://github.com/gpt-cmdr/ras-commander/blob/main/examples/316_terrain_modifications.ipynb) | 2.7 min |
+| [Restart File Output and Warm-Start Settings](../notebooks/317_restart_file_settings.md) | [.ipynb](https://github.com/gpt-cmdr/ras-commander/blob/main/examples/317_restart_file_settings.ipynb) | 24 s |
+| [Validating DSS File Paths and Data Availability](../notebooks/318_validating_dss_paths.md) | [.ipynb](https://github.com/gpt-cmdr/ras-commander/blob/main/examples/318_validating_dss_paths.ipynb) | N/A |
+| [Post-fire debris-flow 2D modeling, built from scratch (non-Newtonian)](../notebooks/319_post_fire_debris_flow_nonnewtonian.md) | [.ipynb](https://github.com/gpt-cmdr/ras-commander/blob/main/examples/319_post_fire_debris_flow_nonnewtonian.ipynb) | N/A |
+| [1D Boundary Condition Visualization](../notebooks/320_1d_boundary_condition_visualization.md) | [.ipynb](https://github.com/gpt-cmdr/ras-commander/blob/main/examples/320_1d_boundary_condition_visualization.ipynb) | N/A |
 
-| Notebook | Why it matters |
-|----------|----------------|
-| [122_rasmapper_spatial_review.ipynb](https://github.com/gpt-cmdr/ras-commander/blob/main/examples/122_rasmapper_spatial_review.ipynb) | Canonical RASMapper spatial review, screenshot capture, and evidence-bundle workflow |
-| [123_rasmapper_geometry_layer_updates.ipynb](https://github.com/gpt-cmdr/ras-commander/blob/main/examples/123_rasmapper_geometry_layer_updates.ipynb) | Mutation-backed RASMapper geometry-layer update workflow |
-| [150_results_dataframe.ipynb](https://github.com/gpt-cmdr/ras-commander/blob/main/examples/150_results_dataframe.ipynb) | Current `results_df` / lightweight HDF summary workflow |
-| [212_landcover_mannings_n_write.ipynb](https://github.com/gpt-cmdr/ras-commander/blob/main/examples/212_landcover_mannings_n_write.ipynb) | HDF geometry association QA and land-cover update workflow |
-| [213_land_classification_polygon_authoring.ipynb](https://github.com/gpt-cmdr/ras-commander/blob/main/examples/213_land_classification_polygon_authoring.ipynb) | Land-classification polygon authoring workflow |
-| [318_validating_dss_paths.ipynb](https://github.com/gpt-cmdr/ras-commander/blob/main/examples/318_validating_dss_paths.ipynb) | DSS path validation reference |
-| [611_validating_map_layers.ipynb](https://github.com/gpt-cmdr/ras-commander/blob/main/examples/611_validating_map_layers.ipynb) | RASMapper layer and HDF asset validation |
-| [721_precipitation_hyetograph_comparison.ipynb](https://github.com/gpt-cmdr/ras-commander/blob/main/examples/721_precipitation_hyetograph_comparison.ipynb) | Multi-method precipitation hyetograph comparison |
-| [920_terrain_creation.ipynb](https://github.com/gpt-cmdr/ras-commander/blob/main/examples/920_terrain_creation.ipynb) | HEC-RAS terrain tutorial workflow |
-| [921_usgs_study_package_from_primitives.ipynb](https://github.com/gpt-cmdr/ras-commander/blob/main/examples/921_usgs_study_package_from_primitives.ipynb) | USGS study package assembly from primitives |
-| [950_ebfe_spring_creek.ipynb](https://github.com/gpt-cmdr/ras-commander/blob/main/examples/950_ebfe_spring_creek.ipynb) through [958_model_sources_showcase.ipynb](https://github.com/gpt-cmdr/ras-commander/blob/main/examples/958_model_sources_showcase.ipynb) | eBFE delivery-validation and model-source workflows |
-| [960_cloud_native_geometry_export.ipynb](https://github.com/gpt-cmdr/ras-commander/blob/main/examples/960_cloud_native_geometry_export.ipynb) through [962_cloud_native_cog_results_export.ipynb](https://github.com/gpt-cmdr/ras-commander/blob/main/examples/962_cloud_native_cog_results_export.ipynb) | Cloud-native export workflow family |
+## 400s
 
-## Current Canonical Inventory
+| Notebook | Source | Runtime |
+| --- | --- | --- |
+| [1D HDF Data Extraction](../notebooks/400_1d_hdf_data_extraction.md) | [.ipynb](https://github.com/gpt-cmdr/ras-commander/blob/main/examples/400_1d_hdf_data_extraction.ipynb) | 21 s |
+| [Steady Flow Analysis](../notebooks/401_steady_flow_analysis.md) | [.ipynb](https://github.com/gpt-cmdr/ras-commander/blob/main/examples/401_steady_flow_analysis.ipynb) | 5.8 min |
+| [2D HDF Data Extraction](../notebooks/410_2d_hdf_data_extraction.md) | [.ipynb](https://github.com/gpt-cmdr/ras-commander/blob/main/examples/410_2d_hdf_data_extraction.ipynb) | 5.4 min |
+| [Pipes and Pumps](../notebooks/411_2d_hdf_pipes_and_pumps.md) | [.ipynb](https://github.com/gpt-cmdr/ras-commander/blob/main/examples/411_2d_hdf_pipes_and_pumps.ipynb) | 3.3 min |
+| [2D Face Data Extraction](../notebooks/412_2d_detail_face_data_extraction.md) | [.ipynb](https://github.com/gpt-cmdr/ras-commander/blob/main/examples/412_2d_detail_face_data_extraction.ipynb) | 3.3 min |
+| [Profile Line Flow Extraction](../notebooks/413_profile_line_flow_extraction.md) | [.ipynb](https://github.com/gpt-cmdr/ras-commander/blob/main/examples/413_profile_line_flow_extraction.ipynb) | 3 s |
+| [414 - Depth-Varying Manning's n for HEC-RAS 2D Models](../notebooks/414_depth_varying_mannings_n.md) | [.ipynb](https://github.com/gpt-cmdr/ras-commander/blob/main/examples/414_depth_varying_mannings_n.ipynb) | 16.8 min |
+| [2D Spatial Result Queries with HdfResultsQuery](../notebooks/415_2d_spatial_result_queries.md) | [.ipynb](https://github.com/gpt-cmdr/ras-commander/blob/main/examples/415_2d_spatial_result_queries.ipynb) | N/A |
+| [2D Velocity Profile Line Extraction](../notebooks/416_2d_velocity_profile_line.md) | [.ipynb](https://github.com/gpt-cmdr/ras-commander/blob/main/examples/416_2d_velocity_profile_line.ipynb) | N/A |
+| [Dam Breach Results](../notebooks/420_breach_results_extraction.md) | [.ipynb](https://github.com/gpt-cmdr/ras-commander/blob/main/examples/420_breach_results_extraction.ipynb) | 2.9 min |
+| [1D Channel Capacity Analysis](../notebooks/430_1d_channel_capacity_analysis.md) | [.ipynb](https://github.com/gpt-cmdr/ras-commander/blob/main/examples/430_1d_channel_capacity_analysis.ipynb) | 11 s |
 
-### 100s
+## 500s
 
-`100_using_ras_examples.ipynb`, `101_project_initialization.ipynb`,
-`102_multiple_project_operations.ipynb`,
-`103_plan_and_geometry_operations.ipynb`,
-`104_plan_parameter_operations.ipynb`, `110_single_plan_execution.ipynb`,
-`111_executing_plan_sets.ipynb`, `112_sequential_plan_execution.ipynb`,
-`113_parallel_execution.ipynb`, `114_parameter_permutation.ipynb`,
-`115_real_time_execution_monitoring.ipynb`,
-`116_hdf_output_options_benchmark.ipynb`,
-`120_automating_ras_with_win32com.ipynb`,
-`121_legacy_hecrascontroller_and_rascontrol.ipynb`,
-`122_rasmapper_spatial_review.ipynb`,
-`123_rasmapper_geometry_layer_updates.ipynb`,
-`124_rasmapper_bank_lines.ipynb`, `150_results_dataframe.ipynb`
+| Notebook | Source | Runtime |
+| --- | --- | --- |
+| [Remote Execution with ras-commander](../notebooks/500_remote_execution_psexec.md) | [.ipynb](https://github.com/gpt-cmdr/ras-commander/blob/main/examples/500_remote_execution_psexec.ipynb) | 33.8 min |
+| [Linux Execution of HEC-RAS with ras-commander](../notebooks/510_linux_execution.md) | [.ipynb](https://github.com/gpt-cmdr/ras-commander/blob/main/examples/510_linux_execution.ipynb) | N/A |
+| [Modified Puls Routing Extraction from HEC-RAS 2D Models](../notebooks/560_modpuls_routing_extraction.md) | [.ipynb](https://github.com/gpt-cmdr/ras-commander/blob/main/examples/560_modpuls_routing_extraction.ipynb) | N/A |
 
-### 200s
+## 600s
 
-`201_1d_plaintext_geometry.ipynb`, `202_2d_plaintext_geometry.ipynb`,
-`203_htab_parameter_optimization.ipynb`,
-`205_extract_xs_xyz_from_geometry.ipynb`,
-`206_structures_and_metadata.ipynb`,
-`207_reference_lines_and_points.ipynb`,
-`208_bridge_method_comparison.ipynb`, `209_culvert_authoring.ipynb`,
-`210_xs_interpolation_settings.ipynb`,
-`211_final_mannings_and_infiltration.ipynb`,
-`212_landcover_mannings_n_write.ipynb`,
-`213_land_classification_polygon_authoring.ipynb`,
-`214_connection_authoring.ipynb`,
-`215_sa2d_bridge_connection_authoring.ipynb`,
-`216_1d_bridge_authoring.ipynb`, `217_1d_levee_authoring.ipynb`,
-`218_infiltration_base_override_authoring.ipynb`,
-`219_1d_bridge_xs_plotting.ipynb`, `220_calibration_workflow.ipynb`,
-`221_calibration_1d_workflow.ipynb`, `222_steady_flow_calibration.ipynb`,
-`223_steady_floodway_encroachment.ipynb`,
-`224_steady_flow_authoring.ipynb`,
-`225_fixit_blocked_obstructions.ipynb`,
-`230_mesh_sensitivity_analysis.ipynb`,
-`231_pipe_network_mesh_generation.ipynb`,
-`232_weise_2d_sediment_mesh_sensitivity.ipynb`
+| Notebook | Source | Runtime |
+| --- | --- | --- |
+| [Floodplain Mapping via GUI Automation](../notebooks/600_floodplain_mapping_gui.md) | [.ipynb](https://github.com/gpt-cmdr/ras-commander/blob/main/examples/600_floodplain_mapping_gui.ipynb) | N/A |
+| [Floodplain Mapping via RasProcess CLI](../notebooks/601_floodplain_mapping_rasprocess.md) | [.ipynb](https://github.com/gpt-cmdr/ras-commander/blob/main/examples/601_floodplain_mapping_rasprocess.ipynb) | N/A |
+| [Fluvial-Pluvial Delineation](../notebooks/610_fluvial_pluvial_delineation.md) | [.ipynb](https://github.com/gpt-cmdr/ras-commander/blob/main/examples/610_fluvial_pluvial_delineation.ipynb) | 1.0 h |
+| [Validating RAS Mapper Layers and Terrain Files](../notebooks/611_validating_map_layers.md) | [.ipynb](https://github.com/gpt-cmdr/ras-commander/blob/main/examples/611_validating_map_layers.ipynb) | 4 s |
 
-### 300s
+## 700s
 
-`300_unsteady_flow_operations.ipynb`,
-`301_flow_hydrograph_optimization.ipynb`,
-`310_dss_boundary_extraction.ipynb`,
-`311_2d_floodway_encroachment.ipynb`,
-`312_boundary_df_qmult_dss_paths.ipynb`,
-`313_hms_to_ras_boundary_matching.ipynb`,
-`314_reference_line_generation.ipynb`,
-`315_2d_computation_options.ipynb`, `316_terrain_modifications.ipynb`,
-`317_restart_file_settings.ipynb`, `318_validating_dss_paths.ipynb`,
-`320_1d_boundary_condition_visualization.ipynb`
+| Notebook | Source | Runtime |
+| --- | --- | --- |
+| [Core Sensitivity Testing with results_df](../notebooks/700_core_sensitivity.md) | [.ipynb](https://github.com/gpt-cmdr/ras-commander/blob/main/examples/700_core_sensitivity.ipynb) | 11.2 min |
+| [Version Benchmarking and Core Scaling (HEC-RAS 6.0, 6.3.1, 6.6, 7.0)](../notebooks/701_benchmarking_versions_6.1_to_6.6.md) | [.ipynb](https://github.com/gpt-cmdr/ras-commander/blob/main/examples/701_benchmarking_versions_6.1_to_6.6.ipynb) | N/A |
+| [Manning's n Bulk Sensitivity Analysis](../notebooks/710_mannings_sensitivity_bulk_analysis.md) | [.ipynb](https://github.com/gpt-cmdr/ras-commander/blob/main/examples/710_mannings_sensitivity_bulk_analysis.ipynb) | N/A |
+| [One-at-a-Time (OAT) Manning's n Sensitivity Analysis](../notebooks/711_mannings_sensitivity_multi_interval.md) | [.ipynb](https://github.com/gpt-cmdr/ras-commander/blob/main/examples/711_mannings_sensitivity_multi_interval.ipynb) | N/A |
+| [Precipitation Hyetograph Generation - Complete Method Comparison](../notebooks/720_precipitation_methods_comprehensive.md) | [.ipynb](https://github.com/gpt-cmdr/ras-commander/blob/main/examples/720_precipitation_methods_comprehensive.ipynb) | N/A |
+| [Precipitation Hyetograph Comparison](../notebooks/721_precipitation_hyetograph_comparison.md) | [.ipynb](https://github.com/gpt-cmdr/ras-commander/blob/main/examples/721_precipitation_hyetograph_comparison.ipynb) | 20.3 min |
+| [Gridded Precipitation for Rain-on-Grid 2D Modeling](../notebooks/722_gridded_precipitation_atlas14.md) | [.ipynb](https://github.com/gpt-cmdr/ras-commander/blob/main/examples/722_gridded_precipitation_atlas14.ipynb) | N/A |
+| [StormGenerator Alternating Block Method - Independent Textbook Validation](../notebooks/723_storm_generator_abm_validation.md) | [.ipynb](https://github.com/gpt-cmdr/ras-commander/blob/main/examples/723_storm_generator_abm_validation.ipynb) | 5 s |
+| [Atlas 14 Spatial Variance Analysis](../notebooks/725_atlas14_spatial_variance.md) | [.ipynb](https://github.com/gpt-cmdr/ras-commander/blob/main/examples/725_atlas14_spatial_variance.ipynb) | N/A |
+| [Gridded ABM Hyetograph Generation](../notebooks/726_abm_hyetograph_grid.md) | [.ipynb](https://github.com/gpt-cmdr/ras-commander/blob/main/examples/726_abm_hyetograph_grid.ipynb) | N/A |
 
-### 400s
+## 800s
 
-`400_1d_hdf_data_extraction.ipynb`, `401_steady_flow_analysis.ipynb`,
-`410_2d_hdf_data_extraction.ipynb`,
-`411_2d_hdf_pipes_and_pumps.ipynb`,
-`412_2d_detail_face_data_extraction.ipynb`,
-`413_profile_line_flow_extraction.ipynb`,
-`414_depth_varying_mannings_n.ipynb`,
-`415_2d_spatial_result_queries.ipynb`,
-`416_2d_velocity_profile_line.ipynb`,
-`420_breach_results_extraction.ipynb`,
-`430_1d_channel_capacity_analysis.ipynb`
+| Notebook | Source | Runtime |
+| --- | --- | --- |
+| [Quality Assurance with RasCheck](../notebooks/800_quality_assurance_rascheck.md) | [.ipynb](https://github.com/gpt-cmdr/ras-commander/blob/main/examples/800_quality_assurance_rascheck.ipynb) | N/A |
+| [Advanced Structure Validation with RasCheck](../notebooks/801_advanced_structure_validation.md) | [.ipynb](https://github.com/gpt-cmdr/ras-commander/blob/main/examples/801_advanced_structure_validation.ipynb) | 5 s |
 
-### 500s
+## 900s
 
-`500_remote_execution_psexec.ipynb`, `510_linux_execution.ipynb`,
-`560_modpuls_routing_extraction.ipynb`
-
-### 600s
-
-`600_floodplain_mapping_gui.ipynb`,
-`601_floodplain_mapping_rasprocess.ipynb`,
-`610_fluvial_pluvial_delineation.ipynb`,
-`611_validating_map_layers.ipynb`
-
-### 700s
-
-`700_core_sensitivity.ipynb`,
-`701_benchmarking_versions_6.1_to_6.6.ipynb`,
-`710_mannings_sensitivity_bulk_analysis.ipynb`,
-`711_mannings_sensitivity_multi_interval.ipynb`,
-`720_precipitation_methods_comprehensive.ipynb`,
-`721_precipitation_hyetograph_comparison.ipynb`,
-`722_gridded_precipitation_atlas14.ipynb`,
-`723_storm_generator_abm_validation.ipynb`,
-`725_atlas14_spatial_variance.ipynb`, `726_abm_hyetograph_grid.ipynb`
-
-### 800s
-
-`800_quality_assurance_rascheck.ipynb`,
-`801_advanced_structure_validation.ipynb`
-
-### 900s
-
-`900_aorc_precipitation.ipynb`,
-`901_aorc_precipitation_catalog.ipynb`, `910_usgs_gauge_catalog.ipynb`,
-`911_usgs_gauge_data_integration.ipynb`,
-`912_usgs_real_time_monitoring.ipynb`,
-`913_bc_generation_from_live_gauge.ipynb`,
-`914_historical_event_validation.ipynb`,
-`915_realtime_forecast_workflow.ipynb`,
-`916_hrrr_precipitation_forecast.ipynb`,
-`917_mrms_precipitation_qpe.ipynb`,
-`918_hms_ras_coupled_forecast.ipynb`,
-`919_operational_forecast_cycling.ipynb`, `920_terrain_creation.ipynb`,
-`921_usgs_study_package_from_primitives.ipynb`,
-`922_model_validation_with_usgs.ipynb`,
-`923_stofs3d_coastal_boundary.ipynb`,
-`925_xs_interpolation_surface.ipynb`,
-`930_terrain_modification_analysis.ipynb`
-
-### 950s
-
-`950_ebfe_spring_creek.ipynb`,
-`951_ebfe_north_galveston_bay.ipynb`,
-`952_ebfe_upper_guadalupe_cascade.ipynb`,
-`953_ebfe_rio_hondo_steady_collection.ipynb`,
-`954_ebfe_lake_maurepas_validation.ipynb`,
-`955_ebfe_tickfaw_validation.ipynb`,
-`957_ebfe_spring_river_validation.ipynb`,
-`958_model_sources_showcase.ipynb`
-
-### 960s
-
-`960_cloud_native_geometry_export.ipynb`,
-`961_cloud_native_results_export.ipynb`,
-`962_cloud_native_cog_results_export.ipynb`
-
-## Using Notebooks as Reference Workflows
-
-- Use `examples/` as the live source of truth for runnable workflows.
-- Use [Project Initialization](../getting-started/project-initialization.md)
-  and [DataFrame Reference](../reference/dataframe-reference.md) when you need
-  the stable API surface behind the notebooks.
-- Use [Spatial Data & RASMapper](../user-guide/spatial-data.md) for the public
-  RASMapper workflow narrative behind notebooks `122`, `123`, `611`, and `920`.
+| Notebook | Source | Runtime |
+| --- | --- | --- |
+| [AORC Precipitation for HEC-RAS Rain-on-Grid Models](../notebooks/900_aorc_precipitation.md) | [.ipynb](https://github.com/gpt-cmdr/ras-commander/blob/main/examples/900_aorc_precipitation.ipynb) | N/A |
+| [AORC Precipitation Catalog for HEC-RAS Rain-on-Grid Models](../notebooks/901_aorc_precipitation_catalog.md) | [.ipynb](https://github.com/gpt-cmdr/ras-commander/blob/main/examples/901_aorc_precipitation_catalog.ipynb) | N/A |
+| [Example 910: USGS Gauge Catalog Generation](../notebooks/910_usgs_gauge_catalog.md) | [.ipynb](https://github.com/gpt-cmdr/ras-commander/blob/main/examples/910_usgs_gauge_catalog.ipynb) | N/A |
+| [USGS Gauge Data Integration for HEC-RAS](../notebooks/911_usgs_gauge_data_integration.md) | [.ipynb](https://github.com/gpt-cmdr/ras-commander/blob/main/examples/911_usgs_gauge_data_integration.ipynb) | N/A |
+| [USGS Real-Time Gauge Monitoring](../notebooks/912_usgs_real_time_monitoring.md) | [.ipynb](https://github.com/gpt-cmdr/ras-commander/blob/main/examples/912_usgs_real_time_monitoring.ipynb) | N/A |
+| [Boundary Condition Generation from Live USGS Gauge Data](../notebooks/913_bc_generation_from_live_gauge.md) | [.ipynb](https://github.com/gpt-cmdr/ras-commander/blob/main/examples/913_bc_generation_from_live_gauge.ipynb) | N/A |
+| [Historical Event Validation with AORC Precipitation and USGS Gauges](../notebooks/914_historical_event_validation.md) | [.ipynb](https://github.com/gpt-cmdr/ras-commander/blob/main/examples/914_historical_event_validation.ipynb) | N/A |
+| [Real-Time Forecast Workflow with ras-commander](../notebooks/915_realtime_forecast_workflow.md) | [.ipynb](https://github.com/gpt-cmdr/ras-commander/blob/main/examples/915_realtime_forecast_workflow.ipynb) | 2.5 min |
+| [HRRR Precipitation Forecast Download](../notebooks/916_hrrr_precipitation_forecast.md) | [.ipynb](https://github.com/gpt-cmdr/ras-commander/blob/main/examples/916_hrrr_precipitation_forecast.ipynb) | N/A |
+| [MRMS Precipitation QPE](../notebooks/917_mrms_precipitation_qpe.md) | [.ipynb](https://github.com/gpt-cmdr/ras-commander/blob/main/examples/917_mrms_precipitation_qpe.ipynb) | 46.5 min |
+| [HMS-RAS Coupled Forecast Execution](../notebooks/918_hms_ras_coupled_forecast.md) | [.ipynb](https://github.com/gpt-cmdr/ras-commander/blob/main/examples/918_hms_ras_coupled_forecast.ipynb) | N/A |
+| [Operational Forecast Cycling](../notebooks/919_operational_forecast_cycling.md) | [.ipynb](https://github.com/gpt-cmdr/ras-commander/blob/main/examples/919_operational_forecast_cycling.ipynb) | N/A |
+| [Creating a RAS Terrain with ras-commander](../notebooks/920_terrain_creation.md) | [.ipynb](https://github.com/gpt-cmdr/ras-commander/blob/main/examples/920_terrain_creation.ipynb) | 2.0 h |
+| [USGS Study Package From Primitives](../notebooks/921_usgs_study_package_from_primitives.md) | [.ipynb](https://github.com/gpt-cmdr/ras-commander/blob/main/examples/921_usgs_study_package_from_primitives.ipynb) | N/A |
+| [Model Validation with USGS Gauge Data](../notebooks/922_model_validation_with_usgs.md) | [.ipynb](https://github.com/gpt-cmdr/ras-commander/blob/main/examples/922_model_validation_with_usgs.ipynb) | N/A |
+| [STOFS-3D Coastal Boundary Integration](../notebooks/923_stofs3d_coastal_boundary.md) | [.ipynb](https://github.com/gpt-cmdr/ras-commander/blob/main/examples/923_stofs3d_coastal_boundary.ipynb) | 1.3 min |
+| [Cross-Section Interpolation Surface](../notebooks/925_xs_interpolation_surface.md) | [.ipynb](https://github.com/gpt-cmdr/ras-commander/blob/main/examples/925_xs_interpolation_surface.ipynb) | 6 s |
+| [Terrain Modification Analysis](../notebooks/930_terrain_modification_analysis.md) | [.ipynb](https://github.com/gpt-cmdr/ras-commander/blob/main/examples/930_terrain_modification_analysis.ipynb) | N/A |
+| [Using eBFE Models: Spring Creek 2D Analysis](../notebooks/950_ebfe_spring_creek.md) | [.ipynb](https://github.com/gpt-cmdr/ras-commander/blob/main/examples/950_ebfe_spring_creek.ipynb) | 4 s |
+| [Using eBFE Models: North Galveston Bay HMS + RAS Integration](../notebooks/951_ebfe_north_galveston_bay.md) | [.ipynb](https://github.com/gpt-cmdr/ras-commander/blob/main/examples/951_ebfe_north_galveston_bay.ipynb) | 3 s |
+| [Using eBFE Models: Upper Guadalupe Cascaded Watersheds](../notebooks/952_ebfe_upper_guadalupe_cascade.md) | [.ipynb](https://github.com/gpt-cmdr/ras-commander/blob/main/examples/952_ebfe_upper_guadalupe_cascade.ipynb) | 12 s |
+| [Using eBFE Models: Rio Hondo 1D Steady Collection](../notebooks/953_ebfe_rio_hondo_steady_collection.md) | [.ipynb](https://github.com/gpt-cmdr/ras-commander/blob/main/examples/953_ebfe_rio_hondo_steady_collection.ipynb) | 9 s |
+| [Using eBFE Models: Lake Maurepas Validation](../notebooks/954_ebfe_lake_maurepas_validation.md) | [.ipynb](https://github.com/gpt-cmdr/ras-commander/blob/main/examples/954_ebfe_lake_maurepas_validation.ipynb) | 3 s |
+| [Using eBFE Models: Tickfaw Results-Ready Validation](../notebooks/955_ebfe_tickfaw_validation.md) | [.ipynb](https://github.com/gpt-cmdr/ras-commander/blob/main/examples/955_ebfe_tickfaw_validation.ipynb) | 3 s |
+| [Using eBFE Models: Spring River Validation](../notebooks/957_ebfe_spring_river_validation.md) | [.ipynb](https://github.com/gpt-cmdr/ras-commander/blob/main/examples/957_ebfe_spring_river_validation.ipynb) | N/A |
+| [Model Sources: Unified Discovery, Download & Visualization](../notebooks/958_model_sources_showcase.md) | [.ipynb](https://github.com/gpt-cmdr/ras-commander/blob/main/examples/958_model_sources_showcase.ipynb) | N/A |
+| [Cloud-Native Geometry Export with ras2cng](../notebooks/960_cloud_native_geometry_export.md) | [.ipynb](https://github.com/gpt-cmdr/ras-commander/blob/main/examples/960_cloud_native_geometry_export.ipynb) | N/A |
+| [Cloud-Native Results Export with ras2cng](../notebooks/961_cloud_native_results_export.md) | [.ipynb](https://github.com/gpt-cmdr/ras-commander/blob/main/examples/961_cloud_native_results_export.ipynb) | N/A |
+| [Cloud Optimized GeoTIFF Results Export with ras2cng](../notebooks/962_cloud_native_cog_results_export.md) | [.ipynb](https://github.com/gpt-cmdr/ras-commander/blob/main/examples/962_cloud_native_cog_results_export.ipynb) | N/A |

--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -19,8 +19,7 @@
 </style>
 <div style="text-align: center; padding: 4px 16px;">
   An open-source project of <a href="https://clbengineering.com/">CLB Engineering Corporation</a> &nbsp;|&nbsp;
-  <a href="https://clbengineering.com/llm-forward">LLM Forward Engineering</a> &nbsp;|&nbsp;
-  <a href="https://clbengineering.com/">Partner with CLB on your next H&H project</a>
+  <a href="https://clbengineering.com/llm-forward">LLM Forward Engineering</a>
 </div>
 {% endblock %}
 


### PR DESCRIPTION
## Summary
Post-cutover docs polish now that rascommander.info (self-hosted) is the primary host.

1. **Examples index table** — `docs/examples/index.md` is now per-section tables instead of comma-separated lists. Each row links to the rendered page + the source `.ipynb` on GitHub, and shows total cell-execution runtime summed from `metadata.execution` timestamps (N/A when the notebook was committed without execution outputs). Generated by a new stdlib-only `.claude/scripts/generate_examples_index.py` (sources the list from disk so it matches exactly what the build ships — 117 notebooks, 64 with runtime data). Wired into `docs-validate.yml` (and the CT 210 `build.sh`) to stay fresh.
2. **GitHub Pages auto-deploy disabled** — `docs.yml` push trigger commented out; kept as a manual `workflow_dispatch` fallback. CT 210 webhook is the live deploy path.
3. **Banner cleanup** — removed the "Partner with CLB on your next H&H project" announcement-bar link (pushy/duplicative).

## Verification
- Generator runs clean (exit 0), 117 rows = disk parity, spot-checked runtimes (100→1.3min, 410→5.4min, 960→N/A).
- Non-strict `mkdocs build` is the production parity gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)