### PR TITLE
fix(remote): eliminate PsExec service race, bound Docker SSH, add dispatch watchdog

### DIFF
--- a/ras_commander/remote/DockerSshStaging.py
+++ b/ras_commander/remote/DockerSshStaging.py
@@ -142,6 +142,13 @@ class LinuxDockerSshStager:
             connect_kwargs["key_filename"] = key_file
         connect_kwargs["look_for_keys"] = True
         connect_kwargs["allow_agent"] = True
+        # Bound the connect handshake so an unreachable/slow Linux Docker host
+        # can never block a worker thread forever (the original deadlock that
+        # wedged the whole ensemble). paramiko's connect() is unbounded by
+        # default.
+        connect_kwargs["timeout"] = 30          # TCP connect
+        connect_kwargs["banner_timeout"] = 30   # SSH banner
+        connect_kwargs["auth_timeout"] = 30     # authentication
         client.connect(**connect_kwargs)
         return client
 
@@ -187,8 +194,15 @@ class LinuxDockerSshStager:
         else:
             client = self._paramiko_client()
             try:
-                stdin, stdout, stderr = client.exec_command(cmd)
-                rc = stdout.channel.recv_exit_status()
+                stdin, stdout, stderr = client.exec_command(cmd, timeout=120)
+                chan = stdout.channel
+                # Bound recv_exit_status: the bare call blocks forever if the
+                # channel never signals exit. status_event.wait() is timeout-able.
+                if not chan.status_event.wait(120):
+                    raise RuntimeError(
+                        f"remote 'mkdir -p' timed out after 120s on {self.target.host}"
+                    )
+                rc = chan.recv_exit_status()
                 if rc != 0:
                     err = stderr.read().decode("utf-8", "replace")
                     raise RuntimeError(f"mkdir -p failed ({rc}): {err}")
@@ -345,8 +359,13 @@ class LinuxDockerSshStager:
             else:
                 client = self._paramiko_client()
                 try:
-                    stdin, stdout, stderr = client.exec_command(cmd)
-                    stdout.channel.recv_exit_status()
+                    stdin, stdout, stderr = client.exec_command(cmd, timeout=120)
+                    chan = stdout.channel
+                    if not chan.status_event.wait(120):
+                        raise RuntimeError(
+                            f"remote cleanup timed out after 120s on {self.target.host}"
+                        )
+                    chan.recv_exit_status()
                 finally:
                     client.close()
         except Exception as e:

