### PR TITLE
Add Klawitter RasExamples tutorial dataset

### DIFF
--- a/examples/100_using_ras_examples.ipynb
+++ b/examples/100_using_ras_examples.ipynb
@@ -12,10 +12,10 @@
    "execution_count": 1,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-12-29T04:26:40.639767Z",
-     "iopub.status.busy": "2025-12-29T04:26:40.639507Z",
-     "iopub.status.idle": "2025-12-29T04:26:40.643302Z",
-     "shell.execute_reply": "2025-12-29T04:26:40.642767Z"
+     "iopub.execute_input": "2026-06-14T04:08:17.239378Z",
+     "iopub.status.busy": "2026-06-14T04:08:17.239378Z",
+     "iopub.status.idle": "2026-06-14T04:08:17.243046Z",
+     "shell.execute_reply": "2026-06-14T04:08:17.243046Z"
     }
    },
    "outputs": [],
@@ -28,10 +28,10 @@
    "execution_count": 2,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-12-29T04:26:40.645634Z",
-     "iopub.status.busy": "2025-12-29T04:26:40.645369Z",
-     "iopub.status.idle": "2025-12-29T04:26:45.341753Z",
-     "shell.execute_reply": "2025-12-29T04:26:45.341068Z"
+     "iopub.execute_input": "2026-06-14T04:08:17.245244Z",
+     "iopub.status.busy": "2026-06-14T04:08:17.244223Z",
+     "iopub.status.idle": "2026-06-14T04:08:19.097165Z",
+     "shell.execute_reply": "2026-06-14T04:08:19.096620Z"
     }
    },
    "outputs": [
@@ -43,10 +43,18 @@
      ]
     },
     {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "C:\\Users\\bill\\.config\\superpowers\\worktrees\\ras-commander\\codex-clb-240-klawitter-rasexamples\\.venv\\Lib\\site-packages\\tqdm\\auto.py:21: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html\n",
+      "  from .autonotebook import tqdm as notebook_tqdm\n"
+     ]
+    },
+    {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "✓ Loaded: c:\\Users\\billk_clb\\anaconda3\\envs\\rascmdr_piptest\\Lib\\site-packages\\ras_commander\\__init__.py\n"
+      "✓ Loaded: C:\\Users\\bill\\.config\\superpowers\\worktrees\\ras-commander\\codex-clb-240-klawitter-rasexamples\\ras_commander\\__init__.py\n"
      ]
     }
    ],
@@ -122,10 +130,10 @@
    "execution_count": 3,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-12-29T04:26:45.344704Z",
-     "iopub.status.busy": "2025-12-29T04:26:45.344228Z",
-     "iopub.status.idle": "2025-12-29T04:26:45.348260Z",
-     "shell.execute_reply": "2025-12-29T04:26:45.347628Z"
+     "iopub.execute_input": "2026-06-14T04:08:19.099238Z",
+     "iopub.status.busy": "2026-06-14T04:08:19.098709Z",
+     "iopub.status.idle": "2026-06-14T04:08:19.101852Z",
+     "shell.execute_reply": "2026-06-14T04:08:19.101333Z"
     }
    },
    "outputs": [],
@@ -166,10 +174,10 @@
    "execution_count": 4,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-12-29T04:26:45.351082Z",
