### PR TITLE
fix(geom): detect text/HDF breakline mismatch so GeomMesh.generate reseeds

### DIFF
--- a/ras_commander/geom/GeomMesh.py
+++ b/ras_commander/geom/GeomMesh.py
@@ -1824,7 +1824,58 @@ def _mesh_hdf_consistency_issues(
                     f"but HDF Spacing {axis}={float(hdf_spacing):g}"
                 )
 
+    # Breakline geometry. HEC-RAS stores breaklines as a flat, global list (not
+    # per-area) in both the .g01 text and the compiled HDF. GeomMesh.generate's .NET
+    # RegenerateMeshPoints seeds the refined corridor from the *HDF* breaklines, so a
+    # text/HDF breakline mismatch -- e.g. set_breaklines just wrote breaklines to the
+    # text but the HDF still holds the pre-breakline mesh -- MUST mark the HDF stale.
+    # Otherwise the seeder sees zero breaklines and silently drops near_repeats
+    # refinement (only Ras.exe enforcement adds a thin 1-row band). The count is global,
+    # so this is reported once rather than per area.
+    text_breaklines = _count_breaklines_in_text(geom_text_path)
+    hdf_breaklines = _count_breaklines_in_hdf(hdf_path)
+    if text_breaklines != hdf_breaklines:
+        issues.append(
+            f"text defines {text_breaklines} breakline(s) "
+            f"but compiled HDF has {hdf_breaklines}"
+        )
+
     return issues
+
+
+def _count_breaklines_in_text(geom_text_path: Path) -> int:
+    """Count 2D-area breaklines defined in geometry text.
+
+    HEC-RAS stores breaklines as a flat list of ``BreakLine Name=`` blocks (not nested
+    under a specific 2D area), so this is a global count.
+    """
+    try:
+        text = Path(geom_text_path).read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return 0
+    return sum(1 for line in text.splitlines() if line.startswith("BreakLine Name="))
+
+
+def _count_breaklines_in_hdf(hdf_path: Path) -> int:
+    """Count breaklines compiled into the geometry HDF (0 if none).
+
+    Reads ``Geometry/2D Flow Area Break Lines`` (a global group); returns 0 when the
+    group is absent (an uncompiled-breakline / pre-breakline mesh).
+    """
+    import h5py
+
+    try:
+        with h5py.File(str(hdf_path), "r") as hf:
+            group = hf.get("Geometry/2D Flow Area Break Lines")
+            if group is None:
+                return 0
+            attrs = group.get("Attributes")
+            if attrs is not None:
+                return int(attrs.shape[0])
+            info = group.get("Polyline Info")
+            return int(info.shape[0]) if info is not None else 0
+    except (OSError, KeyError, ValueError):
+        return 0
 
 
 def _ensure_hdf(

--- a/tests/test_geom_mesh.py
+++ b/tests/test_geom_mesh.py
@@ -726,6 +726,64 @@ class TestGeometryHdfAvailability:
         ) == hdf_path
         assert calls == [(breakline_geom_text, hdf_path, ras_object)]
 
