### PR TITLE
feat: library discovery hooks for LLM agents (project_urls, LLM_GUIDE, docs(), error deep-links) → 0.98.2

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
+include ras_commander/LLM_GUIDE.md
 include ras_commander/native/RasStoreMapHelper.exe
 include ras_commander/native/RasStoreMapHelper.cs
 include ras_commander/resources/land_classification/*.hdf

--- a/ras_commander/LLM_GUIDE.md
+++ b/ras_commander/LLM_GUIDE.md
@@ -1,0 +1,73 @@
+# ras-commander — LLM Agent Quickstart
+
+This file ships inside the `ras-commander` wheel so an agent can read it offline.
+For the live, always-current version see **https://rascommander.info/llms.txt**.
+
+ras-commander is a Python library for automating HEC-RAS 6.x. If you are an LLM
+agent building on this library, follow the cardinal rules below — they prevent
+the most common integration mistakes.
+
+## Cardinal rules
+
+1. **Static classes — do NOT instantiate.** `RasCmdr`, `RasPlan`, `RasGeo`,
+   `RasUtils`, and all `Hdf*` / `Geom*` classes are static namespaces. Call
+   `RasCmdr.compute_plan(...)`, never `RasCmdr().compute_plan(...)`.
+2. **`ras_object=` discipline.** There is a module-global `ras` object, but for
+   multi-project / multi-threaded work create a local project with
+   `ras = init_ras_project(folder, "6.6")` and pass `ras_object=ras` to every
+   API call (e.g. `HdfMesh.get_mesh_cell_points(plan, ras_object=ras)`).
+3. **DataFrame-first.** The project DataFrames are the single source of truth for
+   paths and metadata. Use them instead of globbing the project folder.
+4. **Use real example projects.** `RasExamples.extract_project(suffix="Muncie")`
+   downloads and extracts a real HEC-RAS project for testing — prefer these over
+   synthetic/mock data for domain validation.
+5. **Detect plan type before extracting results.** Call
+   `HdfResultsPlan.is_steady_plan(hdf_path)` first; steady and unsteady results
+   have different HDF structures.
+
+## The 7 project DataFrames
+
+After `ras = init_ras_project(folder, "6.6")`:
+
+- `ras.plan_df` — plans, HDF result paths, geometry/flow associations
+- `ras.geom_df` — geometry files and HDF preprocessor paths
+- `ras.flow_df` — steady flow files
+- `ras.unsteady_df` — unsteady flow files and configurations
+- `ras.boundaries_df` — boundary conditions (type, name, location)
+- `ras.results_df` — lightweight HDF results summaries
+- `ras.rasmap_df` — RASMapper layers, terrain, land cover paths
+
+## Minimal workflow
+
+```python
+from ras_commander import init_ras_project, RasExamples, RasCmdr
+from ras_commander.hdf import HdfResultsPlan
+
+project = RasExamples.extract_project(suffix="Muncie")
+ras = init_ras_project(project, "6.6")
+
+print(ras.plan_df[["plan_number", "Plan Title"]])     # inspect plans
+RasCmdr.compute_plan("01", ras_object=ras)            # run a plan
+
+hdf = ras.plan_df.loc[ras.plan_df["plan_number"] == "01", "HDF_Results_Path"].iloc[0]
+wse = HdfResultsPlan.get_wse(hdf, time_index=-1)       # extract results
+```
+
+## In-package helpers
+
+```python
+import ras_commander as r
+r.docs()              # https://rascommander.info
+r.docs("llms")        # https://rascommander.info/llms.txt
+r.docs("dataframes")  # the DataFrame Reference
+r.__llms_txt__        # canonical llms.txt URL
+r.agent_guide_path()  # path to this file on disk
+```
+
+## Canonical URLs
+
+- AI agent guide (machine-readable index): https://rascommander.info/llms.txt
+- DataFrame Reference (column tables): https://rascommander.info/reference/dataframe-reference/
+- LLM agents page: https://rascommander.info/development/llm-agents/
+- Full docs: https://rascommander.info
+- Source: https://github.com/gpt-cmdr/ras-commander

--- a/ras_commander/RasPlan.py
+++ b/ras_commander/RasPlan.py
@@ -407,7 +407,10 @@ class RasPlan:
         
         plan_file_path = RasPlan.get_plan_path(plan_number, ras_obj)
         if not plan_file_path:
-            raise FileNotFoundError(f"Plan file not found: {plan_number}")
+            raise FileNotFoundError(
+                f"Plan file not found: {plan_number}. "
+                f"See: https://rascommander.info/user-guide/plan-execution/"
+            )
         
         try:
             RasUtils.update_file(plan_file_path, RasPlan._update_steady_in_file, new_steady_flow_number)
@@ -472,7 +475,10 @@ class RasPlan:
         
         plan_file_path = RasPlan.get_plan_path(plan_number, ras_obj)
         if not plan_file_path:
-            raise FileNotFoundError(f"Plan file not found: {plan_number}")
+            raise FileNotFoundError(
+                f"Plan file not found: {plan_number}. "
+                f"See: https://rascommander.info/user-guide/plan-execution/"
+            )
         
         try:
             # Read the plan file
@@ -556,7 +562,10 @@ class RasPlan:
         
         plan_file_path = RasUtils.get_plan_path(plan_number, ras_obj)
         if not plan_file_path:
-            raise FileNotFoundError(f"Plan file not found: {plan_number}. Please provide a valid plan number or path.")
+            raise FileNotFoundError(
+                f"Plan file not found: {plan_number}. Please provide a valid plan number or path. "
+                f"See: https://rascommander.info/user-guide/plan-execution/"
+            )
         
         def update_num_cores(lines):
             updated_lines = []

--- a/ras_commander/RasPrj.py
+++ b/ras_commander/RasPrj.py
@@ -2101,11 +2101,17 @@ def init_ras_project(
         if input_path.suffix.lower() == '.prj':
             error_msg = f"The specified .prj file does not exist: {input_path}"
             logger.error(error_msg)
-            raise FileNotFoundError(f"{error_msg}. Please check the path and try again.")
+            raise FileNotFoundError(
+                f"{error_msg}. Please check the path and try again. "
+                f"See: https://rascommander.info/getting-started/project-initialization/"
+            )
         else:
             error_msg = f"The specified RAS project folder does not exist: {input_path}"
             logger.error(error_msg)
-            raise FileNotFoundError(f"{error_msg}. Please check the path and try again.")
+            raise FileNotFoundError(
+                f"{error_msg}. Please check the path and try again. "
+                f"See: https://rascommander.info/getting-started/project-initialization/"
+            )
 
     # Determine which RasPrj instance to use
     if ras_object is None:
@@ -2226,6 +2232,7 @@ def init_ras_project(
             "ras-commander | HEC-RAS Automation Library\n"
             "Docs: https://rascommander.info/\n"
             "Repo: https://github.com/gpt-cmdr/ras-commander\n"
+            "LLM agents: https://rascommander.info/llms.txt\n"
             "═══════════════════════════════════════════════════════════════════════\n"
             "\n"
             "PROJECT DATAFRAMES (single source of truth — use these, not file globbing):\n"

--- a/ras_commander/RasUtils.py
+++ b/ras_commander/RasUtils.py
@@ -435,7 +435,8 @@ class RasUtils:
         # Validate range (1-99 for HEC-RAS files)
         if not 1 <= ras_int <= 99:
             raise ValueError(
-                f"RAS file number must be between 1 and 99, got: {ras_int}"
+                f"RAS file number must be between 1 and 99, got: {ras_int}. "
+                f"See: https://rascommander.info/user-guide/plan-execution/"
             )
 
         # Return normalized two-digit format

--- a/ras_commander/__init__.py
+++ b/ras_commander/__init__.py
@@ -14,10 +14,39 @@ try:
     __version__ = version("ras-commander")
 except PackageNotFoundError:
     # package is not installed
-    __version__ = "0.98.1"
+    __version__ = "0.98.2"
+
+# Canonical machine-readable agent index (see docs() helper below)
+__llms_txt__ = "https://rascommander.info/llms.txt"
 
 # Set up logging
 setup_logging()
+
+
+def docs(topic=None):
+    """Return (and print) the rascommander.info URL for an optional topic.
+
+    No args -> docs home; topic='llms' -> llms.txt; topic='dataframes' ->
+    the DataFrame Reference; any other topic -> user-guide/<topic>/.
+    Designed for LLM agents to self-locate the documentation at runtime.
+    """
+    base = "https://rascommander.info"
+    if topic is None:
+        url = base
+    elif topic == "llms":
+        url = __llms_txt__
+    elif topic == "dataframes":
+        url = f"{base}/reference/dataframe-reference/"
+    else:
+        url = f"{base}/user-guide/{topic}/"
+    print(url)
+    return url
+
+
+def agent_guide_path():
+    """Return the filesystem path to the packaged LLM_GUIDE.md (offline agent quickstart)."""
+    from importlib.resources import files
+    return files("ras_commander").joinpath("LLM_GUIDE.md")
 
 # Core functionality
 from .RasPrj import RasPrj, init_ras_project, get_ras_exe, ras, create_project_from_template
@@ -245,6 +274,9 @@ __all__ = [
 
     # Utilities
     'get_logger', 'log_call', 'standardize_input',
+
+    # Documentation / LLM agent helpers
+    'docs', 'agent_guide_path',
 
     # Validation framework
     'ValidationSeverity', 'ValidationResult', 'ValidationReport',

--- a/ras_commander/__init__.py
+++ b/ras_commander/__init__.py
@@ -33,18 +33,39 @@ def docs(topic=None):
     base = "https://rascommander.info"
     if topic is None:
         url = base
-    elif topic == "llms":
-        url = __llms_txt__
-    elif topic == "dataframes":
-        url = f"{base}/reference/dataframe-reference/"
     else:
-        url = f"{base}/user-guide/{topic}/"
+        slug = str(topic).strip().strip("/")
+        if slug == "llms":
+            url = __llms_txt__
+        elif slug == "dataframes":
+            url = f"{base}/reference/dataframe-reference/"
+        elif not slug:
+            url = base
+        else:
+            url = f"{base}/user-guide/{slug}/"
     print(url)
     return url
 
 
+def agent_guide_text():
+    """Return the packaged LLM_GUIDE.md content (offline agent quickstart) as a string.
+
+    Importer-safe: works for both directory and zip/non-filesystem installs.
+    Prefer this over agent_guide_path() when you just need the guide text.
+    """
+    from importlib.resources import files
+    return files("ras_commander").joinpath("LLM_GUIDE.md").read_text(encoding="utf-8")
+
+
 def agent_guide_path():
-    """Return the filesystem path to the packaged LLM_GUIDE.md (offline agent quickstart)."""
+    """Return a Traversable for the packaged LLM_GUIDE.md (offline agent quickstart).
+
+    For normal (directory) pip and source installs this behaves like a filesystem
+    path (``str(agent_guide_path())`` is a real path). Under zip/non-filesystem
+    importers it is a ``Traversable`` that is not a real path -- read its content
+    with ``agent_guide_text()``, or materialize a real path with
+    ``importlib.resources.as_file()``.
+    """
     from importlib.resources import files
     return files("ras_commander").joinpath("LLM_GUIDE.md")
 
@@ -276,7 +297,7 @@ __all__ = [
     'get_logger', 'log_call', 'standardize_input',
 
     # Documentation / LLM agent helpers
-    'docs', 'agent_guide_path',
+    'docs', 'agent_guide_path', 'agent_guide_text',
 
     # Validation framework
     'ValidationSeverity', 'ValidationResult', 'ValidationReport',

--- a/ras_commander/hdf/HdfResultsPlan.py
+++ b/ras_commander/hdf/HdfResultsPlan.py
@@ -101,7 +101,10 @@ class HdfResultsPlan:
                 return pd.DataFrame(attrs_dict, index=[0])
                 
         except FileNotFoundError:
-            raise FileNotFoundError(f"HDF file not found: {hdf_path}")
+            raise FileNotFoundError(
+                f"HDF file not found: {hdf_path}. "
+                f"See: https://rascommander.info/user-guide/hdf-data-extraction/"
+            )
         except Exception as e:
             raise RuntimeError(f"Error reading unsteady attributes: {str(e)}")
         
@@ -140,7 +143,10 @@ class HdfResultsPlan:
                 return pd.DataFrame(attrs_dict, index=[0])
                 
         except FileNotFoundError:
-            raise FileNotFoundError(f"HDF file not found: {hdf_path}")
+            raise FileNotFoundError(
+                f"HDF file not found: {hdf_path}. "
+                f"See: https://rascommander.info/user-guide/hdf-data-extraction/"
+            )
         except Exception as e:
             raise RuntimeError(f"Error reading unsteady summary attributes: {str(e)}")
         
@@ -178,7 +184,10 @@ class HdfResultsPlan:
                 return pd.DataFrame(attrs_dict, index=[0])
                 
         except FileNotFoundError:
-            raise FileNotFoundError(f"HDF file not found: {hdf_path}")
+            raise FileNotFoundError(
+                f"HDF file not found: {hdf_path}. "
+                f"See: https://rascommander.info/user-guide/hdf-data-extraction/"
+            )
         except Exception as e:
             raise RuntimeError(f"Error reading volume accounting attributes: {str(e)}")
 
@@ -473,7 +482,10 @@ class HdfResultsPlan:
                 return profile_names
 
         except FileNotFoundError:
-            raise FileNotFoundError(f"HDF file not found: {hdf_path}")
+            raise FileNotFoundError(
+                f"HDF file not found: {hdf_path}. "
+                f"See: https://rascommander.info/user-guide/hdf-data-extraction/"
+            )
         except KeyError as e:
             raise KeyError(f"Error accessing steady state profile names: {str(e)}")
         except Exception as e:
@@ -624,7 +636,10 @@ class HdfResultsPlan:
                 return df
 
         except FileNotFoundError:
-            raise FileNotFoundError(f"HDF file not found: {hdf_path}")
+            raise FileNotFoundError(
+                f"HDF file not found: {hdf_path}. "
+                f"See: https://rascommander.info/user-guide/hdf-data-extraction/"
+            )
         except KeyError as e:
             raise KeyError(f"Error accessing steady state WSE data: {str(e)}")
         except Exception as e:
@@ -708,7 +723,10 @@ class HdfResultsPlan:
                 return pd.DataFrame(attrs_dict, index=[0])
 
         except FileNotFoundError:
-            raise FileNotFoundError(f"HDF file not found: {hdf_path}")
+            raise FileNotFoundError(
+                f"HDF file not found: {hdf_path}. "
+                f"See: https://rascommander.info/user-guide/hdf-data-extraction/"
+            )
         except KeyError as e:
             raise KeyError(f"Error accessing steady state info: {str(e)}")
         except Exception as e:

--- a/setup.py
+++ b/setup.py
@@ -34,11 +34,12 @@ class CustomBuildPy(build_py):
 
 setup(
     name="ras-commander",
-    version="0.98.1",
+    version="0.98.2",
     packages=find_packages(include=['ras_commander', 'ras_commander.*']),
     include_package_data=True,
     package_data={
         "ras_commander": [
+            "LLM_GUIDE.md",
             "resources/*.json",
             "resources/land_classification/*.hdf",
             "resources/templates/*/*",