-     "iopub.status.busy": "2025-12-29T04:26:45.350731Z",
-     "iopub.status.idle": "2025-12-29T04:27:25.288328Z",
-     "shell.execute_reply": "2025-12-29T04:27:25.287533Z"
+     "iopub.execute_input": "2026-06-14T04:08:19.103453Z",
+     "iopub.status.busy": "2026-06-14T04:08:19.103453Z",
+     "iopub.status.idle": "2026-06-14T04:08:34.502211Z",
+     "shell.execute_reply": "2026-06-14T04:08:34.501707Z"
     }
    },
    "outputs": [
@@ -177,46 +185,277 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-01-14 11:31:19 - ras_commander.RasExamples - INFO - Found zip file: C:\\Users\\billk_clb\\anaconda3\\envs\\rascmdr_piptest\\Lib\\site-packages\\examples\\Example_Projects_6_6.zip\n",
-      "2026-01-14 11:31:19 - ras_commander.RasExamples - INFO - Loading project data from CSV...\n",
-      "2026-01-14 11:31:19 - ras_commander.RasExamples - INFO - Loaded 68 projects from CSV.\n",
-      "2026-01-14 11:31:19 - ras_commander.RasExamples - INFO - ----- RasExamples Extracting Project -----\n",
-      "2026-01-14 11:31:19 - ras_commander.RasExamples - INFO - Extracting project 'Balde Eagle Creek'\n",
-      "2026-01-14 11:31:19 - ras_commander.RasExamples - INFO - Successfully extracted project 'Balde Eagle Creek' to C:\\Users\\billk_clb\\anaconda3\\envs\\rascmdr_piptest\\Lib\\site-packages\\examples\\example_projects\\Balde Eagle Creek\n",
-      "2026-01-14 11:31:19 - ras_commander.RasExamples - INFO - ----- RasExamples Extracting Project -----\n",
-      "2026-01-14 11:31:19 - ras_commander.RasExamples - INFO - Extracting project 'BaldEagleCrkMulti2D'\n",
-      "2026-01-14 11:31:19 - ras_commander.RasExamples - INFO - Folder 'BaldEagleCrkMulti2D' already exists. Deleting existing folder...\n",
-      "2026-01-14 11:31:19 - ras_commander.RasExamples - INFO - Existing folder 'BaldEagleCrkMulti2D' has been deleted.\n",
-      "2026-01-14 11:31:21 - ras_commander.RasExamples - INFO - Successfully extracted project 'BaldEagleCrkMulti2D' to C:\\Users\\billk_clb\\anaconda3\\envs\\rascmdr_piptest\\Lib\\site-packages\\examples\\example_projects\\BaldEagleCrkMulti2D\n",
-      "2026-01-14 11:31:21 - ras_commander.RasExamples - INFO - ----- RasExamples Extracting Project -----\n",
-      "2026-01-14 11:31:21 - ras_commander.RasExamples - INFO - Extracting project 'Muncie'\n",
-      "2026-01-14 11:31:21 - ras_commander.RasExamples - INFO - Successfully extracted project 'Muncie' to C:\\Users\\billk_clb\\anaconda3\\envs\\rascmdr_piptest\\Lib\\site-packages\\examples\\example_projects\\Muncie\n",
-      "2026-01-14 11:31:21 - ras_commander.RasExamples - INFO - ----- RasExamples Extracting Project -----\n",
-      "2026-01-14 11:31:21 - ras_commander.RasExamples - INFO - Extracting project 'Davis'\n",
-      "2026-01-14 11:31:21 - ras_commander.RasExamples - INFO - Successfully extracted project 'Davis' to C:\\Users\\billk_clb\\anaconda3\\envs\\rascmdr_piptest\\Lib\\site-packages\\examples\\example_projects\\Davis\n",
-      "2026-01-14 11:31:21 - ras_commander.RasExamples - INFO - ----- RasExamples Extracting Special Project -----\n",
-      "2026-01-14 11:31:21 - ras_commander.RasExamples - INFO - Extracting special project 'NewOrleansMetro'\n",
-      "2026-01-14 11:31:21 - ras_commander.RasExamples - INFO - Downloading special project from: https://www.hec.usace.army.mil/confluence/rasdocs/hgt/files/latest/299502039/299502111/1/1747692522764/NewOrleansMetroPipesExample.zip\n",
-      "2026-01-14 11:31:21 - ras_commander.RasExamples - INFO - This may take a few moments...\n",
-      "2026-01-14 11:31:28 - ras_commander.RasExamples - INFO - Downloaded special project zip file to C:\\Users\\billk_clb\\anaconda3\\envs\\rascmdr_piptest\\Lib\\site-packages\\examples\\example_projects\\NewOrleansMetro_temp.zip\n",
-      "2026-01-14 11:31:29 - ras_commander.RasExamples - INFO - Successfully extracted special project 'NewOrleansMetro' to C:\\Users\\billk_clb\\anaconda3\\envs\\rascmdr_piptest\\Lib\\site-packages\\examples\\example_projects\\NewOrleansMetro\n",
-      "2026-01-14 11:31:29 - ras_commander.RasExamples - INFO - ----- RasExamples Extracting Special Project -----\n",
-      "2026-01-14 11:31:29 - ras_commander.RasExamples - INFO - Extracting special project 'BeaverLake'\n",
-      "2026-01-14 11:31:29 - ras_commander.RasExamples - INFO - Downloading special project from: https://www.hec.usace.army.mil/confluence/rasdocs/hgt/files/latest/299501780/299502090/1/1747692179014/BeaverLake-SWMM-Import-Solution.zip\n",
-      "2026-01-14 11:31:29 - ras_commander.RasExamples - INFO - This may take a few moments...\n",
-      "2026-01-14 11:31:30 - ras_commander.RasExamples - INFO - Downloaded special project zip file to C:\\Users\\billk_clb\\anaconda3\\envs\\rascmdr_piptest\\Lib\\site-packages\\examples\\example_projects\\BeaverLake_temp.zip\n",
-      "2026-01-14 11:31:30 - ras_commander.RasExamples - INFO - Successfully extracted special project 'BeaverLake' to C:\\Users\\billk_clb\\anaconda3\\envs\\rascmdr_piptest\\Lib\\site-packages\\examples\\example_projects\\BeaverLake\n"
+      "2026-06-14 00:08:19 - ras_commander.RasExamples - INFO - Successfully extracted project 'Balde Eagle Creek' to C:\\Users\\bill\\.config\\superpowers\\worktrees\\ras-commander\\codex-clb-240-klawitter-rasexamples\\example_projects\\Balde Eagle Creek\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-06-14 00:08:20 - ras_commander.RasExamples - INFO - Successfully extracted project 'BaldEagleCrkMulti2D' to C:\\Users\\bill\\.config\\superpowers\\worktrees\\ras-commander\\codex-clb-240-klawitter-rasexamples\\example_projects\\BaldEagleCrkMulti2D\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-06-14 00:08:20 - ras_commander.RasExamples - INFO - Successfully extracted project 'Muncie' to C:\\Users\\bill\\.config\\superpowers\\worktrees\\ras-commander\\codex-clb-240-klawitter-rasexamples\\example_projects\\Muncie\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-06-14 00:08:20 - ras_commander.RasExamples - INFO - Successfully extracted project 'Davis' to C:\\Users\\bill\\.config\\superpowers\\worktrees\\ras-commander\\codex-clb-240-klawitter-rasexamples\\example_projects\\Davis\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-06-14 00:08:20 - ras_commander.RasExamples - INFO - Downloading special project from: https://www.hec.usace.army.mil/confluence/rasdocs/hgt/files/latest/299502039/299502111/1/1747692522764/NewOrleansMetroPipesExample.zip\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-06-14 00:08:20 - ras_commander.RasExamples - INFO - This may take a few moments...\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-06-14 00:08:29 - ras_commander.RasExamples - INFO - Downloaded special project zip file to C:\\Users\\bill\\.config\\superpowers\\worktrees\\ras-commander\\codex-clb-240-klawitter-rasexamples\\example_projects\\NewOrleansMetro_temp.zip\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-06-14 00:08:30 - ras_commander.RasExamples - INFO - Successfully extracted special project 'NewOrleansMetro' to C:\\Users\\bill\\.config\\superpowers\\worktrees\\ras-commander\\codex-clb-240-klawitter-rasexamples\\example_projects\\NewOrleansMetro\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-06-14 00:08:30 - ras_commander.RasExamples - INFO - Downloading special project from: https://www.hec.usace.army.mil/confluence/rasdocs/hgt/files/latest/299501780/299502090/1/1747692179014/BeaverLake-SWMM-Import-Solution.zip\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-06-14 00:08:30 - ras_commander.RasExamples - INFO - This may take a few moments...\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-06-14 00:08:31 - ras_commander.RasExamples - INFO - Downloaded special project zip file to C:\\Users\\bill\\.config\\superpowers\\worktrees\\ras-commander\\codex-clb-240-klawitter-rasexamples\\example_projects\\BeaverLake_temp.zip\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-06-14 00:08:31 - ras_commander.RasExamples - INFO - Successfully extracted special project 'BeaverLake' to C:\\Users\\bill\\.config\\superpowers\\worktrees\\ras-commander\\codex-clb-240-klawitter-rasexamples\\example_projects\\BeaverLake\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-06-14 00:08:31 - ras_commander.RasExamples - INFO - Downloading special project from: https://www.hec.usace.army.mil/confluence/download/attachments/276988362/Klawitter_2D_Tutorial.zip?version=1&modificationDate=1740180410184&api=v2\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-06-14 00:08:31 - ras_commander.RasExamples - INFO - This may take a few moments...\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Downloading Klawitter:   0%|          | 0.00/24.5M [00:00<?, ?iB/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Downloading Klawitter:   0%|          | 48.0k/24.5M [00:00<00:55, 463kiB/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Downloading Klawitter:   1%|          | 144k/24.5M [00:00<00:49, 516kiB/s] "
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Downloading Klawitter:   1%|▏         | 328k/24.5M [00:00<00:25, 1.00MiB/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Downloading Klawitter:   2%|▏         | 560k/24.5M [00:00<00:17, 1.43MiB/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Downloading Klawitter:   4%|▎         | 896k/24.5M [00:00<00:12, 2.06MiB/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Downloading Klawitter:   6%|▌         | 1.38M/24.5M [00:00<00:09, 2.46MiB/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Downloading Klawitter:   9%|▊         | 2.11M/24.5M [00:00<00:06, 3.83MiB/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Downloading Klawitter:  14%|█▍        | 3.47M/24.5M [00:00<00:03, 6.64MiB/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Downloading Klawitter:  23%|██▎       | 5.64M/24.5M [00:01<00:01, 11.1MiB/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Downloading Klawitter:  31%|███▏      | 7.70M/24.5M [00:01<00:01, 14.1MiB/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Downloading Klawitter:  41%|████      | 9.91M/24.5M [00:01<00:00, 16.7MiB/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Downloading Klawitter:  49%|████▉     | 12.0M/24.5M [00:01<00:00, 18.3MiB/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Downloading Klawitter:  58%|█████▊    | 14.1M/24.5M [00:01<00:00, 19.3MiB/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Downloading Klawitter:  66%|██████▋   | 16.2M/24.5M [00:01<00:00, 20.2MiB/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Downloading Klawitter:  75%|███████▍  | 18.3M/24.5M [00:01<00:00, 20.6MiB/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Downloading Klawitter:  83%|████████▎ | 20.3M/24.5M [00:01<00:00, 20.0MiB/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Downloading Klawitter:  92%|█████████▏| 22.5M/24.5M [00:01<00:00, 20.9MiB/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Downloading Klawitter: 100%|██████████| 24.5M/24.5M [00:01<00:00, 12.8MiB/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "2026-06-14 00:08:34 - ras_commander.RasExamples - INFO - Downloaded special project zip file to C:\\Users\\bill\\.config\\superpowers\\worktrees\\ras-commander\\codex-clb-240-klawitter-rasexamples\\example_projects\\Klawitter_temp.zip\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-06-14 00:08:34 - ras_commander.RasExamples - INFO - Successfully extracted special project 'Klawitter' to C:\\Users\\bill\\.config\\superpowers\\worktrees\\ras-commander\\codex-clb-240-klawitter-rasexamples\\example_projects\\Klawitter\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "[WindowsPath('C:/Users/billk_clb/anaconda3/envs/rascmdr_piptest/Lib/site-packages/examples/example_projects/Balde Eagle Creek'),\n",
-       " WindowsPath('C:/Users/billk_clb/anaconda3/envs/rascmdr_piptest/Lib/site-packages/examples/example_projects/BaldEagleCrkMulti2D'),\n",
-       " WindowsPath('C:/Users/billk_clb/anaconda3/envs/rascmdr_piptest/Lib/site-packages/examples/example_projects/Muncie'),\n",
-       " WindowsPath('C:/Users/billk_clb/anaconda3/envs/rascmdr_piptest/Lib/site-packages/examples/example_projects/Davis'),\n",
-       " WindowsPath('C:/Users/billk_clb/anaconda3/envs/rascmdr_piptest/Lib/site-packages/examples/example_projects/NewOrleansMetro'),\n",
-       " WindowsPath('C:/Users/billk_clb/anaconda3/envs/rascmdr_piptest/Lib/site-packages/examples/example_projects/BeaverLake')]"
+       "[WindowsPath('C:/Users/bill/.config/superpowers/worktrees/ras-commander/codex-clb-240-klawitter-rasexamples/example_projects/Balde Eagle Creek'),\n",
+       " WindowsPath('C:/Users/bill/.config/superpowers/worktrees/ras-commander/codex-clb-240-klawitter-rasexamples/example_projects/BaldEagleCrkMulti2D'),\n",
+       " WindowsPath('C:/Users/bill/.config/superpowers/worktrees/ras-commander/codex-clb-240-klawitter-rasexamples/example_projects/Muncie'),\n",
+       " WindowsPath('C:/Users/bill/.config/superpowers/worktrees/ras-commander/codex-clb-240-klawitter-rasexamples/example_projects/Davis'),\n",
+       " WindowsPath('C:/Users/bill/.config/superpowers/worktrees/ras-commander/codex-clb-240-klawitter-rasexamples/example_projects/NewOrleansMetro'),\n",
+       " WindowsPath('C:/Users/bill/.config/superpowers/worktrees/ras-commander/codex-clb-240-klawitter-rasexamples/example_projects/BeaverLake'),\n",
+       " WindowsPath('C:/Users/bill/.config/superpowers/worktrees/ras-commander/codex-clb-240-klawitter-rasexamples/example_projects/Klawitter')]"
       ]
      },
      "execution_count": 4,
@@ -229,7 +468,7 @@
     "# This is what this Class was intended to do: Help me make repeatable workflows around HEC-RAS Example Projects for testing and demonstration purposes. \n",
     "\n",
     "# Extract specific projects\n",
-    "RasExamples.extract_project([\"Balde Eagle Creek\", \"BaldEagleCrkMulti2D\", \"Muncie\", \"Davis\", \"NewOrleansMetro\", \"BeaverLake\"])"
+    "RasExamples.extract_project([\"Balde Eagle Creek\", \"BaldEagleCrkMulti2D\", \"Muncie\", \"Davis\", \"NewOrleansMetro\", \"BeaverLake\", \"Klawitter\"])\n"
    ]
   },
   {
@@ -314,10 +553,10 @@
    "execution_count": 5,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-12-29T04:27:25.291239Z",
-     "iopub.status.busy": "2025-12-29T04:27:25.290958Z",
-     "iopub.status.idle": "2025-12-29T04:27:25.302375Z",
-     "shell.execute_reply": "2025-12-29T04:27:25.301882Z"
+     "iopub.execute_input": "2026-06-14T04:08:34.503835Z",
+     "iopub.status.busy": "2026-06-14T04:08:34.503294Z",
+     "iopub.status.idle": "2026-06-14T04:08:34.534620Z",
+     "shell.execute_reply": "2026-06-14T04:08:34.534620Z"
     }
    },
    "outputs": [
@@ -386,6 +625,11 @@
        "      <td>...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
+       "      <th>62</th>\n",
+       "      <td>Applications Guide</td>\n",
+       "      <td>Example 6 - Floodway Determination</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
        "      <th>63</th>\n",
        "      <td>Applications Guide</td>\n",
        "      <td>Example 7 - Multiple Plans</td>\n",
@@ -402,34 +646,29 @@
        "    </tr>\n",
        "    <tr>\n",
        "      <th>66</th>\n",
-       "      <td>Pipes (beta)</td>\n",
+       "      <td>Pipes</td>\n",
        "      <td>Davis</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>67</th>\n",
-       "      <td>Water Quality</td>\n",
-       "      <td>Nutrient Example</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
-       "<p>68 rows × 2 columns</p>\n",
+       "<p>67 rows × 2 columns</p>\n",
        "</div>"
       ],
       "text/plain": [
-       "                 Category                            Project\n",
-       "0   1D Sediment Transport             BSTEM - Simple Example\n",
-       "1   1D Sediment Transport                   Dredging Example\n",
-       "2   1D Sediment Transport           Reservoir Video Tutorial\n",
-       "3   1D Sediment Transport                       SIAM Example\n",
-       "4   1D Sediment Transport  Simple Sediment Transport Example\n",
-       "..                    ...                                ...\n",
-       "63     Applications Guide         Example 7 - Multiple Plans\n",
-       "64     Applications Guide         Example 8 - Looped Network\n",
-       "65     Applications Guide    Example 9 - Mixed Flow Analysis\n",
-       "66           Pipes (beta)                              Davis\n",
-       "67          Water Quality                   Nutrient Example\n",
+       "                 Category                             Project\n",
+       "0   1D Sediment Transport              BSTEM - Simple Example\n",
+       "1   1D Sediment Transport                    Dredging Example\n",
+       "2   1D Sediment Transport            Reservoir Video Tutorial\n",
+       "3   1D Sediment Transport                        SIAM Example\n",
+       "4   1D Sediment Transport   Simple Sediment Transport Example\n",
+       "..                    ...                                 ...\n",
+       "62     Applications Guide  Example 6 - Floodway Determination\n",
+       "63     Applications Guide          Example 7 - Multiple Plans\n",
+       "64     Applications Guide          Example 8 - Looped Network\n",
+       "65     Applications Guide     Example 9 - Mixed Flow Analysis\n",
+       "66                  Pipes                               Davis\n",
        "\n",
-       "[68 rows x 2 columns]"
+       "[67 rows x 2 columns]"
       ]
      },
      "metadata": {},
@@ -454,21 +693,13 @@
    "execution_count": 6,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-12-29T04:27:25.304966Z",
-     "iopub.status.busy": "2025-12-29T04:27:25.304643Z",
-     "iopub.status.idle": "2025-12-29T04:27:25.308309Z",
-     "shell.execute_reply": "2025-12-29T04:27:25.307704Z"
+     "iopub.execute_input": "2026-06-14T04:08:34.536625Z",
+     "iopub.status.busy": "2026-06-14T04:08:34.536625Z",
+     "iopub.status.idle": "2026-06-14T04:08:34.538821Z",
+     "shell.execute_reply": "2026-06-14T04:08:34.538821Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-14 11:31:30 - ras_commander.RasExamples - INFO - Available categories: 1D Sediment Transport, 1D Steady Flow Hydraulics, 1D Unsteady Flow Hydraulics, 2D Sediment Transport, 2D Unsteady Flow Hydraulics, Applications Guide, Pipes (beta), Water Quality\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# List all categories\n",
     "categories = RasExamples.list_categories()"
@@ -479,10 +710,10 @@
    "execution_count": 7,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-12-29T04:27:25.310541Z",
-     "iopub.status.busy": "2025-12-29T04:27:25.310227Z",
-     "iopub.status.idle": "2025-12-29T04:27:25.314426Z",
-     "shell.execute_reply": "2025-12-29T04:27:25.313876Z"
+     "iopub.execute_input": "2026-06-14T04:08:34.540836Z",
+     "iopub.status.busy": "2026-06-14T04:08:34.539830Z",
+     "iopub.status.idle": "2026-06-14T04:08:34.543870Z",
+     "shell.execute_reply": "2026-06-14T04:08:34.543870Z"
     }
    },
    "outputs": [
@@ -503,8 +734,7 @@
        " '2D Sediment Transport',\n",
        " '2D Unsteady Flow Hydraulics',\n",
        " 'Applications Guide',\n",
-       " 'Pipes (beta)',\n",
-       " 'Water Quality']"
+       " 'Pipes']"
       ]
      },
      "execution_count": 7,
@@ -522,20 +752,13 @@
    "execution_count": 8,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-12-29T04:27:25.316983Z",
-     "iopub.status.busy": "2025-12-29T04:27:25.316708Z",
-     "iopub.status.idle": "2025-12-29T04:27:25.321891Z",
-     "shell.execute_reply": "2025-12-29T04:27:25.321317Z"
+     "iopub.execute_input": "2026-06-14T04:08:34.546130Z",
+     "iopub.status.busy": "2026-06-14T04:08:34.546130Z",
+     "iopub.status.idle": "2026-06-14T04:08:34.550708Z",
+     "shell.execute_reply": "2026-06-14T04:08:34.550190Z"
     }
    },
    "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-14 11:31:30 - ras_commander.RasExamples - INFO - Projects in category '1D Sediment Transport': BSTEM - Simple Example, Dredging Example, Reservoir Video Tutorial, SIAM Example, Simple Sediment Transport Example, Unsteady Sediment with Concentration Rules, Video Tutorial (Sediment Intro)\n"
-     ]
-    },
     {
      "data": {
       "text/plain": [
@@ -565,20 +788,13 @@
    "execution_count": 9,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-12-29T04:27:25.324623Z",
-     "iopub.status.busy": "2025-12-29T04:27:25.324263Z",
-     "iopub.status.idle": "2025-12-29T04:27:25.330826Z",
-     "shell.execute_reply": "2025-12-29T04:27:25.330299Z"
+     "iopub.execute_input": "2026-06-14T04:08:34.552217Z",
+     "iopub.status.busy": "2026-06-14T04:08:34.552217Z",
+     "iopub.status.idle": "2026-06-14T04:08:34.555402Z",
+     "shell.execute_reply": "2026-06-14T04:08:34.555402Z"
     }
    },
    "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-14 11:31:30 - ras_commander.RasExamples - INFO - All available projects: BSTEM - Simple Example, Dredging Example, Reservoir Video Tutorial, SIAM Example, Simple Sediment Transport Example, Unsteady Sediment with Concentration Rules, Video Tutorial (Sediment Intro), Baxter RAS Mapper, Chapter 4 Example Data, ConSpan Culvert, Mixed Flow Regime Channel, Wailupe GeoRAS, Balde Eagle Creek, Bridge Hydraulics, ContractionExpansionMinorLosses, Culvert Hydraulics, Culverts with Flap Gates, Dam Breaching, Elevation Controled Gates, Inline Structure with Gated Spillways, Internal Stage and Flow Boundary Condition, JunctionHydraulics, Lateral Strcuture with Gates, Lateral Structure connected to a River Reach, Lateral Structure Overflow Weir, Lateral Structure with Culverts and Gates, Lateral Structure with Culverts, Levee Breaching, Mixed Flow Regime, Multiple Reaches with Hydraulic Structures, NavigationDam, Pumping Station with Rules, Pumping Station, Rule Operations, Simplified Physical Breaching, Storage Area Hydraulic Connection, UngagedAreaInflows, Unsteady Flow Encroachment Analysis, Chippewa_2D, Weise_2D, BaldEagleCrkMulti2D, Muncie, Example 1 - Critical Creek, Example 10 - Stream Junction, Example 11 - Bridge Scour, Example 12 - Inline Structure, Example 13 - Singler Bridge (WSPRO), Example 14 - Ice Covered River, Example 15 - Split Flow Junction with Lateral Weir, Example 16 - Channel Modification, Example 17 - Unsteady Flow Application, Example 18 - Advanced Inline Structure, Example 19 - Hydrologic Routing - ModPuls, Example 2 - Beaver Creek, Example 20 - HagerLatWeir, Example 21 - Overflow Gates, Example 22 - Groundwater Interflow, Example 23 - Urban Modeling, Example 24 - Mannings-n-Calibration, Example 3 - Single Culvert, Example 4 - Multiple Culverts, Example 5 - Multiple Openings, Example 6 - Floodway Determination, Example 7 - Multiple Plans, Example 8 - Looped Network, Example 9 - Mixed Flow Analysis, Davis, Nutrient Example, NewOrleansMetro, BeaverLake\n"
-     ]
-    },
     {
      "data": {
       "text/plain": [
@@ -607,14 +823,14 @@
        " 'Lateral Strcuture with Gates',\n",
        " 'Lateral Structure connected to a River Reach',\n",
        " 'Lateral Structure Overflow Weir',\n",
-       " 'Lateral Structure with Culverts and Gates',\n",
        " 'Lateral Structure with Culverts',\n",
+       " 'Lateral Structure with Culverts and Gates',\n",
        " 'Levee Breaching',\n",
        " 'Mixed Flow Regime',\n",
        " 'Multiple Reaches with Hydraulic Structures',\n",
        " 'NavigationDam',\n",
-       " 'Pumping Station with Rules',\n",
        " 'Pumping Station',\n",
+       " 'Pumping Station with Rules',\n",
        " 'Rule Operations',\n",
        " 'Simplified Physical Breaching',\n",
        " 'Storage Area Hydraulic Connection',\n",
@@ -649,9 +865,9 @@
        " 'Example 8 - Looped Network',\n",
        " 'Example 9 - Mixed Flow Analysis',\n",
        " 'Davis',\n",
-       " 'Nutrient Example',\n",
        " 'NewOrleansMetro',\n",
-       " 'BeaverLake']"
+       " 'BeaverLake',\n",
+       " 'Klawitter']"
       ]
      },
      "execution_count": 9,
@@ -670,10 +886,10 @@
    "execution_count": 10,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-12-29T04:27:25.333699Z",
-     "iopub.status.busy": "2025-12-29T04:27:25.333345Z",
-     "iopub.status.idle": "2025-12-29T04:27:27.640300Z",
-     "shell.execute_reply": "2025-12-29T04:27:27.639618Z"
+     "iopub.execute_input": "2026-06-14T04:08:34.557407Z",
+     "iopub.status.busy": "2026-06-14T04:08:34.557407Z",
+     "iopub.status.idle": "2026-06-14T04:08:36.379817Z",
+     "shell.execute_reply": "2026-06-14T04:08:36.379817Z"
     }
    },
    "outputs": [
@@ -681,21 +897,21 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-01-14 11:31:30 - ras_commander.RasExamples - INFO - ----- RasExamples Extracting Project -----\n",
-      "2026-01-14 11:31:30 - ras_commander.RasExamples - INFO - Extracting project 'Balde Eagle Creek'\n",
-      "2026-01-14 11:31:30 - ras_commander.RasExamples - INFO - Folder 'Balde Eagle Creek' already exists. Deleting existing folder...\n",
-      "2026-01-14 11:31:30 - ras_commander.RasExamples - INFO - Existing folder 'Balde Eagle Creek' has been deleted.\n",
-      "2026-01-14 11:31:30 - ras_commander.RasExamples - INFO - Successfully extracted project 'Balde Eagle Creek' to C:\\Users\\billk_clb\\anaconda3\\envs\\rascmdr_piptest\\Lib\\site-packages\\examples\\example_projects\\Balde Eagle Creek\n",
-      "2026-01-14 11:31:30 - ras_commander.RasExamples - INFO - ----- RasExamples Extracting Project -----\n",
-      "2026-01-14 11:31:30 - ras_commander.RasExamples - INFO - Extracting project 'BaldEagleCrkMulti2D'\n",
-      "2026-01-14 11:31:30 - ras_commander.RasExamples - INFO - Folder 'BaldEagleCrkMulti2D' already exists. Deleting existing folder...\n",
-      "2026-01-14 11:31:30 - ras_commander.RasExamples - INFO - Existing folder 'BaldEagleCrkMulti2D' has been deleted.\n",
-      "2026-01-14 11:31:32 - ras_commander.RasExamples - INFO - Successfully extracted project 'BaldEagleCrkMulti2D' to C:\\Users\\billk_clb\\anaconda3\\envs\\rascmdr_piptest\\Lib\\site-packages\\examples\\example_projects\\BaldEagleCrkMulti2D\n",
-      "2026-01-14 11:31:32 - ras_commander.RasExamples - INFO - ----- RasExamples Extracting Project -----\n",
-      "2026-01-14 11:31:32 - ras_commander.RasExamples - INFO - Extracting project 'Muncie'\n",
-      "2026-01-14 11:31:32 - ras_commander.RasExamples - INFO - Folder 'Muncie' already exists. Deleting existing folder...\n",
-      "2026-01-14 11:31:32 - ras_commander.RasExamples - INFO - Existing folder 'Muncie' has been deleted.\n",
-      "2026-01-14 11:31:32 - ras_commander.RasExamples - INFO - Successfully extracted project 'Muncie' to C:\\Users\\billk_clb\\anaconda3\\envs\\rascmdr_piptest\\Lib\\site-packages\\examples\\example_projects\\Muncie\n"
+      "2026-06-14 00:08:34 - ras_commander.RasExamples - INFO - Successfully extracted project 'Balde Eagle Creek' to C:\\Users\\bill\\.config\\superpowers\\worktrees\\ras-commander\\codex-clb-240-klawitter-rasexamples\\example_projects\\Balde Eagle Creek\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-06-14 00:08:36 - ras_commander.RasExamples - INFO - Successfully extracted project 'BaldEagleCrkMulti2D' to C:\\Users\\bill\\.config\\superpowers\\worktrees\\ras-commander\\codex-clb-240-klawitter-rasexamples\\example_projects\\BaldEagleCrkMulti2D\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-06-14 00:08:36 - ras_commander.RasExamples - INFO - Successfully extracted project 'Muncie' to C:\\Users\\bill\\.config\\superpowers\\worktrees\\ras-commander\\codex-clb-240-klawitter-rasexamples\\example_projects\\Muncie\n"
      ]
     }
    ],
@@ -718,13 +934,19 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### NEW Example Projects:\n",
-    "#### The \"BeaverLake\" and \"NewOrleansMetro\" were published to the HEC-RAS Sample Datasets page.  These sample datasets are specifically for Pipe Systems introduced in HEC-RAS 6.6\n",
+    "### Special Tutorial and Sample Projects\n",
+    "\n",
+    "`NewOrleansMetro`, `BeaverLake`, and `Klawitter` are downloaded separately from the main HEC-RAS example-project archive.\n",
+    "\n",
+    "`NewOrleansMetro` and `BeaverLake` were published on the HEC-RAS sample datasets page for pipe-system workflows introduced in HEC-RAS 6.6:\n",
     "\n",
     "https://www.hec.usace.army.mil/confluence/rasdocs/hgt/latest/sample-datasets/small-city-urban-drainage-davis-ca\n",
     "\n",
     "https://www.hec.usace.army.mil/confluence/rasdocs/hgt/latest/sample-datasets/small-neighborhood-drainage-beaver-lake\n",
-    "\n"
+    "\n",
+    "`Klawitter` is the official Klawitter Pond 2D pipe network tutorial dataset. The extracted folder includes `Data`, `Imports`, and `Solution Model`; initialize the RAS project from `klawitter_path / \"Solution Model\"` when you use it in downstream ras-commander workflows.\n",
+    "\n",
+    "https://www.hec.usace.army.mil/confluence/rasdocs/hgt/latest/tutorials/pipe-networks/pipe-networks-klawitter-pond-2d\n"
    ]
   },
   {
@@ -732,10 +954,10 @@
    "execution_count": 11,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-12-29T04:27:27.642749Z",
-     "iopub.status.busy": "2025-12-29T04:27:27.642462Z",
-     "iopub.status.idle": "2025-12-29T04:27:28.829072Z",
-     "shell.execute_reply": "2025-12-29T04:27:28.828461Z"
+     "iopub.execute_input": "2026-06-14T04:08:36.379817Z",
+     "iopub.status.busy": "2026-06-14T04:08:36.379817Z",
+     "iopub.status.idle": "2026-06-14T04:08:37.656362Z",
+     "shell.execute_reply": "2026-06-14T04:08:37.655790Z"
     }
    },
    "outputs": [
@@ -743,14 +965,28 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-01-14 11:31:32 - ras_commander.RasExamples - INFO - ----- RasExamples Extracting Special Project -----\n",
-      "2026-01-14 11:31:32 - ras_commander.RasExamples - INFO - Extracting special project 'BeaverLake'\n",
-      "2026-01-14 11:31:32 - ras_commander.RasExamples - INFO - Folder 'BeaverLake' already exists. Deleting existing folder...\n",
-      "2026-01-14 11:31:32 - ras_commander.RasExamples - INFO - Existing folder 'BeaverLake' has been deleted.\n",
-      "2026-01-14 11:31:32 - ras_commander.RasExamples - INFO - Downloading special project from: https://www.hec.usace.army.mil/confluence/rasdocs/hgt/files/latest/299501780/299502090/1/1747692179014/BeaverLake-SWMM-Import-Solution.zip\n",
-      "2026-01-14 11:31:32 - ras_commander.RasExamples - INFO - This may take a few moments...\n",
-      "2026-01-14 11:31:33 - ras_commander.RasExamples - INFO - Downloaded special project zip file to C:\\Users\\billk_clb\\anaconda3\\envs\\rascmdr_piptest\\Lib\\site-packages\\examples\\example_projects\\BeaverLake_temp.zip\n",
-      "2026-01-14 11:31:33 - ras_commander.RasExamples - INFO - Successfully extracted special project 'BeaverLake' to C:\\Users\\billk_clb\\anaconda3\\envs\\rascmdr_piptest\\Lib\\site-packages\\examples\\example_projects\\BeaverLake\n"
+      "2026-06-14 00:08:36 - ras_commander.RasExamples - INFO - Downloading special project from: https://www.hec.usace.army.mil/confluence/rasdocs/hgt/files/latest/299501780/299502090/1/1747692179014/BeaverLake-SWMM-Import-Solution.zip\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-06-14 00:08:36 - ras_commander.RasExamples - INFO - This may take a few moments...\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-06-14 00:08:37 - ras_commander.RasExamples - INFO - Downloaded special project zip file to C:\\Users\\bill\\.config\\superpowers\\worktrees\\ras-commander\\codex-clb-240-klawitter-rasexamples\\example_projects\\BeaverLake_temp.zip\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-06-14 00:08:37 - ras_commander.RasExamples - INFO - Successfully extracted special project 'BeaverLake' to C:\\Users\\bill\\.config\\superpowers\\worktrees\\ras-commander\\codex-clb-240-klawitter-rasexamples\\example_projects\\BeaverLake\n"
      ]
     }
    ],
