### PR TITLE
feat(geom): expose 1D culvert US Distance in get/set_culverts (CLB-895)

### DIFF
--- a/examples/204_culvert_gis_validation.ipynb
+++ b/examples/204_culvert_gis_validation.ipynb
@@ -14,10 +14,10 @@
    "id": "52297f66",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-11T19:47:04.027474Z",
-     "iopub.status.busy": "2026-06-11T19:47:04.027474Z",
-     "iopub.status.idle": "2026-06-11T19:47:04.032070Z",
-     "shell.execute_reply": "2026-06-11T19:47:04.030871Z"
+     "iopub.execute_input": "2026-06-12T12:59:42.863739Z",
+     "iopub.status.busy": "2026-06-12T12:59:42.863139Z",
+     "iopub.status.idle": "2026-06-12T12:59:42.870340Z",
+     "shell.execute_reply": "2026-06-12T12:59:42.869150Z"
     }
    },
    "outputs": [],
@@ -43,10 +43,10 @@
    "id": "b8e7f5ab",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-11T19:47:04.036213Z",
-     "iopub.status.busy": "2026-06-11T19:47:04.035497Z",
-     "iopub.status.idle": "2026-06-11T19:47:05.775863Z",
-     "shell.execute_reply": "2026-06-11T19:47:05.775863Z"
+     "iopub.execute_input": "2026-06-12T12:59:42.874482Z",
+     "iopub.status.busy": "2026-06-12T12:59:42.874482Z",
+     "iopub.status.idle": "2026-06-12T12:59:45.061828Z",
+     "shell.execute_reply": "2026-06-12T12:59:45.061828Z"
     }
    },
    "outputs": [
@@ -69,7 +69,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Loaded: G:\\GH\\ras-commander-wt-culverts\\ras_commander\\__init__.py\n"
+      "Loaded: G:\\GH\\ras-commander-wt-usdist\\ras_commander\\__init__.py\n"
      ]
     }
    ],
@@ -164,18 +164,41 @@
    "id": "1cec412d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-11T19:47:05.775863Z",
