### PR TITLE
feat(docs): agent-native API surface (signatures + DataFrame schemas + version provenance)

### DIFF
--- a/.claude/scripts/generate_api_surface.py
+++ b/.claude/scripts/generate_api_surface.py
@@ -1,0 +1,336 @@
+#!/usr/bin/env python3
+"""
+generate_api_surface.py -- emit the agent-native API surface for ras-commander.
+
+Runs during the docs build (invoked by the ras-commander-docs ``build.sh`` ``ras`` prebuild
+profile, AFTER ``uv pip install -e .`` so the library is importable). It introspects the
+**installed** ``ras_commander`` package and reads the declarative ``ras_commander/schemas.py``,
+then writes machine + human artifacts into ``docs/`` so mkdocs publishes them under ``/ras``:
+
+    docs/version.json             -> /ras/version.json            (build provenance)
+    docs/llms/api/index.json      -> /ras/llms/api/index.json      (public signatures)
+    docs/llms/api/dataframes.json -> /ras/llms/api/dataframes.json (DataFrame column contracts)
+    docs/llms/api/index.md        -> /ras/llms/api/                (human index + provenance banner)
+
+The point: a stable, always-in-sync surface an LLM or ras-commander-mcp can pull to resolve
+"current signature of X" / "columns of plan_df" without scraping rendered HTML. mkdocstrings
+still owns the rich *human* API reference; this complements it with machine-readable JSON.
+
+Design notes
+------------
+* Stdlib + ``ras_commander`` only -- no extra build deps.
+* The public surface is ``ras_commander.__all__`` (the authoritative export list). Lazy exports
+  (GUI / remote / DSS) are resolved through the package's ``__getattr__``; on the Linux build box
+  their optional deps (pywin32 / boto3 / jpype) are absent, so **each symbol is introspected in
+  its own try/except** and a failure is recorded as ``available: false`` rather than aborting the
+  build.
+* ``inspect.signature`` is reliable here: the library's ``@log_call`` / ``@standardize_input``
+  decorators use ``functools.wraps``.
+* Output is sorted for stable diffs. A non-fatal generator: any top-level failure prints a clear
+  warning and exits 0 so a surface hiccup never darks the flagship docs build.
+"""
+
+from __future__ import annotations
+
+import datetime
+import inspect
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+GENERATOR = "generate_api_surface.py/1.0"
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DOCS_DIR = REPO_ROOT / "docs"
+API_DIR = DOCS_DIR / "llms" / "api"
+
+
+def _now_utc() -> str:
+    return datetime.datetime.now(datetime.timezone.utc).replace(microsecond=0).isoformat()
+
+
+def build_commit() -> str:
+    """Commit the docs are built from. Provided by build.sh; fall back to local git."""
+    env = os.environ.get("RASDOCS_BUILD_COMMIT")
+    if env:
+        return env.strip()
+    try:
+        out = subprocess.run(
+            ["git", "-C", str(REPO_ROOT), "rev-parse", "--short", "HEAD"],
+            capture_output=True, text=True, timeout=10,
+        )
+        if out.returncode == 0 and out.stdout.strip():
+            return out.stdout.strip()
+    except Exception:
+        pass
+    return "unknown"
+
+
+def _summary(obj) -> str:
+    """First non-empty line of the object's docstring, trimmed."""
+    try:
+        doc = inspect.getdoc(obj)
+    except Exception:
+        return ""
+    if not doc:
+        return ""
+    for line in doc.splitlines():
+        line = line.strip()
+        if line:
+            return line
+    return ""
+
+
+def _signature(obj) -> str:
+    try:
+        return str(inspect.signature(obj))
+    except (ValueError, TypeError):
+        return "(...)"
+    except Exception:
+        return "(...)"
+
+
+def _return_annotation(obj) -> str:
+    try:
+        ann = inspect.signature(obj).return_annotation
+    except Exception:
+        return ""
+    if ann is inspect.Signature.empty:
+        return ""
+    try:
+        return inspect.formatannotation(ann)
+    except Exception:
+        return str(ann)
+
+
+def _member_kind(cls, name) -> str:
+    """Classify a class member without binding it (staticmethod/classmethod/property/method)."""
+    try:
+        raw = inspect.getattr_static(cls, name)
+    except Exception:
+        return "method"
+    if isinstance(raw, staticmethod):
+        return "staticmethod"
+    if isinstance(raw, classmethod):
+        return "classmethod"
+    if isinstance(raw, property):
+        return "property"
+    return "method"
+
+
+def _is_ras_commander(obj) -> bool:
+    mod = getattr(obj, "__module__", "") or ""
+    return mod.startswith("ras_commander")
+
+
+def describe_class(cls) -> dict:
+    """Public methods/properties defined within ras_commander (skip inherited stdlib/pandas)."""
+    methods = []
+    for name, member in inspect.getmembers(cls):
+        if name.startswith("_"):
+            continue
+        kind = _member_kind(cls, name)
+        if kind == "property":
+            methods.append({
+                "name": name, "kind": "property",
+                "summary": _summary(getattr(cls, name, member)),
+            })
+            continue
+        # Resolve the underlying function for module-origin filtering + signature.
+        target = member
+        if not (inspect.isfunction(target) or inspect.ismethod(target) or inspect.isbuiltin(target)):
+            continue
+        if not _is_ras_commander(target):
+            continue
+        methods.append({
+            "name": name,
+            "kind": kind,
+            "signature": _signature(target),
+            "returns": _return_annotation(target),
+            "summary": _summary(target),
+        })
+    methods.sort(key=lambda m: m["name"])
+    return {
+        "kind": "class",
+        "summary": _summary(cls),
+        "method_count": len(methods),
+        "methods": methods,
+    }
+
+
+def describe_function(fn) -> dict:
+    return {
+        "kind": "function",
+        "summary": _summary(fn),
+        "signature": _signature(fn),
+        "returns": _return_annotation(fn),
+    }
+
+
+def build_index(rc) -> dict:
+    symbols = {}
+    available = 0
+    for name in sorted(set(getattr(rc, "__all__", []))):
+        entry = {"name": name}
+        try:
+            obj = getattr(rc, name)
+        except Exception as exc:  # optional dep missing on the build box, etc.
+            entry.update({"available": False, "error": f"{type(exc).__name__}: {exc}"})
+            symbols[name] = entry
+            continue
+        available += 1
+        entry["available"] = True
+        entry["module"] = getattr(obj, "__module__", None)
+        try:
+            if inspect.isclass(obj):
+                entry.update(describe_class(obj))
+            elif callable(obj):
+                entry.update(describe_function(obj))
+            else:
+                entry["kind"] = "object"
+                entry["summary"] = _summary(obj)
+        except Exception as exc:
+            entry["kind"] = "error"
+            entry["error"] = f"{type(exc).__name__}: {exc}"
+        symbols[name] = entry
+    return {
+        "schema": "rascmdr.api-index/1",
+        "generated_at_utc": _now_utc(),
+        "generator": GENERATOR,
+        "ras_commander_version": getattr(rc, "__version__", "unknown"),
+        "build_commit": build_commit(),
+        "symbol_count": len(symbols),
+        "available_count": available,
+        "symbols": [symbols[k] for k in sorted(symbols)],
+    }
+
+
+def build_dataframes(rc) -> dict:
+    try:
+        from ras_commander import schemas  # type: ignore
+        frames = json.loads(json.dumps(schemas.DATAFRAME_SCHEMAS))  # deep copy of plain data
+        schema_version = getattr(schemas, "SCHEMA_VERSION", "unknown")
+    except Exception as exc:
+        return {
+            "schema": "rascmdr.dataframes/1",
+            "generated_at_utc": _now_utc(),
+            "error": f"could not import ras_commander.schemas: {type(exc).__name__}: {exc}",
+            "frames": {},
+        }
+
+    # Cross-check the statically-shaped rasmap_df against live construction; flag drift.
+    rasmap_check = None
+    try:
+        from ras_commander import _land_classification_helper as lch  # type: ignore
+        live_cols = list(lch.empty_rasmap_dataframe().columns)
+        declared = [c["name"] for c in frames.get("rasmap_df", {}).get("columns", [])]
+        rasmap_check = {
+            "matches": live_cols == declared,
+            "live_columns": live_cols,
+            "missing_from_schema": [c for c in live_cols if c not in declared],
+            "extra_in_schema": [c for c in declared if c not in live_cols],
+        }
+    except Exception as exc:
+        rasmap_check = {"matches": None, "error": f"{type(exc).__name__}: {exc}"}
+
+    return {
+        "schema": "rascmdr.dataframes/1",
+        "schema_version": schema_version,
+        "generated_at_utc": _now_utc(),
+        "generator": GENERATOR,
+        "ras_commander_version": getattr(rc, "__version__", "unknown"),
+        "build_commit": build_commit(),
+        "rasmap_df_live_check": rasmap_check,
+        "frames": frames,
+    }
+
+
+def build_version(rc) -> dict:
+    return {
+        "schema": "rascmdr.version/1",
+        "ras_commander_version": getattr(rc, "__version__", "unknown"),
+        "build_commit": build_commit(),
+        "built_at_utc": _now_utc(),
+        "generator": GENERATOR,
+    }
+
+
+def render_api_md(version: dict, index: dict, dataframes: dict) -> str:
+    df_rows = []
+    for fname, fdef in dataframes.get("frames", {}).items():
+        ncols = "dynamic" if fdef.get("dynamic") else str(len(fdef.get("columns", [])))
+        df_rows.append(f"| `{fname}` | {ncols} | {fdef.get('description','')} |")
+    df_table = "\n".join(df_rows)
+    return f"""# Agent-native API surface
+
+!!! info "Build provenance"
+    **ras-commander `{version['ras_commander_version']}`** · docs build `{version['build_commit']}`
+    · generated `{version['built_at_utc']}`
+
+This page is a small, **machine-readable** surface of the public API, generated at build time by
+introspecting the installed library. It is meant for LLMs and
+[ras-commander-mcp](https://github.com/gpt-cmdr/ras-commander-mcp) to resolve current signatures
+and DataFrame columns without scraping HTML. For the full human reference, see the
+[API documentation](../../api/core.md) (rendered from docstrings by mkdocstrings).
+
+## Pullable artifacts
+
+| Artifact | What it is |
+|---|---|
+| [`version.json`](../../version.json) | Built library version + docs commit + build time. |
+| [`index.json`](index.json) | Every public symbol in `__all__`: signatures, return types, one-line summaries ({index['available_count']}/{index['symbol_count']} importable on the build host). |
+| [`dataframes.json`](dataframes.json) | Canonical column contracts for the project DataFrames. |
+
+## DataFrame column contracts
+
+| Frame | Columns | Description |
+|---|---|---|
+{df_table}
+
+Column contracts are the stable core; some frames carry additional project-parsed columns at
+runtime (and the HDF result frames are fully runtime-derived). The contracts live in
+`ras_commander/schemas.py` (the single source of truth) and are emitted to `dataframes.json`.
+
+*Generated by `{GENERATOR}` — do not edit by hand.*
+"""
+
+
+def write_json(path: Path, data: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+
+
+def main() -> int:
+    try:
+        import ras_commander as rc  # noqa: E402
+    except Exception as exc:
+        print(f"[generate_api_surface] WARNING: cannot import ras_commander: {exc} — skipping", file=sys.stderr)
+        return 0
+
+    try:
+        version = build_version(rc)
+        index = build_index(rc)
+        dataframes = build_dataframes(rc)
+
+        write_json(DOCS_DIR / "version.json", version)
+        write_json(API_DIR / "index.json", index)
+        write_json(API_DIR / "dataframes.json", dataframes)
+        API_DIR.mkdir(parents=True, exist_ok=True)
+        (API_DIR / "index.md").write_text(
+            render_api_md(version, index, dataframes), encoding="utf-8"
+        )
+    except Exception as exc:  # never dark the docs build over the surface
+        print(f"[generate_api_surface] WARNING: surface generation failed: {exc} — skipping", file=sys.stderr)
+        return 0
+
+    print(
+        f"[generate_api_surface] ras-commander {version['ras_commander_version']} "
+        f"@ {version['build_commit']}: {index['available_count']}/{index['symbol_count']} symbols, "
+        f"{len(dataframes.get('frames', {}))} dataframe contracts"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.gitignore
+++ b/.gitignore
@@ -117,6 +117,11 @@ docs/cognitive-infrastructure/agents.md
 docs/cognitive-infrastructure/skills.md
 docs/cognitive-infrastructure/commands.md
 
+# Ignore the agent-native API surface (generated at build time by
+# .claude/scripts/generate_api_surface.py; served under /ras)
+docs/version.json
+docs/llms/api/
+
 # Ignore M3 model downloads (large files, downloaded via M3Model.extract_model())
 m3_models/
 examples/m3_models/

--- a/ras_commander/schemas.py
+++ b/ras_commander/schemas.py
@@ -1,0 +1,130 @@
+"""
+schemas.py -- canonical, declarative column contracts for ras-commander's public DataFrames.
+
+This module is the **single source of truth** for the *stable* column surface of the project
+DataFrames that ras-commander attaches to a :class:`RasPrj` instance
+(``plan_df`` / ``geom_df`` / ``boundaries_df`` / ``rasmap_df``), plus a documented note for the
+HDF result frames whose columns are only known at runtime.
+
+It is consumed by ``.claude/scripts/generate_api_surface.py`` to emit the machine-readable
+agent surface published at ``/ras/llms/api/dataframes.json`` (so LLMs and ras-commander-mcp can
+resolve "what columns does ``plan_df`` have?" without scraping rendered HTML).
+
+Why a declarative file rather than re-deriving columns from construction code: the construction
+methods (``RasPrj.get_plan_entries`` / ``get_geom_entries`` / ``get_boundary_conditions``, and
+``_land_classification_helper.empty_rasmap_dataframe``) remain the **runtime authority** and may
+add extra, project-specific columns beyond this stable core. Pinning the documented contract here
+gives agents a stable, reviewable schema and one place to update when a frame's columns change.
+Where a frame is built from a static shape (``rasmap_df``), the generator cross-checks this
+contract against the live construction and flags drift.
+
+Each entry of :data:`DATAFRAME_SCHEMAS`:
+    description   -- one-line summary of the frame
+    accessor      -- how a caller obtains the frame from a RasPrj instance
+    source        -- the construction site (for maintainers)
+    columns       -- list of {name, dtype, description} for the STABLE core columns
+    extra_columns -- True if additional project-parsed columns may appear at runtime
+    dynamic       -- True if the full column set is only knowable at runtime (HDF frames)
+"""
+
+# Schema contract version -- bump when the documented column surface changes meaningfully.
+SCHEMA_VERSION = "1.0"
+
+DATAFRAME_SCHEMAS = {
+    "plan_df": {
+        "description": "One row per HEC-RAS plan in the project, with its linked geometry and flow files.",
+        "accessor": "ras.plan_df  (or RasPrj instance .plan_df; refreshed by RasPrj.get_plan_entries())",
+        "source": "RasPrj.get_plan_entries()",
+        "extra_columns": True,  # additional key=value entries parsed from the .prj plan block
+        "dynamic": False,
+        "columns": [
+            {"name": "plan_number", "dtype": "str", "description": "Plan identifier, e.g. '01'."},
+            {"name": "unsteady_number", "dtype": "str | None", "description": "Linked unsteady-flow number, if the plan is unsteady."},
+            {"name": "geometry_number", "dtype": "str | None", "description": "Linked geometry number."},
+            {"name": "Geom File", "dtype": "str", "description": "Geometry file name (e.g. 'project.g01')."},
+            {"name": "Geom Path", "dtype": "str", "description": "Absolute path to the geometry file."},
+            {"name": "Flow File", "dtype": "str", "description": "Flow file name (unsteady .u## or steady .f##)."},
+            {"name": "Flow Path", "dtype": "str", "description": "Absolute path to the flow file."},
+            {"name": "full_path", "dtype": "str", "description": "Absolute path to the plan file (e.g. 'project.p01')."},
+        ],
+    },
+    "geom_df": {
+        "description": "One row per geometry file, with parsed structure counts and 1D/2D presence flags.",
+        "accessor": "ras.geom_df  (refreshed by RasPrj.get_geom_entries())",
+        "source": "RasPrj.get_geom_entries() (counts via GeomMetadata.get_geometry_counts(), HDF-preferred)",
+        "extra_columns": False,
+        "dynamic": False,
+        "columns": [
+            {"name": "geom_file", "dtype": "str", "description": "Geometry file name (e.g. 'project.g01')."},
+            {"name": "geom_number", "dtype": "str", "description": "Geometry identifier, e.g. '01'."},
+            {"name": "full_path", "dtype": "str", "description": "Absolute path to the geometry file."},
+            {"name": "hdf_path", "dtype": "str | None", "description": "Absolute path to the geometry HDF (.g##.hdf), if present."},
+            {"name": "geom_title", "dtype": "str", "description": "Title from the 'Geom Title=' line."},
+            {"name": "description", "dtype": "str", "description": "Text from the BEGIN/END DESCRIPTION block."},
+            {"name": "has_1d_xs", "dtype": "bool", "description": "Whether the geometry contains 1D cross sections."},
+            {"name": "has_2d_mesh", "dtype": "bool", "description": "Whether the geometry contains a 2D flow-area mesh."},
+            {"name": "num_cross_sections", "dtype": "int", "description": "Count of 1D cross sections."},
+            {"name": "num_inline_structures", "dtype": "int", "description": "Count of inline structures."},
+            {"name": "num_bridges", "dtype": "int", "description": "Count of bridges."},
+            {"name": "num_culverts", "dtype": "int", "description": "Count of culverts."},
+            {"name": "num_weirs", "dtype": "int", "description": "Count of weirs."},
+            {"name": "num_gates", "dtype": "int", "description": "Count of gates."},
+            {"name": "num_lateral_structures", "dtype": "int", "description": "Count of lateral structures."},
+            {"name": "num_sa_2d_connections", "dtype": "int", "description": "Count of storage-area / 2D connections."},
+            {"name": "mesh_cell_count", "dtype": "int", "description": "Total 2D mesh cell count across areas."},
+            {"name": "mesh_area_names", "dtype": "list[str]", "description": "Names of the 2D flow areas."},
+        ],
+    },
+    "boundaries_df": {
+        "description": "One row per boundary condition across the project's unsteady flow files.",
+        "accessor": "ras.boundaries_df  (refreshed by RasPrj.get_boundary_conditions())",
+        "source": "RasPrj.get_boundary_conditions() / RasPrj._parse_boundary_condition()",
+        "extra_columns": True,  # merged columns from unsteady_df
+        "dynamic": False,
+        "columns": [
+            {"name": "unsteady_number", "dtype": "str", "description": "Unsteady-flow file number the BC belongs to."},
+            {"name": "boundary_condition_number", "dtype": "int", "description": "1-based index of the BC within its unsteady file."},
+            {"name": "river_reach_name", "dtype": "str", "description": "River/reach the BC is attached to (1D), if any."},
+            {"name": "river_station", "dtype": "str", "description": "River station of the BC (1D), if any."},
+            {"name": "storage_area_name", "dtype": "str", "description": "Storage area the BC is attached to, if any."},
+            {"name": "pump_station_name", "dtype": "str", "description": "Pump station the BC is attached to, if any."},
+            {"name": "area_2d", "dtype": "str", "description": "2D flow area the BC is attached to, if any."},
+            {"name": "bc_line_name", "dtype": "str", "description": "Named BC line (2D external boundary), if any."},
+            {"name": "bc_type", "dtype": "str", "description": "Boundary type, e.g. 'Flow Hydrograph', 'Stage Hydrograph', 'Rating Curve', 'Normal Depth', 'Lateral Inflow', 'Uniform Lateral Inflow', 'Gate Opening', 'T.S. Gate Openings', 'Unknown'."},
+        ],
+    },
+    "rasmap_df": {
+        "description": "Single-row frame of RASMapper layer/terrain/land-cover/infiltration paths and settings.",
+        "accessor": "ras.rasmap_df  (built by RasMap.initialize_rasmap_df())",
+        "source": "_land_classification_helper.empty_rasmap_dataframe() (shape) + RasMap.parse_rasmap() (.rasmap XML)",
+        "extra_columns": False,
+        "dynamic": False,
+        "columns": [
+            {"name": "projection_path", "dtype": "str | None", "description": "Path to the projection (.prj) referenced by the .rasmap."},
+            {"name": "profile_lines_path", "dtype": "list", "description": "Profile-line layer paths."},
+            {"name": "soil_layer_path", "dtype": "list", "description": "Soil-layer (infiltration) paths."},
+            {"name": "infiltration_hdf_path", "dtype": "list", "description": "Infiltration HDF layer paths."},
+            {"name": "landcover_hdf_path", "dtype": "list", "description": "Land-cover HDF layer paths."},
+            {"name": "terrain_hdf_path", "dtype": "list", "description": "Terrain HDF layer paths."},
+            {"name": "reference_map_layer_names", "dtype": "list", "description": "Names of reference map layers."},
+            {"name": "reference_map_layer_path", "dtype": "list", "description": "Paths of reference map layers."},
+            {"name": "basemap_layer_names", "dtype": "list", "description": "Names of basemap layers."},
+            {"name": "basemap_layer_path", "dtype": "list", "description": "Paths of basemap layers."},
+            {"name": "current_settings", "dtype": "dict", "description": "RASMapper current-settings map (rendering/units/etc.)."},
+        ],
+    },
+    "hdf_result_frames": {
+        "description": "Result DataFrames returned by the Hdf* classes (mesh/xsec/plan/breach results).",
+        "accessor": "Hdf*.<method>(plan_hdf)  -- e.g. HdfResultsMesh.get_mesh_timeseries(...), HdfResultsXsec.get_xsec_timeseries(...)",
+        "source": "ras_commander.hdf.HdfResults* (columns derived from HDF group attributes & datasets at runtime)",
+        "extra_columns": True,
+        "dynamic": True,
+        "columns": [],
+        "note": (
+            "HDF result frames are constructed from the HDF5 file's group attributes and dataset "
+            "schemas at call time, so their exact columns depend on the model and plan and are not "
+            "statically enumerable. See the HdfResultsMesh / HdfResultsXsec / HdfResultsPlan / "
+            "HdfResultsBreach API pages for per-method return shapes."
+        ),
+    },
+}


### PR DESCRIPTION
Adds a **build-time generator** that introspects the installed library and emits a small,
machine-readable API surface — so LLMs and [ras-commander-mcp](https://github.com/gpt-cmdr/ras-commander-mcp)
can resolve the *current* signature of a symbol or the columns of `plan_df` without scraping
rendered HTML. It **complements** the existing mkdocstrings human reference, it doesn't replace it.

This is the library half of `ras-commander-docs` plan **`vivid-coursing-bernoulli.md` Phase 3**.
The docs-build wiring (build.sh prebuild hook + Caddy serving) lands in a companion
`ras-commander-docs` PR.

## What it produces (served under `/ras`)
| Artifact | Contents |
|---|---|
| `version.json` | built `ras_commander` version + docs commit + build time (provenance) |
| `llms/api/index.json` | every public symbol in `__all__`: kind, signature, return type, one-line summary; classes expand their public methods |
| `llms/api/dataframes.json` | canonical column contracts for `plan_df`/`geom_df`/`boundaries_df`/`rasmap_df`; HDF result frames flagged dynamic |
| `llms/api/index.md` | thin human index + provenance banner |

## Files
- **`ras_commander/schemas.py`** (new) — declarative, **single source of truth** for the stable
  DataFrame column contracts. The generator cross-checks `rasmap_df` against the live
  `empty_rasmap_dataframe()` and reports drift in the JSON (`rasmap_df_live_check`).
- **`.claude/scripts/generate_api_surface.py`** (new) — stdlib + `ras_commander` only. Iterates
  `__all__`; **per-symbol `try/except`** so optional deps absent on the Linux build box
  (pywin32 / boto3 / jpype) degrade to `available:false` instead of failing the build. Decorators
  are introspection-safe (`@log_call`/`@standardize_input` use `functools.wraps`). **Best-effort**:
  exits 0 on any error so a surface hiccup never darks the flagship docs build.
- **`.gitignore`** — the generated artifacts (`docs/version.json`, `docs/llms/api/`) are
  regenerated each build and not committed.

## Verification (local, against the installed library)
- `161/161` public symbols introspected; `RasPlan` expands to 63 public methods with typed
  signatures + summaries; functions carry signature + return + summary.
- 5 DataFrame contracts emitted; **`rasmap_df` live-check matches** the construction code.
- Both files `py_compile` clean; generated artifacts confirmed gitignored.

Note: this PR is inert until the companion `ras-commander-docs` build wiring calls the generator
in the `ras` prebuild profile — merging it alone changes nothing in the published docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)