@@ -763,10 +999,10 @@
    "execution_count": 12,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-12-29T04:27:28.831741Z",
-     "iopub.status.busy": "2025-12-29T04:27:28.831219Z",
-     "iopub.status.idle": "2025-12-29T04:27:58.065622Z",
-     "shell.execute_reply": "2025-12-29T04:27:58.064824Z"
+     "iopub.execute_input": "2026-06-14T04:08:37.658119Z",
+     "iopub.status.busy": "2026-06-14T04:08:37.658119Z",
+     "iopub.status.idle": "2026-06-14T04:08:47.862060Z",
+     "shell.execute_reply": "2026-06-14T04:08:47.861417Z"
     }
    },
    "outputs": [
@@ -774,14 +1010,28 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-01-14 11:31:33 - ras_commander.RasExamples - INFO - ----- RasExamples Extracting Special Project -----\n",
-      "2026-01-14 11:31:33 - ras_commander.RasExamples - INFO - Extracting special project 'NewOrleansMetro'\n",
-      "2026-01-14 11:31:33 - ras_commander.RasExamples - INFO - Folder 'NewOrleansMetro' already exists. Deleting existing folder...\n",
-      "2026-01-14 11:31:33 - ras_commander.RasExamples - INFO - Existing folder 'NewOrleansMetro' has been deleted.\n",
-      "2026-01-14 11:31:33 - ras_commander.RasExamples - INFO - Downloading special project from: https://www.hec.usace.army.mil/confluence/rasdocs/hgt/files/latest/299502039/299502111/1/1747692522764/NewOrleansMetroPipesExample.zip\n",
-      "2026-01-14 11:31:33 - ras_commander.RasExamples - INFO - This may take a few moments...\n",
-      "2026-01-14 11:31:40 - ras_commander.RasExamples - INFO - Downloaded special project zip file to C:\\Users\\billk_clb\\anaconda3\\envs\\rascmdr_piptest\\Lib\\site-packages\\examples\\example_projects\\NewOrleansMetro_temp.zip\n",
-      "2026-01-14 11:31:41 - ras_commander.RasExamples - INFO - Successfully extracted special project 'NewOrleansMetro' to C:\\Users\\billk_clb\\anaconda3\\envs\\rascmdr_piptest\\Lib\\site-packages\\examples\\example_projects\\NewOrleansMetro\n"
+      "2026-06-14 00:08:37 - ras_commander.RasExamples - INFO - Downloading special project from: https://www.hec.usace.army.mil/confluence/rasdocs/hgt/files/latest/299502039/299502111/1/1747692522764/NewOrleansMetroPipesExample.zip\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-06-14 00:08:37 - ras_commander.RasExamples - INFO - This may take a few moments...\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-06-14 00:08:47 - ras_commander.RasExamples - INFO - Downloaded special project zip file to C:\\Users\\bill\\.config\\superpowers\\worktrees\\ras-commander\\codex-clb-240-klawitter-rasexamples\\example_projects\\NewOrleansMetro_temp.zip\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-06-14 00:08:47 - ras_commander.RasExamples - INFO - Successfully extracted special project 'NewOrleansMetro' to C:\\Users\\bill\\.config\\superpowers\\worktrees\\ras-commander\\codex-clb-240-klawitter-rasexamples\\example_projects\\NewOrleansMetro\n"
      ]
     }
    ],