-     "iopub.status.busy": "2026-06-11T19:47:05.775863Z",
-     "iopub.status.idle": "2026-06-11T19:47:06.265069Z",
-     "shell.execute_reply": "2026-06-11T19:47:06.264447Z"
+     "iopub.execute_input": "2026-06-12T12:59:45.061828Z",
+     "iopub.status.busy": "2026-06-12T12:59:45.061828Z",
+     "iopub.status.idle": "2026-06-12T12:59:46.503993Z",
+     "shell.execute_reply": "2026-06-12T12:59:46.503993Z"
     }
    },
    "outputs": [
     {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "HECRAS_model_files.zip:   0%|          | 0.00/9.47M [00:00<?, ?B/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "HECRAS_model_files.zip: 100%|██████████| 9.47M/9.47M [00:00<00:00, 13.8MB/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    },
+    {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Project: G:\\GH\\ras-commander-wt-culverts\\working\\culvert_gis\\squannacook\\Squannacook.prj\n"
+      "Project: G:\\GH\\ras-commander-wt-usdist\\working\\culvert_gis\\squannacook\\Squannacook.prj\n"
      ]
     },
     {
@@ -283,10 +306,10 @@
    "id": "41634b48",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-11T19:47:06.266884Z",
-     "iopub.status.busy": "2026-06-11T19:47:06.266884Z",
-     "iopub.status.idle": "2026-06-11T19:47:06.282161Z",
-     "shell.execute_reply": "2026-06-11T19:47:06.282161Z"
+     "iopub.execute_input": "2026-06-12T12:59:46.506001Z",
+     "iopub.status.busy": "2026-06-12T12:59:46.506001Z",
+     "iopub.status.idle": "2026-06-12T12:59:46.522803Z",
+     "shell.execute_reply": "2026-06-12T12:59:46.522803Z"
     }
    },
    "outputs": [
@@ -556,6 +579,103 @@
   },
   {
    "cell_type": "markdown",
+   "id": "3cc5bcae",
+   "metadata": {},
+   "source": [
+    "## US Distance: the offset that places the upstream face\n",
+    "\n",
+    "The structure's **US Distance** is what ties a 1D culvert to a planimetric\n",
+    "location. `GeomCulvert.get_culverts()` exposes it as the `UsDistance` column and\n",
+    "`set_culverts()` preserves it, so it can be read, edited, and round-tripped."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "72ad202f",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-12T12:59:46.522803Z",
+     "iopub.status.busy": "2026-06-12T12:59:46.522803Z",
+     "iopub.status.idle": "2026-06-12T12:59:46.534360Z",
+     "shell.execute_reply": "2026-06-12T12:59:46.534360Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>CulvertName</th>\n",
+       "      <th>ShapeName</th>\n",
+       "      <th>Span</th>\n",
+       "      <th>Rise</th>\n",
+       "      <th>Length</th>\n",
+       "      <th>UsDistance</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>Culvert #1</td>\n",
+       "      <td>Circular</td>\n",
+       "      <td>6.0</td>\n",
+       "      <td>6.0</td>\n",
+       "      <td>40.0</td>\n",
+       "      <td>8.0</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "  CulvertName ShapeName  Span  Rise  Length  UsDistance\n",
+       "0  Culvert #1  Circular   6.0   6.0    40.0         8.0"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "US Distance for Culvert #1: 8.0 ft (upstream-face offset into the reach)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# get_culverts (and get_all) expose **UsDistance** -- the structure's US Distance:\n",
+    "# how far the culvert's upstream face sits downstream of the upstream bounding\n",
+    "# cross section. It is the trailing field of each plain-text `Culvert=` record\n",
+    "# (a float, e.g. 17.07 ft -- earlier library versions mislabeled it as the integer\n",
+    "# chart number). reconstruct_barrels() uses it to locate the upstream face along\n",
+    "# the reach, so it round-trips through set_culverts without loss.\n",
+    "cv = GeomCulvert.get_culverts(GEOM_PIPE, RIVER, REACH, RS)\n",
+    "display(cv[[\"CulvertName\", \"ShapeName\", \"Span\", \"Rise\", \"Length\", \"UsDistance\"]])\n",
+    "print(f\"US Distance for {cv.iloc[0]['CulvertName'].strip()}: \"\n",
+    "      f\"{cv.iloc[0]['UsDistance']} ft (upstream-face offset into the reach)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "6f2b725d",
    "metadata": {},
    "source": [
@@ -571,14 +691,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "id": "73002cfe",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-11T19:47:06.282161Z",
-     "iopub.status.busy": "2026-06-11T19:47:06.282161Z",
-     "iopub.status.idle": "2026-06-11T19:47:06.505446Z",
-     "shell.execute_reply": "2026-06-11T19:47:06.505446Z"
+     "iopub.execute_input": "2026-06-12T12:59:46.534360Z",
+     "iopub.status.busy": "2026-06-12T12:59:46.534360Z",
+     "iopub.status.idle": "2026-06-12T12:59:46.751876Z",
+     "shell.execute_reply": "2026-06-12T12:59:46.751876Z"
     }
    },
    "outputs": [
@@ -683,14 +803,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "id": "cf78a911",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-11T19:47:06.507451Z",
-     "iopub.status.busy": "2026-06-11T19:47:06.507451Z",
-     "iopub.status.idle": "2026-06-11T19:47:06.723001Z",
-     "shell.execute_reply": "2026-06-11T19:47:06.723001Z"
+     "iopub.execute_input": "2026-06-12T12:59:46.752887Z",
+     "iopub.status.busy": "2026-06-12T12:59:46.752887Z",
+     "iopub.status.idle": "2026-06-12T12:59:46.968350Z",
+     "shell.execute_reply": "2026-06-12T12:59:46.968350Z"
     }
    },
    "outputs": [
@@ -746,14 +866,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "id": "633db0d3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-11T19:47:06.723001Z",
-     "iopub.status.busy": "2026-06-11T19:47:06.723001Z",
-     "iopub.status.idle": "2026-06-11T19:47:06.777635Z",
-     "shell.execute_reply": "2026-06-11T19:47:06.777635Z"
+     "iopub.execute_input": "2026-06-12T12:59:46.968350Z",
+     "iopub.status.busy": "2026-06-12T12:59:46.968350Z",
+     "iopub.status.idle": "2026-06-12T12:59:47.027017Z",
+     "shell.execute_reply": "2026-06-12T12:59:47.026461Z"
     }
    },
    "outputs": [
@@ -871,14 +991,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "id": "ee88c7e5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-11T19:47:06.777635Z",
-     "iopub.status.busy": "2026-06-11T19:47:06.777635Z",
-     "iopub.status.idle": "2026-06-11T19:47:07.046655Z",
-     "shell.execute_reply": "2026-06-11T19:47:07.046655Z"
+     "iopub.execute_input": "2026-06-12T12:59:47.028639Z",
+     "iopub.status.busy": "2026-06-12T12:59:47.028639Z",
+     "iopub.status.idle": "2026-06-12T12:59:47.318075Z",
+     "shell.execute_reply": "2026-06-12T12:59:47.318075Z"
     }
    },
    "outputs": [
@@ -1086,14 +1206,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "id": "0ca78ed3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-11T19:47:07.048661Z",
-     "iopub.status.busy": "2026-06-11T19:47:07.048661Z",
-     "iopub.status.idle": "2026-06-11T19:47:07.101694Z",
-     "shell.execute_reply": "2026-06-11T19:47:07.101694Z"
+     "iopub.execute_input": "2026-06-12T12:59:47.318651Z",
+     "iopub.status.busy": "2026-06-12T12:59:47.318651Z",
+     "iopub.status.idle": "2026-06-12T12:59:47.374311Z",
+     "shell.execute_reply": "2026-06-12T12:59:47.374311Z"
     }
    },
    "outputs": [
@@ -1220,14 +1340,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
    "id": "b874319f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-11T19:47:07.101694Z",
-     "iopub.status.busy": "2026-06-11T19:47:07.101694Z",
-     "iopub.status.idle": "2026-06-11T19:47:14.194415Z",
-     "shell.execute_reply": "2026-06-11T19:47:14.194415Z"
+     "iopub.execute_input": "2026-06-12T12:59:47.374311Z",
+     "iopub.status.busy": "2026-06-12T12:59:47.374311Z",
+     "iopub.status.idle": "2026-06-12T12:59:56.209965Z",
+     "shell.execute_reply": "2026-06-12T12:59:56.209965Z"
     }
    },
    "outputs": [
@@ -1235,7 +1355,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "both plans computed in 7.1 s\n",
+      "both plans computed in 8.8 s\n",
       "profile: 0.2-percent AEP\n",
       "max headwater  pipe=297.13 ft  box=295.62 ft  reduction=1.51 ft\n"
      ]
