### PR TITLE
Fix geometry reprojection copy safety

### DIFF
--- a/docs/api/geometry.md
+++ b/docs/api/geometry.md
@@ -20,7 +20,10 @@ engineering review.
 
 `reproject_model_geometry()` always works on a copied project folder. The
 destination cannot be the source project folder or a child of it, even with
-`overwrite=True`.
+`overwrite=True`. When `geometry_files` is supplied, relative paths are resolved
+inside the copied project. Absolute paths under the source project are remapped
+to the copied project; absolute paths outside the source or copied project are
+rejected.
 
 ```python
 from ras_commander import GeomProjection

--- a/ras_commander/geom/GeomProjection.py
+++ b/ras_commander/geom/GeomProjection.py
@@ -143,14 +143,19 @@ class GeomProjection:
         from pyproj import Transformer
 
         transformer = Transformer.from_crs(src_crs, dst_crs, always_xy=True)
-        lines = geom_path.read_text(encoding="utf-8", errors="replace").splitlines(
-            keepends=True
-        )
+        with geom_path.open(
+            "r",
+            encoding="utf-8",
+            errors="replace",
+            newline="",
+        ) as input_file:
+            lines = input_file.read().splitlines(keepends=True)
         transformed_lines, stats = GeomProjection._transform_geometry_lines(
             lines,
             transformer,
         )
-        out_path.write_text("".join(transformed_lines), encoding="utf-8")
+        with out_path.open("w", encoding="utf-8", newline="") as output_file:
+            output_file.write("".join(transformed_lines))
 
         qa = GeomProjection._qa_geometry_lines(transformed_lines)
         result = {
@@ -201,6 +206,9 @@ class GeomProjection:
                 folder named ``<project>_reprojected``.
             geometry_files: Optional geometry filenames/paths to transform.
                 Relative names are resolved in the copied project folder.
+                Absolute paths under the source project are remapped to their
+                copied-project counterparts. Absolute paths outside the source
+                or destination project folders are rejected.
                 Defaults to ``Geom File=`` entries in the copied project file,
                 with a ``*.g##`` fallback.
             projection_filename: Optional destination ``.prj`` filename under
@@ -253,6 +261,7 @@ class GeomProjection:
         )
 
         geom_paths = GeomProjection._resolve_geometry_paths(
+            src_project,
             dest_project,
             geometry_files,
         )
@@ -809,15 +818,41 @@ class GeomProjection:
 
     @staticmethod
     def _resolve_geometry_paths(
+        source_project: Path,
         project_folder: Path,
         geometry_files: Optional[Sequence[PathLike]],
     ) -> List[Path]:
+        source_resolved = RasUtils.safe_resolve(source_project)
+        project_resolved = RasUtils.safe_resolve(project_folder)
         if geometry_files is not None:
             paths = []
             for item in geometry_files:
                 candidate = Path(item)
-                if not candidate.is_absolute():
-                    candidate = project_folder / candidate
+                if candidate.is_absolute():
+                    candidate = RasUtils.safe_resolve(candidate)
+                    if GeomProjection._path_is_relative_to(candidate, source_resolved):
+                        candidate = project_resolved / candidate.relative_to(
+                            source_resolved
+                        )
+                    elif not GeomProjection._path_is_relative_to(
+                        candidate,
+                        project_resolved,
+                    ):
+                        raise ValueError(
+                            "Absolute geometry_files entries must be inside the "
+                            "source project folder or copied destination project "
+                            f"folder: {candidate}"
+                        )
+                else:
+                    candidate = RasUtils.safe_resolve(project_folder / candidate)
+                    if not GeomProjection._path_is_relative_to(
+                        candidate,
+                        project_resolved,
+                    ):
+                        raise ValueError(
+                            "Relative geometry_files entries must resolve inside "
+                            f"the copied destination project folder: {item}"
+                        )
                 if not candidate.exists():
                     raise FileNotFoundError(f"Geometry file not found: {candidate}")
                 paths.append(candidate)
@@ -845,6 +880,14 @@ class GeomProjection:
             for path in project_folder.glob("*.g[0-9][0-9]*")
             if not path.name.lower().endswith(".hdf")
         )
+
+    @staticmethod
+    def _path_is_relative_to(path: Path, base_folder: Path) -> bool:
+        try:
+            path.relative_to(base_folder)
+        except ValueError:
+            return False
+        return True
 
     @staticmethod
     def _qa_geometry_lines(lines: List[str]) -> Dict[str, Any]:

--- a/tests/test_geom_projection.py
+++ b/tests/test_geom_projection.py
@@ -165,6 +165,22 @@ def test_reproject_geometry_transforms_1d_2d_and_line_features(tmp_path):
     assert result["qa"]["breaklines"]["invalid"] == []
 
 
+def test_reproject_geometry_preserves_crlf_line_endings(tmp_path):
+    geom = _write_geometry(tmp_path / "Model.g01")
+    lf_text = geom.read_text(encoding="utf-8")
+    geom.write_bytes(lf_text.replace("\n", "\r\n").encode("utf-8"))
+
+    result = GeomProjection.reproject_geometry(
+        geom,
+        SOURCE_CRS,
+        DEST_CRS,
+    )
+
+    output_bytes = Path(result["output_geometry"]).read_bytes()
+    assert b"\r\r\n" not in output_bytes
+    assert b"\n" not in output_bytes.replace(b"\r\n", b"")
+
+
 def test_reproject_model_geometry_copies_project_updates_rasmap_and_reports_terrain(tmp_path):
     project = tmp_path / "project"
     project.mkdir()
@@ -244,6 +260,52 @@ def test_reproject_model_geometry_copies_project_updates_rasmap_and_reports_terr
     assert result["compiled_geometry"][0]["compiled_hdf_exists"] is True
     assert result["compiled_geometry"][0]["refinement_region_count"] == 1
     assert result["compiled_geometry"][0]["refinement_region_integrity"]["is_valid"] is True
+
+
+def test_reproject_model_geometry_remaps_absolute_source_geometry_to_copy(tmp_path):
+    project = tmp_path / "project"
+    project.mkdir()
+    project_name = "Model"
+    geom = _write_geometry(project / f"{project_name}.g01")
+    original_geom_text = geom.read_text(encoding="utf-8")
+    (project / f"{project_name}.prj").write_text(
+        "Proj Title=Model\nGeom File=g01\n",
+        encoding="utf-8",
+    )
+
+    result = GeomProjection.reproject_model_geometry(
+        project,
+        SOURCE_CRS,
+        DEST_CRS,
+        geometry_files=[geom.resolve()],
+    )
+
+    dest_geom = project.with_name("project_reprojected") / f"{project_name}.g01"
+    assert geom.read_text(encoding="utf-8") == original_geom_text
+    assert dest_geom.read_text(encoding="utf-8") != original_geom_text
+    assert (
+        Path(result["geometry_results"][0]["source_geometry"]).resolve()
+        == dest_geom.resolve()
+    )
+
+
+def test_reproject_model_geometry_rejects_absolute_geometry_outside_project_copy(tmp_path):
+    project = tmp_path / "project"
+    project.mkdir()
+    _write_geometry(project / "Model.g01")
+    outside_geom = _write_geometry(tmp_path / "Outside.g01")
+    (project / "Model.prj").write_text(
+        "Proj Title=Model\nGeom File=g01\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="Absolute geometry_files entries"):
+        GeomProjection.reproject_model_geometry(
+            project,
+            SOURCE_CRS,
+            DEST_CRS,
+            geometry_files=[outside_geom.resolve()],
+        )
 
 
 def test_reproject_geometry_rejects_datum_shift_by_default(tmp_path):


### PR DESCRIPTION
## Summary
- preserve geometry text newline bytes during reprojection reads and writes to avoid CRLF corruption on Windows
- remap absolute source-project geometry_files entries into the copied project and reject absolute geometry paths outside the source/destination project
- document geometry_files copied-project path behavior

## Validation
- pytest tests/test_geom_projection.py -q
- pytest tests/test_geom_projection.py tests/test_geom_storage_2d_flow_area_writer.py tests/test_geom_mesh.py -q
- python -m compileall ras_commander/geom/GeomProjection.py
- from ras_commander import GeomProjection smoke

Note: origin/linear/CLB-327 already backs PR #225 and is currently conflicting, so this PR uses a clean CLB02 branch based on current main without force-pushing over that branch.