@@ -794,10 +1044,10 @@
    "execution_count": 13,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-12-29T04:27:58.068782Z",
-     "iopub.status.busy": "2025-12-29T04:27:58.068419Z",
-     "iopub.status.idle": "2025-12-29T04:27:59.278611Z",
-     "shell.execute_reply": "2025-12-29T04:27:59.278053Z"
+     "iopub.execute_input": "2026-06-14T04:08:47.863799Z",
+     "iopub.status.busy": "2026-06-14T04:08:47.863248Z",
+     "iopub.status.idle": "2026-06-14T04:08:50.448641Z",
+     "shell.execute_reply": "2026-06-14T04:08:50.448641Z"
     }
    },
    "outputs": [
@@ -805,19 +1055,252 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-01-14 11:31:41 - ras_commander.RasExamples - INFO - ----- RasExamples Extracting Special Project -----\n",
-      "2026-01-14 11:31:41 - ras_commander.RasExamples - INFO - Extracting special project 'BeaverLake' as 'BeaverLake_special'\n",
-      "2026-01-14 11:31:41 - ras_commander.RasExamples - INFO - Downloading special project from: https://www.hec.usace.army.mil/confluence/rasdocs/hgt/files/latest/299501780/299502090/1/1747692179014/BeaverLake-SWMM-Import-Solution.zip\n",
-      "2026-01-14 11:31:41 - ras_commander.RasExamples - INFO - This may take a few moments...\n",
-      "2026-01-14 11:31:42 - ras_commander.RasExamples - INFO - Downloaded special project zip file to C:\\Users\\billk_clb\\anaconda3\\envs\\rascmdr_piptest\\Lib\\site-packages\\examples\\example_projects\\BeaverLake_special_temp.zip\n",
-      "2026-01-14 11:31:42 - ras_commander.RasExamples - INFO - Successfully extracted special project 'BeaverLake' to C:\\Users\\billk_clb\\anaconda3\\envs\\rascmdr_piptest\\Lib\\site-packages\\examples\\example_projects\\BeaverLake_special\n"
+      "2026-06-14 00:08:47 - ras_commander.RasExamples - INFO - Downloading special project from: https://www.hec.usace.army.mil/confluence/download/attachments/276988362/Klawitter_2D_Tutorial.zip?version=1&modificationDate=1740180410184&api=v2\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-06-14 00:08:47 - ras_commander.RasExamples - INFO - This may take a few moments...\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Downloading Klawitter:   0%|          | 0.00/24.5M [00:00<?, ?iB/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Downloading Klawitter:   0%|          | 48.0k/24.5M [00:00<00:53, 482kiB/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Downloading Klawitter:   1%|          | 144k/24.5M [00:00<00:50, 508kiB/s] "
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Downloading Klawitter:   1%|          | 312k/24.5M [00:00<00:27, 935kiB/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Downloading Klawitter:   2%|▏         | 552k/24.5M [00:00<00:17, 1.44MiB/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Downloading Klawitter:   4%|▎         | 920k/24.5M [00:00<00:11, 2.19MiB/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Downloading Klawitter:   6%|▌         | 1.38M/24.5M [00:00<00:09, 2.43MiB/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Downloading Klawitter:   9%|▉         | 2.16M/24.5M [00:00<00:05, 3.93MiB/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Downloading Klawitter:  13%|█▎        | 3.23M/24.5M [00:00<00:03, 5.91MiB/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Downloading Klawitter:  21%|██        | 5.11M/24.5M [00:01<00:02, 9.67MiB/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Downloading Klawitter:  28%|██▊       | 6.87M/24.5M [00:01<00:01, 11.9MiB/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Downloading Klawitter:  41%|████      | 9.95M/24.5M [00:01<00:00, 17.7MiB/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Downloading Klawitter:  49%|████▉     | 12.1M/24.5M [00:01<00:00, 19.0MiB/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Downloading Klawitter:  58%|█████▊    | 14.1M/24.5M [00:01<00:00, 19.8MiB/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Downloading Klawitter:  66%|██████▌   | 16.1M/24.5M [00:01<00:00, 20.0MiB/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Downloading Klawitter:  74%|███████▍  | 18.1M/24.5M [00:01<00:00, 20.3MiB/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Downloading Klawitter:  82%|████████▏ | 20.1M/24.5M [00:01<00:00, 20.3MiB/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Downloading Klawitter:  90%|█████████ | 22.1M/24.5M [00:01<00:00, 20.4MiB/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Downloading Klawitter:  98%|█████████▊| 24.0M/24.5M [00:01<00:00, 20.4MiB/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Downloading Klawitter: 100%|██████████| 24.5M/24.5M [00:02<00:00, 12.8MiB/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "2026-06-14 00:08:50 - ras_commander.RasExamples - INFO - Downloaded special project zip file to C:\\Users\\bill\\.config\\superpowers\\worktrees\\ras-commander\\codex-clb-240-klawitter-rasexamples\\example_projects\\Klawitter_temp.zip\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-06-14 00:08:50 - ras_commander.RasExamples - INFO - Successfully extracted special project 'Klawitter' to C:\\Users\\bill\\.config\\superpowers\\worktrees\\ras-commander\\codex-clb-240-klawitter-rasexamples\\example_projects\\Klawitter\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Special project extracted to: C:\\Users\\billk_clb\\anaconda3\\envs\\rascmdr_piptest\\Lib\\site-packages\\examples\\example_projects\\BeaverLake_special\n"
+      "Klawitter tutorial extracted to: C:\\Users\\bill\\.config\\superpowers\\worktrees\\ras-commander\\codex-clb-240-klawitter-rasexamples\\example_projects\\Klawitter\n",
+      "RAS project file: C:\\Users\\bill\\.config\\superpowers\\worktrees\\ras-commander\\codex-clb-240-klawitter-rasexamples\\example_projects\\Klawitter\\Solution Model\\KLW_2D.prj\n"
+     ]
+    }
+   ],
+   "source": [
+    "klawitter_path = RasExamples.extract_project(\"Klawitter\")\n",
+    "klawitter_solution_model = klawitter_path / \"Solution Model\"\n",
+    "print(f\"Klawitter tutorial extracted to: {klawitter_path}\")\n",
+    "print(f\"RAS project file: {klawitter_solution_model / 'KLW_2D.prj'}\")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-14T04:08:50.448641Z",
+     "iopub.status.busy": "2026-06-14T04:08:50.448641Z",
+     "iopub.status.idle": "2026-06-14T04:08:51.809068Z",
+     "shell.execute_reply": "2026-06-14T04:08:51.808550Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-06-14 00:08:50 - ras_commander.RasExamples - INFO - Downloading special project from: https://www.hec.usace.army.mil/confluence/rasdocs/hgt/files/latest/299501780/299502090/1/1747692179014/BeaverLake-SWMM-Import-Solution.zip\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-06-14 00:08:50 - ras_commander.RasExamples - INFO - This may take a few moments...\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-06-14 00:08:51 - ras_commander.RasExamples - INFO - Downloaded special project zip file to C:\\Users\\bill\\.config\\superpowers\\worktrees\\ras-commander\\codex-clb-240-klawitter-rasexamples\\example_projects\\BeaverLake_special_temp.zip\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-06-14 00:08:51 - ras_commander.RasExamples - INFO - Successfully extracted special project 'BeaverLake' to C:\\Users\\bill\\.config\\superpowers\\worktrees\\ras-commander\\codex-clb-240-klawitter-rasexamples\\example_projects\\BeaverLake_special\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Special project extracted to: C:\\Users\\bill\\.config\\superpowers\\worktrees\\ras-commander\\codex-clb-240-klawitter-rasexamples\\example_projects\\BeaverLake_special\n"
      ]
     }
    ],
@@ -830,13 +1313,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 15,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-12-29T04:27:59.280761Z",
-     "iopub.status.busy": "2025-12-29T04:27:59.280348Z",
-     "iopub.status.idle": "2025-12-29T04:27:59.369314Z",
-     "shell.execute_reply": "2025-12-29T04:27:59.368541Z"
+     "iopub.execute_input": "2026-06-14T04:08:51.810678Z",
+     "iopub.status.busy": "2026-06-14T04:08:51.810678Z",
+     "iopub.status.idle": "2026-06-14T04:08:51.870866Z",
+     "shell.execute_reply": "2026-06-14T04:08:51.870866Z"
     }
    },
    "outputs": [
@@ -844,12 +1327,14 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-01-14 11:31:42 - ras_commander.RasExamples - INFO - ----- RasExamples Extracting Project -----\n",
-      "2026-01-14 11:31:42 - ras_commander.RasExamples - INFO - Extracting project 'Balde Eagle Creek' as 'Balde Eagle Creek_unsteady'\n",
-      "2026-01-14 11:31:42 - ras_commander.RasExamples - INFO - Successfully extracted project 'Balde Eagle Creek' to C:\\Users\\billk_clb\\anaconda3\\envs\\rascmdr_piptest\\Lib\\site-packages\\examples\\example_projects\\Balde Eagle Creek_unsteady\n",
-      "2026-01-14 11:31:42 - ras_commander.RasExamples - INFO - ----- RasExamples Extracting Project -----\n",
-      "2026-01-14 11:31:42 - ras_commander.RasExamples - INFO - Extracting project 'Pumping Station' as 'Pumping Station_unsteady'\n",
-      "2026-01-14 11:31:42 - ras_commander.RasExamples - INFO - Successfully extracted project 'Pumping Station' to C:\\Users\\billk_clb\\anaconda3\\envs\\rascmdr_piptest\\Lib\\site-packages\\examples\\example_projects\\Pumping Station_unsteady\n"
+      "2026-06-14 00:08:51 - ras_commander.RasExamples - INFO - Successfully extracted project 'Balde Eagle Creek' to C:\\Users\\bill\\.config\\superpowers\\worktrees\\ras-commander\\codex-clb-240-klawitter-rasexamples\\example_projects\\Balde Eagle Creek_unsteady\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-06-14 00:08:51 - ras_commander.RasExamples - INFO - Successfully extracted project 'Pumping Station' to C:\\Users\\bill\\.config\\superpowers\\worktrees\\ras-commander\\codex-clb-240-klawitter-rasexamples\\example_projects\\Pumping Station_unsteady\n"
      ]
     },
     {
@@ -857,8 +1342,8 @@
      "output_type": "stream",
      "text": [
       "Extracted 2 projects:\n",
-      "  - C:\\Users\\billk_clb\\anaconda3\\envs\\rascmdr_piptest\\Lib\\site-packages\\examples\\example_projects\\Balde Eagle Creek_unsteady\n",
-      "  - C:\\Users\\billk_clb\\anaconda3\\envs\\rascmdr_piptest\\Lib\\site-packages\\examples\\example_projects\\Pumping Station_unsteady\n"
+      "  - C:\\Users\\bill\\.config\\superpowers\\worktrees\\ras-commander\\codex-clb-240-klawitter-rasexamples\\example_projects\\Balde Eagle Creek_unsteady\n",
+      "  - C:\\Users\\bill\\.config\\superpowers\\worktrees\\ras-commander\\codex-clb-240-klawitter-rasexamples\\example_projects\\Pumping Station_unsteady\n"
      ]
     }
    ],
@@ -874,13 +1359,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 16,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-12-29T04:27:59.372173Z",
-     "iopub.status.busy": "2025-12-29T04:27:59.371816Z",
-     "iopub.status.idle": "2025-12-29T04:27:59.526444Z",
-     "shell.execute_reply": "2025-12-29T04:27:59.525776Z"
+     "iopub.execute_input": "2026-06-14T04:08:51.872882Z",
+     "iopub.status.busy": "2026-06-14T04:08:51.872882Z",
+     "iopub.status.idle": "2026-06-14T04:08:51.972401Z",
+     "shell.execute_reply": "2026-06-14T04:08:51.971847Z"
     }
    },
    "outputs": [
@@ -888,16 +1373,14 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-01-14 11:31:42 - ras_commander.RasExamples - INFO - ----- RasExamples Extracting Project -----\n",
-      "2026-01-14 11:31:42 - ras_commander.RasExamples - INFO - Extracting project 'Dam Breaching' as 'Dam Breaching_breach_test'\n",
-      "2026-01-14 11:31:42 - ras_commander.RasExamples - INFO - Successfully extracted project 'Dam Breaching' to C:\\Users\\billk_clb\\anaconda3\\envs\\rascmdr_piptest\\Lib\\site-packages\\examples\\example_projects\\Dam Breaching_breach_test\n"
+      "2026-06-14 00:08:51 - ras_commander.RasExamples - INFO - Successfully extracted project 'Dam Breaching' to C:\\Users\\bill\\.config\\superpowers\\worktrees\\ras-commander\\codex-clb-240-klawitter-rasexamples\\example_projects\\Dam Breaching_breach_test\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Extracted to: C:\\Users\\billk_clb\\anaconda3\\envs\\rascmdr_piptest\\Lib\\site-packages\\examples\\example_projects\\Dam Breaching_breach_test\n"
+      "Extracted to: C:\\Users\\bill\\.config\\superpowers\\worktrees\\ras-commander\\codex-clb-240-klawitter-rasexamples\\example_projects\\Dam Breaching_breach_test\n"
      ]
     }
    ],
@@ -909,13 +1392,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 17,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-12-29T04:27:59.529528Z",
-     "iopub.status.busy": "2025-12-29T04:27:59.529181Z",
-     "iopub.status.idle": "2025-12-29T04:27:59.913177Z",
-     "shell.execute_reply": "2025-12-29T04:27:59.912682Z"
+     "iopub.execute_input": "2026-06-14T04:08:51.974033Z",
+     "iopub.status.busy": "2026-06-14T04:08:51.973518Z",
+     "iopub.status.idle": "2026-06-14T04:08:52.239693Z",
+     "shell.execute_reply": "2026-06-14T04:08:52.239693Z"
     }
    },
    "outputs": [
@@ -923,16 +1406,14 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-01-14 11:31:42 - ras_commander.RasExamples - INFO - ----- RasExamples Extracting Project -----\n",
-      "2026-01-14 11:31:42 - ras_commander.RasExamples - INFO - Extracting project 'Muncie' as 'Muncie_100'\n",
-      "2026-01-14 11:31:43 - ras_commander.RasExamples - INFO - Successfully extracted project 'Muncie' to C:\\Users\\billk_clb\\anaconda3\\envs\\rascmdr_piptest\\Lib\\site-packages\\examples\\example_projects\\Muncie_100\n"
+      "2026-06-14 00:08:52 - ras_commander.RasExamples - INFO - Successfully extracted project 'Muncie' to C:\\Users\\bill\\.config\\superpowers\\worktrees\\ras-commander\\codex-clb-240-klawitter-rasexamples\\example_projects\\Muncie_100\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Extracted to: C:\\Users\\billk_clb\\anaconda3\\envs\\rascmdr_piptest\\Lib\\site-packages\\examples\\example_projects\\Muncie_100\n"
+      "Extracted to: C:\\Users\\bill\\.config\\superpowers\\worktrees\\ras-commander\\codex-clb-240-klawitter-rasexamples\\example_projects\\Muncie_100\n"
      ]
     }
    ],
@@ -1029,7 +1510,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.5"
+   "version": "3.12.13"
   }
  },
  "nbformat": 4,

