### PR TITLE
docs: set mkdocs site_url to per-product rascommander.info/ras/

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,7 +1,7 @@
 site_name: RAS Commander Documentation
 site_description: Python library for automating HEC-RAS operations
 site_author: William Katzenmeyer, P.E., C.F.M.
-site_url: https://rascommander.info/
+site_url: https://rascommander.info/ras/
 
 repo_name: gpt-cmdr/ras-commander
 repo_url: https://github.com/gpt-cmdr/ras-commander


### PR DESCRIPTION
Under the multi-product umbrella, RAS Commander docs are path-routed at **/ras/**. The README already links to `/ras/` everywhere, and Caddy 301-redirects legacy bare paths to `/ras/`. But `mkdocs.yml` `site_url` still read `https://rascommander.info/` (the umbrella **landing**), so a standalone `mkdocs build`/`serve` emits root canonicals + sitemap URLs instead of `/ras/`.

The umbrella build overlay overrides `site_url` at deploy time (live `/ras/` canonical is already correct), so this aligns the in-repo config with the per-product invariant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)