### PR TITLE
Read/author 2D SA/2D connection culverts (GeomLateral)

### DIFF
--- a/examples/227_2d_connection_culvert_authoring.ipynb
+++ b/examples/227_2d_connection_culvert_authoring.ipynb
@@ -1,0 +1,730 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "d20ac577",
+   "metadata": {},
+   "source": [
+    "# Authoring a 2D Connection Culvert (`Connection Culv=`)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "09a3cdbe",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-12T12:32:42.023712Z",
+     "iopub.status.busy": "2026-06-12T12:32:42.023712Z",
+     "iopub.status.idle": "2026-06-12T12:32:42.032030Z",
+     "shell.execute_reply": "2026-06-12T12:32:42.032030Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "#!pip install --upgrade ras-commander"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4e34b994",
+   "metadata": {},
+   "source": [
+    "## Development Mode\n",
+    "\n",
+    "Set `USE_LOCAL_SOURCE = True` when running from a local ras-commander checkout."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "54dde8ba",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-12T12:32:42.034089Z",
+     "iopub.status.busy": "2026-06-12T12:32:42.034089Z",
+     "iopub.status.idle": "2026-06-12T12:32:44.021479Z",
+     "shell.execute_reply": "2026-06-12T12:32:44.021479Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "PIP PACKAGE MODE\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "c:\\Users\\bill\\anaconda3\\envs\\rascommander\\Lib\\site-packages\\tqdm\\auto.py:21: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html\n",
+      "  from .autonotebook import tqdm as notebook_tqdm\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Loaded: G:\\GH\\ras-commander-wt-culvauth\\ras_commander\\__init__.py\n"
+     ]
+    }
+   ],
+   "source": [
+    "USE_LOCAL_SOURCE = False\n",
+    "if USE_LOCAL_SOURCE:\n",
+    "    import sys\n",
+    "    from pathlib import Path\n",
+    "    cwd = Path.cwd()\n",
+    "    local_path = cwd if (cwd / \"ras_commander\").exists() else cwd.parent\n",
+    "    if str(local_path) not in sys.path:\n",
+    "        sys.path.insert(0, str(local_path))\n",
+    "    print(f\"LOCAL SOURCE MODE: {local_path / 'ras_commander'}\")\n",
+    "else:\n",
+    "    print(\"PIP PACKAGE MODE\")\n",
+    "\n",
+    "import logging\n",
+    "import math\n",
+    "import os\n",
+    "import warnings\n",
+    "from pathlib import Path\n",
+    "\n",
+    "import geopandas as gpd\n",
+    "import matplotlib.pyplot as plt\n",
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "from IPython.display import display\n",
+    "from shapely.geometry import LineString, Point\n",
+    "\n",
+    "from ras_commander import HdfResultsPlan, RasCmdr, RasExamples, RasPrj, init_ras_project\n",
+    "from ras_commander.geom import GeomLateral, GeomCulvertGIS\n",
+    "from ras_commander.hdf import HdfMesh\n",
+    "\n",
+    "warnings.filterwarnings(\"ignore\", category=FutureWarning)\n",
+    "logging.getLogger(\"ras_commander\").setLevel(logging.CRITICAL)\n",
+    "pd.set_option(\"display.max_columns\", None); pd.set_option(\"display.width\", 200)\n",
+    "\n",
+    "import ras_commander\n",
+    "print(f\"Loaded: {ras_commander.__file__}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "519556e6",
+   "metadata": {},
+   "source": [
+    "# Authoring a 2D connection culvert\n",
+    "\n",
+    "A culvert through an embankment in a 2D model is placed on a **SA/2D connection**.\n",
+    "Unlike a 1D inline culvert (whose barrel line is *derived*), a 2D connection culvert\n",
+    "**stores explicit per-barrel GIS endpoint coordinates** in the geometry -- a\n",
+    "`Connection Culv=` record followed by one `Conn Culvert Barrel=` + packed\n",
+    "`US_x US_y DS_x DS_y` line per barrel (verified against production LWI 2D models).\n",
+    "\n",
+    "`GeomLateral.set_connection_culverts()` writes that record; `get_connection_culverts()`\n",
+    "reads it back. This notebook authors a retrofit culvert onto BaldEagle's **Lower\n",
+    "Levee** connection, validates it, and (in a separate run) confirms HEC-RAS computes it."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6dc25c31",
+   "metadata": {},
+   "source": [
+    "## Load the model -- the connection starts weir-only"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "d2823770",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-12T12:32:44.021479Z",
+     "iopub.status.busy": "2026-06-12T12:32:44.021479Z",
+     "iopub.status.idle": "2026-06-12T12:32:45.456835Z",
+     "shell.execute_reply": "2026-06-12T12:32:45.456266Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>Name</th>\n",
+       "      <th>Type</th>\n",
+       "      <th>HasGate</th>\n",
+       "      <th>HasCulvert</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>Dam</td>\n",
+       "      <td>SA to 2D</td>\n",
+       "      <td>True</td>\n",
+       "      <td>False</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>Lower Levee</td>\n",
+       "      <td>2D to 2D</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>Middle Levee</td>\n",
+       "      <td>2D to 2D</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>Upper Levee</td>\n",
+       "      <td>2D to 2D</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "           Name      Type  HasGate  HasCulvert\n",
+       "0           Dam  SA to 2D     True       False\n",
+       "1   Lower Levee  2D to 2D    False       False\n",
+       "2  Middle Levee  2D to 2D    False       False\n",
+       "3   Upper Levee  2D to 2D    False       False"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "existing culverts on Lower Levee : 0\n"
+     ]
+    }
+   ],
+   "source": [
+    "WORK = Path(os.environ.get(\"RAS_COMMANDER_WORKDIR\",\n",
+    "            (Path.cwd() if (Path.cwd() / \"ras_commander\").exists() else Path.cwd().parent)\n",
+    "            / \"working\" / \"conn_culvert_authoring\"))\n",
+    "WORK.mkdir(parents=True, exist_ok=True)\n",
+    "\n",
+    "# This notebook authors + validates geometry (no HEC-RAS compute -- see the\n",
+    "# HEC-RAS acceptance section). It needs the example data + rasterio, not Ras.exe.\n",
+    "project_path = Path(RasExamples.extract_project(\"BaldEagleCrkMulti2D\", output_path=WORK, suffix=\"culvauth\"))\n",
+    "GEOM = project_path / \"BaldEagleDamBrk.g01\"\n",
+    "GEOM_HDF = project_path / \"BaldEagleDamBrk.g01.hdf\"\n",
+    "CONN = \"Lower Levee\"\n",
+    "\n",
+    "conns = GeomLateral.get_connections(GEOM)\n",
+    "display(conns[[\"Name\", \"Type\", \"HasGate\", \"HasCulvert\"]])\n",
+    "print(\"existing culverts on\", CONN, \":\", len(GeomLateral.get_connection_culverts(GEOM, CONN)))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f34b9b6f",
+   "metadata": {},
+   "source": [
+    "## Reason a retrofit culvert\n",
+    "\n",
+    "We place the culvert at the **lowest terrain point along the connection** (where\n",
+    "flow concentrates), run the barrel **perpendicular** through the embankment, and\n",
+    "set the inverts **just above each barrel-end cell's terrain minimum** (using the\n",
+    "terrain cell-min check from notebook 226). The two GIS endpoints define the barrel."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "aefa86b4",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-12T12:32:45.458564Z",
+     "iopub.status.busy": "2026-06-12T12:32:45.458564Z",
+     "iopub.status.idle": "2026-06-12T12:32:54.932699Z",
+     "shell.execute_reply": "2026-06-12T12:32:54.932699Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "crossing at terrain low 536.09 ft (arc 7114 ft)\n",
+      "barrel US=(2055956.2, 353790.6) inv 539.56  DS=(2055952.0, 353730.8) inv 539.06\n"
+     ]
+    }
+   ],
+   "source": [
+    "line = GeomLateral.get_connection_line_coords(GEOM, CONN)\n",
+    "conn_ls = LineString(line[[\"X\", \"Y\"]].to_numpy())\n",
+    "\n",
+    "# lowest terrain point along the connection\n",
+    "samples = [(p.x, p.y) for p in\n",
+    "           (conn_ls.interpolate(d, normalized=True) for d in np.linspace(0.15, 0.85, 15))]\n",
+    "sc = GeomCulvertGIS.mesh_cell_min_from_terrain(GEOM_HDF, samples)\n",
+    "sc = sc[sc[\"cell_terrain_min\"].notna()]\n",
+    "low = sc.loc[sc[\"cell_terrain_min\"].idxmin()]\n",
+    "cx, cy = float(low[\"x\"]), float(low[\"y\"])\n",
+    "arc = conn_ls.project(Point(cx, cy))\n",
+    "\n",
+    "# barrel perpendicular to the connection, length L -> US/DS endpoints\n",
+    "LENGTH, SPAN, RISE = 60.0, 8.0, 6.0\n",
+    "pb, pf = conn_ls.interpolate(max(arc - 5, 0)), conn_ls.interpolate(min(arc + 5, conn_ls.length))\n",
+    "tx, ty = pf.x - pb.x, pf.y - pb.y\n",
+    "tl = math.hypot(tx, ty) or 1.0\n",
+    "perp = (-ty / tl, tx / tl)\n",
+    "us_xy = (cx - LENGTH / 2 * perp[0], cy - LENGTH / 2 * perp[1])\n",
+    "ds_xy = (cx + LENGTH / 2 * perp[0], cy + LENGTH / 2 * perp[1])\n",
+    "\n",
+    "# inverts above each end cell's terrain minimum, mild slope\n",
+    "ends = GeomCulvertGIS.mesh_cell_min_from_terrain(GEOM_HDF, [us_xy, ds_xy])\n",
+    "us_inv = round(float(ends[\"cell_terrain_min\"].max()) + 0.5, 2)\n",
+    "ds_inv = round(us_inv - 0.5, 2)\n",
+    "print(f\"crossing at terrain low {low['cell_terrain_min']:.2f} ft (arc {arc:.0f} ft)\")\n",
+    "print(f\"barrel US={tuple(round(v,1) for v in us_xy)} inv {us_inv}  \"\n",
+    "      f\"DS={tuple(round(v,1) for v in ds_xy)} inv {ds_inv}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4c51d603",
+   "metadata": {},
+   "source": [
+    "## Author it with `set_connection_culverts`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "469bc059",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-12T12:32:54.932699Z",
+     "iopub.status.busy": "2026-06-12T12:32:54.932699Z",
+     "iopub.status.idle": "2026-06-12T12:32:55.009594Z",
+     "shell.execute_reply": "2026-06-12T12:32:55.009594Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'culverts_written': 1, 'barrels_written': 1, 'backup_path': 'G:\\\\GH\\\\ras-commander-wt-culvauth\\\\working\\\\conn_culvert_authoring\\\\BaldEagleCrkMulti2D_culvauth\\\\BaldEagleDamBrk.g01.bak', 'length_warnings': []}\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>CulvertName</th>\n",
+       "      <th>ShapeName</th>\n",
+       "      <th>Span</th>\n",
+       "      <th>Rise</th>\n",
+       "      <th>Length</th>\n",
+       "      <th>EntranceLoss</th>\n",
+       "      <th>NumBarrels</th>\n",
+       "      <th>BarrelName</th>\n",
+       "      <th>us_x</th>\n",
+       "      <th>us_y</th>\n",
+       "      <th>ds_x</th>\n",
+       "      <th>ds_y</th>\n",
+       "      <th>UpstreamInvert</th>\n",
+       "      <th>DownstreamInvert</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>Retrofit Cul</td>\n",
+       "      <td>Box</td>\n",
+       "      <td>8.0</td>\n",
+       "      <td>6.0</td>\n",
+       "      <td>60.0</td>\n",
+       "      <td>0.5</td>\n",
+       "      <td>1</td>\n",
+       "      <td>8x6 RCB</td>\n",
+       "      <td>2.055956e+06</td>\n",
+       "      <td>353790.630305</td>\n",
+       "      <td>2.055952e+06</td>\n",
+       "      <td>353730.780417</td>\n",
+       "      <td>539.56</td>\n",
+       "      <td>539.06</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "    CulvertName ShapeName  Span  Rise  Length  EntranceLoss  NumBarrels BarrelName          us_x           us_y          ds_x           ds_y  UpstreamInvert  DownstreamInvert\n",
+       "0  Retrofit Cul       Box   8.0   6.0    60.0           0.5           1    8x6 RCB  2.055956e+06  353790.630305  2.055952e+06  353730.780417          539.56            539.06"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "culvert = {\n",
+    "    \"Shape\": 2, \"Span\": SPAN, \"Rise\": RISE, \"Length\": LENGTH, \"ManningsN\": 0.024,\n",
+    "    \"EntranceLoss\": 0.5, \"ExitLoss\": 1.0, \"Chart\": 8, \"Scale\": 1,\n",
+    "    \"UpstreamInvert\": us_inv, \"DownstreamInvert\": ds_inv, \"Name\": \"Retrofit Culv\",\n",
+    "    \"barrels\": [{\"name\": \"8x6 RCB\", \"us_xy\": us_xy, \"ds_xy\": ds_xy}],\n",
+    "}\n",
+    "result = GeomLateral.set_connection_culverts(GEOM, CONN, [culvert])\n",
+    "print(result)\n",
+    "\n",
+    "authored = GeomLateral.get_connection_culverts(GEOM, CONN)\n",
+    "display(authored[[\"CulvertName\", \"ShapeName\", \"Span\", \"Rise\", \"Length\", \"EntranceLoss\",\n",
+    "                  \"NumBarrels\", \"BarrelName\", \"us_x\", \"us_y\", \"ds_x\", \"ds_y\",\n",
+    "                  \"UpstreamInvert\", \"DownstreamInvert\"]])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "802f9850",
+   "metadata": {},
+   "source": [
+    "## Validate\n",
+    "\n",
+    "A 2D connection culvert **stores** its barrel endpoints, so the HEC-RAS +/-1%\n",
+    "GIS-length rule is exact (endpoint distance vs entered `Length`). Inverts are\n",
+    "checked against the terrain minimum of each barrel-end mesh cell."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "b5f4fd41",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-12T12:32:55.009594Z",
+     "iopub.status.busy": "2026-06-12T12:32:55.009594Z",
+     "iopub.status.idle": "2026-06-12T12:32:59.542026Z",
+     "shell.execute_reply": "2026-06-12T12:32:59.542026Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "barrel GIS length 60.00 ft vs entered 60.0 ft -> 0.00%  (PASS the +/-1% rule)\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>point</th>\n",
+       "      <th>cell_id</th>\n",
+       "      <th>cell_terrain_min</th>\n",
+       "      <th>invert</th>\n",
+       "      <th>status</th>\n",
+       "      <th>detail</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>0</td>\n",
+       "      <td>86257</td>\n",
+       "      <td>536.09375</td>\n",
+       "      <td>539.56</td>\n",
+       "      <td>PASS</td>\n",
+       "      <td>invert 539.56 &gt;= cell terrain min 536.09</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>1</td>\n",
+       "      <td>86256</td>\n",
+       "      <td>539.06250</td>\n",
+       "      <td>539.06</td>\n",
+       "      <td>PASS</td>\n",
+       "      <td>invert 539.06 &gt;= cell terrain min 539.06</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   point  cell_id  cell_terrain_min  invert status                                    detail\n",
+       "0      0    86257         536.09375  539.56   PASS  invert 539.56 >= cell terrain min 536.09\n",
+       "1      1    86256         539.06250  539.06   PASS  invert 539.06 >= cell terrain min 539.06"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "row = authored.iloc[0]\n",
+    "gis_len = math.dist((row[\"us_x\"], row[\"us_y\"]), (row[\"ds_x\"], row[\"ds_y\"]))\n",
+    "err = abs(gis_len - row[\"Length\"]) / row[\"Length\"] * 100\n",
+    "print(f\"barrel GIS length {gis_len:.2f} ft vs entered {row['Length']:.1f} ft \"\n",
+    "      f\"-> {err:.2f}%  ({'PASS' if err <= 1.0 else 'FAIL'} the +/-1% rule)\")\n",
+    "\n",
+    "inv_rep = GeomCulvertGIS.validate_2d_inverts(\n",
+    "    GEOM_HDF, [(row[\"us_x\"], row[\"us_y\"]), (row[\"ds_x\"], row[\"ds_y\"])],\n",
+    "    [row[\"UpstreamInvert\"], row[\"DownstreamInvert\"]])\n",
+    "display(inv_rep[[\"point\", \"cell_id\", \"cell_terrain_min\", \"invert\", \"status\", \"detail\"]])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0ff520ac",
+   "metadata": {},
+   "source": [
+    "## HEC-RAS acceptance\n",
+    "\n",
+    "The authored culvert is a real geometry edit. Computing the 2D plan (`g01`, with\n",
+    "full geometry reprocessing via `force_geompre=True`) confirms HEC-RAS accepts it:\n",
+    "\n",
+    "```python\n",
+    "ras = RasPrj()\n",
+    "init_ras_project(project_path / \"BaldEagleDamBrk.prj\", str(RAS_EXE), ras_object=ras)\n",
+    "ok = RasCmdr.compute_plan(\"02\", ras_object=ras, force_geompre=True,\n",
+    "                          force_rerun=True, num_cores=2, verify=True)\n",
+    "```\n",
+    "\n",
+    "When this was run separately (kept out of the notebook to avoid a multi-minute 2D\n",
+    "breach sim), the same `set_connection_culverts` authoring step on this connection\n",
+    "produced **`ComputeResult(SUCCESS)` with no `data_errors` file**, and the geometry\n",
+    "preprocessor rebuilt the connection including the new culvert -- so the authored\n",
+    "`Connection Culv=` record is a valid, computable structure. (The library's\n",
+    "round-trip tests and the `Connection Culv=` format are also validated against\n",
+    "production 2D models in the test suite.)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f623d6cb",
+   "metadata": {},
+   "source": [
+    "## Plan view: the authored barrel on the connection"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "5f4122e3",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-12T12:32:59.542026Z",
+     "iopub.status.busy": "2026-06-12T12:32:59.542026Z",
+     "iopub.status.idle": "2026-06-12T12:33:04.341397Z",
+     "shell.execute_reply": "2026-06-12T12:33:04.341397Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAqIAAAKyCAYAAAAO17xoAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjgsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvwVt1zgAAAAlwSFlzAAAPYQAAD2EBqD+naQAArbNJREFUeJztvQecFEX6/1+7LLAgWVBAFHMOeJhzxnCG0/vqqWcOZ8B4xjOdOYvomXM+I4YziznnfOYAklGSZNj5v971u5p/7zCzO7M70zVd/Xm/Xs0yMz3TXV3dVZ966nmeqslkMhkjhBBCCCFEzNTGfUAhhBBCCCFAQlQIIYQQQnhBQlQIIYQQQnhBQlQIIYQQQnhBQlQIIYQQQnhBQlQIIYQQQnhBQlQIIYQQQnhBQlQIIYQQQnhBQlQIIYQQQnhBQlQkkp9++snU1NSYyy67zCSBzTbbzG5J5/fffzcHH3yw6d27t73+xx57bLYubr/9dlMNVNv5VDv//Oc/7fWaOHGi71MRomp5+eWX7XPCX1FeJERF2bn22mvtA7vuuuu2+reeeuop21GK4hg9erS9Xh9//HFFLtkFF1xgBd7hhx9u7rrrLrPPPvvk3S/N9VatZafuHn30UW/H576hXXj//fdNqCLloYce8n0qogz9lwax8SIhKsrOPffcY5Zccknz7rvvmu+++67VnfrZZ59dtnNLgxDlelVKiL744otmvfXWM2eddZb561//agYOHGj69+9vZs6c2UiUprneqrXsvoWoEEkWoptssolt5/gryouEqCgrP/74o3nzzTfNFVdcYXr16mVFaZKZPn261+M3NDSYWbNmVez3Z8yYUdL+48ePN926dWv0Hpag+vp606ZNG5NmfN8rorKoftNNbW2tbef4K8qLrqgoKwjP7t27mx122MH8+c9/zitEC/na5Pr27b///uaaa66x/+d9t+Vy4403mmWWWca0b9/erL322ua9997La8nbeOONzUILLWSF1M4772z++9//5vWV+/LLL81ee+1ly7HRRhtlP7/77rutBbBDhw6mR48e5i9/+YsZOXJkwfNhv3XWWce89tprRV8/jj948GB73VZZZRVbpmeeecZ+NmrUKHPggQeaRRdd1L7P57feemuj60r54YADDsheL3c98VFdddVVzQcffGBH9R07djT/+Mc/sgLzoIMOsr9NY7vGGmuYO+64o9Fv81sMNJ588snsb1NnLa23XJ5++mmz6aabms6dO5suXbrYstx7773Zz7Gy89ul+t/iR8zxf/755wU+O/XUU027du3MpEmTsu+98847ZttttzVdu3a114hzeuONN4q6V1padqwwrr779u1rjjzySDN58uQFykn9cczNN9/cnttiiy1mLrnkkmZ/n3NASFGn7pxyryXH4z2eD8rOPZRvoFLsc9BSPvroI7PddtvZe6BTp05myy23NG+//Xaj82TQc9VVV2Xfw78VgbDwwgubTCaTfR8XEvyZo7SmflsL545f9eKLL27retlllzUXX3yxHXDC3Llz7TXl2ucydepU+2yecMIJ2fdmz55tZyf4HX6P3z3ppJPs++WsN9oe2gfuTY6z1FJL2Ws7Z86c7D4//PCD+b//+z/721xXZk5oK6K4duSBBx4w559/vunXr58tE3WcO3tWyv1e6nWgXeb3qFfawueeey7bxnzxxRfmlVdeyT4nrm0p1G89+OCD2evas2dPO1PE9YrCc8W9zPu77LKL/T+GGupy/vz5RdVB0GSEKCMrrrhi5qCDDrL/f/XVV+kRMu+++26jfV566SX7Pn+j/Pjjj/b92267zb5+8803M1tvvbV976677spu0X3XXHPNzLLLLpu5+OKLM5dcckmmZ8+emX79+mXmzJmT/d3nn38+U1dXl1l++eXtPmeffbbdr3v37vZ3HGeddZb9zZVXXjmz8847Z6699trMNddcYz8777zzMjU1NZk99tjDvu9+Y8kll8xMmjQp+xs333yz/Y0NNtggc9VVV2WOPfbYTLdu3TJLL710ZtNNN232+vHdlVZaKdOrVy97DI7/0UcfZcaOHWvLtfjii2fOOeeczHXXXZfZaaed7P5Dhgyx32UfPuO9Qw89NHu9vv/+e/s5x+/du7f97aOOOipzww03ZB599NHMjBkz7DHbtm2bOe644+x5b7zxxvZ3rrzyyuxv81uUecCAAdnf/v3330uqt0LwXa7vqquumjn//PNtuQ8++ODMPvvsk92nf//+mf3222+B71Ku6LXNPZ+ff/7Z/jZ1nwv1ssMOO2RfDx8+PNOuXbvM+uuvn7n88svttV199dXte++8806z90pLyu5+a6uttspcffXVmcGDB2fatGmTWXvttRvdx5Sxb9++9h445phj7DG32GIL+92nnnqqyWNwDu3bt7f16s6Jc40en2dp1113tb/Ltee9k046qdHvFPsc5IP64Dffe++9gvt8/vnnmYUWWijTp0+fzLnnnpu56KKLMksttZQ997fffju7H3Wy2267ZV8PGzYsU1tba3+f33CsssoqmT//+c9lq99CuDbtwQcfLLjP9OnT7bEWXnjhzD/+8Y/M9ddfn9l3333t9aQ+HQceeKBtM2bPnt3o+3fccUej6zd//vzMNttsk+nYsaNtZ3ieuXdo6zjnctXbqFGj7H3njsN5n3HGGbbNcN+lfVh00UUznTt3zpx22mmZK664IrPGGmvYOnnkkUcWuE7cawMHDrTX/5///Kf97XXWWafRcYu930u5DhzLtc+XXnppZujQoZm99torc/LJJ2fvI9pZ+jH3nDz33HMF+y13T/OsUpZTTjkl06FDhwWuK+1WfX29vR+pX9pv7l++e+2112bSjoSoKBvvv/++fbAQftDQ0GAf6mgjW4oQhSOPPNK+l4vbl0b9t99+y77/2GOP2fefeOKJ7HsIp0UWWSTz66+/Zt/75JNPbCNJR5Db+ey5556NjvXTTz9ZYYBAivLZZ5/Zxs69j2jgOBwv2onceOON9neLFaKc1xdffNHofcQ9nfPEiRMbvf+Xv/wl07VrVysmgU4q9xo6OD6f0ZFEQWzy/t133519j7LQWXfq1CkzderURmIwKtxKrbd8TJ482XZg6667bmbmzJmNPuMeaq0QBcpCxxeFARL73XnnndljLbfccplBgwY1Oi7XFjGEwGzuXim17OPHj7ciiI6UDtXxr3/9y/7Grbfe2qic0fMF7jMGF1FRVggEXr7r58pCBxnlT3/6k32+Sn0OWiNEd9llF3s93OAJRo8ebe+PTTbZpNE1Rvg4jj/+ePs5zx+dPPC8I74QG+Ws35YKUYQ1dfDNN980eh/xwnUdMWKEff3ss88u0IbB9ttvbwdODkQSbcVrr73WaD+eb77/xhtvlKXeaCM5Tr56c9cRAcgxo+cybdo0e10RZe7edtcJERttI6kj3uecSr3fi70O3377rd2P+zr6rEXLAYjFfG11br/l2nsGz9F26z//+Y/d78wzz8y+x3PHexgKojhBnnY0NS/KBtPJTO0yjQJMY+yxxx7m3//+d8WmH/h9plccTL+7aSIYM2aMDdxhaoQpI8fqq69utt56axtYksthhx3W6PUjjzxip8523313OwXoNqb8lltuOfPSSy/Z/YgGZoqb7zPd6+DYTAMWC1OFK6+8cvY1+vThhx82O+64o/1/9BwGDRpkpkyZYj788MOifptpq9xpP64BZdlzzz2z77Vt29YcffTRNl0T01SV5PnnnzfTpk0zp5xyip2mi1LMtHax9wkuCd9//332vfvvv99eD9w0gPvk22+/tVOxv/76a/YaM6XN1OGrr76anUItdK+UygsvvGCnN5mujfqeHXLIIXZqOndqkyk9pv4c3GdMM7r7vTXkloVnievAlHApz0FLoY1gipSpy6WXXjr7fp8+fWydvP7669lz4dzGjRtnvv76a/sa9xemWHnfucKwP8+LaxN81G/uFC7nQnsVvX5bbbWVLTvHhy222MJO8XJ/OnAd4TnhPo7+3korrWRWXHHFRr/H98HVR2vqje8R4Ebbs9Zaay3wuXs+aUO4D6PuC9yrhx56qHXdYXo9Cm1QtI3MbbdLud+LvQ6Ug/KceeaZC/h5tqSdce39EUcc0ajdwi2Nc8l9dgs9Yz+U4dlNOnW+T0CEAQ0pghMRih+hgxROl19+uRk+fLjZZpttyn7cJZZYotFrJ0qdz5/zC1xhhRUW+C6N17PPPms7InxHHfg/RaHzokOj0c4Hoi16rNz9+DzasTZH7vEnTJhgfcvwPWXLBw1iMeBjFe0A3HlzzrmNM9fHfV5JnDjEH6xS4Lt2/PHH284dv1jqkw7M+SK6eob99tuv4O8g+qMDn9y6KpVC9yd1xD2Te+3xqcvtNDmfTz/91FTyWeIaFfsctBTuc3xSCz2riAh8GvGldcIF0ck1wa/0vPPOs353Lrcwn3He+Dv7qt8oHJ964hybeobr6urMbrvtZv2j8XFksISYxH80KkT5Pfzcm/u91tQbdYL4b+7Z5D7Nl64v2oZEf6O5druU+73Y60A7QxsXHeS3hqb6FoQoA6EoiNXcc6Qsk3LKnEYkREVZIBgI6yNilC2ftdQJ0UKjz5ZYTQtFakcDFkoFp/ModICcM8E0+Y7HqL2c5Ds+YBko1Ili4W3JbyeJpu6b5iL2CbJAvBAkgRAl+GXEiBE2UCT3Ol966aVmwIABeX8nt67jvp6VuN+L/e24n4Pm6hORiBWRABPOcf3117cd/THHHGNFAkJ0gw02yA6wfNcvx2cWhiCafCy//PLZ/xNIdMMNN9hrjYWY+xZx40S1+73VVlvNZijJBwE71VZvpd7HxexX7HXwTdqzijSFhKgoCwjNRRZZJBsxHIXR/LBhw8z1119vG3Y3+s2NCs5neWvt1Cw5LsFN4UX56quv7BRY1BqaDyLgafjo+KKdRaFjMUJ300KAJQMrcbQTKQU6VyLJEVxM4zVFS64X542FgQY9ahXl+rjPS6WU8+D6wueff26jXgvBfZN7z7j7phiLM9YkptG4F7CMEjXLlGPueWBFa+46l6vs0fszWgam67lnWnMerTmv1jwHLYX7nDop9Kxyb0ZFBQMLhCjng7DkGeEZww2GTBO4q0TzuZarflsKx8fVpZhj42aASwL3KdPdDPRPO+20BX7vk08+sW4FTdVta+qNOuF68Ww2dx8Xqjf3eaUo5TrQxuEmUGggUspzEn12o+29e6+SZQ4N+YiKVkOSX8TmH//4R5uyKXcjHRE+gI8//rjdnweU0aHziYqmsMnFicR8AqQYaMxpdEhbE/0NGlb80bbffvtmf2PXXXe150unljti5zX+ZoAPFQ03gjua1oS0Ri09f+DYTNXhJ5qvQ2D6rDXXi2swduzYRj5p8+bNM1dffbW1luCzWiqlnAeWckTEhRdeuEDO1Oj1piPBkhm9tv/5z3+KTkHDNeRa3nfffXZanvs1OgghBQvHYGoXwdDUdS5X2RElTMOTiiha1ltuucVOE+NvVi44r9bch8U+By2F3+ZeeOyxx6xfoQNfUKapEWTOjcIJUfbjvnVT9YhVrKBYxxgAuvfLWb8tBR/Nt956y7oD5UK98Mw5KAdt5xNPPGFXMOOz6LS8+z3SAd10001522SX97Q19cZ5YJHlPPKtiOV+jzaEBUwon4Pj40qExbpc0+H5KPY6UA7Kc8455yzgCxy9LsU+J7T3GF9o76NporA84ypQzmc3dGQRFa0GgYnQ3GmnnfJ+Tj45l9yexhSLBT57CB1Gn3QOCIp8fo50HkDgDIE5NKhMW5UCU3H4AjJ1Ry48GieOzXkUsxQj54f/GTkn6fho0BBOWKyw9OKQTz44fK3Y729/+5sdIVNW9rnttttK8hHNx0UXXWSd7vHDIpCFhv23336zVh8CXvi/O1fyQNI4co40qnynKV83zp9pQIKqCOih42CpQnIrXnnllfZ3SqWUekNcDBkyxK5hT+5Ql7cRKwc+gy6fKZ9zXuSApPPB54ucgM7S1Rx0GvgwI1K4X3M7djqpm2++2d4r+CESUIFPLZ0c157zpEMuZ9l5LrivEAmUi2cIawqDMq5FNFCjtXBe3CuU301tl7IMb7HPQXOQ+9blxo3ClDq/T1AOohPrNf6S3Jt09Ln5I53I5HqxalTUmogYcHmFy12/TcFg0VkBo+BSc+KJJ9q2kgEQzxr1gUj67LPP7H3NNWWGxsH9STtFfkymnp2/pYOVzJiyJwCG899www3trAnH530EL2KptfXGtWXQzoCUfTkP3LAYzOEHSXtDoCEDPK4t9z2BoTy3HINrUskk8MVeB2ZbsCqfe+659t5BoHOPkHea54GBMFAv1113nb1mfId2I9fiCbT3uPZwH3FtCPZk0DR06FDbhh533HEVK3Nw+A7bF8lnxx13tDnSyJNXiP3339/mqXTphyZMmGBTcJD7jXyef/vb32z+v9y0O/PmzbM5L8l9SSoWd8u6FD3kgsuF90m/EuWFF17IbLjhhjbHW5cuXew5f/nll432cSlbOLd8PPzww5mNNtrIpmBhI9ccaWS+/vrrRvuRF87lPlxrrbVsPtXcFEOF4Pj8Zj7GjRtnPyOvHteSNCZbbrmlTQ8VhRRW5D8kNUv0enJ8UpMU+u0DDjjA5hYkfc5qq62WNwVUsembCtVbUzz++OM2v5+rI/IK3nfffY32IffjYostZq8t9UnKsGLSNzluuukm+xnpgHJTRTnI20o+TVIXcRzKvPvuu9sclMXcKy0pO+mauJ+oV9ISHX744QvkdyxUf6SG4Ryb46uvvrIpjri+nJNL5VSoLC7dUjTXbinPQS7u9wptI0eOtPt9+OGHNsUSqcNoHzbffPNsztNcSJ/Dd7l/Ha+//rp9j5yplajffLjUPoU2l1qIlEannnqqzX3Mc8bzxj1/2WWXNcoZ61IK8azzffKA5oPvkEOZ+4Ky0JaSDog8oVOmTClLvblcvKRx4p7mOKSR4rvRFEyk3CJnKzlQ6Q94fkllVEyaq3zPbCn3eynXgZRopE1y+3Ecl3LQ5USljaONiKbdK5R28P7778/+Xo8ePTJ777135pdfflngnLnmubj7LO3U8I9vMSyEEEIIIdKHfESFEEIIIYQXJESFEEIIIYQXJESFEEIIIYQXJESFEEIIIYQXJESFEEIIIYQXJESFEEIIIYQXlNA+RljNYfTo0TaZcGuX2xNCCCGEqFbIDsriISwY0NSiBhKiMYIIja6VLIQQQggRMizD3K9fv4KfS4jGiFsqkUqJrpkcCqyNDSydGZeFmfWhWSaxkkvI+SyjD1SPYaB6DAPVYxj46DsaYu4jc8s4depUa3xrbploCdEYcdPxiNAQhahbpCuusvGQzZo1yx4vLiEadxl9oHoMA9VjGKgew8BH39EQcx9ZqIzNuSIqWEkIIYQQQnhBQlQIIYQQQnhBQlQIIYQQQnhBPqJCCCFSy/z5883cuXNNtTJnzhz7F1+/uPwKuR4cLy7f+7jL6AMfZWyocF22bdvWtGnTptW/IyEqhBAidRBYMXbsWDN58mRTzSAmYOLEibFdF45J/se48l3HXUYf+ChjJoa67Natm+ndu3erfl9CVAghROpwInSRRRYxHTt2rNpFRubNm2f/1tXVxSZeOCbHi+uaxF1GH/goY6aCdclvz5gxw4wfP96+7tOnT4t/K9xaF0IIIQpMxzsRuvDCC1f1NZIQDYPQhCh06NDB/kWM8iy1FAUrCSGESBXOJxRLqBCi5bhnqDV+1hKiQgghUkm1TscLkaZnSEJUCCGEEEJ4QUJUCCGEEF4555xzzIABA1QLKURCVAghhBCxTuc++uijjd47/vjjzfDhw1ULKURR80IIIYTwSqdOnYJO3yQKI4uoEEIIkRBIUH7JJZeYZZdd1rRv394sscQS5vzzz7efffbZZ2aLLbawaXVIS3XooYea33//Pfvd/fff3+yyyy7msssus3kf2efII49sFPG81FJLmYsuusgceOCBpnPnzvb3b7zxxkbnMHLkSLP77rvbZOY9evQwO++8s/npp58a7XPrrbeaVVZZxZ4jxxo8eLB9f8kll7R///SnP1nLqHudOzVPOXmvX79+9jf47Jlnnsl+zvH4/iOPPGI233xzG729xhprmLfeeqvMV1xUGglRIYQQwhgze/bsWLeWcOqpp1qheMYZZ5gvv/zS3HvvvWbRRRc106dPN4MGDTLdu3c37733nnnwwQfNCy+8kBWAjpdeesl8//339u8dd9xhbr/9drtFufLKK81aa61lPvroI3PEEUeYww8/3Hz99df2M0Qrx0Gkvvbaa+aNN96w1sxtt902u4zlddddZwUuQhhx/Pjjj1vhDJwb3HbbbWbMmDHZ17kMHTrUXH755VY0f/rpp/aYO+20k/n2228b7XfaaaeZE044wXz88cdm+eWXN3vuuWc2Z6dIBrKDCyGEEMaYo48+OtbrcMMNN5S0P0s1ItD+9a9/mf3228++t8wyy5iNNtrI3HTTTXZN8TvvvNMstNBC9jP223HHHc3FF19sxSogVHmfNcJXXHFFs8MOO1jfzEMOOSR7HEQlAhSL48knn2yGDBlihesKK6xg7r//fmutvPnmm7OpexCVWEdffvlls80225jzzjvP/P3vfzfHHHNM9jfXXntt+7dXr16NloaEfMIRAcqx//KXv9jXlIFzQCRfc8012f0QoZQBzj77bGuF/e6772zZRDKQRVQIIYRIAP/973+tJXXLLbfM+xlT006EwoYbbmhFo7NmAkINEepg2twt0+hYbbXVsv9HbCIY3T6ffPKJFXpYRLGEsjE9jwjG0sp+o0ePznuOxTJ16lT7G5x/FF5Tziirr756o7JAbnlEdSOLqBBCCGGMueqqq6r6OrglFVtD27ZtG71GaCJWi90Hn9OBAweae+65Z4HfxtpZWxuvfSt6rs5Cm1seUd3IIiqEEEIYY4Ni4txKZbnllrNiNF+ao5VWWslaK/EVdeC/iTBkSr1c/OEPf7B+mqwtjt9ndOvatau1lBKA1FQqJsTj/PnzC37epUsX07dvX3v+UXi98sorl60sojqQEBVCCCESQH19vfWbPOmkk6wvKFPhb7/9trnlllvM3nvvbT/Hd/Tzzz+3/pRHHXWU2WeffbL+oeWA4/Ts2dNGyhOs9OOPP1rfUPxrf/nlF7vPP//5TxtohIUZ0frhhx+aq6++OvsbTqiOHTvWTJo0Ke9xTjzxROsXik8qrgWnnHKKDUiK+p2KMNDUvAemTJliMpmMCY0ZM2bEWi6ORZQm/kRxrRkddxl9oHoMA9VjYWg3mL4lSKbaI6zdNLM7T6LmsXKeeeaZ1o8Sv0ii09u1a2eefPJJmxiewCDSGZEiiaAf911+i/YrWuZ87/E6arHktbteHOfFF1+057HrrrvaAKrFFlssm0KJfRCrWGYRogQTIVzZ1x2D9FMITQKs+O4333xjjxE9D4KlEKkEPeHzicV32LBhNr1UtN5y/w+ce7XVa249xnnc+U1Yn1sL5eEY3Af8P9o/0jcXQ00m9F61iqBSmLoYMWKEnXoIjZkzZ9qbkMYoDjgW15RrGZcQjbuMPlA9hoHqsWkhirjp37+/tSJWM06gxel7iXCJBjSFWMa48VXG+RWuS4LUfv75Z+uqwbGi/SP9M3loMb41pXlkEfUAYjREIRotXxwwCuMh4FrG/XDHVUafqB7DQPW4ILQbEydOtCv5VPtqPliZGGjHdZ5OMCFe4hrgx11GH/goYyaGuqQ89L/4BrvcuK7NKfaY4Q4/hBBCCCFEVSMhKoQQQgghvCAhKoQQQgghvCAhKoQQQgghvCAhKoQQQgghvCAhKoQQQgghvCAhKoQQQgghvCAhKoQQQgghvCAhKoQQQqQc1n+/8sorTbWw//77m1122aWixyDh+qOPPmqqhc0228wce+yxppqI45wkRIUQQoiUcPvtt5tu3br5Po1UgajebbfdfJ9G1SIhKoQQQoiyM2fOnFRfVdZeZylqn2QyGbu8aDXXjYSoEEKI1JJpaDDzfvvN68Y5FMMzzzxjNtpoI2vRXHjhhc0f//hH8/3332c/f/nll+108+TJk7Pvffzxx/a9n376yX5+wAEHmClTptj32P75z39m950xY4Y58MADTY8ePUz//v3NjTfe2Oj4n332mdliiy1Mhw4d7PEPPfRQ8/vvvy8wnX7++eebvn37mhVWWMG+P3LkSLP77rvb8+a3d955Z3s+UcF2wgknZMt10kknWQHVHG+88YadOu7YsaPp3r27GTRokJk0aVJBV4MBAwY0Km+UDTbYwJx88smN3pswYYJp27atefXVV+1r1lLnPBdbbDGz0EILmXXXXdde01xr8+OPP25WXnll0759e3s977jjDvsev8U1j34nF0Tj4MGD7XrtPXv2NGeccUaja3HXXXeZtdZay67t3rt3b7PXXnuZ8ePHL3APPP3003a/Tp06mddff91eJ36XaXZ+l2sFn3/+udluu+3sfosuuqjZZ599zMSJE02c1MV6NCGEEKKKmD95svl2gw29nsNyb75h6nr0aHa/6dOnm+OPP96svvrqVgCeeeaZ5k9/+pMVm7W1zduVEFuIM7739ddf2/cQII7LL7/cnHPOOVYI4jt5+OGHm0033dQKSo6NeFl//fXNe++9Z8XPwQcfbMUNAswxfPhw06VLF/P888/b13Pnzs1+77XXXjN1dXXmvPPOM9tuu6359NNPTbt27cyQIUPMnXfeaW699Vaz0kor2fMYNmyYFb2FoMxbbrmlFXpDhw61v/vSSy9ZUdsS9t57b3PJJZeYiy66yAo5uP/++62g3njjje1ryvrll1+af//73/Z9zpFyINCXW265rJi/+OKLzc0332xFdZ8+fczMmTOt+Oc9zhMxXog77rjDHHTQQebdd98177//vhX7SyyxhDnkkEOy1/Pcc8+1dUIdcD8wAHjqqaca/c4pp5xiLr30UvvdXr16ZX+bOkXAAwMWrjH1SB1wnohxBg0vvviiiQsJUSGEECIB5PoZItwQGYijVVddtdnvI/qwtCG0sKblsv3225sjjjjCWuUQJIhWxB2i59577zWzZs2yghFrIPzrX/8yO+64oxVeWNOAzxBcHAvuvvtuOz3Ne07g3XbbbdZyiPVum222MVdddZU93q677mo/v/76682zzz7bZFkQjVj8rr322ux7q6yyimkpiC+shVgPnfCkzHvuuac97xEjRtjz5i8iFLCOYqXm/QsuuCArFDmnNdZYI/vbWJC5dlxzhGhTLL744lYUckyuOyKX106IIrwdSy+9tL12a6+9th2YRAcVDCi23nprW5fumIhlrpuDAcGaa66ZPXd3T3EO33zzjVl++eVNHGhqXgghhEgA3377rRVGCBCsjkw/A+KoHGBpdTix6qZ9//vf/1px5UQobLjhhlZkOusqrLbaalkRCp988on57rvv7FQyQokNiyDCDLcCLIVjxowx66yzTvY7CCdEZlM4i2i5QNAjiu+55x77+scffzRvvfWWtZQCghBrK+LMlYPtlVdeaeQeQdmj17FU1ltvvaxgByzJ1Luz9H7wwQdW/GPp5Jpisc53D+S7fgMHDmz0mrphoBEtz4orrmg/i5ap0sgiKoQQQiQABAi+mzfddJO1yiECsYS6wBM3PR/1KcRCVyz4MEZBEJUabBMVqoClDgHkBF4UN2XcErAyNgXXItfPtLlrgeg8+uijzdVXX22toYhqNleONm3aWCHI3yhRSyTnFRWS5WT6/9wj2LieXD8EKK9zg49y6yHfe5TJWbRzwaUgLiREhRBCpJY23bpZH03f59Acv/76q7U8IkLd1DHTyPmEHRZGgnec5TAKFruW+FHiu4kvKGLICRp8DRF8LigpH3/4wx+sr+Uiiyxirbj5QPTgE7n55pvb10wnI/j4biGwOuKPevbZZ+f9nGvBdXBMnTrVWjmbgiAqfDKZbkeI7rvvvtnPmMLmumEhdte/WEq55u+8806j12+//badUkf8fvXVV/Y+wI+V6XPAj7SlcH0ffvhha1lvzmWgkmhqXgghRGqpqa21gUI+N86hORCWBL8Qyc5UN8EkBKpEWXbZZa1AITKc6dwnn3zSBv5EQXRgCUPEER1NcE0xYC2sr683++23n420Zkr3qKOOslHWzj+00PeI0kbkEayEGMQ3FMvjL7/8Yvfhd/BdJEAKsYWfajTyPx+nnnqqDZpiX4Ke+N51112XjfgmCIcIc47JtDrnnWvJzAWBTdQ/keq4IuAG4WBKnrIgTh955BFbDsTzhRdeaK9zU3DNOQcGEpxfU5bZESNG2Hpl3/vuu89aZ4855hj7GdPxiFre++GHH2wkPoFLLeXII480v/32my0n15LpeHxzyazQ0qCvliAhKoQQQlQ5WB6J1sZSyHT8cccdZ6Oic6fWES+IMiyGTLkSkJIbOX/YYYeZPfbYw1oNo8ErTUGKJEQKwoXgmD//+c/WR5OApea+R/ojRBTBSFhWiQrHR9RZSCkLIg+xiE8kvo9kA2gKhOFzzz1n/RzxL+V7jz32WNayh1DFf5IUVzvssIMVmMsss0yz5eQ8+E2snpxzFIKSEKJ///vfrRWY30TA5e6XC4FGnC/+n1xzF7Wej3333ddGr1MmhCIiFCst8F2s0g8++KBND4Vl9LLLLjMtBfcOzgXRiX8sbggEbBFIVkwWhnJRkykmWZcoC0wNELGIc3ahKYokQ7mAMsYBvktMkzDlE9dDE3cZfaB6DAPVY2EQQVi0llpqKWvlq2ZcMvK4pk5dAnSOVylfR99l9IGPMmZiqMvos0Se1Wj/WKzmkUVUCCGEEEJ4QUJUCCGEEEKkT4jiWIwfCyZbNnw8WJbKwZJUbhkyt+Hbkg8iyfr167fA8mY4FZPUFd8Kd4x8iXKvueYa61DMNA3LduGEnGt+xl8DZ3FSNZBYeNy4cWW9HkIIIYQQacKrEEU44myL8zUpCIhyI7Luiy++aOTkSwoGtxVyrMb5OV8SWZykEaIsf8VxSA9B3qyPPvoouw+pJYhSO+uss8yHH35ok/aSlyu6fivO1E888YR1EiaB7ejRo7OrQAghhBBCiNLx6hmMIIxy/vnnWyspebPcUl1E3OVbiiwK38EKyvq5UYsqsERZFJayIrIOUUleMLjiiius4CVlgVtejHQMLHXFeq042t5yyy02r5hb+5boOaL/OFci4YQQQgghRGlUTYga6QOwNpIsl+lzB6sHsFYtYhThSn4vxKmDNXZZU5UksOTVKibSetq0aXaJMWA1AiylpHpwEIG91VZb2eW9gM/J+8V7DpbBImUD+xQSokSQuSgyF0HmzqHU1SqSgEvAEFfZOA7HjPNaxl1GH6gew0D12HzbQb+TlMQxcZ6nO1bc1yYpddEafF3TTIWO654ht0X7x2L7Se9ClCSvCE98MPG9HDZsmM2PBXvttZddzoxcVySsPfnkk22SV/w+AZFHIlZyqSEKixGi5Nwime/uu+9uX5NclguZm5CX1+Rig7Fjx9oksuTWyt2HzwpBott8qz5MmDDBljc03BJjcZWNmxxrNTd/XOmb4i6jD1SPYaB6LIwbwI4aNcomW89d2rKacJ17XKmU3LWhTY3zmBDX8Xzgo4yZCtclBjr0DMdgVtol6nf9I0a/RAhRksKyBBmC4qGHHrIJbfHBRIy6JK5AolWWASOBLtn/SUyLFZPp8b/+9a9FHYupdYQhU/Pknqw0nF905Qssoqx64QKnQsNZfOMqGzc/DxfXMy4hGncZfaB6DAPVY/MrFWFIaMqYkFYB48RLXEiIJrcumaHGYIixLrfNKTZHr3chysmzLBkMHDjQrlIwdOhQc8MNNyywL9HswPJmCFGWOMOiioCN3syMcE877bRG1khWpDj44IPt9H90ip19WfYrNwKe1843lb9YF1D8UatodJ98tG/f3m65cFPE+ZDHhWsoY12RoaYm1uvpo4xxo3oMA9Vj09BJ0oGS8DvO5QxLxVmVWG0oLuFCFhoyxMTVzsVdRh/4KGNDhesS7RRNlp/b5hR7TO9CNN+Fi/pVRsFyClhG4eGHH7ZLYTkQsQceeKBdWza6lBdLnvE+YpSlvnKFMAKYdXdZrsudA68HDx5sX/M5Uze8R9omwEWANWGj/qxCCCGSAx0nbXs1T827/jCuFaDo/7geHC8uIRp3GX3go4wNHuqyJXgVokxdb7fddta/k9ECU+cvv/yyzfPJ9Duvt99+e6vm8RElhdImm2ySTdOUu24s/p7AdL2zXPIbTPdjZcWi6qZhOnTokF2Giulz9llrrbXs+q5E2hM05aLo2Y/0UOxHkBNm56OOOsqKUEXMCyGEEEIkUIiSp3Pfffe1+UERewhMRCh5P0eOHGleeOGFrCjEtxJr5Omnn17SMW688UY79UIyejYHwvP222+3/99jjz2swy3pnxCqAwYMMM8880yjAKYhQ4bYEQXnwMiGPKPXXnttGa+GEEIIIUS6qMmkIV9ClYAjL4KbwKwQg10oFzhLcxzTDgxmCDyLa9oh7jL6QPUYBqrHMFA9hoGPvqMh5j4yt4zFap7qdRoQQgghhBBBIyEqhBBCCCG8ICEqhBBCCCG8ICEqhBBCCCG8ICEqhBBCCCG8ICEqhBBCCCG8ICEqhBBCCCG8ICEqhBBCCCG8ICEqhBBCCCG8ICEqhBBCCCG8ICEqhBBCCCG8ICEqhBBCCCG8ICEqhBBCCCG8ICEqhBBCCCG8ICEqhBBCCCG8ICEqhBBCCCG8ICEqhBBCCCG8ICEqhBBCCCG8ICEqhBBCCCG8ICEqhBBCCCG8ICEqhBBCCCG8UOfnsOlmypQpJpPJmNCYMWNGrOXiWHPmzDFTp041NTU1QZbRB6rHMFA9hoHqMQx89B2ZmPvI3DJy3GKQEBVlIy4x6BOVMQxUj2GgegwD1WO661FC1ANdu3Y1Xbp0MSGXLw4aGhrMrFmz7LWsra0Nsow+UT2GgeoxDFSPYRBn39HgqY90ZSxWmMpHVAghhBBCeEFCVAghhBBCeEFCVAghhBBCeEFCVAghhBBCeEFCVAghhBBCeEFCVAghhBBCeEFCVAghhBBCeEFCVAghhBBCeEFCVAghhBBCeEFCVAghhBBCeEFCVAghhBBCeEFCVAghhBBCeEFCVAghhBBCeEFCVAghhBBCeEFCVAghhBBCeEFCVAghhBBCeEFCVAghhBBCeEFCVAghhBBCeEFCVAghhBBCeEFCVAghhBBCeEFCVAghhBBCeEFCVAghhBBCeEFCVAghhBBCeEFCVAghhBBCeEFCVAghhBBCeEFCVAghhBBCeEFCVAghhBBCeEFCVAghhBBCeEFCVAghhBBCeEFCVAghhBBCeEFCVAghhBBCeEFCVAghhBBCeEFCVAghhBBCeEFCVAghhBBCeEFCVAghhBBCeEFCVAghhBBCeEFCVAghhBBCeEFCVAghhBBCeEFCVAghhBBCeEFCVAghhBBCeEFCVAghhBBCeEFCVAghhBBCeEFCVAghhBBCeEFCVAghhBBCeEFCVAghhBBCeEFCVAghhBBCeEFCVAghhBBCeEFCVAghhBBCeEFCVAghhBBCeEFCVAghhBBCeEFCVAghhBBCeEFCVAghhBBCeEFCVAghhBBCeEFCVAghhBBCeKHOz2HTzcSJE83s2bNNaEyfPt20adPGzJkzJ5bjZTIZM2vWLHs9a2pqgiyjD9JQjzNmzDC1tbVB1yNl5HqGXo9xltEHqscw8HGvZmJ+JmfOnGmP6co4bdq0or4nIeqBTp06mc6dO5vQ4Ibv2bNnbJ1QQ0ODmTt3rr2eiIo4YADRvXt3K9RChUakS5cupm3btsHWozteu3btTKjMmzfPdOzY0bRv3z7Yepw/f74tX4cOHUyo0LHX1dXZugy1Hikjx+KYoeL6xTjL2BBzXXIMnkmnb6jXYpAQ9UB9fb3dQgNxFmeHwEPGMbmWcTWYroxxHc8Hrox0fiHXI8cLWYhSf4i0uNoaH/UYdxl9zVCEXo9Y0qjLkOsRQw1iNM4yNsRclxgx3PHc62IItzcVQgghhBBVjYSoEEIIIYTwgoSoEEIIIYTwgoSoEEIIIYTwgoSoEEIIIYTwgoSoEEIIIYTwgoSoEEIIIYTwgoSoEEIIIYTwgoSoEEIIIYTwgoSoEEIIIYTwgoSoEEIIIYTwgoSoEEIIIYTwgoSoEEIIIYTwgoSoEEIIIYTwgoSoEEIIIYTwgoSoEEIIIYTwgoSoEEIIIYTwgoSoEEIIIYTwgoSoEEIIIYTwgoSoEEIIIYTwgoSoEEIIIYTwgoSoEEIIIYRInxC97rrrzOqrr266dOlit/XXX988/fTT2c8322wzU1NT02g77LDD8v7Wr7/+avr162f3mTx5cqPPXn75ZfOHP/zBtG/f3iy77LLm9ttvX+D711xzjVlyySVNfX29WXfddc27777b6PNZs2aZI4880iy88MKmU6dOZrfddjPjxo0r27UQQgghhEgbXoUowvGiiy4yH3zwgXn//ffNFltsYXbeeWfzxRdfZPc55JBDzJgxY7LbJZdckve3DjroICtqc/nxxx/NDjvsYDbffHPz8ccfm2OPPdYcfPDB5tlnn83uc//995vjjz/enHXWWebDDz80a6yxhhk0aJAZP358dp/jjjvOPPHEE+bBBx80r7zyihk9erTZddddy35NhBBCCCHSglchuuOOO5rtt9/eLLfccmb55Zc3559/vrU2vv3229l9OnbsaHr37p3dsJzms6xiBT3hhBMW+Oz66683Sy21lLn88svNSiutZAYPHmz+/Oc/myFDhmT3ueKKK6zgPeCAA8zKK69sv8Nxb731Vvv5lClTzC233GL3QywPHDjQ3HbbbebNN99sdK5CCCGEEKJ46kyVMH/+fGttnD59up2id9xzzz3m7rvvtiIU4XrGGWdYkej48ssvzTnnnGPeeecd88MPPyzwu2+99ZbZaqutGr2HtRPLKMyZM8daZE899dTs57W1tfY7fBf4fO7cuY1+Z8UVVzRLLLGE3We99dbLW6bZs2fbzTF16lT7t6GhwW6hkclkYi0Xx4r7mHEfzweujHGV00c9uuOGXJdpqEeOl4ZnMg31mIbnEULuIzM59Vjscb0L0c8++8wKT3wwsYYOGzbMWiVhr732Mv379zd9+/Y1n376qTn55JPN119/bR555BH7OSJvzz33NJdeeqkVhfmE6NixY82iiy7a6D1eIwpnzpxpJk2aZEVwvn2++uqr7G+0a9fOdOvWbYF9+KwQF154oTn77LMXeH/ChAm2vKFBfUTdGSoNNznWam5+Bg9xQL1RxriO5wPKOHHixNjK6KMeefbnzZtn2rRpY0KuRwbadXV1QT+PtDvTpk0zoUL5uJ4YaUKtR1dGnstQoYzEsMTZ9zfEXJe0NxyLv1Dsc+ldiK6wwgrWd5OL9dBDD5n99tvP+mAiRg899NDsfquttprp06eP2XLLLc33339vlllmGWvFZLr9r3/9q6lGOD98Tx2I38UXX9z06tUrr4tB0sGHd5FFFon1IePB5nrG1WAy8KCMIQtRgvAIyotTwMRdjwwGu3btageYocJggsE9AZih1iNBqsyQdejQwYQKxhLu04UWWijYesS1jkFh586dTaigcbiucfb9DTHXJcITw54z2hXb9ngXojxgRLIDvpfvvfeeGTp0qLnhhhsW2Jdodvjuu++sEH3xxRetRRUBGzV99+zZ05x22mnWGsmUfm50O6+5GWi8uPnZ8u3Dd4G/KHwelqhVNLpPPojSZ8uFGyJEIcMNH3e53DHjOm7cx/OBjzL6OKbqMYzn0Ue7EzehP49paVdD7yNrco5V7DGrrtZR8FG/yihYTgHLKDz88MPmk08+se+z3Xzzzfb91157zaZaAqb9hw8f3uh3nn/++awfKkIYARzdh3PgtduHz9u2bdtoH1wERowY0cifVQghhBBCFE+d76nr7bbbzvp3YtK99957bc5PUisx/c5rouqZJsRHlBRKm2yySTZNE1bR3KkoYLreWS7JO/qvf/3LnHTSSebAAw+0VtQHHnjAPPnkk9nvMX2OS8Baa61l1llnHXPllVdafxyi6IEpPNJDsV+PHj2sNfWoo46yIrRQoJIQQgghhKhiIUrQx7777mt9CxF7CExE6NZbb21GjhxpXnjhhawoxLeSJPKnn356SccgdROiExHLlD+5S7GcEjnv2GOPPazP2Jlnnml9AAcMGGCeeeaZRgFMpHvCzMw5YLHl+9dee21Zr4cQQgghRJqoyTjHSlFxCFZCcOO0HGKwEkn+yXAQF7hQMJiJM3iIQRMDlJB9mRiM4WcdZ7BS3PWIf3f37t2DDlZicE3wR5zBSnHXI7NgBCtFU/qFBgFZ1GGcwUpx1yMBWbQ3IQcrEWOCDyUaIC4aYq5LNA7HdDPSxWqecHtTIYQQQghR1UiICiGEEEIIL0iICiGEEEIIL0iICiGEEEIIL0iICiGEEEIIL0iICiGEEEIIL0iICiGEEEIIL0iICiGEEEIIL0iICiGEEEIIL0iICiGEEEIIL0iICiGEEEIIL0iICiGEEEIIL0iICiGEEEIIL9T5OawQQgghhAiB+fPnmylTptj/T58+3Sy00EJFf1dCVAghhBBCtIiZM2eaCRMmmN69e5t27dqZhoYGM23aNDN27Niivi8hKoQQQgghSmbSpElWiPbr18/U1v4/b0/+du3a1dTU1BT1G/IR9cDkyZN9HFYIIYQQotVg9cTiyZR83759syK0Jcgi6gFGD6X6UFTbDcg2b948exO6bfbs2fb91tyQQgghREjQL86YMcPMnTvXbl26dLFT2Ell3rx5ZsyYMaZHjx5l0TESoh5YdNFFzW+//Wbatm1b8Zsxk8nYhwChmCsc2ficv6WC2GRr06aN3erq6szCCy9sRo0aZRZbbDGJUSGEEKlnzpw5Zty4caZbt25WtGGIov93/W779u0TJUwxonH+ffr0sf1+OZAQ9QACjkocPXp0I7+KpqyNbuMzxGMp4KcRFY1siGAnIJ2oLAf8LuVqraleCCGESLr/JJbQqGhDjDorIv35zDzCFP9K+tJq49dff7XCutzGJglRT3BT9urVy/z888/2xouCQEQ8Rq2N7MNf91610qFDB2uulxgVQgiRRhCV+E/W19db0VYIxNxCeYQpgs8JU34DYVou62Nr/EE5F0R1uZEQ9UynTp2sIA2Jjh07WqstPiTctNVkGXUW5+j/nfuCey/fa7fhB0sDUU1lEkKIpEIby3Qv7SspfzC6dO7cOTFT1bn8/vvv1hKKC16pZagtIEwnTpzoTZg61wJc7+jbK4GEqEcQNbnW0FDgQeIhwmfUlTEq6Ep1L8iHE4YI3mLTRLCf29f9P3eLpqDA+hx9zYPI8XA98DlCFUKIpIPwJIsMxhgElgvqQchFYxcQdBht2Kda4dzHjx9v+5ByTV3Xeham1A9J6svpD5oP9aQeQUR1797dhAqjWm5iHLGjIi8q7Mrx4C+yyCKxWigR1rgeuOS9QgghSmu7sbIx0I+KNv4iONmi+yK+pk6dan0pHbS9CDTaY98zVLNmzbIJ3csVRV4NwpTy8PtxxHtIiHqEGyd0qxo3cDWPYlsCdcbDiWW0JdMv1YZzQ3D/j74WQvjtI7AQsjGop61hVoY21bf4am3Udc+ePW1MQaniC2ijEH9uGjzaNjvLaVzXB39OjEo+ssXU5hGm3CtRYUrgM1ux/RS/Qd/GbxLpHwdhq6AEkNTGJO3Q4NHwjBw50v6/WNeAaiXqrgBYK6rNv1eINMGUNULLDXYRCAgehFzuoihYBREO7Fetz6yzgnJ+rRVtzk0q6rPI7+PPyDWLXh/aZ64Norec1wZxRwAPwhfDRDVQm2NRdvk+EabOHa4piyn3F3XELGOcBiQJUVExeAiSLtCae+hJsVEtjVA5YboH/95K+wYJIRqDmMLlCOFEer9oe8N7uVbE6NQ1ba6Dthcx4QRqNVhBKxnw4mbfcgUU4gpxikXZgUsA58G1aYk45Vrze9U+I1b7vz7Kua+5wDA37Q7cT7jP8T4+obkpJeNAPYyoGDQA1fyQisLQONHIyhdWVCt0mkxDMkUbtYDR8SJGEBrVnOouH1iuaDfxPy92AJhv6hoQpQjU3MAfJ2jZv9KDzEoE8JQK1uLcoGBnOcWime86FjrPqG/r4osvbpJGbW2tjd1gAydMqSPulyWWWMLLeUmIeiINfngSosmGQQSj4xEjRlR0QNGS7AetBfFCZ1RIqEQXgeCvy+Hr/pZzEQhRGiyRSMeJuMi3IAj3EgKMfaLZOahT7mNEWLX5WLpgF6ZM8Z0sB9yrUdHhQHAgwhC90X7IWQmL8dssBgYJ+E9WOoCnJXAfcF659xXXBaHp7hvnAsD5015wzYr1bU2aMB09erS385AQ9QQ3dehTnpQRk79IdkNFo11J9wMf2Q+whNChFHoGo6ubub90VG51s1IGkvmWw3Wrm0nQFg/X3K3sgrU+X90Vmr5230egIpByfSzdtC6iI85ZHM7JTZPGZTHkuuULQuG6OusYwtgNDLlPnUAt5vxcmRBzSVrumXLmZrFxop1rwgAHi2FSypMkwlZCVQwPeqg5RKMNUuhiWyT33myqQ3ECvBzHyV2ylw7fCdrolGlzRK200VXW+L9bqjdUnI8hAqqlC4AUmsIGBhn5prGBa+vEbTnbM5dDs1oshtzvbFhl3cAQEGAuaj8K/RcCNZo+yaUSqpYylUu0s2ExDPkZ84lUgifojHjgRXJBSIQcjBW6C0kcnYqzeJZDwDhBGxW1bqUvtwJYFD5jwJvrfhBdPjgqZJ2YrabOlrIiinLzTVbCGsaWO4PjIrGdwMp9HhBhWFJLicimvpj+dZk3qul659JcgFQ0fRJ1Vel6EmEiIeoJHloaPpFc6OhDr8M0uJAkBWelLdZS6/Lc5ooCRAQWQCdqqWMsXqW4HOS6G/AcIHDLOXBhGh6xg2XOV9BjoUjsqBhjy7UW8j1EKgIumlLJpWTCqpvkGbF81mWm40kbJBEa7kxRpVAP4xE9sMkmDcFYaShjqGAhzdfGOJHUGiEUtcwiarG88v+ob2EpYjZqleV3mYYngCKavqjaaGqqnzIg7qMplRD81V6m1sBghHshlECetNG2bVvb3vuoPwlRURFCntJNUzAWZYwutycEONEYxVlUiwk6i/rOus2JWfxB+/fvn+iBOteGtiHaPuBjSB7NkIUMdRgq3I/cp6HOELVv315CVISF8xcKmVKWTUtyGZM8hSiqk6Z8Z0MOCvE19RkHtBMEYIVuMQxViNbX1zdaLjVOwnwiqpw0WAvTMqUbaqfS3PSuEKI0GJhHVz4KDQRayH0b/Rn9Wsj1N7+ELB7lRD2MB9JgLeSBlSVNCCH+/44eH0qRXIthyPXn0+AgIeqBNOQQ5YHNF2kqhBBpxAXziOTWny+LYehIiHqyFoYu0jSlK4TfWRe5VFQXEqJC5EdC1ANpCHIJnZB9oUTySXJQRbnzkVYLtPkh+4iKMGjw8OxJiHpC1opkkwY/X1nVkgtTwEkd7Lo0OaFBe5G7+pUQ1YQvP2YJUSFaQBqyAqRh5ahQoTNJat2FHl0eMqFas9NCu3bt7EphcSMhKspOGhqiNGQFIJl96GI7VJKc/xWLqIJCTGIHEbQboRK60K6vr/dSfxKiouykYX1yLE5J7ehLqcfQyxgqSQ4W9JnPULQOBq4hC9HQV49q58mPOZktVcIJ3beQBzV0Sxodfej1iBgIfUAhqg+eKwnRZBJ6ZoDQhXatp8GrhKgHkuq7VSw8qKGnp0oLSbWqieQiIZpcmEEJWYhSvpCFqC/Uy3ggdJGm9FSimsHHC18vUZ2EvlRkyGVj4Bpy+TAiKZCu/EiIeiANfneypIlqhWlf3Z/VS8hiJuSyQejPVejlc8SdZiwdV7XKSMvNLES1ClFZRKuXkNtHrL1k3BCiml1j5sbsXhHuEy9EhUhDoveQrTaULeT6S8P9mVR8JQwXopQZ27gzA6i1EqJE0pDonc4y1Ij50IVoGtKnJRUt8ymSIERnx2y1D7c1Fl5Iw7RnWlZVCrWMaRCioQ+UkoqEaBiEPGPU3kPmg3BbY+EFTPqhd4JpSWYvIZpMkrzOfOiEnhEgDasPUYchp3Cq9TBIlxAVZSUNq/GkIdF7yGIm9Kh5pU8TPgl9mc/Qk9r7INzWWHghDUIUQhYyLn1HqGI7yctfFkMaVv0S1Uvoqyv58KEMnXBb4ypmwoQJwU5dYG0K1ZImwoBnT0JNiMoQusUQIaqk9uVFQtQDHTt2NKNHjzbjxo0LVpAKUa1IiApROUIPyGI2Je6E7z7KGGcdhjn3VuUstNBCpkuXLmbmzJlmzJgxttJ79eoV7FSoENVE6FPzQviE2QZmxkSyBxMzZ840nTt3juV4Uj4e6dChg1lsscXsNMb48ePtez179tTUdhUjC3bykRBNBqGn2QoV1VnyaR9zUnsJ0SoZffTt29eawp3/6MILL2zq6+t9n5pIYbLwNOSCFclYkz1EUeOmPUNvR0SyjWRTp06N7XjhPeUJhoapT58+pnfv3mbKlCnml19+MdOnTzdJgUjJ0INAGCWGHoyVhpWjQgWBE8IgIm4ftTjRMp9hEPLsWG3MfrASolUIYm7RRRe1VlKEKIJ02rRpvk+rWWbMmBG8EFUye1HNhLKqUsh+hhKiJoj7M9SBkg80N1Dlo5JFFlnEjrx+++03ayXt1KmT6datm+9Ts+eESGZzI0M6QawxPKD4uoY49ZQWIdq1a1ffpyFS7DoSshBloBCn/52oTB2GugzyvHnzzMSJE22wEtl9gHKiPSrlLpj8FislghRhh+BzU/b4cHTv3j0WH6p8ohPByU0ZFZxkACD6nw4k5OCrEP3WchuiEKxqaYS6IytHCEI01KToPFu///67CZ1QfXx9BPPENYhFgAIxKtQfs7L8paz4jGIQc5RTnEqIJggeasQnGzcFoxUeCG6acj3w+UQnIHw5TlMCxa3Gw+aCr7ixEaZYcUPoINNCqB1I6CDeQhhEIERDXb2G9jFUa2/ueuyhBtzS7ybBXa4YEJm//vprNo2kaz8wNnGf8iyS+5zNgTbAYporTrkupHwq1fgkIZpQyEPKxsgaQcrNw01UioBwohPfzmjDSOPRo0ePVlsyaYwIvOI4CNJJkyZVjWuBECESytKsIYu1NAzy3DKfoQpR7s+kByvNmDHDikjKQkxKbrtB/49IzWdA4h7m/ehnTpzSz7tnt1ixnvwWK+Ug7NhccnxGL/n8M5sSnVhYKzl9HvV1da4FTuymoVEWQqSvo08zTsSI6mPatGm2H3ZpIwv1wVg3mZUodiYznzidPHlyUd+VEA0sOT43Dv6ZWEYQpdHGPA7RWaxrQdSSy5R/Eqw4jPBDtdIIUU2kYRnFkEmLH2ySmDx5sq0TdEBTAtTBfq2tw2INTdXf+4uSYBTDTTZ27FjrqxGXX2ap1gtnyWXUXI2BTW6agQfRiU86RsQoFl3EdIg+r7JCCSFaS8iuFUlrz2fPnm2NPvh4FiNAfcxKSIgGCjcQVtK4QKC1xKrpRmfRwCZEXtQxOg5wrGfKIhoggaiPWpD5nHLi44pzt/N5xVc3FBcD6iH0XLBCiMoSSntYqG9lBcRoeiMswPQF9BnVUPaG/6V8xNBD0FEpAtQHEqIBE+eN19oVh3IDm3iIsOhWIp8lx8DSic8sVk4X4EFD0lRKLBcF6qIL3XRHJbIX+EKrKgkhROH0RvQXxDfQj7gAYdpNDBUYJxyVzr3ZlEh2BhPO0804VjMSoqJsDykPXTkDmxB55QhsYuRKIxFdCQOLK41IKVZcHu5cYczDzoaoRZDye0lO5h9yypXQCWV5zzRAPYWcZzPE4B7adPom17YT+OuCeZh9jM5AFsq9icHCWU7LybwCM4pJcbVKZm8pgl9xiAYa8clGQ+ACmxB5TU0d80Bi7aSRYORKg0/DgXW1ta4KPNSFBKaLFnTBYoCFNGmrMOUT2yIZhJJDNA2Enmcz6dDWY93EiFEouAeLZ6GocvYtlHsTA0vUf7Z9C3Nv5lpp6RvL3d/ENWCSEA0QX6OgSt2sPKRsjDAJwuLh4KHjeHS+CL/oik80DEzz+7A2uGAxN0Llb5ICm1rq6yv8E8rynmnArTcvIVpdRNttBuQYE5pq6zF4FEuxuTeLEacIYM7TrbpYqSBft5RppeNN1GoFSKhigkabFFU0ElhI3WiNqfFqa9CjPq/VGtjkrMc0hJwn19NlBQjF5zWXpExVtQTqLu4gP9EyQs+zySwW7QptCWWl3au2NjoK58oUOm1gsTNZ5cgMUEiczpgxYwFxyvVDGDLdz6xgviT0lVrKVEJUxB44VO3w8Ln8ozQe1VzWaglsypeOikaXBga/J+fuwPlh0cXntakFEpJKyH55DCyq+VkQYefZdINuZ0Fzq+jxPuKJz4A2xYkv388ivp+IZuoDw0EpGUMqde61tbXZ9Ia5C9JwDZdYYonYrlupVt+WEkbvIhpBQ8AINGSSuJRhnIFNTNPS0UWtLogUjl/MaD+fzyv+utVs1SgGZ/kNkaZ8mEV1EVKeTdoaBJKbnXIDb4wEfJbrn8+ACWGKm5WDdoU+K477NyqYS82t6Yva2lp7HRHNcZ4rfUYc96larQCJ2zIScufu4GEsVxnLHdjkRstsburZTfnQMbSm4Yr6vNJ445eE7xSNYlLrsdo7HRE+IdyD0WjyfBlIXDBPLuzHoDa3/XJR324fhGk5p4QLCeak0RDgrI6EaKDEnUM09GjdSuTXbGlgE9ebToCG1YljLAqtta42NaDgd/FJctGk+H7RSTSVd7UaCbERDxWlOKr+6femrIkIUQRmsda+6ODWtXHOb9MFoTJdXerzyzngFsX3GPAn2X2lTZs2QbrgSIiKVkOjlLQ0RaWC6KtUGZsKbHLJ96N+Oi4dVblX8aAemxOyrjEHpteKTatVDbgpwdCt96HAvRZip8tzxnPuVubhueF5R9hV6yCpJdbE1rgfMLCOugG5wEqm83HLcvsUiiznPLHWIkL5vE+fPhW7tnEObtv/L3gotGdCQlSUpZFKSnqi1nQeWP/iDGwaMWKEbXjwY4ojHVWpVl+EMhsdajStVjU0ki6hNFaVaHAW79ORJdWimyZCs/64wBiXGB23HCyKtJ8MkPjc3acI02oI5mlu+r0pynnuHNf52EeDL7GYOrcpFwSF+CSDBNewX79+ppLEld7IQX/gI8it0mJbQjQwfKSnoSGIM0iCzinuBjruMtLgYgVlJB8XLrCgVGiEXVotX7lTcxcyAAQM/qxRy8q4cePsufFZ1KKLlVeBPtUFz3jSA3qcbzXCiOehUGJ0BnBNBfMwGOXZjGPWwQ3ieDaam373Rb60R7RfXDOeedyI4sD5wcYpRCdFlhENZfEFCdHAoBHzMUUaZ0Plaz30uNMt+bh3WuN+EFfu1ELWzmIWMogOKJxFl99CoPIbSc0MEGLAYJIjy6N5KRn4lCJU8gXzcK9jQXWDLJ5TBFc5B0/R6Xf6kGoUoM2JQsR6nOdMPTBoiItaT4u00EZKiIqi4YYJ3V8TIRrKdF2IA4p8uVOd1aclvx+1djoYiORaO0s5v0ILJURXVUlSZoBi/HuTBiIOcZQUEHDc79yn3O/N5aUsNhiLz7kf3dK7LuE596obsFL3fN6Stj86/e58vV02j6QR90IBHI/2ImTq6+uzbiOVIqyWS9gOKZoIN0Sc/0/IhCK2o7lTSZDvRGoh0eSsnQhP6jkaMVtpP9moRddlBqARxjpV7ZahUNaZd0EmCC3+T7lcR98asVVJogMYLOzF+iUi+ChfqeXJl/A8dw1zfpuBFPdvvnu3qej3JK8+FvdCAdXeLpTrmlZabEuIBkZLGrakEbe/pg8q7ZMTN86fi3K5KUYEnluyDuGBUAXfSwJGMwNgLar04gPlII5l+CoJ19lNcSKw8I1GECHwGBwUElvlzjVZCggeRHNL0wI537tytNdcg+h1cAFQXK9oABTniMtAnLk044wqT7I7R7USR91VZ6sqEjNK8xE4BBwzrpG7DwsBHYmbigsJOkKsL3QWo0aNylp3EJ1xZAYoFZff0C0+4AS0T9GXb7lWhCjniPhA3CMyqt2i7oQl5aH+86XYiT57uWKL8iIEXfCGswIS2FMpopbEQudcLNQThoNKUCgACmGPxTYu63ncmQ+qrf2oZFqzuiodFLeEulIfwldeecW89tpr5ueff7ZWDEZUa665ptlqq63M4osvXrkzFVVJGpLZIwrjfuiTuIRpqR0U9w1pbLDWxOnX1ZrFBxB+dOaIEbeWdhz3HxZDxA/3BdeL83HR/4A1mWvJdY2mtXHJwhFn1dBJUxaEIx0p9d+Um0Zz58s1oMyFrICu7OXIz+lyf3L9y2VJpO6oqzhwAVBxt9cuvVG1D4qSRLv/3TdJ8mFvjqJ6Ogp9+eWXm+uuu842cAMGDLCNMg/4d999Zx599FFzyCGHmG222caceeaZZr311qv8mYuqwFkGQoYOLvSG1Idlm04d4RSXxbkcZeR83QpTWOPwI21NIFYubgGD6HKtiAhEb1M5T51AzbUcUmbO0wUb8KyWO9q6mDIh4niOuH6UoxLuQ7lWwGh+Tq6Ps76Xkp8TUUt9uNyf5bxucfje+aaSVt9qIk73g/r6emsEjFuIVrKMRT1Vyy+/vFl//fXNTTfdZLbeeuu8IyospPfee6/5y1/+Yk477TQrTEX40MiEOIUchQ6tktN91YCvlFhJLSMNMoKKLRqIVaqvIIN8rJ2us0ZMcq+VmjzcnVMu/Ibzd3VT+hMmTMim6OHZrYSbQTToiDJxnLjX9s43Pe2SyjclTIvJ/VkOqsFCXWkYcESzXYQIz1ic7gf1MUSxx+1iUVRL99xzz5mVVlqpyX369+9vTj31VHPCCSfYFWFEOqxadDhxW1fizpdIhxS61TcN02eVsmxHA7GiyyDmJvTn+UQERadjeXbiCszKTQLO+TDDxQYIYARja9oQnhUXdOaCjqpFcEVFebQ+oonjndWn1NyfSULBQ5VJGRWnH2zmf/lk46LSS4sWpSCiIhSRiS9orhjgwowcOdIsscQSZplllin/mYpmoYMLXUz4yJforCchk4aUWM7CVSncmtYu2htfyGg7iVUhruVai8FNN0ddAtxa3m5JxWKm0KPR7PwO1yAJ/s2co7NqA5ZtF/cQKtyDznc4Dnzc58XmZy3ncx+61bd9hZcWLbm1WGqppbKO8VEYVfOZUif4FWlpmEIOXWxjqYnb6puGlFhxRZrSAdI+0hnSVpIsv9rhnN1KU+45Q1y6e9HlrXSde76gIz4js0A1iOyWdrZYSEPGpYwK2Q2HMsa57KaPqfK4qfTSoiW3ylGn+Cio5dCnL6udNEwh04i6zjJU0rKEqY8lKeMsY5KTzNPxuPW6nb8nopr2n41y5QYdJTkRetwp4XyRhuAhykg/EZcQ9TFVHlq7WbQQPf744+1fOo8zzjijkeUNa8o777xjo+mFP+KeQva1HnroFtFyJbmuZtIQHBWK5SkamIWV1AUfhUZSLbmlQNsZutU3DVPlNTU1QeUSLboUH330UVbsfPbZZ43EAP9fY401bKCSSA9JXg+92gVMJX0Zq4E0uFiEtjpW1MdQlI+4/RlDTxlFGUOfKm/Xrp2XeIlKUVQprrrqKvPUU09ZU/cBBxxghg4dGvz0qGgeouhCt9z5yESQBn/NNLhYhJjazAWCiOSuPORjGjnuSP3Qp8rr6+tt/xuKwaK22Gl5Z86/8847q34VlGrn5ptvNg888IB54YUXzMcff2wzERCxmbSHhxFZ6ELU18pRcrFIPi5XZ2hCNO52KmTh64KH0iC2Rflo37597L6+bmnRSlCU2YWEvg8//LDZfvvtbSPEaiKFxCjpm0TT4Nrw9ddf5725SMDMUmzku4tuvMdKCoUCPHxY7jhm6EI0Df6aPpYwhTjvVx+ZCMDHMUMK6HHHC9UdB0toGoKHQnfFiXv997q6utgHaJVcWrSoq3b66aebo446ygwePNg2rGuvvXbBaHr5DzXPbrvtll272G1uLelRo0bZrdADnStO3f8x1cf9oKchOIpOIvQp5DQsYRpK4JBv4p7a5Xghu6pwT8a13rwv0hCp75Lah5yLub6CS4sW9XQfeuihZs8997TLeK6++up2Sjm6QoUojU022WQBcUNHSS7WqDhlc+/hfM3DTMLp6EoguVMgudbU6GsSVCd5qtBHcFTInWCaljBNg9gOcWreTevGOSsRd/BQ6MabNCzz6YKHQheiUyoUBFZ0D4sKXnXVVc1tt91mNtxww+CnK33cyKy4wpYPRCipU1ixJZ9gJdksDRrrSLPlg8YVMZo7/c//eY/0LNUsukKf3vFp9Q0tujuNwVEhWkTjjtJPS/BQnNCnhC62aT8rufJQNVDJe7Wu1CT2++23X9kOft1119ntp59+sq9XWWUVc+aZZ5rtttvOvt5ss83MK6+80ug7f/vb38z1119v/48A23vvvc2nn35q/89qJjvvvLO54IILGnU699xzj7nkkkvMt99+a6NY+f1LL720kVX3wQcftPlROZflllvOXHzxxdYnNnoNzjrrLHPTTTdZQYgY59zZNw7c6iWFlp/Db5esBrmW1OhrGoPo2tK5uPyA+ayp7rVPIZiGlaN8+GumYQnTNOSfDdFHNO5AF549BmYh3ytxL4Hpo21Jg89mTcz12BQ8M05bRDVHITfDXIqqJScQd9111yYfUITeFVdcYfr3729OOeWUZn+3X79+5qKLLrJijs7wjjvusEKSnKUcEw455BBzzjnnZL8TFSJUAPufd955VqB999135sgjj7QX4N5777X7vPHGG2bfffc1Q4YMMTvuuKO9MIcddpj93UceecTu8+abb1rXgwsvvND88Y9/tN/dZZddzIcffmitwICQJY0V58hSpojWQYMGmS+//LIqrElcCycY8+FWR8m9UaIWVmd1Zfv+++8LWsadKKXcBKdFhWolV7Pg/EK3xKdhCtlHYJ2P4Khq6CDKTdxlcj6icQvRkHGR+tXQb1U6QKqaZ/jKUcZZs2bFYpzhOOgENB5b7szs1KlT836v2IwQRdXS1VdfbU4++WRzxBFHmK233tqstdZaNpKeG5kpYcTY66+/br744gsb0HT44YcXdXCEYZTzzz/fWhnffvvtrBDlIhearmYqOXosBDDniLXT8dZbb5kll1zSHH300fY1IhKrKhZPB3lRt912W3PiiSfa1+eee655/vnnzb/+9S9rfUUkX3nllTZoC+Hr0lixBN6jjz5q/vKXv5gkrY6yzDLLLPA5ZSRgKp9AdRsPNvuwOSs2Ij4KQpHpfzaOle//WKtb0qFxjkn2cS2GNPhrpmVVpZA7wVCndbkvQ/dndEtghi5EQx9QtG/fviyzhPSr3PP5ZlLde6SXbA4MKM7Nz82m8t7tt9/e7HeLaim33HJL8/7771uxef/999upbgKXiPbjoGuuuaa1OjJNjuBoCTQ2TI9T4PXXXz/7Pse6++67rRhFuOYuLxpl9OjR1sq56aabZt/jt/7xj3/YhPxMyY8fP9489NBDjabdEatuCVMH1k5EJvz44482QGirrbbKfs4U9rrrrmu/W0iIcpOwOdyoAetkuc343Eyt/U0crdkQ9IVuVnej4gqA5RS/GHez8jnlHTdunN0KgQhFjDphWmjLtX7mlpH/l6PchXC/G+eUCx0EZY/zmJW8hvlwloro9a30OfguYyVp7j4lXdywYcPs88q99ac//cmsttpqZb+WlahHl4klrrpzFtGQnz8G89yfhY5ZiXqMu4zUI31TyPXYvn37ZsvotIab6cx13XN/ozqlEMx20m/jAunEZtR9j+T6uenqCllKcylpyL7RRhvZrZzQSCIWXeoDGsyVV17ZfrbXXntZUYT1FT9QrLLk33RT6g6m1R977DErjBGrJIx34MuJmN1jjz3sMZgyY59rrrkmuw8iE+tmFF676HT3t6l98sFU/9lnn73A+wQTlXNRAG40biREdhw3P/XBgIPRTtRCiYjixsNiyl+3RV+7B8c9GE3BiB1XAG5+Nl5zw7vX3C90GpXyceReYYvjujq4L7BGx0lc946D55T7yKWtcW4jlfRVjbuM1COdYRyLf3D9OE5u+RhAH3fMMead994zXfExb9vOTJg7x7ZJ6629trli6FA7Q1Sua1mJeixUtkoR9/F83Juuvyjke1uJevRRRuox7sFnnGUE2lA0CH0s/Sn1xiw1f3nt/l/MrAJCEgMbfTt/o0YhXtP/UkbuidwZLYxQ+WYS3EJIzeF97miFFVawqwtxsbBUEgxFgBJilLRRDkbwffr0sdZZ/Bej08v4fxJI9M0335hTTz3VWjevvfZa+xluA8ccc4z1ccXKOWbMGDsFj5/oLbfcUtGyuXNxIMQWX3xx689azghebgCXYzQuuI4I8VIbKhoGroMTovk2Hh5ELQ0JW6EsANFMALkuALkPUkumgjkXZ72N87oy4owLOiPqJM5jujK6e4fjM5LmuaiUEI37utI5RMtYSXhWaD+jgYz4y+/8xz+ahWbONFf07Wu27NTZtK2pMXMzGTP892nmqs8/t5+//tZbZtllly3LtaxUPcZddz6Oh4UpLv9b6okZq0JlrEQ9xl1GX898Jco4b9482yfmWjLZEL70p80J7mggsrNiRv8WG4jMjDVilP2LoVj3D+9ClMK7hnDgwIHmvffesz6bN9xwwwL7MhXuGtmoEHVpj1ZccUV7gTbeeGM7hY9wxSqJVdT5f5IHFeXPPgQ5sQ/fzZ1K5rXzTXV/eY/9o/sMGDCgYNmw+uQLruFGLefNSkeE2TzOh5wbuyU+cJyju/ELwUgcAcrDFxWouANgAXXvO+tqU5kAHNR51E81nw8rLh/RqQUagJb6s7YUjh/n8VwAmO97x5W7EufhIkvjDrSJy0fUWa6i5TvogAOsCL2n72Kme+Q8EKPbdu5i1u3Q0ew9epQ5+MADzauvv162e7QS9Rj3MxH38ZwLR1z3C2Vrrozlrse4y+ijHtEyLfHxnzNnTt5sN9Ec4s2lTXL9am62G/o1vovGKkcQLDoDMVrsdS12P+9CtNC0QT6wnEJUDOb7PrjfwFqYe/O76WRXubgGDB8+3Bx77LHZfQhWcr6qTF8hRtnHCU9GIe+8807RgVmVJLQciTQg3PBsuAE4UciUdTRwDRGFdZz6dVMS+Sys7MfDw4aYLQRW06hQ5XcXW2wx+2A7scqoMqSAqTRE6YceHJWbwgV3p9fffNNaQqMiNArvH9Wtu/n7G2/Y/VvjMypaRxpSRrkAqZDLyIA+nxBl+jzfIjVu+72I/KNuxjMqNrG+8uwzq0y/lE/08TlW03INACrl9+5ViDJ1TQARKYDwJSBt0ssvv2yeffZZKzB4TVARFx4f0eOOO86uSoRVEwhAwirJkqP4CxK1j+UTCyiR8oA/KKmaiMZ3U/MIznXWWScrcpi6J8Dp8ssvNzvssIP597//bYOzbrzxxqww4jtYUEk15dI38X3SPPkm7pFmtYgJBCECsakpUAYbCNDcqf/c/7MPnUFTCwK4e4F7jeM6gZq7IViZkkjCOuM0nFiLQyZtQhQf+q7t2tnp+KbYsnNn0/XXdtYvX0LUH2mI8HZCNDToX1zALlqE9JBulUSXeaaYJVzr/xf/UCh/N7ES+foTArQLidAk4VW9oNSJtkcccjERmIhQUkSNHDnSLiVK2iREAr6VrNFOCiUHFjMSzCNQ6WzYh1yn0Rym+++/vxW5pGL6+9//boXCFlts0Sh90wYbbGBFL79NhD1ik4h5l0MUTjrpJHse+K0iXAjaeuaZZ4JOgRHCqkpOOLKRt7YQ0RyqTqBiPcUSm+v07VJYcY8WolAaq+jr3Gl/H7kn07CEKXUb8tJ71GH0vuF+7dW2rZ2Gb4p2NTWmZ9u29t4WfkVaMelxkgxtdzGCrNpwAbi0/YWmz4sR2LQ/TS2/3bGFKZhCScVVcg9UKByfDp/OtxSx0FSwEKIyd1WlXDbffPMF8ljm46ijjrJbU/zf//2f3QpB+UisH02un1Z8CKZKi4l8K1cx2nRWc2d5YvSba1XNta7S4LYkjRXlwzrpshIUSmNVbuKsSx9LmMa9VnnccE2jFl/umQlz59rApKbE6JxMxkycO7fFKfdEeaDu4lw9Kk1lzJ0t4DXuetFsLs6wkO//xaQ1AhcIhKDE4JHrr1mp9qd9+/Y2niJ1QpRGrqkpRyoBKyRR7Ek3F4vqmeqsBsudE45suJM0dX1yxWmucGWEXWwaKyz/+Syr0fcQsUl43uiM4vaxjXsJ07jFdm75mBX65z//aaPjCUwqxPBp08yUOXPs/qIxcS6d6GN5SAhlmU+MFFHx6P4Sxe7iA9x7LcktSv3kRpxH/08b7PrDXONFpan/36JCSV9atOSenSz5p512mhWb+FnCu+++a5e+ZGob/7rLLrvMKnWmuUVl8dGAIbR8WJiSIia4NqS2ys07WyiNlROp+Bcxuo2+z7QLFlY2XFgKgbhzOeAKZQZoaRqranCxSBJxi+3cTgF/z4022MBc9dFHNjo+X8DSpHnzzNWTJ5mNN9ywkQuS+P/Xtw/5Pq3mMrrFU/KJy3zvtSRXL5ZLDAouT3X0b+7/q9nfvy7mlccqtbRoyUIUwUlQz+677559j4AgGj9SLhFZjrWI5TolRCsPN0TcjUloUfo+xEQ0/6kLrGM0TVYAJyoKpbFyIjWaxorGqNg0VlGBShl5XqNiNd8KGeUiBH+mapsxQIjm3qu33XGH2WDddW2KJqLjCUzCJ5TpeCyhiNDpHTqYW4tYfi9tpCGKPe4y0p4iHN3f5sRlqYYA7n8nHBmQ8xeDAGIJg0BUXDJ75Ht2rVzUepgFK9fSolFKrg18Mll/PReW+WS5SyCQZ8SIEeU5Q1F11sm0ROn76IiiDUu+NFb5QIRG01cVk8YK62uxaaxyrautSWPFOfDdkIlbxORzPSBv4JvvvGMO3H9/m6Kpy7ha07OuzkxECDQ0WEsoIrTUZPZpwIm0kHE5L1uaMcMNknMFZK64dK9bEqhEuxddWS+ftdL9n31zB8+Uj7awqZmppLs8+ABDAoFa5aRkNUEQEUFGF110UaP3eY/PgJOUA3w8pCH9ji8hSuOWBBCExSwSwHRXVKSSXoTMFZS1NWmsogK1uTRWaRjExB2lX6jjQ2S+9OST5j8DBpgXpv1upjbMN11q25gDH3rQrLnZZiZJxNm5MxDLt1xhSFDGXHHoMoIwqCUjCEvEMttSSFyWOiVM/UUFZD5BGbVatnZWwce0NccMfdanbdu2ZXcJLLlHwP+T6PKnn37a5u8Ecm5+9dVXdolOYHUk1nYXlYcHLeQppOiSc3GLCcRUKHD9GLCwuTRWdCZMlUUHjfnSWOW+LiWNFfemE6VsiGYGrFGxWknR5uPe8RFYV0ikzZ8yxSzfvt5ujhX+t0JdUqBscQpR7tlC2WGSBINPBpmFpsAZhLqpcraWiG9m46KisilxSfvBYjQhBEg1de9wzeMWog0Jt8KW3FrutNNOVnTiD8ra7kBSevJuOl+3alhtSIQDD3bcHTuNeOiWu3wj93xprHIpJY0Vx6DDYysEDSgCmQjUfG4ArqPLXYK1Wu8dqJZOYX5ORoaadu1MTcKsNVxLBFOcS2D6CAKlzWnu/maQw7PXVMohZ9Vkv1JdDCg7A0Nmg9yzl09U8pf9SjGCcD7VGiBVLhDmxayUlJbAs2Jp0ZPNykK5U/MiHaQpSj8NVt+W+Gu2Jo2VW3kkN42V60CbAiHCMTnnQn9doIKb1uNYvjMF+ASLaJQ2XbtWbQRwUx1tnFOscQ8i3HOCW0w0x2WuBdNZLZtbdzwXBEo+iyW/w+xI9DMXgMLAsakV61pCGoLA6KfiTqfUvn17O+hPnRDloSFlEzdrrjBhpSQRLj7yQKYhSt+H5a7S/pr50ljlWySA9gR/NAQSwjRXvNIB09By7xWTGSCanoW/bjnWqFh1/+fzarFeVoL5k3OEaLfkBYo5i09S4J6O5q5sLml6qUtfOjebYqbDXfR4PgrlvKyUsaG1AVJJwEdbUl9f78WVpJzuACX3Qk888YTZe++9rfmZmz06uub/EqLhWyfjHnklfdqhGEJfD73Q/erSWC222GJNWmDcUntuQ7Cy5XuN9QzLUTE+by7tS65V1Vl8o+8n8R5c0CKaPL9n6sh3FLu7/5qbEuf/9I2lWi0ZELrgv+bEZVIWrygmQEq0HtqluAdq5Q7KKlmIsl77gQceaC644IKy5pESpcONELcVrdz5w4oliQ1vKYS+Hnpr71ca2549e9qtKVx2ACdMf/75ZytknEiNClasVojWYla3AhrdfFbVqGhl8zFALMT8KY3LVZtAiyj3TLFLLRZL7lKPuYKS2T6eyVKXeowStVo2Jy65DxFpzd3fScaHYKrEKkDVRq0nK2w5lxYtuVfAx+voo4+WCK0CfKwxS+MccmoKoLGM++HmuobuB4sQrbRVMZodgGlHhGGhHKzUswvsKGRddX+pH543tqYCr9w5OCtrPqEafV3pZymfj2jSyPURZbBB3bn6QMC5/+d7HX0/arVsyVKPTa3AkxvIU4oLk7sXQ8aHYEpDOiUflHtp0ZKF6KBBg2y6pqWXXrpsJyFaBqP0uPO1xr1ud5qmyUO/rtXmH0Yn5dJKFZO8O1ec5vvrpmWdqG0qtRUgzJsKvnJ/ETgt8c1uqNDUfEusTIhJriPPlxOL/I2+zicm+b+LuHbvlSt4idmdfIKS8pFmLPpeJZd69BGpT1m4jnH7/McJ7bgPIRq6FbauzDlaSxaiO+ywgznxxBPNl19+aZf1zO2wSe8kws1XmAbSsB66ryj9JFp9oytcsQRrUxBI5dK3FPJldX+5z+gkm1s8wJ0DIj6fSHU5Xd170VVmFghWKtEi6nJRRkUis2Jjxoyx5x4Vjfx1Lg75xGapQTnFwP3E5uoHwZG7Rd93wtJthdrP3OV2Q7YWJmXhjqT4pYaQTinu+7VkFXPIIYfYv+ecc07BEZaIj5BHXeDD3y4N/po+rL5psKZzv5KDtZjOHZHmXAPyiVaXMcCtvY3AZWtqedbcNFebff21iUrPEZN+M1+88krBqevc/3OflBp40xycX65AzPc6+j7+vAS0RfdDgFbqfkqDmOD5p60LWYhyj8Tt8uCS2sd577Rp0yYW16dKUbIQrSZHfBE+PtJFpcHSnBarb9yUkifRCa2mFg/ITQeUz38Va6pzHchNc7VxztT8i+++a7798ceSy4Xgc+IPAYN1NtcKyWcc2wnxQuKyJc9WoVRDlSINOS+pR+6bkKEe424HuGfivq7tPIjfchJ2byvKSlrSRUGcljsf1zUNuVl9ZJXAeljugVN0jW6sgk2JNBfp7URq2w8+bLRvr6WWNgstu0xBK2Sh14gWN92P8OVccv3uuI8rkQjdB06IhowPa2Ea/Ce5rnHn9ayvr7eDVZ7LJNZlUa30VVddZQ499FBbWP7fFETUi3DFS1rSRYVu9Q192hGSPFXVUhCMLJXKlmloMF/l5FLd4+CDTP1KK5UlJU7o17Ela68nCdqcuOvRZUAIWYjSR5bbnaUY8VtMCrpK5Pcth99/UapiyJAhNok9QpT/N9VASYjGAzdA3KKQ6Ya4g02SGuBSCorSrwyhB2I0R8P06YxYy56+iXY+7o42bhjA+FitJk58LPXqAqRCX7wjbmpra72I33Itv12UkmH5vXz/F/7wsbasj+ncSkx1VhtpyHOHFSTujg+rb+iDmFJyiJZLiPpINRQ3vtIpcc+G7J+ehmU+00L9/5YWLYcmCNc+HjBuVZC4xUsapnN9BbiELph8WH2py5A79ebITd1k8PMsg5tLGqbmfaVTCt0v1UXqi+TTrowrZdW1xLJx++23m+HDh1vH9NwG6cUXXyzLiYn/B9eXKXGX0DnaaE2cONH+ZVm4uDrckH17fPnBpkEwpcFf04c4a+qYuct7Yg0th1U6DRZRH6QhnRJtQNwpHrlfQ7c0+6CcWqDkmjnmmGOsECWx/aqrrurFzyRUaNyxHCE6o6NGHl6i4fLlzUOkjhs3zr5P2hQ9bK0jySkwikVR+uEEnTUVtTo/J3ihXMt7uo5dlJc0pFPy4cvo/FLj7Bt9iN/aBAvuks/43//+t3nggQfM9ttvX5kzSqHo5CFxgp7GiGTqxSZrZnqelC78hlsDGwtp6GKqUnAdQ09mryj9cAIIm1ohq1LrzKchWMkHtP1uVa44CT2dkvNLjTP7CnVJ/x5ne9D2fwOZJPZfdS2p1GWXXbYyZ5MSWB7PLS9XyNLZknohlyAigyl7pj969OiR6GkeyhJ3A5mGABdF6YfjftBUKpwF15kvn0VU66JX//rdxZCGFaR8ZEBwCebjDMqqr69PrBAtuZf/+9//boYOHaoRcSvo06ePFY0kfkYoltXXoq7OrpHMMXj4fvnlF5voNolRz1qGsnKCKXSxnZags6an5nOEaLduiZ1edfknQ8aHVRIrGu1ByPjwS6UdiDsoq76+Pva6dLlEY7GI7rrrrgsEJD399NNmlVVWWSAS9pFHHmn1SYnyNGqLLrqo7ah+/fVXM2nSJLv2dEtXXmCkFfeoOS3+mnELfBoO7oWQ8eV+4GNqvqAQDWhq3vm/xd0ehD5tnYYodl9+qT6s25mYy+mWM21tRpSiWs3cTutPf/pTqw4q4sMFMdGgIkaxkGK671aidSQuURjNEuBSVDG9EWpnUI6HuFTSEKWfhqVhmxvIfPHDD+axiRPNtIb5pnNtG7P79N/NomU4ZlosommZtiYnddyELvBDLluu5Zd+urVLixbVG912222tOoiojgeDZf+ApcAQpLgFdO/evaiHhlFzJdaxpaHHhSAaLUrjyOAH1wVucnxqQ80KkIa0Rj5IwyIBhQYV3333nTlgv/3M62++abrw3NTVmQnz5plrzjvPbPzSS+bW229vlZ+/Dx9RH0LU5fUM+flkEBx3BgR3/6RFrMXBrFmz7Mwn13X06NH2Pa4vbWAln1V+f0qehTNKpeRefYsttrDT77kWNcTELrvsojyiCYC6Y6POuGlpaIm0b6phoBNoreXOJeLH2ukeDo6JxZPzyXd8Ih3ZXFYALDEI6kqIDKU1CifoLA3uB5DboSNCN1h3XbPQzJnmir59zZadOpu2NTVmbiZjhv8+zVz14Yf28zffeafFYtSHgCiXL1oppCHBvC+/1LgjykNlxowZ5rfffrPXEle86DWNGnkw5jBz4vrbcs0ylmt2pOQ74eWXX87rEEthX3vttVafkIgPluZiI5gJQUoDgdWxXI0T9wkPQvR+wZRPNH+pVoZoVgBGfmQGKLfQUFqjyqBVleITolhCEaH39F3MdI90SojRbTt3Met26Gj2Hj3KHLj//ubV1183ScGHzx3tIR29KP91DV3gV5pp06ZZS6TrF/P12TwzGHjof5lddH7WfHfs2LHZ/cotTqMUay0tWoh++umn2f9/+eWXjQpCA/HMM8/YfJYiebibEF8hRk5YH0pdrYkOEUsnotaNkPgd/FERnuW6wd3IzwVhcTxcDQpZVEtBaY0qQxqCznzBc+CCsj777DM7HY8lNCpCo/D+Ud26m7+/8Ybdf7XVVjNJgDLGPWPhI+2PWz415GlrH9cV4r6ulajLyZMn236WGcFCArS5/hN3PDYHQpXfjGo6njc0AbORpR6DMnOeDOKKHTwWrTQGDBhgLywb0/O54G949dVXl3TCorqgDhlMIByaS46PaGVkFfUv4qaNy4/T+by6tFLFuhik3a/QV5R+EnPbVft1BQZ97n7HZapru3Z2Or4ptuzc2XT9tZ0ZNmxYYoSoD79UX76wobdDPtIp+Qg8cy4Irc3l3fC/QGP6XPrYlgjQpuCaYCyKwj1I/x4dMDjDUqGUk5wnbgLMjhNP0q9fv6IHHEUrhh9//NE2eksvvbR59913reCIFgTTb9zpUkRlYPqcmx0BwRQ4Nxg3pnOCdg8ZN1s1JMxnip4RHtbRllp04/Qr5Hpyrmw0VPyNK/GxD98sOp3Q/cF4Pny0f1GLC1aIXm3b2mn4pmhXU2N6tm1rO7ek4MNC6Mt/knYoZCHqI+uCy5capxB1Se1b2kc2/G/Wj9/Ahc4FG8d17rnHc+I0Ot3uXGawpiL06T/pe0ul6N6hf//+9gHZb7/97AnyWoQNDy+J8RmJIUhJlF/NU0bOxSBq0eVeLTbJeKXSGnE+PMBRX1k6Gme95doiClqSVqtUOIe400VBNd83Sc9+4K4t986EuXNtYFJTYnROJmMmzp3baHpOVAdpSDAfN27Qz/QzFjqsihhRKj1wbKkLQkNDg5kwYYLVWzzTUaOfT/KJU/q2cePG2fsWfdBSSup1ORjTOWeeeWaLDyiSByOdJOXydBZdt9wpf+l047A60oggOvGPifrK0vAV8pVlNoHvMdIkrRYitZx+tVHo5NIwTR43XFffswMsPPLPf/7TRscTmFSI4Vg15sxZYKESUR2dfTlWwisFF8QS0qyFa0+5llxTXM6cqwXtM4YK107QX2BxLPdAkt8rJTXWvAQuz+2uXWvdkkq+83beeWfz6KOPmuOOO65VBxbJoRx+Lj5wy51GV5cqt9Ux11eWB5JrVaqvLI2kcyLn91wWA0ag5ewgOM/Ql/f0lf3A93XF33OjDTYwV330kY2OzxewNGnePHP15Elm4w03NKuuuqqX8xTVlR2AYzKQCkGI0tYj5tyAGz/F3HaW6WPngsX+tOH0Da4N5zo05QtZLMV+d86cOfacMVwwS+a7HSkV+qloHvCWUPKdt9xyy5lzzjnHvPHGG2bgwIELWJmOPvroVp2QqD7mJnwaL7q6FFMlWB152BF5pTQ0NFRuxafoQ8iIsJw+XVhP2Xi4mfZA3BYKGmtNcEuopDld1G133GHzhJKiieh4ApPwCWU6HksoInR6hw42qb2oPnw8myHkS42KuVKsidHURdHfop/A59rtw+/RzpezflwS+tr/9U8+XKbKAedNv9gaSm45b7nlFmtR+uCDD+wWhQ5TQjQ8eLhDCETjgXfJ/F3uVBrhfIFNbqTMA+YsFNzfNFhx+coibplSQgDjM8Q5MSDAxykp+JgmD301nKYgST3J6skTSoomouMJTMInlOl4LKGtXVlJhAXPSlLzpbr0ffRPuDiVYzDosq84nAGDgBznbtWa6fymktCn1Ypf8hUgel6IpONGwYxK3YpNuZkBaGwQfr5FDQ86QWNu2olGzC1GUK1wXV2AFsKQ13FFAqchXVRTIDJJVk+eUHz6mXbkPsYnVNPxpRNyXs/o6juICdqUOKaGW+OXGs1TSZtC21jJ+okaMHKn87lm9B2Ug1kszqfQuRSThD6JlKMcrZLibnTgI3+eEOXAJQamMcb6Wc2ZATgvF9hEQ4yLAVNGiAyf55xvMQPXMNOpOR9dtxoW71eSNKSLKtZnNCl5QqsVH/kn4wAhxYCWvpupbNpBxCjtoMsFiVsQwrS1vpL54PksNZUczzVtCANNzivX/zMumprOdynR2IeZK9pD3qNtbGkS+jTQotb6zjvvNJdeeqn59ttv7evll1/enHjiiWafffYp9/kJEQuIJaxoSWgkOEc6D7ZoYFM5l2ctdenWphYz4Jzcalg0ynEI6CTUo6h+nP9kCELUTTEzaKS9yJ0WRiixsR+zRFgA2TfqK0kbWY4MKlzPYv1SEawMZEv1/4yT3Ol8RDNts/NXlwAtsxC94oorzBlnnGEGDx5sNtxwQ/ve66+/bg477DA7WlE0fVj48PHzAaIqjmT25cYFNrnlWd2KU/k6Tiw7LVmuzeXhc/dCc+moCuHODegQo5kBhKhGQgjkiealREgWK4pyxZWbxne+ks5nnrag1HalmAAXN5VNHZTL/zMuaCPdVD7XRgPjpim5ZlnG87rrrjP77rtv9r2ddtrJrLLKKjaHnYRoWISS1qM5aGSTGrUYXZ6V+sJ6QOeTaz0oJprcrZ7BvtHfbslKVU3hfFwR0EwBcrykLm3YEoEvkrEOO8+Lj0CecpST6XWm2ctlSeT5jy4FmRvE41LXIUybaytw2XGW1kLLWYYwlU05484Lm0RK7lmwumywwQYLvM97fCbCAoEQwrRUMSS5wXNQVy6wCSsIotT5ZebWZSFrJ1aTuPxO6bg4Xzoz12liSYhrydNyQIefhsGab1yASxztUVQQcU+OGjXKPhsuVVslnw1nhW1p0BDikA0RXUlLYr4gHqycLsMHcK1of3LPIXeZT+qVtsotsxzKLEkhwS0aU9eSiMwHHnjA/OMf/2j0/v33329zjIqwcOvcimSRzy+Txh7hh8Uzd6lR30LKBWJBa5Y8jWMN62iksTse1xkxXQ3XMlQQgpVO9o4QQhC5dbOjgigakIL1j3uWAV65g3lcgvlShGg0kTv+2j4siRwvms3DRZe71YKAQQTX1Q0mnNUWXNBUSOQKbpGfklvMs88+2+yxxx7m1VdfzfqIktx++PDhVqCKsAgxYjRNRP0yf/75Z9tJVfNyrdHMAG7J01IWH6DDK3fOW7d6lvMV5Pe5hojk6Dm5VGBQrgUIxIIW0UqAJY/7rSkf61yfSSdM+Z7LtVwOYYols1i/1KgrDvejG8xVA/miy3FzcKsY8bxw7ZLm/ynK705Scu3vtttu5p133jFDhgyxS33CSiutZN59912z5pprtugkRHVTraJFlN7BVTp1UrmILnna3OIDUUpNCZOLc1dAmLjpxWJXz3I+bW7NaP5y/klyM2gOrg3igbIxXc21RgDFkXuy3BZR6telKmpJPspCwtRNxbZUmHK/MfgpNpCn1OWEfcJA2C3IwTPNrI1IPtzfsQpRYGnPu+++u0UHFKLaSEtmgKTirCqITLf4AFarfMKwVJ/m3Gl2F3DRms6d75GP1k2XttTNoFpw/ntudgTx4KzOiC9n4eLaVXLqnOva2jWtc62ITBNHxWRryBWmWDVbIkz5nXzXMSqc+Y2kB/KIcGjTpo2931vcZpb9jIRIGK15gER8YHVzFsdCCfKbW1Wp2Gn2SrkZIJ5LTXvlA7doAtfLWafzCX8nTMGtTOaCVrmu5Vyfu7UW0agVsdD0eznJTU3Gfcvxo8KUexULYfQa5foVVko4i/hwg9xQqaura5XbTNG9Lw9HcxeSzyvlwyNEpUhTZoAQcGs0OwsRnbtLkB9dVSm64lOp0+yVcjOILkCASGmtG0Glpt7pOBH4CP9iO1DKwnV1forR1D4MIhD7rSkv3y21zG5VL55x31ZEJ4BzhSnXKZow3k1du3XUm/JbFcmxFoZcf3WtzLdbdKvAmsWFeOutt8xVV12lKc7AoBEPeRTncJGmIROi+wEdtLMOuQT5CI7cvIbV5EPnFiBwSyhyji0NbCpXTk06EAS9m3ovxzK3ual9EFUurQ8dM6K8VL9S54dW6mo8nAP3QLXRlDDl/mCwUul11EXloR5DN3a0LcKvuSmKbp133nnnBd77+uuvzSmnnGKeeOIJs/fee5tzzjmnxSciqg/XGIYOHXFoaUPS5n7g0sYw/V0OIVVpuN9YgADx4QQa4qyUAVFrBoourRfPuFsytpIBR9Ho6Vy/UqabiwnoKqZOXQ7NJK7GExWmDKqqUTyXm7gXKPABz1U5fJur/d5tjdtMi55SHpKzzjrL3HHHHWbQoEHm448/NquuumqLT0JUJ4zi4oiG9Q1Wk9Abw9BH5I6kLadHA+4WIMDnFcskFtNilpul4S+1rG66FxDuPhKHR/1KEaOcjzunlviVVkMOTRF/pHVSoA+N5m4Okbq6ulblSy1JiDJtcMEFF9hlPgcMGGBzh2688cYtPriobmjYQ0o9k2bS4H6QZKKBTYiyYgKbiu3EqXsELsKVTrGapntdSq58S0YiWLESF7JqRpewLNWaLKonL2ySrNZx+TanjaLvgEsuucRcfPHFdtrrvvvuyztVL8IiGvghkk0a3A9CwE2Ts0UDmxBruYn6mxKi0al3vsfvVbtFvBi/UkCoE4RW6SUsRfJXyhLJoOgnGF9QHP9Z4pMpebZ8PPLII+U8P+GZarGciNaRBvcDrCshldEFNhEEgJUwN3qaTjzXR9StEORz6r2SfqVcC02/hyNElWVHlCRE991331REUAshkusHG2JwHQYAApuwauML6QKbGFy4dcmrdeq93H6llDGpCwOUSuj+ky6tkRBFC9Hbb79dV0sER2hWtDRDpxaiEHW4dD4IFKasmbrm3nW+pNU+9S6KJw2BPOVaKUskHznXiFQTqhUtjWAZLCbaPOkgTrAOIkZJgI7FVIRFGgJ5sIimJYjHLfYTcn22hnCHW6JVpMVSmJYUVWm5Z9M0qHBBPGkjDeIlDYE8rc09mSSYraCvEfkJX2mIFsGUSRqm+pjODV2IusThaSANg6c0BaClNcAlDeVM071LX8qMTcjU1NS0eJCYnjtBlERaLIWMyEO3osn9IExC9yGsxJrWSSFN1sI0QF8auhBt04rgs3S1YqJoeGjSIETTgOoyXNImRNNgKQQJ0bBIQ33WtWKQmK5WTBSNSw0jkg+NQxrcLET4MHshISqSRhoGjHV1dS1+NsO/OkKknLQF8YhwSYsQdembhEgKEqJCiFSPyNMUkJVm0jDFmYbnVYQ5SJzfwmdTd7tILVgcJF7C8YOV1Td8JNCECC/lmISoWIC0TAkRTS4/2HCEqPxghRDVTMh9a20rrPgSoiJvcEsaBBpCVOIlDCREhRDVDDM2oadwaikSoiK1Ai0NaY1CHoHn+oim4Z4VQiQT2icWihELIiEqUpvMPg3ihTKmZRlI+Q8KkTzSMlhOQ1L7lhL+/KtoVqj8/vvvdqTmGgQcjnlg+vTpE3znHnr50mLdFkIkN01V6O0w0A6nIfVYS5AQTQk87IjN6dOnN1r9gAagvr7e9OzZs5Ff6IwZM8yoUaOsGE2Dv2ioMKCgfoUQotqg/0GcpaGPSYPYbinh136KrZwzZ860KyRFR2SdOnWyUwTNPRQdO3a0+48ZM8aK1A4dOsRw5qLcMOjo2rWrLqwIBlKupUW8hE5rUv6IcNCTnHArJ2IT62WulRPh2KtXr1Y11nx3scUWM2PHjrVTvN26dTNJvU6cP+IcC6HLHUpnNnXqVNOlSxcTKpRdHbYIcU1r3ddhCFFNV4dFS1wtJERTZOVsCfxm3759zYQJE8y4cePMoosuapLggsC1ijZwpM7Id50Q2YzIu3fv7umMRWvRwgTpojVLCSYJBsy0TSEHG1K2qBFFhDGwKDUuQUI0QVZOpstba+VsKRwX66HzG60GfxeuFddo/PjxjSIveQiwchbjG9m7d2/7/YkTJ1oXBJE8tDBBOi2iaenUQxai1GXaUhqFHJzV5n8DCwnRBEGFETwUt5WzpSDuODfEKJbROKOxeXi5Vgh051PENeN9XAZaE5CzyCKLmF9//TURFl+RX4hqec/0QF3TZqZFiIacSo8ypiV9U2sshnHi6oO/bPSzrq91/y/0Hs8lG0YrXk+bNq2oY8oi6gECgJg69m3lbAkIPqbqKQMCEMFcbri5uT6IzmgjxbGZQncPMZ9hzSzHQ73wwgubyZMn23IhRqtpACCaH9BV4j6sZtLUeefC856GAJc0BPLQ74VextxB1KRJk+zgwgk5iIo699ptrQWLM/2ai40oBvaNbkCfmPt+7nuuPPSnfIYgLYZkqJ/AYGo7yQEyNJCIUUQg1ihuupbC6NBZhd1NzA2N6OR347R0IawpGw9ttbgftIa0+E6GbjVK2/Rec1DucnTQ1U4aAnnSdA+7Wb2FFlpoAQFX+7/X7nrwN/r/1hyTfppZvziuNYMKBSuJ2OCmxr+SKW0Cfoq50fMFXPHwEeGfm8fUF507d7bngfsBGQOS3FCmZcqaeynJ9dQS0jLISDO0QzzDIgxw/erRo4cVoqIx/nt+kWiwWjLKGz16tBWmTkwiOvEPYVrAiU6XVgrRWs0O+Jwj0/O//PKLtfxWg0BuCWkRomkEy0PaxHfaSMPUfFogGJZZG4nQ/CSzhxVVBQ8XggcrohM+dJK8n1R/S/zQEKFOYFezc3khyJmaZBcQUZg0T82nhbT5T4YKBhnqUVlZCiMhKsoCQg0RingLqSPo16+fFdhJXF2q2qMzRcvR1Hz4aKCRfJiVmjJliu1HRGE0pBaiqQekttb6iuILi39r0lBnFiayiApR3WAFxS80JONMpZAQFaLI1aVIRcHoVlQPaU1jRLmr2c9aiDTD80n2Fdy6ZAxoHglRIUoQowRf/fbbb7pmVeQHm9RgstYgi2h6ByGi+iFlEukA5RpVHBKiQpQAwVd0gBMmTNB1qxIhmsbGPu1CNA05NkUywY2LeIm0LbLRGtLbkgnRQghcoiPE/0f4Jc1CNM1T82lZb14kL0Ke+7I1i7ykEQlRIVoAiYmJoie9UzVOEdIYpkGoUM40CtE0JvGPgsVJQjQcqrENbcmgmBgC8mSL0khvSyZEKyFHZ9euXatSjKYlmT2CTD6i6YM619R8GDCgqrb2s1Q4f1YYDGFpaB/oignRCkjaz1Q9uUarKfk0QjSNlsI0keYOj3tbQjSc+zjJdclgGGME8QNpmIWqBOltyYQoE/X19bYRQoxWy3QhDTvnJUSIhGBFE2EsZUqEPDNjLOEpWoaEqBBlXBKU6Rmskb6hYU/jlLVIB2mxBtfU1AQvuJMsREnlx/l37tzZ96kkmnQ8zULEAMKPVZgYIc+YMUPXXAiR6mnrkFNxTZ8+3RodtIZ865EQFaICS4JOmjTJpvIQlSN0S5EQSRVppQ7gk/YsEyGPNRSXLNF6JESFqJAYZW36yZMn6/pWCPxx5X4gQibJ09ahlhHRTA5pRciXDwlRISoEDRUjZ1baEOWHa5uGFFUivSRNpLUEBpNJKiNryPfq1UuD4DIiISpEBXHJjfEbjYukTXO1lLSuqiTSQxqEaJICz7CEEpikjCTlJTl3gBAJheXeEExE1Mcl0NIwZc3UvFKmpJvQB11Y/EMXokkBv39EMwuZiPIiISpEDHTr1s0mvyfXaKU7z7Qks+c6pkFwi/TmEk2DRTQJkAVl5syZdkpelB8JUSFigimd7t27V1yMylIo0gCDEKz/oQtRVu4R/qA9xc+/d+/eqoYQheh1111nVl99dWvqZlt//fXN008/nf18s802swl9o9thhx2W/ZybY9ttt7WJxJmiW3zxxc3gwYPN1KlTF7AQnXbaaaZ///52vyWXXNLceuutjfZ58MEHzYorrmh9P1ZbbTXz1FNPNfqcxuDMM8+0ASgdOnQwW221lfn2228rdm1EmHTs2NH6jSJGK5WWRUJUpAGtNy8qDQYDgpMUIR+wEO3Xr5+56KKLzAcffGDef/99s8UWW5idd97ZfPHFF9l9DjnkEHsjuO2SSy5pNDXD/o8//rj55ptvzO23325eeOGFRmIVdt99dzN8+HBzyy23mK+//trcd999ZoUVVsh+/uabb5o999zTHHTQQeajjz4yu+yyi90+//zz7D4c96qrrjLXX3+9eeedd+w066BBg8ysWbMqfp1EWDAYYnTN+sSVsOgwaEpSAIAQLfWfrJYldUWYKEI+JjJVRvfu3TM333yz/f+mm26aOeaYY0r6/tChQzP9+vXLvn766aczXbt2zfz6668Fv7P77rtndthhh0bvrbvuupm//e1v9v8NDQ2Z3r17Zy699NLs55MnT860b98+c9999xV9blOmTGGOxf4NkVGjRsV6vPnz52fGjBlj/yaRuXPnZkaMGJGZOXNmouvBVz0mrZzlpBrLHvfzOHv27MzYsWMzoZOGdrUa7+dx48ZlJk2alEky82OuS7RN9JoVq3mqxtMfh2ymx1k2iyl6xz333GPuvvtua0HacccdzRlnnGGnN/OBhemRRx4xm266afY9rKVrrbWWtWjedddd1pK50047mXPPPddOscNbb71ljj/++Ea/hbXz0Ucftf//8ccfbcQz0/GOrl27mnXXXdd+9y9/+Uve88ElILruuHMZwNwfopM9lrg4y8Wx4j5mOcFqyZQP9xb3E/dmOUjaNWlJPSa97ltLNZY97jrh+aHfqLbrUG7S0K5W2/3sFiLBZbCazqva69Idyx2v2ON6F6KfffaZFZ5McXfq1MkMGzbMrLzyyvazvfbay/p14gP66aefmpNPPtlOrSM2ozCt/thjj9moNsTqzTffnP3shx9+MK+//rr1/eS3J06caI444gjrX3rbbbfZfRACuUt18dql23F/m9onHxdeeKE5++yzF3h/woQJQU7pI7rjzpc5ZcqUxE9Fc+7cE6QHKUe0e9z14KMe+Q5uDUkqZzmpxjr28TzSjlbbdSg3aWhXq+l+xnef88EwUC3nlJS6pE3mWM7lrNhlrr0LUXw1P/74Y3uxHnroIbPffvuZV155xYrRQw89NLsfAURYj7bcckvz/fffm2WWWSb72ZAhQ8xZZ51l/URPPfVUa9289tprsxVBkBOWVaxOcMUVV5g///nPdh9nFa0E7lyiFlECqkgBEWIuMvxpXAL3OHB1y/VMshCNJkvG743I+lKvg2s8aQC4Fj179kzMNWlJPbJ8Kr62pV6rEHBLDMb5rFXr8xh3m+ODNLSr1VKPtKM8WxjAktJ+VlNdIjyZpSBdIRSb+N+7EMUCtOyyy9r/Dxw40Lz33ntm6NCh5oYbblhgX6bC4bvvvmskRJm2ZyPqvUePHmbjjTe2U/gIVzbW/XYiFFZaaSWr2n/55Rez3HLL2e9y80XhtUvX4P669WWj+wwYMKBg2ego8yXc5oYI4SbPhRs+7nK5Y4ZwPbm3sIz+9ttvVki6hgSrDwKTrVCkPWleeJYYxbvk+YhafofPqp1S69FlBgih3kuFe4I6rcayx/08+mhz4iYN7SrHA591GV1DPqT8xDUx1mXusYo9ZtU9wdwMUb/KKFhOISoG830f3G9suOGG1ncUC4oDyykXiKh9wDWAqPoozz//fNZXdamllrJiNLoP1k2i56P+rEK0FkauuJgwSOK+pWEkmTL3K4Mp7kNcVXI33ESwDuI/zX7c21jdEaSVis73CYI8DUn7m7JyCBEKvhYncC4+xKbQTrIKXkgiNCl4veJMXW+33XZmiSWWsCbde++917z88svm2WeftdPvvN5+++3tzYGP6HHHHWc22WQTm3sUyPVJR7322mtb/1LSPp144olWfJIr1PmZEph0wAEHWH9NfETZ58ADD8xOyx9zzDE2wOnyyy83O+ywg/n3v/9t00ndeOON9nMa/WOPPdacd9551oKKMMXiigAgzZMQ5YL7k/vSWURbA7/DbACijd91UyblCoqKC+d24FwP3GCVzou2IXSLWC4SoiI0eIZ5zksVgc4tKXcrNiDYWfDccbWKVQqFKI7A++67r/UPwYqDwESEbr311mbkyJE2J+iVV15pRyv4Vu62227m9NNPb9TR3nTTTVag0jGxz6677mpOOeWU7D4IVKybRx11lI2ep+Miryii0rHBBhtY0ctv/+Mf/7Bik4j5VVddNbvPSSedZM8Dv1Ui6jbaaCPzzDPPFO0DIURzIBahHCI0Co0sllQaZoL0CIriucBi6lvEOdcDnl/cEvJ1BHQWWD+ZiuecXafB4BUrBp8lySe2tXCNkuBuIcr7nIR2fzsRyV/uaZ5nZn/4fynZEHgWaBOcexKzQrxuyXQ07YlbBU/ERw05nGI8XqphOh/BTWBWiMFKPMRYieOChorBDE7uSW+kKyVCC8FgCneVSoo419E4H1f8OvM1N3Qa7EM9cj6lngsDRMQ1PrGhBK456JCdUHfWYLfxrFXTNKKP5zHuNscHzPrFOWXMM0s9Em/h0vE4Yej+uq018sFZI/nL/U35GCDzHLdUSJbrnkKIhiBGG2J+JtE4HNMFKxWreaqnFRMipcQtQoGGgg0Rx4wE1gSOX0pn56bMEUqIzHwWjKiVgtmDfI2hayxbIkIBVwM2fGspC7+BIK0mkdbUNeS8uY75hHohazCi1GVZSJM1OBeuT4jWwiiUjXuDuncCkPumKXHYGpHI97gfEQ8uKI6N/3O/uf+zlSuQioEk5asG8cfARpbReKn+llqIgPEhQvOJOJeTk04ISwjCx/llsuWbMqcDomNiX0a9voWf84mN5hfluvoKaopahNnyZTzgGnJ+nDvXvdhOne9QVhdkQR2GnsrKXU9EmZu+pa4JyOPec8Kr0N+kQhkZrFDGqBUxKhJ5Dp04jL7fEtzAMLTZhVKQGI0XCVEhUipCc4UNjS+dOxH7dHrOEofl1FlCkoArC6IFv1M6VqY2y+3P7SJu3dR5PrGOKOAaYumpRLopN5DAokS9IUarKRgt14Ln/katecXixJfb3D2KiGfLTQHEa/de9P9JA79u7t1qqtc0IDEaHxKiQqRchOYTTqVO01cjnD+p3lzWAP5idSy0RHChQCrn45rP9YBjIBIQgM6vzQccH6s05cT/F2tWayzBTiS6KGQnHqPTwIWmdHNXm4tO7TpXDa5VOfwAOZ4bMAlRbiRG4yHZPY0QCaRaRWioRLMGcO1ZMAArLwIyGgiUzz/TuR5E/TOrFQQdQQnOEkx5sBRGBWQp09TRaV7K7oJICk39hhQ8KIRDYrTyVHfLKkRgSIT6F2oIplGjRtnXiFG2avBxLbclmGAmhKdLZ+PTYitEkpEYrSxhtLxCJACJ0OrABQgxnR3y6kyU02UrEEK0DonRyqHhsRAxIBEqhBDJF6Mk3mcT5UNCVIgKIxEqhBBhIDFafiREhaggEqFCCBEWEqPlRUJUiAohESqEEGEiMVo+JESFqAASoUIIETYSo+VBQlSIMiMRKoQQ6UBitPVIiApRRiRChRAiXUiMtg4JUSHKhESoEEKkE4nRliMhKkQZkAgVQoh0IzHaMiREhWglEqFCCCFAYrR0JESFaAUSoUIIIaJIjJaGhKgQLUQiVAghRD4kRotHQlSIFiARKoQQoikkRotDQlSIEpEIFUIIUQwSo81TV8Q+ogJCZvbs2cFd1zlz5pjx48ebmpqaWI7X0NBgZs2aZSZMmGBqa2tjK2O7du1Mr169YjmeEEKI5IvRUaNGmenTp5s2bdrEdtyGmPtIdA3HnDt3rn09bdq0or4nIeqBTp06mc6dO5vQcAKU8sUBN/y8efPstYxLiE6aNCm28gkhhAiDhRZayPZXcfYfDTH3kbkaIJPJFPU9CVEP1NfX2y00nJU3rrLxkDG65HhxCdG2bdvGchwhhBBhQf8RZ9/fEHMfmasBmEEsBvmICiGEEEIIL0iICiGEEEIIL0iICiGEEEIIL0iICiGEEEIIL0iICiGEEEIIL0iICiGEEEIIL0iICiGEEEIIL0iICiGEEEIIL0iICiGEEEIIL0iICiGEEEIIL0iICiGEEEIIL0iICiGEEEIIL0iICiGEEEIIL0iICiGEEEIIL0iICiGEEEIIL0iICiGEEEIIL0iICiGEEEIIL0iICiGEEEIIL0iICiGEEEIIL0iICiGEEEIIL0iICiGEEEIIL0iICiGEEEIIL0iICiGEEEIIL0iICiGEEEIIL0iICiGEEEIIL0iICiGEEEIIL0iICiGEEEIIL0iICiGEEEIIL0iICiGEEEIIL0iICiGEEEIIL0iICiGEEEIIL0iICiGEEEIIL0iICiGEEEIIL0iICiGEEEIIL0iICiGEEEIIL0iICiGEEEIIL0iICiGEEEIIL0iICiGEEEIIL0iICiGEEEIIL0iICiGEEEIIL0iICiGEEEIIL0iICiGEEEIIL0iICiGEEEIIL0iICiGEEEIIL0iICiGEEEIIL0iICiGEEEIIL0iICiGEEEIIL0iICiGEEEIIL0iICiGEEEIIL0iICiGEEEIIL0iICiGEEEIIL0iICiGEEEIIL0iICiGEEEIIL0iICiGEEEIIL9T5OWy6mTJlislkMiY0ZsyYEWu5ONacOXPM1KlTTU1NTSzHnDVrlpk9e7Zp166dCRXKOHHiRNOmTZvY6tEdM656nDlzpmloaDB1deE2gTyP8+bNi62MvuqR53H69OkmVLimbNRnqPXI8TgWf0OF+zSuNtVXH5mrAThuMYTbCovYiavR8gmdOlunTp1M6PUYVxkRhHPnzrXHq62tDbKMPlA9hoHqMZx6ZGAYMjUt1AASoh7o2rWr6dKliwm5fHEJGEbQXMu4BIyjvr7ehDxyj7OM1COWAo4XVz3GXUYfqB7DQPUYTj22bds2tv7RZx/pylisMJWPqBBCCCGE8IKEqBBCCCGE8IKEqBBCCCGE8IKEqBBCCCGE8IKEqBBCCCGE8IKEqBBCCCGE8IKEqBBCCCGE8IKEqBBCCCGE8IKEqBBCCCGE8IKEqBBCCCGE8IKEqBBCCCGE8IKEqBBCCCGE8IKEqBBCCCGE8IKEqBBCCCGE8IKEqBBCCCGE8IKEqBBCCCGE8IKEqBBCCCGE8IKEqBBCCCGE8IKEqBBCCCGE8IKEqBBCCCGE8IKEqBBCCCGE8IKEqBBCCCGESJ8Qve6668zqq69uunTpYrf111/fPP3009nPN9tsM1NTU9NoO+yww7Kf//rrr2bbbbc1ffv2Ne3btzeLL764GTx4sJk6dWre473xxhumrq7ODBgwYIHPrrnmGrPkkkua+vp6s+6665p333230eezZs0yRx55pFl44YVNp06dzG677WbGjRtX1ushhBBCCJEmvArRfv36mYsuush88MEH5v333zdbbLGF2Xnnnc0XX3yR3eeQQw4xY8aMyW6XXHJJ9rPa2lq7/+OPP26++eYbc/vtt5sXXnihkVh1TJ482ey7775myy23XOCz+++/3xx//PHmrLPOMh9++KFZY401zKBBg8z48eOz+xx33HHmiSeeMA8++KB55ZVXzOjRo82uu+5akesihBBCCJEG6nwefMcdd2z0+vzzz7dW0rffftusssoq9r2OHTua3r175/1+9+7dzeGHH5593b9/f3PEEUeYSy+9dIF9Ead77bWXadOmjXn00UcbfXbFFVdYwXvAAQfY19dff7158sknza233mpOOeUUM2XKFHPLLbeYe++914pluO2228xKK61kz3W99dYrw9UQQgghhEgXXoVolPnz51tr4/Tp0+0UveOee+4xd999txWjCNczzjjDitN8YKV85JFHzKabbtrofUTjDz/8YH/nvPPOa/TZnDlzrEX21FNPbWRp3Wqrrcxbb71lX/P53Llz7XuOFVdc0SyxxBJ2n0JCdPbs2XZzOJeBhoYGu4VGJpOxf+MqG8fhmHFey7jL6APVYxioHsNA9RgGPvqOhpj7yNwyFntc70L0s88+s8ITH0x8L4cNG2ZWXnll+xkWTKyc+IB++umn5uSTTzZff/21FZtR9txzT/PYY4+ZmTNnWrF68803Zz/79ttvrVXztddes/6huUycONGK4EUXXbTR+7z+6quv7P/Hjh1r2rVrZ7p167bAPnxWiAsvvNCcffbZC7w/YcIEW97QQNRDXGXjJsdazc3P4CHEMvpA9RgGqscwUD2GgY++oyHmPjK3jNOmTUuGEF1hhRXMxx9/bC/WQw89ZPbbbz/rg4kYPfTQQ7P7rbbaaqZPnz7Wx/P77783yyyzTPazIUOGWP9O/ESxbOLvee2111qBiZhFDC6//PKxl82dS9QiSkBVr169bHBWaDiLb1xl4yEjgI3rGZcQjbuMPlA9hoHqMQxUj2Hgo+9oiLmPzC0jwd+JEKJYGpdddln7/4EDB5r33nvPDB061Nxwww0L7Es0O3z33XeNhCjT9mxMl/fo0cNsvPHGdgq/Q4cONgjqo48+stH0UVM11tHnnnvObLTRRtZvNDcCntfON5W/KH0CnqJW0eg++SCSny0Xboi4hFOccMNDnGXjmHFeTx9ljBvVYxioHsNA9RgGvvqOmhj7yNwyFnvMqutNEYpRv8ooWE4By2hT3wd+A1XO1D/fcxtBS84Ki7BFCCOAhw8f3ug3eO18Vfm8bdu2jfbBRWDEiBGN/FmFEEIIIUTxeLWIMnW93Xbb2aAffAmISn/55ZfNs88+a6ffeb399tvb3J34iJJCaZNNNrG5R+Gpp56yVsm1117b+peS9unEE080G264oc0JCquuumqjYy6yyCLWXBx9n+lzXALWWmsts84665grr7zSBk25KPquXbuagw46yO6HxRWBe9RRR1kRqoh5IYQQQogEClHydJLbk/ygiD0EJiJ06623NiNHjrQ5QZ0oxLeSJPKnn3569vtMvd90001WoGIBZR9yexKcVAp77LGHDSA688wzbfARCe+feeaZRgFM+KFiZuYcOBZ5RvFDFUIIIYQQLaMm4+LtRSyOvAhuArNCDHahXEAZ4wAXCgYzWLnj8ruJu4w+UD2GgeoxDFSPYeCj72iIuY/MLWOxmqfqfESFEEIIIUQ6kBAVQgghhBBekBAVQgghhBBekBAVQgghhBBekBAVQgghhBBekBAVQgghhBBekBAVQgghhBBekBAVQgghhBBekBAVQgghhBBekBAVQgghhBBekBAVQgghhBBekBAVQgghhBBekBAVQgghhBBekBAVQgghhBBekBAVQgghhBBekBAVQgghhBBekBAVQgghhBBekBAVQgghhBBekBAVQgghhBBekBAVQgghhBBekBAVQgghhBBeqPNz2HQzZcoUk8lkTGjMmDEj1nJxrDlz5pipU6eampqaIMvoA9VjGKgew0D1GAY++o5MzH1kbhk5bjFIiIqyEZcY9InKGAaqxzBQPYaB6jHd9Sgh6oGuXbuaLl26mJDLFwcNDQ1m1qxZ9lrW1tYGWUafqB7DQPUYBqrHMIiz72jw1Ee6MhYrTOUjKoQQQgghvCAhKoQQQgghvCAhKoQQQgghvCAhKoQQQgghvCAhKoQQQgghvCAhKoQQQgghvCAhKoQQQgghvCAhKoQQQgghvCAhKoQQQgghvCAhKoQQQgghvCAhKoQQQgghvCAhKoQQQgghvCAhKoQQQgghvCAhKoQQQgghvCAhKoQQQgghvCAhKoQQQgghvCAhKoQQQgghvCAhKoQQQgghvCAhKoQQQgghvCAhKoQQQgghvCAhKoQQQgghvCAhKoQQQgghvCAhKoQQQgghvCAhKoQQQgghvCAhKoQQQgghvCAhKoQQQgghvCAhKoQQQgghvCAhKoQQQgghvCAhKoQQQgghvCAhKoQQQgghvCAhKoQQQgghvCAhKoQQQgghvCAhKoQQQgghvCAhKoQQQgghvCAhKoQQQgghvCAhKoQQQgghvCAhKoQQQgghvCAhKoQQQgghvCAhKoQQQgghvCAhKoQQQgghvCAhKoQQQgghvCAhKoQQQgghvCAhKoQQQgghvCAhKoQQQgghvCAhKoQQQgghvCAhKoQQQgghvCAhKoQQQgghvCAhKoQQQgghvCAhKoQQQgghvCAhKoQQQgghvCAhKoQQQgghvCAhKoQQQgghvCAhKoQQQgghvCAhKoQQQgghvFDn57DpZsqUKSaTyZjQmDFjRqzl4lhz5swxU6dONTU1NUGW0QeqxzBQPYaB6jEMfPQdmZj7yNwyctxikBAVZSMuMegTlTEMVI9hoHoMA9VjuutRQtQDXbt2NV26dDEhly8OGhoazKxZs+y1rK2tDbKMPlE9hoHqMQxUj2EQZ9/R4KmPdGUsVpjKR1QIIYQQQnhBQlQIIYQQQnhBQlQIIYQQQnhBQlQIIYQQQnhBQlQIIYQQQnhBQlQIIYQQQnhBQlQIIYQQQnhBQlQIIYQQQnhBCe1jxC19VeyyV0nDlSuuVTJI1jtt2jRTX18fW7LeuMvoA9VjGKgew0D1GAY++o6GmPvI3DK6180tbSohGiPcELD44ovHeVghhBBCCG/ap6kVpWoyzUlVUdbRyejRo03nzp2DtqjFBaMtRP3IkSODXjI1dFSPYaB6DAPVYzhM9dxHIi8RoX379m3SIiuLaIxQEf369YvzkKmAB0xCNPmoHsNA9RgGqsdw6OKxj2zKEupQsJIQQgghhPCChKgQQgghhPCChKhILO3btzdnnXWW/SuSi+oxDFSPYaB6DIf2CekjFawkhBBCCCG8IIuoEEIIIYTwgoSoEEIIIYTwgoSoEEIIIYTwgoSoqDgXXnihWXvttW0i/0UWWcTssssu5uuvv272ew8++KBZccUV7fJkq622mnnqqacafb7//vvbhQGi27bbbttonyWXXHKBfS666KIFku5edtllZvnll7dO3Ysttpg5//zzy1T6cKj2enz22WfNeuutZ8+vV69eZrfddjM//fRTmUofDj7rEZ588kmz7rrrmg4dOpju3bvb40cZMWKE2WGHHUzHjh3t+Z144olm3rx5ZSh5WFRzPX7yySdmzz33tMnU+XyllVYyQ4cOLVPJw+LCKq7HKL/++qvNg87vTJ482ZQVVlYSopIMGjQoc9ttt2U+//zzzMcff5zZfvvtM0sssUTm999/L/idN954I9OmTZvMJZdckvnyyy8zp59+eqZt27aZzz77LLvPfvvtl9l2220zY8aMyW6//fZbo9/p379/5pxzzmm0T+5xjzrqqMwKK6yQeeyxxzI//PBD5v33388899xzFbgSyaaa65F6a9++febUU0/NfPfdd5kPPvggs8kmm2TWXHPNCl2N5OKzHh966KFM9+7dM9ddd13m66+/znzxxReZ+++/P/v5vHnzMquuumpmq622ynz00UeZp556KtOzZ09bryI59XjLLbdkjj766MzLL7+c+f777zN33XVXpkOHDpmrr75a1Zigeoyy8847Z7bbbjtW4sxMmjQpU04kREXsjB8/3t7Mr7zySsF9dt9998wOO+zQ6L11110387e//a3Rg8bD0RQImCFDhhT8nIe4rq4u89VXX5VUBlFd9fjggw/aepw/f372vccffzxTU1OTmTNnjqqrCupx7ty5mcUWWyxz8803F9wH4VlbW5sZO3Zs9j06yS5dumRmz56tekxIPebjiCOOyGy++eaqwwTW47XXXpvZdNNNM8OHD6+IENXUvIidKVOm2L89evQouM9bb71lttpqq0bvDRo0yL4f5eWXX7bTGSussII5/PDD7fRBLkzhLrzwwmbNNdc0l156aaNpvieeeMIsvfTS5j//+Y9Zaqml7BTwwQcfbH777bcylDRsqqkeBw4caJfQve2228z8+fPtud1111322G3bti1DacMlrnr88MMPzahRo2w9UYd9+vQx2223nfn8888bHYdpxkUXXbTRcVgz+4svvihLeUOlmuqx0Pk1dW6iOuvxyy+/NOecc4658847m1wvvlWUVdYK0QxYrBjJbbjhhk3uxzTDvffe2+i9a665JrPIIotkX9933312Ov3TTz/NDBs2LLPSSitl1l57bTu957j88sszL730UuaTTz6xlpVu3bpljjvuuOznjCCZ0mU0+eqrr9p9BwwYoJF7wuoRmAbkd5myomlbf/31yz5yD40465HPqRemHZkSxAVmzz33zCy88MKZX3/91e5zyCGHZLbZZptGx5k+fbr9HtZSkYx6zDeVzIzFs88+qypMUD3OmjUrs/rqq1vXCqAN1tS8SDyHHXaYnWYdOXJkqx+0XPBF4iF54YUXCu6D7xINIg+Y6/j4Dv4xDvwLeU/T9cmpR/yflltuucyJJ56Y+fDDD+20FlNJW265ZaahoaHJc0wzcdbjPffcY1/fcMMN2X2oP3xAr7/+evtaQjSMeoyC3yKfnXvuuS0oWbo4rMrqkcH+Hnvskf28UkJUU/MiNgYPHmynwF966SUbfdcUvXv3NuPGjWv0Hq95vxBMsffs2dN89913BfchOpApXRdNzXREXV2djZh3EOHpondFMurxmmuuMV27djWXXHKJnWbaZJNNzN13322GDx9u3nnnHVVjFdQjzxqsvPLK2X3IUsF+7lkrdBz3mUhGPUandbfccktz6KGHmtNPP13Vl7B6fPHFF210Pn0kG3UJ/A5Lh5YLCVFRcQiK4yEbNmyYvbHxxWyO9ddf34qIKM8//7x9vxC//PKL9YFxD1g+Pv74Y+vngt8MbLjhhlbQfP/999l9vvnmG/u3f//+RZUvLVRzPc6YMWMB/6U2bdrYvw0NDc2eZ5rwVY/48dLRRVPTzJ071w4m3LPG73322Wdm/PjxjY7TpUuXRh2mqO56BHx6N998c7PffvspHV5C6/Hhhx+2qbhob9luvvlm+/5rr71mjjzySFM2ympfFSIPhx9+eKZr167Why+aSmLGjBnZffbZZ5/MKaecsoBP0WWXXZb573//mznrrLMapaeYNm1a5oQTTsi89dZbmR9//NFON/zhD3+w07NuuvbNN9+0kdakxGBa4u6778706tUrs++++zbyyeF7pPphShc/GfxFt956a9VlguqRaE4i5M8+++zMN998Y90rSIvCNFf0/IS/eoRjjjnGRuriK4jry0EHHWSnE11aGZe+CT9R6vuZZ56xda30TcmqR36PevvrX//a6NyICBfJqcdc5CMqEgvjnXwbudMc+PORbiLKAw88kFl++eUz7dq1y6yyyiqZJ598MvsZDymdFY0dDyCCA/+yaNoXxAiikoe8vr7eOmtfcMEFjR5EGDVqVGbXXXfNdOrUKbPoootm9t9//4JO92mm2usR53vyhi600EL293baaSfbSIvqqEcgldbf//5329l17tzZ5gslf2KUn376yeYrJO8k/mrsT6oZkZx6RBjlOzd+TySnHuMSojX8Uz77qhBCCCGEEMUhH1EhhBBCCOEFCVEhhBBCCOEFCVEhhBBCCOEFCVEhhBBCCOEFCVEhhBBCCOEFCVEhhBBCCOEFCVEhhBBCCOEFCVEhhBBCCOEFCVEhhAiAzTbbzBx77LGxHIv1qXv37m2mTZuWfe/RRx81yy67rGnTpk3B85g4caJZZJFF7LrXQgi/vPrqq2bHHXc0ffv2NTU1NfYZLhXWRLrsssvM8ssvb9euX2yxxcz5559f0m9IiAohRBnZf//9baOeu2277bZl+f2XX37Z/t7kyZMbvf/II4+Yc88918TBqaeeao466ijTuXPn7Ht/+9vfzJ///GczcuRIex5ch1122aXR93r27Gn23Xdfc9ZZZ8VynkKIwkyfPt2sscYa5pprrjEt5ZhjjjE333yzFaNfffWVefzxx80666xT0m/UtfjoQggh8oLovO222xq9h7WgkvTo0SOW2hgxYoT5z3/+Y66++urse7///rsZP368GTRokLWuNMUBBxxgBg4caC699NLYzlkIsSDbbbed3Qoxe/Zsc9ppp5n77rvPDnxXXXVVc/HFF9vZF/jvf/9rrrvuOvP555+bFVZYwb631FJLmVKRRVQIIcoMopOp6+jWvXv37OdXXHGFWW211cxCCy1kFl98cXPEEUdYMef4+eef7ZQZ32GfVVZZxTz11FPmp59+Mptvvrndh8+wjGJ5zDc1v+SSS5oLLrjAHHjggdZyucQSS5gbb7yx0Xm++eabZsCAAaa+vt6stdZadmqO3/z4448Llu2BBx6wVhSm4JyF1llGt9hiC/t9zuWOO+4wjz32WNYizH5AWRCrw4YNK9PVFkJUgsGDB5u33nrL/Pvf/zaffvqp+b//+z87yP7222/t50888YRZeuml7cAUAUqbc/DBB5vffvutpONIiAohRMzU1taaq666ynzxxRdWsL344ovmpJNOyn5+5JFHWmsEPlyfffaZtUJ06tTJitaHH34466c5ZswYM3To0ILHufzyy63A/Oijj6zYPfzww+33YOrUqVbsIog//PBDO51+8sknN3vur732mv1NxwYbbJD9Tc6Nc2J6bvfdd7edFq/Z2M/B1B2/I4SoTpj5YFbnwQcfNBtvvLFZZpllzAknnGA22mij7GzPDz/8YAfN7HPnnXea22+/3XzwwQfWRacUNDUvhBBlBgsBwjHKP/7xD7tBruXyvPPOM4cddpi59tprs53AbrvtZkUiYHVwuOlsgn66devW5Hlsv/32VoACInPIkCHmpZdestNo9957r7VU3nTTTdYiuvLKK5tRo0aZQw45pMnfpOOJCtF27drZc3HnhvUXOnToYMW0ex0FiyjiWAhRnTAAnj9/vg1CisIzvfDCC9v/NzQ02NeIULffLbfcYl1vGJy66frmkBAVQogyw/Q5vlNRov6QL7zwgrnwwgutcz+WyXnz5plZs2aZGTNmmI4dO5qjjz7aWi+fe+45s9VWW1lRuvrqq5d8HtHvIDoRhfhyAh0FnyNCHcUEGcycObPRd1oCIpWyCiGqE1yFyICBhZO/Udwgu0+fPqaurq6RWF1ppZWyg+lihaim5oUQoszg10kqo+jmhCh+nn/84x+tCGQqm4beRa3OmTPH/sXPimmvffbZx1omsEBGg4OKpW3bto1eI0axYrQGIt8nTZrUqt/Ah6xXr16t+g0hROVYc801rUWUgWtuW+ZmOTbccEM7iP7++++z3/vmm2/s3/79+xd9LAlRIYSIEYQnYhD/zfXWW89aE0aPHr3AfviDMl1PWqa///3vdgrdTYUDnURrwFqByGVqzfHee+8V1UF9+eWXze7HeRY6R6Js+R0hhF+rJ4GJLjjxxx9/tP/Hmkm7tPfee9t0a7RBfPbuu+/amZwnn3zS7s9szR/+8AcbEImrDW0bady23nrrBab0m0JCVAghygzibuzYsY02krkDFoW5c+daCydWz7vuustcf/31jb6PD+mzzz5rG38CifDrdFNeWBqwbOKHOmHChEbR9qWw1157WUF86KGH2jQsHI9cgMDvF4IUTUTSNieE8X0l0hYXAMpOmYEpeTqsbbbZpkXnLYQoD++//74dELpB4fHHH2//f+aZZ9rXBCUhRBkIM3AlLzCDVTJwuKBLIueZJdlkk03MDjvsYNspouxLIiOEEKJs7Lfffhma1txthRVWyO5zxRVXZPr06ZPp0KFDZtCgQZk777zT7jNp0iT7+eDBgzPLLLNMpn379plevXpl9tlnn8zEiROz3z/nnHMyvXv3ztTU1Njjwaabbpo55phjsvv0798/M2TIkEbntsYaa2TOOuus7Os33ngjs/rqq2fatWuXGThwYObee++15/HVV18VLN/cuXMzffv2zTzzzDPZ9zhvvvfSSy9l3xs/fnxm6623znTq1KnRZxwjei2EEOmmhn/KJK6FEEIkmHvuuccmnJ8yZYoNKCoEPq2kaMKKWiq4IxCMhUVWCCEUNS+EECmFtCukhiI5/SeffGJTPJH/sykRCviBsdIKa81Hl/lsDqbod911V7PnnnuW4eyFECEgi6gQQqSUSy65xOYuxYeVVCz4gJ1//vk2hZQQQsSBhKgQQgghhPCCouaFEEIIIYQXJESFEEIIIYQXJESFEEIIIYQXJESFEEIIIYQXJESFEEIIIYQXJESFEEIIIYQXJESFEEIIIYQXJESFEEIIIYQXJESFEEIIIYTxwf8HHZX+SkfmWRgAAAAASUVORK5CYII=",
+      "text/plain": [
+       "<Figure size 900x700 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "cells = HdfMesh.get_mesh_cell_polygons(GEOM_HDF)\n",
+    "near = cells[cells.intersects(conn_ls.buffer(800))]\n",
+    "fig, ax = plt.subplots(figsize=(9, 7))\n",
+    "near.boundary.plot(ax=ax, color=\"0.85\", linewidth=0.3)\n",
+    "gpd.GeoSeries([conn_ls], crs=cells.crs).plot(ax=ax, color=\"0.4\", linewidth=1.5, label=\"connection\")\n",
+    "bx = [row[\"us_x\"], row[\"ds_x\"]]; by = [row[\"us_y\"], row[\"ds_y\"]]\n",
+    "ax.plot(bx, by, color=\"C3\", linewidth=3, label=\"authored culvert barrel\")\n",
+    "ax.scatter(bx, by, color=\"C3\", s=60, zorder=5, edgecolor=\"k\")\n",
+    "ax.set_xlim(min(bx) - 500, max(bx) + 500); ax.set_ylim(min(by) - 500, max(by) + 500)\n",
+    "ax.set_title(\"Authored retrofit culvert on the Lower Levee connection\")\n",
+    "ax.set_aspect(\"equal\", adjustable=\"box\"); ax.legend(); ax.grid(True, alpha=0.3)\n",
+    "ax.set_xlabel(\"Easting (ft)\"); ax.set_ylabel(\"Northing (ft)\")\n",
+    "plt.tight_layout(); plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "10ff89dd",
+   "metadata": {},
+   "source": [
+    "## Summary"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "dcfcb246",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-12T12:33:04.341397Z",
+     "iopub.status.busy": "2026-06-12T12:33:04.341397Z",
+     "iopub.status.idle": "2026-06-12T12:33:04.352704Z",
+     "shell.execute_reply": "2026-06-12T12:33:04.352704Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>Connection</th>\n",
+       "      <th>Shape</th>\n",
+       "      <th>Span x Rise (ft)</th>\n",
+       "      <th>Length (ft)</th>\n",
+       "      <th>GIS length err (%)</th>\n",
+       "      <th>US invert</th>\n",
+       "      <th>DS invert</th>\n",
+       "      <th>invert check</th>\n",
+       "      <th>HEC-RAS computes</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>Lower Levee</td>\n",
+       "      <td>Box</td>\n",
+       "      <td>8 x 6</td>\n",
+       "      <td>60.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>539.56</td>\n",
+       "      <td>539.06</td>\n",
+       "      <td>[PASS, PASS]</td>\n",
+       "      <td>verified separately (SUCCESS, no data_errors)</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "    Connection Shape Span x Rise (ft)  Length (ft)  GIS length err (%)  US invert  DS invert  invert check                               HEC-RAS computes\n",
+       "0  Lower Levee   Box            8 x 6         60.0                 0.0     539.56     539.06  [PASS, PASS]  verified separately (SUCCESS, no data_errors)"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Authored a 2D SA/2D connection culvert with explicit GIS coordinates, validated it (exact length + terrain-based inverts), and confirmed in a separate HEC-RAS run that it computes (SUCCESS, no data_errors). 2D connection culvert authoring workflow complete.\n"
+     ]
+    }
+   ],
+   "source": [
+    "summary = pd.DataFrame([{\n",
+    "    \"Connection\": CONN, \"Shape\": row[\"ShapeName\"],\n",
+    "    \"Span x Rise (ft)\": f\"{row['Span']:.0f} x {row['Rise']:.0f}\",\n",
+    "    \"Length (ft)\": row[\"Length\"], \"GIS length err (%)\": round(err, 2),\n",
+    "    \"US invert\": row[\"UpstreamInvert\"], \"DS invert\": row[\"DownstreamInvert\"],\n",
+    "    \"invert check\": inv_rep[\"status\"].tolist(),\n",
+    "    \"HEC-RAS computes\": \"verified separately (SUCCESS, no data_errors)\",\n",
+    "}])\n",
+    "display(summary)\n",
+    "print(\"Authored a 2D SA/2D connection culvert with explicit GIS coordinates, validated \"\n",
+    "      \"it (exact length + terrain-based inverts), and confirmed in a separate HEC-RAS run that it computes (SUCCESS, no data_errors). \"\n",
+    "      \"2D connection culvert authoring workflow complete.\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/ras_commander/geom/AGENTS.md
+++ b/ras_commander/geom/AGENTS.md
@@ -65,6 +65,24 @@ Reconstruct and validate culvert placement from geometry; complements `GeomCulve
   (`Connection Culv=` + `Conn Culvert Barrel=` + a packed `US_x US_y DS_x DS_y` line), so
   for 2D the +/-1% GIS-length rule is exact. 1D inline culverts do not store a GIS line.
 
+## SA/2D Connection Culvert Authoring (`GeomLateral`)
+
+- `get_connection_culverts(geom, connection_name)` reads the `Connection Culv=` group(s)
+  on a connection -> one row per barrel (shape/dims/inverts/loss + per-barrel US/DS
+  stations and GIS endpoint coordinates). `set_connection_culverts(geom, connection_name,
+  culverts)` authors/replaces them (list of group dicts, each with a `barrels` list of
+  `us_xy`/`ds_xy`); stations default to the connection-line projection of the barrel
+  midpoint. Format verified against production LA LWI 2D models and the authored output
+  confirmed to compute in HEC-RAS.
+- Record layout: per group `Connection Culv=Shape,Span,Rise,Length,n,Ke,Kex,Chart,Scale,
+  USinv,DSinv,NumBarrels,Name, 0 ,` then an 8-char fixed-width station line (one US/DS pair
+  per barrel), then per barrel `Conn Culvert Barrel=<id>,<name>,2` + a 16-char fixed-width
+  `US_x US_y DS_x DS_y` line, then `Conn Culv Bottom n=`. The 3 `Conn HTab` lines appear
+  ONCE after the last group. Coordinate lines may be fixed-width *packed* (no delimiter) ->
+  parse by column (`_parse_fw_floats`).
+- `set_connection_culverts` warns when a barrel's GIS endpoint distance differs from the
+  entered `Length` by > 1% (HEC-RAS may reject it).
+
 ## Land Cover Manning's n Override Architecture
 
 HEC-RAS resolves per-cell Manning's n through a layered override hierarchy:

--- a/ras_commander/geom/GeomLateral.py
+++ b/ras_commander/geom/GeomLateral.py
@@ -843,6 +843,342 @@ class GeomLateral:
             logger.error(f"Error reading connection line coords: {str(e)}")
             raise IOError(f"Failed to read connection line coords: {str(e)}")
 
+    # ------------------------------------------------------------------
+    # SA/2D connection culverts (Connection Culv=)
+    # ------------------------------------------------------------------
+    # Field order of a ``Connection Culv=`` record (mirrors the GUI):
+    #   Shape, Span, Rise, Length, ManningsN, EntranceLoss, ExitLoss, Chart,
+    #   Scale, UpstreamInvert, DownstreamInvert, NumBarrels, Name, <flag>, <blank>
+    # Followed by a fixed-width station line (one US/DS pair per barrel), then one
+    # ``Conn Culvert Barrel=<id>,<name>,2`` + a fixed-width ``US_x US_y DS_x DS_y``
+    # coordinate line per barrel, then ``Conn Culv Bottom n=`` and HTab lines.
+    # Verified against production LA LWI 2D models (HEC-RAS 6.31-6.41).
+    CONN_CULV_SHAPE_NAMES = {
+        1: "Circular", 2: "Box", 3: "Pipe Arch", 4: "Ellipse", 5: "Arch",
+        6: "Semi-Circle", 7: "Low Profile Arch", 8: "High Profile Arch", 9: "Con Span",
+    }
+
+    @staticmethod
+    def _parse_fw_floats(raw: str, col_width: int = 16,
+                         expected_count: Optional[int] = None) -> List[float]:
+        """Parse a coordinate/station line that may be fixed-width packed
+        (no delimiter between abutting values) or whitespace separated.
+
+        When ``expected_count`` is given, prefer whichever interpretation yields
+        exactly that many values. A whitespace token wider than ``col_width``
+        means the line is NOT fixed-width packed, so the whitespace split wins.
+        """
+        s = raw.rstrip("\n")
+        fw: List[float] = []
+        for j in range(0, len(s), col_width):
+            chunk = s[j:j + col_width].strip()
+            if chunk:
+                try:
+                    fw.append(float(chunk))
+                except ValueError:
+                    pass
+        ws: List[float] = []
+        for p in s.split():
+            try:
+                ws.append(float(p))
+            except ValueError:
+                pass
+        if expected_count is not None:
+            if len(fw) == expected_count:
+                return fw
+            if len(ws) == expected_count:
+                return ws
+        # a real token wider than the field => not packed fixed-width
+        if ws and any(len(p) > col_width for p in s.split()):
+            return ws
+        return fw if len(fw) > len(ws) else ws
+
+    @staticmethod
+    @log_call
+    def get_connection_culverts(geom_file: Union[str, Path],
+                                connection_name: str) -> pd.DataFrame:
+        """
+        Read the culvert(s) on a SA/2D connection, one row per barrel.
+
+        A 2D connection culvert stores explicit per-barrel GIS endpoint
+        coordinates (unlike a 1D inline culvert, whose barrel line is derived).
+
+        Returns:
+            pd.DataFrame with columns: CulvertName, GroupIndex, Shape, ShapeName,
+            Span, Rise, Length, ManningsN, EntranceLoss, ExitLoss, Chart, Scale,
+            UpstreamInvert, DownstreamInvert, NumBarrels, BottomN, BarrelIndex,
+            BarrelName, us_station, ds_station, us_x, us_y, ds_x, ds_y.
+            Empty DataFrame if the connection has no culverts.
+        """
+        geom_file = Path(geom_file)
+        if not geom_file.exists():
+            raise FileNotFoundError(f"Geometry file not found: {geom_file}")
+        with open(geom_file, "r", encoding="utf-8", errors="replace") as f:
+            lines = f.readlines()
+        block = GeomLateral._find_connection_block(lines, connection_name)
+        if block is None:
+            raise ValueError(f"Connection not found: {connection_name}")
+        _, _, block_lines, _ = block
+
+        rows: List[Dict[str, Any]] = []
+        group = 0
+        i = 0
+        n = len(block_lines)
+        while i < n:
+            line = block_lines[i]
+            if not line.startswith("Connection Culv="):
+                i += 1
+                continue
+            parts = line.split("=", 1)[1].split(",")
+            def fnum(idx, default=float("nan")):
+                try:
+                    return float(parts[idx].strip())
+                except (IndexError, ValueError):
+                    return default
+            shape = int(fnum(0)) if fnum(0) == fnum(0) else None
+            span, rise, length = fnum(1), fnum(2), fnum(3)
+            mann, ke, kex = fnum(4), fnum(5), fnum(6)
+            chart, scale = int(fnum(7, 0)), int(fnum(8, 0))
+            us_inv, ds_inv = fnum(9), fnum(10)
+            nbar = int(fnum(11, 1))
+            name = parts[12].strip() if len(parts) > 12 else ""
+
+            # station line(s): one US/DS pair per barrel, 8-char fixed width.
+            # >5 barrels wrap onto multiple lines (10 values/line), so accumulate
+            # across lines until 2*NumBarrels values are read.
+            station_count = max(0, 2 * nbar)
+            stations: List[float] = []
+            i += 1
+            while i < n and len(stations) < station_count:
+                if block_lines[i].startswith(("Conn Culvert Barrel=", "Connection Culv=",
+                                              "Conn Culv Bottom n=")):
+                    break
+                stations.extend(GeomLateral._parse_fw_floats(
+                    block_lines[i], col_width=GeomLateral.FIXED_WIDTH_COLUMN))
+                i += 1
+            bottom_n = float("nan")
+            barrels: List[Dict[str, Any]] = []
+            while i < n and block_lines[i].startswith("Conn Culvert Barrel="):
+                bparts = block_lines[i].split("=", 1)[1].split(",")
+                b_name = bparts[1].strip() if len(bparts) > 1 else ""
+                i += 1
+                coords = (GeomLateral._parse_fw_floats(block_lines[i], col_width=16,
+                                                       expected_count=4)
+                          if i < n else [])
+                barrels.append({"name": b_name, "coords": coords})
+                i += 1
+            # trailing culvert metadata
+            while i < n and not block_lines[i].startswith(("Connection Culv=", "Conn Culvert Barrel=")) \
+                    and block_lines[i].strip():
+                if block_lines[i].startswith("Conn Culv Bottom n="):
+                    try:
+                        bottom_n = float(block_lines[i].split("=", 1)[1].strip())
+                    except ValueError:
+                        pass
+                i += 1
+
+            for b_idx, b in enumerate(barrels):
+                us_sta = stations[2 * b_idx] if 2 * b_idx < len(stations) else float("nan")
+                ds_sta = stations[2 * b_idx + 1] if 2 * b_idx + 1 < len(stations) else float("nan")
+                c = b["coords"]
+                rows.append({
+                    "CulvertName": name, "GroupIndex": group,
+                    "Shape": shape, "ShapeName": GeomLateral.CONN_CULV_SHAPE_NAMES.get(shape),
+                    "Span": span, "Rise": rise, "Length": length, "ManningsN": mann,
+                    "EntranceLoss": ke, "ExitLoss": kex, "Chart": chart, "Scale": scale,
+                    "UpstreamInvert": us_inv, "DownstreamInvert": ds_inv,
+                    "NumBarrels": nbar, "BottomN": bottom_n,
+                    "BarrelIndex": b_idx + 1, "BarrelName": b["name"],
+                    "us_station": us_sta, "ds_station": ds_sta,
+                    "us_x": c[0] if len(c) > 0 else float("nan"),
+                    "us_y": c[1] if len(c) > 1 else float("nan"),
+                    "ds_x": c[2] if len(c) > 2 else float("nan"),
+                    "ds_y": c[3] if len(c) > 3 else float("nan"),
+                })
+            group += 1
+        return pd.DataFrame(rows)
+
+    @staticmethod
+    @log_call
+    def set_connection_culverts(geom_file: Union[str, Path],
+                                connection_name: str,
+                                culverts: List[Dict[str, Any]]) -> Dict[str, Any]:
+        """
+        Author (replace) the culvert group(s) on a SA/2D connection, writing the
+        ``Connection Culv=`` records with explicit per-barrel GIS endpoint
+        coordinates. Verified to compute in HEC-RAS.
+
+        Parameters:
+            geom_file: Path to geometry file (.g##). A ``.bak`` backup is created.
+            connection_name: Connection (must already exist with a ``Connection Line=``).
+            culverts: list of culvert-group dicts, each with::
+
+                {
+                  "Shape": 2, "Span": 8.0, "Rise": 6.0, "Length": 60.0,
+                  "ManningsN": 0.024, "EntranceLoss": 0.5, "ExitLoss": 1.0,
+                  "Chart": 8, "Scale": 1, "Name": "Retrofit Culv",
+                  "UpstreamInvert": 539.56, "DownstreamInvert": 539.06,
+                  "BottomN": 0.024,                     # optional (-> ManningsN)
+                  "barrels": [
+                    {"name": "Barrel #1", "us_xy": (x, y), "ds_xy": (x, y),
+                     "us_station": 7113.55, "ds_station": 7113.55},  # stations optional
+                  ],
+                }
+
+            If a barrel omits ``us_station``/``ds_station`` they default to the
+            arc-length projection of the barrel midpoint onto the connection line.
+
+        Returns:
+            dict: {culverts_written, barrels_written, backup_path, length_warnings}
+        """
+        import math
+        geom_file = Path(geom_file)
+        if not geom_file.exists():
+            raise FileNotFoundError(f"Geometry file not found: {geom_file}")
+        if not culverts:
+            raise ValueError("Provide at least one culvert group")
+
+        with open(geom_file, "r", encoding="utf-8", errors="replace") as f:
+            lines = f.readlines()
+        block = GeomLateral._find_connection_block(lines, connection_name)
+        if block is None:
+            raise ValueError(f"Connection not found: {connection_name}")
+        start_idx, end_idx, block_lines, _ = block
+
+        # connection line (for default station projection)
+        try:
+            conn_xy = GeomLateral.get_connection_line_coords(geom_file, connection_name)
+            from shapely.geometry import LineString, Point
+            conn_ls = LineString(conn_xy[["X", "Y"]].to_numpy())
+        except Exception:
+            conn_ls = None
+
+        def fw_coords(pairs):
+            return GeomStorage._format_breakline_coord_lines(pairs)[0].rstrip("\n")
+
+        length_warnings: List[str] = []
+        new_lines: List[str] = []
+        n_barrels_total = 0
+        for ci, cv in enumerate(culverts):
+            barrels = cv.get("barrels") or []
+            if not barrels:
+                raise ValueError(f"Culvert group {ci} ('{cv.get('Name','')}') has no barrels")
+            shape = int(cv["Shape"])
+            span = float(cv["Span"])
+            rise = float(cv["Rise"])
+            length = float(cv["Length"])
+            mann = float(cv["ManningsN"])
+            ke = float(cv.get("EntranceLoss", 0.5))
+            kex = float(cv.get("ExitLoss", 1.0))
+            chart = int(cv.get("Chart", 1))
+            scale = int(cv.get("Scale", 1))
+            us_inv = float(cv["UpstreamInvert"])
+            ds_inv = float(cv["DownstreamInvert"])
+            name = str(cv.get("Name", f"Culvert #{ci + 1}"))[:12].ljust(12)
+            bottom_n = float(cv.get("BottomN", mann))
+            nbar = len(barrels)
+
+            # record line (flag field is 0; trailing comma + empty field per HEC-RAS)
+            new_lines.append(
+                f"Connection Culv={shape},{span},{rise},{length},{mann},{ke},{kex},"
+                f"{chart},{scale},{us_inv},{ds_inv}, {nbar} ,{name}, 0 ,\n")
+
+            # station line (8-char fixed width, one US/DS pair per barrel)
+            stations: List[float] = []
+            for b in barrels:
+                us_xy = tuple(map(float, b["us_xy"]))
+                ds_xy = tuple(map(float, b["ds_xy"]))
+                if "us_station" in b and "ds_station" in b:
+                    us_s, ds_s = float(b["us_station"]), float(b["ds_station"])
+                elif conn_ls is not None:
+                    mid = ((us_xy[0] + ds_xy[0]) / 2, (us_xy[1] + ds_xy[1]) / 2)
+                    us_s = ds_s = float(conn_ls.project(Point(*mid)))
+                else:
+                    us_s = ds_s = 0.0
+                stations.extend([us_s, ds_s])
+                # length consistency (HEC-RAS rejects > ~1%)
+                glen = math.dist(us_xy, ds_xy)
+                if length and abs(glen - length) / length > 0.01:
+                    length_warnings.append(
+                        f"{name.strip()} barrel '{b.get('name','')}' GIS length "
+                        f"{glen:.2f} differs from Length {length:.2f} by "
+                        f"{abs(glen - length) / length * 100:.1f}% (>1%; HEC-RAS may reject)")
+            new_lines.extend(
+                GeomParser.format_fixed_width(
+                    stations, column_width=GeomLateral.FIXED_WIDTH_COLUMN,
+                    values_per_line=GeomLateral.VALUES_PER_LINE, precision=2))
+            # per-barrel record + GIS coordinate line
+            for bi, b in enumerate(barrels, start=1):
+                bname = str(b.get("name", f"Barrel #{bi}"))
+                new_lines.append(f"Conn Culvert Barrel={bi},{bname},2\n")
+                us_xy = tuple(map(float, b["us_xy"]))
+                ds_xy = tuple(map(float, b["ds_xy"]))
+                new_lines.append(fw_coords([us_xy, ds_xy]) + "\n")
+            new_lines.append(f"Conn Culv Bottom n={bottom_n}\n")
+            n_barrels_total += nbar
+
+        # shared HTab lines (once, after all groups) + trailing blank
+        new_lines.append("Conn HTab FreeFlow Pts= 100 \n")
+        new_lines.append("Conn HTab Sub Flow Curves= 60 \n")
+        new_lines.append("Conn HTab Sub Flow Pts= 50 \n")
+        new_lines.append("\n")
+
+        # locate insertion / replacement range within the block (absolute indices)
+        abs_lines = lines
+        first_culv = None
+        for bi, bl in enumerate(block_lines):
+            if bl.startswith("Connection Culv="):
+                first_culv = start_idx + bi
+                break
+        if first_culv is not None:
+            # Replace ONLY the culvert section: from the first Connection Culv= up
+            # to the first line that is a different record. Consume culvert keys,
+            # their numeric station/coordinate continuation lines, and blanks.
+            # BOUNDED by end_idx and the connection terminator so a connection that
+            # lacks a trailing Conn Outlet Rating Curve= (or a legacy
+            # "SA/2D Area Conn=" block, or a following Conn BR:/Storage Area/River
+            # Reach) cannot be swept up and deleted.
+            culv_keys = ("Connection Culv=", "Conn Culvert Barrel=",
+                         "Conn Culv Bottom n=", "Conn HTab")
+            j = first_culv
+            while j < end_idx:
+                ln = abs_lines[j]
+                if ln.startswith(culv_keys):
+                    j += 1
+                    continue
+                if ln.strip() == "":  # blank within / trailing the culvert section
+                    j += 1
+                    continue
+                if j != first_culv and GeomLateral._is_connection_block_terminator(ln):
+                    break
+                if "=" in ln and not ln[:1].isspace():  # a different record key -> stop
+                    break
+                # numeric station/coordinate continuation line (no key)
+                j += 1
+            replace_start, replace_end = first_culv, j
+        else:
+            # insert before Conn Outlet Rating Curve= (else end of block)
+            ins = None
+            for bi, bl in enumerate(block_lines):
+                if bl.startswith("Conn Outlet Rating Curve="):
+                    ins = start_idx + bi
+                    break
+            if ins is None:
+                ins = end_idx
+            replace_start, replace_end = ins, ins
+
+        backup_path = geom_file.with_suffix(geom_file.suffix + ".bak")
+        backup_path.write_text("".join(lines), encoding="utf-8")
+        out_lines = abs_lines[:replace_start] + new_lines + abs_lines[replace_end:]
+        geom_file.write_text("".join(out_lines), encoding="utf-8")
+
+        return {
+            "culverts_written": len(culverts),
+            "barrels_written": n_barrels_total,
+            "backup_path": str(backup_path),
+            "length_warnings": length_warnings,
+        }
+
     @staticmethod
     @log_call
     def get_connection_profile(geom_file: Union[str, Path],

--- a/tests/test_geom_connection_culverts.py
+++ b/tests/test_geom_connection_culverts.py
@@ -1,0 +1,186 @@
+"""Tests for SA/2D connection culvert read/author (GeomLateral).
+
+Pure-logic coverage of the fixed-width parser, plus a model-based round-trip that
+authors a culvert onto BaldEagle's Lower Levee connection (downloaded once) and
+reads it back. Skips cleanly when the example model is unavailable. End-to-end
+HEC-RAS acceptance is exercised by examples/227_2d_connection_culvert_authoring.ipynb.
+"""
+from pathlib import Path
+
+import pytest
+
+from ras_commander.geom import GeomLateral
+
+
+class TestFixedWidthFloatParser:
+    def test_whitespace_separated(self):
+        vals = GeomLateral._parse_fw_floats("   85.24   85.24")
+        assert vals == [85.24, 85.24]
+
+    def test_packed_16char(self):
+        # two 16-char coordinate fields with no delimiter between them
+        line = f"{2055956.24304882:16.8f}{353790.63030504:16.8f}"
+        vals = GeomLateral._parse_fw_floats(line)
+        assert len(vals) == 2
+        assert abs(vals[0] - 2055956.24304882) < 1e-4
+        assert abs(vals[1] - 353790.63030504) < 1e-4
+
+    def test_four_value_coord_line(self):
+        line = ("      2673720.12       678043.93"
+                "      2673774.66       678051.46")
+        vals = GeomLateral._parse_fw_floats(line)
+        assert len(vals) == 4
+        assert vals == [2673720.12, 678043.93, 2673774.66, 678051.46]
+
+
+@pytest.fixture(scope="module")
+def baldeagle(tmp_path_factory):
+    from ras_commander import RasExamples
+    out = tmp_path_factory.mktemp("baldeagle_culvauth")
+    try:
+        proj = Path(RasExamples.extract_project(
+            "BaldEagleCrkMulti2D", output_path=out, suffix="culvauthtest"))
+    except Exception as exc:
+        pytest.skip(f"BaldEagleCrkMulti2D unavailable: {exc}")
+    geom = proj / "BaldEagleDamBrk.g01"
+    if not geom.exists():
+        pytest.skip("BaldEagle geometry not extracted")
+    return geom
+
+
+# A plausible culvert on the Lower Levee embankment (coords in EPSG:2271).
+_CULVERT = {
+    "Shape": 2, "Span": 8.0, "Rise": 6.0, "Length": 60.0, "ManningsN": 0.024,
+    "EntranceLoss": 0.5, "ExitLoss": 1.0, "Chart": 8, "Scale": 1,
+    "UpstreamInvert": 540.0, "DownstreamInvert": 539.5, "Name": "Retrofit Culv",
+    "barrels": [{"name": "8x6 RCB",
+                 "us_xy": (2055956.243, 353790.630),
+                 "ds_xy": (2055952.001, 353730.780)}],
+}
+
+
+class TestAuthorRoundTrip:
+    def test_author_and_read_back(self, baldeagle):
+        # Lower Levee starts weir-only (no culverts)
+        before = GeomLateral.get_connection_culverts(baldeagle, "Lower Levee")
+        assert before.empty
+
+        res = GeomLateral.set_connection_culverts(baldeagle, "Lower Levee", [_CULVERT])
+        assert res["culverts_written"] == 1
+        assert res["barrels_written"] == 1
+
+        after = GeomLateral.get_connection_culverts(baldeagle, "Lower Levee")
+        assert len(after) == 1
+        row = after.iloc[0]
+        assert row["ShapeName"] == "Box"
+        assert abs(row["Span"] - 8.0) < 1e-6
+        assert abs(row["Length"] - 60.0) < 1e-6
+        # GIS endpoints round-trip
+        assert abs(row["us_x"] - 2055956.243) < 0.01
+        assert abs(row["ds_y"] - 353730.780) < 0.01
+
+    def test_has_culvert_flag_after_authoring(self, baldeagle):
+        GeomLateral.set_connection_culverts(baldeagle, "Lower Levee", [_CULVERT])
+        conns = GeomLateral.get_connections(baldeagle)
+        assert bool(conns.set_index("Name").loc["Lower Levee", "HasCulvert"])
+
+    def test_length_warning_on_mismatch(self, baldeagle):
+        bad = dict(_CULVERT)
+        bad["Length"] = 200.0  # GIS endpoints are ~60 ft apart -> >1% mismatch
+        res = GeomLateral.set_connection_culverts(baldeagle, "Lower Levee", [bad])
+        assert res["length_warnings"]
+
+    def test_empty_barrels_raises(self, baldeagle):
+        bad = dict(_CULVERT); bad["barrels"] = []
+        with pytest.raises(ValueError):
+            GeomLateral.set_connection_culverts(baldeagle, "Lower Levee", [bad])
+
+
+# ---------------------------------------------------------------------------
+# Regression tests for QAQC blockers (pure synthetic geometry; no HEC-RAS).
+# ---------------------------------------------------------------------------
+_NEW = {
+    "Shape": 2, "Span": 8.0, "Rise": 6.0, "Length": 60.0, "ManningsN": 0.024,
+    "EntranceLoss": 0.5, "ExitLoss": 1.0, "Chart": 8, "Scale": 1,
+    "UpstreamInvert": 540.0, "DownstreamInvert": 539.5, "Name": "New Culv",
+    "barrels": [{"name": "B1", "us_xy": (1000.0, 2000.0), "ds_xy": (1060.0, 2000.0),
+                 "us_station": 50.0, "ds_station": 50.0}],
+}
+
+_EXISTING_CULV_BLOCK = (
+    "Connection=Test            ,500,500\n"
+    "Connection Line=2\n"
+    "             0.0           0.0           100.0           0.0\n"
+    "Conn Weir SE= 1 \n"
+    "       0   10.0\n"
+    "Connection Culv=1,5,5,40,0.013,0.5,1,1,1,10.0,9.5, 1 ,Old Culv    , 0 ,\n"
+    "    50.0    50.0\n"
+    "Conn Culvert Barrel=1,B1,2\n"
+    "          0.0          0.0         40.0          0.0\n"
+    "Conn Culv Bottom n=0.013\n"
+    "Conn HTab FreeFlow Pts= 100 \n"
+    "Conn HTab Sub Flow Curves= 60 \n"
+    "Conn HTab Sub Flow Pts= 50 \n"
+    "\n"
+)
+
+
+def _write(tmp_path, text):
+    p = tmp_path / "synthetic.g01"
+    p.write_text(text, encoding="utf-8")
+    return p
+
+
+class TestWriterSafety:
+    def test_no_rating_curve_preserves_downstream_storage_area(self, tmp_path):
+        # CRITICAL: replacing a culvert on a connection with no
+        # Conn Outlet Rating Curve= must not delete the following Storage Area.
+        geom = _write(tmp_path, _EXISTING_CULV_BLOCK
+                      + "Storage Area=KEEP_ME      ,0,0\n"
+                      + "Storage Area Surface Line= 0 \n")
+        GeomLateral.set_connection_culverts(geom, "Test", [_NEW])
+        txt = geom.read_text()
+        assert "Storage Area=KEEP_ME" in txt
+        assert "River" not in txt or "KEEP_ME" in txt  # sanity
+        after = GeomLateral.get_connection_culverts(geom, "Test")
+        assert len(after) == 1 and after.iloc[0]["CulvertName"] == "New Culv"
+
+    def test_legacy_sa2d_area_conn_next_block_preserved(self, tmp_path):
+        # CRITICAL: a legacy "SA/2D Area Conn=" header must terminate the scan.
+        block = _EXISTING_CULV_BLOCK.replace("Connection=Test            ,500,500",
+                                             "SA/2D Area Conn=First           ,0,0")
+        geom = _write(tmp_path, block
+                      + "SA/2D Area Conn=Second          ,1,1\n"
+                      + "Conn Weir SE= 1 \n")
+        GeomLateral.set_connection_culverts(geom, "First", [_NEW])
+        assert "SA/2D Area Conn=Second" in geom.read_text()
+
+    def test_six_barrel_round_trip(self, tmp_path):
+        # HIGH: >5 barrels wrap stations onto 2 lines; reader must read all 6.
+        geom = _write(tmp_path, _EXISTING_CULV_BLOCK
+                      + "Conn Outlet Rating Curve= 0 ,False,,\n")
+        six = dict(_NEW)
+        six["barrels"] = [{"name": f"B{i}", "us_station": 100.0 + i, "ds_station": 100.0 + i,
+                           "us_xy": (1000.0 + 10 * i, 2000.0), "ds_xy": (1060.0 + 10 * i, 2000.0)}
+                          for i in range(6)]
+        GeomLateral.set_connection_culverts(geom, "Test", [six])
+        after = GeomLateral.get_connection_culverts(geom, "Test")
+        assert len(after) == 6
+        assert not after["us_station"].isna().any()
+
+    def test_packed_8char_stations_parse(self, tmp_path):
+        # HIGH: packed 8-char station line must not parse as NaN.
+        block = _EXISTING_CULV_BLOCK.replace(
+            "Connection Culv=1,5,5,40,0.013,0.5,1,1,1,10.0,9.5, 1 ,Old Culv    , 0 ,\n"
+            "    50.0    50.0\n"
+            "Conn Culvert Barrel=1,B1,2\n",
+            "Connection Culv=1,5,5,40,0.013,0.5,1,1,1,10.0,9.5, 2 ,Old Culv    , 0 ,\n"
+            "12345.6712345.6812345.6912345.70\n"
+            "Conn Culvert Barrel=1,B1,2\n"
+            "          0.0          0.0         40.0          0.0\n"
+            "Conn Culvert Barrel=2,B2,2\n")
+        geom = _write(tmp_path, block)
+        df = GeomLateral.get_connection_culverts(geom, "Test")
+        assert len(df) == 2
+        assert not df["us_station"].isna().any()
+        assert abs(df.iloc[0]["us_station"] - 12345.67) < 0.01


### PR DESCRIPTION
## Summary
Adds **`GeomLateral.get_connection_culverts()`** and **`set_connection_culverts()`** — read and author the `Connection Culv=` records on a SA/2D connection. 2D connection culverts **store explicit per-barrel GIS endpoint coordinates** (a `Conn Culvert Barrel=` + packed `US_x US_y DS_x DS_y` line per barrel), unlike 1D inline culverts which derive them — so the HEC-RAS ±1% GIS-length rule is **exact** for 2D.

**Validated:**
- Format decoded + the reader verified against **production LA LWI 2D models** (single-barrel, multi-barrel, multi-culvert-per-connection; stored GIS lengths match entered `Length` within ~1%).
- Reader **round-trips losslessly** through the writer on those models.
- An API-authored culvert on **BaldEagle** is **accepted by HEC-RAS** (`ComputeResult(SUCCESS)`, no `data_errors`).

## Also
- **`examples/227_2d_connection_culvert_authoring.ipynb`** — author a retrofit culvert onto BaldEagle's Lower Levee connection (terrain-validated inverts via `GeomCulvertGIS`), validate it (exact ±1% length), plan view. HEC-RAS acceptance documented (run separately to keep the notebook fast).
- **`tests/test_geom_connection_culverts.py`** — fixed-width parser, BaldEagle round-trip, and writer-safety regressions. **11 tests pass.**
- `geom/AGENTS.md` documents the methods + the record layout.

## QAQC
Adversarially reviewed by **Codex (gpt-5.2-codex)** — returned **DO-NOT-MERGE** with 2 CRITICAL + 2 HIGH blockers, all reproduced and fixed (+ regression-tested):
- **CRITICAL — silent geometry deletion.** The writer's replacement scan ran to EOF looking for a `Conn Outlet Rating Curve=` sentinel; on a connection lacking it (or a legacy `SA/2D Area Conn=` block), it could **delete the following Storage Area / River Reach / next connection**. Now the replacement is bounded by the connection block (`end_idx`) and the connection terminator, and consumes **only the culvert section**.
- **HIGH — 6+ barrels & packed stations.** Station lines now parse at 8-char width and accumulate across wrapped lines, so >5-barrel groups round-trip; packed 8-char stations no longer read as `NaN`.
- **MEDIUM — `_parse_fw_floats`** takes `expected_count` and prefers the whitespace split when a token exceeds the field width.

Refs CLB-895.

🤖 Generated with [Claude Code](https://claude.com/claude-code)