+    def test_consistency_flags_text_breaklines_missing_from_hdf(self, tmp_path):
+        # Regression: set_breaklines writes breaklines to the .g01 TEXT, but
+        # RegenerateMeshPoints seeds from the HDF. If the consistency check ignores
+        # breakline geometry, the stale (pre-breakline) HDF is accepted and near_repeats
+        # is silently dropped. The text/HDF breakline-count mismatch must be flagged.
+        geom_text = tmp_path / "bl.g01"
+        geom_text.write_text(
+            "Geom Title=Test\n"
+            "Storage Area=MainArea\n"
+            "Storage Area Point Generation Data=,,50.000000,50.000000\n"
+            "Storage Area 2D Points= 0 \n"
+            "BreakLine Name=Channel\n"
+            "BreakLine CellSize Min=12.000000\n"
+            "BreakLine CellSize Max=12.000000\n"
+            "BreakLine Near Repeats=2\n",
+            encoding="utf-8",
+        )
+        hdf_path = geom_text.with_suffix(geom_text.suffix + ".hdf")
+        # compiled HDF still holds the pre-breakline (uniform) mesh: no breakline group
+        _write_mesh_hdf(
+            hdf_path,
+            [{"name": "MainArea", "spacing_dx": 50.0, "spacing_dy": 50.0, "cell_count": 0}],
+        )
+
+        issues = geom_mesh_module._mesh_hdf_consistency_issues(geom_text, hdf_path)
+        assert any("breakline" in issue.lower() for issue in issues), issues
+        with pytest.raises(RuntimeError, match="text defines 1 breakline"):
+            _ensure_hdf(geom_text)
+
+    def test_consistency_passes_when_breakline_counts_match(self, tmp_path):
+        geom_text = tmp_path / "bl_match.g01"
+        geom_text.write_text(
+            "Geom Title=Test\n"
+            "Storage Area=MainArea\n"
+            "Storage Area Point Generation Data=,,50.000000,50.000000\n"
+            "Storage Area 2D Points= 0 \n"
+            "BreakLine Name=Channel\n"
+            "BreakLine CellSize Min=12.000000\n",
+            encoding="utf-8",
+        )
+        hdf_path = geom_text.with_suffix(geom_text.suffix + ".hdf")
+        _write_mesh_hdf(
+            hdf_path,
+            [{"name": "MainArea", "spacing_dx": 50.0, "spacing_dy": 50.0, "cell_count": 0}],
+        )
+        # add a matching compiled breakline (1) to the HDF
+        with h5py.File(str(hdf_path), "r+") as hf:
+            bl = hf.create_group("Geometry/2D Flow Area Break Lines")
+            bl.create_dataset(
+                "Attributes",
+                data=np.array([(b"Channel",)], dtype=np.dtype([("Name", "S32")])),
+            )
+
+        assert geom_mesh_module._mesh_hdf_consistency_issues(geom_text, hdf_path) == []
+        assert geom_mesh_module._count_breaklines_in_text(geom_text) == 1
+        assert geom_mesh_module._count_breaklines_in_hdf(hdf_path) == 1
+        assert _ensure_hdf(geom_text) == hdf_path
+
 
 class TestGeometryAssociation:
     """Test geometry HDF association API."""


### PR DESCRIPTION
## Problem

`GeomMesh.generate`'s .NET `RegenerateMeshPoints` seeds the refined corridor from the breaklines in the **compiled HDF**, not the `.g01` text. But `_mesh_hdf_consistency_issues` (which decides whether `_ensure_hdf` recompiles a stale HDF) only compared **area presence, seed/cell count, and spacing dx/dy** — never breakline geometry.

So the common sequence

```python
GeomStorage.set_breaklines(geom_text, area, [...])      # writes breaklines to TEXT
GeomMesh.set_breakline_spacing(geom_text, near_repeats=2, ...)
GeomMesh.generate(geom_text, recompile_via_rasexe=True) # seeds from HDF
```

silently under-refines: the freshly-written breaklines are in the text but the compiled HDF still holds the pre-breakline mesh, the consistency check finds "no issues", the Ras.exe recompile is skipped, and the seeder reports **"0 breaklines"** — dropping `near_repeats` entirely (only Ras.exe enforcement adds a thin 1-row band).

## Fix

HEC-RAS stores breaklines as a flat global list in both representations — `BreakLine Name=` blocks in the text and the `Geometry/2D Flow Area Break Lines` group in the HDF. Compare those counts and flag a mismatch as stale, so `generate(recompile_via_rasexe=True)` recompiles the HDF (pulling breakline geometry in) **before** seeding.

Adds `_count_breaklines_in_text` / `_count_breaklines_in_hdf` and two regression tests.

## Validation

- `tests/test_geom_mesh.py`: 87 passed, 1 skipped (2 new).
- End-to-end (Ether Hollow greenfield breakline build): the seeder now reports **"3 breaklines"** instead of "0" with **no caller-side workaround**, 11,994 → 13,730 cells (near_repeats=1).

## Context

Found while fixing the post-fire debris-flow notebook (#249), which ships an example-level workaround (an explicit `compute_plan(force_geompre=True)` before `generate`). This PR removes the need for that workaround for all callers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