--- a/ras_commander/RasExamples.py
+++ b/ras_commander/RasExamples.py
@@ -135,7 +135,8 @@ class RasExamples:
     # Special projects that are not in the main zip file
     SPECIAL_PROJECTS = {
         'NewOrleansMetro': 'https://www.hec.usace.army.mil/confluence/rasdocs/hgt/files/latest/299502039/299502111/1/1747692522764/NewOrleansMetroPipesExample.zip',
-        'BeaverLake': 'https://www.hec.usace.army.mil/confluence/rasdocs/hgt/files/latest/299501780/299502090/1/1747692179014/BeaverLake-SWMM-Import-Solution.zip'
+        'BeaverLake': 'https://www.hec.usace.army.mil/confluence/rasdocs/hgt/files/latest/299501780/299502090/1/1747692179014/BeaverLake-SWMM-Import-Solution.zip',
+        'Klawitter': 'https://www.hec.usace.army.mil/confluence/download/attachments/276988362/Klawitter_2D_Tutorial.zip?version=1&modificationDate=1740180410184&api=v2',
     }
 
     _folder_df = None
@@ -484,8 +485,8 @@ class RasExamples:
         """
         List all projects or projects in a specific category.
         
-        Note: Special projects (NewOrleansMetro, BeaverLake) are also available but not listed
-        in categories as they are downloaded separately.
+        Note: Special projects are also available but not listed in categories as they
+        are downloaded separately.
         """
         if cls._folder_df is None:
             logger.warning("No projects available. Make sure the zip file is properly loaded.")
