### PR TITLE
feat(remote): native-Linux Docker host support over SSH

### DIFF
--- a/ras_commander/remote/DockerSshStaging.py
+++ b/ras_commander/remote/DockerSshStaging.py
@@ -1,0 +1,353 @@
+"""
+DockerSshStaging - SSH/SFTP file staging helpers for native-Linux Docker hosts.
+
+When a DockerWorker targets a native-Linux Docker daemon over an ``ssh://`` URL
+(e.g. CLB07), there is no Windows UNC share to copy project files into. Instead
+the project is transferred to a Linux staging directory on the Docker host using
+SSH (SFTP via paramiko, or scp/ssh via the system client) and results are copied
+back the same way.
+
+This module is intentionally self-contained so the Windows-Docker-Desktop code
+path in :mod:`DockerWorker` is left completely untouched.
+
+Two transports are supported, matching the existing ``use_ssh_client`` option:
+
+    - paramiko (default): in-process SSH/SFTP, no external ssh binary required.
+    - system ssh client (``use_ssh_client=True``): shells out to ``ssh``/``scp``
+      so that SSH agent and ``~/.ssh/config`` settings are honored.
+
+The host/user/port are parsed from the ``ssh://user@host:port`` Docker host URL.
+"""
+
+import os
+import shlex
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+from typing import List, Optional
+from urllib.parse import urlparse
+
+from ..LoggingConfig import get_logger
+
+logger = get_logger(__name__)
+
+
+@dataclass
+class SshTarget:
+    """Parsed connection details for an ``ssh://user@host:port`` Docker host."""
+
+    host: str
+    user: Optional[str] = None
+    port: int = 22
+
+    @property
+    def user_host(self) -> str:
+        return f"{self.user}@{self.host}" if self.user else self.host
+
+
+def parse_ssh_host(docker_host: str) -> SshTarget:
+    """
+    Parse an ``ssh://user@host[:port]`` Docker host URL into an SshTarget.
+
+    Args:
+        docker_host: e.g. "ssh://root@192.168.3.81" or "ssh://root@host:2222"
+
+    Returns:
+        SshTarget with host, user, and port.
+
+    Raises:
+        ValueError: if the URL is not an ssh:// URL or has no host.
+    """
+    if not docker_host or not docker_host.startswith("ssh://"):
+        raise ValueError(
+            f"Linux Docker host requires an ssh:// URL, got: {docker_host!r}"
+        )
+    parsed = urlparse(docker_host)
+    if not parsed.hostname:
+        raise ValueError(f"Could not parse host from ssh URL: {docker_host!r}")
+    return SshTarget(
+        host=parsed.hostname,
+        user=parsed.username,
+        port=parsed.port or 22,
+    )
+
+
+def _is_windows_reserved(name: str) -> bool:
+    """Local helper mirroring RasUtils.is_windows_reserved_name without import cost."""
+    reserved = {
+        "CON", "PRN", "AUX", "NUL",
+        *(f"COM{i}" for i in range(1, 10)),
+        *(f"LPT{i}" for i in range(1, 10)),
+    }
+    stem = name.split(".")[0].upper()
+    return stem in reserved
+
+
+def _iter_project_files(local_dir: Path):
+    """
+    Yield (absolute_local_path, posix_relative_path) for every file under
+    local_dir, skipping Windows reserved names.
+    """
+    local_dir = Path(local_dir)
+    for path in sorted(local_dir.rglob("*")):
+        if path.is_dir():
+            continue
+        rel = path.relative_to(local_dir)
+        if any(_is_windows_reserved(part) for part in rel.parts):
+            continue
+        yield path, PurePosixPath(*rel.parts)
+
+
+class LinuxDockerSshStager:
+    """
+    Stages files to and from a native-Linux Docker host over SSH.
+
+    Usage:
+        stager = LinuxDockerSshStager(worker)
+        stager.mkdirs([input_remote, output_remote])
+        stager.upload_dir(local_input, input_remote)
+        ... run container ...
+        stager.download_matching(output_remote, ["*.hdf"], local_dest)
+        stager.rmtree(staging_root)
+    """
+
+    def __init__(
+        self,
+        docker_host: str,
+        use_ssh_client: bool = False,
+        ssh_key_path: Optional[str] = None,
+    ):
+        self.target = parse_ssh_host(docker_host)
+        self.use_ssh_client = use_ssh_client
+        self.ssh_key_path = (
+            os.path.expanduser(ssh_key_path) if ssh_key_path else None
+        )
+
+    # ------------------------------------------------------------------ #
+    # paramiko transport
+    # ------------------------------------------------------------------ #
+    def _paramiko_client(self):
+        import paramiko
+
+        client = paramiko.SSHClient()
+        client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+        connect_kwargs = {
+            "hostname": self.target.host,
+            "port": self.target.port,
+            "username": self.target.user,
+        }
+        # Allow an explicit key, the env var workaround, or agent/default keys.
+        key_file = self.ssh_key_path or os.environ.get("DOCKER_SSH_KEY_FILE")
+        if key_file and os.path.exists(key_file):
+            connect_kwargs["key_filename"] = key_file
+        connect_kwargs["look_for_keys"] = True
+        connect_kwargs["allow_agent"] = True
+        client.connect(**connect_kwargs)
+        return client
+
+    # ------------------------------------------------------------------ #
+    # system ssh/scp transport
+    # ------------------------------------------------------------------ #
+    def _ssh_base_args(self) -> List[str]:
+        args = ["ssh", "-o", "BatchMode=yes", "-o", "StrictHostKeyChecking=accept-new"]
+        if self.target.port != 22:
+            args += ["-p", str(self.target.port)]
+        if self.ssh_key_path:
+            args += ["-i", self.ssh_key_path]
+        return args
+
+    def _scp_base_args(self) -> List[str]:
+        args = ["scp", "-o", "BatchMode=yes", "-o", "StrictHostKeyChecking=accept-new", "-r"]
+        if self.target.port != 22:
+            args += ["-P", str(self.target.port)]
+        if self.ssh_key_path:
+            args += ["-i", self.ssh_key_path]
+        return args
+
+    def _run_ssh_command(self, remote_cmd: str) -> None:
+        args = self._ssh_base_args() + [self.target.user_host, remote_cmd]
+        result = subprocess.run(
+            args, capture_output=True, text=True, timeout=300
+        )
+        if result.returncode != 0:
+            raise RuntimeError(
+                f"Remote command failed ({result.returncode}): {remote_cmd}\n"
+                f"stderr: {result.stderr.strip()}"
+            )
+
+    # ------------------------------------------------------------------ #
+    # public API
+    # ------------------------------------------------------------------ #
+    def mkdirs(self, remote_dirs: List[str]) -> None:
+        """Create remote directories (recursively) on the Linux host."""
+        quoted = " ".join(shlex.quote(str(d)) for d in remote_dirs)
+        cmd = f"mkdir -p {quoted}"
+        if self.use_ssh_client:
+            self._run_ssh_command(cmd)
+        else:
+            client = self._paramiko_client()
+            try:
+                stdin, stdout, stderr = client.exec_command(cmd)
+                rc = stdout.channel.recv_exit_status()
+                if rc != 0:
+                    err = stderr.read().decode("utf-8", "replace")
+                    raise RuntimeError(f"mkdir -p failed ({rc}): {err}")
+            finally:
+                client.close()
+
+    def upload_dir(self, local_dir: Path, remote_dir: str) -> int:
+        """
+        Upload every file under local_dir into remote_dir, preserving the
+        relative directory structure. Returns the number of files uploaded.
+        """
+        local_dir = Path(local_dir)
+        remote_root = PurePosixPath(remote_dir)
+        files = list(_iter_project_files(local_dir))
+
+        if self.use_ssh_client:
+            # scp -r the whole directory's contents.
+            self.mkdirs([str(remote_root)])
+            # Upload each subtree at top level for structure fidelity.
+            for child in sorted(local_dir.iterdir()):
+                if _is_windows_reserved(child.name):
+                    continue
+                args = self._scp_base_args() + [
+                    str(child),
+                    f"{self.target.user_host}:{shlex.quote(str(remote_root))}/",
+                ]
+                # shlex.quote already applied to remote path component; scp target
+                # must not be shell-quoted by us, rebuild cleanly:
+                args[-1] = f"{self.target.user_host}:{remote_root}/"
+                result = subprocess.run(
+                    args, capture_output=True, text=True, timeout=600
+                )
+                if result.returncode != 0:
+                    raise RuntimeError(
+                        f"scp upload failed for {child}: {result.stderr.strip()}"
+                    )
+            return len(files)
+
+        # paramiko SFTP transport
+        client = self._paramiko_client()
+        try:
+            sftp = client.open_sftp()
+            made = set()
+
+            def _ensure_remote_dir(rdir: PurePosixPath):
+                parts = rdir.parts
+                cur = PurePosixPath(parts[0]) if parts else rdir
+                # Build progressively from root.
+                accum = PurePosixPath("/") if str(rdir).startswith("/") else PurePosixPath("")
+                for part in parts:
+                    if part == "/":
+                        continue
+                    accum = accum / part
+                    key = str(accum)
+                    if key in made:
+                        continue
+                    try:
+                        sftp.stat(key)
+                    except IOError:
+                        try:
+                            sftp.mkdir(key)
+                        except IOError:
+                            pass
+                    made.add(key)
+
+            _ensure_remote_dir(remote_root)
+            for local_path, rel in files:
+                remote_path = remote_root / rel
+                _ensure_remote_dir(remote_path.parent)
+                sftp.put(str(local_path), str(remote_path))
+            sftp.close()
+            return len(files)
+        finally:
+            client.close()
+
+    def list_matching(self, remote_dir: str, patterns: List[str]) -> List[str]:
+        """Return remote file paths in remote_dir matching any glob pattern."""
+        remote_root = PurePosixPath(remote_dir)
+        if self.use_ssh_client:
+            # Use a remote shell glob.
+            globs = " ".join(
+                shlex.quote(str(remote_root / p)) for p in patterns
+            )
+            cmd = f"ls -1 {globs} 2>/dev/null || true"
+            args = self._ssh_base_args() + [self.target.user_host, cmd]
+            result = subprocess.run(args, capture_output=True, text=True, timeout=120)
+            lines = [l.strip() for l in result.stdout.splitlines() if l.strip()]
+            return lines
+
+        import fnmatch
+
+        client = self._paramiko_client()
+        try:
+            sftp = client.open_sftp()
+            try:
+                names = sftp.listdir(str(remote_root))
+            except IOError:
+                names = []
+            matches = []
+            for name in names:
+                if any(fnmatch.fnmatch(name, p) for p in patterns):
+                    matches.append(str(remote_root / name))
+            sftp.close()
+            return matches
+        finally:
+            client.close()
+
+    def download_files(self, remote_files: List[str], local_dest: Path) -> List[Path]:
+        """Download specific remote files into local_dest. Returns local paths."""
+        local_dest = Path(local_dest)
+        local_dest.mkdir(parents=True, exist_ok=True)
+        downloaded: List[Path] = []
+
+        if self.use_ssh_client:
+            for rfile in remote_files:
+                name = PurePosixPath(rfile).name
+                args = self._scp_base_args() + [
+                    f"{self.target.user_host}:{rfile}",
+                    str(local_dest / name),
+                ]
+                result = subprocess.run(
+                    args, capture_output=True, text=True, timeout=600
+                )
+                if result.returncode != 0:
+                    logger.warning(
+                        f"scp download failed for {rfile}: {result.stderr.strip()}"
+                    )
+                    continue
+                downloaded.append(local_dest / name)
+            return downloaded
+
+        client = self._paramiko_client()
+        try:
+            sftp = client.open_sftp()
+            for rfile in remote_files:
+                name = PurePosixPath(rfile).name
+                local_path = local_dest / name
+                try:
+                    sftp.get(rfile, str(local_path))
+                    downloaded.append(local_path)
+                except IOError as e:
+                    logger.warning(f"SFTP download failed for {rfile}: {e}")
+            sftp.close()
+            return downloaded
+        finally:
+            client.close()
+
+    def rmtree(self, remote_dir: str) -> None:
+        """Remove a remote directory tree (best effort)."""
+        cmd = f"rm -rf {shlex.quote(str(remote_dir))}"
+        try:
+            if self.use_ssh_client:
+                self._run_ssh_command(cmd)
+            else:
+                client = self._paramiko_client()
+                try:
+                    stdin, stdout, stderr = client.exec_command(cmd)
+                    stdout.channel.recv_exit_status()
+                finally:
+                    client.close()
+        except Exception as e:
+            logger.debug(f"Remote cleanup failed for {remote_dir}: {e}")

