### PR TITLE
docs(nav): fix empty homepage sidebar + numbered/grouped notebooks in left menu

### DIFF
--- a/.claude/scripts/_docs_notebook_common.py
+++ b/.claude/scripts/_docs_notebook_common.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""Shared helpers for the docs notebook build steps (stdlib only).
+
+Both ``generate_examples_index.py`` (the Example Notebooks *overview table*) and
+``prepare_notebooks_for_docs.py`` (which injects the Example Notebooks *left-nav*
+into ``mkdocs.yml`` at build time) source the notebook list from disk
+(``examples/*.ipynb``) -- never from the hand-authored nav -- so the table and the
+sidebar always reflect exactly what ships. Putting the title / numbering / section
+logic here guarantees the two never drift.
+
+The published site builds from ``main``, where the ``Example Notebooks`` nav block
+is just a single ``Overview`` entry; ``prepare_notebooks_for_docs.py`` expands it
+from disk during the build. See that script and ``generate_examples_index.py``.
+
+stdlib only (json, re, pathlib) so it runs under a bare ``python3``.
+"""
+
+import json
+import re
+from pathlib import Path
+from typing import List, Optional, Tuple
+
+# Descriptive names for each hundreds bucket, shown in the index headings and the
+# left-nav group labels (e.g. "100s - Initialization & Execution"). Buckets without
+# an entry fall back to the bare "<N>s" label, so adding a new 1000s series needs no
+# code change -- only an (optional) label here.
+BUCKET_LABELS = {
+    100: "Initialization & Execution",
+    200: "Geometry & Calibration",
+    300: "Unsteady Flow & DSS",
+    400: "HDF Results Extraction",
+    500: "Remote Execution",
+    600: "Floodplain Mapping",
+    700: "Sensitivity & Precipitation",
+    800: "Quality Assurance",
+    900: "Data Integration & Forecasting",
+}
+
+
+def load_notebook(notebook_path: Path) -> Optional[dict]:
+    """Parse a notebook JSON, or return ``None`` if it can't be read."""
+    try:
+        with notebook_path.open(encoding="utf-8") as fh:
+            return json.load(fh)
+    except (OSError, json.JSONDecodeError, UnicodeDecodeError):
+        return None
+
+
+def _cell_source_lines(cell: dict) -> List[str]:
+    """A notebook cell's source as lines (source may be a str or list of str)."""
+    source = cell.get("source", "")
+    text = "".join(source) if isinstance(source, list) else source
+    return text.splitlines()
+
+
+def numeric_prefix(name: str) -> str:
+    """The leading numeric id of a notebook basename, e.g. ``116`` or ``911a``.
+
+    Returns ``""`` when the name has no numeric prefix.
+    """
+    m = re.match(r"^(\d+[a-zA-Z]?)_", name)
+    return m.group(1) if m else ""
+
+
+def prettify_filename(name: str) -> str:
+    """Fallback title from a basename: drop the ``NNN_`` prefix, Title-Case the rest."""
+    stem = re.sub(r"^\d+[a-zA-Z]?_", "", name)
+    stem = stem.replace("_", " ").strip()
+    if not stem:
+        stem = name.replace("_", " ").strip()
+    return stem.title()
+
+
+def derive_title(notebook_path: Path, nb: Optional[dict]) -> str:
+    """Title = first markdown ``# `` H1 in the notebook, else prettified filename."""
+    name = notebook_path.stem
+    if nb is not None:
+        for cell in nb.get("cells", []):
+            if cell.get("cell_type") != "markdown":
+                continue
+            for line in _cell_source_lines(cell):
+                stripped = line.strip()
+                if stripped.startswith("# "):
+                    return stripped[1:].strip()
+    return prettify_filename(name)
+
+
+def numbered_title(name: str, title: str) -> str:
+    """Display title with its leading number restored, e.g. ``100 - Using RasExamples``.
+
+    If the notebook H1 already starts with the number, it is not duplicated. Notebooks
+    with no numeric prefix are returned unchanged.
+    """
+    num = numeric_prefix(name)
+    if not num:
+        return title
+    if re.match(rf"^{re.escape(num)}\b", title):
+        return title
+    return f"{num} - {title}"
+
+
+def section_for(name: str) -> Tuple[int, str]:
+    """``(sort_key, label)`` hundreds bucket for a basename (``911a_...`` -> 900s)."""
+    m = re.match(r"^(\d+)", name)
+    if not m:
+        return (10_000, "Other")
+    n = int(m.group(1))
+    bucket = (n // 100) * 100
+    desc = BUCKET_LABELS.get(bucket)
+    label = f"{bucket}s - {desc}" if desc else f"{bucket}s"
+    return (bucket, label)

--- a/.claude/scripts/generate_examples_index.py
+++ b/.claude/scripts/generate_examples_index.py
@@ -35,91 +35,26 @@ Usage:
     python .claude/scripts/generate_examples_index.py
 """
 
-import json
-import re
 import sys
 from datetime import datetime
 from pathlib import Path
 from typing import List, Optional, Tuple
 
+# Shared title / numbering / section logic, also used by prepare_notebooks_for_docs.py
+# (which injects the left-nav) so the overview table and the sidebar never drift.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _docs_notebook_common import (  # noqa: E402
+    derive_title,
+    load_notebook,
+    numbered_title,
+    section_for,
+)
+
 GITHUB_BLOB_BASE = "https://github.com/gpt-cmdr/ras-commander/blob/main/examples"
 
 
 # ---------------------------------------------------------------------------
-# Title derivation
-# ---------------------------------------------------------------------------
-
-def _load_notebook(notebook_path: Path) -> Optional[dict]:
-    try:
-        with notebook_path.open(encoding="utf-8") as fh:
-            return json.load(fh)
-    except (OSError, json.JSONDecodeError, UnicodeDecodeError):
-        return None
-
-
-def _cell_source_lines(cell: dict) -> List[str]:
-    """Return a notebook cell's source as a list of text lines.
-
-    nbformat stores ``source`` either as a single string or a list of strings.
-    """
-    source = cell.get("source", "")
-    if isinstance(source, list):
-        text = "".join(source)
-    else:
-        text = source
-    return text.splitlines()
-
-
-def prettify_filename(name: str) -> str:
-    """Fallback title from a notebook basename (no extension).
-
-    Drops a leading numeric prefix (e.g. ``116`` or ``911a``), replaces
-    underscores with spaces, and Title-Cases the result. Deterministic.
-    """
-    stem = re.sub(r"^\d+[a-zA-Z]?_", "", name)
-    stem = stem.replace("_", " ").strip()
-    if not stem:
-        stem = name.replace("_", " ").strip()
-    return stem.title()
-
-
-def derive_title(notebook_path: Path, nb: Optional[dict]) -> str:
-    """Title = first markdown cell's first ``# `` H1, else prettified filename."""
-    name = notebook_path.stem
-    if nb is not None:
-        for cell in nb.get("cells", []):
-            if cell.get("cell_type") != "markdown":
-                continue
-            for line in _cell_source_lines(cell):
-                stripped = line.strip()
-                if stripped.startswith("# "):
-                    return stripped[1:].strip()
-            # First markdown cell had no H1; keep scanning later markdown cells
-            # in case the title lives further down (still deterministic).
-    return prettify_filename(name)
-
-
-# ---------------------------------------------------------------------------
-# Section grouping
-# ---------------------------------------------------------------------------
-
-def section_for(name: str) -> Tuple[int, str]:
-    """Return ``(sort_key, label)`` section bucket for a notebook basename.
-
-    The leading run of digits in the filename prefix (e.g. ``911a_...`` -> 911,
-    ``116_...`` -> 116) is bucketed by hundreds into ``100s``..``900s``. Names
-    without a numeric prefix fall into a trailing "Other" bucket.
-    """
-    m = re.match(r"^(\d+)", name)
-    if not m:
-        return (10_000, "Other")
-    n = int(m.group(1))
-    bucket = (n // 100) * 100
-    return (bucket, f"{bucket}s")
-
-
-# ---------------------------------------------------------------------------
-# Runtime calculation (stdlib json only)
+# Runtime calculation (stdlib only)
 # ---------------------------------------------------------------------------
 
 def _parse_ts(ts: str) -> Optional[datetime]:
@@ -233,8 +168,8 @@ def build_index_markdown(examples_dir: Path) -> Tuple[str, int, int]:
 
     for nb_path in notebooks:
         name = nb_path.stem
-        nb = _load_notebook(nb_path)
-        title = derive_title(nb_path, nb)
+        nb = load_notebook(nb_path)
+        title = numbered_title(name, derive_title(nb_path, nb))
         seconds = compute_runtime_seconds(nb)
         runtime = format_runtime(seconds)
         if seconds is not None:

--- a/.claude/scripts/prepare_notebooks_for_docs.py
+++ b/.claude/scripts/prepare_notebooks_for_docs.py
@@ -23,6 +23,16 @@ import subprocess
 import sys
 from pathlib import Path
 
+# Shared title / numbering / section logic, also used by generate_examples_index.py
+# so the left-nav and the overview table never drift. stdlib-only import.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _docs_notebook_common import (  # noqa: E402
+    derive_title,
+    load_notebook,
+    numbered_title,
+    section_for,
+)
+
 
 def convert_notebooks(examples_dir: Path, output_dir: Path) -> int:
     """Convert all notebooks to markdown using batch processing."""
@@ -59,12 +69,92 @@ def convert_notebooks(examples_dir: Path, output_dir: Path) -> int:
     return len(md_files)
 
 
-def update_mkdocs_config(mkdocs_path: Path) -> None:
-    """Update mkdocs.yml to use .md files and disable jupyter plugin."""
+def _yaml_dq(text: str) -> str:
+    """Double-quote a YAML scalar, escaping backslashes and double-quotes.
+
+    Notebook H1 titles can contain ``:``, ``&``, ``'`` etc. (e.g.
+    "Using eBFE Models: Spring Creek 2D Analysis"), which break a bare YAML key,
+    so every generated nav label is double-quoted.
+    """
+    escaped = text.replace("\\", "\\\\").replace('"', '\\"')
+    return f'"{escaped}"'
+
+
+def build_notebook_nav(examples_dir: Path) -> str:
+    """Build the ``Example Notebooks`` nav block from notebooks on disk.
+
+    Sourced from ``examples/*.ipynb`` (NOT the hand-authored nav) so the sidebar
+    always matches what ships. Entries are numbered, grouped by hundreds bucket,
+    and sequential within each group -- the same source and ordering as the
+    overview table in generate_examples_index.py. Returns the YAML block (2-space
+    indented to sit under the top-level ``nav:`` list), Overview entry first.
+    """
+    notebooks = sorted(examples_dir.glob("*.ipynb"))
+
+    grouped: dict = {}
+    section_order = []
+    for nb_path in notebooks:
+        name = nb_path.stem
+        nb = load_notebook(nb_path)
+        label = numbered_title(name, derive_title(nb_path, nb))
+        sort_key, section_label = section_for(name)
+        key = (sort_key, section_label)
+        if key not in grouped:
+            grouped[key] = []
+            section_order.append(key)
+        grouped[key].append((name, label))
+
+    section_order.sort(key=lambda k: k[0])
+
+    lines = ["  - Example Notebooks:", "    - Overview: examples/index.md"]
+    for key in section_order:
+        lines.append(f"    - {_yaml_dq(key[1])}:")
+        for name, label in sorted(grouped[key], key=lambda r: r[0]):
+            lines.append(f"      - {_yaml_dq(label)}: notebooks/{name}.md")
+    return "\n".join(lines)
+
+
+def inject_notebook_nav(content: str, examples_dir: Path) -> str:
+    """Replace the ``- Example Notebooks:`` nav block with one generated from disk.
+
+    On ``main`` the block is a lone ``Overview`` entry; this expands it to the full
+    numbered/grouped tree. Robust to a populated block too (e.g. a feature branch):
+    it consumes the header line and every more-indented line beneath it, stopping at
+    the next top-level (2-space) sibling.
+    """
+    lines = content.split("\n")
+    start = None
+    for i, line in enumerate(lines):
+        if line.rstrip() == "  - Example Notebooks:":
+            start = i
+            break
+    if start is None:
+        print("  WARNING: '  - Example Notebooks:' nav anchor not found — nav not injected")
+        return content
+
+    # Consume children: blank lines or lines indented deeper than the 2-space header.
+    end = start + 1
+    while end < len(lines):
+        line = lines[end]
+        if line.strip() == "" or line.startswith("   "):
+            end += 1
+        else:
+            break
+
+    new_block = build_notebook_nav(examples_dir).split("\n")
+    rebuilt = lines[:start] + new_block + lines[end:]
+    return "\n".join(rebuilt)
+
+
+def update_mkdocs_config(mkdocs_path: Path, examples_dir: Path) -> None:
+    """Update mkdocs.yml: inject notebook nav, use .md files, disable jupyter plugin."""
     print(f"Updating {mkdocs_path}...")
 
     content = mkdocs_path.read_text(encoding='utf-8')
     original = content
+
+    # 0. Inject the numbered/grouped Example Notebooks nav generated from disk.
+    content = inject_notebook_nav(content, examples_dir)
 
     # 1. Replace .ipynb with .md in nav entries
     # Pattern: notebooks/XXX.ipynb -> notebooks/XXX.md
@@ -109,6 +199,7 @@ def update_mkdocs_config(mkdocs_path: Path) -> None:
     if content != original:
         mkdocs_path.write_text(content, encoding='utf-8')
         print("  Updated mkdocs.yml:")
+        print("    - Injected numbered/grouped Example Notebooks nav from disk")
         print("    - Changed .ipynb references to .md")
         print("    - Disabled mkdocs-jupyter plugin")
     else:
@@ -141,7 +232,7 @@ def main():
     print()
 
     # Step 2: Update mkdocs.yml
-    update_mkdocs_config(mkdocs_path)
+    update_mkdocs_config(mkdocs_path, examples_dir)
 
     print()
     print("=" * 60)

--- a/agent_tasks/2026-06-22_docs_navigability_audit.md
+++ b/agent_tasks/2026-06-22_docs_navigability_audit.md
@@ -1,0 +1,94 @@
+# rascommander.info — Documentation Navigability & Usability Audit
+
+**Date:** 2026-06-22
+**Scope:** Full audit of the rascommander.info docs site (umbrella `/` + `/ras` `/hms` `/mcp`
+`/hydro` `/qgis`) for navigability, consistency, and usability, plus the two reported defects
+(empty homepage left menu; example notebooks missing numbers / not grouped in the left menu).
+
+The umbrella deployment infra lives in `ras-commander-docs`; **the nav, theme features, and page
+content for `/ras` live in this repo** (`gpt-cmdr/ras-commander`). The build pulls this repo at
+deploy time, so navigation fixes land here.
+
+---
+
+## Shipped in this PR (the two discrete fixes)
+
+### 1. Empty homepage left menu — FIXED
+**Root cause:** `mkdocs.yml` `theme.features` had `navigation.tabs`, which promotes top-level nav
+items to a tab bar and shows only the *active tab's children* in the left sidebar. `Home` is a lone
+top-level leaf with no children, so the `/ras/` homepage sidebar collapsed to just "Home" + the
+page's own H2 headings.
+**Fix:** removed `navigation.tabs` and `navigation.expand`. The full section tree now renders in the
+left sidebar on every page (homepage included); groups stay collapsible so the large notebook tree
+is scannable.
+
+### 2. Example notebooks: numbers + sequential + groupings in the left menu — FIXED
+**Root cause:** on `main` the `Example Notebooks` nav is deliberately collapsed to a single
+`Overview` entry (see the docstring in `generate_examples_index.py`): the team avoids hand-authoring
+~120 nav entries because they go stale and reference notebooks that don't exist on `main`. The
+notebooks were surfaced only as a table on the overview page, and titles were rendered with the
+leading number **stripped** (`derive_title`/`prettify_filename`).
+**Fix (generate from disk at build time — single source of truth, never stale):**
+- New shared module `.claude/scripts/_docs_notebook_common.py` holds the title/numbering/section
+  logic so the overview table and the left-nav can't drift.
+- `prepare_notebooks_for_docs.py` now **injects** the `Example Notebooks` nav block from
+  `examples/*.ipynb`: numbered labels (`100 - Using RasExamples`), grouped by hundreds with
+  descriptive headings (`100s - Initialization & Execution` … `900s - Data Integration &
+  Forecasting`), sequential within each group. It replaces the lone `Overview` entry at build time;
+  the source `mkdocs.yml` stays collapsed (design intent preserved). Labels are YAML double-quoted
+  (notebook H1s contain `:`/`&`).
+- `generate_examples_index.py` now shows the number in each overview-table title and uses the same
+  descriptive group headings.
+- No `ras-commander-docs` change needed: `build.sh` (`ras` profile) already runs both scripts.
+
+**Validated locally:** 124 notebooks → valid YAML, 9 groups + Overview, nav entry count == notebook
+count, full `mkdocs.yml` parses, sibling sections preserved.
+
+**Note:** `docs/examples/index.md` is a build artifact (regenerated every deploy) and is intentionally
+NOT regenerated in this PR to avoid coupling the diff to local notebook drift. It refreshes on the
+next build after merge.
+
+---
+
+## Backlog — not in this PR (ranked; from the audit)
+
+### Notebook hygiene
+- **Duplicate notebook numbers (5 collisions / 10 notebooks):** `116`, `211`, `315`, `918`, `919`
+  each used by two different notebooks. With numbers now shown, these appear as two same-numbered
+  entries. Resolving means renaming the source `.ipynb` (+ any references). Candidates to renumber:
+  `116_monte_carlo_uncertainty`, `211_fixit_blocked_obstructions`, `315_validating_dss_paths`,
+  `918_model_validation_with_usgs`, `919_stofs3d_coastal_boundary`.
+
+### Content / editorial (HIGH)
+- **Internal pages shipping publicly:** `docs/DOCUMENTATION_PLAN.md` and `docs/AGENTS.md` build into
+  the live site (reachable by URL, not in nav). Add to `exclude_docs` or relocate. `docs/ebfe_models.md`
+  is orphaned — add to nav or fold into the eBFE user-guide page.
+- **Cognitive Infrastructure half-broken:** `mkdocs.yml` `exclude_docs` hides `agents.md`/`skills.md`/
+  `commands.md`, but `cognitive-infrastructure/index.md` describes and links to them. Either publish
+  them (+nav) or trim the index so it doesn't dangle pointers.
+- **Contradictory scale numbers:** notebook count is variously "109", "30+", "50+", "25+" across
+  `index.md`, `quickstart.md`, `about/clb-engineering.md`, `development/llm-development.md`. The "30+"
+  on the landing page badly undersells ~120 notebooks. Pick one number (now derivable from disk).
+- **`plan_df` column names contradict** between the table and the examples in
+  `getting-started/project-initialization.md` (`HDF_Results_Path` vs `hdf_path`, `Plan Title` vs
+  `plan_title`) — breaks copy-paste. Also verify `max_workers` vs `num_workers` between
+  `quickstart.md` and `parallel-compute/index.md`. Reconcile against `reference/dataframe-reference.md`.
+
+### Content / editorial (MEDIUM)
+- Landing page doesn't funnel new users to Install → Quick Start; grid cards aren't clickable links.
+- `examples/index.md` overview has no "start here" guided path for a ~120-notebook library.
+- `user-guide/overview.md` H1 says "Architecture Overview" but nav labels it "Overview".
+- ~4 near-verbatim copies of the CLB marketing paragraph; de-duplicate to one canonical statement.
+- Mixed heading case repo-wide (standardize Title Case); a few untagged code fences in
+  `reference/file-formats.md`.
+- *Positive:* no TODO/placeholder/stub content; API, parallel-compute, file-formats overviews strong;
+  getting-started sequence is sound.
+
+### Design / UX — these belong in `ras-commander-docs` (infra), not here
+- **Switcher has no link back to `/`** (umbrella landing). `hub_url` is already injected into
+  `extra` but unused — easy add to `theme/overrides/partials/clb-switcher.html`.
+- **Audit the other 4 products' `theme.features`** for the same empty-menu pattern (nothing enforces
+  consistency across products since the overlay can't set `theme.features`).
+- Landing cards are hand-maintained, duplicating `products.yml` taglines (drift risk) — generate them.
+- No cross-product search (per-product indexes) — known federated-model limitation; roadmap note.
+- Landing page sets no logo; switcher font is very small (0.66rem).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -29,9 +29,11 @@ theme:
         icon: material/brightness-4
         name: Switch to light mode
   features:
-    - navigation.tabs
+    # navigation.tabs + a lone top-level "Home" left the homepage sidebar empty
+    # (the active "Home" tab has no children). Without tabs, the full section tree
+    # renders in the left sidebar on every page; groups stay collapsible (no
+    # navigation.expand) so the large Example Notebooks tree is scannable.
     - navigation.sections
-    - navigation.expand
     - navigation.top
     - search.suggest
     - search.highlight


### PR DESCRIPTION
## What & why

Two navigability fixes for the **rascommander.info `/ras` site**, plus a full audit + backlog.

### 1. Empty homepage left menu
`theme.features` had `navigation.tabs`, which turns top-level nav items into a tab bar and shows only the *active tab's children* in the sidebar. `Home` is a lone top-level leaf with no children, so the `/ras/` homepage sidebar collapsed to just "Home" + the page's own H2 headings.

**Fix:** remove `navigation.tabs` and `navigation.expand`. The full section tree now renders in the left sidebar on **every** page (homepage included); groups stay collapsible so the large notebook tree is scannable.

### 2. Example notebooks — numbers + sequential + groupings in the left menu
On `main` the `Example Notebooks` nav is intentionally a lone `Overview` entry (per the `generate_examples_index.py` docstring: hand-authoring ~120 entries goes stale and references notebooks that don't exist on `main`). Notebooks were surfaced only as an overview table, with the leading number **stripped** from titles.

**Fix — generate the nav from disk at build time** (single source of truth, never stale):
- New shared `.claude/scripts/_docs_notebook_common.py` — title/number/section logic shared by the overview table and the left-nav so they can't drift.
- `prepare_notebooks_for_docs.py` now **injects** the `Example Notebooks` nav from `examples/*.ipynb`: numbered labels (`100 - Using RasExamples`), grouped by hundreds with descriptive headings (`100s - Initialization & Execution` … `900s - Data Integration & Forecasting`), sequential within each group. Labels are YAML double-quoted (H1s contain `:`/`&`). Source `mkdocs.yml` stays collapsed — design intent preserved.
- `generate_examples_index.py` shows the number in each overview-table title and uses the same descriptive group headings.

**No `ras-commander-docs` change needed** — `build.sh` (`ras` profile) already runs both scripts.

## Validation
124 notebooks → valid YAML; nav entry count == notebook count; full `mkdocs.yml` parses (with `!!python/name` tags); sibling sections preserved; index titles numbered. `docs/examples/index.md` is a build artifact (regenerated on deploy) — intentionally not regenerated here to avoid coupling the diff to local notebook drift.

## Not in this PR (see `agent_tasks/2026-06-22_docs_navigability_audit.md`)
Full audit + ranked backlog: 5 duplicate notebook numbers (116/211/315/918/919), internal pages shipping publicly (`DOCUMENTATION_PLAN.md`, `docs/AGENTS.md`), Cognitive-Infrastructure exclusion, contradictory notebook counts, `plan_df` column mismatches, and infra-repo design items (switcher → landing link, per-product `theme.features` audit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DSzTbhmYBPJBVCjXq8pEqi