@@ -55,6 +56,12 @@ setup(
     long_description=open('README.md').read(),
     long_description_content_type="text/markdown",
     url="https://github.com/gpt-cmdr/ras-commander",
+    project_urls={
+        "Documentation": "https://rascommander.info",
+        "AI Agent Guide": "https://rascommander.info/llms.txt",
+        "Changelog": "https://rascommander.info/development/release-notes/",
+        "Source": "https://github.com/gpt-cmdr/ras-commander",
+    },
     cmdclass={
         'build_py': CustomBuildPy,
     },

--- a/tests/test_docs_helper.py
+++ b/tests/test_docs_helper.py
@@ -1,0 +1,48 @@
+"""Tests for the docs()/agent_guide_path() discovery helpers and module constants.
+
+These exercise the LLM-agent discovery hooks added in 0.98.2: the docs() URL
+resolver, the __llms_txt__ constant, and the packaged LLM_GUIDE.md guide.
+"""
+
+import os
+
+import ras_commander
+
+
+def test_llms_txt_constant():
+    assert ras_commander.__llms_txt__ == "https://rascommander.info/llms.txt"
+
+
+def test_docs_base_url():
+    assert ras_commander.docs() == "https://rascommander.info"
+
+
+def test_docs_llms_topic():
+    assert ras_commander.docs("llms") == "https://rascommander.info/llms.txt"
+
+
+def test_docs_dataframes_topic():
+    assert ras_commander.docs("dataframes") == (
+        "https://rascommander.info/reference/dataframe-reference/"
+    )
+
+
+def test_docs_user_guide_topic():
+    assert ras_commander.docs("plan-execution") == (
+        "https://rascommander.info/user-guide/plan-execution/"
+    )
+
+
+def test_agent_guide_path_exists():
+    guide = ras_commander.agent_guide_path()
+    # importlib.resources Traversable -> resolvable filesystem path with content
+    text = guide.read_text(encoding="utf-8")
+    assert "ras-commander" in text
+    assert "rascommander.info/llms.txt" in text
+    # The on-disk file should exist (package data shipped in the wheel)
+    assert os.path.exists(str(guide))
+
+
+def test_docs_and_guide_exported():
+    assert "docs" in ras_commander.__all__
+    assert "agent_guide_path" in ras_commander.__all__

--- a/tests/test_docs_helper.py
+++ b/tests/test_docs_helper.py
@@ -43,6 +43,32 @@ def test_agent_guide_path_exists():
     assert os.path.exists(str(guide))
 
 
+def test_docs_topic_slash_normalization():
+    # Leading/trailing slashes must not produce double-slash URLs.
+    expected = "https://rascommander.info/user-guide/plan-execution/"
+    assert ras_commander.docs("/plan-execution") == expected
+    assert ras_commander.docs("plan-execution/") == expected
+    assert ras_commander.docs("/plan-execution/") == expected
+    # Empty/whitespace topic falls back to the docs home.
+    assert ras_commander.docs("/") == "https://rascommander.info"
+    assert ras_commander.docs("  ") == "https://rascommander.info"
+
+
+def test_docs_special_topics_with_slashes():
+    assert ras_commander.docs("/llms/") == "https://rascommander.info/llms.txt"
+    assert ras_commander.docs("dataframes/") == (
+        "https://rascommander.info/reference/dataframe-reference/"
+    )
+
+
+def test_agent_guide_text():
+    text = ras_commander.agent_guide_text()
+    assert isinstance(text, str)
+    assert "ras-commander" in text
+    assert "rascommander.info/llms.txt" in text
+
+
 def test_docs_and_guide_exported():
     assert "docs" in ras_commander.__all__
     assert "agent_guide_path" in ras_commander.__all__
+    assert "agent_guide_text" in ras_commander.__all__


### PR DESCRIPTION
Makes the installed pip package actively point LLM agents at the docs (Workstream 3). Bumps **0.98.1 → 0.98.2**.

- **`setup.py`** `project_urls` (Documentation, AI Agent Guide → llms.txt, Changelog, Source); ships **`ras_commander/LLM_GUIDE.md`** in the wheel (package_data + MANIFEST.in).
- **`ras_commander/__init__.py`**: `__llms_txt__` constant, `docs(topic=None)` URL helper, `agent_guide_path()` (importlib.resources), exported in `__all__`.
- **`RasPrj.py`** init banner: one line `LLM agents: https://rascommander.info/llms.txt`.
- **Error-message deep links** added to common exceptions (init/plan/HDF FileNotFoundError, invalid plan-number ValueError) → existing docs pages only (no 404s). 4 patterns / 12 raise sites.
- **`tests/test_docs_helper.py`** — 7 tests pass. `python -m build` confirms `LLM_GUIDE.md` ships + all Project-URLs in PKG-INFO.

🤖 Generated with [Claude Code](https://claude.com/claude-code)