--- a/ras_commander/remote/DockerWorker.py
+++ b/ras_commander/remote/DockerWorker.py
@@ -244,7 +244,10 @@ def init_docker_worker(**kwargs) -> DockerWorker:
         remote_host_os: OS of the remote Docker host: "windows" or "linux".
             If omitted, ssh:// hosts default to "linux" and all other remote
             hosts default to "windows". Linux hosts are staged over SFTP/scp and
-            do NOT require share_path; geometry preprocessing runs in-container.
+            do NOT require share_path; with preprocess_on_host=True (default)
+            HEC-RAS geometry preprocessing runs on the Windows host and the
+            resulting .tmp.hdf/.x## are shipped to the container (the container
+            runs RasUnsteady only).
         worker_id: Custom worker ID (auto-generated if not provided)
         cores_total: Total CPU cores available for this worker
         cores_per_plan: CPU cores to allocate per plan
@@ -447,8 +450,9 @@ def execute_docker_plan(
     """
     docker = check_docker_dependencies()
 
-    # Native-Linux Docker host (ssh://): stage over SSH, preprocess in-container.
-    # Windows-Docker-Desktop path below is left unchanged for compatibility.
+    # Native-Linux Docker host (ssh://): stage over SSH; with preprocess_on_host
+    # the geometry is preprocessed on the Windows host and shipped (container runs
+    # RasUnsteady only). Windows-Docker-Desktop path below is unchanged.
     if getattr(worker, "_is_linux_host", False):
         return execute_docker_plan_linux(
             worker=worker,

--- a/ras_commander/remote/DockerWorker.py
+++ b/ras_commander/remote/DockerWorker.py
@@ -120,6 +120,13 @@ class DockerWorker(RasWorker):
     share_path: Optional[str] = None  # UNC path for file transfer: \\\\host\\share
     remote_staging_path: Optional[str] = None  # Path on Docker host: C:\\RasRemote
 
+    # Remote host OS. "windows" => Windows Docker Desktop host reached via a UNC
+    # share (legacy/default behavior). "linux" => native-Linux Docker daemon
+    # reached over ssh://, staged via SFTP/scp (no UNC share). When left as None
+    # the OS is inferred: ssh:// hosts default to "linux", everything else to
+    # "windows" for backward compatibility.
+    remote_host_os: Optional[str] = None
+
     # Container paths (Linux paths inside container)
     container_input_path: str = "/app/input"
     container_output_path: str = "/app/output"
@@ -158,18 +165,48 @@ class DockerWorker(RasWorker):
         # Check if this is a remote Docker host
         self._is_remote = bool(self.docker_host and not self.docker_host.startswith("unix:"))
 
+        # Determine remote host OS. ssh:// hosts default to Linux; everything
+        # else defaults to Windows for backward compatibility. An explicit
+        # remote_host_os always wins.
+        is_ssh_host = bool(self.docker_host and self.docker_host.startswith("ssh://"))
+        if self.remote_host_os:
+            host_os = self.remote_host_os.strip().lower()
+            if host_os not in ("windows", "linux"):
+                raise ValueError(
+                    f"remote_host_os must be 'windows' or 'linux', got: {self.remote_host_os!r}"
+                )
+            self.remote_host_os = host_os
+        else:
+            self.remote_host_os = "linux" if is_ssh_host else "windows"
+
+        self._is_linux_host = self._is_remote and self.remote_host_os == "linux"
+
         # Validate remote Docker configuration
         if self._is_remote:
-            if not self.share_path:
-                raise ValueError(
-                    "share_path is required for remote Docker hosts. "
-                    "Example: '\\\\\\\\192.168.3.8\\\\RasRemote'"
-                )
-            if not self.remote_staging_path:
-                raise ValueError(
-                    "remote_staging_path is required for remote Docker hosts. "
-                    "Example: 'C:\\\\RasRemote'"
-                )
+            if self._is_linux_host:
+                # Native-Linux Docker host: staged over SSH, no UNC share needed.
+                if not is_ssh_host:
+                    raise ValueError(
+                        "remote_host_os='linux' requires an ssh:// docker_host URL "
+                        "(e.g. 'ssh://root@192.168.3.81'). File staging uses SFTP/scp."
+                    )
+                if not self.remote_staging_path:
+                    raise ValueError(
+                        "remote_staging_path is required for Linux Docker hosts. "
+                        "Example: '/opt/RasRemote'"
+                    )
+            else:
+                # Windows Docker Desktop host: staged over a UNC share (legacy).
+                if not self.share_path:
+                    raise ValueError(
+                        "share_path is required for remote Docker hosts. "
+                        "Example: '\\\\\\\\192.168.3.8\\\\RasRemote'"
+                    )
+                if not self.remote_staging_path:
+                    raise ValueError(
+                        "remote_staging_path is required for remote Docker hosts. "
+                        "Example: 'C:\\\\RasRemote'"
+                    )
 
         # Calculate parallel capacity
         if self.cores_total is not None and self.cores_per_plan:
@@ -184,6 +221,7 @@ class DockerWorker(RasWorker):
 
         logger.debug(f"DockerWorker initialized: image={self.docker_image}, "
                     f"host={self.docker_host or 'local'}, remote={self._is_remote}, "
+                    f"host_os={self.remote_host_os if self._is_remote else 'local'}, "
                     f"max_parallel={self.max_parallel_plans}")
 
 
@@ -197,10 +235,16 @@ def init_docker_worker(**kwargs) -> DockerWorker:
         docker_host: Docker daemon URL (optional, default: local)
             For remote TCP: "tcp://192.168.3.8:2375"
             For remote SSH: "ssh://user@192.168.3.8" (requires key-based auth)
-        share_path: UNC path for file transfer to remote Docker host (required for remote)
+        share_path: UNC path for file transfer to a *Windows* remote Docker host
+            (required for Windows remote hosts; NOT used for Linux hosts)
             Example: "\\\\\\\\192.168.3.8\\\\RasRemote"
         remote_staging_path: Path on Docker host for volume mounts (required for remote)
-            Example: "C:\\\\RasRemote" or "/mnt/c/RasRemote" (WSL paths)
+            Windows host: "C:\\\\RasRemote" or "/mnt/c/RasRemote" (WSL paths)
+            Linux host:   "/opt/RasRemote"
+        remote_host_os: OS of the remote Docker host: "windows" or "linux".
+            If omitted, ssh:// hosts default to "linux" and all other remote
+            hosts default to "windows". Linux hosts are staged over SFTP/scp and
+            do NOT require share_path; geometry preprocessing runs in-container.
         worker_id: Custom worker ID (auto-generated if not provided)
         cores_total: Total CPU cores available for this worker
         cores_per_plan: CPU cores to allocate per plan
@@ -229,13 +273,25 @@ def init_docker_worker(**kwargs) -> DockerWorker:
         ...     cores_per_plan=4
         ... )
 
-    Example (remote Docker via SSH):
+    Example (remote Windows Docker Desktop via SSH):
         >>> worker = init_docker_worker(
         ...     docker_image="hecras:6.6",
         ...     docker_host="ssh://user@192.168.3.8",
+        ...     remote_host_os="windows",
         ...     share_path="\\\\\\\\192.168.3.8\\\\RasRemote",
         ...     remote_staging_path="/mnt/c/RasRemote",
         ...     use_ssh_client=True,  # Use system ssh command
+        ...     cores_total=8,
+        ...     cores_per_plan=4
+        ... )
+
+    Example (native-Linux Docker host via SSH, e.g. CLB07):
+        >>> worker = init_docker_worker(
+        ...     docker_image="hecras:6.6",
+        ...     docker_host="ssh://root@192.168.3.81",
+        ...     remote_staging_path="/opt/RasRemote",
+        ...     # remote_host_os inferred as "linux" from ssh:// URL
+        ...     use_ssh_client=True,
         ...     cores_total=8,
         ...     cores_per_plan=4
         ... )
@@ -390,6 +446,19 @@ def execute_docker_plan(
         bool: True if execution succeeded, False otherwise
     """
     docker = check_docker_dependencies()
+
+    # Native-Linux Docker host (ssh://): stage over SSH, preprocess in-container.
+    # Windows-Docker-Desktop path below is left unchanged for compatibility.
+    if getattr(worker, "_is_linux_host", False):
+        return execute_docker_plan_linux(
+            worker=worker,
+            plan_number=plan_number,
+            ras_obj=ras_obj,
+            num_cores=num_cores,
+            clear_geompre=clear_geompre,
+            sub_worker_id=sub_worker_id,
+            autoclean=autoclean,
+        )
 
     # CRITICAL: Capture project info at the START of execution
     # This prevents issues if another thread modifies ras_obj during execution
@@ -653,3 +722,282 @@ def execute_docker_plan(
                 pass
         elif not autoclean:
             logger.info(f"Preserving staging: {local_staging_folder}")
+
+
+@log_call
+def execute_docker_plan_linux(
+    worker: DockerWorker,
+    plan_number: str,
+    ras_obj,
+    num_cores: int,
+    clear_geompre: bool,
+    sub_worker_id: int = 1,
+    autoclean: bool = True,
+) -> bool:
+    """
+    Execute a HEC-RAS plan on a native-Linux Docker host reached over ssh://.
+
+    Differences from the Windows-Docker-Desktop path:
+        - File staging uses SSH (SFTP via paramiko, or scp/ssh via the system
+          client) into a Linux ``remote_staging_path`` -- no UNC share required.
+        - Linux staging paths are bind-mounted directly (no ``/mnt/c`` -> ``C:``
+          rewrite).
+
+    Preprocessing (IMPORTANT):
+        The bundled HEC-RAS 6.6 Linux image runs RasUnsteady against a plan HDF
+        (``.p##.tmp.hdf``) plus an execution file (``.x##``) that HEC-RAS produces
+        during GEOMETRY PREPROCESSING. Empirically the Linux ``RasGeomPreprocess``
+        binary cannot regenerate these standalone (it reads the ``.x##`` file as
+        input on unit 5, and RasUnsteady requires the plan-structured tmp HDF, not
+        a bare geometry HDF). Therefore the controller must preprocess on Windows
+        and ship the preprocessed project; the container only runs RasUnsteady.
+
+        Accordingly, when ``preprocess_on_host=True`` (the default) this function
+        runs HEC-RAS preprocessing locally on the Windows controller before
+        upload -- exactly like the Windows-Docker-Desktop path -- and the
+        resulting ``.tmp.hdf`` + ``.x##`` are staged to the Linux host. If
+        ``preprocess_on_host=False``, the project is shipped as-is and is expected
+        to already contain a results-free ``.tmp.hdf`` and ``.x##`` (e.g. produced
+        by a prior preprocessing pass).
+
+    Args:
+        worker: DockerWorker instance (must be a Linux host: _is_linux_host True).
+        plan_number: Plan number to execute (e.g., "01").
+        ras_obj: RasPrj object with project information.
+        num_cores: Number of cores for simulation (informational here).
+        clear_geompre: Whether to clear geometry preprocessor files before upload.
+        sub_worker_id: Sub-worker identifier for parallel execution.
+        autoclean: Remove local and remote staging files after completion.
+
+    Returns:
+        bool: True if execution succeeded and an HDF result was retrieved.
+    """
+    import tempfile
+    import re as _re
+
+    docker = check_docker_dependencies()
+    from .DockerSshStaging import LinuxDockerSshStager
+    from ..RasPreprocess import RasPreprocess
+
+    # Capture project info up front (thread-safety, mirrors Windows path).
+    project_folder = Path(ras_obj.project_folder)
+    project_name = ras_obj.project_name
+
+    if not project_folder.exists():
+        logger.error(f"Project folder does not exist: {project_folder}")
+        return False
+
+    logger.info(
+        f"Starting Linux Docker execution: plan {plan_number}, "
+        f"sub-worker {sub_worker_id}, host {worker.docker_host}"
+    )
+
+    staging_id = (
+        f"ras_docker_{project_name}_p{plan_number}_sw{sub_worker_id}_{uuid.uuid4().hex[:8]}"
+    )
+
+    # Local temp staging (used only to assemble the upload set).
+    local_staging_folder = Path(tempfile.gettempdir()) / staging_id
+    local_input_staging = local_staging_folder / "input"
+
+    # Remote Linux staging layout (POSIX paths on the Docker host).
+    remote_base = str(worker.remote_staging_path).replace("\\", "/").rstrip("/")
+    remote_staging_folder = f"{remote_base}/{staging_id}"
+    remote_input = f"{remote_staging_folder}/input"
+    remote_output = f"{remote_staging_folder}/output"
+
+    stager = LinuxDockerSshStager(
+        docker_host=worker.docker_host,
+        use_ssh_client=worker.use_ssh_client,
+        ssh_key_path=worker.ssh_key_path,
+    )
+
+    try:
+        # 1. Assemble project into local temp input dir.
+        local_input_staging.mkdir(parents=True, exist_ok=True)
+        logger.info("Copying project to local staging for upload...")
+        for item in project_folder.iterdir():
+            if RasUtils.is_windows_reserved_name(item.name):
+                continue
+            if item.is_file():
+                shutil.copy2(item, local_input_staging / item.name)
+            elif item.is_dir():
+                shutil.copytree(
+                    item,
+                    local_input_staging / item.name,
+                    dirs_exist_ok=True,
+                    ignore=RasUtils.ignore_windows_reserved,
+                )
+
+        # Optionally clear stale geometry preprocessor (.c) files before a
+        # Windows preprocessing pass regenerates them. Note: the .x## execution
+        # file is REQUIRED by the Linux RasUnsteady binary, so it is only cleared
+        # when we are about to regenerate it via preprocess_on_host.
+        if clear_geompre:
+            globs = ["*.c*"]
+            if worker.preprocess_on_host:
+                globs.append("*.x*")
+            for pattern in globs:
+                for stale in local_input_staging.glob(pattern):
+                    try:
+                        stale.unlink()
+                    except OSError:
+                        pass
+
+        # Preprocess on the Windows controller (default). The Linux container
+        # cannot self-preprocess, so this produces the .tmp.hdf + .x## that
+        # RasUnsteady needs, which are then uploaded.
+        if worker.preprocess_on_host:
+            logger.info("Running Windows preprocessing locally before upload...")
+            from ..RasPrj import RasPrj, init_ras_project
+            temp_ras = RasPrj()
+            init_ras_project(
+                str(local_input_staging), ras_obj.ras_version, ras_object=temp_ras
+            )
+            preprocess_result = RasPreprocess.preprocess_plan(
+                plan_number, ras_object=temp_ras
+            )
+            if not preprocess_result:
+                logger.error(
+                    f"Windows preprocessing failed for plan {plan_number}: "
+                    f"{getattr(preprocess_result, 'error', preprocess_result)}"
+                )
+                return False
+
+        # Extract geometry number from the local plan file.
+        plan_files = list(local_input_staging.glob(f"*.p{plan_number}"))
+        geometry_number = (
+            RasPreprocess._extract_geometry_number(plan_files[0])
+            if plan_files
+            else None
+        )
+        if not geometry_number:
+            logger.error(f"Could not extract geometry number for plan {plan_number}")
+            return False
+        logger.info(f"Plan {plan_number} uses geometry {geometry_number}")
+
+        # 2. Create remote dirs and upload over SSH.
+        logger.info(f"Staging project to Linux host: {remote_staging_folder}")
+        stager.mkdirs([remote_input, remote_output])
+        uploaded = stager.upload_dir(local_input_staging, remote_input)
+        logger.info(f"Uploaded {uploaded} file(s) to {remote_input}")
+
+        # 3. Run the container with Linux bind mounts (no path rewrite).
+        client_kwargs = {"base_url": worker.docker_host}
+        if worker.use_ssh_client:
+            client_kwargs["use_ssh_client"] = True
+        client = docker.DockerClient(**client_kwargs)
+
+        volumes = {
+            remote_input: {"bind": worker.container_input_path, "mode": "rw"},
+            remote_output: {"bind": worker.container_output_path, "mode": "rw"},
+        }
+        environment = {
+            "MAX_RUNTIME_MINUTES": str(worker.max_runtime_minutes),
+            "GEOMETRY_NUMBER": geometry_number,
+        }
+        container_kwargs = {
+            "image": worker.docker_image,
+            "command": [worker.container_script_path, str(int(plan_number))],
+            "volumes": volumes,
+            "environment": environment,
+            "detach": True,
+            "remove": False,
+        }
+        if worker.cpu_limit:
+            container_kwargs["nano_cpus"] = int(float(worker.cpu_limit) * 1e9)
+        if worker.memory_limit:
+            container_kwargs["mem_limit"] = worker.memory_limit
+
+        logger.info(f"Starting container on Linux host: {worker.docker_image}")
+        container = client.containers.run(**container_kwargs)
+        logger.info(f"Container started: {container.short_id}")
+
+        timeout_seconds = worker.max_runtime_minutes * 60
+        start_time = time.time()
+        exit_code = -1
+        try:
+            result = container.wait(timeout=timeout_seconds)
+            exit_code = result.get("StatusCode", -1)
+            elapsed = time.time() - start_time
+            logger.info(f"Container finished in {elapsed:.1f}s, exit code {exit_code}")
+            logs = container.logs(stdout=True, stderr=True).decode("utf-8", errors="replace")
+            if exit_code != 0:
+                logger.error(f"Container logs:\n{logs}")
+            else:
+                logger.debug(f"Container logs:\n{logs}")
+        except Exception as e:
+            logger.error(f"Container execution failed: {e}")
+            try:
+                container.kill()
+            except Exception:
+                pass
+            return False
+        finally:
+            try:
+                container.remove()
+            except Exception:
+                pass
+            client.close()
+
+        if exit_code != 0:
+            logger.error(f"Simulation failed with exit code {exit_code}")
+            return False
+
+        # 4. Download HDF results (and logs) back from the Linux host.
+        result_patterns = [
+            f"{project_name}.p{plan_number}*.hdf",
+            f"{project_name}.p{plan_number}.tmp.hdf",
+        ]
+        remote_results = []
+        for rdir in (remote_output, remote_input):
+            remote_results.extend(stager.list_matching(rdir, result_patterns))
+        # Deduplicate by basename, preferring output dir entries (listed first).
+        seen = set()
+        ordered = []
+        for rfile in remote_results:
+            name = Path(rfile).name
+            if name in seen:
+                continue
+            seen.add(name)
+            ordered.append(rfile)
+
+        if not ordered:
+            logger.error("No HDF results found on Linux host")
+            return False
+
+        downloaded = stager.download_files(ordered, project_folder)
+        if not downloaded:
+            logger.error("Failed to download HDF results from Linux host")
+            return False
+        for path in downloaded:
+            logger.info(f"Retrieved result: {path.name}")
+
+        # Logs (best effort).
+        log_patterns = ["*.log", "*.computeMsgs.txt"]
+        remote_logs = []
+        for rdir in (remote_output, remote_input):
+            remote_logs.extend(stager.list_matching(rdir, log_patterns))
+        if remote_logs:
+            stager.download_files(remote_logs, project_folder)
+
+        logger.info(f"Linux Docker execution completed for plan {plan_number}")
+        return True
+
+    except Exception as e:
+        logger.error(f"Linux Docker execution error: {e}", exc_info=True)
+        return False
+
+    finally:
+        if autoclean:
+            try:
+                stager.rmtree(remote_staging_folder)
+            except Exception:
+                pass
+            if local_staging_folder.exists():
+                shutil.rmtree(local_staging_folder, ignore_errors=True)
+        else:
+            logger.info(
+                f"Preserving staging: local={local_staging_folder} "
+                f"remote={remote_staging_folder}"
+            )

--- a/tests/test_docker_linux_host.py
+++ b/tests/test_docker_linux_host.py
@@ -1,0 +1,245 @@
+"""
+Unit tests for the native-Linux Docker host path of DockerWorker.
+
+These tests mock all SSH and Docker interactions so they run without a live
+host. A separate live smoke test against CLB07 is documented in the PR notes.
+
+Covered:
+    - remote_host_os inference (ssh:// => linux, tcp:// => windows)
+    - explicit remote_host_os override and validation of bad values
+    - Linux hosts do NOT require share_path; Windows hosts still do
+    - ssh:// URL parsing (user/host/port)
+    - LinuxDockerSshStager paramiko + system-ssh transports (mocked)
+    - execute_docker_plan dispatches to the Linux path for Linux hosts
+"""
+
+import sys
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+# Ensure the package under test is importable when run directly.
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from ras_commander.remote.DockerWorker import DockerWorker, execute_docker_plan
+from ras_commander.remote.DockerSshStaging import (
+    LinuxDockerSshStager,
+    parse_ssh_host,
+    SshTarget,
+)
+
+
+def _make_worker(**overrides):
+    """Build a DockerWorker without going through Docker daemon validation."""
+    kwargs = dict(
+        worker_type="docker",
+        worker_id="docker_test",
+        docker_image="hecras:6.6",
+    )
+    kwargs.update(overrides)
+    return DockerWorker(**kwargs)
+
+
+# --------------------------------------------------------------------------- #
+# Host OS inference + validation
+# --------------------------------------------------------------------------- #
+def test_ssh_host_infers_linux():
+    w = _make_worker(
+        docker_host="ssh://root@192.168.3.81",
+        remote_staging_path="/opt/RasRemote",
+    )
+    assert w.remote_host_os == "linux"
+    assert w._is_remote is True
+    assert w._is_linux_host is True
+
+
+def test_tcp_host_infers_windows_and_requires_share():
+    with pytest.raises(ValueError, match="share_path is required"):
+        _make_worker(
+            docker_host="tcp://192.168.3.8:2375",
+            remote_staging_path="C:/RasRemote",
+        )
+
+
+def test_linux_host_does_not_require_share_path():
+    # Should not raise even though share_path is None.
+    w = _make_worker(
+        docker_host="ssh://root@192.168.3.81",
+        remote_staging_path="/opt/RasRemote",
+    )
+    assert w.share_path is None
+    assert w._is_linux_host is True
+
+
+def test_linux_host_requires_remote_staging_path():
+    with pytest.raises(ValueError, match="remote_staging_path is required for Linux"):
+        _make_worker(docker_host="ssh://root@192.168.3.81")
+
+
+def test_explicit_windows_over_ssh_requires_share_path():
+    with pytest.raises(ValueError, match="share_path is required"):
+        _make_worker(
+            docker_host="ssh://user@winhost",
+            remote_host_os="windows",
+            remote_staging_path="C:/RasRemote",
+        )
+
+
+def test_explicit_linux_requires_ssh_url():
+    with pytest.raises(ValueError, match="requires an ssh:// docker_host"):
+        _make_worker(
+            docker_host="tcp://192.168.3.8:2375",
+            remote_host_os="linux",
+            remote_staging_path="/opt/RasRemote",
+        )
+
+
+def test_invalid_remote_host_os_rejected():
+    with pytest.raises(ValueError, match="remote_host_os must be"):
+        _make_worker(
+            docker_host="ssh://root@host",
+            remote_host_os="solaris",
+            remote_staging_path="/opt/RasRemote",
+        )
+
+
+def test_local_worker_unaffected():
+    w = _make_worker()  # no docker_host
+    assert w._is_remote is False
+    assert w._is_linux_host is False
+    assert w.remote_host_os == "windows"  # default placeholder, unused when local
+
+
+# --------------------------------------------------------------------------- #
+# SSH URL parsing
+# --------------------------------------------------------------------------- #
+def test_parse_ssh_host_basic():
+    t = parse_ssh_host("ssh://root@192.168.3.81")
+    assert t == SshTarget(host="192.168.3.81", user="root", port=22)
+    assert t.user_host == "root@192.168.3.81"
+
+
+def test_parse_ssh_host_with_port():
+    t = parse_ssh_host("ssh://deploy@host.example:2222")
+    assert t.host == "host.example"
+    assert t.user == "deploy"
+    assert t.port == 2222
+
+
+def test_parse_ssh_host_rejects_non_ssh():
+    with pytest.raises(ValueError):
+        parse_ssh_host("tcp://1.2.3.4:2375")
+
+
+# --------------------------------------------------------------------------- #
+# Stager transports (mocked)
+# --------------------------------------------------------------------------- #
+def test_stager_system_ssh_mkdirs_invokes_ssh():
+    stager = LinuxDockerSshStager(
+        docker_host="ssh://root@10.0.0.5", use_ssh_client=True
+    )
+    with mock.patch("subprocess.run") as run:
+        run.return_value = mock.Mock(returncode=0, stdout="", stderr="")
+        stager.mkdirs(["/opt/RasRemote/run1/input", "/opt/RasRemote/run1/output"])
+        assert run.called
+        args = run.call_args[0][0]
+        assert args[0] == "ssh"
+        assert "root@10.0.0.5" in args
+        assert "mkdir -p" in args[-1]
+
+
+def test_stager_system_ssh_list_matching_parses_output():
+    stager = LinuxDockerSshStager(
+        docker_host="ssh://root@10.0.0.5", use_ssh_client=True
+    )
+    fake_out = "/opt/RasRemote/run1/output/Muncie.p04.hdf\n"
+    with mock.patch("subprocess.run") as run:
+        run.return_value = mock.Mock(returncode=0, stdout=fake_out, stderr="")
+        matches = stager.list_matching(
+            "/opt/RasRemote/run1/output", ["*.hdf"]
+        )
+        assert matches == ["/opt/RasRemote/run1/output/Muncie.p04.hdf"]
+
+
+def test_stager_paramiko_download(tmp_path):
+    stager = LinuxDockerSshStager(
+        docker_host="ssh://root@10.0.0.5", use_ssh_client=False
+    )
+    fake_sftp = mock.Mock()
+    fake_client = mock.Mock()
+    fake_client.open_sftp.return_value = fake_sftp
+
+    def fake_get(remote, local):
+        Path(local).write_text("hdf-bytes")
+
+    fake_sftp.get.side_effect = fake_get
+
+    with mock.patch.object(stager, "_paramiko_client", return_value=fake_client):
+        out = stager.download_files(
+            ["/opt/RasRemote/run1/output/Muncie.p04.hdf"], tmp_path
+        )
+    assert len(out) == 1
+    assert out[0].name == "Muncie.p04.hdf"
+    assert out[0].read_text() == "hdf-bytes"
+    fake_client.close.assert_called()
+
+
+def test_stager_paramiko_upload(tmp_path):
+    # Build a small local project tree.
+    proj = tmp_path / "proj"
+    (proj / "sub").mkdir(parents=True)
+    (proj / "Muncie.prj").write_text("prj")
+    (proj / "Muncie.p04").write_text("Geom File=g04\n")
+    (proj / "sub" / "extra.txt").write_text("x")
+
+    stager = LinuxDockerSshStager(
+        docker_host="ssh://root@10.0.0.5", use_ssh_client=False
+    )
+    fake_sftp = mock.Mock()
+    # stat raises IOError so mkdir is attempted for each dir.
+    fake_sftp.stat.side_effect = IOError("missing")
+    fake_client = mock.Mock()
+    fake_client.open_sftp.return_value = fake_sftp
+
+    with mock.patch.object(stager, "_paramiko_client", return_value=fake_client):
+        count = stager.upload_dir(proj, "/opt/RasRemote/run1/input")
+
+    assert count == 3
+    # Three files put to remote.
+    assert fake_sftp.put.call_count == 3
+
+
+# --------------------------------------------------------------------------- #
+# Dispatch
+# --------------------------------------------------------------------------- #
+def test_execute_dispatches_to_linux_path(tmp_path):
+    proj = tmp_path / "proj"
+    proj.mkdir()
+    (proj / "Muncie.prj").write_text("prj")
+
+    ras_obj = mock.Mock()
+    ras_obj.project_folder = str(proj)
+    ras_obj.project_name = "Muncie"
+    ras_obj.ras_version = "6.6"
+
+    w = _make_worker(
+        docker_host="ssh://root@192.168.3.81",
+        remote_staging_path="/opt/RasRemote",
+    )
+
+    with mock.patch(
+        "ras_commander.remote.DockerWorker.execute_docker_plan_linux",
+        return_value=True,
+    ) as linux_fn:
+        ok = execute_docker_plan(
+            worker=w,
+            plan_number="04",
+            ras_obj=ras_obj,
+            num_cores=2,
+            clear_geompre=False,
+        )
+    assert ok is True
+    linux_fn.assert_called_once()


### PR DESCRIPTION
Extends `DockerWorker` to drive **native-Linux Docker hosts over SSH** (e.g. CLB07), in addition to the existing Windows Docker Desktop path.

- **OS detection**: `remote_host_os` ("windows"/"linux"); `ssh://` hosts default to linux, others to windows. Windows path **unchanged** (backward compatible).
- **SSH staging**: new `DockerSshStaging.py` (paramiko SFTP or system scp) stages the project to a Linux `remote_staging_path` and pulls results back. No UNC share needed for Linux.
- **Preprocessing**: `preprocess_on_host=True` (default) runs HEC-RAS geometry preprocessing on the Windows controller and ships `.tmp.hdf`/`.x##`; the Linux container runs `RasUnsteady` only (the in-container `RasGeomPreprocess` can't produce the plan-structured `.tmp.hdf` HEC-RAS needs).

**Verified live against CLB07** (`ssh://root@192.168.3.81`, `hecras:6.6`): a real Muncie p01 unsteady run produced a full **289-timestep Results/Unsteady** time series. 16 new unit tests (SSH/docker mocked) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)