### PR TITLE
fix(montecarlo): tolerate missing runtime column in remote batch summary

### DIFF
--- a/ras_commander/RasPermutation.py
+++ b/ras_commander/RasPermutation.py
@@ -901,10 +901,19 @@ class RasPermutation:
                 axis=1,
             )
 
-            runtime_hours = pd.to_numeric(
-                summary_df["runtime_complete_process_hours"],
-                errors="coerce",
-            )
+            # The remote execution path (compute_parallel_remote) returns a
+            # results_df without the local-compute 'runtime_complete_process_hours'
+            # column. Default to NaN runtimes when it is absent rather than raising
+            # KeyError -- this otherwise crashes batch summarization whenever a
+            # remote batch has no successful plans (e.g. a transient worker/network
+            # outage fails every plan), masking the real failure with a KeyError.
+            if "runtime_complete_process_hours" in summary_df.columns:
+                runtime_hours = pd.to_numeric(
+                    summary_df["runtime_complete_process_hours"],
+                    errors="coerce",
+                )
+            else:
+                runtime_hours = pd.Series(np.nan, index=summary_df.index)
             summary_df["runtime_seconds"] = runtime_hours * 3600.0
 
             summary_df["max_wse"] = summary_df["hdf_path"].apply(


### PR DESCRIPTION
## Problem

`RasPermutation.execute_and_summarize` read `summary_df["runtime_complete_process_hours"]` unconditionally. That column is populated only by the **local** compute path; the **remote** path (`compute_parallel_remote`) returns a results frame without it.

When a remote batch produced a non-empty results frame but had **no successful plans** — e.g. a transient worker/network outage (`WinError 53` / PsExec service comms loss) fails every plan in the batch — summarization raised:

```
KeyError: 'runtime_complete_process_hours'
```

…which masked the underlying failure (the run looked like a code bug rather than an infrastructure outage). Observed live: a 30-plan remote ensemble where the LAN dropped mid-run, failing all 30, then crashing here instead of reporting "0 succeeded, 30 failed."

## Fix

Guard the column access — use it when present, otherwise default per-plan runtime to `NaN`:

```python
if "runtime_complete_process_hours" in summary_df.columns:
    runtime_hours = pd.to_numeric(summary_df["runtime_complete_process_hours"], errors="coerce")
else:
    runtime_hours = pd.Series(np.nan, index=summary_df.index)
summary_df["runtime_seconds"] = runtime_hours * 3600.0
```

The already-handled empty-frame branch is unchanged; successful runs (which do carry the column on the local path / via `update_results_df`) are unaffected.

## Risk
Minimal — additive guard, no behavior change when the column is present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)