--- a/ras_commander/remote/Execution.py
+++ b/ras_commander/remote/Execution.py
@@ -146,8 +146,24 @@ def compute_parallel_remote(
     # Results dictionary
     results: Dict[str, ExecutionResult] = {}
 
-    # Execute plans using thread pool
-    with ThreadPoolExecutor(max_workers=max_concurrent) as executor:
+    # No-progress watchdog: a single hung worker thread (e.g. an unbounded
+    # SSH/SFTP call) must not be able to deadlock the whole ensemble. The
+    # ThreadPoolExecutor context manager blocks on shutdown(wait=True) until
+    # every submitted thread returns, and as_completed() never yields a future
+    # that never finishes -- so an unbounded worker.run() would hang forever.
+    # We bound the wait by the slowest worker's max_runtime_minutes plus a
+    # staging/copy-back margin: if NO plan completes within that window the
+    # fleet is presumed deadlocked, the stragglers are marked failed, and the
+    # executor is torn down without waiting on the wedged threads.
+    import time as _wtime
+
+    _max_rt_min = max(
+        (getattr(w, "max_runtime_minutes", 600) or 600) for w in sorted_workers
+    )
+    no_progress_timeout_sec = _max_rt_min * 60 + 900  # + 15 min staging margin
+
+    executor = ThreadPoolExecutor(max_workers=max_concurrent)
+    try:
         futures = {}
 
         for idx, plan_number in enumerate(plan_numbers):
@@ -173,31 +189,65 @@ def compute_parallel_remote(
             )
             futures[future] = plan_number
 
-        # Collect results as they complete
-        for future in as_completed(futures):
-            plan_number = futures[future]
-            try:
-                result = future.result()
-                results[plan_number] = result
+        # Collect results as they complete, with a no-progress watchdog.
+        pending = set(futures)
+        last_progress = _wtime.monotonic()
+        while pending:
+            done = {f for f in pending if f.done()}
+            if not done:
+                if _wtime.monotonic() - last_progress > no_progress_timeout_sec:
+                    for f in list(pending):
+                        pn = futures[f]
+                        f.cancel()
+                        logger.error(
+                            f"Plan {pn} abandoned: no plan completed in "
+                            f"{no_progress_timeout_sec}s (fleet watchdog) -- "
+                            f"a worker thread is presumed hung."
+                        )
+                        results[pn] = ExecutionResult(
+                            plan_number=pn,
+                            worker_id="unknown",
+                            success=False,
+                            error_message=(
+                                f"fleet watchdog: no progress in "
+                                f"{no_progress_timeout_sec}s"
+                            ),
+                        )
+                    pending.clear()
+                    break
+                _wtime.sleep(3)
+                continue
 
-                if result.success:
-                    logger.info(
-                        f"Plan {plan_number} completed successfully "
-                        f"({result.execution_time:.1f}s)"
-                    )
-                else:
-                    logger.error(
-                        f"Plan {plan_number} failed: {result.error_message}"
-                    )
+            last_progress = _wtime.monotonic()
+            for future in done:
+                pending.discard(future)
+                plan_number = futures[future]
+                try:
+                    result = future.result()
+                    results[plan_number] = result
 
-            except Exception as e:
-                logger.error(f"Plan {plan_number} raised exception: {e}")
-                results[plan_number] = ExecutionResult(
-                    plan_number=plan_number,
-                    worker_id="unknown",
-                    success=False,
-                    error_message=str(e)
-                )
+                    if result.success:
+                        logger.info(
+                            f"Plan {plan_number} completed successfully "
+                            f"({result.execution_time:.1f}s)"
+                        )
+                    else:
+                        logger.error(
+                            f"Plan {plan_number} failed: {result.error_message}"
+                        )
+
+                except Exception as e:
+                    logger.error(f"Plan {plan_number} raised exception: {e}")
+                    results[plan_number] = ExecutionResult(
+                        plan_number=plan_number,
+                        worker_id="unknown",
+                        success=False,
+                        error_message=str(e)
+                    )
+    finally:
+        # wait=False so a wedged worker thread cannot block teardown; healthy
+        # threads have already completed by the time we reach a clean exit.
+        executor.shutdown(wait=False)
 
     # Summary
     successful = sum(1 for r in results.values() if r.success)

--- a/ras_commander/remote/PsexecWorker.py
+++ b/ras_commander/remote/PsexecWorker.py
@@ -441,6 +441,20 @@ def execute_psexec_plan(
 
         psexec_cmd.extend(["-accepteula", "-h"])
 
+        # Unique PSEXESVC instance name per concurrent call. PsExec's default
+        # shared service name ("PSEXESVC") races when several calls hit the same
+        # host in parallel -- one call removes the service while another starts
+        # it, producing "Could not start PSEXESVC service ... marked for
+        # deletion" and a fast-fail with no result HDF. -r gives each call its
+        # own service instance, eliminating the race. A uniquely-named service
+        # also can't be left in a blocking half-deleted state by an abrupt kill,
+        # because the next call uses a different name.
+        _svc_raw = f"RasRemote_{plan_number}_{worker_temp_folder.name}"
+        service_name = "".join(
+            c if (c.isalnum() or c == "_") else "_" for c in _svc_raw
+        )[:100]
+        psexec_cmd.extend(["-r", service_name])
+
         if worker.system_account:
             psexec_cmd.append("-s")
         else:


### PR DESCRIPTION
## Summary

Three reliability fixes for `ras_commander.remote` distributed execution, all surfaced and validated end-to-end while running a 100-sample Monte Carlo ensemble (`116_monte_carlo_uncertainty`) across a 5-worker CLB fleet (4 PsExec + 1 Docker on a native-Linux host).

### 1. PsExec service-name race (`PsexecWorker`)
Every concurrent PsExec call to a host used the **default shared `PSEXESVC` service name**. With multiple sub-workers per host, one call removes the service while another starts it → `Could not start PSEXESVC service ... marked for deletion` → RAS never launches → fast-fail with no result HDF. **Every plan on the affected host failed.**

Fix: pass `-r RasRemote_<plan>_<hash>` — a **unique service instance per call**. Eliminates the race; a uniquely-named service also can't be left in a blocking half-deleted state by an abrupt kill (the next call uses a different name).

### 2. Unbounded Docker SSH staging (`DockerSshStaging`)
`paramiko` `connect()` and `exec_command()`/`recv_exit_status()` had **no timeouts** — an unreachable/slow Linux Docker host could block a worker thread forever (the original deadlock).

Fix: bound `connect()` (connect/banner/auth = 30s) and bound `recv_exit_status` via channel `timeout` + `status_event.wait(120)` (the bare call is not interruptible).

### 3. Dispatch-loop deadlock (`compute_parallel_remote`)
The collection loop used unbounded `as_completed(futures)` inside a `with ThreadPoolExecutor(...)` block. `__exit__` calls `shutdown(wait=True)`, so **one wedged worker thread hangs the entire ensemble** — observed as a multi-hour silent stall.

Fix: a **no-progress watchdog**. If no plan completes within the slowest worker's `max_runtime_minutes` (+15m margin), stragglers are marked failed and the executor is torn down with `wait=False` instead of blocking on hung threads.

## Validation
- **CLB01** now runs 4 concurrent plans, each under its own `RasRemote_<plan>_<hash>` service — **0 `marked for deletion`** (was failing 100% of its plans).
- **CLB07 Docker** runs 2 containers under the bounded SSH path.
- `tests/test_docker_linux_host.py`: **16 passed**.

## Risk
Low — scoped to `ras_commander/remote/`. The watchdog preserves existing success/fail result semantics; only the wait mechanics change. PsExec `-r` and the Docker timeouts are additive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)