@@ -618,7 +619,7 @@ class RasExamples:
         Download and extract special projects that are not in the main zip file.
 
         Args:
-            project_name: Name of the special project ('NewOrleansMetro' or 'BeaverLake')
+            project_name: Name of a registered special project.
             output_path: Base output directory path. If None, uses cls.projects_dir
             suffix: Optional suffix to append to folder name using format "{project_name}_{suffix}".
 

--- a/tests/test_ras_examples_special_projects.py
+++ b/tests/test_ras_examples_special_projects.py
@@ -1,0 +1,26 @@
+import pandas as pd
+
+from ras_commander import RasExamples
+
+
+def test_klawitter_registered_as_special_project():
+    url = RasExamples.SPECIAL_PROJECTS["Klawitter"]
+
+    assert "Klawitter_2D_Tutorial.zip" in url
+    assert url.startswith("https://www.hec.usace.army.mil/confluence/")
+
+
+def test_list_projects_includes_klawitter_special_project(monkeypatch):
+    project_df = pd.DataFrame(
+        [
+            {
+                "Category": "Sample",
+                "Project": "Muncie",
+            }
+        ]
+    )
+    monkeypatch.setattr(RasExamples, "_folder_df", project_df)
+
+    projects = RasExamples.list_projects()
+
+    assert "Klawitter" in projects