@@ -1275,14 +1395,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 12,
    "id": "b46c553e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-11T19:47:14.194415Z",
-     "iopub.status.busy": "2026-06-11T19:47:14.194415Z",
-     "iopub.status.idle": "2026-06-11T19:47:14.297640Z",
-     "shell.execute_reply": "2026-06-11T19:47:14.297640Z"
+     "iopub.execute_input": "2026-06-12T12:59:56.209965Z",
+     "iopub.status.busy": "2026-06-12T12:59:56.209965Z",
+     "iopub.status.idle": "2026-06-12T12:59:56.322523Z",
+     "shell.execute_reply": "2026-06-12T12:59:56.321998Z"
     }
    },
    "outputs": [
@@ -1322,14 +1442,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 13,
    "id": "44bc836b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-11T19:47:14.300680Z",
-     "iopub.status.busy": "2026-06-11T19:47:14.300680Z",
-     "iopub.status.idle": "2026-06-11T19:47:14.501140Z",
-     "shell.execute_reply": "2026-06-11T19:47:14.500479Z"
+     "iopub.execute_input": "2026-06-12T12:59:56.324638Z",
+     "iopub.status.busy": "2026-06-12T12:59:56.324116Z",
+     "iopub.status.idle": "2026-06-12T12:59:56.605896Z",
+     "shell.execute_reply": "2026-06-12T12:59:56.605896Z"
     }
    },
    "outputs": [
@@ -1369,14 +1489,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 14,
    "id": "7ae7fc41",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-11T19:47:14.502968Z",
-     "iopub.status.busy": "2026-06-11T19:47:14.502968Z",
-     "iopub.status.idle": "2026-06-11T19:47:14.514619Z",
-     "shell.execute_reply": "2026-06-11T19:47:14.514097Z"
+     "iopub.execute_input": "2026-06-12T12:59:56.605896Z",
+     "iopub.status.busy": "2026-06-12T12:59:56.605896Z",
+     "iopub.status.idle": "2026-06-12T12:59:56.620179Z",
+     "shell.execute_reply": "2026-06-12T12:59:56.620179Z"
     }
    },
    "outputs": [

--- a/ras_commander/geom/AGENTS.md
+++ b/ras_commander/geom/AGENTS.md
@@ -54,6 +54,9 @@ Reconstruct and validate culvert placement from geometry; complements `GeomCulve
   basis). Accuracy ~mean 2.6% vs HEC-RAS, so the length check is an informational
   `REVIEW`. `validate_placement` runs: invert vs the **local bed under the opening**
   (not a far-off XS minimum), HDS-5 entrance/exit-loss guidance, and the length indicator.
+  The `US Distance` (trailing field of each plain-text `Culvert=` / `Multiple Barrel Culv=`
+  record) is exposed by `GeomCulvert.get_culverts` as the `UsDistance` column and preserved
+  by `set_culverts` -- it is a float (do not treat it as the integer chart number).
 - **2D connection culverts** (`mesh_cell_min_from_terrain`, `validate_2d_inverts`): for a
   culvert/structure end on a SA/2D connection, the relevant streambed is the minimum
   terrain elevation of the nearest 2D mesh cell. Computed **directly from the terrain

--- a/ras_commander/geom/GeomCulvert.py
+++ b/ras_commander/geom/GeomCulvert.py
@@ -177,6 +177,11 @@ class GeomCulvert:
         'chartnumber': 'ChartNumber',
         'culvert_code': 'CulvertCode',
         'culvertcode': 'CulvertCode',
+        'usdistance': 'UsDistance',
+        'us_distance': 'UsDistance',
+        'us distance': 'UsDistance',
+        'upstreamdistance': 'UsDistance',
+        'upstream_distance': 'UsDistance',
     }
 
     REQUIRED_FIELDS = (
@@ -252,6 +257,16 @@ class GeomCulvert:
             return float(str(value).strip())
         except (TypeError, ValueError):
             return None
+
+    @staticmethod
+    def _coalesce_us_distance(record: Dict[str, Any]) -> Any:
+        """Pick the trailing-field value for a culvert record: ``UsDistance`` when
+        present and not NaN, otherwise the legacy ``ChartNumber`` alias. Both
+        derive from the same source token, so this keeps them from diverging."""
+        us = record.get('UsDistance')
+        if not GeomCulvert._is_missing(us):
+            return us
+        return record.get('ChartNumber')
 
     @staticmethod
     def _parse_int(value: Any) -> Optional[int]:
@@ -525,6 +540,11 @@ class GeomCulvert:
             'BottomDepth': GeomCulvert._parse_float(record.get('BottomDepth')),
             'ChartNumber': GeomCulvert._parse_int(record.get('ChartNumber')),
             'CulvertCode': GeomCulvert._parse_int(record.get('CulvertCode')),
+            # US Distance is the trailing record field (legacy alias: ChartNumber).
+            # Fall back to ChartNumber when UsDistance is absent *or* NaN so the two
+            # (which always derive from the same source token) never diverge.
+            'UsDistance': GeomCulvert._parse_float(
+                GeomCulvert._coalesce_us_distance(record)),
         }
 
         for field in GeomCulvert.REQUIRED_FIELDS:
@@ -587,6 +607,10 @@ class GeomCulvert:
             normalized['CulvertCode'] = 0
         if normalized['ChartNumber'] is None:
             normalized['ChartNumber'] = 0
+        # The trailing field defaults to ChartNumber (0 when unset) so a record
+        # with no US Distance serializes byte-identically to the legacy behavior.
+        if GeomCulvert._is_missing(normalized['UsDistance']):
+            normalized['UsDistance'] = normalized['ChartNumber']
 
         return normalized
 
@@ -654,6 +678,7 @@ class GeomCulvert:
             'BarrelStations': [],
             'ChartNumber': None,
             'CulvertCode': None,
+            'UsDistance': None,
             'BottomN': None,
             'BottomDepth': None,
             'NumBarrels': 1,
@@ -679,7 +704,12 @@ class GeomCulvert:
             data['NumBarrels'] = GeomCulvert._parse_int(parts[11]) if len(parts) > 11 else 1
             data['CulvertName'] = GeomCulvert._parse_text(parts[12]) if len(parts) > 12 else None
             data['CulvertCode'] = GeomCulvert._parse_int(parts[13]) if len(parts) > 13 else None
+            # trailing field is the structure's US Distance (distance from the
+            # upstream bounding XS to the culvert), historically mislabeled
+            # ChartNumber. Expose it properly as a float; keep ChartNumber for
+            # backward compatibility.
             data['ChartNumber'] = GeomCulvert._parse_int(parts[14]) if len(parts) > 14 else None
+            data['UsDistance'] = GeomCulvert._parse_float(parts[14]) if len(parts) > 14 else None
 
             expected_values = max(data['NumBarrels'] or 0, 0) * 2
             station_values, next_idx = GeomCulvert._parse_station_values(
@@ -701,7 +731,9 @@ class GeomCulvert:
             data['DownstreamStation'] = GeomCulvert._parse_float(parts[12]) if len(parts) > 12 else None
             data['CulvertName'] = GeomCulvert._parse_text(parts[13]) if len(parts) > 13 else None
             data['CulvertCode'] = GeomCulvert._parse_int(parts[14]) if len(parts) > 14 else None
+            # trailing field is the structure's US Distance (see multi-barrel note)
             data['ChartNumber'] = GeomCulvert._parse_int(parts[15]) if len(parts) > 15 else None
+            data['UsDistance'] = GeomCulvert._parse_float(parts[15]) if len(parts) > 15 else None
             if data['UpstreamStation'] is not None and data['DownstreamStation'] is not None:
                 data['BarrelStations'] = [(data['UpstreamStation'], data['DownstreamStation'])]
                 data['UpstreamStations'] = [data['UpstreamStation']]
@@ -786,7 +818,7 @@ class GeomCulvert:
                 record['NumBarrels'],
                 record['CulvertName'],
                 record['CulvertCode'],
-                record['ChartNumber'],
+                record.get('UsDistance', record.get('ChartNumber')),
             ]
             output = [f"Multiple Barrel Culv={','.join(GeomCulvert._format_value(v) for v in fields)}\n"]
             station_values = []
@@ -815,7 +847,7 @@ class GeomCulvert:
                 record['DownstreamStation'],
                 record['CulvertName'],
                 record['CulvertCode'],
-                record['ChartNumber'],
+                record.get('UsDistance', record.get('ChartNumber')),
             ]
             output = [f"Culvert={','.join(GeomCulvert._format_value(v) for v in fields)}\n"]
 
@@ -858,7 +890,12 @@ class GeomCulvert:
             - UpstreamStation: Upstream station location
             - DownstreamInvert: Downstream invert elevation
             - DownstreamStation: Downstream station location
-            - ChartNumber: Inlet control chart number
+            - ChartNumber: Inlet control chart number (legacy alias of the
+              trailing record field; kept as an int for backward compatibility)
+            - UsDistance: Structure US Distance (float) -- the offset of the
+              culvert's upstream face downstream of the upstream bounding cross
+              section. This is the trailing field of the plain-text record;
+              ``set_culverts`` preserves it. Do not treat it as the chart number.
             - BottomN: Bottom Manning's n (if different)
             - NumBarrels: Number of barrels
 

--- a/ras_commander/geom/GeomCulvertGIS.py
+++ b/ras_commander/geom/GeomCulvertGIS.py
@@ -57,7 +57,6 @@ flags proposed inverts that fall below their cell minimum. These methods require
 from __future__ import annotations
 
 import math
-import re
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Sequence, Tuple, Union
 
@@ -69,16 +68,6 @@ from ras_commander.geom.GeomCulvert import GeomCulvert
 from ras_commander.geom.GeomCrossSection import GeomCrossSection
 
 logger = get_logger(__name__)
-
-
-def _normalize_rs(rs: str) -> str:
-    """Normalize a river-station string for tolerant comparison (numeric when
-    possible, else stripped text)."""
-    s = str(rs).strip()
-    try:
-        return repr(float(s.replace("*", "")))
-    except (ValueError, AttributeError):
-        return s.casefold()
 
 
 class GeomCulvertGIS:
@@ -121,55 +110,6 @@ class GeomCulvertGIS:
     ENTRANCE_LOSS_TOLERANCE = 0.15  # warn if |Ke - recommended| exceeds this
     TYPICAL_EXIT_LOSS = 1.0
     INVERT_TOLERANCE = 0.1  # ft; invert below thalweg by less than this is survey noise
-
-    # ------------------------------------------------------------------
-    # raw culvert-record parsing (US Distance is not exposed by get_culverts)
-    # ------------------------------------------------------------------
-    @staticmethod
-    def _structure_us_distances(geom_text: str, river: str, reach: str,
-                                struct_rs: str) -> List[float]:
-        """Return the ``US Distance`` (last field) of each culvert record in the
-        structure block at ``river``/``reach``/``struct_rs``, in file order.
-
-        Scoped to the correct ``River Reach=`` block so a duplicate river station
-        in another reach cannot be matched. (``US Distance`` is not exposed by
-        ``GeomCulvert.get_culverts``.)
-        """
-        out: List[float] = []
-        in_reach = False
-        in_block = False
-        target_river = str(river).strip().casefold()
-        target_reach = str(reach).strip().casefold()
-        rs_clean = str(struct_rs).strip()
-        # tolerate trailing zeros / formatting on the RS field
-        rs_pat = re.compile(r"^Type RM Length L Ch R = 2\s*,\s*([^,]+),")
-        for line in geom_text.splitlines():
-            if line.startswith("River Reach="):
-                payload = line.split("=", 1)[1]
-                parts = [p.strip().casefold() for p in payload.split(",")]
-                in_reach = (len(parts) >= 2
-                            and parts[0] == target_river
-                            and parts[1] == target_reach)
-                in_block = False
-                continue
-            if not in_reach:
-                continue
-            m = rs_pat.match(line)
-            if m:
-                this_rs = m.group(1).strip()
-                in_block = (this_rs == rs_clean
-                            or _normalize_rs(this_rs) == _normalize_rs(rs_clean))
-                continue
-            if in_block and line.startswith("Type RM Length L Ch R"):
-                in_block = False
-                continue
-            if in_block and (line.startswith("Culvert=")
-                             or line.startswith("Multiple Barrel Culv=")):
-                try:
-                    out.append(float(line.rsplit(",", 1)[-1].strip()))
-                except (ValueError, IndexError):
-                    out.append(float("nan"))
-        return out
 
     # ------------------------------------------------------------------
     # geometry helpers
@@ -272,20 +212,15 @@ class GeomCulvertGIS:
                 - length_error_pct  (|planimetric - entered| / entered * 100)
         """
         geom_file = Path(geom_file)
-        text = geom_file.read_text(encoding="utf-8", errors="replace")
 
         culverts = GeomCulvert.get_culverts(geom_file, river, reach, rs)
         if culverts.empty:
             return pd.DataFrame()
 
-        us_dists = GeomCulvertGIS._structure_us_distances(text, river, reach, rs)
-        if len(us_dists) != len(culverts):
-            raise ValueError(
-                f"US Distance parse mismatch for {river}/{reach}/RS {rs}: found "
-                f"{len(us_dists)} culvert records in the geometry block but "
-                f"get_culverts returned {len(culverts)}. Refusing to align by "
-                f"index (could assign foreign US Distance values)."
-            )
+        # US Distance is exposed per-culvert by get_culverts (no separate raw
+        # parse / index-alignment needed).
+        us_dists = [float(v) if v is not None and v == v else float("nan")
+                    for v in culverts.get("UsDistance", [float("nan")] * len(culverts))]
 
         adj = GeomCulvert.get_adjacent_cross_sections(geom_file, river, reach, rs)
         us_rs = str(adj["upstream"]["RS"])

--- a/tests/test_geom_culvert_authoring.py
+++ b/tests/test_geom_culvert_authoring.py
@@ -202,6 +202,11 @@ def test_set_culverts_round_trips_circular_box_and_multi_barrel(tmp_path):
     assert culverts.loc[2, "BarrelStations"] == [(980.0, 980.0), (1000.0, 1000.0), (1020.0, 1020.0)]
     assert culverts.loc[2, "BottomN"] == pytest.approx(0.02)
     assert culverts.loc[2, "ChartNumber"] == 30
+    # Backward compat: records carry ChartNumber but no UsDistance key. The
+    # trailing field must still serialize from ChartNumber (legacy behavior), so
+    # UsDistance reads back equal to ChartNumber.
+    assert culverts.loc[0, "UsDistance"] == pytest.approx(5)
+    assert culverts.loc[2, "UsDistance"] == pytest.approx(30)
 
     all_culverts = GeomCulvert.get_all(geom_file)
     assert all_culverts[["River", "Reach", "RS"]].drop_duplicates().values.tolist() == [
@@ -263,6 +268,38 @@ def test_reader_parses_existing_culvert_and_multiple_barrel_records(tmp_path):
     assert culverts.loc[1, "ShapeName"] == "Box"
     assert culverts.loc[1, "NumBarrels"] == 2
     assert culverts.loc[1, "BarrelStations"] == [(988.5, 988.5), (1011.5, 1011.5)]
+
+
+def test_reader_exposes_us_distance(tmp_path):
+    # The trailing record field is the structure's US Distance (offset of the
+    # upstream face into the reach), not the chart number. Both fixture records
+    # carry US Distance = 5.
+    geom_file = _write_geometry(tmp_path, _real_world_culvert_text())
+
+    culverts = GeomCulvert.get_culverts(geom_file, "Test River", "Reach 1", "100")
+
+    assert "UsDistance" in culverts.columns
+    assert culverts.loc[0, "UsDistance"] == pytest.approx(5.0)
+    assert culverts.loc[1, "UsDistance"] == pytest.approx(5.0)
+
+
+def test_set_culverts_round_trips_non_integer_us_distance(tmp_path):
+    # US Distance is a float in real models (e.g. 17.07). It must survive a
+    # read -> set -> read cycle without being truncated to an int (the field was
+    # previously mislabeled/parsed as the integer ChartNumber).
+    geom_file = _write_geometry(tmp_path)
+    record = {**_culvert_records()[0], "UsDistance": 17.07}
+
+    GeomCulvert.set_culverts(geom_file, "Test River", "Reach 1", "100", [record])
+    culverts = GeomCulvert.get_culverts(geom_file, "Test River", "Reach 1", "100")
+    assert culverts.loc[0, "UsDistance"] == pytest.approx(17.07)
+
+    # round-trip the read-back records and confirm the value is stable
+    GeomCulvert.set_culverts(
+        geom_file, "Test River", "Reach 1", "100", culverts.to_dict("records")
+    )
+    again = GeomCulvert.get_culverts(geom_file, "Test River", "Reach 1", "100")
+    assert again.loc[0, "UsDistance"] == pytest.approx(17.07)
 
 
 def test_set_culvert_updates_existing_record_and_appends(tmp_path):

--- a/tests/test_geom_culvert_gis.py
+++ b/tests/test_geom_culvert_gis.py
@@ -135,8 +135,8 @@ class TestReconstructionRegression:
         assert status(rep_box, "ds_invert") == "PASS"
 
     def test_us_distance_scoped_to_reach(self, squannacook_dir):
-        # _structure_us_distances must find exactly the culverts in this reach's
-        # structure block (count matches get_culverts -> no raise, all placed).
+        # reconstruct_barrels reads UsDistance from get_culverts (per-culvert,
+        # reach-scoped), so every culvert in this structure block is placed.
         geom = squannacook_dir / "Squannacook.g06"
         barrels = GeomCulvertGIS.reconstruct_barrels(geom, *MEADOW)
         assert not barrels["planimetric_length"].isna().any()


### PR DESCRIPTION
## Summary

The trailing field of every plain-text `Culvert=` / `Multiple Barrel Culv=` record is the structure's **US Distance** — a float offset of the culvert's upstream face into the reach — **not** the chart number. The library historically parsed it as the integer `ChartNumber`, truncating the float and never exposing US Distance through the public API. `GeomCulvertGIS.reconstruct_barrels` needed it and carried a duplicate raw-text parser to get it.

This is the final increment of the CLB-895 culvert-GIS feature (follows PRs #207, #212, #220).

## Changes

- **`GeomCulvert`**: `get_culverts` now returns a `UsDistance` (float) column; `set_culverts` preserves it. `ChartNumber` stays as a backward-compatible int alias. A record with neither field serializes byte-identically to the legacy `,0` trailing field (`_coalesce_us_distance` + a `UsDistance` default mirroring the `ChartNumber=0` default). Five input aliases accepted (`usdistance`/`us_distance`/`us distance`/`upstreamdistance`/`upstream_distance`).
- **`GeomCulvertGIS.reconstruct_barrels`**: reads the new `UsDistance` column from `get_culverts` instead of its own duplicate raw parser. The now-dead `_structure_us_distances` / `_normalize_rs` helpers and `import re` are removed. 1D reconstruction accuracy is unchanged (mean 2.72% / median 1.44% / max 10.74% across the 16 Squannacook crossings).
- **`examples/204`**: new section demonstrating the `UsDistance` column (executed, 0 error cells, 330 KB).
- **Tests**: `test_reader_exposes_us_distance`, `test_set_culverts_round_trips_non_integer_us_distance` (17.07 round-trip + second read→set→read cycle), and backward-compat assertions that a `ChartNumber`-only record still serializes the trailing field.
- **Docs**: `geom/AGENTS.md` and the `get_culverts` docstring document the column.

## Verification

- `pytest tests/test_geom_culvert_authoring.py tests/test_geom_culvert_gis.py` → **35 passed** (full culvert suite incl. connection culverts: 46 passed).
- Round-trip: `UsDistance` 17.07 → read/set/read preserved; integer-valued US Distance (`8.0`) renders as `8` (no `.0` regression); no-field record writes `,0`.
- **Adversarial Codex QAQC**: safe to merge, no blockers. LOW polish applied (NaN-aware fallback, byte-identical trailing default, docstring + backward-compat test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)