### PR TITLE
fix(remote): configurable PsExec per-plan timeout (default 10h)

### DIFF
--- a/ras_commander/remote/PsexecWorker.py
+++ b/ras_commander/remote/PsexecWorker.py
@@ -116,6 +116,7 @@ class PsexecWorker(RasWorker):
     cores_total: int = None
     cores_per_plan: int = 4
     max_parallel_plans: int = None
+    max_runtime_minutes: int = 600  # per-plan PsExec subprocess timeout (default 10h; heavy 2D models can take 4-6h)
 
     def __post_init__(self):
         """Validate PsExec worker configuration."""
@@ -468,7 +469,7 @@ def execute_psexec_plan(
             psexec_cmd,
             capture_output=True,
             text=True,
-            timeout=7200
+            timeout=worker.max_runtime_minutes * 60
         )
 
         # Step 6: Check for HDF file


### PR DESCRIPTION
`PsexecWorker` hard-coded a **2-hour** subprocess timeout for the remote RasUnsteady run. Heavy 2D models (dam-break, Monte Carlo ensembles) take **4-6 hours per plan**, so each was killed at the 2h mark — silently failing the sample and wasting the worker.

Adds a configurable `max_runtime_minutes` field (default **600 = 10h**, matching `DockerWorker`) and uses it for the subprocess timeout. Settable per-worker in `RemoteWorkers.json`.

Found while running the 116 Monte Carlo ensemble across the CLB RasRemote fleet (plans take ~5h each).

🤖 Generated with [Claude Code](https://claude.com/claude-code)