### PR TITLE
feat: rasmap_df schema drift guard (shape_fn)

### DIFF
--- a/ras_commander/schemas.py
+++ b/ras_commander/schemas.py
@@ -97,6 +97,9 @@ DATAFRAME_SCHEMAS = {
         "description": "Single-row frame of RASMapper layer/terrain/land-cover/infiltration paths and settings.",
         "accessor": "ras.rasmap_df  (built by RasMap.initialize_rasmap_df())",
         "source": "_land_classification_helper.empty_rasmap_dataframe() (shape) + RasMap.parse_rasmap() (.rasmap XML)",
+        # shape_fn: zero-arg callable returning this frame's empty shape; the docs build's schema
+        # validator (validate_api_schemas.py) calls it and fails the build if these columns drift.
+        "shape_fn": "ras_commander._land_classification_helper.empty_rasmap_dataframe",
         "extra_columns": False,
         "dynamic": False,
         "columns": [


### PR DESCRIPTION
Adds a `shape_fn` to the `rasmap_df` entry in `ras_commander/schemas.py` so the docs build's new schema validator (ras-commander-docs) can **fail the build on column drift**: it calls `empty_rasmap_dataframe()` and asserts the declared columns match the live shape.

This makes the previously advisory 'keep schemas.py in sync' rule **enforceable** for `rasmap_df` (the one project DataFrame with a zero-arg empty constructor). plan_df/geom_df/boundaries_df are project-built (no zero-arg shape) and stay covered by the AGENTS.md rule until a fixture-based check is added.

One-line data change; no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)