### PR TITLE
docs(examples): backfill runtimes on 15 executed notebooks (N/A -> real)

### DIFF
--- a/examples/720_precipitation_methods_comprehensive.ipynb
+++ b/examples/720_precipitation_methods_comprehensive.ipynb
@@ -1744,6 +1744,7 @@
   }
  ],
  "metadata": {
+  "execution_runtime_seconds": 15.76,
   "kernelspec": {
    "display_name": "ras-commander-dev",
    "language": "python",

--- a/examples/725_atlas14_spatial_variance.ipynb
+++ b/examples/725_atlas14_spatial_variance.ipynb
@@ -997,6 +997,7 @@
   }
  ],
  "metadata": {
+  "execution_runtime_seconds": 75.27,
   "kernelspec": {
    "display_name": "ras-commander",
    "language": "python",

--- a/examples/800_quality_assurance_rascheck.ipynb
+++ b/examples/800_quality_assurance_rascheck.ipynb
@@ -1701,6 +1701,7 @@
   }
  ],
  "metadata": {
+  "execution_runtime_seconds": 16.52,
   "kernelspec": {
    "display_name": "rascmdr_piptest",
    "language": "python",

--- a/examples/900_aorc_precipitation.ipynb
+++ b/examples/900_aorc_precipitation.ipynb
@@ -2552,6 +2552,7 @@
   }
  ],
  "metadata": {
+  "execution_runtime_seconds": 11130.06,
   "kernelspec": {
    "display_name": "rascmdr_piptest",
    "language": "python",

--- a/examples/901_aorc_precipitation_catalog.ipynb
+++ b/examples/901_aorc_precipitation_catalog.ipynb
@@ -1686,6 +1686,7 @@
   }
  ],
  "metadata": {
+  "execution_runtime_seconds": 89.23,
   "kernelspec": {
    "display_name": "rascmdr_piptest",
    "language": "python",

--- a/examples/910_usgs_gauge_catalog.ipynb
+++ b/examples/910_usgs_gauge_catalog.ipynb
@@ -2516,6 +2516,7 @@
   }
  ],
  "metadata": {
+  "execution_runtime_seconds": 439.55,
   "kernelspec": {
    "display_name": "rascmdr_local",
    "language": "python",

--- a/examples/911_usgs_gauge_data_integration.ipynb
+++ b/examples/911_usgs_gauge_data_integration.ipynb
@@ -4185,6 +4185,7 @@
   }
  ],
  "metadata": {
+  "execution_runtime_seconds": 31.98,
   "kernelspec": {
    "display_name": "rascmdr_piptest",
    "language": "python",

--- a/examples/912_usgs_real_time_monitoring.ipynb
+++ b/examples/912_usgs_real_time_monitoring.ipynb
@@ -1143,6 +1143,7 @@
   }
  ],
  "metadata": {
+  "execution_runtime_seconds": 165.82,
   "kernelspec": {
    "display_name": "rascmdr_local",
    "language": "python",

--- a/examples/914_historical_event_validation.ipynb
+++ b/examples/914_historical_event_validation.ipynb
@@ -1768,6 +1768,7 @@
   }
  ],
  "metadata": {
+  "execution_runtime_seconds": 35.34,
   "kernelspec": {
    "display_name": "rascmdr_local",
    "language": "python",

--- a/examples/916_hrrr_precipitation_forecast.ipynb
+++ b/examples/916_hrrr_precipitation_forecast.ipynb
@@ -591,6 +591,7 @@
   }
  ],
  "metadata": {
+  "execution_runtime_seconds": 338.86,
   "kernelspec": {
    "display_name": "rascmdr_local",
    "language": "python",

--- a/examples/918_hms_ras_coupled_forecast.ipynb
+++ b/examples/918_hms_ras_coupled_forecast.ipynb
@@ -672,6 +672,7 @@
   }
  ],
  "metadata": {
+  "execution_runtime_seconds": 10.78,
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",

--- a/examples/919_operational_forecast_cycling.ipynb
+++ b/examples/919_operational_forecast_cycling.ipynb
@@ -567,6 +567,7 @@
   }
  ],
  "metadata": {
+  "execution_runtime_seconds": 11.85,
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",

--- a/examples/921_usgs_study_package_from_primitives.ipynb
+++ b/examples/921_usgs_study_package_from_primitives.ipynb
@@ -583,6 +583,7 @@
   }
  ],
  "metadata": {
+  "execution_runtime_seconds": 13.27,
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",

--- a/examples/922_model_validation_with_usgs.ipynb
+++ b/examples/922_model_validation_with_usgs.ipynb
@@ -848,6 +848,7 @@
   }
  ],
  "metadata": {
+  "execution_runtime_seconds": 108.56,
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",

--- a/examples/930_terrain_modification_analysis.ipynb
+++ b/examples/930_terrain_modification_analysis.ipynb
@@ -492,6 +492,7 @@
   }
  ],
  "metadata": {
+  "execution_runtime_seconds": 15.27,
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",


### PR DESCRIPTION
Companion to #215 (runtime parser). Backfills `metadata.execution_runtime_seconds` from the Symphony runner's recorded total wall time (artifact terminal-log `# Duration`) for 15 already-executed notebooks that showed **N/A** in the [examples index](https://rascommander.info/examples/) because `nbconvert --execute` did not emit per-cell timing.

One-line metadata insert per file — no output or code-cell changes. Index with-runtime coverage **65 → 93** of 119.

Stamped: 720, 725, 800, 900, 901, 910, 911, 912, 914, 916, 918, 919, 921, 922, 930.

Going forward the runner stamps this field itself (record_timing + total-wall stamp, deployed to CLB01/CLB02), so new executions populate it natively.

🤖 Generated with [Claude Code](https://claude.com/claude-code)