### PR TITLE
docs: LLM-agent-friendly site — llms.txt, robots (AI crawlers), agent guide, DataFrame columns

### DIFF
--- a/docs/development/llm-agents.md
+++ b/docs/development/llm-agents.md
@@ -1,0 +1,151 @@
+# LLM Agent Guide
+
+This page is the canonical, copy-runnable landing page for **LLM agents** building on
+RAS Commander. It is intentionally dense: install, the cardinal rules, and complete recipes
+you can paste and run.
+
+!!! tip "Machine-readable docs"
+    A curated index of this site is published at
+    [`https://rascommander.info/llms.txt`](https://rascommander.info/llms.txt), with the full
+    concatenated corpus at
+    [`https://rascommander.info/llms-full.txt`](https://rascommander.info/llms-full.txt).
+    Most pages are also mirrored as raw markdown (append `.md` to the page URL).
+
+## Install
+
+```bash
+pip install ras-commander
+```
+
+RAS Commander automates an **installed HEC-RAS** (`Ras.exe`). Execution recipes require
+HEC-RAS on Windows; parsing/extraction recipes work anywhere the result files exist.
+
+## Cardinal rules
+
+1. **Static classes — call, don't instantiate.** `RasCmdr`, `RasPlan`, `RasGeometry`,
+   `RasUnsteady`, and every `Hdf*` class are static namespaces. Call methods directly:
+   `RasCmdr.compute_plan("01")`, **not** `RasCmdr().compute_plan(...)`. The only object you
+   instantiate (indirectly) is the project object via `init_ras_project()`.
+
+2. **DataFrame-first.** After `init_ras_project()`, the project metadata lives in pandas
+   DataFrames: `plan_df`, `geom_df`, `flow_df`, `unsteady_df`, `boundaries_df`, `rasmap_df`,
+   `results_df`. Use them as the source of truth for file paths, plan/geometry linkage, and
+   boundary inventory instead of globbing the folder. See the
+   [DataFrame Reference](../reference/dataframe-reference.md) for every column.
+
+3. **`ras_object=` discipline for multi-project work.** A global `ras` object is convenient
+   for a single project. The moment you work with more than one project, capture the object
+   returned by `init_ras_project(...)` and pass it explicitly:
+   `RasCmdr.compute_plan("01", ras_object=my_ras)`. Mixing the global with a second project is
+   the most common agent bug.
+
+4. **`RasExamples.extract_project(...)` for real test data.** Do not invent or mock HEC-RAS
+   projects. Extract a bundled, real project. Use `suffix=` to get an isolated copy you can
+   mutate without colliding with other runs:
+   `RasExamples.extract_project("Muncie", suffix="_run1")`.
+
+5. **Detect steady vs unsteady before extracting results.** Steady and unsteady HDF results
+   have different structures. Call `HdfResultsPlan.is_steady_plan(hdf_path)` first.
+
+6. **Normalize plan/geometry numbers.** `"1"`, `"01"`, `"p01"`, and `Path("Model.p01")` all
+   resolve to plan `01`. Most APIs accept any of these; `RasUtils.normalize_ras_number()`
+   makes it explicit.
+
+## Recipe 1 — Initialize and inspect plans
+
+```python
+from ras_commander import init_ras_project, RasExamples
+
+# Extract a real bundled project to an isolated copy
+project_path = RasExamples.extract_project("Muncie", suffix="_inspect")
+
+# init_ras_project returns the project object (also sets the global `ras`)
+my_ras = init_ras_project(project_path, "6.6")
+
+# DataFrame-first inspection
+print(my_ras.plan_df[["plan_number", "Plan Title", "geometry_number",
+                      "unsteady_number", "flow_type"]])
+print(my_ras.geom_df[["geom_number", "geom_title", "has_2d_mesh",
+                      "num_cross_sections"]])
+
+# Which plans already have computed HDF results?
+computed = my_ras.plan_df[my_ras.plan_df["HDF_Results_Path"].notna()]
+print(f"{len(computed)} of {len(my_ras.plan_df)} plans have HDF results")
+```
+
+## Recipe 2 — Compute a plan, then verify success
+
+```python
+from ras_commander import init_ras_project, RasExamples, RasCmdr
+
+project_path = RasExamples.extract_project("Muncie", suffix="_compute")
+my_ras = init_ras_project(project_path, "6.6")
+
+# Execute to a separate destination folder so the source stays immutable
+success = RasCmdr.compute_plan(
+    "01",
+    dest_folder=str(project_path) + "_results",
+    overwrite_dest=True,
+    ras_object=my_ras,
+)
+print(f"Execution {'succeeded' if success else 'failed'}")
+
+# Refresh and read the results summary (completion, errors, runtime)
+my_ras.update_results_df(["01"])
+print(my_ras.results_df[["plan_number", "completed", "has_errors",
+                         "runtime_complete_process_hours"]])
+```
+
+## Recipe 3 — Extract maximum WSE from a 2D mesh
+
+```python
+from ras_commander import init_ras_project, RasExamples
+from ras_commander.hdf import HdfResultsPlan, HdfResultsMesh
+
+# A 2D example with computed results
+project_path = RasExamples.extract_project("BaldEagleCrkMulti2D", suffix="_wse")
+my_ras = init_ras_project(project_path, "6.6")
+
+# Pick a plan that has results
+plan_number = my_ras.plan_df[my_ras.plan_df["HDF_Results_Path"].notna()] \
+                    ["plan_number"].iloc[0]
+
+# Steady and unsteady results differ — detect first
+hdf_path = my_ras.plan_df.set_index("plan_number") \
+                  .loc[plan_number, "HDF_Results_Path"]
+if HdfResultsPlan.is_steady_plan(hdf_path):
+    raise RuntimeError("This recipe expects an unsteady 2D plan")
+
+# Maximum water surface elevation per mesh cell (GeoDataFrame, one row per cell)
+max_ws = HdfResultsMesh.get_mesh_max_ws(plan_number, ras_object=my_ras)
+print(max_ws.columns.tolist())
+print(f"Peak WSE across mesh: {max_ws['maximum_water_surface'].max():.2f} ft")
+```
+
+## Recipe 4 — Audit boundary conditions and DSS paths
+
+```python
+from ras_commander import init_ras_project, RasExamples
+
+project_path = RasExamples.extract_project("BaldEagleCrkMulti2D", suffix="_bc")
+my_ras = init_ras_project(project_path, "6.6")
+
+bc = my_ras.boundaries_df
+
+# Inventory by type
+print(bc["bc_type"].value_counts())
+
+# DSS-backed boundaries with their parsed pathname parts
+dss = bc[bc["Use DSS"] == "True"]
+print(dss[["unsteady_number", "bc_type", "river_reach_name",
+           "dss_part_b", "dss_part_c", "DSS File"]])
+```
+
+## Where to go next
+
+- [DataFrame Reference](../reference/dataframe-reference.md) — every column of every
+  project DataFrame, with dtypes and meanings (the #1 thing an integrating agent cannot
+  introspect without running HEC-RAS).
+- [HDF Data Extraction](../user-guide/hdf-data-extraction.md) — mesh/cross-section result APIs.
+- [Plan Execution](../user-guide/plan-execution.md) — parallel compute, destination folders.
+- [API Reference](../api/index.md) — full class/method signatures from docstrings.

--- a/docs/reference/dataframe-reference.md
+++ b/docs/reference/dataframe-reference.md
@@ -65,25 +65,40 @@ from project metadata.
 `plan_df` is the main execution and metadata table. It is assembled from the
 `.prj` file, parsed `.p##` contents, and project-relative path resolution.
 
-Key columns you can rely on:
+Key columns you can rely on (column names preserve the HEC-RAS plan-file keys
+verbatim, including spaces and the HEC-RAS spelling of `Reoccurance`). Values
+parsed from the plan text are strings unless noted:
 
-| Column | Meaning |
-|--------|---------|
-| `plan_number` | normalized two-digit plan id such as `01` |
-| `geometry_number` | normalized geometry id used by the plan |
-| `unsteady_number` | normalized unsteady-flow id when the plan is unsteady |
-| `Plan Title` | HEC-RAS plan title |
-| `Short Identifier` | HEC-RAS short id used by stored-map/result folders |
-| `Geom File` / `Geom Path` | geometry reference and resolved path |
-| `Flow File` / `Flow Path` | steady or unsteady flow reference and resolved path |
-| `Computation Interval` / `Output Interval` | time-step metadata |
-| `Write IC File` / `IC Time` | restart / hot-start output-save settings when present |
-| `Write IC File Reoccurance` | restart output recurrence interval, preserving the HEC-RAS spelling |
-| `Write IC File at Sim End` | final-step restart output flag |
-| `Program Version` | HEC-RAS version recorded in the plan |
-| `HDF_Results_Path` | resolved `.p##.hdf` path when present |
-| `full_path` | resolved `.p##` path |
-| `flow_type` | convenience flow-type classification |
+| Column | Dtype | Meaning |
+|--------|-------|---------|
+| `plan_number` | str | normalized two-digit plan id such as `01` |
+| `geometry_number` | str | normalized geometry id used by the plan |
+| `unsteady_number` | str / None | normalized unsteady-flow id when the plan is unsteady; `None` for steady plans |
+| `Plan Title` | str | HEC-RAS plan title (`Plan Title=`) |
+| `Short Identifier` | str | HEC-RAS short id used by stored-map/result folders |
+| `Geom File` | str | geometry reference number from the plan (`Geom File=`) |
+| `Geom Path` | str | resolved absolute `.g##` path |
+| `Flow File` | str | steady/unsteady flow reference number (`Flow File=`) |
+| `Flow Path` | str | resolved absolute `.f##` / `.u##` path |
+| `Computation Interval` | str | computation time step (`Computation Interval=`) |
+| `Mapping Interval` | str | RAS Mapper output interval (`Mapping Interval=`) |
+| `Simulation Date` | str | simulation date/time window (`Simulation Date=`) |
+| `Run HTab` / `Run UNet` / `Run PostProcess` / `Run Sediment` / `Run WQNet` | str | run-flag toggles parsed from the plan |
+| `UNET D1 Cores` / `UNET D2 Cores` / `PS Cores` | int / None | core counts; cast to `int` when present, else `None` |
+| `Write IC File` / `IC Time` | str | restart / hot-start output-save settings when present |
+| `Write IC File at Fixed DateTime` | str | restart-at-fixed-datetime flag when present |
+| `Write IC File Reoccurance` | str | restart output recurrence interval (HEC-RAS spelling preserved) |
+| `Write IC File at Sim End` | str | final-step restart output flag |
+| `Program Version` | str | HEC-RAS version recorded in the plan |
+| `description` | str / None | plan `BEGIN DESCRIPTION` block when present |
+| `HDF_Results_Path` | str / None | resolved `.p##.hdf` path; `None` when results do not exist yet |
+| `full_path` | str | resolved absolute `.p##` path |
+| `flow_type` | str | `"Unsteady"`, `"Steady"`, or `"Unknown"` (derived from `unsteady_number`) |
+
+!!! note
+    Columns derive directly from `_parse_plan_file()` in `ras_commander/RasPrj.py`,
+    so any plan key present in the file appears as a same-named column. Not every plan
+    contains every key; missing keys are simply absent or `None`.
 
 Common patterns:
 
@@ -103,31 +118,63 @@ paths = ras.get_hdf_paths("01")
 
 `geom_df` inventories geometry files and compiled HDF companions.
 
-Useful columns:
+Columns (the metadata columns come from `GeomMetadata`, which prefers fast
+HDF-based extraction when `.g##.hdf` exists and falls back to plain-text parsing):
 
-| Column | Meaning |
-|--------|---------|
-| `geom_number` | normalized geometry id |
-| `geom_file` | raw `.g##` reference from the project |
-| `full_path` | resolved `.g##` path |
-| `hdf_path` | expected compiled `.g##.hdf` path |
-| `geom_title` | parsed geometry title when present |
-| `description` | geometry description block when present |
+| Column | Dtype | Meaning |
+|--------|-------|---------|
+| `geom_file` | str | raw `.g##` reference token from the project (e.g. `g01`) |
+| `geom_number` | str | normalized geometry id (e.g. `01`) |
+| `full_path` | str | resolved absolute `.g##` path |
+| `hdf_path` | str | expected compiled `.g##.hdf` path |
+| `geom_title` | str / None | parsed `Geom Title=` value when present |
+| `description` | str / None | geometry `BEGIN DESCRIPTION` block when present |
+| `has_1d_xs` | bool | `True` if the geometry has 1D cross sections |
+| `has_2d_mesh` | bool | `True` if the geometry has 2D mesh / flow areas |
+| `num_cross_sections` | int | count of 1D cross sections |
+| `num_inline_structures` | int | total inline structures (bridges + culverts + weirs) |
+| `num_bridges` | int | count of bridge structures |
+| `num_culverts` | int | count of culvert structures |
+| `num_weirs` | int | count of inline weir structures |
+| `num_gates` | int | count of gate structures |
+| `num_lateral_structures` | int | count of lateral structures |
+| `num_sa_2d_connections` | int | count of SA/2D connections |
+| `mesh_cell_count` | int | total 2D mesh cells across all areas |
+| `mesh_area_names` | list[str] | names of 2D flow areas |
 
-The table may also include counts or metadata parsed from the geometry file.
-Use it for geometry discovery first, then move to `RasGeometry`, `Geom*`, or
-HDF readers for detailed geometry content.
+When metadata extraction fails for a geometry, counts default to `0`, booleans to
+`False`, and `mesh_area_names` to an empty list. Use this table for geometry
+discovery first, then move to `RasGeometry`, `Geom*`, or HDF readers for detail.
 
 ## `flow_df` and `unsteady_df`
 
 These inventory steady and unsteady flow files referenced by the project.
+Both come from `_parse_flow_file()` / `_parse_unsteady_file()` in `RasPrj.py`.
 
-Typical columns:
+`flow_df` (steady `.f##`):
 
-| DataFrame | Common columns |
-|-----------|----------------|
-| `flow_df` | `flow_number`, `full_path`, `description` |
-| `unsteady_df` | `unsteady_number`, `full_path`, `description`, `Use Restart`, `Restart Filename`, plus parsed unsteady metadata |
+| Column | Dtype | Meaning |
+|--------|-------|---------|
+| `flow_number` | str | normalized steady-flow id |
+| `unsteady_number` | None | always `None` for steady-flow rows |
+| `full_path` | str | resolved absolute `.f##` path |
+| `Flow Title` | str / None | parsed `Flow Title=` value |
+| `Program Version` | str / None | HEC-RAS version recorded in the flow file |
+| `description` | str | flow `BEGIN DESCRIPTION` block (empty string when absent) |
+
+`unsteady_df` (unsteady `.u##`):
+
+| Column | Dtype | Meaning |
+|--------|-------|---------|
+| `unsteady_number` | str | normalized unsteady-flow id |
+| `full_path` | str | resolved absolute `.u##` path |
+| `Flow Title` | str / None | parsed `Flow Title=` value |
+| `Program Version` | str / None | HEC-RAS version recorded in the file |
+| `Use Restart` | str / None | restart/hot-start flag (`Use Restart=`) |
+| `Restart Filename` | str / None | restart source file when restart is enabled |
+| `Precipitation Mode` / `Wind Mode` | str / None | meteorology mode toggles when present |
+| `Met BC=Precipitation\|...` | str / None | parsed gridded-precip / met-BC settings when present |
+| `description` | str | unsteady `BEGIN DESCRIPTION` block (empty string when absent) |
 
 Use these tables when you need to audit which `.f##` / `.u##` files exist
 before editing them through `RasPlan` or `RasUnsteady`.
@@ -137,21 +184,31 @@ before editing them through `RasPlan` or `RasUnsteady`.
 `boundaries_df` is built from the unsteady boundary blocks and is the main
 table for DSS-path audits and boundary-condition summaries.
 
-Common columns:
+Common columns (from `_parse_boundary_condition()` in `RasPrj.py`; DSS/typed
+columns appear only when the source line is present):
 
-| Column | Meaning |
-|--------|---------|
-| `unsteady_number` | parent `.u##` file |
-| `boundary_condition_number` | boundary sequence within the file |
-| `bc_type` | high-level boundary type |
-| `hydrograph_type` | parsed hydrograph subtype when present |
-| `river_reach_name` / `river_station` | 1D location metadata |
-| `storage_area_name` | 2D/storage-area location when present |
-| `Interval` | time interval |
-| `Use DSS` | whether the boundary uses DSS |
-| `DSS File` / `DSS Path` | raw DSS references |
-| `dss_part_a` ... `dss_part_f` | parsed DSS pathname components |
-| `hydrograph_num_values` | number of inline hydrograph values |
+| Column | Dtype | Meaning |
+|--------|-------|---------|
+| `unsteady_number` | str | parent `.u##` file |
+| `boundary_condition_number` | int | boundary sequence within the file (1-based) |
+| `bc_type` | str | high-level boundary type (e.g. `Flow Hydrograph`, `Normal Depth`, `Unknown`) |
+| `hydrograph_type` | str / None | hydrograph subtype when the BC is a hydrograph, else `None` |
+| `river_reach_name` | str | 1D river/reach location field (may be empty string) |
+| `river_station` | str | 1D river-station field (may be empty string) |
+| `storage_area_name` | str | storage-area location field when present |
+| `pump_station_name` | str | pump-station field when present |
+| `area_2d` | str | 2D flow-area name field when present |
+| `bc_line_name` | str | boundary-condition line name when present |
+| `Interval` | str | time interval (`Interval=`) |
+| `Use DSS` | str | `"True"` / `"False"` string (note: string, not bool) |
+| `DSS File` | str | raw DSS file reference |
+| `DSS Path` | str | raw DSS pathname |
+| `dss_part_a` … `dss_part_f` | str | parsed DSS pathname components A–F |
+| `Friction Slope` | str | raw friction-slope field for `Normal Depth` BCs |
+| `friction_slope_value` | float / None | parsed friction-slope value |
+| `critical_fallback_flag` | int / None | parsed critical-boundary fallback flag |
+| `hydrograph_num_values` | int | number of inline hydrograph values (0 if none) |
+| `hydrograph_values` | list[str] | inline hydrograph values when present |
 
 Examples:
 
@@ -169,18 +226,21 @@ flow_bcs = ras.boundaries_df[ras.boundaries_df["bc_type"] == "Flow Hydrograph"]
 Several columns contain lists because the dataframe is optimized for project
 overview, not one-row-per-layer discovery.
 
-Current default columns:
+Current default columns (each cell is one element because the DataFrame is a
+single row; "Dtype" describes the value inside that cell):
 
-| Column | Shape | Meaning |
+| Column | Dtype | Meaning |
 |--------|-------|---------|
-| `projection_path` | scalar | project projection reference |
-| `profile_lines_path` | list | profile/reference line paths |
-| `soil_layer_path` | list | soils sidecar paths |
-| `infiltration_hdf_path` | list | infiltration sidecar HDFs |
-| `landcover_hdf_path` | list | land-cover sidecar HDFs |
-| `terrain_hdf_path` | list | terrain HDFs |
-| `reference_map_layer_names` / `reference_map_layer_path` | list | reference map layers |
-| `basemap_layer_names` / `basemap_layer_path` | list | basemap layers |
+| `projection_path` | str / None | project projection (`.prj`) reference |
+| `profile_lines_path` | list[str] | profile/reference line paths |
+| `soil_layer_path` | list[str] | soils sidecar paths |
+| `infiltration_hdf_path` | list[str] | infiltration sidecar HDFs |
+| `landcover_hdf_path` | list[str] | land-cover sidecar HDFs |
+| `terrain_hdf_path` | list[str] | terrain HDFs |
+| `reference_map_layer_names` | list[str] | reference map layer names |
+| `reference_map_layer_path` | list[str] | reference map layer paths |
+| `basemap_layer_names` | list[str] | basemap layer names |
+| `basemap_layer_path` | list[str] | basemap layer paths |
 | `current_settings` | dict | compact `.rasmap` settings summary |
 
 ```python
@@ -209,21 +269,37 @@ For compiled HDF asset resolution, pair the `.rasmap` summary with
 `ResultsSummary`. It is intended for fast execution-status and runtime queries,
 not heavy spatial extraction.
 
-Typical columns:
+Columns (from `ResultsSummary.summarize_plan()` /
+`get_summary_columns()` in `ras_commander/results/ResultsSummary.py`; identity,
+health, and runtime columns are always present, `None`/`0` when unavailable):
 
-| Column | Meaning |
-|--------|---------|
-| `plan_number` / `plan_title` / `flow_type` | copied project metadata |
-| `hdf_path` / `hdf_exists` / `hdf_file_modified` | result-file status |
-| `completed` | completion flag parsed from compute metadata |
-| `has_errors` / `has_warnings` | summary health flags |
-| `error_count` / `warning_count` | parsed message counts |
-| `first_error_line` | first blocking compute-message line when present |
-| `runtime_simulation_hours` | simulation duration |
-| `runtime_complete_process_hours` | end-to-end runtime |
-| `runtime_unsteady_compute_hours` | unsteady compute runtime when present |
-| `runtime_complete_process_speed` | normalized throughput metric |
-| `runtime_source` | whether runtime came from HDF metadata or compute-message fallback |
+| Column | Dtype | Meaning |
+|--------|-------|---------|
+| `plan_number` | str | copied plan id |
+| `plan_title` | str / None | copied plan title |
+| `flow_type` | str / None | `Steady` / `Unsteady` classification |
+| `hdf_path` | str | path to the `.p##.hdf` result file |
+| `hdf_exists` | bool | whether the HDF result file exists |
+| `hdf_file_modified` | datetime / None | HDF modification timestamp |
+| `ras_version` | str / None | HEC-RAS version (`Program Version`) |
+| `completed` | bool | completion flag parsed from compute metadata |
+| `has_errors` | bool | summary error flag |
+| `has_warnings` | bool | summary warning flag |
+| `error_count` | int | parsed error-message count |
+| `warning_count` | int | parsed warning-message count |
+| `first_error_line` | str / None | first blocking compute-message line when present |
+| `runtime_simulation_start` | datetime / None | simulation start time |
+| `runtime_simulation_end` | datetime / None | simulation end time |
+| `runtime_simulation_hours` | float / None | simulated duration (hours) |
+| `runtime_complete_process_hours` | float / None | end-to-end wall-clock runtime (hours) |
+| `runtime_unsteady_compute_hours` | float / None | unsteady compute runtime (hours) |
+| `runtime_complete_process_speed` | float / None | normalized throughput (sim hr / wall hr) |
+| `runtime_source` | str / None | `'hdf'` or `'compute_messages'` provenance |
+| `vol_error` | float / None | volume-accounting error (unsteady only) |
+| `vol_accounting_units` | str / None | volume units |
+| `vol_error_percent` | float / None | volume error as percent |
+| `vol_flux_in` / `vol_flux_out` | float / None | total inflow / outflow volume |
+| `vol_starting` / `vol_ending` | float / None | starting / ending storage volume |
 
 ```python
 print(ras.results_df[[

--- a/docs/requirements-docs.txt
+++ b/docs/requirements-docs.txt
@@ -13,6 +13,9 @@ mkdocstrings[python]>=0.24.0
 # Git revision dates
 mkdocs-git-revision-date-localized-plugin>=1.2.0
 
+# llms.txt / llms-full.txt + per-page markdown mirrors for LLM agents
+mkdocs-llmstxt>=0.2
+
 # For cognitive infrastructure doc generation
 PyYAML>=6.0
 

--- a/docs/robots.txt
+++ b/docs/robots.txt
@@ -1,0 +1,23 @@
+# robots.txt for https://rascommander.info/
+#
+# AI agents welcome. A curated, machine-readable index of this documentation
+# is available at https://rascommander.info/llms.txt
+# (and the full concatenated corpus at https://rascommander.info/llms-full.txt).
+
+User-agent: *
+Allow: /
+
+# Explicitly allow AI / LLM crawlers.
+User-agent: GPTBot
+Allow: /
+
+User-agent: ClaudeBot
+Allow: /
+
+User-agent: PerplexityBot
+Allow: /
+
+User-agent: Google-Extended
+Allow: /
+
+Sitemap: https://rascommander.info/sitemap.xml

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -44,6 +44,31 @@ theme:
 
 plugins:
   - search
+  - llmstxt:
+      full_output: llms-full.txt
+      sections:
+        LLM Agent Guide:
+          - development/llm-agents.md
+        Getting Started:
+          - getting-started/installation.md
+          - getting-started/quickstart.md
+          - getting-started/project-initialization.md
+        Reference:
+          - reference/dataframe-reference.md
+          - reference/quick-reference.md
+          - reference/file-formats.md
+        User Guide:
+          - user-guide/overview.md
+          - user-guide/plan-execution.md
+          - user-guide/workflows-and-patterns.md
+          - user-guide/hdf-data-extraction.md
+          - user-guide/geometry-operations.md
+          - user-guide/boundary-conditions.md
+        API Reference:
+          - api/index.md
+          - api/core.md
+          - api/hdf.md
+          - api/geometry.md
   - mkdocstrings:
       default_handler: python
       handlers:
@@ -187,6 +212,7 @@ nav:
     - Overview: cognitive-infrastructure/index.md
   - LLM Forward Development:
     - Overview: development/llm-development.md
+    - LLM Agent Guide: development/llm-agents.md
     - Agent Infrastructure: development/agent-infrastructure.md
     - Multi-Harness Agent Contract: development/multi-harness-agent-contract.md
     - Contributing: development/contributing.md


### PR DESCRIPTION
Makes rascommander.info machine-consumable for LLM agents (Workstream 1 of the agent-friendliness plan).

- **`mkdocs-llmstxt`** plugin → generates `/llms.txt` (curated index) + `/llms-full.txt` (concatenated markdown) + per-page markdown mirrors at `<path>/index.md`. Added to `mkdocs.yml` plugins + `docs/requirements-docs.txt`. Verified the build-time `prepare_notebooks_for_docs.py` does NOT clobber the plugin block (no patch needed).
- **`docs/robots.txt`** — explicitly ALLOWS AI crawlers (GPTBot, ClaudeBot, PerplexityBot, Google-Extended) + Sitemap line.
- **`docs/development/llm-agents.md`** (new) — canonical on-site agent guide: cardinal rules + complete copy-runnable recipes; wired into nav.
- **`docs/reference/dataframe-reference.md`** — added explicit per-DataFrame **column tables** (name · dtype · meaning), sourced from `RasPrj.py`/`ResultsSummary.py` (not invented).

Verified: `mkdocs build` clean; `site/llms.txt`, `site/llms-full.txt`, `site/robots.txt` generated. Per-page `.md` mirror URL pattern: `<page-path>/index.md` (only for pages in the llmstxt `sections:`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)