### PR DESCRIPTION
## Summary

- Registers the official HEC-RAS Klawitter Pond 2D tutorial ZIP as a
  `RasExamples` special project.
- Updates `examples/100_using_ras_examples.ipynb` to extract Klawitter,
  document the tutorial source, and note that the RAS project is under
  `Solution Model`.
- Re-executes the notebook so committed outputs include the new tutorial.
- Adds regression coverage that keeps Klawitter exposed through
  `RasExamples.list_projects()`.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)
- [x] Example notebook

---

## LLM Self-Review

> **ras-commander encourages LLM-assisted contributions.** If your agent prepared this code, confirm it reviewed the style guide. See [CONTRIBUTING.md](../CONTRIBUTING.md) for details.

### Style Compliance

- [x] Static class pattern followed (`RasExamples` remains a static namespace)
- [x] `@staticmethod` + `@log_call` on public methods (no public methods added)
- [x] Naming conventions followed (`Klawitter` matches special-project keys)
- [x] `pathlib.Path` used, accepts both `str` and `Path` (existing extraction path preserved)
- [x] DataFrames used for project metadata, not glob (list-project behavior preserved)

### Code Quality

- [x] Google-style docstrings with Args, Returns, Raises (only existing docstrings generalized)
- [x] Tested with real HEC-RAS project (`RasExamples.extract_project()`)
- [x] No hardcoded local file paths
- [x] Uses logging, not `print()` (library path unchanged; notebook prints demonstration output)
- [x] Proper error handling with informative messages (existing special-project handling preserved)

### API Changes (if applicable)

- [x] `ras_object=None` parameter included for multi-project support (not applicable; no API signature change)
- [x] Standard parameter names (`plan_number`, `geom_file`) (not applicable; no API signature change)
- [x] API consistency auditor 5 rules followed (`.claude/agents/api-consistency-auditor.md`) (not applicable; no API signature change)
- [x] Return types consistent (DataFrames for tabular data) (existing `list_projects()` return type preserved)

### Notebooks (if applicable)

- [x] First cell is markdown with H1 title
- [x] Uses `RasExamples.extract_project()` for data
- [x] Development toggle cell included (`USE_LOCAL_SOURCE`) (not applicable to this existing notebook; import/setup cells preserved)

---

## Test Plan

- `uv run pytest tests/test_ras_examples_special_projects.py tests/test_rasutils_cleanup.py -q`
- Executed `examples/100_using_ras_examples.ipynb` in place with `nbclient`
- Verified all 17 notebook code cells have execution counts and no error outputs
- Verified `RasExamples.extract_project("Klawitter")` downloads and extracts the official tutorial data, including `Solution Model/KLW_2D.prj`

## LLM Attribution

**Model/Tool used**: Codex CLI (GPT-5)