### PR TITLE
Improve HDF diagnostics and concise logging

### DIFF
--- a/docs/api/hdf.md
+++ b/docs/api/hdf.md
@@ -122,10 +122,12 @@ Storage area volume-elevation curve extraction from HDF.
 
 ### HdfStruc1D
 
-1D inline structure data extraction from HDF.
+1D structure result extraction from plan HDF results.
 
-- `get_inline_structure_data(hdf_path)` - Extract inline structure geometry and results
-- `get_structure_flow_timeseries(hdf_path, structure_name)` - Get flow time series through a structure
+- `get_structure_max_values(hdf_path, river, reach, rs)` - Extract maximum headwater, tailwater, and flow for a bridge, culvert, inline weir, or inline control structure. Raises an actionable `ValueError` when the plan HDF has no steady/unsteady results, required cross-section result datasets are absent, or the requested structure is not present in the results.
+- `list_1d_structures(hdf_path)` - List 1D structures identified from result markers. Returns an empty DataFrame quietly when no structures are present in an otherwise readable HDF.
+
+For steady plans, `get_structure_max_values()` can use the flanking cross sections when the structure is represented in HDF `Node Info` instead of `Cross Section Attributes`. The returned `hw_source`, `tw_source`, and `flow_source` fields identify the result locations used.
 
 ### HdfHydraulicTables
 

--- a/ras_commander/hdf/HdfBase.py
+++ b/ras_commander/hdf/HdfBase.py
@@ -55,6 +55,7 @@ from ..Decorators import standardize_input, log_call
 from ..LoggingConfig import setup_logging, get_logger
 
 logger = get_logger(__name__)
+_missing_projection_warning_paths: set[str] = set()
 
 class HdfBase:
     """
@@ -153,22 +154,50 @@ class HdfBase:
         Raises:
             ValueError: If there's an error reading the HDF file or accessing the required data.
         """
+        flow_area_2d_path = "Geometry/2D Flow Areas"
+        attributes_path = f"{flow_area_2d_path}/Attributes"
+        cell_info_path = f"{flow_area_2d_path}/Cell Info"
+
         try:
             with h5py.File(hdf_path, 'r') as hdf_file:
-                flow_area_2d_path = "Geometry/2D Flow Areas"
                 if flow_area_2d_path not in hdf_file:
                     return []
-                
-                attributes = hdf_file[f"{flow_area_2d_path}/Attributes"][()]
+
+                missing = [
+                    dataset_path
+                    for dataset_path in (attributes_path, cell_info_path)
+                    if dataset_path not in hdf_file
+                ]
+                if missing:
+                    raise ValueError(
+                        "2D flow area name/count extraction requires dataset(s) "
+                        f"{missing} in {Path(hdf_path).name}."
+                    )
+
+                attributes = hdf_file[attributes_path][()]
+                if "Name" not in attributes.dtype.names:
+                    raise ValueError(
+                        f"2D flow area attributes at '{attributes_path}' in "
+                        f"{Path(hdf_path).name} do not include a 'Name' field."
+                    )
                 names = [HdfUtils.convert_ras_string(name) for name in attributes["Name"]]
-                
-                cell_info = hdf_file[f"{flow_area_2d_path}/Cell Info"][()]
+
+                cell_info = hdf_file[cell_info_path][()]
                 cell_counts = [info[1] for info in cell_info]
-                
+                if len(names) != len(cell_counts):
+                    raise ValueError(
+                        f"2D flow area names/counts mismatch in {Path(hdf_path).name}: "
+                        f"names={len(names)} cell_info_rows={len(cell_counts)}."
+                    )
+
                 return list(zip(names, cell_counts))
+        except ValueError:
+            raise
         except Exception as e:
-            logger.error(f"Error reading 2D flow area names and counts from {hdf_path}: {str(e)}")
-            raise ValueError(f"Failed to get 2D flow area names and counts: {str(e)}")
+            raise ValueError(
+                f"Failed to read 2D flow area names/counts from "
+                f"{Path(hdf_path).name}: {e}"
+            ) from e
 
 
     @staticmethod
@@ -314,7 +343,11 @@ class HdfBase:
                             if projection:
                                 return projection
         except Exception as e:
-            logger.error(f"Error reading RASMapper projection file: {str(e)}")
+            logger.debug(
+                "Error reading RASMapper projection file while checking %s: %s",
+                hdf_path,
+                str(e),
+            )
 
         if proj_file:
             error_msg = (
@@ -338,7 +371,24 @@ class HdfBase:
             "4. Save the RASMapper project"
         )
 
-        logger.critical(error_msg)
+        logger.debug(error_msg)
+
+        try:
+            warning_key = str(hdf_path.resolve())
+        except OSError:
+            warning_key = str(hdf_path.absolute())
+
+        if (
+            warning_key not in _missing_projection_warning_paths
+            and logger.isEnabledFor(logging.WARNING)
+        ):
+            logger.warning(
+                "Projection not found for %s; returned geospatial outputs will "
+                "not have a CRS. Enable DEBUG for checked paths and RASMapper "
+                "projection setup guidance.",
+                hdf_path.name,
+            )
+            _missing_projection_warning_paths.add(warning_key)
         return None
 
     @staticmethod
@@ -356,13 +406,16 @@ class HdfBase:
         """
         try:
             if attr_path not in hdf_file:
-                logger.warning(f"Path {attr_path} not found in HDF file")
+                logger.debug("Attribute path '%s' not found in HDF file", attr_path)
                 return {}
-            
+
             return HdfUtils.convert_hdf5_attrs_to_dict(hdf_file[attr_path].attrs)
         except Exception as e:
-            logger.error(f"Error getting attributes from {attr_path}: {str(e)}")
-            return {}
+            file_label = Path(getattr(hdf_file, "filename", "HDF file")).name
+            raise ValueError(
+                f"Failed to read HDF attributes at '{attr_path}' in "
+                f"{file_label}: {e}"
+            ) from e
 
     @staticmethod
     @standardize_input(file_type='plan_hdf')
@@ -397,19 +450,31 @@ class HdfBase:
             else:
                 print(f"{spacer}Unknown object: {name}")
 
+        if group_path is None:
+            group_path = "/"
+
         try:
             with h5py.File(file_path, 'r') as hdf_file:
-                if group_path in hdf_file:
-                    print("")
-                    print(f"Exploring group: {group_path}\n")
-                    group = hdf_file[group_path]
+                if group_path not in hdf_file:
+                    raise KeyError(
+                        f"Group path '{group_path}' not found in "
+                        f"{Path(file_path).name}."
+                    )
+
+                print("")
+                print(f"Exploring group: {group_path}\n")
+                group = hdf_file[group_path]
+                if isinstance(group, h5py.Group):
                     for key in group:
                         print("")
                         recurse(f"{group_path}/{key}", group[key], indent=1)
                 else:
-                    print(f"Group path '{group_path}' not found in the HDF5 file.")
-        except Exception as e:
-            print(f"Error exploring HDF5 file: {e}")
+                    print("")
+                    recurse(group_path, group, indent=1)
+        except OSError as e:
+            raise OSError(
+                f"Could not open HDF file {Path(file_path).name}: {e}"
+            ) from e
 
     @staticmethod
     @log_call
@@ -436,11 +501,34 @@ class HdfBase:
             - Parts information for multi-part lines
             - Point coordinates
         """
+        polyline_info_path = f"{path}/{info_name}"
+        polyline_parts_path = f"{path}/{parts_name}"
+        polyline_points_path = f"{path}/{points_name}"
+
         try:
             with h5py.File(hdf_path, 'r') as hdf_file:
-                polyline_info_path = f"{path}/{info_name}"
-                polyline_parts_path = f"{path}/{parts_name}"
-                polyline_points_path = f"{path}/{points_name}"
+                if path not in hdf_file:
+                    logger.debug(
+                        "Polyline group '%s' not found in %s.",
+                        path,
+                        Path(hdf_path).name,
+                    )
+                    return []
+
+                missing = [
+                    dataset_path
+                    for dataset_path in (
+                        polyline_info_path,
+                        polyline_parts_path,
+                        polyline_points_path,
+                    )
+                    if dataset_path not in hdf_file
+                ]
+                if missing:
+                    raise ValueError(
+                        "Polyline extraction requires dataset(s) "
+                        f"{missing} under '{path}' in {Path(hdf_path).name}."
+                    )
 
                 polyline_info = hdf_file[polyline_info_path][()]
                 polyline_parts = hdf_file[polyline_parts_path][()]
@@ -462,9 +550,13 @@ class HdfBase:
                             )
                         )
                 return geoms
+        except ValueError:
+            raise
         except Exception as e:
-            logger.error(f"Error getting polylines: {str(e)}")
-            return []
+            raise ValueError(
+                f"Failed to extract polylines from '{path}' in "
+                f"{Path(hdf_path).name}: {e}"
+            ) from e
 
     @staticmethod
     def print_attrs(name: str, obj: Union[h5py.Dataset, h5py.Group]) -> None:

--- a/ras_commander/hdf/HdfBenefitAreas.py
+++ b/ras_commander/hdf/HdfBenefitAreas.py
@@ -202,10 +202,16 @@ class HdfBenefitAreas:
         proposed_points = HdfResultsMesh.get_mesh_max_ws(proposed_path)
 
         if existing_points is None or existing_points.empty:
-            raise ValueError(f"No max WSE data found in existing plan: {existing_path}")
+            raise ValueError(
+                f"No maximum water-surface summary data found in existing plan: {existing_path}. "
+                f"Compute the plan and ensure the 'Maximum Water Surface' summary output is available."
+            )
 
         if proposed_points is None or proposed_points.empty:
-            raise ValueError(f"No max WSE data found in proposed plan: {proposed_path}")
+            raise ValueError(
+                f"No maximum water-surface summary data found in proposed plan: {proposed_path}. "
+                f"Compute the plan and ensure the 'Maximum Water Surface' summary output is available."
+            )
 
         # Step 2: Match points between plans and compute differences
         logger.debug("Matching points between plans...")
@@ -214,7 +220,10 @@ class HdfBenefitAreas:
         )
 
         if matched_df.empty:
-            raise ValueError("No matching points found between the two plans")
+            raise ValueError(
+                "No matching 2D mesh cell-center points found between the existing and proposed plans. "
+                "Confirm both plans use the same 2D mesh geometry and coordinate system."
+            )
 
         # Step 3: Apply threshold and classify points
         logger.debug(f"Applying minimum delta threshold of {min_delta} feet...")
@@ -227,7 +236,11 @@ class HdfBenefitAreas:
         cells_gdf = HdfMesh.get_mesh_cell_polygons(existing_path)
 
         if cells_gdf is None or cells_gdf.empty:
-            raise ValueError(f"No mesh cells found in existing plan: {existing_path}")
+            raise ValueError(
+                f"No 2D mesh cell polygons found for the existing plan geometry: {existing_path}. "
+                f"This API requires 2D mesh geometry; run the geometry preprocessor to populate "
+                f"preprocessor-created mesh datasets if they are missing."
+            )
 
         # Step 5: Build contiguous polygons
         logger.debug("Building contiguous benefit areas...")
@@ -257,10 +270,15 @@ class HdfBenefitAreas:
             )
         )
 
-        logger.info("Analysis complete")
-        logger.info(f"  Benefit areas: {len(benefit_polygons) if not benefit_polygons.empty else 0}")
-        logger.info(f"  Rise areas: {len(rise_polygons) if not rise_polygons.empty else 0}")
-        logger.info(f"  Matched points: {len(matched_df)}")
+        logger.info(
+            "Benefit analysis complete: benefit_areas=%d rise_areas=%d "
+            "matched_points=%d significant_points=%d threshold_ft=%s",
+            len(benefit_polygons) if not benefit_polygons.empty else 0,
+            len(rise_polygons) if not rise_polygons.empty else 0,
+            len(matched_df),
+            len(benefit_points) + len(rise_points),
+            min_delta,
+        )
 
         return {
             'benefit_polygons': benefit_polygons,
@@ -355,7 +373,7 @@ class HdfBenefitAreas:
         except Exception as e:
             # If we can't resolve, try constructing expected path
             # This allows FileNotFoundError to be raised later with the expected path
-            logger.warning(f"Could not resolve {label} plan '{input_str}': {e}")
+            logger.debug(f"Could not resolve {label} plan '{input_str}': {e}")
             if hasattr(ras_object, 'folder') and ras_object.folder:
                 return Path(ras_object.folder) / f"unknown.p{plan_number}.hdf"
             else:
@@ -398,7 +416,7 @@ class HdfBenefitAreas:
         )
 
         if matched.empty:
-            logger.warning("No matching points found between plans")
+            logger.debug("No matching points found between plans")
             return gpd.GeoDataFrame()
 
         # Compute WSE difference (proposed - existing, negative = benefit)
@@ -447,7 +465,7 @@ class HdfBenefitAreas:
         significant = matched_df[abs(matched_df['wse_difference']) >= min_delta].copy()
 
         if significant.empty:
-            logger.warning(f"No points exceed minimum delta threshold of {min_delta} feet")
+            logger.debug(f"No points exceed minimum delta threshold of {min_delta} feet")
             empty_gdf = gpd.GeoDataFrame(columns=matched_df.columns, crs=matched_df.crs)
             return empty_gdf, empty_gdf
 
@@ -494,14 +512,28 @@ class HdfBenefitAreas:
 
         # Step 1: Associate points with cells using spatial join
         logger.debug(f"Associating {len(points_df)} points with mesh cells...")
+        cell_join_gdf = cells_gdf[['cell_id', 'mesh_name', 'geometry']].rename(
+            columns={
+                'cell_id': 'cell_id_cell',
+                'mesh_name': 'mesh_name_cell',
+            }
+        )
         points_with_cells = gpd.sjoin(
-            points_df, cells_gdf[['cell_id', 'mesh_name', 'geometry']],
+            points_df, cell_join_gdf,
             how='inner', predicate='within'
         )
 
+        if 'mesh_name' in points_with_cells.columns and 'mesh_name_cell' in points_with_cells.columns:
+            points_with_cells = points_with_cells[
+                points_with_cells['mesh_name'] == points_with_cells['mesh_name_cell']
+            ].copy()
+
         # Get unique cell IDs (with mesh_name for multi-mesh support)
-        target_cells = points_with_cells[['mesh_name', 'cell_id_right']].drop_duplicates()
-        target_cells.rename(columns={'cell_id_right': 'cell_id'}, inplace=True)
+        target_cells = (
+            points_with_cells[['mesh_name_cell', 'cell_id_cell']]
+            .drop_duplicates()
+            .rename(columns={'mesh_name_cell': 'mesh_name', 'cell_id_cell': 'cell_id'})
+        )
 
         if target_cells.empty:
             logger.warning(f"No cells associated with {area_type} points")
@@ -572,6 +604,7 @@ class HdfBenefitAreas:
         # Filter cells to target cells only
         target_cell_keys = set(zip(target_cells['mesh_name'], target_cells['cell_id']))
 
+        edge_extraction_failures = 0
         for _, cell_row in cells_gdf.iterrows():
             cell_key = (cell_row['mesh_name'], cell_row['cell_id'])
 
@@ -591,7 +624,8 @@ class HdfBenefitAreas:
                     edge = edge_key(coords[i], coords[i + 1])
                     edge_to_cells[edge].add(cell_key)
             except Exception as e:
-                logger.warning(f"Could not extract edges from cell {cell_key}: {e}")
+                edge_extraction_failures += 1
+                logger.debug(f"Could not extract edges from cell {cell_key}: {e}")
                 continue
 
         # Build adjacency from shared edges
@@ -609,6 +643,12 @@ class HdfBenefitAreas:
         adjacency_dict = {k: list(v) for k, v in adjacency.items()}
 
         logger.debug(f"Built adjacency for {len(adjacency_dict)} cells")
+        if edge_extraction_failures:
+            logger.warning(
+                "Skipped %d mesh cells while building polygon-edge adjacency; "
+                "enable DEBUG logging for cell-level details.",
+                edge_extraction_failures,
+            )
 
         return adjacency_dict
 
@@ -645,7 +685,10 @@ class HdfBenefitAreas:
                 topo = HdfMesh.get_mesh_sloped_topology(hdf_path, mesh_name)
 
                 if 'face_cells' not in topo:
-                    logger.warning(f"No face_cells found for mesh {mesh_name}, falling back to edge-based")
+                    logger.warning(
+                        f"No face_cells found for mesh {mesh_name}; "
+                        f"topology adjacency is unavailable for this mesh"
+                    )
                     continue
 
                 face_cells = topo['face_cells']
@@ -747,6 +790,7 @@ class HdfBenefitAreas:
 
         features = []
 
+        dissolve_failures = 0
         for group_idx, cell_group in enumerate(cell_groups):
             # Get geometries for this group
             group_geoms = []
@@ -764,7 +808,8 @@ class HdfBenefitAreas:
                 try:
                     merged_geom = unary_union(group_geoms)
                 except Exception as e:
-                    logger.warning(f"Could not dissolve group {group_idx + 1}: {e}")
+                    dissolve_failures += 1
+                    logger.debug(f"Could not dissolve group {group_idx + 1}: {e}")
                     continue
 
                 if merged_geom is None or not merged_geom.is_valid:
@@ -803,5 +848,12 @@ class HdfBenefitAreas:
                 'area_acres': [],
                 'geometry': []
             }, crs=cells_gdf.crs)
+
+        if dissolve_failures:
+            logger.warning(
+                "Skipped %d contiguous polygon groups that could not be dissolved; "
+                "enable DEBUG logging for group-level details.",
+                dissolve_failures,
+            )
 
         return result

--- a/ras_commander/hdf/HdfBndry.py
+++ b/ras_commander/hdf/HdfBndry.py
@@ -71,10 +71,15 @@ class HdfBndry:
         gpd.GeoDataFrame
             A GeoDataFrame containing the boundary condition lines and their attributes.
         """
+        bc_lines_path = "Geometry/Boundary Condition Lines"
         try:
             with h5py.File(hdf_path, 'r') as hdf_file:
-                bc_lines_path = "Geometry/Boundary Condition Lines"
                 if bc_lines_path not in hdf_file:
+                    logger.debug(
+                        "Boundary condition lines group '%s' not found in %s.",
+                        bc_lines_path,
+                        hdf_path.name,
+                    )
                     return gpd.GeoDataFrame()
                 
                 # Get geometries
@@ -104,7 +109,12 @@ class HdfBndry:
                 return gdf
 
         except Exception as e:
-            logger.error(f"Error reading boundary condition lines: {str(e)}")
+            logger.error(
+                "Error reading boundary condition lines from %s (%s): %s",
+                hdf_path,
+                bc_lines_path,
+                str(e),
+            )
             return gpd.GeoDataFrame()
 
     @staticmethod
@@ -129,11 +139,15 @@ class HdfBndry:
         - Single-point breaklines are logged and skipped.
         - These invalid breaklines should be removed in RASMapper to prevent potential issues.
         """
+        breaklines_path = "Geometry/2D Flow Area Break Lines"
         try:
             with h5py.File(hdf_path, 'r') as hdf_file:
-                breaklines_path = "Geometry/2D Flow Area Break Lines"
                 if breaklines_path not in hdf_file:
-                    logger.warning(f"Breaklines path '{breaklines_path}' not found in HDF file.")
+                    logger.debug(
+                        "Breaklines group '%s' not found in %s.",
+                        breaklines_path,
+                        hdf_path.name,
+                    )
                     return gpd.GeoDataFrame()
 
                 bl_line_data = hdf_file[breaklines_path]
@@ -211,7 +225,15 @@ class HdfBndry:
 
                 # Create GeoDataFrame with valid breaklines
                 if not valid_ids:
-                    logger.warning("No valid breaklines found in the HDF file.")
+                    logger.warning(
+                        "No valid breaklines found in %s; skipped %d invalid "
+                        "breaklines (zero_length=%d, single_point=%d, other=%d).",
+                        hdf_path.name,
+                        total_invalid,
+                        zero_length_count,
+                        single_point_count,
+                        other_error_count,
+                    )
                     return gpd.GeoDataFrame()
 
                 return gpd.GeoDataFrame(
@@ -225,7 +247,12 @@ class HdfBndry:
                 )
 
         except Exception as e:
-            logger.error(f"Error reading breaklines: {str(e)}")
+            logger.error(
+                "Error reading breaklines from %s (%s): %s",
+                hdf_path,
+                breaklines_path,
+                str(e),
+            )
             return gpd.GeoDataFrame()
 
     @staticmethod
@@ -244,10 +271,15 @@ class HdfBndry:
         gpd.GeoDataFrame
             A GeoDataFrame containing the refinement regions.
         """
+        refinement_regions_path = "/Geometry/2D Flow Area Refinement Regions"
         try:
             with h5py.File(hdf_path, 'r') as hdf_file:
-                refinement_regions_path = "/Geometry/2D Flow Area Refinement Regions"
                 if refinement_regions_path not in hdf_file:
+                    logger.debug(
+                        "Refinement regions group '%s' not found in %s.",
+                        refinement_regions_path,
+                        hdf_path.name,
+                    )
                     return gpd.GeoDataFrame()
                 rr_data = hdf_file[refinement_regions_path]
                 rr_ids = range(rr_data["Attributes"][()].shape[0])
@@ -273,7 +305,12 @@ class HdfBndry:
                     crs=HdfBase.get_projection(hdf_file),
                 )
         except Exception as e:
-            logger.error(f"Error reading refinement regions: {str(e)}")
+            logger.error(
+                "Error reading refinement regions from %s (%s): %s",
+                hdf_path,
+                refinement_regions_path,
+                str(e),
+            )
             return gpd.GeoDataFrame()
 
     @staticmethod
@@ -295,11 +332,16 @@ class HdfBndry:
             A GeoDataFrame containing the reference lines. If mesh_name is provided,
             returns only lines for that mesh.
         """
+        reference_lines_path = "Geometry/Reference Lines"
+        attributes_path = f"{reference_lines_path}/Attributes"
         try:
             with h5py.File(hdf_path, 'r') as hdf_file:
-                reference_lines_path = "Geometry/Reference Lines"
-                attributes_path = f"{reference_lines_path}/Attributes"
                 if attributes_path not in hdf_file:
+                    logger.debug(
+                        "Reference lines attributes group '%s' not found in %s.",
+                        attributes_path,
+                        hdf_path.name,
+                    )
                     return gpd.GeoDataFrame()
                 
                 attributes = hdf_file[attributes_path][()]
@@ -311,6 +353,12 @@ class HdfBndry:
                 try:
                     types = v_conv_str(attributes["Type"])
                 except ValueError:
+                    logger.debug(
+                        "Reference line Type field not found in %s (%s); "
+                        "using blank Type values.",
+                        hdf_path.name,
+                        attributes_path,
+                    )
                     types = np.array([""] * attributes.shape[0])
                 
                 geoms = HdfBase.get_polylines_from_parts(hdf_path, reference_lines_path)
@@ -334,7 +382,12 @@ class HdfBndry:
                 return gdf
                 
         except Exception as e:
-            logger.error(f"Error reading reference lines: {str(e)}")
+            logger.error(
+                "Error reading reference lines from %s (%s): %s",
+                hdf_path,
+                reference_lines_path,
+                str(e),
+            )
             return gpd.GeoDataFrame()
 
     @staticmethod
@@ -356,11 +409,16 @@ class HdfBndry:
             A GeoDataFrame containing the reference points. If mesh_name is provided,
             returns only points for that mesh.
         """
+        reference_points_path = "Geometry/Reference Points"
+        attributes_path = f"{reference_points_path}/Attributes"
         try:
             with h5py.File(hdf_path, 'r') as hdf_file:
-                reference_points_path = "Geometry/Reference Points"
-                attributes_path = f"{reference_points_path}/Attributes"
                 if attributes_path not in hdf_file:
+                    logger.debug(
+                        "Reference points attributes group '%s' not found in %s.",
+                        attributes_path,
+                        hdf_path.name,
+                    )
                     return gpd.GeoDataFrame()
                 
                 ref_points_group = hdf_file[reference_points_path]
@@ -390,7 +448,12 @@ class HdfBndry:
                 return gdf
                 
         except Exception as e:
-            logger.error(f"Error reading reference points: {str(e)}")
+            logger.error(
+                "Error reading reference points from %s (%s): %s",
+                hdf_path,
+                reference_points_path,
+                str(e),
+            )
             return gpd.GeoDataFrame()
 
     

--- a/ras_commander/hdf/HdfChannelCapacity.py
+++ b/ras_commander/hdf/HdfChannelCapacity.py
@@ -181,7 +181,7 @@ class HdfChannelCapacity:
                 return Path(hdf_path)
             return Path(project_folder) / f"unknown.p{plan_number}.hdf"
         except Exception as e:
-            logger.warning(f"Could not resolve {label} '{input_str}': {e}")
+            logger.debug(f"Could not resolve {label} '{input_str}': {e}")
             if hasattr(ras_object, 'folder') and ras_object.folder:
                 return Path(ras_object.folder) / f"unknown.p{plan_number}.hdf"
             raise ValueError(f"Failed to resolve {label} '{input_str}': {e}")
@@ -415,14 +415,21 @@ class HdfChannelCapacity:
                     geom_path = geom_file.with_suffix(geom_file.suffix + '.hdf')
 
         if not geom_path.exists():
-            raise FileNotFoundError(f"Geometry HDF not found: {geom_path}")
+            raise FileNotFoundError(
+                f"Geometry HDF not found: {geom_path}. "
+                f"Run the geometry preprocessor or verify the geometry HDF path."
+            )
 
         logger.info(f"Extracting bank elevations from: {geom_path.name}")
 
         xs_gdf = HdfXsec.get_cross_sections(str(geom_path), ras_object=_ras)
 
         if xs_gdf is None or len(xs_gdf) == 0:
-            raise ValueError("No cross sections found in geometry HDF.")
+            raise ValueError(
+                f"No 1D cross sections found in geometry HDF: {geom_path}. "
+                f"Verify this is a 1D geometry HDF and run the geometry preprocessor "
+                f"if the geometry HDF has not been generated."
+            )
 
         rows = []
         for _, row in xs_gdf.iterrows():
@@ -506,7 +513,10 @@ class HdfChannelCapacity:
         )
 
         if not hdf_path.exists():
-            raise FileNotFoundError(f"HDF file not found: {hdf_path}")
+            raise FileNotFoundError(
+                f"Plan HDF not found: {hdf_path}. "
+                f"Compute the plan first so steady profile results are written to HDF."
+            )
 
         logger.info(f"Extracting steady-state profiles from: {hdf_path.name}")
 
@@ -518,7 +528,8 @@ class HdfChannelCapacity:
             if ws_path not in hdf:
                 raise ValueError(
                     f"No steady-state Water Surface data found in {hdf_path.name}. "
-                    f"This method requires a steady-state plan HDF."
+                    f"This method requires a computed steady-state plan HDF with "
+                    f"Steady Profiles/Cross Sections/Water Surface results."
                 )
 
             ws_data = np.asarray(hdf[ws_path][:], dtype=float)
@@ -662,10 +673,13 @@ class HdfChannelCapacity:
             )
 
             if not hdf_path.exists():
-                logger.warning(f"HDF not found for {pname}: {hdf_path}")
+                logger.warning(
+                    f"HDF not found for {pname}: {hdf_path}. "
+                    f"Compute the plan before extracting maximum WSE."
+                )
                 continue
 
-            logger.info(f"Extracting Max WSE from {hdf_path.name} as '{pname}'")
+            logger.debug(f"Extracting Max WSE from {hdf_path.name} as '{pname}'")
 
             try:
                 max_wse_values, attrs, source = HdfChannelCapacity._extract_single_plan_wse(
@@ -677,7 +691,11 @@ class HdfChannelCapacity:
                     f"  Format: {source} ({len(max_wse_values)} XS)"
                 )
             except Exception as exc:
-                logger.warning(f"Could not extract WSE from {hdf_path.name}: {exc}")
+                logger.warning(
+                    f"Could not extract WSE from {hdf_path.name}: {exc}. "
+                    f"Compute the plan and verify the HDF contains steady profiles "
+                    f"or unsteady cross-section water-surface output."
+                )
                 continue
 
             plan_df = pd.DataFrame({
@@ -695,7 +713,11 @@ class HdfChannelCapacity:
                 )
 
         if result_df is None:
-            raise ValueError("No WSE data extracted from any plan input.")
+            raise ValueError(
+                "No WSE data extracted from any plan input. Compute the plans and "
+                "verify each HDF contains steady profiles or unsteady cross-section "
+                "water-surface output."
+            )
 
         logger.info(
             f"Extracted Max WSE: {len(result_df)} XS, "
@@ -746,6 +768,15 @@ class HdfChannelCapacity:
                         'left_bank_elev', 'right_bank_elev', 'controlling_bank_elev',
                         'Len Channel'}
             storm_order = [c for c in merged.columns if c not in key_cols]
+        else:
+            missing_storms = [storm for storm in storm_order if storm not in merged.columns]
+            if missing_storms:
+                message = (
+                    f"Storm columns not found in WSE data: {missing_storms}. "
+                    f"Available WSE columns: "
+                    f"{[c for c in max_wse.columns if c not in ('River', 'Reach', 'RS')]}"
+                )
+                raise ValueError(message)
 
         n_xs = len(merged)
         n_storms = len(storm_order)
@@ -989,13 +1020,18 @@ class HdfChannelCapacity:
 
         summary = summary.sort_values('capacity_level').reset_index(drop=True)
 
-        logger.info("System Capacity Summary:")
-        for _, row in summary.iterrows():
-            if row['channel_length_ft'] > 0:
-                logger.info(
-                    f"  Level {row['capacity_level']} ({row['capacity_category']}): "
-                    f"{row['channel_length_ft']:.0f} ft ({row['percent_of_total']:.1f}%)"
-                )
+        nonzero = summary[summary['channel_length_ft'] > 0]
+        logger.info(
+            "System capacity summary: levels=%d total_length_ft=%.0f xs=%d",
+            len(nonzero),
+            summary['channel_length_ft'].sum(),
+            summary['xs_count'].sum(),
+        )
+        for _, row in nonzero.iterrows():
+            logger.debug(
+                f"  Level {row['capacity_level']} ({row['capacity_category']}): "
+                f"{row['channel_length_ft']:.0f} ft ({row['percent_of_total']:.1f}%)"
+            )
 
         return summary[['capacity_level', 'capacity_category', 'channel_length_ft',
                         'percent_of_total', 'xs_count']]

--- a/ras_commander/hdf/HdfFluvialPluvial.py
+++ b/ras_commander/hdf/HdfFluvialPluvial.py
@@ -17,10 +17,11 @@ import pandas as pd
 import geopandas as gpd
 from collections import defaultdict
 from shapely.geometry import LineString, MultiLineString
+import sys
 from tqdm import tqdm
 from .HdfMesh import HdfMesh
 from .HdfUtils import HdfUtils
-from ..Decorators import standardize_input
+from ..Decorators import standardize_input, log_call
 from .HdfResultsMesh import HdfResultsMesh
 from ..LoggingConfig import get_logger
 from pathlib import Path
@@ -66,6 +67,7 @@ class HdfFluvialPluvial:
     """
 
     @staticmethod
+    @log_call
     @standardize_input(file_type='plan_hdf')
     def calculate_fluvial_pluvial_boundary(
         hdf_path: Path, 
@@ -120,14 +122,22 @@ class HdfFluvialPluvial:
                 crs=cell_polygons_gdf.crs
             )
 
-            logger.info("Boundary line calculation completed successfully.")
+            filter_text = f", min_line_length={min_line_length}" if min_line_length is not None else ""
+            logger.info(
+                f"Fluvial/pluvial boundary: {len(boundary_gdf)} line(s), delta_t={delta_t} hr{filter_text}."
+            )
             return boundary_gdf
 
         except Exception as e:
-            logger.error(f"Error calculating fluvial-pluvial boundary lines: {str(e)}")
+            logger.error(
+                f"Error calculating fluvial-pluvial boundary lines for {hdf_path} "
+                f"(delta_t={delta_t} hr, min_line_length={min_line_length}): {str(e)}",
+                exc_info=True,
+            )
             return gpd.GeoDataFrame()
 
     @staticmethod
+    @log_call
     @standardize_input(file_type='plan_hdf')
     def generate_fluvial_pluvial_polygons(
         hdf_path: Path, 
@@ -194,7 +204,14 @@ class HdfFluvialPluvial:
             pluvial_frontier = set(classifications[classifications == 'pluvial'].index)
             
             iteration = 0
-            with tqdm(desc="Region Growing", unit="iter") as pbar:
+            show_progress = getattr(sys.stderr, "isatty", lambda: False)()
+            with tqdm(
+                desc="Region Growing",
+                unit="iter",
+                leave=False,
+                mininterval=1.0,
+                disable=not show_progress,
+            ) as pbar:
                 while fluvial_frontier or pluvial_frontier:
                     iteration += 1
                     
@@ -239,7 +256,7 @@ class HdfFluvialPluvial:
                         "Ambiguous": len(ambiguous_cells)
                     })
             
-            logger.info(f"Region growing completed in {iteration} iterations.")
+            logger.debug(f"Region growing completed in {iteration} iterations.")
             
             # --- 4. Finalization and Dissolving ---
             # Classify any remaining unclassified (likely isolated) cells as ambiguous
@@ -257,7 +274,10 @@ class HdfFluvialPluvial:
                 # Calculate area in acres (1 acre = 4046.8564224 m^2)
                 # If CRS is not projected, warn and skip area filtering
                 if not final_regions_gdf.crs or not final_regions_gdf.crs.is_projected:
-                    logger.warning("CRS is not projected. Area-based filtering skipped.")
+                    logger.warning(
+                        f"CRS is not projected ({final_regions_gdf.crs}); "
+                        f"skipped area filter min_polygon_area_acres={min_polygon_area_acres}."
+                    )
                 else:
                     # Explode to individual polygons for area filtering
                     exploded = final_regions_gdf.explode(index_parts=False, ignore_index=True)
@@ -280,11 +300,27 @@ class HdfFluvialPluvial:
                     final_regions_gdf = exploded.dissolve(by='classification', aggfunc='first').reset_index()
                     logger.debug("Redissolved polygons after reclassification of small areas.")
 
-            logger.info("Polygon generation completed successfully.")
+            component_counts = (
+                final_regions_gdf.explode(index_parts=False)
+                .groupby("classification", sort=True)
+                .size()
+                .to_dict()
+            )
+            class_summary = ", ".join(f"{label}: {count}" for label, count in component_counts.items())
+            logger.info(
+                f"Fluvial/pluvial polygons: {len(final_regions_gdf)} dissolved class(es), "
+                f"delta_t={delta_t} hr, tolerance={temporal_tolerance_hours} hr, "
+                f"iterations={iteration}, components={class_summary}."
+            )
             return final_regions_gdf
             
         except Exception as e:
-            logger.error(f"Error generating fluvial-pluvial polygons: {str(e)}", exc_info=True)
+            logger.error(
+                f"Error generating fluvial-pluvial polygons for {hdf_path} "
+                f"(delta_t={delta_t} hr, tolerance={temporal_tolerance_hours} hr, "
+                f"min_polygon_area_acres={min_polygon_area_acres}): {str(e)}",
+                exc_info=True,
+            )
             return gpd.GeoDataFrame()
         
         

--- a/ras_commander/hdf/HdfHydraulicTables.py
+++ b/ras_commander/hdf/HdfHydraulicTables.py
@@ -89,6 +89,39 @@ class HdfHydraulicTables:
     Property tables provide preprocessed hydraulic properties (area, conveyance,
     wetted perimeter, etc.) as functions of elevation for cross sections and structures.
     """
+    _PROPERTY_TABLES_PATH = '/Geometry/Cross Sections/Property Tables'
+    _REQUIRED_PROPERTY_TABLE_DATASETS = ('XSEC Info', 'XSEC Value')
+    _PREPROCESSOR_GUIDANCE = (
+        "HTAB property tables are created by the HEC-RAS geometry preprocessor; "
+        "run the geometry preprocessor first if you need these data."
+    )
+
+    @staticmethod
+    def _missing_property_table_items(hdf_file: h5py.File) -> list[str]:
+        """Return missing HDF items required for cross-section HTAB reads."""
+        prop_path = HdfHydraulicTables._PROPERTY_TABLES_PATH
+        if prop_path not in hdf_file:
+            return [prop_path]
+
+        prop_tables = hdf_file[prop_path]
+        return [
+            f"{prop_path}/{dataset_name}"
+            for dataset_name in HdfHydraulicTables._REQUIRED_PROPERTY_TABLE_DATASETS
+            if dataset_name not in prop_tables
+        ]
+
+    @staticmethod
+    def _missing_property_tables_message(
+        hdf_path: Path,
+        missing_items: list[str],
+        context: str,
+    ) -> str:
+        missing_text = ", ".join(missing_items)
+        return (
+            f"HTAB property tables not found in {hdf_path.name} for {context}. "
+            f"{HdfHydraulicTables._PREPROCESSOR_GUIDANCE} "
+            f"Missing HDF item(s): {missing_text}."
+        )
 
     @staticmethod
     def _get_xs_index(hdf_file: h5py.File, river: str, reach: str, rs: str) -> Optional[int]:
@@ -133,11 +166,11 @@ class HdfHydraulicTables:
                     logger.debug(f"Found XS at index {i}: {river}/{reach}/RS {rs}")
                     return i
 
-            logger.warning(f"Cross section not found: {river}/{reach}/RS {rs}")
+            logger.debug(f"Cross section not found: {river}/{reach}/RS {rs}")
             return None
 
         except Exception as e:
-            logger.error(f"Error finding XS index: {str(e)}")
+            logger.debug(f"Error finding XS index: {str(e)}")
             return None
 
     @staticmethod
@@ -157,22 +190,22 @@ class HdfHydraulicTables:
             - Returns DataFrame with elevation + 22 other properties
         """
         try:
-            prop_path = '/Geometry/Cross Sections/Property Tables'
+            prop_path = HdfHydraulicTables._PROPERTY_TABLES_PATH
             if prop_path not in hdf_file:
-                logger.error(f"Property Tables path not found: {prop_path}")
+                logger.debug(f"Property Tables path not found: {prop_path}")
                 return None
 
             prop_tables = hdf_file[prop_path]
 
             # Read index info
             if 'XSEC Info' not in prop_tables:
-                logger.error("XSEC Info not found in Property Tables")
+                logger.debug("XSEC Info not found in Property Tables")
                 return None
 
             xsec_info = prop_tables['XSEC Info'][:]
 
             if xs_index >= len(xsec_info):
-                logger.error(f"XS index {xs_index} out of range (max: {len(xsec_info)-1})")
+                logger.debug(f"XS index {xs_index} out of range (max: {len(xsec_info)-1})")
                 return None
 
             # Get start index and count for this XS
@@ -183,7 +216,7 @@ class HdfHydraulicTables:
 
             # Read property table values
             if 'XSEC Value' not in prop_tables:
-                logger.error("XSEC Value not found in Property Tables")
+                logger.debug("XSEC Value not found in Property Tables")
                 return None
 
             xsec_value = prop_tables['XSEC Value']
@@ -231,7 +264,7 @@ class HdfHydraulicTables:
             return df
 
         except Exception as e:
-            logger.error(f"Error extracting property table: {str(e)}")
+            logger.debug(f"Error extracting property table: {str(e)}", exc_info=True)
             return None
 
     @staticmethod
@@ -337,6 +370,16 @@ class HdfHydraulicTables:
                     )
 
                 # Extract property table
+                missing_items = HdfHydraulicTables._missing_property_table_items(hdf)
+                if missing_items:
+                    raise IOError(
+                        HdfHydraulicTables._missing_property_tables_message(
+                            hdf_path,
+                            missing_items,
+                            f"{river}/{reach}/RS {rs}",
+                        )
+                    )
+
                 df = HdfHydraulicTables._extract_property_table(hdf, xs_index)
 
                 if df is None:
@@ -354,7 +397,7 @@ class HdfHydraulicTables:
         except ValueError:
             raise
         except Exception as e:
-            logger.error(f"Error reading property table from HDF: {str(e)}")
+            logger.error(f"Error reading HTAB property table from {hdf_path.name}: {str(e)}")
             raise IOError(f"Failed to read property table: {str(e)}")
 
     @staticmethod
@@ -413,6 +456,7 @@ class HdfHydraulicTables:
 
         try:
             all_htabs = {}
+            failed_htabs = []
 
             with h5py.File(hdf_path, 'r') as hdf:
                 # Read attributes to get all river/reach/RS combinations
@@ -422,6 +466,17 @@ class HdfHydraulicTables:
                     return all_htabs
 
                 attrs = hdf[attrs_path][:]
+
+                missing_items = HdfHydraulicTables._missing_property_table_items(hdf)
+                if missing_items:
+                    logger.error(
+                        HdfHydraulicTables._missing_property_tables_message(
+                            hdf_path,
+                            missing_items,
+                            "all cross sections",
+                        )
+                    )
+                    return all_htabs
 
                 # Extract property table for each cross section
                 for i, attr in enumerate(attrs):
@@ -435,9 +490,19 @@ class HdfHydraulicTables:
                     if df is not None:
                         all_htabs[(river, reach, rs)] = df
                     else:
-                        logger.warning(f"Failed to extract HTAB for {river}/{reach}/RS {rs}")
+                        failed_htabs.append(f"{river}/{reach}/RS {rs}")
 
-            logger.info(f"Extracted {len(all_htabs)} property tables from {hdf_path.name}")
+            if failed_htabs:
+                preview = ", ".join(failed_htabs[:5])
+                more_text = f", ... plus {len(failed_htabs) - 5} more" if len(failed_htabs) > 5 else ""
+                logger.warning(
+                    f"Skipped {len(failed_htabs)}/{len(attrs)} HTAB property table(s) "
+                    f"from {hdf_path.name}; first failures: {preview}{more_text}"
+                )
+                logger.debug(f"Skipped HTAB cross sections from {hdf_path}: {failed_htabs}")
+
+            if all_htabs:
+                logger.info(f"Extracted {len(all_htabs)} HTAB property table(s) from {hdf_path.name}")
 
             return all_htabs
 

--- a/ras_commander/hdf/HdfInfiltration.py
+++ b/ras_commander/hdf/HdfInfiltration.py
@@ -73,6 +73,39 @@ class HdfInfiltration:
     SQM_TO_ACRE = 0.000247105
     SQM_TO_SQMILE = 3.861e-7
 
+    @staticmethod
+    def _format_log_samples(items: List[str], max_items: int = 5) -> str:
+        """Return a compact sample list for aggregate log messages."""
+        sample = ", ".join(str(item) for item in items[:max_items])
+        if len(items) > max_items:
+            sample = f"{sample}, ... plus {len(items) - max_items} more"
+        return sample
+
+    @staticmethod
+    def _log_raster_mesh_diagnostics(
+        raster_label: str,
+        total_meshes: int,
+        no_stats_meshes: List[str],
+        nodata_only_meshes: List[str],
+        mesh_errors: List[str],
+    ) -> None:
+        """Emit concise raster-stat diagnostic summaries after mesh loops."""
+        if no_stats_meshes:
+            logger.warning(
+                f"No {raster_label} raster stats for {len(no_stats_meshes)}/{total_meshes} "
+                f"2D flow area(s); first: {HdfInfiltration._format_log_samples(no_stats_meshes)}"
+            )
+        if nodata_only_meshes:
+            logger.warning(
+                f"Only NoData {raster_label} pixels for {len(nodata_only_meshes)}/{total_meshes} "
+                f"2D flow area(s); first: {HdfInfiltration._format_log_samples(nodata_only_meshes)}"
+            )
+        if mesh_errors:
+            logger.warning(
+                f"Failed {raster_label} raster statistics for {len(mesh_errors)}/{total_meshes} "
+                f"2D flow area(s); first: {HdfInfiltration._format_log_samples(mesh_errors)}"
+            )
+
     # Valid infiltration variables for preprocessed cell-level data
     INFILTRATION_VARIABLES = [
         'Curve Number', 'Abstraction Ratio', 'Minimum Infiltration Rate',
@@ -298,7 +331,7 @@ class HdfInfiltration:
             with h5py.File(hdf_path, 'r') as hdf_file:
                 table_path = '/Geometry/Infiltration/Base Overrides'
                 if table_path not in hdf_file:
-                    logger.warning(f"No infiltration data found in {hdf_path}")
+                    logger.debug(f"No infiltration data found in {hdf_path}")
                     return None
 
                 # Get column info
@@ -353,7 +386,7 @@ class HdfInfiltration:
             with h5py.File(hdf_path, 'r') as hdf_file:
                 attrs_path = "Geometry/Infiltration/Attributes"
                 if attrs_path not in hdf_file:
-                    logger.warning(f"No infiltration attributes found in {hdf_path}")
+                    logger.debug(f"No infiltration attributes found in {hdf_path}")
                     return None
 
                 data = hdf_file[attrs_path][()]
@@ -395,7 +428,7 @@ class HdfInfiltration:
                 attrs_path = "Geometry/Infiltration/Attributes"
 
                 if variables_path not in hdf_file or attrs_path not in hdf_file:
-                    logger.warning(f"No infiltration variables or attributes found in {hdf_path}")
+                    logger.debug(f"No infiltration variables or attributes found in {hdf_path}")
                     return None
 
                 # Read region names
@@ -715,7 +748,7 @@ class HdfInfiltration:
             'Minimum Infiltration Rate': np.full(n_overrides, -9999.0),
         })
 
-        logger.info(
+        logger.debug(
             f"Created Infiltration group in {hdf_path}: "
             f"{n_regions} region(s), {n_overrides} override rows "
             f"({len(lc_class_names)} land cover classes x {len(soil_groups)} soil groups)"
@@ -861,7 +894,7 @@ class HdfInfiltration:
                 else:
                     result_df[col] = structured_array[col]
 
-            logger.info(f"Successfully wrote {len(result_df)} infiltration base override rows to {hdf_path}")
+            logger.debug(f"Successfully wrote {len(result_df)} infiltration base override rows to {hdf_path}")
             return result_df
 
         except ValueError:
@@ -1189,6 +1222,10 @@ class HdfInfiltration:
             
             # List to store all results
             all_results = []
+            total_meshes = len(mesh_areas)
+            no_stats_meshes = []
+            nodata_only_meshes = []
+            mesh_errors = []
             
             # Calculate zonal statistics for each 2D flow area
             for _, mesh_row in mesh_areas.iterrows():
@@ -1207,7 +1244,8 @@ class HdfInfiltration:
                     
                     # Skip if no stats
                     if not stats:
-                        logger.warning(f"No soil data found for 2D flow area: {mesh_name}")
+                        no_stats_meshes.append(mesh_name)
+                        logger.debug(f"No soil data found for 2D flow area: {mesh_name}")
                         continue
 
                     area_by_value, total_area_sqm = (
@@ -1218,7 +1256,8 @@ class HdfInfiltration:
                         )
                     )
                     if not area_by_value:
-                        logger.warning(
+                        nodata_only_meshes.append(mesh_name)
+                        logger.debug(
                             f"No non-NoData soil pixels found for 2D flow area: "
                             f"{mesh_name}"
                         )
@@ -1243,8 +1282,20 @@ class HdfInfiltration:
                             'area_sqmiles': area_sqm * HdfInfiltration.SQM_TO_SQMILE
                         })
                 except Exception as e:
-                    logger.error(f"Error calculating statistics for mesh {mesh_name}: {str(e)}")
+                    mesh_errors.append(mesh_name)
+                    logger.debug(
+                        f"Error calculating soil statistics for mesh {mesh_name}: {str(e)}",
+                        exc_info=True,
+                    )
                     continue
+
+            HdfInfiltration._log_raster_mesh_diagnostics(
+                "soil",
+                total_meshes,
+                no_stats_meshes,
+                nodata_only_meshes,
+                mesh_errors,
+            )
         
         # Create DataFrame with results
         results_df = pd.DataFrame(all_results)
@@ -1400,6 +1451,9 @@ class HdfInfiltration:
         
         # List to store all results
         all_results = []
+        total_meshes = len(mesh_areas)
+        no_stats_meshes = []
+        mesh_errors = []
         
         # Read the raster data
         try:
@@ -1431,7 +1485,8 @@ class HdfInfiltration:
                         
                         # Skip if no stats
                         if not landcover_stats or not soil_stats:
-                            logger.warning(f"No land cover or soil data found for 2D flow area: {mesh_name}")
+                            no_stats_meshes.append(mesh_name)
+                            logger.debug(f"No land cover or soil data found for 2D flow area: {mesh_name}")
                             continue
                         
                         # Calculate total area
@@ -1452,7 +1507,7 @@ class HdfInfiltration:
                         for lc_id, lc_pct in landcover_pct.items():
                             lc_name = landcover_map.get(int(lc_id), f"Unknown-{lc_id}")
                             
-                            for soil_id, soil_pct in soil_pct.items():
+                            for soil_id, soil_fraction in soil_pct.items():
                                 try:
                                     soil_name = soil_map.get(int(soil_id), f"Unknown-{soil_id}")
                                 except (ValueError, TypeError):
@@ -1460,7 +1515,7 @@ class HdfInfiltration:
                                 
                                 # Calculate combined percentage (approximate)
                                 # This is a simplification; actual overlap would require pixel-by-pixel analysis
-                                combined_pct = lc_pct * soil_pct * 100
+                                combined_pct = lc_pct * soil_fraction * 100
                                 combined_area_sqm = mesh_area_sqm * (combined_pct / 100)
                                 
                                 # Create combined name
@@ -1493,8 +1548,19 @@ class HdfInfiltration:
                                     'min_infiltration_rate': min_infiltration_rate
                                 })
                     except Exception as e:
-                        logger.error(f"Error calculating statistics for mesh {mesh_name}: {str(e)}")
+                        mesh_errors.append(mesh_name)
+                        logger.debug(
+                            f"Error calculating land cover/soil statistics for mesh {mesh_name}: {str(e)}",
+                            exc_info=True,
+                        )
                         continue
+                HdfInfiltration._log_raster_mesh_diagnostics(
+                    "land cover/soil",
+                    total_meshes,
+                    no_stats_meshes,
+                    [],
+                    mesh_errors,
+                )
         except Exception as e:
             logger.error(f"Error opening raster files: {str(e)}")
             return pd.DataFrame()
@@ -1653,6 +1719,9 @@ class HdfInfiltration:
         
         # List to store all results
         all_results = []
+        total_meshes = len(mesh_areas)
+        no_stats_meshes = []
+        mesh_errors = []
         
         # Read the raster data
         try:
@@ -1684,7 +1753,8 @@ class HdfInfiltration:
                         
                         # Skip if no stats
                         if not landcover_stats or not soil_stats:
-                            logger.warning(f"No land cover or soil data found for 2D flow area: {mesh_name}")
+                            no_stats_meshes.append(mesh_name)
+                            logger.debug(f"No land cover or soil data found for 2D flow area: {mesh_name}")
                             continue
                         
                         # Calculate total area
@@ -1705,7 +1775,7 @@ class HdfInfiltration:
                         for lc_id, lc_pct in landcover_pct.items():
                             lc_name = landcover_map.get(int(lc_id), f"Unknown-{lc_id}")
                             
-                            for soil_id, soil_pct in soil_pct.items():
+                            for soil_id, soil_fraction in soil_pct.items():
                                 try:
                                     soil_name = soil_map.get(int(soil_id), f"Unknown-{soil_id}")
                                 except (ValueError, TypeError):
@@ -1713,7 +1783,7 @@ class HdfInfiltration:
                                 
                                 # Calculate combined percentage (approximate)
                                 # This is a simplification; actual overlap would require pixel-by-pixel analysis
-                                combined_pct = lc_pct * soil_pct * 100
+                                combined_pct = lc_pct * soil_fraction * 100
                                 combined_area_sqm = mesh_area_sqm * (combined_pct / 100)
                                 
                                 # Create combined name
@@ -1746,8 +1816,19 @@ class HdfInfiltration:
                                     'min_infiltration_rate': min_infiltration_rate
                                 })
                     except Exception as e:
-                        logger.error(f"Error calculating statistics for mesh {mesh_name}: {str(e)}")
+                        mesh_errors.append(mesh_name)
+                        logger.debug(
+                            f"Error calculating land cover/soil statistics for mesh {mesh_name}: {str(e)}",
+                            exc_info=True,
+                        )
                         continue
+                HdfInfiltration._log_raster_mesh_diagnostics(
+                    "land cover/soil",
+                    total_meshes,
+                    no_stats_meshes,
+                    [],
+                    mesh_errors,
+                )
         except Exception as e:
             logger.error(f"Error opening raster files: {str(e)}")
             return pd.DataFrame()
@@ -2116,6 +2197,11 @@ class HdfInfiltration:
         
         # List to store all results
         all_results = []
+        total_meshes = len(mesh_areas)
+        no_stats_meshes = []
+        nodata_only_meshes = []
+        mesh_errors = []
+        value_errors = []
         
         # Read the raster data and info
         try:
@@ -2139,7 +2225,8 @@ class HdfInfiltration:
                         
                         # Skip if no stats
                         if not stats:
-                            logger.warning(f"No land cover data found for 2D flow area: {mesh_name}")
+                            no_stats_meshes.append(mesh_name)
+                            logger.debug(f"No land cover data found for 2D flow area: {mesh_name}")
                             continue
 
                         area_by_value, total_area_sqm = (
@@ -2150,7 +2237,8 @@ class HdfInfiltration:
                             )
                         )
                         if not area_by_value:
-                            logger.warning(
+                            nodata_only_meshes.append(mesh_name)
+                            logger.debug(
                                 f"No non-NoData land cover pixels found for 2D "
                                 f"flow area: {mesh_name}"
                             )
@@ -2180,11 +2268,32 @@ class HdfInfiltration:
                                     'percent_impervious': percent_impervious
                                 })
                             except Exception as e:
-                                logger.warning(f"Error processing raster value {raster_val}: {e}")
+                                value_errors.append(f"{mesh_name}/{raster_val}")
+                                logger.debug(
+                                    f"Error processing land cover raster value {raster_val} "
+                                    f"for mesh {mesh_name}: {e}",
+                                    exc_info=True,
+                                )
                                 continue
                     except Exception as e:
-                        logger.error(f"Error calculating statistics for mesh {mesh_name}: {str(e)}")
+                        mesh_errors.append(mesh_name)
+                        logger.debug(
+                            f"Error calculating land cover statistics for mesh {mesh_name}: {str(e)}",
+                            exc_info=True,
+                        )
                         continue
+                HdfInfiltration._log_raster_mesh_diagnostics(
+                    "land cover",
+                    total_meshes,
+                    no_stats_meshes,
+                    nodata_only_meshes,
+                    mesh_errors,
+                )
+                if value_errors:
+                    logger.warning(
+                        f"Skipped {len(value_errors)} land cover raster value(s) during "
+                        f"stats processing; first: {HdfInfiltration._format_log_samples(value_errors)}"
+                    )
         except ValueError:
             raise
         except Exception as e:

--- a/ras_commander/hdf/HdfLandCover.py
+++ b/ras_commander/hdf/HdfLandCover.py
@@ -43,6 +43,12 @@ from .HdfUtils import HdfUtils
 logger = get_logger(__name__)
 
 
+def _path_name(path: Union[str, Path]) -> str:
+    """Return a concise path label for default log messages."""
+    path = Path(path)
+    return path.name or str(path)
+
+
 class HdfLandCover:
     """
     Final Manning's n computation from land cover, base values, and calibration regions.
@@ -95,7 +101,7 @@ class HdfLandCover:
             with h5py.File(hdf_path, 'r') as hdf_file:
                 areas_path = "Geometry/2D Flow Areas"
                 if areas_path not in hdf_file:
-                    logger.warning(f"No 2D Flow Areas found in {hdf_path}")
+                    logger.debug(f"No 2D Flow Areas found in {hdf_path}")
                     return pd.DataFrame(columns=['mesh_name', 'cell_id', 'mannings_n'])
 
                 areas_group = hdf_file[areas_path]
@@ -164,7 +170,7 @@ class HdfLandCover:
             with h5py.File(hdf_path, 'r') as hdf_file:
                 table_path = "Geometry/Land Cover (Manning's n)/Calibration Table"
                 if table_path not in hdf_file:
-                    logger.warning(f"No Manning's n calibration table in {hdf_path}")
+                    logger.debug(f"No Manning's n calibration table in {hdf_path}")
                     return None
 
                 data = hdf_file[table_path][()]
@@ -274,7 +280,7 @@ class HdfLandCover:
             with h5py.File(hdf_path, 'r') as hdf_file:
                 lc_path = "Geometry/Land Cover (Manning's n)"
                 if lc_path not in hdf_file:
-                    logger.warning(f"No Land Cover (Manning's n) group in {hdf_path}")
+                    logger.debug(f"No Land Cover (Manning's n) group in {hdf_path}")
                     return gpd.GeoDataFrame()
 
                 lc_group = hdf_file[lc_path]
@@ -282,7 +288,7 @@ class HdfLandCover:
                 if ("Polygon Info" not in lc_group or
                     "Attributes" not in lc_group or
                     "Polygon Points" not in lc_group):
-                    logger.warning(f"Missing polygon datasets in {lc_path}")
+                    logger.debug(f"Missing polygon datasets in {lc_path}")
                     return gpd.GeoDataFrame()
 
                 attrs = lc_group["Attributes"][()]
@@ -293,12 +299,13 @@ class HdfLandCover:
                     area_names = np.vectorize(HdfUtils.convert_ras_string)(attrs["2D Area Name"])
 
                 geoms = []
+                missing_parts_regions = []
                 for pnt_start, pnt_cnt, part_start, part_cnt in lc_group["Polygon Info"][()]:
                     points = lc_group["Polygon Points"][()][pnt_start:pnt_start + pnt_cnt]
                     if part_cnt == 1:
                         geoms.append(Polygon(points))
                     elif "Polygon Parts" not in lc_group:
-                        logger.warning("Multi-part polygon but 'Polygon Parts' dataset missing")
+                        missing_parts_regions.append(len(geoms))
                         geoms.append(Polygon(points))
                     else:
                         parts = lc_group["Polygon Parts"][()][part_start:part_start + part_cnt]
@@ -308,6 +315,17 @@ class HdfLandCover:
                         else:
                             # First ring is exterior, rest are holes
                             geoms.append(Polygon(rings[0], rings[1:]))
+
+                if missing_parts_regions:
+                    logger.warning(
+                        "'Polygon Parts' dataset missing for "
+                        f"{len(missing_parts_regions)} multi-part Manning's n "
+                        "calibration polygon(s); using raw point order as polygon shells"
+                    )
+                    logger.debug(
+                        "Manning's n calibration polygon indices missing parts: "
+                        f"{missing_parts_regions}"
+                    )
 
                 data = {
                     "region_id": range(len(names)),
@@ -404,7 +422,11 @@ class HdfLandCover:
                         rmap_path = candidate
                         break
                 if rmap_path is None:
-                    logger.warning(f"No Raster Map found in {landcover_hdf_path}")
+                    logger.warning(
+                        "No Raster Map dataset found in land cover sidecar "
+                        f"{_path_name(landcover_hdf_path)}"
+                    )
+                    logger.debug(f"Land cover sidecar missing Raster Map: {landcover_hdf_path}")
                     return None
 
                 rmap_data = hdf_file[rmap_path][()]
@@ -418,7 +440,11 @@ class HdfLandCover:
                         vars_path = candidate
                         break
                 if vars_path is None:
-                    logger.warning(f"No Variables found in {landcover_hdf_path}")
+                    logger.warning(
+                        "No Variables dataset found in land cover sidecar "
+                        f"{_path_name(landcover_hdf_path)}"
+                    )
+                    logger.debug(f"Land cover sidecar missing Variables: {landcover_hdf_path}")
                     return None
 
                 vars_data = hdf_file[vars_path][()]
@@ -539,7 +565,7 @@ class HdfLandCover:
 
         backup_path = Path(str(hdf_path) + '.bak')
         shutil.copy2(hdf_path, backup_path)
-        logger.info(f"Created backup for land cover sidecar: {backup_path}")
+        logger.debug(f"Created backup for land cover sidecar: {backup_path}")
 
         sidecar_format = HdfLandCover._detect_sidecar_format(hdf_path)
         class_names: List[str] = []
@@ -742,9 +768,13 @@ class HdfLandCover:
 
         actually_changed = sum(1 for d in class_details if d['value_changed'])
         logger.info(
-            f"Completed land cover update for {hdf_path}: "
+            f"Updated land cover sidecar {hdf_path.name}: "
             f"format={sidecar_format}, changed={actually_changed}, "
             f"unchanged={len(class_names) - len(normalized_mapping)}"
+        )
+        logger.debug(
+            f"Completed land cover update for {hdf_path}: "
+            f"backup={backup_path}"
         )
 
         return {
@@ -912,7 +942,12 @@ class HdfLandCover:
                 if lc_path.exists():
                     return lc_path
                 else:
-                    logger.warning(f"Land cover file not found: {lc_path}")
+                    logger.warning(
+                        "Land cover sidecar "
+                        f"{_path_name(lc_path)} referenced by "
+                        f"{_path_name(hdf_path)} was not found"
+                    )
+                    logger.debug(f"Resolved land cover sidecar path does not exist: {lc_path}")
                     return None
 
         except Exception as e:
@@ -964,7 +999,11 @@ class HdfLandCover:
         if landcover_hdf_path is None:
             landcover_hdf_path = HdfLandCover.get_landcover_association(hdf_path)
             if landcover_hdf_path is None:
-                logger.error("Cannot resolve land cover HDF path")
+                logger.error(
+                    "No land cover sidecar association found in "
+                    f"{_path_name(hdf_path)}; assign one in RASMapper Manage "
+                    "Associations before computing final Manning's n raster"
+                )
                 return None
         landcover_hdf_path = Path(landcover_hdf_path)
 
@@ -978,10 +1017,17 @@ class HdfLandCover:
             if candidates:
                 lc_tif_path = candidates[0]
             else:
-                logger.error(f"Land cover TIF not found for {landcover_hdf_path}")
+                logger.error(
+                    "Land cover TIF not found for sidecar "
+                    f"{_path_name(landcover_hdf_path)}"
+                )
+                logger.debug(f"Expected land cover TIF next to: {landcover_hdf_path}")
                 return None
 
-        logger.info(f"Reading land cover TIF: {lc_tif_path.name} ({lc_tif_path.stat().st_size / 1024 / 1024:.0f} MB)")
+        logger.debug(
+            f"Reading land cover TIF: {lc_tif_path.name} "
+            f"({lc_tif_path.stat().st_size / 1024 / 1024:.0f} MB)"
+        )
 
         # Step 1: Read the raster map (pixel_id → class_name → base_n)
         raster_map = HdfLandCover.get_landcover_raster_map(landcover_hdf_path)
@@ -1146,6 +1192,7 @@ class HdfLandCover:
                     out = final_raster.copy()
                     out[out == 0] = -9999.0
                     dst.write(out, 1)
-                logger.info(f"Wrote final Manning's n raster to {output_tif_path}")
+                logger.info(f"Wrote final Manning's n raster: {output_tif_path.name}")
+                logger.debug(f"Wrote final Manning's n raster to {output_tif_path}")
 
         return final_raster

--- a/ras_commander/hdf/HdfMesh.py
+++ b/ras_commander/hdf/HdfMesh.py
@@ -410,7 +410,7 @@ class HdfMesh:
                             logger.warning(f"Error converting attribute '{name}': {str(e)}")
                     return pd.DataFrame.from_dict(result, orient='index', columns=['Value'])
                 else:
-                    logger.info("No 2D Flow Area attributes found or invalid dataset.")
+                    logger.debug("No 2D Flow Area attributes found or invalid dataset.")
                     return pd.DataFrame()  # Return an empty DataFrame
         except Exception as e:
             logger.error(f"Error reading 2D flow area attributes from {hdf_path}: {str(e)}")
@@ -455,6 +455,10 @@ class HdfMesh:
             with h5py.File(hdf_path, 'r') as hdf_file:
                 mesh_area_names = HdfMesh.get_mesh_area_names(hdf_path)
                 if not mesh_area_names:
+                    logger.error(
+                        f"No 2D mesh areas found in {hdf_path}; this API "
+                        "requires a geometry HDF with 2D Flow Areas."
+                    )
                     return {}
 
                 result = {}
@@ -464,7 +468,12 @@ class HdfMesh:
                     values_path = f"{base_path}/Faces Area Elevation Values"
 
                     if info_path not in hdf_file or values_path not in hdf_file:
-                        logger.warning(f"Face property tables not found for mesh '{mesh_name}'")
+                        logger.error(
+                            f"Face property tables not found for mesh '{mesh_name}'; "
+                            "run the geometry preprocessor to create "
+                            "'Faces Area Elevation Info' and "
+                            "'Faces Area Elevation Values' before using this API."
+                        )
                         result[mesh_name] = pd.DataFrame(columns=['Face ID', 'Elevation', 'Area', 'Wetted Perimeter', "Manning's n"])
                         continue
 
@@ -1045,6 +1054,10 @@ class HdfMesh:
             with h5py.File(hdf_path, 'r') as hdf_file:
                 mesh_area_names = HdfMesh.get_mesh_area_names(hdf_path)
                 if not mesh_area_names:
+                    logger.error(
+                        f"No 2D mesh areas found in {hdf_path}; this API "
+                        "requires a geometry HDF with 2D Flow Areas."
+                    )
                     return {}
 
                 result = {}
@@ -1054,7 +1067,12 @@ class HdfMesh:
                     values_path = f"{base_path}/Cells Volume Elevation Values"
 
                     if info_path not in hdf_file or values_path not in hdf_file:
-                        logger.warning(f"Cell property tables not found for mesh '{mesh_name}'")
+                        logger.error(
+                            f"Cell volume/elevation tables not found for mesh "
+                            f"'{mesh_name}'; run the geometry preprocessor to "
+                            "create 'Cells Volume Elevation Info' and "
+                            "'Cells Volume Elevation Values' before using this API."
+                        )
                         result[mesh_name] = pd.DataFrame(columns=['Cell ID', 'Elevation', 'Volume'])
                         continue
 
@@ -1390,7 +1408,7 @@ class HdfMesh:
 
         # Create result GeoDataFrame
         if not selected_indices:
-            logger.info("No faces found along profile line with given thresholds")
+            logger.debug("No faces found along profile line with given thresholds")
             result = faces.iloc[0:0].copy()  # Empty GeoDataFrame with same structure
             result['distance_along_profile'] = []
             result['angle_to_profile'] = []
@@ -1409,7 +1427,7 @@ class HdfMesh:
         if order_by_distance:
             result = result.sort_values('distance_along_profile').reset_index(drop=True)
 
-        logger.info(f"Found {len(result)} faces along profile line")
+        logger.debug(f"Found {len(result)} faces along profile line")
         return result
 
     @staticmethod
@@ -1542,7 +1560,10 @@ class HdfMesh:
                 # Get mesh area names
                 mesh_area_names = HdfMesh.get_mesh_area_names(hdf_path)
                 if not mesh_area_names:
-                    logger.warning(f"No 2D mesh areas found in {hdf_path}")
+                    logger.error(
+                        f"No 2D mesh areas found in {hdf_path}; this API "
+                        "requires a geometry HDF with 2D Flow Areas."
+                    )
                     return {}
 
                 # Select mesh
@@ -1635,7 +1656,11 @@ class HdfMesh:
             with h5py.File(hdf_path, 'r') as hdf_file:
                 table_path = "Geometry/Land Cover (Manning's n)/Calibration Table"
                 if table_path not in hdf_file:
-                    logger.warning(f"No Manning's n calibration table found in {hdf_path}")
+                    logger.error(
+                        f"No Manning's n calibration table found in {hdf_path}; "
+                        "create Manning's n calibration regions before using "
+                        "this API."
+                    )
                     return None
 
                 data = hdf_file[table_path][()]
@@ -2374,7 +2399,7 @@ class HdfMesh:
         else:
             raise ValueError(f"method must be 'midpoint' or 'any_vertex', got '{method}'")
 
-        logger.info(
+        logger.debug(
             f"Found {len(matching_ids)} faces in polygon "
             f"(mesh '{mesh_name}', method='{method}')"
         )

--- a/ras_commander/hdf/HdfPipe.py
+++ b/ras_commander/hdf/HdfPipe.py
@@ -34,9 +34,41 @@ from .HdfUtils import HdfUtils
 from ..Decorators import standardize_input, log_call
 from ..LoggingConfig import get_logger
 from .HdfResultsMesh import HdfResultsMesh
-import logging  
 
 logger = get_logger(__name__)
+
+
+_PIPE_GEOMETRY_PREPROCESSOR_ACTION = (
+    "Run the HEC-RAS geometry preprocessor, then retry if pipe geometry data is expected."
+)
+_PIPE_RESULTS_ACTION = (
+    "Compute the plan with pipe-network output enabled, or request an available pipe-network variable."
+)
+
+
+def _missing_hdf_object_message(context: str, hdf_path: str, action: str) -> str:
+    return f"{context} requires HDF object '{hdf_path}', but it was not found. {action}"
+
+
+def _format_available_items(items: List[str], max_items: int = 12) -> str:
+    if not items:
+        return "none"
+
+    shown = items[:max_items]
+    suffix = f", ... ({len(items) - max_items} more)" if len(items) > max_items else ""
+    return ", ".join(shown) + suffix
+
+
+def _list_hdf_datasets(group: h5py.Group) -> List[str]:
+    datasets = []
+
+    def collect_dataset(name, obj):
+        if isinstance(obj, h5py.Dataset):
+            datasets.append(name)
+
+    group.visititems(collect_dataset)
+    return sorted(datasets)
+
 
 class HdfPipe:
     """
@@ -69,9 +101,24 @@ class HdfPipe:
             - Terrain_Profiles: List of (station, elevation) tuples
         """
         with h5py.File(hdf_path, 'r') as f:
+            if '/Geometry/Pipe Conduits' not in f:
+                raise KeyError(_missing_hdf_object_message(
+                    "Pipe conduit extraction",
+                    "/Geometry/Pipe Conduits",
+                    _PIPE_GEOMETRY_PREPROCESSOR_ACTION,
+                ))
+
             group = f['/Geometry/Pipe Conduits/']
             
             # --- Read and Process Attributes ---
+            for dataset_name in ["Attributes", "Polyline Info", "Polyline Points"]:
+                if dataset_name not in group:
+                    raise KeyError(_missing_hdf_object_message(
+                        "Pipe conduit extraction",
+                        f"/Geometry/Pipe Conduits/{dataset_name}",
+                        _PIPE_GEOMETRY_PREPROCESSOR_ACTION,
+                    ))
+
             attributes = group['Attributes'][:]
             attr_df = pd.DataFrame(attributes)
             
@@ -138,24 +185,33 @@ class HdfPipe:
 
         Returns:
             gpd.GeoDataFrame: GeoDataFrame containing pipe node attributes and
-                Point geometries.  Returns an empty GeoDataFrame if the
-                ``Geometry/Pipe Nodes`` group does not exist.
+                Point geometries.
 
         Raises:
-            KeyError: If the group exists but required datasets are missing.
+            KeyError: If the required pipe node geometry datasets are missing.
 
         Example:
             >>> nodes_gdf = HdfPipe.get_pipe_nodes("path/to/plan.hdf")
         """
         with h5py.File(hdf_path, 'r') as f:
-            # --- Gracefully handle missing group ---
             if '/Geometry/Pipe Nodes' not in f:
-                logger.warning("Geometry/Pipe Nodes group not found in HDF file")
-                return gpd.GeoDataFrame()
+                raise KeyError(_missing_hdf_object_message(
+                    "Pipe node extraction",
+                    "/Geometry/Pipe Nodes",
+                    _PIPE_GEOMETRY_PREPROCESSOR_ACTION,
+                ))
 
             group = f['/Geometry/Pipe Nodes/']
 
             # --- Read and Process Attributes ---
+            for dataset_name in ["Attributes", "Points"]:
+                if dataset_name not in group:
+                    raise KeyError(_missing_hdf_object_message(
+                        "Pipe node extraction",
+                        f"/Geometry/Pipe Nodes/{dataset_name}",
+                        _PIPE_GEOMETRY_PREPROCESSOR_ACTION,
+                    ))
+
             attributes = group['Attributes'][:]
             attr_df = pd.DataFrame(attributes)
 
@@ -228,7 +284,7 @@ class HdfPipe:
                 frames.append(df)
 
         if not frames:
-            logger.warning("No inlet attribute data found in HDF file")
+            logger.debug("No inlet attribute data found in HDF file")
             return pd.DataFrame()
 
         return pd.concat(frames, ignore_index=True)
@@ -253,9 +309,23 @@ class HdfPipe:
             - Associated attributes
         """
         with h5py.File(hdf_path, 'r') as f:
+            if '/Geometry/Pipe Networks' not in f:
+                raise KeyError(_missing_hdf_object_message(
+                    "Pipe network extraction",
+                    "/Geometry/Pipe Networks",
+                    _PIPE_GEOMETRY_PREPROCESSOR_ACTION,
+                ))
+
             pipe_networks_group = f['/Geometry/Pipe Networks/']
-            
+
             # --- Determine Pipe Network to Use ---
+            if "Attributes" not in pipe_networks_group:
+                raise KeyError(_missing_hdf_object_message(
+                    "Pipe network extraction",
+                    "/Geometry/Pipe Networks/Attributes",
+                    _PIPE_GEOMETRY_PREPROCESSOR_ACTION,
+                ))
+
             attributes = pipe_networks_group['Attributes'][:]
             attr_df = pd.DataFrame(attributes)
             
@@ -271,11 +341,54 @@ class HdfPipe:
             
             # Get the name of the selected pipe network
             selected_network_name = attr_df.at[network_idx, 'Name']
-            logging.info(f"Selected Pipe Network: {selected_network_name}")
+            logger.debug("Selected pipe network: %s", selected_network_name)
             
             # Access the selected pipe network group
-            network_group_path = f"/Geometry/Pipe Networks/{selected_network_name}/"
+            network_group_path = f"/Geometry/Pipe Networks/{selected_network_name}"
+            if network_group_path not in f:
+                raise KeyError(_missing_hdf_object_message(
+                    "Pipe network extraction",
+                    network_group_path,
+                    _PIPE_GEOMETRY_PREPROCESSOR_ACTION,
+                ))
+
             network_group = f[network_group_path]
+
+            required_network_datasets = [
+                "Cell Polygons Info",
+                "Cell Polygons Parts",
+                "Cell Polygons Points",
+                "Face Polylines Info",
+                "Face Polylines Parts",
+                "Face Polylines Points",
+                "Node Connectivity Info",
+                "Node Connectivity Values",
+                "Node Indices",
+                "Node Surface Connectivity",
+                "Cell Property Table",
+                "Cells DS Face Indices Info",
+                "Cells DS Face Indices Values",
+                "Cells Face Indices Info",
+                "Cells Face Indices Values",
+                "Cells Minimum Elevations",
+                "Cells Node and Conduit IDs",
+                "Cells US Face Indices Info",
+                "Cells US Face Indices Values",
+                "Conduit Indices",
+                "Face Property Table",
+                "Faces Conduit ID and Stations",
+            ]
+            missing_network_datasets = [
+                f"{network_group_path}/{dataset_name}"
+                for dataset_name in required_network_datasets
+                if dataset_name not in network_group
+            ]
+            if missing_network_datasets:
+                raise KeyError(
+                    "Pipe network extraction found an incomplete pipe network geometry group. "
+                    f"Missing: {_format_available_items(missing_network_datasets)}. "
+                    f"{_PIPE_GEOMETRY_PREPROCESSOR_ACTION}"
+                )
             
             # --- Helper Functions ---
             def decode_bytes(df: pd.DataFrame) -> pd.DataFrame:
@@ -578,33 +691,32 @@ class HdfPipe:
             KeyError: If the required datasets are not found in the HDF file.
             IndexError: If the specified conduit_id is out of range.
         """
-        try:
-            with h5py.File(hdf_path, 'r') as hdf:
-                # Get conduit info
-                terrain_profiles_info = hdf['/Geometry/Pipe Conduits/Terrain Profiles Info'][()]
-                
-                if conduit_id >= len(terrain_profiles_info):
-                    raise IndexError(f"conduit_id {conduit_id} is out of range")
+        profile_info_path = "/Geometry/Pipe Conduits/Terrain Profiles Info"
+        profile_values_path = "/Geometry/Pipe Conduits/Terrain Profiles Values"
 
-                start, count = terrain_profiles_info[conduit_id]
+        with h5py.File(hdf_path, 'r') as hdf:
+            missing_paths = [
+                path for path in [profile_info_path, profile_values_path] if path not in hdf
+            ]
+            if missing_paths:
+                raise KeyError(
+                    "Pipe conduit terrain profile data is absent from the HDF file. "
+                    f"Missing: {_format_available_items(missing_paths)}. "
+                    f"{_PIPE_GEOMETRY_PREPROCESSOR_ACTION}"
+                )
 
-                # Extract profile data
-                profile_values = hdf['/Geometry/Pipe Conduits/Terrain Profiles Values'][start:start+count]
+            terrain_profiles_info = hdf[profile_info_path][()]
 
-                # Create DataFrame
-                df = pd.DataFrame(profile_values, columns=['Station', 'Elevation'])
+            if conduit_id < 0 or conduit_id >= len(terrain_profiles_info):
+                raise IndexError(
+                    f"conduit_id {conduit_id} is out of range for "
+                    f"{len(terrain_profiles_info)} pipe terrain profiles."
+                )
 
-                return df
+            start, count = terrain_profiles_info[conduit_id]
+            profile_values = hdf[profile_values_path][start:start+count]
 
-        except KeyError as e:
-            logger.error(f"Required dataset not found in HDF file: {e}")
-            raise
-        except IndexError as e:
-            logger.error(f"Invalid conduit_id: {e}")
-            raise
-        except Exception as e:
-            logger.error(f"Error extracting pipe profile data: {e}")
-            raise
+            return pd.DataFrame(profile_values, columns=['Station', 'Elevation'])
         
         
    
@@ -635,30 +747,25 @@ class HdfPipe:
         Raises:
             KeyError: If the required datasets are not found in the HDF file.
         """
-        try:
-            with h5py.File(hdf_path, 'r') as hdf:
-                # Extract summary data
-                summary_path = "/Results/Unsteady/Summary/Pipe Network"
-                if summary_path not in hdf:
-                    logger.warning("Pipe Network summary data not found in HDF file")
-                    return pd.DataFrame()
+        with h5py.File(hdf_path, 'r') as hdf:
+            summary_path = "/Results/Unsteady/Summary/Pipe Network"
+            if summary_path not in hdf:
+                raise KeyError(_missing_hdf_object_message(
+                    "Pipe network summary extraction",
+                    summary_path,
+                    "Compute an unsteady plan with pipe-network summary output available, then retry.",
+                ))
 
-                summary_data = hdf[summary_path][()]
-                
-                # Create DataFrame
-                df = pd.DataFrame(summary_data)
+            summary_data = hdf[summary_path][()]
+            df = pd.DataFrame(summary_data)
 
-                # Convert column names
-                df.columns = [col.decode('utf-8') for col in df.columns]
+            # Convert column names
+            df.columns = [
+                col.decode('utf-8') if isinstance(col, bytes) else str(col)
+                for col in df.columns
+            ]
 
-                return df
-
-        except KeyError as e:
-            logger.error(f"Required dataset not found in HDF file: {e}")
-            raise
-        except Exception as e:
-            logger.error(f"Error extracting pipe network summary data: {e}")
-            raise
+            return df
 
 
 
@@ -684,18 +791,19 @@ class HdfPipe:
             - Drop Inlet Flow
             - Water Surface
         """
-        try:
-            node_variables = ["Nodes/Depth", "Nodes/Drop Inlet Flow", "Nodes/Water Surface"]
-            node_data = {}
+        node_variables = ["Nodes/Depth", "Nodes/Drop Inlet Flow", "Nodes/Water Surface"]
+        node_data = {}
 
-            for variable in node_variables:
-                data = HdfPipe.get_pipe_network_timeseries(plan_hdf_path, variable=variable)
+        for variable in node_variables:
+            data = HdfPipe.get_pipe_network_timeseries(plan_hdf_path, variable=variable)
+            try:
                 node_data[variable] = data.sel(location=node_id)
-            
-            return node_data
-        except Exception as e:
-            logger.error(f"Error extracting time series data for node {node_id}: {str(e)}")
-            raise
+            except KeyError as exc:
+                raise KeyError(
+                    f"Pipe node id {node_id} was not found in timeseries variable '{variable}'."
+                ) from exc
+
+        return node_data
 
     @staticmethod
     @log_call
@@ -717,19 +825,20 @@ class HdfPipe:
             - Pipe Flow (US/DS)
             - Velocity (US/DS)
         """
-        try:
-            conduit_variables = ["Pipes/Pipe Flow DS", "Pipes/Pipe Flow US", 
-                                "Pipes/Vel DS", "Pipes/Vel US"]
-            conduit_data = {}
+        conduit_variables = ["Pipes/Pipe Flow DS", "Pipes/Pipe Flow US",
+                            "Pipes/Vel DS", "Pipes/Vel US"]
+        conduit_data = {}
 
-            for variable in conduit_variables:
-                data = HdfPipe.get_pipe_network_timeseries(plan_hdf_path, variable=variable)
+        for variable in conduit_variables:
+            data = HdfPipe.get_pipe_network_timeseries(plan_hdf_path, variable=variable)
+            try:
                 conduit_data[variable] = data.sel(location=conduit_id)
-            
-            return conduit_data
-        except Exception as e:
-            logger.error(f"Error extracting time series data for conduit {conduit_id}: {str(e)}")
-            raise
+            except KeyError as exc:
+                raise KeyError(
+                    f"Pipe conduit id {conduit_id} was not found in timeseries variable '{variable}'."
+                ) from exc
+
+        return conduit_data
 
 
     @staticmethod
@@ -760,48 +869,72 @@ class HdfPipe:
         if variable not in valid_variables:
             raise ValueError(f"Invalid variable. Must be one of: {', '.join(valid_variables)}")
 
-        try:
-            with h5py.File(hdf_path, 'r') as hdf:
-                # Extract timeseries data
-                data_path = f"/Results/Unsteady/Output/Output Blocks/DSS Hydrograph Output/Unsteady Time Series/Pipe Networks/Davis/{variable}"
-                data = hdf[data_path][()]
+        with h5py.File(hdf_path, 'r') as hdf:
+            network_name = "Davis"
+            pipe_networks_path = (
+                "/Results/Unsteady/Output/Output Blocks/DSS Hydrograph Output/"
+                "Unsteady Time Series/Pipe Networks"
+            )
+            network_path = f"{pipe_networks_path}/{network_name}"
+            data_path = f"{network_path}/{variable}"
 
-                # Extract time information - try DSS-specific timestamps first
-                dss_time_path = "/Results/Unsteady/Output/Output Blocks/DSS Hydrograph Output/Unsteady Time Series/Time Date Stamp (ms)"
-
-                if dss_time_path in hdf:
-                    # Use DSS Hydrograph Output timestamps
-                    raw_datetimes = hdf[dss_time_path][:]
-                    time = [HdfUtils.parse_ras_datetime_ms(x.decode("utf-8")) for x in raw_datetimes]
+            if data_path not in hdf:
+                if network_path in hdf:
+                    available = _list_hdf_datasets(hdf[network_path])
+                    available_detail = (
+                        f" Available variables for pipe network '{network_name}': "
+                        f"{_format_available_items(available)}."
+                    )
+                elif pipe_networks_path in hdf:
+                    available_networks = sorted(hdf[pipe_networks_path].keys())
+                    available_detail = (
+                        f" Available pipe networks: {_format_available_items(available_networks)}."
+                    )
                 else:
-                    # Fallback to Base Output timestamps
-                    time = HdfBase.get_unsteady_timestamps(hdf)
+                    available_detail = " No pipe-network timeseries group was found in the HDF file."
 
-                # Verify time dimension matches data, use index if mismatch
-                if len(time) != data.shape[0]:
-                    logger.warning(f"Timestamp count ({len(time)}) doesn't match data time dimension ({data.shape[0]}). Using numeric index.")
-                    time = list(range(data.shape[0]))
-
-                # Create DataArray
-                da = xr.DataArray(
-                    data=data,
-                    dims=['time', 'location'],
-                    coords={'time': time, 'location': range(data.shape[1])},
-                    name=variable
+                raise KeyError(
+                    f"Pipe network timeseries variable '{variable}' was not found "
+                    f"under pipe network '{network_name}'.{available_detail} "
+                    f"{_PIPE_RESULTS_ACTION}"
                 )
 
-                # Add attributes
-                da.attrs['units'] = hdf[data_path].attrs.get('Units', b'').decode('utf-8')
-                da.attrs['variable'] = variable
+            data = hdf[data_path][()]
 
-                return da
+            # Extract time information - try DSS-specific timestamps first
+            dss_time_path = "/Results/Unsteady/Output/Output Blocks/DSS Hydrograph Output/Unsteady Time Series/Time Date Stamp (ms)"
 
-        except KeyError as e:
-            logger.error(f"Required dataset not found in HDF file: {e}")
-            raise
-        except Exception as e:
-            logger.error(f"Error extracting pipe network timeseries data: {e}")
-            raise
+            if dss_time_path in hdf:
+                # Use DSS Hydrograph Output timestamps
+                raw_datetimes = hdf[dss_time_path][:]
+                time = [HdfUtils.parse_ras_datetime_ms(x.decode("utf-8")) for x in raw_datetimes]
+            else:
+                # Fallback to Base Output timestamps
+                time = HdfBase.get_unsteady_timestamps(hdf)
+
+            # Verify time dimension matches data, use index if mismatch
+            if len(time) != data.shape[0]:
+                logger.warning(
+                    "Pipe timeseries timestamp mismatch: timestamps=%d rows=%d; using numeric time index",
+                    len(time),
+                    data.shape[0],
+                )
+                time = list(range(data.shape[0]))
+
+            # Create DataArray
+            da = xr.DataArray(
+                data=data,
+                dims=['time', 'location'],
+                coords={'time': time, 'location': range(data.shape[1])},
+                name=variable
+            )
+
+            # Add attributes
+            units = hdf[data_path].attrs.get('Units', b'')
+            da.attrs['units'] = units.decode('utf-8') if isinstance(units, bytes) else str(units)
+            da.attrs['variable'] = variable
+
+            return da
 
 
 

--- a/ras_commander/hdf/HdfPlan.py
+++ b/ras_commander/hdf/HdfPlan.py
@@ -108,6 +108,8 @@ class HdfPlan:
     Note: This code is partially derived from the rashdf library (https://github.com/fema-ffrd/rashdf)
     under MIT license.
     """
+    _PLAN_PARAMETERS_PATH = "Plan Data/Plan Parameters"
+    _PLAN_INFORMATION_PATH = "Plan Data/Plan Information"
 
     @staticmethod
     @log_call
@@ -235,9 +237,12 @@ class HdfPlan:
         """
         try:
             with h5py.File(hdf_path, 'r') as hdf_file:
-                plan_params_path = "Plan Data/Plan Parameters"
+                plan_params_path = HdfPlan._PLAN_PARAMETERS_PATH
                 if plan_params_path not in hdf_file:
-                    logger.warning(f"Plan Parameters not found in {hdf_path} - may be a steady flow or minimal HDF file")
+                    logger.debug(
+                        "Plan Parameters not found in %s; returning empty parameter table.",
+                        hdf_path.name,
+                    )
                     return pd.DataFrame(columns=['Plan', 'Parameter', 'Value'])
                 
                 # Extract parameters
@@ -273,7 +278,11 @@ class HdfPlan:
                     plan_num = plan_match.group(1)
                 else:
                     plan_num = "00"  # Default if no match found
-                    logger.warning(f"Could not extract plan number from filename: {filename}")
+                    logger.warning(
+                        "Could not extract plan number from filename %s; "
+                        "using fallback Plan value '00'.",
+                        filename,
+                    )
                 
                 df['Plan'] = plan_num
                 
@@ -321,6 +330,80 @@ class HdfPlan:
         return value
 
     @staticmethod
+    def _parse_major_version(version: Any) -> Optional[int]:
+        """
+        Parse the leading major HEC-RAS version number from an HDF attribute.
+        """
+        if version is None:
+            return None
+        match = re.search(r"\d+", str(version))
+        if not match:
+            return None
+        try:
+            return int(match.group(0))
+        except ValueError:
+            return None
+
+    @staticmethod
+    def _get_plan_hdf_program_version(hdf_file: h5py.File) -> Optional[str]:
+        """
+        Return Program Version from the plan information group when present.
+        """
+        info_path = HdfPlan._PLAN_INFORMATION_PATH
+        if info_path not in hdf_file:
+            return None
+        program_version = hdf_file[info_path].attrs.get("Program Version")
+        if program_version is None:
+            return None
+        return str(HdfPlan._decode_hdf_attr_value(program_version))
+
+    @staticmethod
+    def _find_legacy_output_file_for_plan(hdf_path: Path) -> Optional[Path]:
+        """
+        Return a sibling legacy HEC-RAS .O## output file for this plan HDF if present.
+        """
+        match = re.search(r"\.p(?P<plan_number>\d{2})\.hdf$", hdf_path.name, re.IGNORECASE)
+        if not match:
+            return None
+
+        project_name = hdf_path.name[:match.start()]
+        plan_number = match.group("plan_number")
+        for suffix in (f".O{plan_number}", f".o{plan_number}"):
+            candidate = hdf_path.with_name(f"{project_name}{suffix}")
+            if candidate.exists():
+                return candidate
+        return None
+
+    @staticmethod
+    def _missing_plan_parameters_message(hdf_path: Path, hdf_file: h5py.File) -> str:
+        """
+        Build concise guidance for HDF calls that require Plan Parameters.
+        """
+        message_parts = [
+            "HdfPlan.get_2d_flow_options() requires a HEC-RAS 5.x+ computed "
+            "plan HDF containing 'Plan Data/Plan Parameters'.",
+            f"{hdf_path.name} does not contain that group.",
+        ]
+
+        program_version = HdfPlan._get_plan_hdf_program_version(hdf_file)
+        major_version = HdfPlan._parse_major_version(program_version)
+        if program_version and major_version is not None and major_version < 5:
+            message_parts.append(
+                f"Program Version {program_version} indicates HEC-RAS 4.x or earlier."
+            )
+
+        legacy_output = HdfPlan._find_legacy_output_file_for_plan(hdf_path)
+        if legacy_output is not None:
+            message_parts.append(f"Found legacy output file {legacy_output.name}.")
+
+        message_parts.append(
+            "HEC-RAS 4.x and earlier did not produce plan HDF output; those "
+            "results are stored in legacy .O## files and should be accessed "
+            "with RasControl."
+        )
+        return " ".join(message_parts)
+
+    @staticmethod
     @log_call
     @standardize_input(file_type='plan_hdf')
     def get_2d_flow_options(
@@ -361,9 +444,9 @@ class HdfPlan:
 
         try:
             with h5py.File(hdf_path, 'r') as hdf_file:
-                params_path = "Plan Data/Plan Parameters"
+                params_path = HdfPlan._PLAN_PARAMETERS_PATH
                 if params_path not in hdf_file:
-                    raise ValueError(f"Plan Parameters not found in {hdf_path}")
+                    raise ValueError(HdfPlan._missing_plan_parameters_message(hdf_path, hdf_file))
 
                 params_group = hdf_file[params_path]
                 attrs = {
@@ -406,7 +489,7 @@ class HdfPlan:
                         raise ValueError(f"2D flow area '{mesh_name}' not found in {hdf_path.name}")
 
                 plan_info = {}
-                info_path = "Plan Data/Plan Information"
+                info_path = HdfPlan._PLAN_INFORMATION_PATH
                 if info_path in hdf_file:
                     plan_info = {
                         key: HdfPlan._decode_hdf_attr_value(value)
@@ -451,7 +534,10 @@ class HdfPlan:
             with h5py.File(hdf_path, 'r') as hdf_file:
                 precip_path = "Event Conditions/Meteorology/Precipitation"
                 if precip_path not in hdf_file:
-                    logger.error(f"Precipitation data not found in {hdf_path}")
+                    logger.debug(
+                        "Precipitation data not found in %s; returning empty precipitation attributes.",
+                        hdf_path.name,
+                    )
                     return {}
                 
                 attrs = {}
@@ -507,7 +593,7 @@ class HdfPlan:
                     logger.debug(f"Geometry attribute: {key} = {value}")
 
                 logger.debug(f"Successfully extracted {len(attrs)} root level geometry attributes")
-                return pd.DataFrame.from_dict(attrs, orient='index', columns=['Value'])
+                return pd.DataFrame({"Value": pd.Series(attrs, dtype=object)})
 
         except (OSError, RuntimeError) as e:
             logger.error(f"Failed to read HDF file {hdf_path}: {str(e)}")
@@ -548,7 +634,7 @@ class HdfPlan:
                 result = {}
 
                 # Try to get starting WSE method from Plan Parameters
-                plan_params_path = "Plan Data/Plan Parameters"
+                plan_params_path = HdfPlan._PLAN_PARAMETERS_PATH
                 if plan_params_path in hdf_file:
                     plan_params = hdf_file[plan_params_path]
 
@@ -599,7 +685,7 @@ class HdfPlan:
 
                 # If method not found in Plan Parameters, try Plan Information
                 if 'method' not in result:
-                    plan_info_path = "Plan Data/Plan Information"
+                    plan_info_path = HdfPlan._PLAN_INFORMATION_PATH
                     if plan_info_path in hdf_file:
                         plan_info = hdf_file[plan_info_path]
                         for attr_name in ['Flow Regime', 'Simulation Type']:
@@ -611,7 +697,10 @@ class HdfPlan:
 
                 # If still no method found, return indication
                 if 'method' not in result:
-                    logger.warning(f"Starting WSE method not found in {hdf_path}")
+                    logger.debug(
+                        "Starting WSE method not found in %s; returning method='Unknown'.",
+                        hdf_path.name,
+                    )
                     result['method'] = 'Unknown'
                     result['note'] = 'Boundary condition method not found in HDF file'
 

--- a/ras_commander/hdf/HdfPlot.py
+++ b/ras_commander/hdf/HdfPlot.py
@@ -10,8 +10,8 @@ Lazy Loading:
 """
 
 import pandas as pd
-from typing import Optional, Union, Tuple, TYPE_CHECKING
-from ..Decorators import log_call, standardize_input
+from typing import Tuple, TYPE_CHECKING
+from ..Decorators import log_call
 from .HdfUtils import HdfUtils
 
 # Type hints only - not imported at runtime
@@ -37,7 +37,7 @@ class HdfPlot:
         projection: str,
         title: str = '2D Flow Area Mesh Cells',
         figsize: Tuple[int, int] = (12, 8)
-    ) -> Optional['gpd.GeoDataFrame']:
+    ) -> 'gpd.GeoDataFrame':
         """
         Plots the mesh cells from the provided DataFrame and returns the GeoDataFrame.
 
@@ -48,27 +48,25 @@ class HdfPlot:
             figsize (Tuple[int, int], optional): Figure size. Defaults to (12, 8).
 
         Returns:
-            Optional[gpd.GeoDataFrame]: GeoDataFrame containing the mesh cells, or None if no cells found.
+            gpd.GeoDataFrame: GeoDataFrame containing the mesh cells.
+
+        Raises:
+            ValueError: If the input DataFrame is empty.
         """
         # Lazy imports for heavy dependencies
         import matplotlib.pyplot as plt
         import geopandas as gpd
 
         if cell_polygons_df.empty:
-            print("No Cell Polygons found.")
-            return None
+            raise ValueError(
+                "Cannot plot mesh cells because the input DataFrame is empty. "
+                "Provide cell polygon data before calling plot_mesh_cells()."
+            )
 
         # Convert any datetime columns to strings using HdfUtils
         cell_polygons_df = HdfUtils.convert_df_datetimes_to_str(cell_polygons_df)
 
         cell_polygons_gdf = gpd.GeoDataFrame(cell_polygons_df, crs=projection)
-
-        print("Cell Polygons CRS:", cell_polygons_gdf.crs)
-        try:
-            display(cell_polygons_gdf.head())
-        except NameError:
-            # display() not available outside Jupyter
-            print(cell_polygons_gdf.head())
 
         fig, ax = plt.subplots(figsize=figsize)
         cell_polygons_gdf.plot(ax=ax, edgecolor='blue', facecolor='none')
@@ -102,6 +100,13 @@ class HdfPlot:
         """
         # Lazy import for heavy dependency
         import matplotlib.pyplot as plt
+
+        missing_columns = [col for col in (x_col, y_col) if col not in df.columns]
+        if missing_columns:
+            raise ValueError(
+                f"Cannot plot time series; missing column(s): {missing_columns}. "
+                f"Available columns: {list(df.columns)}"
+            )
 
         # Convert any datetime columns to strings
         df = HdfUtils.convert_df_datetimes_to_str(df)

--- a/ras_commander/hdf/HdfProject.py
+++ b/ras_commander/hdf/HdfProject.py
@@ -34,6 +34,7 @@ Example Usage:
 from pathlib import Path
 from typing import Tuple, Optional, Union, List, TYPE_CHECKING
 import logging
+import h5py
 
 from .HdfBase import HdfBase
 from .HdfMesh import HdfMesh
@@ -57,6 +58,37 @@ class HdfProject:
 
     All methods are static and designed to work with HEC-RAS geometry HDF files.
     """
+
+    @staticmethod
+    def _has_hdf_paths(
+        hdf_path: Path,
+        paths: Tuple[str, ...],
+        label: str,
+    ) -> bool:
+        """Return True when all required HDF paths exist for an optional probe."""
+        try:
+            with h5py.File(hdf_path, "r") as hdf_file:
+                missing = [path for path in paths if path not in hdf_file]
+        except Exception as e:
+            logger.debug(
+                "Could not inspect %s paths in %s: %s",
+                label,
+                hdf_path,
+                e,
+                exc_info=True,
+            )
+            return False
+
+        if missing:
+            logger.debug(
+                "%s not available in %s; missing HDF path(s): %s",
+                label,
+                hdf_path.name,
+                ", ".join(missing),
+            )
+            return False
+
+        return True
 
     @staticmethod
     @log_call
@@ -133,25 +165,56 @@ class HdfProject:
 
         # Get 1D cross sections and river centerlines
         if include_1d:
-            try:
-                cross_sections = HdfXsec.get_cross_sections(hdf_path)
-                if not cross_sections.empty:
-                    geometries.extend(cross_sections.geometry.tolist())
-                    if crs is None:
-                        crs = cross_sections.crs
-                    logger.debug(f"Found {len(cross_sections)} cross sections")
-            except Exception as e:
-                logger.debug(f"No cross sections found or error: {e}")
+            cross_section_paths = (
+                "/Geometry/Cross Sections/Polyline Info",
+                "/Geometry/Cross Sections/Polyline Parts",
+                "/Geometry/Cross Sections/Polyline Points",
+                "/Geometry/Cross Sections/Station Elevation Info",
+                "/Geometry/Cross Sections/Station Elevation Values",
+                "/Geometry/Cross Sections/Attributes",
+                "/Geometry/Cross Sections/Manning's n Info",
+                "/Geometry/Cross Sections/Manning's n Values",
+            )
+            if HdfProject._has_hdf_paths(
+                hdf_path,
+                cross_section_paths,
+                "Cross-section geometry",
+            ):
+                try:
+                    cross_sections = HdfXsec.get_cross_sections(hdf_path)
+                    if not cross_sections.empty:
+                        geometries.extend(cross_sections.geometry.tolist())
+                        if crs is None:
+                            crs = cross_sections.crs
+                        logger.debug(f"Found {len(cross_sections)} cross sections")
+                except Exception as e:
+                    logger.debug(
+                        "Could not extract cross sections from %s: %s",
+                        hdf_path,
+                        e,
+                        exc_info=True,
+                    )
 
-            try:
-                centerlines = HdfXsec.get_river_centerlines(hdf_path)
-                if not centerlines.empty:
-                    geometries.extend(centerlines.geometry.tolist())
-                    if crs is None:
-                        crs = centerlines.crs
-                    logger.debug(f"Found {len(centerlines)} river centerlines")
-            except Exception as e:
-                logger.debug(f"No river centerlines found or error: {e}")
+            river_centerline_paths = ("Geometry/River Centerlines",)
+            if HdfProject._has_hdf_paths(
+                hdf_path,
+                river_centerline_paths,
+                "River centerline geometry",
+            ):
+                try:
+                    centerlines = HdfXsec.get_river_centerlines(hdf_path)
+                    if not centerlines.empty:
+                        geometries.extend(centerlines.geometry.tolist())
+                        if crs is None:
+                            crs = centerlines.crs
+                        logger.debug(f"Found {len(centerlines)} river centerlines")
+                except Exception as e:
+                    logger.debug(
+                        "Could not extract river centerlines from %s: %s",
+                        hdf_path,
+                        e,
+                        exc_info=True,
+                    )
 
         # Get CRS from HDF if still None
         if crs is None:
@@ -160,7 +223,19 @@ class HdfProject:
 
         # Handle empty geometries
         if not geometries:
-            logger.warning("No geometries found in HDF file")
+            logger.warning(
+                "No project geometries found in %s; returning empty extent "
+                "and zero project-coordinate bounds.",
+                hdf_path.name,
+            )
+            logger.debug(
+                "No project geometries found in %s "
+                "(include_1d=%s, include_2d=%s, include_storage=%s).",
+                hdf_path,
+                include_1d,
+                include_2d,
+                include_storage,
+            )
             empty_gdf = GeoDataFrame(geometry=[], crs=crs)
             return empty_gdf, (0.0, 0.0, 0.0, 0.0)
 
@@ -269,7 +344,10 @@ class HdfProject:
         )
 
         if extent_gdf.empty:
-            logger.warning("Empty extent, returning zeros")
+            logger.debug(
+                "Empty project extent for %s; returning zero bounds.",
+                hdf_path.name,
+            )
             return (0.0, 0.0, 0.0, 0.0)
 
         # Transform to WGS84
@@ -279,10 +357,23 @@ class HdfProject:
                 logger.debug(f"No CRS in HDF file, using provided project_crs: {project_crs}")
                 extent_gdf = extent_gdf.set_crs(project_crs)
             else:
-                logger.warning("No CRS defined and no project_crs provided. Cannot transform to WGS84.")
                 bounds = extent_gdf.total_bounds
                 west, south, east, north = bounds
-                logger.warning(f"Original bounds (no CRS): W={west:.6f}, S={south:.6f}, E={east:.6f}, N={north:.6f}")
+                logger.warning(
+                    "Project CRS unavailable for %s; returning untransformed "
+                    "project-coordinate bounds. Pass project_crs=... to return "
+                    "WGS84 bounds.",
+                    hdf_path.name,
+                )
+                logger.debug(
+                    "Original project-coordinate bounds for %s: W=%.6f, "
+                    "S=%.6f, E=%.6f, N=%.6f",
+                    hdf_path,
+                    west,
+                    south,
+                    east,
+                    north,
+                )
                 return (west, south, east, north)
         
         try:
@@ -298,22 +389,49 @@ class HdfProject:
             # Validate the transformation actually worked (WGS84 bounds check)
             if not (-180 <= west <= 180 and -180 <= east <= 180 and 
                     -90 <= south <= 90 and -90 <= north <= 90):
-                logger.error(f"CRS transformation failed - coordinates not in valid WGS84 range. "
-                           f"Got: W={west:.6f}, S={south:.6f}, E={east:.6f}, N={north:.6f}. "
-                           f"Source CRS: {source_crs.name}")
-                # Return original bounds with warning
                 original_bounds = extent_gdf.total_bounds
-                logger.warning(f"Returning original projected coordinates: {original_bounds}")
+                logger.error(
+                    "CRS transformation failed for %s; returning original "
+                    "project-coordinate bounds, not WGS84. Enable DEBUG for "
+                    "CRS and bounds.",
+                    hdf_path.name,
+                )
+                logger.debug(
+                    "Invalid WGS84 bounds for %s from source CRS %s: "
+                    "W=%.6f, S=%.6f, E=%.6f, N=%.6f; original bounds=%s",
+                    hdf_path,
+                    source_crs.name,
+                    west,
+                    south,
+                    east,
+                    north,
+                    original_bounds,
+                )
                 return tuple(original_bounds)
             
             logger.debug(f"WGS84 bounds: W={west:.6f}, S={south:.6f}, E={east:.6f}, N={north:.6f}")
             return (west, south, east, north)
             
         except Exception as e:
-            logger.error(f"Failed to transform CRS to WGS84: {e}")
             bounds = extent_gdf.total_bounds
             west, south, east, north = bounds
-            logger.warning(f"Returning original projected coordinates: W={west:.6f}, S={south:.6f}, E={east:.6f}, N={north:.6f}")
+            logger.error(
+                "CRS transformation failed for %s; returning original "
+                "project-coordinate bounds, not WGS84. Enable DEBUG for CRS "
+                "and bounds.",
+                hdf_path.name,
+            )
+            logger.debug(
+                "CRS transformation exception for %s: %s; original "
+                "project-coordinate bounds W=%.6f, S=%.6f, E=%.6f, N=%.6f",
+                hdf_path,
+                e,
+                west,
+                south,
+                east,
+                north,
+                exc_info=True,
+            )
             return (west, south, east, north)
 
     @staticmethod
@@ -386,6 +504,7 @@ class HdfProject:
             extent_gdf = extent_gdf.to_crs("EPSG:4326")
 
         extent_gdf.to_file(output_path, driver="GeoJSON")
-        logger.info(f"Exported project extent to: {output_path}")
+        logger.info("Exported project extent to %s", output_path.name)
+        logger.debug("Exported project extent full path: %s", output_path)
 
         return output_path

--- a/ras_commander/hdf/HdfPump.py
+++ b/ras_commander/hdf/HdfPump.py
@@ -29,6 +29,35 @@ from ..LoggingConfig import get_logger
 
 logger = get_logger(__name__)
 
+
+_PUMP_RESULTS_ACTION = (
+    "Compute the plan with pump station output available, then retry."
+)
+
+
+def _format_available_items(items: List[str], max_items: int = 12) -> str:
+    if not items:
+        return "none"
+
+    shown = items[:max_items]
+    suffix = f", ... ({len(items) - max_items} more)" if len(items) > max_items else ""
+    return ", ".join(shown) + suffix
+
+
+def _available_group_names(hdf: h5py.File, group_path: str) -> List[str]:
+    if group_path not in hdf:
+        return []
+    return sorted(str(name) for name in hdf[group_path].keys())
+
+
+def _missing_hdf_object_message(context: str, hdf_path: str, action: str) -> str:
+    return f"{context} requires HDF object '{hdf_path}', but it was not found. {action}"
+
+
+def _empty_pump_stations_gdf() -> gpd.GeoDataFrame:
+    return gpd.GeoDataFrame({"station_id": []}, geometry=[], crs=None)
+
+
 class HdfPump:
     """
     A class for handling pump station related data from HEC-RAS HDF files.
@@ -56,47 +85,52 @@ class HdfPump:
             gpd.GeoDataFrame: GeoDataFrame containing pump station data with columns:
                 - geometry: Point geometry of pump station location
                 - station_id: Unique identifier for each pump station
-                - Additional attributes from the HDF file
+                - Additional attributes from the HDF file. Returns an empty
+                  GeoDataFrame when the HDF file contains no pump station group.
 
         Raises:
-            KeyError: If pump station datasets are not found in the HDF file.
-            Exception: If there are errors processing the pump station data.
+            KeyError: If the pump station group exists but required datasets are missing.
         """
-        try:
-            with h5py.File(hdf_path, 'r') as hdf:
-                # Extract pump station data
-                attributes = hdf['/Geometry/Pump Stations/Attributes'][()]
-                points = hdf['/Geometry/Pump Stations/Points'][()]
+        with h5py.File(hdf_path, 'r') as hdf:
+            pump_stations_path = "/Geometry/Pump Stations"
+            if pump_stations_path not in hdf:
+                logger.debug("No pump station geometry group found in HDF file")
+                return _empty_pump_stations_gdf()
 
-                # Create geometries
-                geometries = [Point(x, y) for x, y in points]
+            group = hdf[pump_stations_path]
+            for dataset_name in ["Attributes", "Points"]:
+                if dataset_name not in group:
+                    raise KeyError(_missing_hdf_object_message(
+                        "Pump station geometry extraction",
+                        f"{pump_stations_path}/{dataset_name}",
+                        "Verify the HDF was written with pump station geometry data.",
+                    ))
 
-                # Create GeoDataFrame
-                gdf = gpd.GeoDataFrame(geometry=geometries)
-                gdf['station_id'] = range(len(gdf))
+            attributes = group['Attributes'][()]
+            points = group['Points'][()]
 
-                # Add attributes and decode byte strings
-                attr_df = pd.DataFrame(attributes)
-                string_columns = attr_df.select_dtypes([object]).columns
-                for col in string_columns:
-                    attr_df[col] = attr_df[col].apply(lambda x: x.decode('utf-8') if isinstance(x, bytes) else x)
-                
-                for col in attr_df.columns:
-                    gdf[col] = attr_df[col]
+            # Create geometries
+            geometries = [Point(x, y) for x, y in points]
 
-                # Set CRS if available
-                crs = HdfBase.get_projection(hdf_path)
-                if crs:
-                    gdf.set_crs(crs, inplace=True)
+            # Create GeoDataFrame
+            gdf = gpd.GeoDataFrame(geometry=geometries)
+            gdf['station_id'] = range(len(gdf))
 
-                return gdf
+            # Add attributes and decode byte strings
+            attr_df = pd.DataFrame(attributes)
+            string_columns = attr_df.select_dtypes([object]).columns
+            for col in string_columns:
+                attr_df[col] = attr_df[col].apply(lambda x: x.decode('utf-8') if isinstance(x, bytes) else x)
 
-        except KeyError as e:
-            logger.error(f"Required dataset not found in HDF file: {e}")
-            raise
-        except Exception as e:
-            logger.error(f"Error extracting pump station data: {e}")
-            raise
+            for col in attr_df.columns:
+                gdf[col] = attr_df[col]
+
+            # Set CRS if available
+            crs = HdfBase.get_projection(hdf_path)
+            if crs:
+                gdf.set_crs(crs, inplace=True)
+
+            return gdf
 
     @staticmethod
     @log_call
@@ -113,43 +147,57 @@ class HdfPump:
                 - efficiency_curve_start: Starting index of efficiency curve data
                 - efficiency_curve_count: Number of points in efficiency curve
                 - efficiency_curve: List of efficiency curve values
-                - Additional attributes from the HDF file
+                - Additional attributes from the HDF file. Returns an empty
+                  DataFrame when the HDF file contains no pump station group.
 
         Raises:
-            KeyError: If pump group datasets are not found in the HDF file.
-            Exception: If there are errors processing the pump group data.
+            KeyError: If the pump group exists but required datasets are missing.
         """
-        try:
-            with h5py.File(hdf_path, 'r') as hdf:
-                # Extract pump group data
-                attributes = hdf['/Geometry/Pump Stations/Pump Groups/Attributes'][()]
-                efficiency_curves_info = hdf['/Geometry/Pump Stations/Pump Groups/Efficiency Curves Info'][()]
-                efficiency_curves_values = hdf['/Geometry/Pump Stations/Pump Groups/Efficiency Curves Values'][()]
+        with h5py.File(hdf_path, 'r') as hdf:
+            pump_groups_path = "/Geometry/Pump Stations/Pump Groups"
+            if pump_groups_path not in hdf:
+                logger.debug("No pump station pump-group geometry found in HDF file")
+                return pd.DataFrame()
 
-                # Create DataFrame and decode byte strings
-                df = pd.DataFrame(attributes)
-                string_columns = df.select_dtypes([object]).columns
-                for col in string_columns:
-                    df[col] = df[col].apply(lambda x: x.decode('utf-8') if isinstance(x, bytes) else x)
+            group = hdf[pump_groups_path]
+            required_datasets = [
+                "Attributes",
+                "Efficiency Curves Info",
+                "Efficiency Curves Values",
+            ]
+            missing_datasets = [
+                f"{pump_groups_path}/{dataset_name}"
+                for dataset_name in required_datasets
+                if dataset_name not in group
+            ]
+            if missing_datasets:
+                raise KeyError(
+                    "Pump group extraction found an incomplete pump group geometry. "
+                    f"Missing: {_format_available_items(missing_datasets)}. "
+                    "Verify the HDF was written with pump group geometry data."
+                )
 
-                # Add efficiency curve data
-                df['efficiency_curve_start'] = efficiency_curves_info[:, 0]
-                df['efficiency_curve_count'] = efficiency_curves_info[:, 1]
+            attributes = group['Attributes'][()]
+            efficiency_curves_info = group['Efficiency Curves Info'][()]
+            efficiency_curves_values = group['Efficiency Curves Values'][()]
 
-                # Process efficiency curves
-                def get_efficiency_curve(start, count):
-                    return efficiency_curves_values[start:start+count].tolist()
+            # Create DataFrame and decode byte strings
+            df = pd.DataFrame(attributes)
+            string_columns = df.select_dtypes([object]).columns
+            for col in string_columns:
+                df[col] = df[col].apply(lambda x: x.decode('utf-8') if isinstance(x, bytes) else x)
 
-                df['efficiency_curve'] = df.apply(lambda row: get_efficiency_curve(row['efficiency_curve_start'], row['efficiency_curve_count']), axis=1)
+            # Add efficiency curve data
+            df['efficiency_curve_start'] = efficiency_curves_info[:, 0]
+            df['efficiency_curve_count'] = efficiency_curves_info[:, 1]
 
-                return df
+            # Process efficiency curves
+            def get_efficiency_curve(start, count):
+                return efficiency_curves_values[start:start+count].tolist()
 
-        except KeyError as e:
-            logger.error(f"Required dataset not found in HDF file: {e}")
-            raise
-        except Exception as e:
-            logger.error(f"Error extracting pump group data: {e}")
-            raise
+            df['efficiency_curve'] = df.apply(lambda row: get_efficiency_curve(row['efficiency_curve_start'], row['efficiency_curve_count']), axis=1)
+
+            return df
 
     @staticmethod
     @log_call
@@ -172,65 +220,80 @@ class HdfPump:
         Raises:
             KeyError: If required datasets are not found in the HDF file.
             ValueError: If the specified pump station name is not found.
-            Exception: If there are errors processing the timeseries data.
         """
-        try:
-            with h5py.File(hdf_path, 'r') as hdf:
-                # Check if the pump station exists
-                pumping_stations_path = "/Results/Unsteady/Output/Output Blocks/DSS Hydrograph Output/Unsteady Time Series/Pumping Stations"
-                if pump_station not in hdf[pumping_stations_path]:
-                    raise ValueError(f"Pump station '{pump_station}' not found in HDF file")
+        with h5py.File(hdf_path, 'r') as hdf:
+            pumping_stations_path = (
+                "/Results/Unsteady/Output/Output Blocks/DSS Hydrograph Output/"
+                "Unsteady Time Series/Pumping Stations"
+            )
+            if pumping_stations_path not in hdf:
+                raise KeyError(_missing_hdf_object_message(
+                    "Pump station timeseries extraction",
+                    pumping_stations_path,
+                    _PUMP_RESULTS_ACTION,
+                ))
 
-                # Extract timeseries data
-                data_path = f"{pumping_stations_path}/{pump_station}/Structure Variables"
-                data = hdf[data_path][()]
-
-                # Extract time information - try DSS-specific timestamps first
-                dss_time_path = "/Results/Unsteady/Output/Output Blocks/DSS Hydrograph Output/Unsteady Time Series/Time Date Stamp (ms)"
-
-                if dss_time_path in hdf:
-                    # Use DSS Hydrograph Output timestamps
-                    raw_datetimes = hdf[dss_time_path][:]
-                    time = [HdfUtils.parse_ras_datetime_ms(x.decode("utf-8")) for x in raw_datetimes]
-                else:
-                    # Fallback to Base Output timestamps
-                    time = HdfBase.get_unsteady_timestamps(hdf)
-
-                # Verify time dimension matches data, use index if mismatch
-                if len(time) != data.shape[0]:
-                    logger.warning(f"Timestamp count ({len(time)}) doesn't match data time dimension ({data.shape[0]}). Using numeric index.")
-                    time = list(range(data.shape[0]))
-
-                variable_units = hdf[data_path].attrs.get('Variable_Unit', None)
-                variable_names, unit_by_variable = HdfPump._pump_variable_columns(
-                    variable_units,
-                    data.shape[1],
+            available_stations = _available_group_names(hdf, pumping_stations_path)
+            if pump_station not in hdf[pumping_stations_path]:
+                raise ValueError(
+                    f"Pump station '{pump_station}' was not found in HDF group "
+                    f"'{pumping_stations_path}'. Available pump stations: "
+                    f"{_format_available_items(available_stations)}."
                 )
 
-                # Create DataArray
-                da = xr.DataArray(
-                    data=data,
-                    dims=['time', 'variable'],
-                    coords={'time': time, 'variable': variable_names},
-                    name=pump_station
+            data_path = f"{pumping_stations_path}/{pump_station}/Structure Variables"
+            if data_path not in hdf:
+                raise KeyError(_missing_hdf_object_message(
+                    f"Pump station timeseries extraction for '{pump_station}'",
+                    data_path,
+                    _PUMP_RESULTS_ACTION,
+                ))
+
+            data = hdf[data_path][()]
+
+            # Extract time information - try DSS-specific timestamps first
+            dss_time_path = "/Results/Unsteady/Output/Output Blocks/DSS Hydrograph Output/Unsteady Time Series/Time Date Stamp (ms)"
+
+            if dss_time_path in hdf:
+                # Use DSS Hydrograph Output timestamps
+                raw_datetimes = hdf[dss_time_path][:]
+                time = [HdfUtils.parse_ras_datetime_ms(x.decode("utf-8")) for x in raw_datetimes]
+            else:
+                # Fallback to Base Output timestamps
+                time = HdfBase.get_unsteady_timestamps(hdf)
+
+            # Verify time dimension matches data, use index if mismatch
+            if len(time) != data.shape[0]:
+                logger.warning(
+                    "Pump station timeseries timestamp mismatch for '%s' at '%s': "
+                    "timestamps=%d rows=%d; using numeric time index",
+                    pump_station,
+                    data_path,
+                    len(time),
+                    data.shape[0],
                 )
+                time = list(range(data.shape[0]))
 
-                # Add attributes and decode byte strings
-                da.attrs['units'] = variable_units
-                da.attrs['unit_by_variable'] = unit_by_variable
-                da.attrs['pump_station'] = pump_station
+            variable_units = hdf[data_path].attrs.get('Variable_Unit', None)
+            variable_names, unit_by_variable = HdfPump._pump_variable_columns(
+                variable_units,
+                data.shape[1],
+            )
 
-                return da
+            # Create DataArray
+            da = xr.DataArray(
+                data=data,
+                dims=['time', 'variable'],
+                coords={'time': time, 'variable': variable_names},
+                name=pump_station
+            )
 
-        except KeyError as e:
-            logger.error(f"Required dataset not found in HDF file: {e}")
-            raise
-        except ValueError as e:
-            logger.error(str(e))
-            raise
-        except Exception as e:
-            logger.error(f"Error extracting pump station timeseries data: {e}")
-            raise
+            # Add attributes and decode byte strings
+            da.attrs['units'] = variable_units
+            da.attrs['unit_by_variable'] = unit_by_variable
+            da.attrs['pump_station'] = pump_station
+
+            return da
 
     @staticmethod
     @log_call
@@ -247,34 +310,25 @@ class HdfPump:
                 operational statistics and performance metrics. Returns empty DataFrame
                 if no summary data is found.
 
-        Raises:
-            KeyError: If the summary dataset is not found in the HDF file.
-            Exception: If there are errors processing the summary data.
+        Notes:
+            Missing pump station summary output returns an empty DataFrame.
         """
-        try:
-            with h5py.File(hdf_path, 'r') as hdf:
-                # Extract summary data
-                summary_path = "/Results/Unsteady/Summary/Pump Station"
-                if summary_path not in hdf:
-                    logger.warning("Pump Station summary data not found in HDF file")
-                    return pd.DataFrame()
+        with h5py.File(hdf_path, 'r') as hdf:
+            # Extract summary data
+            summary_path = "/Results/Unsteady/Summary/Pump Station"
+            if summary_path not in hdf:
+                logger.debug("Pump station summary data not found in HDF file")
+                return pd.DataFrame()
 
-                summary_data = hdf[summary_path][()]
-                
-                # Create DataFrame and decode byte strings
-                df = pd.DataFrame(summary_data)
-                string_columns = df.select_dtypes([object]).columns
-                for col in string_columns:
-                    df[col] = df[col].apply(lambda x: x.decode('utf-8') if isinstance(x, bytes) else x)
+            summary_data = hdf[summary_path][()]
 
-                return df
+            # Create DataFrame and decode byte strings
+            df = pd.DataFrame(summary_data)
+            string_columns = df.select_dtypes([object]).columns
+            for col in string_columns:
+                df[col] = df[col].apply(lambda x: x.decode('utf-8') if isinstance(x, bytes) else x)
 
-        except KeyError as e:
-            logger.error(f"Required dataset not found in HDF file: {e}")
-            raise
-        except Exception as e:
-            logger.error(f"Error extracting pump station summary data: {e}")
-            raise
+            return df
 
     @staticmethod
     @log_call
@@ -299,48 +353,57 @@ class HdfPump:
         Raises:
             KeyError: If required datasets are not found in the HDF file.
             ValueError: If the specified pump station name is not found.
-            Exception: If there are errors processing the operation data.
         """
-        try:
-            with h5py.File(hdf_path, 'r') as hdf:
-                # Check if the pump station exists
-                pump_stations_path = "/Results/Unsteady/Output/Output Blocks/DSS Profile Output/Unsteady Time Series/Pumping Stations"
-                if pump_station not in hdf[pump_stations_path]:
-                    raise ValueError(f"Pump station '{pump_station}' not found in HDF file")
+        with h5py.File(hdf_path, 'r') as hdf:
+            pump_stations_path = (
+                "/Results/Unsteady/Output/Output Blocks/DSS Profile Output/"
+                "Unsteady Time Series/Pumping Stations"
+            )
+            if pump_stations_path not in hdf:
+                raise KeyError(_missing_hdf_object_message(
+                    "Pump station operation extraction",
+                    pump_stations_path,
+                    _PUMP_RESULTS_ACTION,
+                ))
 
-                # Extract pump operation data
-                data_path = f"{pump_stations_path}/{pump_station}/Structure Variables"
-                data = hdf[data_path][()]
-
-                # Extract time information - Updated to use new method name
-                time = HdfBase.get_unsteady_timestamps(hdf)
-
-                variable_units = hdf[data_path].attrs.get('Variable_Unit', None)
-                variable_names, unit_by_variable = HdfPump._pump_variable_columns(
-                    variable_units,
-                    data.shape[1],
+            available_stations = _available_group_names(hdf, pump_stations_path)
+            if pump_station not in hdf[pump_stations_path]:
+                raise ValueError(
+                    f"Pump station '{pump_station}' was not found in HDF group "
+                    f"'{pump_stations_path}'. Available pump stations: "
+                    f"{_format_available_items(available_stations)}."
                 )
 
-                # Create DataFrame and decode byte strings
-                df = pd.DataFrame(data, columns=variable_names)
-                string_columns = df.select_dtypes([object]).columns
-                for col in string_columns:
-                    df[col] = df[col].apply(lambda x: x.decode('utf-8') if isinstance(x, bytes) else x)
-                    
-                df['Time'] = time
-                df.attrs['unit_by_variable'] = unit_by_variable
+            # Extract pump operation data
+            data_path = f"{pump_stations_path}/{pump_station}/Structure Variables"
+            if data_path not in hdf:
+                raise KeyError(_missing_hdf_object_message(
+                    f"Pump station operation extraction for '{pump_station}'",
+                    data_path,
+                    _PUMP_RESULTS_ACTION,
+                ))
 
-                return df
+            data = hdf[data_path][()]
 
-        except KeyError as e:
-            logger.error(f"Required dataset not found in HDF file: {e}")
-            raise
-        except ValueError as e:
-            logger.error(str(e))
-            raise
-        except Exception as e:
-            logger.error(f"Error extracting pump operation data: {e}")
-            raise
+            # Extract time information - Updated to use new method name
+            time = HdfBase.get_unsteady_timestamps(hdf)
+
+            variable_units = hdf[data_path].attrs.get('Variable_Unit', None)
+            variable_names, unit_by_variable = HdfPump._pump_variable_columns(
+                variable_units,
+                data.shape[1],
+            )
+
+            # Create DataFrame and decode byte strings
+            df = pd.DataFrame(data, columns=variable_names)
+            string_columns = df.select_dtypes([object]).columns
+            for col in string_columns:
+                df[col] = df[col].apply(lambda x: x.decode('utf-8') if isinstance(x, bytes) else x)
+
+            df['Time'] = time
+            df.attrs['unit_by_variable'] = unit_by_variable
+
+            return df
 
     @staticmethod
     def _pump_variable_columns(variable_units: Any, column_count: int) -> tuple[List[str], Dict[str, str]]:

--- a/ras_commander/hdf/HdfResultsAnalysis.py
+++ b/ras_commander/hdf/HdfResultsAnalysis.py
@@ -5,8 +5,9 @@ Provides methods for comparing results across multiple plan HDF files,
 including identification of critical storm duration at reference locations.
 """
 
+from numbers import Number
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional, Tuple, Union
 import logging
 
 import pandas as pd
@@ -45,6 +46,7 @@ class HdfResultsAnalysis:
         threshold_pct: float = 5.0,
         plan_labels: Optional[Dict[str, str]] = None,
         reftype: str = 'lines',
+        variable: str = 'Water Surface',
         ras_object: Optional[Any] = None
     ) -> pd.DataFrame:
         """
@@ -70,6 +72,8 @@ class HdfResultsAnalysis:
             Used for column naming in output. If None, plan numbers are used.
         reftype : str, default 'lines'
             Reference type for HDF extraction ('lines' or 'points')
+        variable : str, default 'Water Surface'
+            Native HDF reference output variable to compare across plans.
         ras_object : optional
             Custom RAS object to use instead of the global one
 
@@ -95,46 +99,87 @@ class HdfResultsAnalysis:
         >>> critical = result[result['exceeds_threshold']]
         >>> print(f"{len(critical)} locations exceed {5.0}% threshold")
         """
-        from ras_commander.hdf.HdfResultsPlan import HdfResultsPlan
+        from ras_commander.hdf.HdfResultsXsec import HdfResultsXsec
         from ras_commander import ras as global_ras
 
         _ras = ras_object if ras_object is not None else global_ras
         _ras.check_initialized()
+
+        reftype = reftype.lower().strip()
+        if reftype not in {"lines", "points"}:
+            raise ValueError("reftype must be either 'lines' or 'points'")
+
+        if not isinstance(variable, str) or not variable.strip():
+            raise ValueError("variable must be a non-empty HDF dataset name")
+        variable = variable.strip()
 
         if plan_labels is None:
             plan_labels = {pn: pn for pn in plan_numbers}
 
         # Extract peaks from each plan
         plan_peaks = {}
-        for plan_num in plan_numbers:
-            label = plan_labels.get(plan_num, plan_num)
-            plan_hdf = _ras.project_folder / f"{_ras.project_name}.p{plan_num}.hdf"
+        for raw_plan_num in plan_numbers:
+            plan_num = HdfResultsAnalysis._normalize_plan_number(raw_plan_num)
+            label = plan_labels.get(plan_num, plan_labels.get(raw_plan_num, raw_plan_num))
+            plan_hdf, path_source = HdfResultsAnalysis._resolve_plan_hdf_path(_ras, plan_num)
 
             if not plan_hdf.exists():
-                logger.warning(f"Plan HDF not found: {plan_hdf}")
+                logger.warning(
+                    f"Skipping plan {plan_num} ({label}): plan HDF not found at "
+                    f"{plan_hdf} (resolved from {path_source})"
+                )
                 continue
 
             try:
-                ts_df = HdfResultsPlan.get_reference_timeseries(plan_hdf, reftype=reftype)
-                if ts_df.empty:
-                    logger.warning(f"No reference timeseries in plan {plan_num}")
+                if reftype == 'lines':
+                    ds = HdfResultsXsec.get_ref_lines_timeseries(
+                        plan_hdf,
+                        variables=variable,
+                    )
+                else:
+                    ds = HdfResultsXsec.get_ref_points_timeseries(
+                        plan_hdf,
+                        variables=variable,
+                    )
+
+                if variable not in ds.data_vars:
+                    available = ", ".join(sorted(ds.data_vars)) or "none"
+                    logger.warning(
+                        f"Skipping plan {plan_num} ({label}): variable '{variable}' "
+                        f"not found in {reftype} reference timeseries at {plan_hdf} "
+                        f"(resolved from {path_source}); available variables: {available}"
+                    )
                     continue
 
                 # Extract peak for each reference location
-                peaks = {}
-                for col in ts_df.columns:
-                    if col == 'Time':
-                        continue
-                    peaks[col] = float(ts_df[col].max())
+                peaks = HdfResultsAnalysis._extract_reference_peaks(
+                    ds,
+                    reftype=reftype,
+                    variable=variable,
+                )
+                if not peaks:
+                    logger.warning(
+                        f"Skipping plan {plan_num} ({label}): no named {reftype} "
+                        f"reference features found for variable '{variable}' in {plan_hdf} "
+                        f"(resolved from {path_source})"
+                    )
+                    continue
 
                 plan_peaks[label] = peaks
                 logger.debug(f"Plan {plan_num} ({label}): extracted peaks for {len(peaks)} locations")
 
             except Exception as e:
-                logger.error(f"Error processing plan {plan_num}: {e}")
+                logger.error(
+                    f"Skipping plan {plan_num} ({label}): failed to extract {reftype} "
+                    f"reference timeseries variable '{variable}' from {plan_hdf} "
+                    f"(resolved from {path_source}): {type(e).__name__}: {e}"
+                )
 
         if not plan_peaks:
-            logger.warning("No plan data could be extracted")
+            logger.warning(
+                f"No reference timeseries data extracted from {len(plan_numbers)} plan(s) "
+                f"for reftype={reftype}, variable='{variable}'; returning empty DataFrame"
+            )
             return pd.DataFrame()
 
         # Collect all locations across plans
@@ -190,7 +235,134 @@ class HdfResultsAnalysis:
         result = pd.DataFrame(rows)
         n_exceed = result['exceeds_threshold'].sum() if not result.empty else 0
         logger.info(
-            f"Critical duration analysis: {len(result)} locations, "
+            f"Critical duration analysis (reftype={reftype}, variable='{variable}'): "
+            f"{len(result)} locations, "
             f"{n_exceed} exceeding {threshold_pct}% threshold"
         )
         return result
+
+    @staticmethod
+    def _normalize_plan_number(plan_number: Any) -> str:
+        """Normalize plan identifiers to the zero-padded p## number."""
+        try:
+            missing = pd.isna(plan_number)
+            if isinstance(missing, (bool, np.bool_)) and missing:
+                return ""
+        except (TypeError, ValueError):
+            pass
+
+        if isinstance(plan_number, Number) and not isinstance(plan_number, bool):
+            number = float(plan_number)
+            if np.isfinite(number) and number.is_integer():
+                return f"{int(number):02d}"
+
+        text = str(plan_number).strip()
+        if text.lower().startswith('p'):
+            text = text[1:]
+        if text.isdigit():
+            return text.zfill(2)
+        try:
+            number = float(text)
+            if number.is_integer():
+                return f"{int(number):02d}"
+        except ValueError:
+            pass
+        return text
+
+    @staticmethod
+    def _has_path_value(value: Any) -> bool:
+        """Return True when a plan_df path-like cell is populated."""
+        if value is None:
+            return False
+
+        try:
+            missing = pd.isna(value)
+            if isinstance(missing, (bool, np.bool_)) and missing:
+                return False
+        except (TypeError, ValueError):
+            pass
+
+        text = str(value).strip()
+        return bool(text) and text.lower() not in {'nan', 'nat', 'none'}
+
+    @staticmethod
+    def _resolve_plan_hdf_path(_ras: Any, plan_num: str) -> Tuple[Path, str]:
+        """Resolve a plan results HDF path, preferring plan_df metadata."""
+        fallback = Path(_ras.project_folder) / f"{_ras.project_name}.p{plan_num}.hdf"
+        plan_df = getattr(_ras, 'plan_df', None)
+
+        if plan_df is None or plan_df.empty:
+            return fallback, "fallback project path (plan_df unavailable)"
+
+        if 'plan_number' not in plan_df.columns:
+            return fallback, "fallback project path (plan_df has no plan_number column)"
+
+        normalized_numbers = plan_df['plan_number'].map(
+            HdfResultsAnalysis._normalize_plan_number
+        )
+        matching = plan_df[normalized_numbers == plan_num]
+        if matching.empty:
+            return (
+                fallback,
+                f"fallback project path (no plan_df row matched plan_number {plan_num})",
+            )
+
+        row = matching.iloc[0]
+        if (
+            'HDF_Results_Path' in row.index
+            and HdfResultsAnalysis._has_path_value(row['HDF_Results_Path'])
+        ):
+            return Path(str(row['HDF_Results_Path'])), "plan_df HDF_Results_Path"
+
+        if (
+            'full_path' in row.index
+            and HdfResultsAnalysis._has_path_value(row['full_path'])
+        ):
+            return Path(f"{row['full_path']}.hdf"), "plan_df full_path + .hdf"
+
+        return (
+            fallback,
+            "fallback project path (matched plan_df row has no populated "
+            "HDF_Results_Path or full_path)",
+        )
+
+    @staticmethod
+    def _extract_reference_peaks(
+        ds: Any,
+        reftype: str,
+        variable: str,
+    ) -> Dict[str, float]:
+        """Extract per-feature peak values from a native reference output dataset."""
+        coord_name = 'refln_name' if reftype == 'lines' else 'refpt_name'
+        feature_dim = 'refln_id' if reftype == 'lines' else 'refpt_id'
+        data = ds[variable]
+
+        if 'time' not in data.dims:
+            raise ValueError(
+                f"Variable '{variable}' has dimensions {data.dims}; expected a time dimension"
+            )
+        if feature_dim not in data.dims:
+            raise ValueError(
+                f"Variable '{variable}' has dimensions {data.dims}; expected {feature_dim}"
+            )
+        if coord_name not in data.coords:
+            raise ValueError(
+                f"Variable '{variable}' is missing coordinate {coord_name}"
+            )
+
+        peak_data = data.max(dim='time', skipna=True)
+        extra_dims = [dim for dim in peak_data.dims if dim != feature_dim]
+        if extra_dims:
+            raise ValueError(
+                f"Variable '{variable}' has unsupported dimensions after time max: "
+                f"{peak_data.dims}"
+            )
+
+        names = peak_data.coords[coord_name].values
+        values = peak_data.transpose(feature_dim).values
+        peaks = {}
+        for name, value in zip(names, values):
+            location = str(name).strip()
+            if location:
+                peaks[location] = float(value)
+        return peaks

--- a/ras_commander/hdf/HdfResultsBreach.py
+++ b/ras_commander/hdf/HdfResultsBreach.py
@@ -181,7 +181,7 @@ class HdfResultsBreach:
                     return pd.DataFrame()
 
         except Exception as e:
-            logger.error(f"Error extracting structure variables: {e}")
+            logger.error(f"Error extracting structure variables from {hdf_path}: {e}")
             raise
 
     @staticmethod
@@ -316,7 +316,7 @@ class HdfResultsBreach:
                     return pd.DataFrame()
 
         except Exception as e:
-            logger.error(f"Error extracting breaching variables: {e}")
+            logger.error(f"Error extracting breaching variables from {hdf_path}: {e}")
             raise
 
     @staticmethod
@@ -407,7 +407,7 @@ class HdfResultsBreach:
                 return pd.DataFrame()
 
             if breach_df.empty:
-                logger.warning("No breach data available, returning structure data only")
+                logger.debug("No breach data available, returning structure data only")
                 return struct_df
 
             # Determine merge columns
@@ -438,11 +438,11 @@ class HdfResultsBreach:
 
             combined_df = combined_df[col_order]
 
-            logger.info(f"Created combined breach timeseries with {len(combined_df)} rows")
+            logger.debug(f"Created combined breach timeseries with {len(combined_df)} rows")
             return combined_df
 
         except Exception as e:
-            logger.error(f"Error creating combined breach timeseries: {e}")
+            logger.error(f"Error creating combined breach timeseries from {hdf_path}: {e}")
             raise
 
     @staticmethod
@@ -568,9 +568,9 @@ class HdfResultsBreach:
                 summary_list.append(summary)
 
             result_df = pd.DataFrame(summary_list)
-            logger.info(f"Generated breach summary for {len(structures)} structure(s)")
+            logger.debug(f"Generated breach summary for {len(structures)} structure(s)")
             return result_df
 
         except Exception as e:
-            logger.error(f"Error generating breach summary: {e}")
+            logger.error(f"Error generating breach summary from {hdf_path}: {e}")
             raise

--- a/ras_commander/hdf/HdfResultsMesh.py
+++ b/ras_commander/hdf/HdfResultsMesh.py
@@ -1172,7 +1172,7 @@ class HdfResultsMesh:
             return xr.Dataset()
         
         try:
-            return xr.merge(datasets)
+            return xr.merge(datasets, join="outer")
         except Exception as e:
             logger.error(f"Failed to merge datasets: {str(e)}")
             return xr.Dataset()
@@ -1457,7 +1457,7 @@ class HdfResultsMesh:
             if crs:
                 result.set_crs(crs, inplace=True)
 
-            logger.info(f"Extracted max depth for {len(result)} cells")
+            logger.debug(f"Extracted max depth for {len(result)} cells")
             return result
 
         except Exception as e:
@@ -1553,7 +1553,8 @@ class HdfResultsMesh:
             dst.build_overviews([2, 4, 8, 16], rasterio.enums.Resampling.average)
             dst.update_tags(ns="rio_overview", resampling="average")
 
-        logger.info(f"Wrote max depth raster ({rows}x{cols} px, {resolution_m}m): {output_path}")
+        logger.info("Wrote max depth raster (%sx%s px, %sm): %s", rows, cols, resolution_m, output_path.name)
+        logger.debug("Max depth raster path: %s", output_path)
         return output_path
 
     @staticmethod
@@ -1834,12 +1835,8 @@ class HdfResultsMesh:
 
                 output_paths[str(original_value)] = raster_path
 
-        logger.info(
-            "Wrote %s depth raster(s) for mesh '%s' to %s",
-            len(output_paths),
-            mesh_name,
-            output_dir,
-        )
+        logger.info("Wrote %s depth raster(s) for mesh '%s'", len(output_paths), mesh_name)
+        logger.debug("Depth raster output directory: %s", output_dir)
         return output_paths
 
     @staticmethod
@@ -1972,7 +1969,8 @@ class HdfResultsMesh:
             elif isinstance(mesh_names, str):
                 mesh_names = [mesh_names]
 
-            if var:
+            explicit_var = var is not None
+            if explicit_var:
                 variables = [var]
             else:
                 variables = TIME_SERIES_OUTPUT_VARS["cell"] + TIME_SERIES_OUTPUT_VARS["face"]
@@ -1980,9 +1978,22 @@ class HdfResultsMesh:
             datasets = {}
             for mesh_name in mesh_names:
                 data_vars = {}
+                missing_optional_variables = []
                 for variable in variables:
                     try:
                         path = HdfResultsMesh._get_mesh_timeseries_output_path(mesh_name, variable)
+                        if path not in hdf_path:
+                            if explicit_var:
+                                logger.error(
+                                    "Requested mesh time-series variable '%s' was not found for mesh '%s' at HDF path '%s'",
+                                    variable,
+                                    mesh_name,
+                                    path,
+                                )
+                            else:
+                                missing_optional_variables.append(variable)
+                            continue
+
                         dataset = hdf_path[path]
                         values = dataset[:]
                         units = HdfResultsMesh._decode_hdf_attr(
@@ -2019,9 +2030,27 @@ class HdfResultsMesh:
                             attrs={'units': units}
                         )
                     except KeyError:
-                        logger.warning(f"Variable '{variable}' not found in the HDF file for mesh '{mesh_name}'. Skipping.")
+                        if explicit_var:
+                            logger.error(
+                                "Requested mesh time-series variable '%s' was not found for mesh '%s'",
+                                variable,
+                                mesh_name,
+                            )
+                        else:
+                            missing_optional_variables.append(variable)
                     except Exception as e:
                         logger.error(f"Error processing variable '{variable}' for mesh '{mesh_name}': {str(e)}")
+
+                if missing_optional_variables:
+                    logger.debug(
+                        "Mesh '%s' time-series probe found %s variable(s) and skipped %s unavailable variable(s). "
+                        "Available: %s. Missing: %s",
+                        mesh_name,
+                        len(data_vars),
+                        len(missing_optional_variables),
+                        ", ".join(data_vars.keys()) if data_vars else "none",
+                        ", ".join(missing_optional_variables),
+                    )
 
                 if data_vars:
                     datasets[mesh_name] = xr.Dataset(
@@ -2029,7 +2058,14 @@ class HdfResultsMesh:
                         attrs={'mesh_name': mesh_name, 'start_time': start_time}
                     )
                 else:
-                    logger.warning(f"No valid data variables found for mesh '{mesh_name}'")
+                    if explicit_var:
+                        logger.error(
+                            "No valid data variables found for mesh '%s' for requested variable '%s'",
+                            mesh_name,
+                            var,
+                        )
+                    else:
+                        logger.warning(f"No valid data variables found for mesh '{mesh_name}'")
 
             return datasets
         except Exception as e:
@@ -2300,7 +2336,7 @@ class HdfResultsMesh:
             
             gdf.attrs.update(combined_attrs)
             
-            logger.info(f"Processed {len(gdf)} rows of summary output data")
+            logger.debug(f"Processed {len(gdf)} rows of summary output data")
             return gdf
         
         except Exception as e:

--- a/ras_commander/hdf/HdfResultsPlan.py
+++ b/ras_commander/hdf/HdfResultsPlan.py
@@ -242,7 +242,11 @@ class HdfResultsPlan:
                     simulation_duration = end_time - start_time
                     simulation_hours = simulation_duration.total_seconds() / 3600
                 except ValueError as e:
-                    logger.error(f"Error parsing simulation times: {e}")
+                    logger.debug(
+                        "Runtime metadata unavailable for %s: could not parse simulation times (%s)",
+                        Path(hdf_file.filename).name,
+                        e,
+                    )
                     return None
 
                 logger.debug(f"Plan Name: {plan_name}")
@@ -334,7 +338,7 @@ class HdfResultsPlan:
                 ref_path = f"{base_path}/Reference {reftype.capitalize()}"
                 
                 if ref_path not in hdf_file:
-                    logger.warning(f"Reference {reftype} data not found in HDF file")
+                    logger.debug(f"Reference {reftype} data not found in HDF file")
                     return pd.DataFrame()
 
                 ref_group = hdf_file[ref_path]
@@ -377,7 +381,7 @@ class HdfResultsPlan:
                 ref_path = f"{base_path}/Reference {reftype.capitalize()}"
                 
                 if ref_path not in hdf_file:
-                    logger.warning(f"Reference {reftype} summary data not found in HDF file")
+                    logger.debug(f"Reference {reftype} summary data not found in HDF file")
                     return pd.DataFrame()
 
                 ref_group = hdf_file[ref_path]
@@ -425,7 +429,7 @@ class HdfResultsPlan:
             with h5py.File(hdf_path, 'r') as hdf_file:
                 return "Results/Steady" in hdf_file
         except Exception as e:
-            logger.error(f"Error checking if plan is steady: {str(e)}")
+            logger.debug(f"Error checking if plan is steady: {str(e)}")
             return False
 
     @staticmethod
@@ -775,7 +779,7 @@ class HdfResultsPlan:
 
                 # Check if path exists in HDF
                 if compute_msgs_path not in hdf_file:
-                    logger.warning(
+                    logger.debug(
                         f"Compute Messages not found in HDF at '{compute_msgs_path}', "
                         f"falling back to .txt file extraction"
                     )
@@ -789,7 +793,7 @@ class HdfResultsPlan:
                         # e.g., "C:/path/BaldEagle.p10.hdf" -> use path for RasControl
                         txt_contents = RasControl.get_comp_msgs(hdf_path)
                         if txt_contents:
-                            logger.info(f"Successfully retrieved {len(txt_contents)} characters from .txt file")
+                            logger.debug(f"Successfully retrieved {len(txt_contents)} characters from .txt file")
                             return txt_contents
                     except Exception as e:
                         logger.debug(f".txt file fallback failed: {e}")
@@ -828,7 +832,7 @@ class HdfResultsPlan:
                 from ..RasControl import RasControl
                 txt_contents = RasControl.get_comp_msgs(hdf_path)
                 if txt_contents:
-                    logger.warning(
+                    logger.debug(
                         f"HDF file not found, successfully retrieved computation messages from .txt file"
                     )
                     return txt_contents
@@ -846,7 +850,7 @@ class HdfResultsPlan:
                 from ..RasControl import RasControl
                 txt_contents = RasControl.get_comp_msgs(hdf_path)
                 if txt_contents:
-                    logger.warning(
+                    logger.debug(
                         f"HDF extraction failed, successfully retrieved computation messages from .txt file"
                     )
                     return txt_contents
@@ -1183,7 +1187,7 @@ class HdfResultsPlan:
 
             with h5py.File(hdf_path, 'r') as hdf_file:
                 if "Results/Steady" not in hdf_file:
-                    logger.warning("No steady state results in this file")
+                    logger.debug("No steady state results in this file")
                     return result
 
                 base_path = "Results/Steady/Output/Output Blocks/Base Output/Steady Profiles"

--- a/ras_commander/hdf/HdfResultsPlot.py
+++ b/ras_commander/hdf/HdfResultsPlot.py
@@ -24,11 +24,12 @@ Input DataFrames must contain:
     - Variable data columns as specified in individual function docstrings
 """
 
+import warnings
+from typing import Any, Dict, Optional
+
 import matplotlib.pyplot as plt
 import pandas as pd
-from typing import Dict
 from ..Decorators import log_call
-from .HdfMesh import HdfMesh
 
 class HdfResultsPlot:
     """
@@ -37,6 +38,39 @@ class HdfResultsPlot:
     This class provides visualization methods for various types of HEC-RAS results,
     including maximum water surface elevations and timing information.
     """
+
+    @staticmethod
+    def _prepare_xy_dataframe(
+        df: pd.DataFrame,
+        required_columns: list[str],
+        plot_name: str,
+    ) -> pd.DataFrame:
+        """Validate required columns and add x/y columns from point geometry."""
+        missing_columns = [col for col in required_columns if col not in df.columns]
+        if missing_columns:
+            raise ValueError(
+                f"Cannot plot {plot_name}; missing column(s): {missing_columns}. "
+                f"Available columns: {list(df.columns)}"
+            )
+
+        plot_df = df.copy()
+
+        def get_coord(geom, attr: str):
+            if geom is None or not hasattr(geom, attr):
+                return None
+            return getattr(geom, attr)
+
+        plot_df['x'] = plot_df['geometry'].apply(lambda geom: get_coord(geom, 'x'))
+        plot_df['y'] = plot_df['geometry'].apply(lambda geom: get_coord(geom, 'y'))
+        plot_df = plot_df.dropna(subset=['x', 'y'])
+
+        if plot_df.empty:
+            raise ValueError(
+                f"Cannot plot {plot_name}; no valid point geometries were found "
+                "in the 'geometry' column."
+            )
+
+        return plot_df
 
     @staticmethod
     @log_call
@@ -48,18 +82,15 @@ class HdfResultsPlot:
             max_ws_df (pd.DataFrame): DataFrame containing merged data with coordinates 
                                     and max water surface elevations.
         """
-        # Extract x and y coordinates from the geometry column
-        max_ws_df['x'] = max_ws_df['geometry'].apply(lambda geom: geom.x if geom is not None else None)
-        max_ws_df['y'] = max_ws_df['geometry'].apply(lambda geom: geom.y if geom is not None else None)
-
-        if 'x' not in max_ws_df.columns or 'y' not in max_ws_df.columns:
-            print("Error: 'x' or 'y' columns not found in the merged dataframe.")
-            print("Available columns:", max_ws_df.columns.tolist())
-            return
+        plot_df = HdfResultsPlot._prepare_xy_dataframe(
+            max_ws_df,
+            ['geometry', 'maximum_water_surface'],
+            'maximum water surface',
+        )
 
         fig, ax = plt.subplots(figsize=(12, 8))
-        scatter = ax.scatter(max_ws_df['x'], max_ws_df['y'], 
-                           c=max_ws_df['maximum_water_surface'], 
+        scatter = ax.scatter(plot_df['x'], plot_df['y'],
+                           c=plot_df['maximum_water_surface'],
                            cmap='viridis', s=10)
 
         ax.set_title('Max Water Surface per Cell')
@@ -74,30 +105,54 @@ class HdfResultsPlot:
 
     @staticmethod
     @log_call
-    def plot_results_max_wsel_time(max_ws_df: pd.DataFrame) -> None:
+    def plot_results_max_wsel_time(
+        max_ws_df: pd.DataFrame,
+        show_stats: bool = False,
+    ) -> Optional[Dict[str, Any]]:
         """
         Plots the time of the maximum water surface elevation (WSEL) per cell.
 
         Args:
             max_ws_df (pd.DataFrame): DataFrame containing merged data with coordinates 
                                     and max water surface timing information.
+            show_stats (bool): If True, return concise timing statistics.
         """
-        # Convert datetime strings using the renamed utility function
-        max_ws_df['max_wsel_time'] = pd.to_datetime(max_ws_df['maximum_water_surface_time'])
-        
-        # Extract coordinates
-        max_ws_df['x'] = max_ws_df['geometry'].apply(lambda geom: geom.x if geom is not None else None)
-        max_ws_df['y'] = max_ws_df['geometry'].apply(lambda geom: geom.y if geom is not None else None)
-
-        if 'x' not in max_ws_df.columns or 'y' not in max_ws_df.columns:
-            raise ValueError("x and y coordinates are missing from the DataFrame. Make sure the 'geometry' column exists and contains valid coordinate data.")
+        plot_df = HdfResultsPlot._prepare_xy_dataframe(
+            max_ws_df,
+            ['geometry', 'maximum_water_surface_time'],
+            'maximum water surface timing',
+        )
+        try:
+            with warnings.catch_warnings():
+                warnings.filterwarnings(
+                    "ignore",
+                    message="Could not infer format",
+                    category=UserWarning,
+                )
+                parsed_times = pd.to_datetime(
+                    plot_df['maximum_water_surface_time'],
+                    errors='coerce',
+                )
+        except Exception as exc:
+            raise ValueError(
+                "Cannot plot maximum water surface timing; "
+                "'maximum_water_surface_time' could not be parsed as datetimes."
+            ) from exc
+        invalid_count = int(parsed_times.isna().sum())
+        if invalid_count:
+            raise ValueError(
+                "Cannot plot maximum water surface timing; "
+                "'maximum_water_surface_time' could not be parsed as datetimes "
+                f"for {invalid_count} row(s)."
+            )
+        plot_df['max_wsel_time'] = parsed_times
 
         fig, ax = plt.subplots(figsize=(12, 8))
 
-        min_time = max_ws_df['max_wsel_time'].min()
-        color_values = (max_ws_df['max_wsel_time'] - min_time).dt.total_seconds() / 3600
+        min_time = plot_df['max_wsel_time'].min()
+        color_values = (plot_df['max_wsel_time'] - min_time).dt.total_seconds() / 3600
 
-        scatter = ax.scatter(max_ws_df['x'], max_ws_df['y'], 
+        scatter = ax.scatter(plot_df['x'], plot_df['y'],
                            c=color_values, cmap='viridis', s=10)
 
         ax.set_title('Time of Maximum Water Surface Elevation per Cell')
@@ -114,11 +169,18 @@ class HdfResultsPlot:
         plt.tight_layout()
         plt.show()
 
-        # Print timing information
-        print(f"\nSimulation Start Time: {min_time}")
-        print(f"Time Range: {color_values.max():.1f} hours")
-        print("\nTiming Statistics (hours since start):")
-        print(color_values.describe()) 
+        if show_stats:
+            stats = color_values.describe()
+            return {
+                'simulation_start_time': min_time,
+                'time_range_hours': float(color_values.max()),
+                'count': int(stats['count']),
+                'mean_hours': float(stats['mean']),
+                'min_hours': float(stats['min']),
+                'max_hours': float(stats['max']),
+            }
+
+        return None
 
     @staticmethod
     @log_call
@@ -139,36 +201,17 @@ class HdfResultsPlot:
             ImportError: If matplotlib is not installed
             ValueError: If required columns are missing from variable_df
         """
-        try:
-            import matplotlib.pyplot as plt
-        except ImportError:
-            logger.error("matplotlib is required for plotting. Please install it with 'pip install matplotlib'")
-            raise ImportError("matplotlib is required for plotting")
+        merged_df = HdfResultsPlot._prepare_xy_dataframe(
+            variable_df,
+            ['geometry', variable_name],
+            variable_name,
+        )
 
-        # Get cell coordinates if not in variable_df
-        if 'geometry' not in variable_df.columns:
-            cell_coords = HdfMesh.mesh_cell_points(plan_hdf_path)
-            merged_df = pd.merge(variable_df, cell_coords, on=['mesh_name', 'cell_id'])
-        else:
-            merged_df = variable_df
-            
-        # Extract coordinates, handling None values
-        merged_df = merged_df.dropna(subset=['geometry'])
-        merged_df['x'] = merged_df['geometry'].apply(lambda geom: geom.x if geom is not None else None)
-        merged_df['y'] = merged_df['geometry'].apply(lambda geom: geom.y if geom is not None else None)
-        
-        # Drop any rows with None coordinates
-        merged_df = merged_df.dropna(subset=['x', 'y'])
-        
-        if len(merged_df) == 0:
-            logger.error("No valid coordinates found for plotting")
-            raise ValueError("No valid coordinates found for plotting")
-            
         # Create plot
         fig, ax = plt.subplots(figsize=(12, 8))
-        scatter = ax.scatter(merged_df['x'], merged_df['y'], 
-                           c=merged_df[variable_name], 
-                           cmap=colormap, 
+        scatter = ax.scatter(merged_df['x'], merged_df['y'],
+                           c=merged_df[variable_name],
+                           cmap=colormap,
                            s=point_size)
         
         # Customize plot

--- a/ras_commander/hdf/HdfResultsQuery.py
+++ b/ras_commander/hdf/HdfResultsQuery.py
@@ -191,6 +191,7 @@ def _resolve_geometry_hdf(
     plan_hdf_path = Path(plan_hdf_path)
     project_folder = plan_hdf_path.parent
     project_name = _project_name_from_plan_hdf(plan_hdf_path)
+    missing_geometry_error: Optional[FileNotFoundError] = None
 
     try:
         with h5py.File(plan_hdf_path, "r") as hdf_file:
@@ -212,9 +213,11 @@ def _resolve_geometry_hdf(
                 )
                 if geom_hdf_path.exists():
                     return geom_hdf_path
-                raise FileNotFoundError(
-                    f"Geometry HDF not found: {geom_hdf_path}"
+                missing_geometry_error = FileNotFoundError(
+                    "Geometry HDF referenced by plan metadata was not found: "
+                    f"{geom_hdf_path}"
                 )
+                break
     except Exception:
         pass
 
@@ -271,6 +274,10 @@ def _resolve_geometry_hdf(
                 geom_hdf_path = geom_base.parent / f"{geom_base.name}.hdf"
                 if geom_hdf_path.exists():
                     return geom_hdf_path
+                missing_geometry_error = FileNotFoundError(
+                    "Geometry HDF referenced by ras_object plan_df was not found: "
+                    f"{geom_hdf_path}"
+                )
 
             geom_number = _extract_geometry_number(row.get("Geom File"))
             if geom_number is None:
@@ -300,15 +307,23 @@ def _resolve_geometry_hdf(
                         geom_hdf_path = Path(str(geom_rows.iloc[0]["hdf_path"]))
                         if geom_hdf_path.exists():
                             return geom_hdf_path
+                        missing_geometry_error = FileNotFoundError(
+                            "Geometry HDF referenced by ras_object geom_df was not found: "
+                            f"{geom_hdf_path}"
+                        )
 
                 geom_hdf_path = (
                     project_folder / f"{project_name}.g{geom_number}.hdf"
                 )
                 if geom_hdf_path.exists():
                     return geom_hdf_path
-                raise FileNotFoundError(
-                    f"Geometry HDF not found: {geom_hdf_path}"
+                missing_geometry_error = FileNotFoundError(
+                    "Geometry HDF referenced by ras_object metadata was not found: "
+                    f"{geom_hdf_path}"
                 )
+
+    if missing_geometry_error is not None:
+        raise missing_geometry_error
 
     raise FileNotFoundError(
         "Could not resolve geometry HDF from plan HDF. "
@@ -534,12 +549,13 @@ def _collapse_steady_dataset(
 
     if values.ndim == 2:
         if values.shape[0] > 1:
-            logger.info(
-                "Steady 2D dataset for mesh '%s' variable '%s' contains "
-                "%s profiles; using the last profile.",
+            logger.warning(
+                "Steady 2D dataset for mesh '%s' variable '%s' contains %s profiles; "
+                "profile selection is not yet exposed, using last profile index %s.",
                 mesh_name,
                 variable_name,
                 values.shape[0],
+                values.shape[0] - 1,
             )
         return np.asarray(values[-1, :], dtype=float)
 
@@ -881,8 +897,9 @@ def _get_unsteady_variable_values(
             ) from direct_read_error
         try:
             logger.debug(
-                "'Velocity' dataset not found; computing from Velocity X "
-                "and Velocity Y."
+                "Requested velocity result '%s' not found directly; "
+                "using Velocity X/Velocity Y component fallback when available.",
+                variable_name,
             )
             vx = _read_unsteady_direct(
                 plan_hdf_path, cache, "Velocity X", time_index,
@@ -1350,7 +1367,10 @@ def _timeseries_dataframe(
     return result_df
 
 
-def _warn_on_large_distances(distances: np.ndarray) -> None:
+def _warn_on_large_distances(
+    distances: np.ndarray,
+    point_label: str = "query point",
+) -> None:
     """Warn when nearest-cell distances suggest a CRS mismatch."""
     distances = np.asarray(distances, dtype=float)
     large = distances > 1000.0
@@ -1359,10 +1379,14 @@ def _warn_on_large_distances(distances: np.ndarray) -> None:
 
     count = int(np.sum(large))
     max_distance = float(np.max(distances[large]))
+    point_label = point_label.strip() or "query point"
+    label = point_label if count == 1 else f"{point_label}s"
     logger.warning(
-        "Nearest-cell distance exceeds 1000 model units for %s query "
-        "point(s) (max distance %.2f). This often indicates a CRS mismatch.",
+        "Nearest-cell distance exceeds 1000 model units for %s %s "
+        "(max distance %.2f). Verify CRS/units or whether the query "
+        "geometry extends outside the 2D mesh.",
         count,
+        label,
         max_distance,
     )
 
@@ -1415,6 +1439,7 @@ def _query_points_core(
     time_index: Union[int, str],
     method: str,
     ras_object: Optional[Any] = None,
+    point_label: str = "query point",
 ) -> pd.DataFrame:
     """Shared implementation for single-point and batch point queries."""
     method = method.lower().strip()
@@ -1449,7 +1474,7 @@ def _query_points_core(
             dtype=float,
         )
 
-    _warn_on_large_distances(distances)
+    _warn_on_large_distances(distances, point_label=point_label)
 
     return pd.DataFrame(
         {
@@ -1729,13 +1754,15 @@ class HdfResultsQuery:
             n_points,
         )
 
-        points_df = HdfResultsQuery.query_points(
+        profile_points = pd.DataFrame({"x": xs, "y": ys})
+        points_df = _query_points_core(
             hdf_path,
-            np.column_stack((xs, ys)),
-            variable=variable,
-            time_index=time_index,
-            method="nearest",
+            profile_points,
+            variable,
+            time_index,
+            "nearest",
             ras_object=ras_object,
+            point_label="profile sample point",
         )
         points_df.insert(0, "station", stations)
         return points_df[
@@ -2486,7 +2513,10 @@ class HdfResultsQuery:
             seed_point,
             mesh_name=mesh_name,
         )
-        _warn_on_large_distances(np.array([seed_distance], dtype=float))
+        _warn_on_large_distances(
+            np.array([seed_distance], dtype=float),
+            point_label="transverse seed point",
+        )
 
         seed_mesh_name = str(cache["mesh_names"][seed_global_index])
         seed_cell_id = int(cache["cell_ids"][seed_global_index])

--- a/ras_commander/hdf/HdfResultsXsec.py
+++ b/ras_commander/hdf/HdfResultsXsec.py
@@ -59,6 +59,12 @@ class HdfResultsXsec:
         - HdfBase: Core HDF file operations
         - HdfUtils: Utility functions for HDF processing
     """
+    _BASE_TS_PATH = (
+        "Results/Unsteady/Output/Output Blocks/Base Output/"
+        "Unsteady Time Series"
+    )
+    _XSEC_OUTPUT_PATH = f"{_BASE_TS_PATH}/Cross Sections"
+    _TIME_STAMP_PATH = f"{_BASE_TS_PATH}/Time Date Stamp (ms)"
 
 
 # Tested functions from AWS webinar where the code was developed
@@ -88,18 +94,33 @@ class HdfResultsXsec:
         try:
             with h5py.File(hdf_path, 'r') as hdf_file:
                 # Define base paths
-                base_output_path = "/Results/Unsteady/Output/Output Blocks/Base Output/Unsteady Time Series/Cross Sections/"
-                time_stamp_path = "/Results/Unsteady/Output/Output Blocks/Base Output/Unsteady Time Series/Time Date Stamp (ms)"
+                base_output_path = HdfResultsXsec._XSEC_OUTPUT_PATH
+                time_stamp_path = HdfResultsXsec._TIME_STAMP_PATH
+                required_dataset_paths = [
+                    f"{base_output_path}/Cross Section Attributes",
+                    f"{base_output_path}/Cross Section Only",
+                    time_stamp_path,
+                    f"{base_output_path}/Water Surface",
+                    f"{base_output_path}/Velocity Total",
+                    f"{base_output_path}/Velocity Channel",
+                    f"{base_output_path}/Flow Lateral",
+                    f"{base_output_path}/Flow",
+                ]
+                HdfResultsXsec._validate_xsec_timeseries_paths(
+                    hdf_path,
+                    hdf_file,
+                    required_dataset_paths,
+                )
                 
                 # Extract Cross Section Attributes
-                attrs_dataset = hdf_file[f"{base_output_path}Cross Section Attributes"][:]
+                attrs_dataset = hdf_file[f"{base_output_path}/Cross Section Attributes"][:]
                 rivers = [attr['River'].decode('utf-8').strip() for attr in attrs_dataset]
                 reaches = [attr['Reach'].decode('utf-8').strip() for attr in attrs_dataset]
                 stations = [attr['Station'].decode('utf-8').strip() for attr in attrs_dataset]
                 names = [attr['Name'].decode('utf-8').strip() for attr in attrs_dataset]
                 
                 # Extract Cross Section Only (Unique Names)
-                cross_section_only_dataset = hdf_file[f"{base_output_path}Cross Section Only"][:]
+                cross_section_only_dataset = hdf_file[f"{base_output_path}/Cross Section Only"][:]
                 cross_section_names = [cs.decode('utf-8').strip() for cs in cross_section_only_dataset]
                 
                 # Extract Time Stamps and convert to datetime
@@ -110,11 +131,11 @@ class HdfResultsXsec:
                 times = pd.to_datetime(time_stamps, format='%d%b%Y %H:%M:%S:%f')
                 
                 # Extract Required Datasets
-                water_surface = hdf_file[f"{base_output_path}Water Surface"][:]
-                velocity_total = hdf_file[f"{base_output_path}Velocity Total"][:]
-                velocity_channel = hdf_file[f"{base_output_path}Velocity Channel"][:]
-                flow_lateral = hdf_file[f"{base_output_path}Flow Lateral"][:]
-                flow = hdf_file[f"{base_output_path}Flow"][:]
+                water_surface = hdf_file[f"{base_output_path}/Water Surface"][:]
+                velocity_total = hdf_file[f"{base_output_path}/Velocity Total"][:]
+                velocity_channel = hdf_file[f"{base_output_path}/Velocity Channel"][:]
+                flow_lateral = hdf_file[f"{base_output_path}/Flow Lateral"][:]
+                flow = hdf_file[f"{base_output_path}/Flow"][:]
                 
                 # Calculate maximum values along time axis
                 max_water_surface = np.max(water_surface, axis=0)
@@ -147,18 +168,94 @@ class HdfResultsXsec:
                     },
                     attrs={
                         'description': 'Cross-section results extracted from HEC-RAS HDF file',
-                        'source_file': str(hdf_path)
+                        'source_file': hdf_path.name
                     }
                 )
                 
                 return ds
 
         except KeyError as e:
-            logger.error(f"Required dataset not found in HDF file: {e}")
+            message = e.args[0] if e.args else str(e)
+            logger.error(
+                "%s",
+                message,
+            )
+            logger.debug(
+                "Full HDF path for failed cross-section results extraction: %s",
+                hdf_path,
+                exc_info=True,
+            )
             raise
         except Exception as e:
-            logger.error(f"Error extracting cross section results: {e}")
+            logger.error(
+                "Error extracting cross-section results from %s: %s",
+                hdf_path.name,
+                e,
+            )
+            logger.debug(
+                "Full HDF path for failed cross-section results extraction: %s",
+                hdf_path,
+                exc_info=True,
+            )
             raise
+
+    @staticmethod
+    def _validate_xsec_timeseries_paths(
+        hdf_path: Path,
+        hdf_file: h5py.File,
+        required_dataset_paths: Sequence[str],
+    ) -> None:
+        """Raise an actionable error if required 1D time-series data is absent."""
+        for dataset_path in required_dataset_paths:
+            if dataset_path not in hdf_file:
+                raise KeyError(
+                    HdfResultsXsec._missing_xsec_timeseries_message(
+                        hdf_path,
+                        hdf_file,
+                        dataset_path,
+                    )
+                )
+
+    @staticmethod
+    def _missing_xsec_timeseries_message(
+        hdf_path: Path,
+        hdf_file: h5py.File,
+        dataset_path: str,
+    ) -> str:
+        """Return condition-specific guidance for missing 1D result datasets."""
+        filename = hdf_path.name
+
+        if "Results" not in hdf_file:
+            return (
+                f"Cannot extract 1D cross-section time series from {filename}: "
+                "/Results is absent; this appears to be a minimal, geometry-only, "
+                "or uncomputed HDF."
+            )
+
+        if "Results/Steady" in hdf_file and "Results/Unsteady" not in hdf_file:
+            return (
+                f"Cannot extract 1D unsteady cross-section time series from {filename}: "
+                "file contains steady results, not unsteady time-series output. "
+                "Use HdfResultsPlan.get_steady_wse() for steady profiles."
+            )
+
+        if "Results/Unsteady" not in hdf_file:
+            return (
+                f"Cannot extract 1D unsteady cross-section time series from {filename}: "
+                "/Results/Unsteady is absent; the HDF does not contain unsteady "
+                "time-series output."
+            )
+
+        if HdfResultsXsec._XSEC_OUTPUT_PATH not in hdf_file:
+            return (
+                f"Cannot extract 1D cross-section time series from {filename}: "
+                "unsteady results exist but Cross Sections output is absent."
+            )
+
+        return (
+            f"Missing required 1D cross-section result dataset in {filename}: "
+            f"{dataset_path}"
+        )
 
 
 
@@ -291,15 +388,19 @@ class HdfResultsXsec:
         if reftype == "lines":
             output_path = "Results/Unsteady/Output/Output Blocks/Base Output/Unsteady Time Series/Reference Lines"
             abbrev = "refln"
+            ref_label = "line"
         elif reftype == "points":
             output_path = "Results/Unsteady/Output/Output Blocks/Base Output/Unsteady Time Series/Reference Points"
             abbrev = "refpt"
+            ref_label = "point"
         else:
             raise ValueError('reftype must be either "lines" or "points".')
 
+        filename = HdfResultsXsec._hdf_filename(hdf_file)
         should_close = not isinstance(hdf_file, h5py.File)
         if should_close:
             hdf_file = h5py.File(hdf_file, "r")
+            filename = HdfResultsXsec._hdf_filename(hdf_file)
 
         variable_filter = HdfResultsXsec._normalize_reference_variable_filter(variables)
 
@@ -307,11 +408,29 @@ class HdfResultsXsec:
             try:
                 reference_group = hdf_file[output_path]
             except KeyError:
-                logger.error(
-                    f"Could not find HDF group at path '{output_path}'. "
-                    f"The Plan HDF file may not contain reference {reftype[:-1]} output data."
+                logger.debug(
+                    "Reference %s time-series group not found in %s; returning empty Dataset.",
+                    ref_label,
+                    filename,
                 )
                 return xr.Dataset()
+
+            if "Name" not in reference_group:
+                message = (
+                    f"Reference {ref_label} time-series group in {filename} is missing "
+                    "required dataset 'Name'; cannot build feature coordinates."
+                )
+                logger.error("%s", message)
+                raise KeyError(message)
+
+            if HdfResultsXsec._TIME_STAMP_PATH not in hdf_file:
+                message = (
+                    f"Reference {ref_label} time-series group in {filename} exists but "
+                    "unsteady timestamps are missing; this appears to be incomplete "
+                    "or minimal results output."
+                )
+                logger.error("%s", message)
+                raise KeyError(message)
 
             reference_names = reference_group["Name"][:]
             names = []
@@ -353,10 +472,25 @@ class HdfResultsXsec:
                     attrs={"units": units, "hdf_path": f"{output_path}/{var}"},
                 )
                 das[var] = da
+            if not das:
+                logger.debug(
+                    "Reference %s group found in %s, but no numeric datasets matched "
+                    "expected shape %s; returning empty Dataset.",
+                    ref_label,
+                    filename,
+                    expected_shape,
+                )
             return xr.Dataset(das)
         finally:
             if should_close:
                 hdf_file.close()
+
+    @staticmethod
+    def _hdf_filename(hdf_file: Union[h5py.File, Path]) -> str:
+        """Return a display-safe filename for an HDF file object or path."""
+        if isinstance(hdf_file, h5py.File):
+            return Path(hdf_file.filename).name
+        return Path(hdf_file).name
 
     @staticmethod
     def _normalize_reference_variable_filter(

--- a/ras_commander/hdf/HdfStorageArea.py
+++ b/ras_commander/hdf/HdfStorageArea.py
@@ -40,7 +40,10 @@ class HdfStorageArea:
     """
 
     _STORAGE_AREA_PATH = "Geometry/Storage Areas"
+    _VOLUME_ELEVATION_INFO = "Volume Elevation Info"
+    _VOLUME_ELEVATION_VALUES = "Volume Elevation Values"
     _ACRE_SQFT = 43560.0
+    _ACRE_SQM = 4046.8564224
 
     @staticmethod
     def _decode_hdf_value(value: Any) -> Any:
@@ -135,6 +138,134 @@ class HdfStorageArea:
             }
 
     @staticmethod
+    def _compute_volume_below_elevation_from_terrain(
+        terrain_path: Path,
+        polygon: Any,
+        elevation: float,
+    ) -> float:
+        """Compute storage volume without public API logging around each sample."""
+        rasterio, rasterio_mask_fn = HdfStorageArea._require_rasterio()
+        terrain_path = Path(terrain_path)
+        if not terrain_path.exists():
+            raise FileNotFoundError(f"Terrain file not found: {terrain_path}")
+
+        with rasterio.open(terrain_path) as src:
+            terrain_data, _, cell_area = HdfStorageArea._masked_terrain_array(
+                src, polygon, rasterio_mask_fn,
+            )
+            depths = float(elevation) - terrain_data
+            valid_depths = depths[~np.isnan(depths) & (depths > 0)]
+            return float(np.sum(valid_depths * cell_area))
+
+    @staticmethod
+    def _log_missing_volume_elevation_curve(
+        hdf_path: Path,
+        sa_name: str,
+        reason: str,
+    ) -> None:
+        info_path = (
+            f"{HdfStorageArea._STORAGE_AREA_PATH}/"
+            f"{HdfStorageArea._VOLUME_ELEVATION_INFO}"
+        )
+        values_path = (
+            f"{HdfStorageArea._STORAGE_AREA_PATH}/"
+            f"{HdfStorageArea._VOLUME_ELEVATION_VALUES}"
+        )
+        logger.error(
+            "Volume-elevation curve data unavailable for storage area '%s' "
+            "in %s (%s). These datasets are created by the HEC-RAS geometry "
+            "preprocessor; run the geometry preprocessor first if you need "
+            "this curve. Required HDF datasets: '%s' and '%s'.",
+            sa_name,
+            hdf_path.name,
+            reason,
+            info_path,
+            values_path,
+        )
+        logger.debug(
+            "Volume-elevation curve request failed for storage area '%s' in %s",
+            sa_name,
+            hdf_path,
+        )
+
+    @staticmethod
+    def _get_storage_unit_conversion(hdf_path: Path) -> Dict[str, Any]:
+        """Return metadata for converting terrain-integrated volume to storage units."""
+        hdf_path = Path(hdf_path)
+        units_system_raw = None
+        si_units_raw = None
+
+        try:
+            with h5py.File(hdf_path, "r") as hdf_file:
+                units_system_raw = hdf_file.attrs.get("Units System")
+                geom_group = hdf_file.get("Geometry")
+                if geom_group is not None:
+                    si_units_raw = geom_group.attrs.get("SI Units")
+        except Exception as exc:
+            logger.debug(
+                "Unable to read storage unit metadata from %s: %s",
+                hdf_path,
+                exc,
+            )
+
+        units_system_text = str(
+            HdfStorageArea._decode_hdf_value(units_system_raw) or ""
+        ).strip()
+        si_units_text = str(
+            HdfStorageArea._decode_hdf_value(si_units_raw) or ""
+        ).strip().lower()
+        units_system_key = units_system_text.lower()
+
+        if si_units_text in {"false", "0", "no"}:
+            return {
+                "units_system": "US Customary",
+                "storage_units": "acre-ft",
+                "raw_storage_units": "cubic ft",
+                "storage_conversion_factor": 1.0 / HdfStorageArea._ACRE_SQFT,
+                "area_units": "sq ft",
+                "area_to_acres_factor": 1.0 / HdfStorageArea._ACRE_SQFT,
+            }
+
+        if si_units_text in {"true", "1", "yes"}:
+            return {
+                "units_system": "SI",
+                "storage_units": "m^3",
+                "raw_storage_units": "m^3",
+                "storage_conversion_factor": 1.0,
+                "area_units": "m^2",
+                "area_to_acres_factor": 1.0 / HdfStorageArea._ACRE_SQM,
+            }
+
+        if units_system_key in {"us customary", "customary", "english"}:
+            return {
+                "units_system": "US Customary",
+                "storage_units": "acre-ft",
+                "raw_storage_units": "cubic ft",
+                "storage_conversion_factor": 1.0 / HdfStorageArea._ACRE_SQFT,
+                "area_units": "sq ft",
+                "area_to_acres_factor": 1.0 / HdfStorageArea._ACRE_SQFT,
+            }
+
+        if units_system_key in {"si", "metric"}:
+            return {
+                "units_system": "SI",
+                "storage_units": "m^3",
+                "raw_storage_units": "m^3",
+                "storage_conversion_factor": 1.0,
+                "area_units": "m^2",
+                "area_to_acres_factor": 1.0 / HdfStorageArea._ACRE_SQM,
+            }
+
+        return {
+            "units_system": "unknown",
+            "storage_units": "cubic project units",
+            "raw_storage_units": "cubic project units",
+            "storage_conversion_factor": 1.0,
+            "area_units": "square project units",
+            "area_to_acres_factor": None,
+        }
+
+    @staticmethod
     def _get_perimeter_polygon(
         hdf_path: Path, sa_name: str, *, ras_object: Any = None,
     ) -> Any:
@@ -169,13 +300,27 @@ class HdfStorageArea:
         """
         with h5py.File(hdf_path, "r") as hdf_file:
             if HdfStorageArea._STORAGE_AREA_PATH not in hdf_file:
+                logger.debug(
+                    "Storage areas group '%s' not found in %s.",
+                    HdfStorageArea._STORAGE_AREA_PATH,
+                    hdf_path.name,
+                )
                 return []
             sa_group = hdf_file[HdfStorageArea._STORAGE_AREA_PATH]
             if "Attributes" not in sa_group:
+                logger.debug(
+                    "Storage area attributes not found in %s (%s).",
+                    hdf_path.name,
+                    HdfStorageArea._STORAGE_AREA_PATH,
+                )
                 return []
 
             attrs = sa_group["Attributes"][()]
             if not getattr(attrs.dtype, "names", None) or "Name" not in attrs.dtype.names:
+                logger.debug(
+                    "Storage area attributes in %s do not include a Name field.",
+                    hdf_path.name,
+                )
                 return []
 
             return [
@@ -201,15 +346,29 @@ class HdfStorageArea:
         """
         with h5py.File(hdf_path, "r") as hdf_file:
             if HdfStorageArea._STORAGE_AREA_PATH not in hdf_file:
+                logger.debug(
+                    "Storage areas group '%s' not found in %s.",
+                    HdfStorageArea._STORAGE_AREA_PATH,
+                    hdf_path.name,
+                )
                 return {}
 
             sa_group = hdf_file[HdfStorageArea._STORAGE_AREA_PATH]
             if "Attributes" not in sa_group:
+                logger.debug(
+                    "Storage area attributes not found in %s (%s).",
+                    hdf_path.name,
+                    HdfStorageArea._STORAGE_AREA_PATH,
+                )
                 return {}
 
             attrs = sa_group["Attributes"][()]
             names = attrs.dtype.names or ()
             if "Name" not in names:
+                logger.debug(
+                    "Storage area attributes in %s do not include a Name field.",
+                    hdf_path.name,
+                )
                 return {}
 
             for row in attrs:
@@ -252,6 +411,11 @@ class HdfStorageArea:
 
                 return properties
 
+        logger.debug(
+            "Storage area '%s' not found in %s.",
+            sa_name,
+            hdf_path.name,
+        )
         return {}
 
     @staticmethod
@@ -286,14 +450,28 @@ class HdfStorageArea:
         try:
             with h5py.File(hdf_path, "r") as hdf_file:
                 if HdfStorageArea._STORAGE_AREA_PATH not in hdf_file:
+                    logger.debug(
+                        "Storage areas group '%s' not found in %s.",
+                        HdfStorageArea._STORAGE_AREA_PATH,
+                        hdf_path.name,
+                    )
                     return empty
                 sa_group = hdf_file[HdfStorageArea._STORAGE_AREA_PATH]
 
                 if "Attributes" not in sa_group:
+                    logger.debug(
+                        "Storage area attributes not found in %s (%s).",
+                        hdf_path.name,
+                        HdfStorageArea._STORAGE_AREA_PATH,
+                    )
                     return empty
                 attrs = sa_group["Attributes"][()]
                 field_names = getattr(attrs.dtype, "names", None)
                 if not field_names or "Name" not in field_names:
+                    logger.debug(
+                        "Storage area attributes in %s do not include a Name field.",
+                        hdf_path.name,
+                    )
                     return empty
 
                 sa_index = None
@@ -303,17 +481,45 @@ class HdfStorageArea:
                         sa_index = idx
                         break
                 if sa_index is None:
+                    logger.debug(
+                        "Storage area '%s' not found in %s.",
+                        sa_name,
+                        hdf_path.name,
+                    )
                     return empty
 
-                if "Volume Elevation Info" not in sa_group or "Volume Elevation Values" not in sa_group:
+                if (
+                    HdfStorageArea._VOLUME_ELEVATION_INFO not in sa_group
+                    or HdfStorageArea._VOLUME_ELEVATION_VALUES not in sa_group
+                ):
+                    missing = [
+                        dataset
+                        for dataset in (
+                            HdfStorageArea._VOLUME_ELEVATION_INFO,
+                            HdfStorageArea._VOLUME_ELEVATION_VALUES,
+                        )
+                        if dataset not in sa_group
+                    ]
+                    HdfStorageArea._log_missing_volume_elevation_curve(
+                        hdf_path,
+                        sa_name,
+                        "missing " + ", ".join(missing),
+                    )
                     return empty
 
-                info = sa_group["Volume Elevation Info"][()]
+                info = sa_group[HdfStorageArea._VOLUME_ELEVATION_INFO][()]
                 start, count = int(info[sa_index, 0]), int(info[sa_index, 1])
                 if count == 0:
+                    HdfStorageArea._log_missing_volume_elevation_curve(
+                        hdf_path,
+                        sa_name,
+                        "zero points",
+                    )
                     return empty
 
-                values = sa_group["Volume Elevation Values"][start:start + count]
+                values = sa_group[HdfStorageArea._VOLUME_ELEVATION_VALUES][
+                    start:start + count
+                ]
                 df = pd.DataFrame(
                     {"elevation": values[:, 1].astype("float64"),
                      "volume": values[:, 0].astype("float64")},
@@ -325,7 +531,14 @@ class HdfStorageArea:
                 return df
 
         except Exception as e:
-            logger.error("Error reading volume-elevation curve for SA '%s': %s", sa_name, e)
+            logger.error(
+                "Error reading volume-elevation curve for SA '%s' from %s "
+                "(%s): %s",
+                sa_name,
+                hdf_path,
+                HdfStorageArea._STORAGE_AREA_PATH,
+                e,
+            )
             return empty
 
     @staticmethod
@@ -346,16 +559,19 @@ class HdfStorageArea:
         with h5py.File(hdf_path, "r") as hdf_file:
             geom_group = hdf_file.get("Geometry")
             if geom_group is None:
+                logger.debug("Geometry group not found in %s.", hdf_path.name)
                 return None
 
             terrain_raw = geom_group.attrs.get("Terrain Filename")
             if terrain_raw is None:
                 terrain_raw = hdf_file.attrs.get("Terrain Filename")
             if terrain_raw is None:
+                logger.debug("Terrain Filename attribute not found in %s.", hdf_path.name)
                 return None
 
         terrain_text = str(HdfStorageArea._decode_hdf_value(terrain_raw)).strip()
         if not terrain_text:
+            logger.debug("Terrain Filename attribute is empty in %s.", hdf_path.name)
             return None
 
         terrain_text = terrain_text.replace("\\", "/")
@@ -374,7 +590,11 @@ class HdfStorageArea:
             if candidate.exists():
                 return candidate
 
-        logger.warning("Terrain referenced by %s was not found: %s", hdf_path, terrain_path)
+        logger.debug(
+            "Terrain referenced by %s was not found. Checked candidate path(s): %s",
+            hdf_path.name,
+            ", ".join(str(candidate) for candidate in candidates),
+        )
         return None
 
     @staticmethod
@@ -390,18 +610,11 @@ class HdfStorageArea:
         The returned volume is in cubic project units, matching the horizontal
         and vertical units of the terrain raster.
         """
-        rasterio, rasterio_mask_fn = HdfStorageArea._require_rasterio()
-        terrain_path = Path(terrain_path)
-        if not terrain_path.exists():
-            raise FileNotFoundError(f"Terrain file not found: {terrain_path}")
-
-        with rasterio.open(terrain_path) as src:
-            terrain_data, _, cell_area = HdfStorageArea._masked_terrain_array(
-                src, polygon, rasterio_mask_fn,
-            )
-            depths = float(elevation) - terrain_data
-            valid_depths = depths[~np.isnan(depths) & (depths > 0)]
-            return float(np.sum(valid_depths * cell_area))
+        return HdfStorageArea._compute_volume_below_elevation_from_terrain(
+            terrain_path,
+            polygon,
+            elevation,
+        )
 
     @staticmethod
     @log_call
@@ -438,7 +651,9 @@ class HdfStorageArea:
         -------
         Tuple[pandas.DataFrame, dict]
             DataFrame columns are ``stage`` and ``storage``.  ``storage`` is in
-            cubic project units.  Metadata is also copied to ``df.attrs``.
+            acre-feet for US Customary projects, cubic meters for SI projects,
+            or cubic project units when the HDF unit system is unknown.
+            Metadata is also copied to ``df.attrs``.
         """
         if elevation_interval <= 0:
             raise ValueError("elevation_interval must be greater than zero")
@@ -463,7 +678,10 @@ class HdfStorageArea:
                 ras_object=ras_object,
             )
             if terrain_path is None:
-                raise ValueError(f"Terrain file not found from geometry HDF: {hdf_path}")
+                raise ValueError(
+                    "Terrain file referenced by "
+                    f"{hdf_path.name} for storage area '{sa_name}' was not found."
+                )
 
             if progress_callback:
                 progress_callback(20, 100, "Extracting terrain statistics")
@@ -490,20 +708,30 @@ class HdfStorageArea:
             if progress_callback:
                 progress_callback(30, 100, f"Computing {len(elevations)} volumes")
 
+            unit_info = HdfStorageArea._get_storage_unit_conversion(hdf_path)
+            storage_conversion_factor = float(unit_info["storage_conversion_factor"])
+
             rows = []
             total = len(elevations)
             for idx, elev in enumerate(elevations, start=1):
-                volume = HdfStorageArea.compute_volume_below_elevation(
+                raw_volume = HdfStorageArea._compute_volume_below_elevation_from_terrain(
                     terrain_path,
                     polygon,
                     float(elev),
                 )
-                rows.append({"stage": float(elev), "storage": float(volume)})
+                rows.append(
+                    {
+                        "stage": float(elev),
+                        "storage": float(raw_volume) * storage_conversion_factor,
+                    }
+                )
                 if progress_callback:
                     percent = 30 + int(70 * idx / max(total, 1))
                     progress_callback(percent, 100, f"Computed volume {idx}/{total}")
 
             df = pd.DataFrame(rows, columns=["stage", "storage"])
+            area_to_acres_factor = unit_info["area_to_acres_factor"]
+            storage_area = float(polygon.area)
             metadata: Dict[str, Any] = {
                 "storage_area_name": sa_name,
                 "terrain_path": str(terrain_path),
@@ -512,13 +740,19 @@ class HdfStorageArea:
                 "mean_terrain_elev": stats["mean_interior"],
                 "min_perimeter_elev": stats["min_perimeter"],
                 "max_perimeter_elev": stats["max_perimeter"],
-                "storage_area_acres": float(polygon.area) / HdfStorageArea._ACRE_SQFT,
+                "storage_area_area": storage_area,
+                "storage_area_area_units": unit_info["area_units"],
+                "storage_area_acres": (
+                    storage_area * float(area_to_acres_factor)
+                    if area_to_acres_factor is not None
+                    else None
+                ),
                 "num_elevation_points": int(len(elevations)),
                 "elevation_interval": float(elevation_interval),
                 "valid_cell_count": stats["valid_cell_count"],
                 "cell_area": stats["cell_area"],
-                "storage_units": "cubic project units",
             }
+            metadata.update(unit_info)
             df.attrs.update(metadata)
             df.attrs["storage_area"] = sa_name
 
@@ -530,11 +764,14 @@ class HdfStorageArea:
         except (FileNotFoundError, ValueError):
             raise
         except Exception as e:
-            logger.error(
+            logger.debug(
                 "Error computing stage-storage curve for SA '%s' in %s: %s",
-                sa_name, hdf_path, e,
+                sa_name, hdf_path, e, exc_info=True,
             )
-            raise IOError(f"Failed to compute stage-storage curve: {e}") from e
+            raise IOError(
+                f"Failed to compute stage-storage curve for storage area "
+                f"'{sa_name}' in {hdf_path.name}: {e}"
+            ) from e
 
     @staticmethod
     @log_call

--- a/ras_commander/hdf/HdfStruc.py
+++ b/ras_commander/hdf/HdfStruc.py
@@ -47,6 +47,42 @@ class HdfStruc:
     - All methods use @log_call for operation logging
     - Returns GeoDataFrames with both geometric and attribute data
     """
+
+    SA_2D_CONN_RESULTS_PATH = (
+        "Results/Unsteady/Output/Output Blocks/Base Output/Unsteady Time Series/"
+        "SA 2D Area Conn"
+    )
+
+    @staticmethod
+    def _decode_bytes_columns(df: pd.DataFrame) -> pd.DataFrame:
+        """Decode HDF byte-string columns in place and return the DataFrame."""
+        for col in df.columns:
+            if df[col].dtype.kind in {'S', 'a'}:
+                df[col] = df[col].str.decode('utf-8', errors='ignore')
+            elif df[col].dtype == object:
+                df[col] = df[col].apply(
+                    lambda x: x.decode('utf-8', errors='ignore')
+                    if isinstance(x, (bytes, np.bytes_))
+                    else x
+                )
+        return df
+
+    @staticmethod
+    def _list_sa2d_connections_from_hdf(
+        hdf_file: h5py.File,
+        hdf_path: Path,
+    ) -> List[str]:
+        base_path = HdfStruc.SA_2D_CONN_RESULTS_PATH
+        if base_path not in hdf_file:
+            logger.debug(f"No SA 2D Area Conn data found in {hdf_path.name}")
+            return []
+
+        structures = list(hdf_file[base_path].keys())
+        logger.debug(
+            f"Found {len(structures)} SA/2D connection structures in "
+            f"{hdf_path.name}: {structures}"
+        )
+        return structures
     
     @staticmethod
     @log_call
@@ -83,18 +119,25 @@ class HdfStruc:
         try:
             with h5py.File(hdf_path, 'r') as hdf:
                 if "Geometry/Structures" not in hdf:
-                    logger.error(f"No Structures Found in the HDF, Empty Geodataframe Returned: {hdf_path}")
+                    logger.debug(
+                        f"No Geometry/Structures group in {hdf_path.name}; "
+                        "returning empty GeoDataFrame."
+                    )
                     return GeoDataFrame()
                 
                 # Check if required datasets exist
                 required_datasets = [
+                    "Geometry/Structures/Attributes",
                     "Geometry/Structures/Centerline Info",
                     "Geometry/Structures/Centerline Points"
                 ]
                 
                 for dataset in required_datasets:
                     if dataset not in hdf:
-                        logger.error(f"No Structures Found in the HDF, Empty Geodataframe Returned: {hdf_path}")
+                        logger.warning(
+                            f"Required structure dataset missing in {hdf_path.name}: "
+                            f"{dataset}; returning empty GeoDataFrame."
+                        )
                         return GeoDataFrame()
 
                 def get_dataset_df(path: str) -> pd.DataFrame:
@@ -119,18 +162,16 @@ class HdfStruc:
                     Automatically decodes byte strings to UTF-8 with error handling.
                     """
                     if path not in hdf:
-                        logger.warning(f"Dataset not found: {path}")
+                        logger.debug(
+                            f"Optional structure dataset not found in {hdf_path.name}: {path}"
+                        )
                         return pd.DataFrame()
                     
                     data = hdf[path][()]
                     
                     if data.dtype.names:
                         df = pd.DataFrame(data)
-                        # Decode byte strings to UTF-8
-                        for col in df.columns:
-                            if df[col].dtype.kind in {'S', 'a'}:  # Byte strings
-                                df[col] = df[col].str.decode('utf-8', errors='ignore')
-                        return df
+                        return HdfStruc._decode_bytes_columns(df)
                     else:
                         # If no named fields, assign generic column names
                         return pd.DataFrame(data, columns=[f'Value_{i}' for i in range(data.shape[1])])
@@ -138,9 +179,15 @@ class HdfStruc:
                 # Extract relevant datasets
                 group_attrs = HdfBase.get_attrs(hdf, "Geometry/Structures")
                 struct_attrs = get_dataset_df("Geometry/Structures/Attributes")
-                bridge_coef = get_dataset_df("Geometry/Structures/Bridge Coefficient Attributes")
-                table_info = get_dataset_df("Geometry/Structures/Table Info")
-                profile_data = get_dataset_df("Geometry/Structures/Profile Data")
+                bridge_coef_path = "Geometry/Structures/Bridge Coefficient Attributes"
+                table_info_path = "Geometry/Structures/Table Info"
+                profile_data_path = "Geometry/Structures/Profile Data"
+                bridge_coef_present = bridge_coef_path in hdf
+                table_info_present = table_info_path in hdf
+                profile_data_present = profile_data_path in hdf
+                bridge_coef = get_dataset_df(bridge_coef_path)
+                table_info = get_dataset_df(table_info_path)
+                profile_data = get_dataset_df(profile_data_path)
 
                 # Assign 'Structure ID' based on index (starting from 1)
                 struct_attrs.reset_index(drop=True, inplace=True)
@@ -158,6 +205,7 @@ class HdfStruc:
                 
                 # Create LineString geometries for each structure
                 geoms = []
+                invalid_indices = []
                 for i in range(len(centerline_info)):
                     start_idx = centerline_info[i][0]  # Point Starting Index
                     point_count = centerline_info[i][1]  # Point Count
@@ -165,7 +213,11 @@ class HdfStruc:
                     if len(points) >= 2:
                         geoms.append(LineString(points))
                     else:
-                        logger.warning(f"Insufficient points for LineString in structure index {i}.")
+                        invalid_indices.append(i)
+                        logger.debug(
+                            f"Structure index {i} in {hdf_path.name} has "
+                            f"{len(points)} centerline point(s); LineString requires at least 2."
+                        )
                         geoms.append(None)
 
                 # Create base GeoDataFrame with Structures Attributes and geometries
@@ -180,7 +232,13 @@ class HdfStruc:
                 struct_gdf = struct_gdf.dropna(subset=['geometry']).reset_index(drop=True)
                 final_count = len(struct_gdf)
                 if final_count < initial_count:
-                    logger.warning(f"Dropped {initial_count - final_count} structures due to invalid geometries.")
+                    preview = invalid_indices[:5]
+                    suffix = "..." if len(invalid_indices) > 5 else ""
+                    logger.warning(
+                        f"Dropped {initial_count - final_count} structure(s) from "
+                        f"{hdf_path.name} due to invalid centerline geometry "
+                        f"(indices: {preview}{suffix})."
+                    )
 
                 # Merge Bridge Coefficient Attributes on 'Structure ID'
                 if not bridge_coef.empty and 'Structure ID' in bridge_coef.columns:
@@ -192,17 +250,33 @@ class HdfStruc:
                     )
                     logger.debug("Merged Bridge Coefficient Attributes successfully.")
                 else:
-                    logger.warning("Bridge Coefficient Attributes missing or 'Structure ID' not present.")
+                    if bridge_coef_present:
+                        logger.warning(
+                            f"Bridge Coefficient Attributes in {hdf_path.name} "
+                            "could not be merged because 'Structure ID' is missing."
+                        )
+                    else:
+                        logger.debug(
+                            f"Bridge Coefficient Attributes dataset absent in {hdf_path.name}; "
+                            "continuing without bridge coefficient attributes."
+                        )
 
                 # Merge Table Info based on the DataFrame index (one-to-one correspondence)
                 if not table_info.empty:
                     if len(table_info) != len(struct_gdf):
-                        logger.warning("Table Info count does not match Structures count. Skipping merge.")
+                        logger.warning(
+                            f"Table Info row count ({len(table_info)}) does not match "
+                            f"structure count ({len(struct_gdf)}) in {hdf_path.name}; "
+                            "skipping Table Info merge."
+                        )
                     else:
                         struct_gdf = pd.concat([struct_gdf, table_info.reset_index(drop=True)], axis=1)
                         logger.debug("Merged Table Info successfully.")
                 else:
-                    logger.warning("Table Info dataset is empty or missing.")
+                    if table_info_present:
+                        logger.debug(f"Table Info dataset is empty in {hdf_path.name}.")
+                    else:
+                        logger.debug(f"Table Info dataset is absent in {hdf_path.name}.")
 
                 # Process Profile Data based on Table Info
                 if not profile_data.empty and not table_info.empty:
@@ -222,9 +296,25 @@ class HdfStruc:
                         )
                         logger.debug("Processed Profile Data successfully.")
                     else:
-                        logger.warning("Required columns for Profile Data not found in Table Info.")
+                        logger.warning(
+                            f"Profile Data in {hdf_path.name} could not be processed; "
+                            "expected Table Info columns 'Centerline Profile (Index)' "
+                            "and 'Centerline Profile (Count)'."
+                        )
                 else:
-                    logger.warning("Profile Data dataset is empty or Table Info is missing.")
+                    missing = []
+                    if not profile_data_present:
+                        missing.append("Profile Data")
+                    elif profile_data.empty:
+                        missing.append("non-empty Profile Data")
+                    if not table_info_present:
+                        missing.append("Table Info")
+                    elif table_info.empty:
+                        missing.append("non-empty Table Info")
+                    logger.debug(
+                        f"Skipping Profile Data processing for {hdf_path.name}; "
+                        f"missing {', '.join(missing)}."
+                    )
 
                 # Convert datetime columns to string if requested
                 if datetime_to_str:
@@ -234,11 +324,7 @@ class HdfStruc:
                         logger.debug(f"Converted datetime column '{col}' to string.")
 
                 # Ensure all byte strings are decoded (if any remain)
-                for col in struct_gdf.columns:
-                    if struct_gdf[col].dtype == object:
-                        struct_gdf[col] = struct_gdf[col].apply(
-                            lambda x: x.decode('utf-8', errors='ignore') if isinstance(x, bytes) else x
-                        )
+                struct_gdf = HdfStruc._decode_bytes_columns(struct_gdf)
 
                 # Final GeoDataFrame
                 logger.debug("Successfully extracted structures GeoDataFrame.")
@@ -295,7 +381,7 @@ class HdfStruc:
                 return pd.DataFrame(attrs_dict, index=[0])
 
         except Exception as e:
-            logger.error(f"Error reading geometry structures attributes: {str(e)}")
+            logger.error(f"Error reading geometry structures attributes from {hdf_path}: {str(e)}")
             return pd.DataFrame()
 
     @staticmethod
@@ -344,17 +430,19 @@ class HdfStruc:
 
                 struct_attrs = hdf_file["Geometry/Structures/Attributes"][()]
                 struct_df = pd.DataFrame(struct_attrs)
-
-                # Decode byte strings in structure attributes
-                for col in struct_df.columns:
-                    if struct_df[col].dtype.kind in {'S', 'a'}:  # Byte strings
-                        struct_df[col] = struct_df[col].str.decode('utf-8', errors='ignore')
+                struct_df = HdfStruc._decode_bytes_columns(struct_df)
 
                 # Filter for culverts only (assuming Type field exists)
                 if 'Type' in struct_df.columns:
-                    culvert_df = struct_df[struct_df['Type'].str.contains('Culvert', case=False, na=False)].copy()
+                    type_series = struct_df['Type'].astype(str)
+                    culvert_df = struct_df[
+                        type_series.str.contains('Culvert', case=False, na=False)
+                    ].copy()
                 else:
-                    logger.warning("No 'Type' column in structure attributes, returning all structures")
+                    logger.warning(
+                        f"No 'Type' column in structure attributes for {hdf_path.name}; "
+                        f"returning all {len(struct_df)} structure row(s)."
+                    )
                     culvert_df = struct_df.copy()
 
                 if culvert_df.empty:
@@ -370,21 +458,25 @@ class HdfStruc:
                 if culvert_data_path in hdf_file:
                     culvert_data = hdf_file[culvert_data_path][()]
                     culvert_data_df = pd.DataFrame(culvert_data)
-
-                    # Decode byte strings in culvert data
-                    for col in culvert_data_df.columns:
-                        if culvert_data_df[col].dtype.kind in {'S', 'a'}:
-                            culvert_data_df[col] = culvert_data_df[col].str.decode('utf-8', errors='ignore')
+                    culvert_data_df = HdfStruc._decode_bytes_columns(culvert_data_df)
 
                     # Merge culvert-specific data with structure attributes
                     # Note: We assume culvert data is in same order as culvert structures
                     if len(culvert_data_df) == len(culvert_df):
                         result_df = pd.concat([culvert_df, culvert_data_df], axis=1)
                     else:
-                        logger.warning(f"Culvert data count ({len(culvert_data_df)}) doesn't match culvert structure count ({len(culvert_df)})")
+                        logger.warning(
+                            f"Culvert Data row count ({len(culvert_data_df)}) does not match "
+                            f"culvert structure count ({len(culvert_df)}) in {hdf_path.name}; "
+                            "returning structure attributes only."
+                        )
                         result_df = culvert_df
                 else:
-                    logger.warning(f"No 'Culvert Data' dataset found in {hdf_path}")
+                    logger.warning(
+                        f"Culvert structures found in {hdf_path.name}, but "
+                        "Geometry/Structures/Culvert Data is absent; returning "
+                        "structure attributes only."
+                    )
                     result_df = culvert_df
 
                 # Standardize column names to match API specification
@@ -406,11 +498,7 @@ class HdfStruc:
                         result_df[col] = result_df[col].dt.isoformat()
 
                 # Ensure all byte strings are decoded (if any remain)
-                for col in result_df.columns:
-                    if result_df[col].dtype == object:
-                        result_df[col] = result_df[col].apply(
-                            lambda x: x.decode('utf-8', errors='ignore') if isinstance(x, bytes) else x
-                        )
+                result_df = HdfStruc._decode_bytes_columns(result_df)
 
                 logger.debug(f"Successfully extracted hydraulic data for {len(result_df)} culverts")
                 return result_df
@@ -456,16 +544,7 @@ class HdfStruc:
         """
         try:
             with h5py.File(hdf_path, 'r') as hdf_file:
-                base_path = "Results/Unsteady/Output/Output Blocks/Base Output/Unsteady Time Series/SA 2D Area Conn"
-
-                if base_path not in hdf_file:
-                    logger.warning(f"No SA 2D Area Conn data found in {hdf_path.name}")
-                    return []
-
-                # List all groups (structure names) under SA 2D Area Conn
-                structures = list(hdf_file[base_path].keys())
-                logger.debug(f"Found {len(structures)} SA/2D connection structures: {structures}")
-                return structures
+                return HdfStruc._list_sa2d_connections_from_hdf(hdf_file, hdf_path)
 
         except Exception as e:
             logger.error(f"Error listing SA/2D connection structures: {e}")
@@ -509,12 +588,12 @@ class HdfStruc:
         """
         try:
             with h5py.File(hdf_path, 'r') as hdf_file:
-                structures = HdfStruc.list_sa2d_connections(hdf_path, ras_object=ras_object)
+                structures = HdfStruc._list_sa2d_connections_from_hdf(hdf_file, hdf_path)
 
                 if not structures:
                     return pd.DataFrame()
 
-                base_path = "Results/Unsteady/Output/Output Blocks/Base Output/Unsteady Time Series/SA 2D Area Conn"
+                base_path = HdfStruc.SA_2D_CONN_RESULTS_PATH
 
                 info_list = []
                 for struct_name in structures:

--- a/ras_commander/hdf/HdfStruc1D.py
+++ b/ras_commander/hdf/HdfStruc1D.py
@@ -134,31 +134,34 @@ class HdfStruc1D:
             'found': False
         }
 
-        try:
-            with h5py.File(hdf_path, 'r') as hdf_file:
-                # Determine if unsteady or steady results
-                is_unsteady = "Results/Unsteady" in hdf_file
-                is_steady = "Results/Steady" in hdf_file
+        with h5py.File(hdf_path, 'r') as hdf_file:
+            # Determine if unsteady or steady results
+            is_unsteady = "Results/Unsteady" in hdf_file
+            is_steady = "Results/Steady" in hdf_file
 
-                if is_unsteady:
-                    result = HdfStruc1D._extract_unsteady_structure_max(
-                        hdf_file, river, reach, rs, result
-                    )
-                elif is_steady:
-                    result = HdfStruc1D._extract_steady_structure_max(
-                        hdf_file, river, reach, rs, result
-                    )
-                else:
-                    logger.warning(f"No steady or unsteady results found in {hdf_path}")
-                    return result
+            if is_unsteady:
+                result = HdfStruc1D._extract_unsteady_structure_max(
+                    hdf_file, river, reach, rs, result
+                )
+            elif is_steady:
+                result = HdfStruc1D._extract_steady_structure_max(
+                    hdf_file, river, reach, rs, result
+                )
+            else:
+                raise ValueError(
+                    f"No steady or unsteady results were found in {Path(hdf_path).name}. "
+                    "Compute a steady or unsteady plan and pass the plan HDF with results."
+                )
 
-                return result
+        if not result.get('found'):
+            raise ValueError(
+                f"No 1D structure results were found for {river}/{reach}/RS {rs} "
+                f"in {Path(hdf_path).name}. Checked cross-section output and direct "
+                "structure output; confirm the plan has been computed and this "
+                "structure is included in the results."
+            )
 
-        except FileNotFoundError:
-            raise
-        except Exception as e:
-            logger.error(f"Error extracting structure max values: {str(e)}")
-            return result
+        return result
 
     @staticmethod
     def _extract_unsteady_structure_max(
@@ -172,14 +175,19 @@ class HdfStruc1D:
         base_path = "Results/Unsteady/Output/Output Blocks/Base Output/Unsteady Time Series/Cross Sections"
 
         if base_path not in hdf_file:
-            logger.warning("No cross section results found in unsteady output")
-            return result
+            raise ValueError(
+                "Unsteady 1D structure extraction requires cross-section results at "
+                f"'{base_path}'. Confirm the plan has been computed with 1D structure "
+                "results available."
+            )
 
         # Get cross section attributes to find structure location
         attrs_path = f"{base_path}/Cross Section Attributes"
         if attrs_path not in hdf_file:
-            logger.warning("No cross section attributes found")
-            return result
+            raise ValueError(
+                "Unsteady 1D structure extraction requires cross-section attributes at "
+                f"'{attrs_path}'. Confirm the plan HDF includes 1D cross-section output."
+            )
 
         attrs_data = hdf_file[attrs_path][()]
 
@@ -307,16 +315,24 @@ class HdfStruc1D:
         base_path = "Results/Steady/Output/Output Blocks/Base Output/Steady Profiles/Cross Sections"
 
         if base_path not in hdf_file:
-            logger.warning("No cross section results found in steady output")
-            return result
+            raise ValueError(
+                "Steady 1D structure extraction requires cross-section results at "
+                f"'{base_path}'. Confirm the plan has been computed with steady "
+                "profile results available."
+            )
 
         # Get cross section attributes
         attrs_path = f"{base_path}/Attributes"
         if attrs_path not in hdf_file:
             attrs_path = "Results/Steady/Output/Geometry Info/Cross Section Attributes"
             if attrs_path not in hdf_file:
-                logger.warning("No cross section attributes found")
-                return result
+                raise ValueError(
+                    "Steady 1D structure extraction requires cross-section attributes at "
+                    "'Results/Steady/Output/Output Blocks/Base Output/Steady Profiles/"
+                    "Cross Sections/Attributes' or 'Results/Steady/Output/Geometry Info/"
+                    "Cross Section Attributes'. Confirm the plan HDF includes steady "
+                    "geometry output."
+                )
 
         attrs_data = hdf_file[attrs_path][()]
 
@@ -400,7 +416,7 @@ class HdfStruc1D:
                             result['tw_source'] = result['hw_source']
 
                         if hw_idx is not None:
-                            logger.info(
+                            logger.debug(
                                 f"Steady structure {rs}: using flanking XS "
                                 f"US={upstream['station'] if upstream else 'N/A'}, "
                                 f"DS={downstream['station'] if downstream else 'N/A'}"
@@ -547,60 +563,56 @@ class HdfStruc1D:
         """
         structures = []
 
-        try:
-            with h5py.File(hdf_path, 'r') as hdf_file:
-                # Check unsteady results
-                unsteady_path = "Results/Unsteady/Output/Output Blocks/Base Output/Unsteady Time Series/Cross Sections/Cross Section Attributes"
-                if unsteady_path in hdf_file:
-                    attrs_data = hdf_file[unsteady_path][()]
+        with h5py.File(hdf_path, 'r') as hdf_file:
+            # Check unsteady results
+            unsteady_path = "Results/Unsteady/Output/Output Blocks/Base Output/Unsteady Time Series/Cross Sections/Cross Section Attributes"
+            if unsteady_path in hdf_file:
+                attrs_data = hdf_file[unsteady_path][()]
 
-                    for attr in attrs_data:
-                        name = attr['Name'].decode('utf-8').strip() if 'Name' in attr.dtype.names and isinstance(attr['Name'], bytes) else ""
+                for attr in attrs_data:
+                    name = attr['Name'].decode('utf-8').strip() if 'Name' in attr.dtype.names and isinstance(attr['Name'], bytes) else ""
 
-                        # Identify structure markers
-                        is_structure = 'BR U' in name or 'BR D' in name or 'IC' in name or 'Culv' in name.lower()
+                    # Identify structure markers
+                    is_structure = 'BR U' in name or 'BR D' in name or 'IC' in name or 'Culv' in name.lower()
 
-                        if is_structure:
-                            river = attr['River'].decode('utf-8').strip() if isinstance(attr['River'], bytes) else str(attr['River']).strip()
-                            reach = attr['Reach'].decode('utf-8').strip() if isinstance(attr['Reach'], bytes) else str(attr['Reach']).strip()
-                            station = attr['Station'].decode('utf-8').strip() if isinstance(attr['Station'], bytes) else str(attr['Station']).strip()
+                    if is_structure:
+                        river = attr['River'].decode('utf-8').strip() if isinstance(attr['River'], bytes) else str(attr['River']).strip()
+                        reach = attr['Reach'].decode('utf-8').strip() if isinstance(attr['Reach'], bytes) else str(attr['Reach']).strip()
+                        station = attr['Station'].decode('utf-8').strip() if isinstance(attr['Station'], bytes) else str(attr['Station']).strip()
 
-                            struct_type = "Unknown"
-                            if 'BR' in name:
-                                struct_type = "Bridge"
-                            elif 'IC' in name:
-                                struct_type = "Inline"
-                            elif 'Culv' in name.lower():
-                                struct_type = "Culvert"
-
-                            structures.append({
-                                'River': river,
-                                'Reach': reach,
-                                'RS': station,
-                                'Name': name,
-                                'Type': struct_type
-                            })
-
-                # Check Structures group if exists
-                struct_attrs_path = "Results/Unsteady/Output/Output Blocks/Base Output/Unsteady Time Series/Structures/Structure Attributes"
-                if struct_attrs_path in hdf_file:
-                    struct_attrs = hdf_file[struct_attrs_path][()]
-                    for attr in struct_attrs:
-                        river = attr['River'].decode('utf-8').strip() if 'River' in attr.dtype.names and isinstance(attr['River'], bytes) else ""
-                        reach = attr['Reach'].decode('utf-8').strip() if 'Reach' in attr.dtype.names and isinstance(attr['Reach'], bytes) else ""
-                        rs = attr['RS'].decode('utf-8').strip() if 'RS' in attr.dtype.names and isinstance(attr['RS'], bytes) else ""
-                        name = attr['Name'].decode('utf-8').strip() if 'Name' in attr.dtype.names and isinstance(attr['Name'], bytes) else ""
+                        struct_type = "Unknown"
+                        if 'BR' in name:
+                            struct_type = "Bridge"
+                        elif 'IC' in name:
+                            struct_type = "Inline"
+                        elif 'Culv' in name.lower():
+                            struct_type = "Culvert"
 
                         structures.append({
                             'River': river,
                             'Reach': reach,
-                            'RS': rs,
+                            'RS': station,
                             'Name': name,
-                            'Type': 'Structure'
+                            'Type': struct_type
                         })
 
-        except Exception as e:
-            logger.error(f"Error listing 1D structures: {str(e)}")
+            # Check Structures group if exists
+            struct_attrs_path = "Results/Unsteady/Output/Output Blocks/Base Output/Unsteady Time Series/Structures/Structure Attributes"
+            if struct_attrs_path in hdf_file:
+                struct_attrs = hdf_file[struct_attrs_path][()]
+                for attr in struct_attrs:
+                    river = attr['River'].decode('utf-8').strip() if 'River' in attr.dtype.names and isinstance(attr['River'], bytes) else ""
+                    reach = attr['Reach'].decode('utf-8').strip() if 'Reach' in attr.dtype.names and isinstance(attr['Reach'], bytes) else ""
+                    rs = attr['RS'].decode('utf-8').strip() if 'RS' in attr.dtype.names and isinstance(attr['RS'], bytes) else ""
+                    name = attr['Name'].decode('utf-8').strip() if 'Name' in attr.dtype.names and isinstance(attr['Name'], bytes) else ""
+
+                    structures.append({
+                        'River': river,
+                        'Reach': reach,
+                        'RS': rs,
+                        'Name': name,
+                        'Type': 'Structure'
+                    })
 
         df = pd.DataFrame(structures)
         if not df.empty:

--- a/ras_commander/hdf/HdfUtils.py
+++ b/ras_commander/hdf/HdfUtils.py
@@ -119,7 +119,7 @@ class HdfUtils:
                 ]
             return HdfUtils.parse_ras_window_datetime(s)
         elif re.match(rf"^{ras_duration_format_re}$", s):
-            return HdfUtils.parse_ras_duration(s)
+            return HdfUtils.parse_duration(s)
         return s
 
 
@@ -329,25 +329,6 @@ class HdfUtils:
 
 
 
-# Datetime Parsing Methods:
-
-    @staticmethod
-    @log_call
-    def parse_ras_datetime_ms(datetime_str: str) -> datetime:
-        """
-        Public method to parse a datetime string with milliseconds from a RAS file.
-
-        Args:
-            datetime_str (str): The datetime string to parse.
-
-        Returns:
-            datetime: The parsed datetime object.
-        """
-        milliseconds = int(datetime_str[-3:])
-        microseconds = milliseconds * 1000
-        parsed_dt = HdfUtils.parse_ras_datetime(datetime_str[:-4]).replace(microsecond=microseconds)
-        return parsed_dt
-    
 # Rename to convert_timesteps_to_datetimes and make public
     @staticmethod
     def convert_timesteps_to_datetimes(timesteps: np.ndarray, start_time: datetime, time_unit: str = "days", round_to: str = "100ms") -> pd.DatetimeIndex:
@@ -411,8 +392,13 @@ class HdfUtils:
             time window.
         """
         split = window.split(" to ")
-        begin = HdfUtils._parse_ras_datetime(split[0])
-        end = HdfUtils._parse_ras_datetime(split[1])
+        if len(split) != 2 or not all(part.strip() for part in split):
+            raise ValueError(
+                "RAS run time window must use the format "
+                "'DDMMMYYYY HH:MM:SS to DDMMMYYYY HH:MM:SS'."
+            )
+        begin = HdfUtils.parse_ras_datetime(split[0].strip())
+        end = HdfUtils.parse_ras_datetime(split[1].strip())
         return begin, end
 
     
@@ -511,5 +497,4 @@ class HdfUtils:
         microseconds = milliseconds * 1000
         parsed_dt = HdfUtils.parse_ras_datetime(datetime_str[:-4]).replace(microsecond=microseconds)
         return parsed_dt
-    
     

--- a/ras_commander/hdf/HdfXsec.py
+++ b/ras_commander/hdf/HdfXsec.py
@@ -63,6 +63,61 @@ class HdfXsec:
         Requires HEC-RAS geometry HDF files with standard structure and naming conventions.
         All methods use proper error handling and logging.
     """
+    CROSS_SECTION_GROUP = "Geometry/Cross Sections"
+    CROSS_SECTION_REQUIRED_DATASETS = (
+        f"{CROSS_SECTION_GROUP}/Polyline Info",
+        f"{CROSS_SECTION_GROUP}/Polyline Parts",
+        f"{CROSS_SECTION_GROUP}/Polyline Points",
+        f"{CROSS_SECTION_GROUP}/Station Elevation Info",
+        f"{CROSS_SECTION_GROUP}/Station Elevation Values",
+        f"{CROSS_SECTION_GROUP}/Attributes",
+        f"{CROSS_SECTION_GROUP}/Manning's n Info",
+        f"{CROSS_SECTION_GROUP}/Manning's n Values",
+    )
+    CROSS_SECTION_CORE_GEOMETRY_DATASETS = (
+        f"{CROSS_SECTION_GROUP}/Polyline Info",
+        f"{CROSS_SECTION_GROUP}/Polyline Parts",
+        f"{CROSS_SECTION_GROUP}/Polyline Points",
+    )
+
+    @staticmethod
+    def _filename(hdf_path) -> str:
+        return Path(hdf_path).name
+
+    @staticmethod
+    def _convert_hdf_value(value):
+        if isinstance(value, (bytes, np.bytes_)):
+            converted = HdfUtils.convert_ras_string(value)
+            return converted.strip() if isinstance(converted, str) else converted
+        if isinstance(value, np.str_):
+            converted = HdfUtils.convert_ras_string(str(value))
+            return converted.strip() if isinstance(converted, str) else converted
+        if isinstance(value, np.generic):
+            return value.item()
+        return value
+
+    @staticmethod
+    def _datetime_value_to_str(value):
+        if pd.isna(value):
+            return None
+        try:
+            return pd.Timestamp(value).isoformat()
+        except (TypeError, ValueError):
+            return value
+
+    @staticmethod
+    def _structured_array_to_dict(attrs) -> dict:
+        if not getattr(attrs.dtype, "names", None):
+            return {}
+        return {
+            name: [HdfXsec._convert_hdf_value(value) for value in attrs[name]]
+            for name in attrs.dtype.names
+        }
+
+    @staticmethod
+    def _alternating_bank_sides(count: int) -> List[str]:
+        return ["Left" if idx % 2 == 0 else "Right" for idx in range(count)]
+
     @staticmethod
     @log_call
     def get_cross_sections(hdf_path: str, datetime_to_str: bool = True, ras_object=None) -> gpd.GeoDataFrame:
@@ -124,6 +179,36 @@ class HdfXsec:
         """
         try:
             with h5py.File(hdf_path, 'r') as hdf:
+                if HdfXsec.CROSS_SECTION_GROUP not in hdf:
+                    logger.debug(
+                        "No Geometry/Cross Sections group in %s; returning empty GeoDataFrame.",
+                        HdfXsec._filename(hdf_path),
+                    )
+                    return gpd.GeoDataFrame()
+
+                missing_datasets = [
+                    dataset
+                    for dataset in HdfXsec.CROSS_SECTION_REQUIRED_DATASETS
+                    if dataset not in hdf
+                ]
+                if missing_datasets:
+                    if all(
+                        dataset in missing_datasets
+                        for dataset in HdfXsec.CROSS_SECTION_CORE_GEOMETRY_DATASETS
+                    ):
+                        logger.debug(
+                            "No cross-section geometry datasets found in %s; missing %s; returning empty GeoDataFrame.",
+                            HdfXsec._filename(hdf_path),
+                            ", ".join(missing_datasets),
+                        )
+                    else:
+                        logger.warning(
+                            "Cross-section geometry in %s is missing required dataset(s): %s; returning empty GeoDataFrame.",
+                            HdfXsec._filename(hdf_path),
+                            ", ".join(missing_datasets),
+                        )
+                    return gpd.GeoDataFrame()
+
                 # Extract required datasets
                 poly_info = hdf['/Geometry/Cross Sections/Polyline Info'][:]
                 poly_parts = hdf['/Geometry/Cross Sections/Polyline Parts'][:]
@@ -332,14 +417,14 @@ class HdfXsec:
                         proj = hdf['/Geometry'].attrs['Projection']
                         if isinstance(proj, bytes):
                             proj = proj.decode('utf-8')
-                        gdf.set_crs(proj, allow_override=True)
+                        gdf = gdf.set_crs(proj, allow_override=True)
                     
                     return gdf
                 
                 return gpd.GeoDataFrame()
                 
         except Exception as e:
-            logger.error(f"Error processing cross-section data: {str(e)}")
+            logger.error(f"Error processing cross-section data from {hdf_path}: {str(e)}")
             return gpd.GeoDataFrame()
 
     @staticmethod
@@ -380,7 +465,10 @@ class HdfXsec:
         try:
             with h5py.File(hdf_path, 'r') as hdf_file:
                 if "Geometry/River Centerlines" not in hdf_file:
-                    logger.warning("No river centerlines found in geometry file")
+                    logger.debug(
+                        "No Geometry/River Centerlines group in %s; returning empty GeoDataFrame.",
+                        HdfXsec._filename(hdf_path),
+                    )
                     return GeoDataFrame()
 
                 centerline_data = hdf_file["Geometry/River Centerlines"]
@@ -389,16 +477,7 @@ class HdfXsec:
                 attrs = centerline_data["Attributes"][()]
                 
                 # Create initial dictionary for DataFrame
-                centerline_dict = {}
-                
-                # Process each attribute field
-                for name in attrs.dtype.names:
-                    values = attrs[name]
-                    if values.dtype.kind == 'S':
-                        # Convert byte strings to regular strings
-                        centerline_dict[name] = [val.decode('utf-8').strip() for val in values]
-                    else:
-                        centerline_dict[name] = values.tolist()  # Convert numpy array to list
+                centerline_dict = HdfXsec._structured_array_to_dict(attrs)
 
                 # Get polylines using utility function
                 geoms = HdfBase.get_polylines_from_parts(
@@ -439,7 +518,7 @@ class HdfXsec:
                 return centerline_gdf
 
         except Exception as e:
-            logger.error(f"Error reading river centerlines: {str(e)}")
+            logger.error(f"Error reading river centerlines from {hdf_path}: {str(e)}")
             return GeoDataFrame()
 
 
@@ -473,7 +552,7 @@ class HdfXsec:
         at 100 evenly spaced points along each centerline.
         """
         if centerlines_gdf.empty:
-            logger.warning("Empty centerlines GeoDataFrame provided")
+            logger.debug("Empty centerlines GeoDataFrame provided; returning unchanged.")
             return centerlines_gdf
 
         try:
@@ -578,15 +657,16 @@ class HdfXsec:
         try:
             with h5py.File(hdf_path, 'r') as hdf_file:
                 if "Geometry/River Centerlines" not in hdf_file:
+                    logger.debug(
+                        "No Geometry/River Centerlines group in %s; returning empty GeoDataFrame.",
+                        HdfXsec._filename(hdf_path),
+                    )
                     return GeoDataFrame()
 
                 river_data = hdf_file["Geometry/River Centerlines"]
-                v_conv_val = np.vectorize(HdfUtils.convert_ras_string)
                 river_attrs = river_data["Attributes"][()]
-                river_dict = {"river_id": range(river_attrs.shape[0])}
-                river_dict.update(
-                    {name: v_conv_val(river_attrs[name]) for name in river_attrs.dtype.names}
-                )
+                river_dict = {"river_id": list(range(river_attrs.shape[0]))}
+                river_dict.update(HdfXsec._structured_array_to_dict(river_attrs))
                 
                 # Get polylines for river reaches
                 geoms = HdfBase.get_polylines_from_parts(
@@ -598,13 +678,13 @@ class HdfXsec:
                     geometry=geoms,
                     crs=HdfBase.get_projection(hdf_path),
                 )
-                if datetime_to_str:
+                if datetime_to_str and "Last Edited" in river_gdf.columns:
                     river_gdf["Last Edited"] = river_gdf["Last Edited"].apply(
-                        lambda x: pd.Timestamp.isoformat(x)
+                        HdfXsec._datetime_value_to_str
                     )
                 return river_gdf
         except Exception as e:
-            logger.error(f"Error reading river reaches: {str(e)}")
+            logger.error(f"Error reading river reaches from {hdf_path}: {str(e)}")
             return GeoDataFrame()
 
 
@@ -638,29 +718,13 @@ class HdfXsec:
         try:
             with h5py.File(hdf_path, 'r') as hdf_file:
                 if "Geometry/River Edge Lines" not in hdf_file:
-                    logger.warning("No river edge lines found in geometry file")
+                    logger.debug(
+                        "No Geometry/River Edge Lines group in %s; returning empty GeoDataFrame.",
+                        HdfXsec._filename(hdf_path),
+                    )
                     return GeoDataFrame()
 
                 edge_data = hdf_file["Geometry/River Edge Lines"]
-                
-                # Get attributes if they exist
-                if "Attributes" in edge_data:
-                    attrs = edge_data["Attributes"][()]
-                    v_conv_val = np.vectorize(HdfUtils.convert_ras_string)
-                    
-                    # Create dictionary of attributes
-                    edge_dict = {"edge_id": range(attrs.shape[0])}
-                    edge_dict.update(
-                        {name: v_conv_val(attrs[name]) for name in attrs.dtype.names}
-                    )
-                    
-                    # Add bank side indicator
-                    if edge_dict["edge_id"].size % 2 == 0:  # Ensure even number of edges
-                        edge_dict["bank_side"] = ["Left", "Right"] * (edge_dict["edge_id"].size // 2)
-                else:
-                    edge_dict = {"edge_id": [], "bank_side": []}
-
-                # Get polyline geometries
                 geoms = HdfBase.get_polylines_from_parts(
                     hdf_path, 
                     "Geometry/River Edge Lines",
@@ -668,6 +732,17 @@ class HdfXsec:
                     parts_name="Polyline Parts",
                     points_name="Polyline Points"
                 )
+
+                # Get attributes if they exist
+                if "Attributes" in edge_data:
+                    attrs = edge_data["Attributes"][()]
+
+                    # Create dictionary of attributes
+                    edge_dict = {"edge_id": list(range(attrs.shape[0]))}
+                    edge_dict.update(HdfXsec._structured_array_to_dict(attrs))
+                else:
+                    edge_dict = {"edge_id": list(range(len(geoms)))}
+                edge_dict["bank_side"] = HdfXsec._alternating_bank_sides(len(geoms))
 
                 # Create GeoDataFrame
                 edge_gdf = GeoDataFrame(
@@ -679,7 +754,7 @@ class HdfXsec:
                 # Convert datetime objects to strings if requested
                 if datetime_to_str and 'Last Edited' in edge_gdf.columns:
                     edge_gdf["Last Edited"] = edge_gdf["Last Edited"].apply(
-                        lambda x: pd.Timestamp.isoformat(x) if pd.notnull(x) else None
+                        HdfXsec._datetime_value_to_str
                     )
 
                 # Add length calculation in project units
@@ -689,7 +764,7 @@ class HdfXsec:
                 return edge_gdf
 
         except Exception as e:
-            logger.error(f"Error reading river edge lines: {str(e)}")
+            logger.error(f"Error reading river edge lines from {hdf_path}: {str(e)}")
             return GeoDataFrame()
 
     @staticmethod
@@ -721,7 +796,10 @@ class HdfXsec:
         try:
             with h5py.File(hdf_path, 'r') as hdf_file:
                 if "Geometry/River Bank Lines" not in hdf_file:
-                    logger.warning("No river bank lines found in geometry file")
+                    logger.debug(
+                        "No Geometry/River Bank Lines group in %s; returning empty GeoDataFrame.",
+                        HdfXsec._filename(hdf_path),
+                    )
                     return GeoDataFrame()
 
                 # Get polyline geometries using existing helper method
@@ -735,8 +813,8 @@ class HdfXsec:
 
                 # Create basic attributes
                 bank_dict = {
-                    "bank_id": range(len(geoms)),
-                    "bank_side": ["Left", "Right"] * (len(geoms) // 2)  # Assuming pairs of left/right banks
+                    "bank_id": list(range(len(geoms))),
+                    "bank_side": HdfXsec._alternating_bank_sides(len(geoms)),
                 }
 
                 # Create GeoDataFrame
@@ -753,6 +831,6 @@ class HdfXsec:
                 return bank_gdf
 
         except Exception as e:
-            logger.error(f"Error reading river bank lines: {str(e)}")
+            logger.error(f"Error reading river bank lines from {hdf_path}: {str(e)}")
             return GeoDataFrame()
 

--- a/tests/test_hdf_base_logging.py
+++ b/tests/test_hdf_base_logging.py
@@ -1,0 +1,273 @@
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import h5py
+import numpy as np
+import pytest
+from shapely.geometry import LineString
+
+from ras_commander.hdf.HdfBase import HdfBase
+from ras_commander.hdf.HdfUtils import HdfUtils
+
+
+LOGGER_NAME = "ras_commander.hdf.HdfBase"
+
+
+def _records(caplog: pytest.LogCaptureFixture):
+    return [record for record in caplog.records if record.name == LOGGER_NAME]
+
+
+def _write_empty_hdf(path: Path) -> Path:
+    with h5py.File(path, "w"):
+        pass
+    return path
+
+
+def _write_2d_flow_area_hdf(
+    path: Path,
+    *,
+    include_cell_info: bool = True,
+) -> Path:
+    attrs = np.array(
+        [(b"Mesh A",), (b"Mesh B",)],
+        dtype=np.dtype([("Name", "S16")]),
+    )
+    with h5py.File(path, "w") as hdf:
+        group = hdf.require_group("Geometry/2D Flow Areas")
+        group.create_dataset("Attributes", data=attrs)
+        if include_cell_info:
+            group.create_dataset(
+                "Cell Info",
+                data=np.array([[0, 12], [0, 5]], dtype=np.int32),
+            )
+    return path
+
+
+def _write_dataset_info_hdf(path: Path) -> Path:
+    with h5py.File(path, "w") as hdf:
+        group = hdf.require_group("Geometry")
+        group.attrs["Description"] = "geometry root"
+        group.create_dataset("Values", data=np.array([1, 2, 3], dtype=np.int32))
+    return path
+
+
+def _write_polyline_hdf(
+    path: Path,
+    *,
+    include_parts: bool = True,
+    include_points: bool = True,
+) -> Path:
+    with h5py.File(path, "w") as hdf:
+        group = hdf.require_group("Geometry/River Centerlines")
+        group.create_dataset(
+            "Polyline Info",
+            data=np.array([[0, 2, 0, 1]], dtype=np.int32),
+        )
+        if include_parts:
+            group.create_dataset(
+                "Polyline Parts",
+                data=np.array([[0, 2]], dtype=np.int32),
+            )
+        if include_points:
+            group.create_dataset(
+                "Polyline Points",
+                data=np.array([[0.0, 0.0], [1.0, 1.0]], dtype=np.float64),
+            )
+    return path
+
+
+def test_2d_flow_area_absence_is_quiet_empty_result(tmp_path, caplog):
+    hdf_path = _write_empty_hdf(tmp_path / "empty.p01.hdf")
+
+    with caplog.at_level(logging.WARNING, logger=LOGGER_NAME):
+        result = HdfBase.get_2d_flow_area_names_and_counts(hdf_path)
+
+    assert result == []
+    assert _records(caplog) == []
+
+
+def test_2d_flow_area_names_and_counts_success_no_default_logs(tmp_path, caplog):
+    hdf_path = _write_2d_flow_area_hdf(tmp_path / "mesh.g01.hdf")
+
+    with caplog.at_level(logging.INFO, logger=LOGGER_NAME):
+        result = HdfBase.get_2d_flow_area_names_and_counts(hdf_path)
+
+    assert result == [("Mesh A", 12), ("Mesh B", 5)]
+    assert _records(caplog) == []
+
+
+def test_2d_flow_area_malformed_schema_raises_without_error_log(tmp_path, caplog):
+    hdf_path = _write_2d_flow_area_hdf(
+        tmp_path / "malformed.g01.hdf",
+        include_cell_info=False,
+    )
+
+    with caplog.at_level(logging.ERROR, logger=LOGGER_NAME):
+        with pytest.raises(ValueError) as exc_info:
+            HdfBase.get_2d_flow_area_names_and_counts(hdf_path)
+
+    message = str(exc_info.value)
+    assert "2D flow area name/count extraction requires dataset" in message
+    assert "Geometry/2D Flow Areas/Cell Info" in message
+    assert "malformed.g01.hdf" in message
+    assert str(tmp_path) not in message
+    assert _records(caplog) == []
+
+
+def test_get_attrs_missing_path_is_debug_only(tmp_path, caplog):
+    hdf_path = _write_empty_hdf(tmp_path / "attrs.p01.hdf")
+
+    with h5py.File(hdf_path, "r") as hdf:
+        with caplog.at_level(logging.WARNING, logger=LOGGER_NAME):
+            assert HdfBase.get_attrs(hdf, "Geometry/Missing") == {}
+
+    assert [record for record in _records(caplog) if record.levelno >= logging.WARNING] == []
+
+    caplog.clear()
+    with h5py.File(hdf_path, "r") as hdf:
+        with caplog.at_level(logging.DEBUG, logger=LOGGER_NAME):
+            assert HdfBase.get_attrs(hdf, "Geometry/Missing") == {}
+
+    messages = [record.getMessage() for record in _records(caplog)]
+    assert any("Attribute path 'Geometry/Missing' not found" in msg for msg in messages)
+    assert [record for record in _records(caplog) if record.levelno >= logging.WARNING] == []
+
+
+def test_get_attrs_conversion_failure_raises_without_error_log(
+    tmp_path,
+    caplog,
+    monkeypatch,
+):
+    hdf_path = tmp_path / "attrs.p01.hdf"
+    with h5py.File(hdf_path, "w") as hdf:
+        group = hdf.require_group("Geometry")
+        group.attrs["Description"] = "test"
+
+    def fail_convert(_attrs, prefix=None):
+        raise RuntimeError("decode failed")
+
+    monkeypatch.setattr(
+        HdfUtils,
+        "convert_hdf5_attrs_to_dict",
+        staticmethod(fail_convert),
+    )
+
+    with h5py.File(hdf_path, "r") as hdf:
+        with caplog.at_level(logging.ERROR, logger=LOGGER_NAME):
+            with pytest.raises(ValueError) as exc_info:
+                HdfBase.get_attrs(hdf, "Geometry")
+
+    message = str(exc_info.value)
+    assert "Failed to read HDF attributes at 'Geometry'" in message
+    assert "attrs.p01.hdf" in message
+    assert "decode failed" in message
+    assert str(tmp_path) not in message
+    assert _records(caplog) == []
+
+
+def test_get_dataset_info_success_prints_requested_structure(tmp_path, capsys):
+    hdf_path = _write_dataset_info_hdf(tmp_path / "dataset_info.p01.hdf")
+
+    HdfBase.get_dataset_info(hdf_path, group_path="/Geometry")
+
+    captured = capsys.readouterr()
+    assert "Exploring group: /Geometry" in captured.out
+    assert "Dataset: /Geometry/Values" in captured.out
+    assert "Shape: (3,)" in captured.out
+
+
+def test_get_dataset_info_missing_group_raises_without_stdout_error(
+    tmp_path,
+    capsys,
+    caplog,
+):
+    hdf_path = _write_dataset_info_hdf(tmp_path / "dataset_info.p01.hdf")
+
+    with caplog.at_level(logging.ERROR, logger=LOGGER_NAME):
+        with pytest.raises(KeyError) as exc_info:
+            HdfBase.get_dataset_info(hdf_path, group_path="/Missing")
+
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert "Group path '/Missing' not found in dataset_info.p01.hdf" in str(exc_info.value)
+    assert str(tmp_path) not in str(exc_info.value)
+    assert _records(caplog) == []
+
+
+def test_polylines_missing_group_is_quiet_empty_result(tmp_path, caplog):
+    hdf_path = _write_empty_hdf(tmp_path / "polylines.g01.hdf")
+
+    with caplog.at_level(logging.WARNING, logger=LOGGER_NAME):
+        geoms = HdfBase.get_polylines_from_parts(
+            hdf_path,
+            "Geometry/River Centerlines",
+        )
+
+    assert geoms == []
+    assert [record for record in _records(caplog) if record.levelno >= logging.WARNING] == []
+
+
+def test_polylines_success_has_no_default_log_noise(tmp_path, caplog):
+    hdf_path = _write_polyline_hdf(tmp_path / "polylines.g01.hdf")
+
+    with caplog.at_level(logging.INFO, logger=LOGGER_NAME):
+        geoms = HdfBase.get_polylines_from_parts(
+            hdf_path,
+            "Geometry/River Centerlines",
+        )
+
+    assert len(geoms) == 1
+    assert isinstance(geoms[0], LineString)
+    assert list(geoms[0].coords) == [(0.0, 0.0), (1.0, 1.0)]
+    assert _records(caplog) == []
+
+
+def test_polylines_malformed_schema_raises_without_error_log(tmp_path, caplog):
+    hdf_path = _write_polyline_hdf(
+        tmp_path / "malformed_polylines.g01.hdf",
+        include_points=False,
+    )
+
+    with caplog.at_level(logging.ERROR, logger=LOGGER_NAME):
+        with pytest.raises(ValueError) as exc_info:
+            HdfBase.get_polylines_from_parts(
+                hdf_path,
+                "Geometry/River Centerlines",
+            )
+
+    message = str(exc_info.value)
+    assert "Polyline extraction requires dataset" in message
+    assert "Geometry/River Centerlines/Polyline Points" in message
+    assert "malformed_polylines.g01.hdf" in message
+    assert str(tmp_path) not in message
+    assert _records(caplog) == []
+
+
+def test_strip_results_success_logs_basename_only(tmp_path, caplog):
+    hdf_path = tmp_path / "strip.p01.hdf"
+    with h5py.File(hdf_path, "w") as hdf:
+        hdf.require_group("Results")
+
+    with caplog.at_level(logging.INFO, logger=LOGGER_NAME):
+        assert HdfBase.strip_results(hdf_path) is True
+
+    records = _records(caplog)
+    assert len(records) == 1
+    assert records[0].levelno == logging.INFO
+    message = records[0].getMessage()
+    assert "Stripped /Results group from strip.p01.hdf" in message
+    assert str(tmp_path) not in message
+
+    with h5py.File(hdf_path, "r") as hdf:
+        assert "Results" not in hdf
+
+
+def test_strip_results_no_results_group_is_debug_only(tmp_path, caplog):
+    hdf_path = _write_empty_hdf(tmp_path / "strip_empty.p01.hdf")
+
+    with caplog.at_level(logging.INFO, logger=LOGGER_NAME):
+        assert HdfBase.strip_results(hdf_path) is False
+
+    assert _records(caplog) == []

--- a/tests/test_hdf_benefit_areas.py
+++ b/tests/test_hdf_benefit_areas.py
@@ -13,6 +13,10 @@ or in CI/CD with HEC-RAS installed.
 
 import pytest
 from pathlib import Path
+import logging
+
+import geopandas as gpd
+from shapely.geometry import Point, Polygon
 
 
 class TestHdfBenefitAreasImport:
@@ -121,6 +125,155 @@ class TestExpectedBehavior:
 
         for key in expected_keys:
             assert key in docstring, f"Expected key '{key}' not documented"
+
+
+class TestBenefitAreaLoggingAndPolygons:
+    """Focused regressions for benefit/rise analysis logging and polygon building."""
+
+    @staticmethod
+    def _sample_points(existing_values=(10.0, 10.0), proposed_values=(9.5, 10.3)):
+        return (
+            gpd.GeoDataFrame(
+                {
+                    "mesh_name": ["M1", "M1"],
+                    "cell_id": [0, 1],
+                    "maximum_water_surface": list(existing_values),
+                },
+                geometry=[Point(0.5, 0.5), Point(1.5, 0.5)],
+                crs="EPSG:2272",
+            ),
+            gpd.GeoDataFrame(
+                {
+                    "mesh_name": ["M1", "M1"],
+                    "cell_id": [0, 1],
+                    "maximum_water_surface": list(proposed_values),
+                },
+                geometry=[Point(0.5, 0.5), Point(1.5, 0.5)],
+                crs="EPSG:2272",
+            ),
+        )
+
+    @staticmethod
+    def _sample_cells():
+        return gpd.GeoDataFrame(
+            {
+                "mesh_name": ["M1", "M1"],
+                "cell_id": [0, 1],
+            },
+            geometry=[
+                Polygon([(0, 0), (1, 0), (1, 1), (0, 1)]),
+                Polygon([(1, 0), (2, 0), (2, 1), (1, 1)]),
+            ],
+            crs="EPSG:2272",
+        )
+
+    def test_spatial_join_handles_mesh_name_and_cell_id_columns(self):
+        """Benefit polygons should build when points and cells share standard columns."""
+        from ras_commander.hdf.HdfBenefitAreas import HdfBenefitAreas
+
+        existing_points, proposed_points = self._sample_points()
+        matched = HdfBenefitAreas._match_points_by_xy(existing_points, proposed_points, 6)
+        benefit_points, _ = HdfBenefitAreas._apply_threshold_and_classify(matched, 0.1)
+        cells = self._sample_cells()
+
+        benefit_polygons = HdfBenefitAreas._build_contiguous_polygons(
+            benefit_points,
+            cells,
+            "Benefit Area",
+            adjacency_method="polygon_edges",
+            dissolve=True,
+        )
+
+        assert not benefit_polygons.empty
+        assert benefit_polygons["cell_count"].sum() == 1
+        assert benefit_polygons["area_sqft"].sum() == pytest.approx(1.0)
+
+    def test_identify_benefit_areas_logs_one_concise_success_line(
+        self, tmp_path, monkeypatch, caplog
+    ):
+        """Successful analysis should leave one compact INFO summary."""
+        from ras_commander.hdf import HdfBenefitAreas, HdfMesh, HdfResultsMesh
+
+        existing_hdf = tmp_path / "existing.p01.hdf"
+        proposed_hdf = tmp_path / "proposed.p02.hdf"
+        existing_hdf.touch()
+        proposed_hdf.touch()
+
+        existing_points, proposed_points = self._sample_points()
+        cells = self._sample_cells()
+
+        def fake_get_mesh_max_ws(hdf_path):
+            return existing_points if Path(hdf_path) == existing_hdf else proposed_points
+
+        monkeypatch.setattr(HdfResultsMesh, "get_mesh_max_ws", fake_get_mesh_max_ws)
+        monkeypatch.setattr(HdfMesh, "get_mesh_cell_polygons", lambda _hdf_path: cells)
+
+        caplog.set_level(logging.INFO, logger="ras_commander.hdf.HdfBenefitAreas")
+        results = HdfBenefitAreas.identify_benefit_areas(
+            existing_hdf,
+            proposed_hdf,
+            min_delta=0.1,
+        )
+
+        assert set(results) == {
+            "benefit_polygons",
+            "rise_polygons",
+            "existing_points",
+            "proposed_points",
+            "difference_points",
+        }
+        messages = [
+            record.getMessage()
+            for record in caplog.records
+            if record.name == "ras_commander.hdf.HdfBenefitAreas"
+        ]
+        success_messages = [
+            message for message in messages
+            if message.startswith("Benefit analysis complete:")
+        ]
+        assert len(success_messages) == 1
+        assert "benefit_areas=1" in success_messages[0]
+        assert "rise_areas=1" in success_messages[0]
+        assert "matched_points=2" in success_messages[0]
+        assert not any(message.strip().startswith("Benefit areas:") for message in messages)
+
+    def test_missing_max_wse_error_is_actionable(self, tmp_path, monkeypatch):
+        from ras_commander.hdf import HdfBenefitAreas, HdfResultsMesh
+
+        existing_hdf = tmp_path / "existing.p01.hdf"
+        proposed_hdf = tmp_path / "proposed.p02.hdf"
+        existing_hdf.touch()
+        proposed_hdf.touch()
+
+        monkeypatch.setattr(
+            HdfResultsMesh,
+            "get_mesh_max_ws",
+            lambda _hdf_path: gpd.GeoDataFrame(),
+        )
+
+        with pytest.raises(ValueError, match="Maximum Water Surface"):
+            HdfBenefitAreas.identify_benefit_areas(existing_hdf, proposed_hdf)
+
+    def test_missing_mesh_cells_error_mentions_geometry_preprocessor(
+        self, tmp_path, monkeypatch
+    ):
+        from ras_commander.hdf import HdfBenefitAreas, HdfMesh, HdfResultsMesh
+
+        existing_hdf = tmp_path / "existing.p01.hdf"
+        proposed_hdf = tmp_path / "proposed.p02.hdf"
+        existing_hdf.touch()
+        proposed_hdf.touch()
+
+        existing_points, proposed_points = self._sample_points()
+
+        def fake_get_mesh_max_ws(hdf_path):
+            return existing_points if Path(hdf_path) == existing_hdf else proposed_points
+
+        monkeypatch.setattr(HdfResultsMesh, "get_mesh_max_ws", fake_get_mesh_max_ws)
+        monkeypatch.setattr(HdfMesh, "get_mesh_cell_polygons", lambda _hdf_path: gpd.GeoDataFrame())
+
+        with pytest.raises(ValueError, match="geometry preprocessor"):
+            HdfBenefitAreas.identify_benefit_areas(existing_hdf, proposed_hdf)
 
 
 # Integration test - requires HEC-RAS execution

--- a/tests/test_hdf_bndry_logging.py
+++ b/tests/test_hdf_bndry_logging.py
@@ -1,0 +1,171 @@
+"""Logging behavior tests for HdfBndry geometry extraction APIs."""
+
+from pathlib import Path
+
+import h5py
+import numpy as np
+import pytest
+from pyproj import CRS
+
+from ras_commander.hdf import HdfBndry
+
+
+LOGGER_NAME = "ras_commander.hdf.HdfBndry"
+
+
+def _hdf_bndry_messages(caplog: pytest.LogCaptureFixture) -> list[str]:
+    return [
+        record.getMessage()
+        for record in caplog.records
+        if record.name == LOGGER_NAME
+    ]
+
+
+def _write_empty_geometry_hdf(path: Path) -> None:
+    with h5py.File(path, "w") as hdf_file:
+        hdf_file.create_group("Geometry")
+
+
+def _write_invalid_breaklines_hdf(path: Path) -> None:
+    attributes_dtype = np.dtype([("Name", "S32")])
+    attributes = np.array(
+        [(b"ZeroLength",), (b"SinglePoint",), (b"MultipartInvalid",)],
+        dtype=attributes_dtype,
+    )
+
+    with h5py.File(path, "w") as hdf_file:
+        group = hdf_file.create_group("Geometry/2D Flow Area Break Lines")
+        group.create_dataset("Attributes", data=attributes)
+        group.create_dataset(
+            "Polyline Info",
+            data=np.array(
+                [
+                    (0, 0, 0, 1),
+                    (0, 1, 0, 1),
+                    (0, 2, 0, 2),
+                ],
+                dtype=np.int32,
+            ),
+        )
+        group.create_dataset(
+            "Polyline Parts",
+            data=np.array([(0, 1), (1, 1)], dtype=np.int32),
+        )
+        group.create_dataset(
+            "Polyline Points",
+            data=np.array([[0.0, 0.0], [1.0, 1.0]], dtype=np.float64),
+        )
+
+
+def _write_reference_lines_without_type_hdf(path: Path) -> None:
+    attributes_dtype = np.dtype([("Name", "S32"), ("SA-2D", "S32")])
+    attributes = np.array([(b"Line A", b"Mesh 1")], dtype=attributes_dtype)
+
+    with h5py.File(path, "w") as hdf_file:
+        hdf_file.attrs["Projection"] = CRS.from_epsg(4326).to_wkt()
+        group = hdf_file.create_group("Geometry/Reference Lines")
+        group.create_dataset("Attributes", data=attributes)
+        group.create_dataset(
+            "Polyline Info",
+            data=np.array([(0, 2, 0, 1)], dtype=np.int32),
+        )
+        group.create_dataset("Polyline Parts", data=np.array([(0, 2)], dtype=np.int32))
+        group.create_dataset(
+            "Polyline Points",
+            data=np.array([[0.0, 0.0], [1.0, 1.0]], dtype=np.float64),
+        )
+
+
+def test_optional_missing_boundary_groups_are_quiet_by_default(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+):
+    geom_hdf = tmp_path / "model.g01.hdf"
+    _write_empty_geometry_hdf(geom_hdf)
+
+    with caplog.at_level("WARNING", logger=LOGGER_NAME):
+        assert HdfBndry.get_bc_lines(geom_hdf).empty
+        assert HdfBndry.get_breaklines(geom_hdf).empty
+        assert HdfBndry.get_refinement_regions(geom_hdf).empty
+        assert HdfBndry.get_reference_lines(geom_hdf).empty
+        assert HdfBndry.get_reference_points(geom_hdf).empty
+
+    assert _hdf_bndry_messages(caplog) == []
+
+
+def test_optional_missing_boundary_groups_log_debug_context(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+):
+    geom_hdf = tmp_path / "model.g01.hdf"
+    _write_empty_geometry_hdf(geom_hdf)
+
+    with caplog.at_level("DEBUG", logger=LOGGER_NAME):
+        HdfBndry.get_breaklines(geom_hdf)
+        HdfBndry.get_reference_lines(geom_hdf)
+
+    messages = _hdf_bndry_messages(caplog)
+    assert any("Breaklines group" in message for message in messages)
+    assert any("Reference lines attributes group" in message for message in messages)
+    optional_group_messages = [
+        message
+        for message in messages
+        if "Breaklines group" in message
+        or "Reference lines attributes group" in message
+    ]
+    assert all(str(tmp_path) not in message for message in optional_group_messages)
+
+
+def test_invalid_breaklines_warning_includes_counts_not_full_path(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+):
+    geom_hdf = tmp_path / "model.g01.hdf"
+    _write_invalid_breaklines_hdf(geom_hdf)
+
+    with caplog.at_level("WARNING", logger=LOGGER_NAME):
+        result = HdfBndry.get_breaklines(geom_hdf)
+
+    assert result.empty
+    messages = _hdf_bndry_messages(caplog)
+    assert len(messages) == 1
+    assert "No valid breaklines found in model.g01.hdf" in messages[0]
+    assert "skipped 3 invalid breaklines" in messages[0]
+    assert "zero_length=1" in messages[0]
+    assert "single_point=1" in messages[0]
+    assert "other=1" in messages[0]
+    assert str(tmp_path) not in messages[0]
+
+
+def test_boundary_parse_errors_include_hdf_path_and_group(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+):
+    geom_hdf = tmp_path / "model.g01.hdf"
+    with h5py.File(geom_hdf, "w") as hdf_file:
+        hdf_file.create_group("Geometry/Boundary Condition Lines")
+
+    with caplog.at_level("ERROR", logger=LOGGER_NAME):
+        result = HdfBndry.get_bc_lines(geom_hdf)
+
+    assert result.empty
+    messages = _hdf_bndry_messages(caplog)
+    assert len(messages) == 1
+    assert str(geom_hdf) in messages[0]
+    assert "Geometry/Boundary Condition Lines" in messages[0]
+
+
+def test_reference_line_missing_type_logs_debug_fallback(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+):
+    geom_hdf = tmp_path / "model.g01.hdf"
+    _write_reference_lines_without_type_hdf(geom_hdf)
+
+    with caplog.at_level("DEBUG", logger=LOGGER_NAME):
+        result = HdfBndry.get_reference_lines(geom_hdf)
+
+    assert len(result) == 1
+    assert result["Type"].tolist() == [""]
+    messages = _hdf_bndry_messages(caplog)
+    assert any("using blank Type values" in message for message in messages)

--- a/tests/test_hdf_channel_capacity_logging.py
+++ b/tests/test_hdf_channel_capacity_logging.py
@@ -1,0 +1,121 @@
+import logging
+from types import SimpleNamespace
+
+import h5py
+import pandas as pd
+import pytest
+
+from ras_commander.hdf import HdfChannelCapacity, HdfUtils
+
+
+def test_system_capacity_summary_logs_one_concise_info_line(caplog):
+    capacity_df = pd.DataFrame(
+        {
+            "RS": ["300", "200", "100", "050"],
+            "capacity_level": [1, 1, 3, 7],
+            "Len Channel": [100.0, 200.0, 300.0, 400.0],
+        }
+    )
+
+    caplog.set_level(logging.INFO, logger="ras_commander.hdf.HdfChannelCapacity")
+
+    summary = HdfChannelCapacity.system_capacity_summary(capacity_df)
+
+    assert summary["channel_length_ft"].sum() == pytest.approx(1000.0)
+    messages = [
+        record.getMessage()
+        for record in caplog.records
+        if record.name == "ras_commander.hdf.HdfChannelCapacity"
+    ]
+    assert messages == ["System capacity summary: levels=3 total_length_ft=1000 xs=4"]
+
+
+def test_standardize_hdf_input_resolution_probe_is_debug_only(
+    tmp_path, monkeypatch, caplog
+):
+    ras_object = SimpleNamespace(folder=tmp_path)
+
+    def fail_resolve(*_args, **_kwargs):
+        raise RuntimeError("resolver unavailable")
+
+    monkeypatch.setattr(HdfUtils, "resolve_hdf_paths", fail_resolve)
+    caplog.set_level(logging.DEBUG, logger="ras_commander.hdf.HdfChannelCapacity")
+
+    result = HdfChannelCapacity._standardize_hdf_input("01", "plan", ras_object)
+
+    assert result == tmp_path / "unknown.p01.hdf"
+    records = [
+        record
+        for record in caplog.records
+        if record.name == "ras_commander.hdf.HdfChannelCapacity"
+    ]
+    assert any(record.levelno == logging.DEBUG for record in records)
+    assert not any(record.levelno >= logging.WARNING for record in records)
+
+
+def test_extract_steady_profile_wse_missing_attrs_is_actionable(tmp_path, caplog):
+    hdf_path = tmp_path / "steady.p01.hdf"
+    with h5py.File(hdf_path, "w") as hdf:
+        hdf.create_dataset(
+            "Results/Steady/Output/Output Blocks/Base Output/Steady Profiles/"
+            "Cross Sections/Water Surface",
+            data=[[10.0, 11.0]],
+        )
+
+    caplog.set_level(logging.WARNING, logger="ras_commander.hdf.HdfChannelCapacity")
+
+    result = HdfChannelCapacity.extract_steady_profile_wse(hdf_path)
+
+    assert list(result["RS"]) == ["1", "2"]
+    messages = [
+        record.getMessage()
+        for record in caplog.records
+        if record.name == "ras_commander.hdf.HdfChannelCapacity"
+    ]
+    assert any("using positional station labels" in message for message in messages)
+
+
+def test_extract_max_wse_empty_hdf_warning_is_actionable(tmp_path, caplog):
+    hdf_path = tmp_path / "empty.p01.hdf"
+    with h5py.File(hdf_path, "w"):
+        pass
+
+    caplog.set_level(logging.WARNING, logger="ras_commander.hdf.HdfChannelCapacity")
+
+    with pytest.raises(ValueError, match="No WSE data extracted"):
+        HdfChannelCapacity.extract_max_wse(hdf_path, profile_names=["AEP"])
+
+    messages = [
+        record.getMessage()
+        for record in caplog.records
+        if record.name == "ras_commander.hdf.HdfChannelCapacity"
+    ]
+    assert any("Compute the plan" in message for message in messages)
+    assert any("steady profiles or unsteady cross-section" in message for message in messages)
+
+
+def test_determine_capacity_explicit_missing_storm_columns_raise():
+    bank_elevations = pd.DataFrame(
+        {
+            "River": ["R"],
+            "Reach": ["A"],
+            "RS": ["100"],
+            "controlling_bank_elev": [10.0],
+            "Len Channel": [100.0],
+        }
+    )
+    max_wse = pd.DataFrame(
+        {
+            "River": ["R"],
+            "Reach": ["A"],
+            "RS": ["100"],
+            "10P": [9.5],
+        }
+    )
+
+    with pytest.raises(ValueError, match="Storm columns not found"):
+        HdfChannelCapacity.determine_capacity(
+            bank_elevations,
+            max_wse,
+            storm_order=["10P", "1P"],
+        )

--- a/tests/test_hdf_fluvial_pluvial_logging.py
+++ b/tests/test_hdf_fluvial_pluvial_logging.py
@@ -1,0 +1,88 @@
+import logging
+from pathlib import Path
+
+import pytest
+
+from ras_commander.hdf.HdfFluvialPluvial import HdfFluvialPluvial
+
+
+LOGGER_NAME = "ras_commander.hdf.HdfFluvialPluvial"
+
+
+@pytest.fixture(scope="module")
+def bald_eagle_2d_plan_hdf() -> Path:
+    candidates = [
+        Path("examples/example_projects/BaldEagleCrkMulti2D_11/BaldEagleDamBrk.p06.hdf"),
+        Path("examples/example_projects/BaldEagleCrkMulti2D_14/BaldEagleDamBrk.p06.hdf"),
+        Path("examples/example_projects/BaldEagleCrkMulti2D_415/BaldEagleDamBrk.p06.hdf"),
+    ]
+    for candidate in candidates:
+        if candidate.exists():
+            return candidate
+    pytest.skip("Bald Eagle 2D plan HDF example is not available")
+
+
+def _messages(caplog: pytest.LogCaptureFixture) -> list[str]:
+    return [record.getMessage() for record in caplog.records if record.name == LOGGER_NAME]
+
+
+def test_fluvial_pluvial_default_info_logs_are_concise(
+    bald_eagle_2d_plan_hdf: Path,
+    caplog: pytest.LogCaptureFixture,
+):
+    with caplog.at_level(logging.INFO, logger=LOGGER_NAME):
+        boundary_gdf = HdfFluvialPluvial.calculate_fluvial_pluvial_boundary(
+            bald_eagle_2d_plan_hdf,
+            delta_t=72,
+        )
+        polygon_gdf = HdfFluvialPluvial.generate_fluvial_pluvial_polygons(
+            bald_eagle_2d_plan_hdf,
+            delta_t=12,
+            temporal_tolerance_hours=1.0,
+            min_polygon_area_acres=200,
+        )
+
+    assert not boundary_gdf.empty
+    assert not polygon_gdf.empty
+
+    messages = _messages(caplog)
+    assert len(messages) == 2
+    assert messages[0].startswith("Fluvial/pluvial boundary: ")
+    assert "line(s), delta_t=72 hr." in messages[0]
+    assert messages[1].startswith("Fluvial/pluvial polygons: ")
+    assert "dissolved class(es)" in messages[1]
+    assert "iterations=" in messages[1]
+    assert "components=" in messages[1]
+
+    noisy_fragments = [
+        "Getting cell polygons",
+        "Loading mesh and results data",
+        "Processing cell adjacencies",
+        "Final validated file path",
+        "Using HDF file",
+        str(bald_eagle_2d_plan_hdf),
+    ]
+    for message in messages:
+        assert not any(fragment in message for fragment in noisy_fragments)
+
+
+def test_fluvial_pluvial_debug_logs_include_call_and_processing_context(
+    bald_eagle_2d_plan_hdf: Path,
+    caplog: pytest.LogCaptureFixture,
+):
+    with caplog.at_level(logging.DEBUG, logger=LOGGER_NAME):
+        boundary_gdf = HdfFluvialPluvial.calculate_fluvial_pluvial_boundary(
+            bald_eagle_2d_plan_hdf,
+            delta_t=72,
+            min_line_length=3000,
+        )
+
+    assert boundary_gdf.empty
+
+    messages = _messages(caplog)
+    assert "Calling calculate_fluvial_pluvial_boundary" in messages
+    assert "Finished calculate_fluvial_pluvial_boundary" in messages
+    assert "Getting cell polygons from HDF file..." in messages
+    assert "Identifying boundary edges..." in messages
+    assert any("boundary line(s) shorter than 3000 units were dropped" in message for message in messages)
+    assert any("Final validated file path" in message for message in messages)

--- a/tests/test_hdf_hydraulic_tables_logging.py
+++ b/tests/test_hdf_hydraulic_tables_logging.py
@@ -1,0 +1,196 @@
+import logging
+from pathlib import Path
+
+import h5py
+import numpy as np
+import pytest
+
+from ras_commander.hdf.HdfHydraulicTables import HdfHydraulicTables
+
+
+LOGGER_NAME = "ras_commander.hdf.HdfHydraulicTables"
+
+
+def _records(caplog: pytest.LogCaptureFixture):
+    return [record for record in caplog.records if record.name == LOGGER_NAME]
+
+
+def _write_hydraulic_tables_hdf(
+    hdf_path: Path,
+    *,
+    include_property_tables: bool = True,
+    xs_count: int = 2,
+) -> Path:
+    attrs_dtype = np.dtype([
+        ("River", "S32"),
+        ("Reach", "S32"),
+        ("RS", "S32"),
+    ])
+    attrs = np.array(
+        [
+            (b"River", b"Reach", f"{100 + i}".encode("ascii"))
+            for i in range(xs_count)
+        ],
+        dtype=attrs_dtype,
+    )
+
+    with h5py.File(hdf_path, "w") as hdf:
+        xs_group = hdf.create_group("Geometry").create_group("Cross Sections")
+        xs_group.create_dataset("Attributes", data=attrs)
+
+        if include_property_tables:
+            prop_group = xs_group.create_group("Property Tables")
+            rows_per_xs = 2
+            xsec_info = np.array(
+                [[i * rows_per_xs, rows_per_xs, 0] for i in range(xs_count)],
+                dtype=np.int32,
+            )
+            prop_group.create_dataset("XSEC Info", data=xsec_info)
+
+            values = np.zeros((xs_count * rows_per_xs, 23), dtype=np.float64)
+            for i in range(xs_count):
+                start = i * rows_per_xs
+                values[start:start + rows_per_xs, 0] = [100.0 + i, 101.0 + i]
+                values[start:start + rows_per_xs, 1:4] = 1.0
+                values[start:start + rows_per_xs, 7:10] = 2.0
+                values[start:start + rows_per_xs, 10:13] = 3.0
+
+            value_ds = prop_group.create_dataset("XSEC Value", data=values)
+            variable_names = [
+                "Elevation",
+                "Area LOB",
+                "Area Chan",
+                "Area ROB",
+                "Area Ineff LOB",
+                "Area Ineff Chan",
+                "Area Ineff ROB",
+                "Conv LOB",
+                "Conv Chan",
+                "Conv ROB",
+                "WP LOB",
+                "WP Chan",
+                "WP ROB",
+                "Mann N LOB",
+                "Mann N Chan",
+                "Mann N ROB",
+                "Top Width",
+                "Top Width LOB",
+                "Top Width Chan",
+                "Top Width ROB",
+                "Alpha",
+                "Storage Area",
+                "Beta",
+            ]
+            value_ds.attrs["Variables"] = np.array(
+                [(name.encode("ascii"), b"") for name in variable_names],
+                dtype=[("name", "S32"), ("unit", "S16")],
+            )
+
+    return hdf_path
+
+
+def test_successful_htab_reads_keep_one_concise_batch_info(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+):
+    hdf_path = _write_hydraulic_tables_hdf(tmp_path / "synthetic.g01.hdf")
+
+    with caplog.at_level(logging.INFO, logger=LOGGER_NAME):
+        htab = HdfHydraulicTables.get_xs_htab(hdf_path, "River", "Reach", "100")
+        all_htabs = HdfHydraulicTables.get_all_xs_htabs(hdf_path)
+
+    assert not htab.empty
+    assert len(all_htabs) == 2
+
+    records = _records(caplog)
+    messages = [record.getMessage() for record in records]
+    assert len(records) == 1
+    assert records[0].levelno == logging.INFO
+    assert messages == ["Extracted 2 HTAB property table(s) from synthetic.g01.hdf"]
+    assert str(tmp_path) not in messages[0]
+
+
+def test_missing_htab_tables_single_read_logs_preprocessor_guidance(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+):
+    hdf_path = _write_hydraulic_tables_hdf(
+        tmp_path / "missing_tables.g01.hdf",
+        include_property_tables=False,
+        xs_count=1,
+    )
+
+    with caplog.at_level(logging.ERROR, logger=LOGGER_NAME):
+        with pytest.raises(IOError) as exc_info:
+            HdfHydraulicTables.get_xs_htab(hdf_path, "River", "Reach", "100")
+
+    records = _records(caplog)
+    assert len(records) == 1
+    message = records[0].getMessage()
+    assert records[0].levelno == logging.ERROR
+    assert "missing_tables.g01.hdf" in message
+    assert "River/Reach/RS 100" in message
+    assert "created by the HEC-RAS geometry preprocessor" in message
+    assert "run the geometry preprocessor first" in message
+    assert "/Geometry/Cross Sections/Property Tables" in message
+    assert str(tmp_path) not in message
+    assert "run the geometry preprocessor first" in str(exc_info.value)
+
+
+def test_missing_htab_tables_batch_read_logs_one_preprocessor_error(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+):
+    hdf_path = _write_hydraulic_tables_hdf(
+        tmp_path / "missing_batch.g01.hdf",
+        include_property_tables=False,
+        xs_count=2,
+    )
+
+    with caplog.at_level(logging.ERROR, logger=LOGGER_NAME):
+        all_htabs = HdfHydraulicTables.get_all_xs_htabs(hdf_path)
+
+    assert all_htabs == {}
+    records = _records(caplog)
+    assert len(records) == 1
+    message = records[0].getMessage()
+    assert records[0].levelno == logging.ERROR
+    assert "missing_batch.g01.hdf" in message
+    assert "all cross sections" in message
+    assert "created by the HEC-RAS geometry preprocessor" in message
+    assert "/Geometry/Cross Sections/Property Tables" in message
+    assert str(tmp_path) not in message
+
+
+def test_partial_htab_batch_failure_keeps_details_at_debug(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+):
+    hdf_path = _write_hydraulic_tables_hdf(tmp_path / "partial.g01.hdf", xs_count=2)
+
+    with h5py.File(hdf_path, "a") as hdf:
+        del hdf["/Geometry/Cross Sections/Property Tables/XSEC Info"]
+        hdf["/Geometry/Cross Sections/Property Tables"].create_dataset(
+            "XSEC Info",
+            data=np.array([[0, 2, 0]], dtype=np.int32),
+        )
+
+    with caplog.at_level(logging.WARNING, logger=LOGGER_NAME):
+        all_htabs = HdfHydraulicTables.get_all_xs_htabs(hdf_path)
+
+    assert len(all_htabs) == 1
+    warning_records = _records(caplog)
+    warning_messages = [record.getMessage() for record in warning_records]
+    assert len(warning_records) == 1
+    assert warning_records[0].levelno == logging.WARNING
+    assert "Skipped 1/2 HTAB property table(s) from partial.g01.hdf" in warning_messages[0]
+    assert "River/Reach/RS 101" in warning_messages[0]
+    assert str(tmp_path) not in warning_messages[0]
+
+    caplog.clear()
+    with caplog.at_level(logging.DEBUG, logger=LOGGER_NAME):
+        HdfHydraulicTables.get_all_xs_htabs(hdf_path)
+
+    debug_messages = [record.getMessage() for record in _records(caplog)]
+    assert any("Skipped HTAB cross sections from" in message for message in debug_messages)
+    assert any(str(hdf_path) in message for message in debug_messages)

--- a/tests/test_hdf_infiltration_raster_stats.py
+++ b/tests/test_hdf_infiltration_raster_stats.py
@@ -10,31 +10,42 @@ import rasterio
 from rasterio.transform import from_origin
 
 
-def _write_geom_hdf(path: Path, mesh_name: str = "Mesh 1") -> None:
-    """Create a minimal geometry HDF with one 2D flow area perimeter."""
+def _write_geom_hdf(
+    path: Path,
+    mesh_name: str = "Mesh 1",
+    mesh_specs: list[tuple[str, tuple[float, float, float, float]]] | None = None,
+) -> None:
+    """Create a minimal geometry HDF with one or more 2D flow area perimeters."""
+    if mesh_specs is None:
+        mesh_specs = [(mesh_name, (0.0, 0.0, 20.0, 20.0))]
+
     attrs_dtype = np.dtype([("Name", "S32")])
-    attrs_data = np.array([(mesh_name.encode("utf-8"),)], dtype=attrs_dtype)
-    perimeter = np.array(
-        [
-            [0.0, 0.0],
-            [20.0, 0.0],
-            [20.0, 20.0],
-            [0.0, 20.0],
-            [0.0, 0.0],
-        ],
-        dtype=float,
+    attrs_data = np.array(
+        [(name.encode("utf-8"),) for name, _ in mesh_specs],
+        dtype=attrs_dtype,
     )
 
     with h5py.File(path, "w") as hdf:
         hdf.create_dataset("Geometry/2D Flow Areas/Attributes", data=attrs_data)
-        hdf.create_dataset(
-            f"Geometry/2D Flow Areas/{mesh_name}/Perimeter",
-            data=perimeter,
-        )
+        for name, (xmin, ymin, xmax, ymax) in mesh_specs:
+            perimeter = np.array(
+                [
+                    [xmin, ymin],
+                    [xmax, ymin],
+                    [xmax, ymax],
+                    [xmin, ymax],
+                    [xmin, ymin],
+                ],
+                dtype=float,
+            )
+            hdf.create_dataset(
+                f"Geometry/2D Flow Areas/{name}/Perimeter",
+                data=perimeter,
+            )
 
 
 def _write_soil_hdf(path: Path) -> None:
-    """Create a minimal soil HDF with a raster map."""
+    """Create a minimal soil HDF with a raster map and infiltration variables."""
     raster_map_dtype = np.dtype([("RasterValue", "<i4"), ("Name", "S32")])
     raster_map = np.array(
         [
@@ -43,9 +54,27 @@ def _write_soil_hdf(path: Path) -> None:
         ],
         dtype=raster_map_dtype,
     )
+    variables_dtype = np.dtype(
+        [
+            ("Name", "S32"),
+            ("Curve Number", "<f8"),
+            ("Abstraction Ratio", "<f8"),
+            ("Minimum Infiltration Rate", "<f8"),
+        ]
+    )
+    variables = np.array(
+        [
+            (b"Forest : Soil A", 70.0, 0.2, 0.1),
+            (b"Forest : Soil B", 75.0, 0.2, 0.08),
+            (b"Urban : Soil A", 85.0, 0.1, 0.04),
+            (b"Urban : Soil B", 90.0, 0.1, 0.03),
+        ],
+        dtype=variables_dtype,
+    )
 
     with h5py.File(path, "w") as hdf:
         hdf.create_dataset("Raster Map", data=raster_map)
+        hdf.create_dataset("Variables", data=variables)
 
 
 def _write_landcover_hdf(path: Path) -> None:
@@ -272,3 +301,244 @@ class TestPublicRasterStats:
         assert urban["percentage"] == pytest.approx(33.3333333)
         assert forest["mannings_n"] == pytest.approx(0.12)
         assert urban["percent_impervious"] == pytest.approx(85.0)
+
+    def test_get_soils_raster_stats_aggregates_empty_mesh_warnings(
+        self,
+        tmp_path: Path,
+        caplog: pytest.LogCaptureFixture,
+    ):
+        """Meshes without raster pixels should produce one summary warning."""
+        from ras_commander import HdfInfiltration
+
+        geom_hdf_path = tmp_path / "model.g01.hdf"
+        soil_hdf_path = tmp_path / "soil_layer.hdf"
+        soil_tif_path = soil_hdf_path.with_suffix(".tif")
+
+        _write_geom_hdf(
+            geom_hdf_path,
+            mesh_specs=[
+                ("Inside", (0.0, 0.0, 20.0, 20.0)),
+                ("Outside A", (100.0, 100.0, 120.0, 120.0)),
+                ("Outside B", (130.0, 130.0, 150.0, 150.0)),
+            ],
+        )
+        _write_soil_hdf(soil_hdf_path)
+        _write_raster(
+            soil_tif_path,
+            array=np.array([[1, 1], [2, -9999]], dtype=np.int16),
+            x_res=10.0,
+            y_res=10.0,
+        )
+
+        with caplog.at_level("WARNING", logger="ras_commander.hdf.HdfInfiltration"):
+            result = HdfInfiltration.get_soils_raster_stats(
+                geom_hdf_path,
+                soil_hdf_path=soil_hdf_path,
+            )
+
+        assert not result.empty
+        warning_messages = [
+            record.getMessage()
+            for record in caplog.records
+            if record.name == "ras_commander.hdf.HdfInfiltration"
+        ]
+        assert len(warning_messages) == 1
+        assert "No soil raster stats for 2/3 2D flow area(s)" in warning_messages[0]
+        assert "Outside A" in warning_messages[0]
+        assert "Outside B" in warning_messages[0]
+
+    def test_get_soils_raster_stats_aggregates_nodata_warnings(
+        self,
+        tmp_path: Path,
+        caplog: pytest.LogCaptureFixture,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        """NoData-only meshes should produce one concise summary warning."""
+        import rasterstats
+
+        from ras_commander import HdfInfiltration
+
+        geom_hdf_path = tmp_path / "model.g01.hdf"
+        soil_hdf_path = tmp_path / "soil_layer.hdf"
+        soil_tif_path = soil_hdf_path.with_suffix(".tif")
+
+        _write_geom_hdf(geom_hdf_path, mesh_name="Inside")
+        _write_soil_hdf(soil_hdf_path)
+        _write_raster(
+            soil_tif_path,
+            array=np.array([[1, 1], [2, -9999]], dtype=np.int16),
+            x_res=10.0,
+            y_res=10.0,
+        )
+        monkeypatch.setattr(
+            rasterstats,
+            "zonal_stats",
+            lambda *args, **kwargs: [{-9999: 4}],
+        )
+
+        with caplog.at_level("WARNING", logger="ras_commander.hdf.HdfInfiltration"):
+            result = HdfInfiltration.get_soils_raster_stats(
+                geom_hdf_path,
+                soil_hdf_path=soil_hdf_path,
+            )
+
+        assert result.empty
+        warning_messages = [
+            record.getMessage()
+            for record in caplog.records
+            if record.name == "ras_commander.hdf.HdfInfiltration"
+        ]
+        assert len(warning_messages) == 1
+        assert "Only NoData soil pixels for 1/1 2D flow area(s)" in warning_messages[0]
+        assert "Inside" in warning_messages[0]
+
+    def test_get_soils_raster_stats_warning_omits_exception_details(
+        self,
+        tmp_path: Path,
+        caplog: pytest.LogCaptureFixture,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        """Aggregate WARNING output should identify meshes, not repeat trace detail."""
+        import rasterstats
+
+        from ras_commander import HdfInfiltration
+
+        geom_hdf_path = tmp_path / "model.g01.hdf"
+        soil_hdf_path = tmp_path / "soil_layer.hdf"
+        soil_tif_path = soil_hdf_path.with_suffix(".tif")
+
+        _write_geom_hdf(geom_hdf_path, mesh_name="Inside")
+        _write_soil_hdf(soil_hdf_path)
+        _write_raster(
+            soil_tif_path,
+            array=np.array([[1, 1], [2, -9999]], dtype=np.int16),
+            x_res=10.0,
+            y_res=10.0,
+        )
+
+        def failing_zonal_stats(*args, **kwargs):
+            raise RuntimeError("very long diagnostic path C:/tmp/example/soil.tif")
+
+        monkeypatch.setattr(rasterstats, "zonal_stats", failing_zonal_stats)
+
+        with caplog.at_level("WARNING", logger="ras_commander.hdf.HdfInfiltration"):
+            result = HdfInfiltration.get_soils_raster_stats(
+                geom_hdf_path,
+                soil_hdf_path=soil_hdf_path,
+            )
+
+        assert result.empty
+        warning_messages = [
+            record.getMessage()
+            for record in caplog.records
+            if record.name == "ras_commander.hdf.HdfInfiltration"
+        ]
+        assert len(warning_messages) == 1
+        assert "Failed soil raster statistics for 1/1 2D flow area(s)" in warning_messages[0]
+        assert "Inside" in warning_messages[0]
+        assert "RuntimeError" not in warning_messages[0]
+        assert "C:/tmp/example/soil.tif" not in warning_messages[0]
+
+    def test_get_landcover_raster_stats_aggregates_empty_mesh_warnings(
+        self,
+        tmp_path: Path,
+        caplog: pytest.LogCaptureFixture,
+    ):
+        """Land-cover raster misses should also be summarized once."""
+        from ras_commander import HdfInfiltration
+
+        geom_hdf_path = tmp_path / "model.g01.hdf"
+        landcover_hdf_path = tmp_path / "landcover_layer.hdf"
+        landcover_tif_path = landcover_hdf_path.with_suffix(".tif")
+
+        _write_geom_hdf(
+            geom_hdf_path,
+            mesh_specs=[
+                ("Inside", (0.0, 0.0, 20.0, 20.0)),
+                ("Outside A", (100.0, 100.0, 120.0, 120.0)),
+                ("Outside B", (130.0, 130.0, 150.0, 150.0)),
+            ],
+        )
+        _write_landcover_hdf(landcover_hdf_path)
+        _write_raster(
+            landcover_tif_path,
+            array=np.array([[1, 1], [2, -9999]], dtype=np.int16),
+            x_res=10.0,
+            y_res=10.0,
+        )
+
+        with caplog.at_level("WARNING", logger="ras_commander.hdf.HdfInfiltration"):
+            result = HdfInfiltration.get_landcover_raster_stats(
+                geom_hdf_path,
+                landcover_hdf_path=landcover_hdf_path,
+            )
+
+        assert not result.empty
+        warning_messages = [
+            record.getMessage()
+            for record in caplog.records
+            if record.name == "ras_commander.hdf.HdfInfiltration"
+        ]
+        assert len(warning_messages) == 1
+        assert "No land cover raster stats for 2/3 2D flow area(s)" in warning_messages[0]
+        assert "Outside A" in warning_messages[0]
+        assert "Outside B" in warning_messages[0]
+
+    @pytest.mark.parametrize(
+        "method_name",
+        ["get_soil_raster_stats", "get_infiltration_stats"],
+    )
+    def test_combined_raster_stats_aggregates_empty_mesh_warnings(
+        self,
+        tmp_path: Path,
+        caplog: pytest.LogCaptureFixture,
+        method_name: str,
+    ):
+        """Both combined raster-stat public names should summarize mesh misses."""
+        from ras_commander import HdfInfiltration
+
+        geom_hdf_path = tmp_path / "model.g01.hdf"
+        landcover_hdf_path = tmp_path / "landcover_layer.hdf"
+        soil_hdf_path = tmp_path / "soil_layer.hdf"
+
+        _write_geom_hdf(
+            geom_hdf_path,
+            mesh_specs=[
+                ("Inside", (0.0, 0.0, 20.0, 20.0)),
+                ("Outside A", (100.0, 100.0, 120.0, 120.0)),
+                ("Outside B", (130.0, 130.0, 150.0, 150.0)),
+            ],
+        )
+        _write_landcover_hdf(landcover_hdf_path)
+        _write_soil_hdf(soil_hdf_path)
+        _write_raster(
+            landcover_hdf_path.with_suffix(".tif"),
+            array=np.array([[1, 1], [2, -9999]], dtype=np.int16),
+            x_res=10.0,
+            y_res=10.0,
+        )
+        _write_raster(
+            soil_hdf_path.with_suffix(".tif"),
+            array=np.array([[1, 1], [2, -9999]], dtype=np.int16),
+            x_res=10.0,
+            y_res=10.0,
+        )
+
+        method = getattr(HdfInfiltration, method_name)
+        with caplog.at_level("WARNING", logger="ras_commander.hdf.HdfInfiltration"):
+            result = method(
+                geom_hdf_path,
+                landcover_hdf_path=landcover_hdf_path,
+                soil_hdf_path=soil_hdf_path,
+            )
+
+        assert not result.empty
+        warning_messages = [
+            record.getMessage()
+            for record in caplog.records
+            if record.name == "ras_commander.hdf.HdfInfiltration"
+        ]
+        assert len(warning_messages) == 1
+        assert "No land cover/soil raster stats for 2/3 2D flow area(s)" in warning_messages[0]
+        assert "Outside A" in warning_messages[0]
+        assert "Outside B" in warning_messages[0]

--- a/tests/test_hdf_infiltration_regions.py
+++ b/tests/test_hdf_infiltration_regions.py
@@ -7,9 +7,11 @@ Tests verify:
 3. Returns expected output (None/empty) for projects without infiltration regions
 """
 
-import pytest
-from pathlib import Path
 import inspect
+from pathlib import Path
+
+import h5py
+import pytest
 
 
 class TestImport:
@@ -112,6 +114,31 @@ class TestExpectedBehavior:
 
         result = HdfInfiltration.get_infiltration_calibration_regions(geom_hdfs[0])
         assert result is None or result == {}
+
+    def test_missing_optional_infiltration_metadata_does_not_warn(
+        self,
+        tmp_path: Path,
+        caplog: pytest.LogCaptureFixture,
+    ):
+        """Optional infiltration metadata should be quiet at default log levels."""
+        from ras_commander import HdfInfiltration
+
+        hdf_path = tmp_path / "empty.g01.hdf"
+        with h5py.File(hdf_path, "w"):
+            pass
+
+        with caplog.at_level("WARNING", logger="ras_commander.hdf.HdfInfiltration"):
+            names = HdfInfiltration.get_infiltration_region_names(hdf_path)
+            regions = HdfInfiltration.get_infiltration_calibration_regions(hdf_path)
+
+        assert names is None
+        assert regions is None
+        warning_messages = [
+            record.getMessage()
+            for record in caplog.records
+            if record.name == "ras_commander.hdf.HdfInfiltration"
+        ]
+        assert warning_messages == []
 
     def test_region_polygons_returns_empty_gdf_without_infiltration(self):
         """Test that get_infiltration_region_polygons returns empty GeoDataFrame for project without infiltration."""

--- a/tests/test_hdf_landcover_logging.py
+++ b/tests/test_hdf_landcover_logging.py
@@ -1,0 +1,288 @@
+"""Logging behavior tests for HdfLandCover notebook-facing APIs."""
+
+from pathlib import Path
+
+import h5py
+import numpy as np
+import pytest
+
+from ras_commander.hdf import HdfLandCover
+
+
+LOGGER_NAME = "ras_commander.hdf.HdfLandCover"
+
+
+def _write_empty_geom_hdf(path: Path) -> None:
+    with h5py.File(path, "w") as hdf_file:
+        hdf_file.create_group("Geometry")
+
+
+def _write_geom_hdf_with_landcover_attr(path: Path, landcover_attr: str) -> None:
+    with h5py.File(path, "w") as hdf_file:
+        geometry = hdf_file.create_group("Geometry")
+        geometry.attrs["Land Cover Filename"] = landcover_attr
+
+
+def _write_landcover_sidecar(path: Path) -> None:
+    raster_map_dtype = np.dtype([("ID", "<i4"), ("Name", "S64")])
+    raster_map = np.array(
+        [
+            (11, b"Open Water"),
+            (31, b"Barren Land"),
+        ],
+        dtype=raster_map_dtype,
+    )
+    variables_dtype = np.dtype(
+        [
+            ("Name", "S64"),
+            ("ManningsN", "<f8"),
+            ("Percent Impervious", "<f8"),
+        ]
+    )
+    variables = np.array(
+        [
+            (b"Open Water", 0.03, 0.0),
+            (b"Barren Land", 0.12, 0.0),
+        ],
+        dtype=variables_dtype,
+    )
+
+    with h5py.File(path, "w") as hdf_file:
+        hdf_file.create_dataset("Raster Map", data=raster_map)
+        hdf_file.create_dataset("Variables", data=variables)
+
+
+def _write_sidecar_without_raster_map(path: Path) -> None:
+    variables_dtype = np.dtype(
+        [
+            ("Name", "S64"),
+            ("ManningsN", "<f8"),
+        ]
+    )
+    variables = np.array([(b"Open Water", 0.03)], dtype=variables_dtype)
+
+    with h5py.File(path, "w") as hdf_file:
+        hdf_file.create_dataset("Variables", data=variables)
+
+
+def _write_multipart_regions_without_parts(path: Path) -> None:
+    attrs_dtype = np.dtype([("Name", "S64")])
+    attrs = np.array([(b"Region A",), (b"Region B",)], dtype=attrs_dtype)
+    polygon_info = np.array(
+        [
+            (0, 5, 0, 2),
+            (5, 5, 0, 2),
+        ],
+        dtype=np.int32,
+    )
+    points = np.array(
+        [
+            [0.0, 0.0],
+            [1.0, 0.0],
+            [1.0, 1.0],
+            [0.0, 1.0],
+            [0.0, 0.0],
+            [2.0, 2.0],
+            [3.0, 2.0],
+            [3.0, 3.0],
+            [2.0, 3.0],
+            [2.0, 2.0],
+        ],
+        dtype=np.float64,
+    )
+
+    with h5py.File(path, "w") as hdf_file:
+        landcover = hdf_file.create_group("Geometry/Land Cover (Manning's n)")
+        landcover.create_dataset("Attributes", data=attrs)
+        landcover.create_dataset("Polygon Info", data=polygon_info)
+        landcover.create_dataset("Polygon Points", data=points)
+
+
+def _write_landcover_tif(path: Path) -> None:
+    rasterio = pytest.importorskip("rasterio")
+    from rasterio.transform import from_origin
+
+    with rasterio.open(
+        path,
+        "w",
+        driver="GTiff",
+        height=2,
+        width=2,
+        count=1,
+        dtype=np.int16,
+        crs="EPSG:5070",
+        transform=from_origin(0.0, 20.0, 10.0, 10.0),
+        nodata=-9999,
+    ) as dst:
+        dst.write(np.array([[11, 31], [31, 11]], dtype=np.int16), 1)
+
+
+def _hdf_landcover_messages(caplog: pytest.LogCaptureFixture) -> list[str]:
+    return [
+        record.getMessage()
+        for record in caplog.records
+        if record.name == LOGGER_NAME
+    ]
+
+
+def test_missing_optional_landcover_metadata_does_not_warn(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+):
+    """Absent optional Manning's n metadata should not appear in default output."""
+    geom_hdf = tmp_path / "model.g01.hdf"
+    _write_empty_geom_hdf(geom_hdf)
+
+    pytest.importorskip("geopandas")
+    with caplog.at_level("WARNING", logger=LOGGER_NAME):
+        mannings = HdfLandCover.get_preprocessed_mannings_n(geom_hdf)
+        calibration = HdfLandCover.get_mannings_calibration_table(geom_hdf)
+        regions = HdfLandCover.get_mannings_region_polygons(geom_hdf)
+
+    assert mannings.empty
+    assert calibration is None
+    assert regions.empty
+    assert _hdf_landcover_messages(caplog) == []
+
+
+def test_missing_landcover_association_target_warns_concisely(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+):
+    """Missing associated sidecars should name the files without full paths."""
+    geom_hdf = tmp_path / "model.g01.hdf"
+    _write_geom_hdf_with_landcover_attr(geom_hdf, "LandCover_missing.hdf")
+
+    with caplog.at_level("WARNING", logger=LOGGER_NAME):
+        result = HdfLandCover.get_landcover_association(geom_hdf)
+
+    assert result is None
+    messages = _hdf_landcover_messages(caplog)
+    assert messages == [
+        "Land cover sidecar LandCover_missing.hdf referenced by "
+        "model.g01.hdf was not found"
+    ]
+    assert str(tmp_path) not in "\n".join(messages)
+
+
+def test_missing_raster_map_warning_is_concise(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+):
+    """Required sidecar datasets should be identified without full paths."""
+    sidecar = tmp_path / "LandCover.hdf"
+    _write_sidecar_without_raster_map(sidecar)
+
+    with caplog.at_level("WARNING", logger=LOGGER_NAME):
+        result = HdfLandCover.get_landcover_raster_map(sidecar)
+
+    assert result is None
+    messages = _hdf_landcover_messages(caplog)
+    assert messages == [
+        "No Raster Map dataset found in land cover sidecar LandCover.hdf"
+    ]
+    assert str(tmp_path) not in "\n".join(messages)
+
+
+def test_missing_final_raster_dependencies_log_concisely(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+):
+    """Final-raster failures should be actionable without full paths by default."""
+    pytest.importorskip("rasterio")
+    geom_hdf = tmp_path / "model.g01.hdf"
+    sidecar = tmp_path / "LandCover.hdf"
+    _write_empty_geom_hdf(geom_hdf)
+    _write_landcover_sidecar(sidecar)
+
+    with caplog.at_level("ERROR", logger=LOGGER_NAME):
+        no_association = HdfLandCover.compute_final_mannings_raster(geom_hdf)
+        missing_tif = HdfLandCover.compute_final_mannings_raster(
+            geom_hdf,
+            landcover_hdf_path=sidecar,
+        )
+
+    assert no_association is None
+    assert missing_tif is None
+    messages = _hdf_landcover_messages(caplog)
+    assert messages == [
+        "No land cover sidecar association found in model.g01.hdf; assign one "
+        "in RASMapper Manage Associations before computing final Manning's n raster",
+        "Land cover TIF not found for sidecar LandCover.hdf",
+    ]
+    assert str(tmp_path) not in "\n".join(messages)
+
+
+def test_missing_polygon_parts_warning_is_collapsed(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+):
+    """A malformed polygon-parts dataset should warn once, not once per polygon."""
+    pytest.importorskip("geopandas")
+    geom_hdf = tmp_path / "model.g01.hdf"
+    _write_multipart_regions_without_parts(geom_hdf)
+
+    with caplog.at_level("WARNING", logger=LOGGER_NAME):
+        regions = HdfLandCover.get_mannings_region_polygons(geom_hdf)
+
+    assert len(regions) == 2
+    messages = _hdf_landcover_messages(caplog)
+    assert messages == [
+        "'Polygon Parts' dataset missing for 2 multi-part Manning's n "
+        "calibration polygon(s); using raw point order as polygon shells"
+    ]
+
+
+def test_set_landcover_raster_map_info_is_concise(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+):
+    """Successful sidecar writes should summarize without full paths at INFO."""
+    sidecar = tmp_path / "LandCover.hdf"
+    _write_landcover_sidecar(sidecar)
+
+    with caplog.at_level("INFO", logger=LOGGER_NAME):
+        result = HdfLandCover.set_landcover_raster_map(
+            sidecar,
+            {"Open Water": 0.04},
+        )
+
+    assert result["changed"] == 1
+    assert Path(result["backup_path"]).exists()
+    messages = _hdf_landcover_messages(caplog)
+    assert messages == [
+        "Updated land cover sidecar LandCover.hdf: "
+        "format=v6_modern, changed=1, unchanged=1"
+    ]
+    assert str(tmp_path) not in "\n".join(messages)
+
+
+def test_compute_final_mannings_raster_info_is_concise(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+):
+    """Raster computation should leave one concise INFO summary plus output name."""
+    geom_hdf = tmp_path / "model.g01.hdf"
+    sidecar = tmp_path / "LandCover.hdf"
+    output_tif = tmp_path / "final_n.tif"
+    _write_empty_geom_hdf(geom_hdf)
+    _write_landcover_sidecar(sidecar)
+    _write_landcover_tif(sidecar.with_suffix(".tif"))
+
+    with caplog.at_level("INFO", logger=LOGGER_NAME):
+        final_raster = HdfLandCover.compute_final_mannings_raster(
+            geom_hdf,
+            landcover_hdf_path=sidecar,
+            output_tif_path=output_tif,
+        )
+
+    assert final_raster is not None
+    assert final_raster.shape == (2, 2)
+    assert output_tif.exists()
+    messages = _hdf_landcover_messages(caplog)
+    assert messages == [
+        "Final Manning's n: shape=(2, 2), range=0.0300-0.1200, mean=0.0750",
+        "Wrote final Manning's n raster: final_n.tif",
+    ]
+    assert "Reading land cover TIF" not in "\n".join(messages)
+    assert str(tmp_path) not in "\n".join(messages)

--- a/tests/test_hdf_mesh_logging.py
+++ b/tests/test_hdf_mesh_logging.py
@@ -1,0 +1,121 @@
+"""Logging behavior tests for direct HdfMesh 2D data APIs."""
+
+from pathlib import Path
+
+import h5py
+import numpy as np
+import pytest
+
+from ras_commander.hdf import HdfMesh
+
+
+LOGGER_NAME = "ras_commander.hdf.HdfMesh"
+
+
+def _write_empty_hdf(path: Path) -> None:
+    with h5py.File(path, "w") as hdf_file:
+        hdf_file.create_group("Geometry")
+
+
+def _write_mesh_hdf_without_preprocessor_tables(
+    path: Path,
+    mesh_name: str = "MainArea",
+) -> None:
+    attrs_dtype = np.dtype([("Name", "S32")])
+    attrs = np.array([(mesh_name.encode("utf-8"),)], dtype=attrs_dtype)
+
+    with h5py.File(path, "w") as hdf_file:
+        hdf_file.create_dataset("Geometry/2D Flow Areas/Attributes", data=attrs)
+        hdf_file.create_group(f"Geometry/2D Flow Areas/{mesh_name}")
+
+
+def _hdf_mesh_messages(caplog: pytest.LogCaptureFixture) -> list[str]:
+    return [
+        record.getMessage()
+        for record in caplog.records
+        if record.name == LOGGER_NAME
+    ]
+
+
+def test_missing_face_property_tables_logs_preprocessor_error(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+):
+    """Direct face-property table reads should explain the required preprocessing."""
+    geom_hdf = tmp_path / "model.g01.hdf"
+    _write_mesh_hdf_without_preprocessor_tables(geom_hdf)
+
+    with caplog.at_level("ERROR", logger=LOGGER_NAME):
+        result = HdfMesh.get_mesh_face_property_tables(geom_hdf)
+
+    assert list(result) == ["MainArea"]
+    assert result["MainArea"].empty
+    messages = _hdf_mesh_messages(caplog)
+    assert len(messages) == 1
+    assert "Face property tables not found for mesh 'MainArea'" in messages[0]
+    assert "run the geometry preprocessor" in messages[0]
+    assert "Faces Area Elevation Info" in messages[0]
+    assert "Faces Area Elevation Values" in messages[0]
+
+
+def test_missing_cell_property_tables_logs_preprocessor_error(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+):
+    """Direct cell volume/elevation table reads should point to geompre."""
+    geom_hdf = tmp_path / "model.g01.hdf"
+    _write_mesh_hdf_without_preprocessor_tables(geom_hdf)
+
+    with caplog.at_level("ERROR", logger=LOGGER_NAME):
+        result = HdfMesh.get_mesh_cell_property_tables(geom_hdf)
+
+    assert list(result) == ["MainArea"]
+    assert result["MainArea"].empty
+    messages = _hdf_mesh_messages(caplog)
+    assert len(messages) == 1
+    assert "Cell volume/elevation tables not found for mesh 'MainArea'" in messages[0]
+    assert "run the geometry preprocessor" in messages[0]
+    assert "Cells Volume Elevation Info" in messages[0]
+    assert "Cells Volume Elevation Values" in messages[0]
+
+
+@pytest.mark.parametrize(
+    "method_name",
+    ["get_mesh_face_property_tables", "get_mesh_cell_property_tables"],
+)
+def test_no_2d_mesh_areas_logs_direct_api_error(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+    method_name: str,
+):
+    """No mesh areas is a direct API failure, not a silent optional branch."""
+    geom_hdf = tmp_path / "model.g01.hdf"
+    _write_empty_hdf(geom_hdf)
+    method = getattr(HdfMesh, method_name)
+
+    with caplog.at_level("ERROR", logger=LOGGER_NAME):
+        result = method(geom_hdf)
+
+    assert result == {}
+    messages = _hdf_mesh_messages(caplog)
+    assert len(messages) == 1
+    assert "No 2D mesh areas found" in messages[0]
+    assert "requires a geometry HDF with 2D Flow Areas" in messages[0]
+
+
+def test_missing_mannings_calibration_table_logs_direct_api_error(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+):
+    """A direct calibration-table read should log that the requested data is absent."""
+    geom_hdf = tmp_path / "model.g01.hdf"
+    _write_mesh_hdf_without_preprocessor_tables(geom_hdf)
+
+    with caplog.at_level("ERROR", logger=LOGGER_NAME):
+        result = HdfMesh.get_mannings_calibration_table(geom_hdf)
+
+    assert result is None
+    messages = _hdf_mesh_messages(caplog)
+    assert len(messages) == 1
+    assert "No Manning's n calibration table found" in messages[0]
+    assert "create Manning's n calibration regions" in messages[0]

--- a/tests/test_hdf_pipe_logging.py
+++ b/tests/test_hdf_pipe_logging.py
@@ -1,0 +1,121 @@
+import logging
+
+import h5py
+import numpy as np
+import pandas as pd
+import pytest
+
+from ras_commander.hdf import HdfPipe
+
+
+LOGGER_NAME = "ras_commander.hdf.HdfPipe"
+
+
+def _records(caplog: pytest.LogCaptureFixture):
+    return [record for record in caplog.records if record.name == LOGGER_NAME]
+
+
+def _write_empty_hdf(path):
+    with h5py.File(path, "w"):
+        pass
+    return path
+
+
+def _write_pipe_timeseries_hdf(path):
+    with h5py.File(path, "w") as hdf:
+        dataset = hdf.create_dataset(
+            "Results/Unsteady/Output/Output Blocks/DSS Hydrograph Output/"
+            "Unsteady Time Series/Pipe Networks/Davis/Nodes/Depth",
+            data=np.zeros((2, 3)),
+        )
+        dataset.attrs["Units"] = b"ft"
+    return path
+
+
+def _write_pipe_summary_hdf(path):
+    with h5py.File(path, "w") as hdf:
+        dtype = np.dtype([("Name", "S10"), ("Maximum", "f8")])
+        hdf.create_dataset(
+            "Results/Unsteady/Summary/Pipe Network",
+            data=np.array([(b"Depth", 1.2)], dtype=dtype),
+        )
+    return path
+
+
+def test_optional_pipe_inlets_absence_is_quiet_by_default(tmp_path, caplog):
+    hdf_path = _write_empty_hdf(tmp_path / "empty.p01.hdf")
+
+    with caplog.at_level(logging.WARNING, logger=LOGGER_NAME):
+        inlets = HdfPipe.get_pipe_inlets(hdf_path)
+
+    assert inlets.empty
+    assert _records(caplog) == []
+
+
+def test_missing_pipe_nodes_raise_preprocessor_guidance_without_error_log(
+    tmp_path, caplog
+):
+    hdf_path = _write_empty_hdf(tmp_path / "empty.p01.hdf")
+
+    with caplog.at_level(logging.ERROR, logger=LOGGER_NAME):
+        with pytest.raises(KeyError, match="Run the HEC-RAS geometry preprocessor"):
+            HdfPipe.get_pipe_nodes(hdf_path)
+
+    assert _records(caplog) == []
+
+
+def test_missing_pipe_profile_raise_preprocessor_guidance_without_error_log(
+    tmp_path, caplog
+):
+    hdf_path = _write_empty_hdf(tmp_path / "empty.p01.hdf")
+
+    with caplog.at_level(logging.ERROR, logger=LOGGER_NAME):
+        with pytest.raises(KeyError) as exc_info:
+            HdfPipe.get_pipe_profile(hdf_path, conduit_id=0)
+
+    message = str(exc_info.value)
+    assert "Pipe conduit terrain profile data is absent" in message
+    assert "Run the HEC-RAS geometry preprocessor" in message
+    assert _records(caplog) == []
+
+
+def test_missing_pipe_summary_raise_plan_output_guidance_without_error_log(
+    tmp_path, caplog
+):
+    hdf_path = _write_empty_hdf(tmp_path / "empty.p01.hdf")
+
+    with caplog.at_level(logging.ERROR, logger=LOGGER_NAME):
+        with pytest.raises(KeyError, match="pipe-network summary output"):
+            HdfPipe.get_pipe_network_summary(hdf_path)
+
+    assert _records(caplog) == []
+
+
+def test_missing_pipe_timeseries_variable_lists_available_without_error_log(
+    tmp_path, caplog
+):
+    hdf_path = _write_pipe_timeseries_hdf(tmp_path / "pipes.p01.hdf")
+
+    with caplog.at_level(logging.ERROR, logger=LOGGER_NAME):
+        with pytest.raises(KeyError) as exc_info:
+            HdfPipe.get_pipe_network_timeseries(
+                hdf_path,
+                variable="Nodes/Drop Inlet Flow",
+            )
+
+    message = str(exc_info.value)
+    assert "Nodes/Drop Inlet Flow" in message
+    assert "Nodes/Depth" in message
+    assert "Compute the plan with pipe-network output enabled" in message
+    assert _records(caplog) == []
+
+
+def test_pipe_summary_success_has_no_default_log_noise(tmp_path, caplog):
+    hdf_path = _write_pipe_summary_hdf(tmp_path / "summary.p01.hdf")
+
+    with caplog.at_level(logging.INFO, logger=LOGGER_NAME):
+        summary = HdfPipe.get_pipe_network_summary(hdf_path)
+
+    assert isinstance(summary, pd.DataFrame)
+    assert summary["Name"].iloc[0] == b"Depth"
+    assert _records(caplog) == []

--- a/tests/test_hdf_plan_logging.py
+++ b/tests/test_hdf_plan_logging.py
@@ -1,0 +1,118 @@
+import logging
+from pathlib import Path
+
+import h5py
+import numpy as np
+import pytest
+
+from ras_commander.hdf.HdfPlan import HdfPlan
+
+
+LOGGER_NAME = "ras_commander.hdf.HdfPlan"
+
+
+def _records(caplog: pytest.LogCaptureFixture):
+    return [record for record in caplog.records if record.name == LOGGER_NAME]
+
+
+def _write_plan_hdf(
+    hdf_path: Path,
+    *,
+    include_plan_parameters: bool = False,
+    program_version: str | None = "6.60",
+):
+    with h5py.File(hdf_path, "w") as hdf:
+        plan_data = hdf.create_group("Plan Data")
+        if program_version is not None:
+            info = plan_data.create_group("Plan Information")
+            info.attrs["Program Version"] = np.bytes_(program_version)
+        if include_plan_parameters:
+            params = plan_data.create_group("Plan Parameters")
+            params.attrs["Example Parameter"] = np.bytes_("Example Value")
+
+
+def test_optional_plan_metadata_absence_is_quiet_by_default(tmp_path, caplog):
+    hdf_path = tmp_path / "Project.p01.hdf"
+    _write_plan_hdf(hdf_path, include_plan_parameters=False)
+
+    with caplog.at_level(logging.WARNING, logger=LOGGER_NAME):
+        params = HdfPlan.get_plan_parameters(hdf_path)
+        precip = HdfPlan.get_plan_met_precip(hdf_path)
+        wse_method = HdfPlan.get_starting_wse_method(hdf_path)
+
+    assert params.empty
+    assert list(params.columns) == ["Plan", "Parameter", "Value"]
+    assert precip == {}
+    assert wse_method["method"] == "Unknown"
+    assert _records(caplog) == []
+
+
+def test_optional_plan_metadata_absence_has_debug_context(tmp_path, caplog):
+    hdf_path = tmp_path / "Project.p01.hdf"
+    _write_plan_hdf(hdf_path, include_plan_parameters=False)
+
+    with caplog.at_level(logging.DEBUG, logger=LOGGER_NAME):
+        HdfPlan.get_plan_parameters(hdf_path)
+        HdfPlan.get_plan_met_precip(hdf_path)
+        HdfPlan.get_starting_wse_method(hdf_path)
+
+    messages = [record.getMessage() for record in _records(caplog)]
+    assert any("Plan Parameters not found in Project.p01.hdf" in message for message in messages)
+    assert any("Precipitation data not found in Project.p01.hdf" in message for message in messages)
+    assert any("Starting WSE method not found in Project.p01.hdf" in message for message in messages)
+
+
+def test_get_2d_flow_options_missing_plan_parameters_mentions_legacy_output(
+    tmp_path,
+):
+    hdf_path = tmp_path / "Project.p01.hdf"
+    _write_plan_hdf(hdf_path, include_plan_parameters=False, program_version="4.10")
+    (tmp_path / "Project.O01").write_text("legacy output\n", encoding="utf-8")
+
+    with pytest.raises(ValueError) as exc_info:
+        HdfPlan.get_2d_flow_options(hdf_path)
+
+    message = str(exc_info.value)
+    assert "HEC-RAS 5.x+ computed plan HDF" in message
+    assert "Plan Data/Plan Parameters" in message
+    assert "Project.p01.hdf does not contain that group" in message
+    assert "Program Version 4.10 indicates HEC-RAS 4.x or earlier" in message
+    assert "Found legacy output file Project.O01" in message
+    assert "legacy .O## files" in message
+    assert "RasControl" in message
+    assert str(tmp_path) not in message
+
+
+def test_get_2d_flow_options_missing_plan_parameters_without_legacy_file(
+    tmp_path,
+):
+    hdf_path = tmp_path / "Project.p01.hdf"
+    _write_plan_hdf(hdf_path, include_plan_parameters=False, program_version="6.60")
+
+    with pytest.raises(ValueError) as exc_info:
+        HdfPlan.get_2d_flow_options(hdf_path)
+
+    message = str(exc_info.value)
+    assert "HEC-RAS 5.x+ computed plan HDF" in message
+    assert "Project.p01.hdf does not contain that group" in message
+    assert "Found legacy output file" not in message
+    assert "Program Version 6.60 indicates HEC-RAS 4.x or earlier" not in message
+    assert "RasControl" in message
+    assert str(tmp_path) not in message
+
+
+def test_plan_number_filename_fallback_warning_is_explicit(tmp_path, caplog):
+    hdf_path = tmp_path / "Project.results.hdf"
+    _write_plan_hdf(hdf_path, include_plan_parameters=True)
+
+    with caplog.at_level(logging.WARNING, logger=LOGGER_NAME):
+        params = HdfPlan.get_plan_parameters(hdf_path)
+
+    assert not params.empty
+    assert params["Plan"].tolist() == ["00"]
+    records = _records(caplog)
+    assert len(records) == 1
+    message = records[0].getMessage()
+    assert "Could not extract plan number from filename Project.results.hdf" in message
+    assert "using fallback Plan value '00'" in message
+    assert str(tmp_path) not in message

--- a/tests/test_hdf_plot_logging.py
+++ b/tests/test_hdf_plot_logging.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import logging
+
+import matplotlib
+
+matplotlib.use("Agg", force=True)
+
+import matplotlib.pyplot as plt
+import pandas as pd
+import pytest
+from shapely.geometry import Polygon
+
+from ras_commander.hdf.HdfPlot import HdfPlot
+
+
+LOGGER_NAME = "ras_commander.hdf.HdfPlot"
+
+
+def _records(caplog: pytest.LogCaptureFixture):
+    return [record for record in caplog.records if record.name == LOGGER_NAME]
+
+
+@pytest.fixture(autouse=True)
+def _disable_show(monkeypatch):
+    monkeypatch.setattr(plt, "show", lambda: None)
+    yield
+    plt.close("all")
+
+
+def test_plot_mesh_cells_success_has_no_stdout_or_default_logs(
+    capsys,
+    caplog,
+):
+    cells = pd.DataFrame(
+        {
+            "cell_id": [1],
+            "geometry": [
+                Polygon(
+                    [
+                        (0.0, 0.0),
+                        (1.0, 0.0),
+                        (1.0, 1.0),
+                        (0.0, 1.0),
+                    ]
+                )
+            ],
+        }
+    )
+
+    with caplog.at_level(logging.INFO, logger=LOGGER_NAME):
+        result = HdfPlot.plot_mesh_cells(cells, projection="EPSG:4326")
+
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert result.crs.to_string() == "EPSG:4326"
+    assert result["cell_id"].tolist() == [1]
+    assert _records(caplog) == []
+
+
+def test_plot_mesh_cells_empty_input_raises_without_stdout(capsys, caplog):
+    with caplog.at_level(logging.ERROR, logger=LOGGER_NAME):
+        with pytest.raises(ValueError) as exc_info:
+            HdfPlot.plot_mesh_cells(pd.DataFrame(), projection="EPSG:4326")
+
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert "input DataFrame is empty" in str(exc_info.value)
+    assert _records(caplog) == []
+
+
+def test_plot_time_series_success_has_no_stdout_or_default_logs(
+    capsys,
+    caplog,
+):
+    data = pd.DataFrame(
+        {
+            "time": pd.date_range("2024-01-01", periods=2, freq="h"),
+            "stage": [10.0, 11.5],
+        }
+    )
+
+    with caplog.at_level(logging.INFO, logger=LOGGER_NAME):
+        HdfPlot.plot_time_series(data, x_col="time", y_col="stage")
+
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert _records(caplog) == []
+
+
+def test_plot_time_series_missing_columns_are_actionable(capsys, caplog):
+    data = pd.DataFrame({"time": [1, 2], "flow": [100.0, 200.0]})
+
+    with caplog.at_level(logging.ERROR, logger=LOGGER_NAME):
+        with pytest.raises(ValueError) as exc_info:
+            HdfPlot.plot_time_series(data, x_col="timestamp", y_col="stage")
+
+    captured = capsys.readouterr()
+    message = str(exc_info.value)
+    assert captured.out == ""
+    assert "missing column(s): ['timestamp', 'stage']" in message
+    assert "Available columns: ['time', 'flow']" in message
+    assert _records(caplog) == []

--- a/tests/test_hdf_project_logging.py
+++ b/tests/test_hdf_project_logging.py
@@ -1,0 +1,182 @@
+"""Logging behavior tests for HdfProject extent/bounds helpers."""
+
+import logging
+from pathlib import Path
+
+import h5py
+import numpy as np
+import pytest
+from pyproj import CRS
+
+from ras_commander.hdf import HdfProject
+
+
+PROJECT_LOGGER = "ras_commander.hdf.HdfProject"
+XSEC_LOGGER = "ras_commander.hdf.HdfXsec"
+
+
+def _messages(caplog: pytest.LogCaptureFixture, logger_name: str) -> list[str]:
+    return [
+        record.getMessage()
+        for record in caplog.records
+        if record.name == logger_name
+    ]
+
+
+def _write_2d_geometry_hdf(
+    path: Path,
+    *,
+    epsg: int | None = 4326,
+    perimeter: np.ndarray | None = None,
+) -> None:
+    perimeter = perimeter if perimeter is not None else np.array(
+        [
+            [-77.6, 40.9],
+            [-77.3, 40.9],
+            [-77.3, 41.1],
+            [-77.6, 41.1],
+            [-77.6, 40.9],
+        ],
+        dtype=np.float64,
+    )
+    attrs_dtype = np.dtype([("Name", "S32")])
+    attrs = np.array([(b"Mesh 1",)], dtype=attrs_dtype)
+
+    with h5py.File(path, "w") as hdf_file:
+        if epsg is not None:
+            hdf_file.attrs["Projection"] = CRS.from_epsg(epsg).to_wkt()
+        hdf_file.create_dataset("Geometry/2D Flow Areas/Attributes", data=attrs)
+        hdf_file.create_dataset(
+            "Geometry/2D Flow Areas/Mesh 1/Perimeter",
+            data=perimeter,
+        )
+
+
+def _write_empty_geometry_hdf(path: Path, *, epsg: int | None = 4326) -> None:
+    with h5py.File(path, "w") as hdf_file:
+        if epsg is not None:
+            hdf_file.attrs["Projection"] = CRS.from_epsg(epsg).to_wkt()
+        hdf_file.create_group("Geometry")
+
+
+def test_2d_only_bounds_skip_optional_1d_probe_logs(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+):
+    geom_hdf = tmp_path / "model.g01.hdf"
+    _write_2d_geometry_hdf(geom_hdf)
+
+    with caplog.at_level(logging.WARNING):
+        bounds = HdfProject.get_project_bounds_latlon(geom_hdf, buffer_percent=0.0)
+
+    assert bounds[0] == pytest.approx(-77.6)
+    assert bounds[2] == pytest.approx(-77.3)
+    assert _messages(caplog, PROJECT_LOGGER) == []
+    assert _messages(caplog, XSEC_LOGGER) == []
+
+
+def test_empty_project_extent_logs_one_concise_warning(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+):
+    geom_hdf = tmp_path / "empty.g01.hdf"
+    _write_empty_geometry_hdf(geom_hdf)
+
+    with caplog.at_level(logging.WARNING, logger=PROJECT_LOGGER):
+        bounds = HdfProject.get_project_bounds_latlon(geom_hdf)
+
+    assert bounds == (0.0, 0.0, 0.0, 0.0)
+    messages = _messages(caplog, PROJECT_LOGGER)
+    assert len(messages) == 1
+    assert "No project geometries found in empty.g01.hdf" in messages[0]
+    assert "returning empty extent and zero project-coordinate bounds" in messages[0]
+    assert str(tmp_path) not in messages[0]
+
+
+def test_missing_project_crs_logs_one_project_warning(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+):
+    geom_hdf = tmp_path / "missing_crs.g01.hdf"
+    _write_2d_geometry_hdf(geom_hdf, epsg=None)
+
+    with caplog.at_level(logging.WARNING):
+        bounds = HdfProject.get_project_bounds_latlon(geom_hdf, buffer_percent=0.0)
+
+    assert bounds[0] == pytest.approx(-77.6)
+    project_messages = _messages(caplog, PROJECT_LOGGER)
+    assert len(project_messages) == 1
+    assert "Project CRS unavailable for missing_crs.g01.hdf" in project_messages[0]
+    assert "Pass project_crs=..." in project_messages[0]
+    assert str(tmp_path) not in project_messages[0]
+
+
+def test_invalid_wgs84_transform_logs_single_error_no_warning(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+):
+    geom_hdf = tmp_path / "invalid_wgs84.g01.hdf"
+    _write_2d_geometry_hdf(
+        geom_hdf,
+        epsg=4326,
+        perimeter=np.array(
+            [
+                [1000.0, 1000.0],
+                [1001.0, 1000.0],
+                [1001.0, 1001.0],
+                [1000.0, 1001.0],
+                [1000.0, 1000.0],
+            ],
+            dtype=np.float64,
+        ),
+    )
+
+    with caplog.at_level(logging.WARNING, logger=PROJECT_LOGGER):
+        bounds = HdfProject.get_project_bounds_latlon(geom_hdf, buffer_percent=0.0)
+
+    assert bounds == pytest.approx((1000.0, 1000.0, 1001.0, 1001.0))
+    project_records = [
+        record
+        for record in caplog.records
+        if record.name == PROJECT_LOGGER
+    ]
+    assert [record.levelno for record in project_records] == [logging.ERROR]
+    assert (
+        "CRS transformation failed for invalid_wgs84.g01.hdf"
+        in project_records[0].getMessage()
+    )
+    assert "not WGS84" in project_records[0].getMessage()
+
+
+def test_export_extent_geojson_info_uses_filename_debug_uses_full_path(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    class FakeExtent:
+        crs = "EPSG:4326"
+
+        def to_file(self, output_path, driver):
+            Path(output_path).write_text("{}", encoding="utf-8")
+
+    monkeypatch.setattr(
+        HdfProject,
+        "get_project_extent",
+        staticmethod(lambda *args, **kwargs: (FakeExtent(), (0.0, 0.0, 1.0, 1.0))),
+    )
+    output_path = tmp_path / "nested" / "extent.geojson"
+    output_path.parent.mkdir()
+
+    with caplog.at_level(logging.DEBUG, logger=PROJECT_LOGGER):
+        result = HdfProject.export_extent_geojson("model.g01.hdf", output_path)
+
+    assert result == output_path
+    messages = _messages(caplog, PROJECT_LOGGER)
+    assert "Exported project extent to extent.geojson" in messages
+    assert any(str(output_path) in message for message in messages)
+    info_messages = [
+        record.getMessage()
+        for record in caplog.records
+        if record.name == PROJECT_LOGGER and record.levelno == logging.INFO
+    ]
+    assert info_messages == ["Exported project extent to extent.geojson"]

--- a/tests/test_hdf_pump_logging.py
+++ b/tests/test_hdf_pump_logging.py
@@ -1,0 +1,208 @@
+import logging
+
+import h5py
+import numpy as np
+import pytest
+
+from ras_commander.hdf import HdfPump
+
+
+LOGGER_NAME = "ras_commander.hdf.HdfPump"
+
+
+def _records(caplog: pytest.LogCaptureFixture):
+    return [record for record in caplog.records if record.name == LOGGER_NAME]
+
+
+def _write_empty_hdf(path):
+    with h5py.File(path, "w"):
+        pass
+    return path
+
+
+def _variable_units(column_count=5):
+    rows = [
+        [b"Flow", b"cfs"],
+        [b"Stage HW", b"ft"],
+        [b"Stage TW", b"ft"],
+        [b"Pump Station", b""],
+        [b"Pumps on", b"Pumps on"],
+    ]
+    return np.array(rows[:column_count], dtype="S32")
+
+
+def _write_pump_results_hdf(path, station_name="Pump A", rows=2, timestamp_count=2):
+    data = np.arange(rows * 5, dtype=np.float32).reshape(rows, 5)
+    timestamps = np.array(
+        [
+            b"10APR2024 00:00:00:000",
+            b"10APR2024 00:05:00:000",
+            b"10APR2024 00:10:00:000",
+        ][:timestamp_count],
+        dtype="S24",
+    )
+
+    with h5py.File(path, "w") as hdf:
+        for output_block in ("DSS Hydrograph Output", "DSS Profile Output"):
+            base = (
+                "Results/Unsteady/Output/Output Blocks/"
+                f"{output_block}/Unsteady Time Series"
+            )
+            base_group = hdf.require_group(base)
+            base_group.create_dataset("Time Date Stamp (ms)", data=timestamps)
+            station_group = base_group.require_group(f"Pumping Stations/{station_name}")
+            dataset = station_group.create_dataset("Structure Variables", data=data)
+            dataset.attrs["Variable_Unit"] = _variable_units()
+
+        base_output = hdf.require_group(
+            "Results/Unsteady/Output/Output Blocks/Base Output/Unsteady Time Series"
+        )
+        base_output.create_dataset("Time Date Stamp (ms)", data=timestamps)
+
+    return path
+
+
+def _write_station_without_structure_variables(path, station_name="Pump A"):
+    with h5py.File(path, "w") as hdf:
+        base = (
+            "Results/Unsteady/Output/Output Blocks/DSS Hydrograph Output/"
+            "Unsteady Time Series/Pumping Stations"
+        )
+        hdf.require_group(f"{base}/{station_name}")
+    return path
+
+
+def test_missing_optional_pump_geometry_is_quiet_by_default(tmp_path, caplog):
+    hdf_path = _write_empty_hdf(tmp_path / "empty.p01.hdf")
+
+    with caplog.at_level(logging.WARNING, logger=LOGGER_NAME):
+        stations = HdfPump.get_pump_stations(hdf_path)
+        groups = HdfPump.get_pump_groups(hdf_path)
+        summary = HdfPump.get_pump_station_summary(hdf_path)
+
+    assert stations.empty
+    assert groups.empty
+    assert summary.empty
+    assert _records(caplog) == []
+
+
+def test_missing_optional_pump_geometry_has_debug_context(tmp_path, caplog):
+    hdf_path = _write_empty_hdf(tmp_path / "empty.p01.hdf")
+
+    with caplog.at_level(logging.DEBUG, logger=LOGGER_NAME):
+        HdfPump.get_pump_stations(hdf_path)
+        HdfPump.get_pump_groups(hdf_path)
+        HdfPump.get_pump_station_summary(hdf_path)
+
+    messages = [record.getMessage() for record in _records(caplog)]
+    assert any("No pump station geometry group" in message for message in messages)
+    assert any("No pump station pump-group geometry" in message for message in messages)
+    assert any("Pump station summary data not found" in message for message in messages)
+    assert not any(record.levelno >= logging.WARNING for record in _records(caplog))
+
+
+def test_missing_pump_station_timeseries_group_raises_without_error_log(
+    tmp_path, caplog
+):
+    hdf_path = _write_empty_hdf(tmp_path / "empty.p01.hdf")
+
+    with caplog.at_level(logging.ERROR, logger=LOGGER_NAME):
+        with pytest.raises(KeyError) as exc_info:
+            HdfPump.get_pump_station_timeseries(hdf_path, pump_station="Pump A")
+
+    message = str(exc_info.value)
+    assert "Pump station timeseries extraction" in message
+    assert "Compute the plan with pump station output available" in message
+    assert _records(caplog) == []
+
+
+def test_missing_requested_pump_station_lists_available_without_error_log(
+    tmp_path, caplog
+):
+    hdf_path = _write_pump_results_hdf(tmp_path / "pump.p01.hdf", station_name="Pump A")
+
+    with caplog.at_level(logging.ERROR, logger=LOGGER_NAME):
+        with pytest.raises(ValueError) as exc_info:
+            HdfPump.get_pump_station_timeseries(hdf_path, pump_station="Pump B")
+
+    message = str(exc_info.value)
+    assert "Pump B" in message
+    assert "Pump A" in message
+    assert "Available pump stations" in message
+    assert _records(caplog) == []
+
+
+def test_missing_pump_structure_variables_raise_without_error_log(tmp_path, caplog):
+    hdf_path = _write_station_without_structure_variables(
+        tmp_path / "missing_structure.p01.hdf",
+        station_name="Pump A",
+    )
+
+    with caplog.at_level(logging.ERROR, logger=LOGGER_NAME):
+        with pytest.raises(KeyError) as exc_info:
+            HdfPump.get_pump_station_timeseries(hdf_path, pump_station="Pump A")
+
+    message = str(exc_info.value)
+    assert "Structure Variables" in message
+    assert "Pump A" in message
+    assert "Compute the plan with pump station output available" in message
+    assert _records(caplog) == []
+
+
+def test_pump_operation_missing_station_lists_available_without_error_log(
+    tmp_path, caplog
+):
+    hdf_path = _write_pump_results_hdf(tmp_path / "pump.p01.hdf", station_name="Pump A")
+
+    with caplog.at_level(logging.ERROR, logger=LOGGER_NAME):
+        with pytest.raises(ValueError) as exc_info:
+            HdfPump.get_pump_operation_timeseries(hdf_path, pump_station="Pump B")
+
+    message = str(exc_info.value)
+    assert "Pump B" in message
+    assert "Pump A" in message
+    assert "Available pump stations" in message
+    assert _records(caplog) == []
+
+
+def test_successful_pump_results_do_not_log_by_default(tmp_path, caplog):
+    hdf_path = _write_pump_results_hdf(tmp_path / "pump.p01.hdf", station_name="Pump A")
+
+    with caplog.at_level(logging.INFO, logger=LOGGER_NAME):
+        timeseries = HdfPump.get_pump_station_timeseries(
+            hdf_path,
+            pump_station="Pump A",
+        )
+        operation = HdfPump.get_pump_operation_timeseries(
+            hdf_path,
+            pump_station="Pump A",
+        )
+
+    assert timeseries.shape == (2, 5)
+    assert len(operation) == 2
+    assert _records(caplog) == []
+
+
+def test_timestamp_mismatch_warning_is_specific_and_path_concise(tmp_path, caplog):
+    hdf_path = _write_pump_results_hdf(
+        tmp_path / "mismatch.p01.hdf",
+        station_name="Pump A",
+        rows=2,
+        timestamp_count=1,
+    )
+
+    with caplog.at_level(logging.WARNING, logger=LOGGER_NAME):
+        timeseries = HdfPump.get_pump_station_timeseries(
+            hdf_path,
+            pump_station="Pump A",
+        )
+
+    records = _records(caplog)
+    assert len(records) == 1
+    message = records[0].getMessage()
+    assert records[0].levelno == logging.WARNING
+    assert "Pump A" in message
+    assert "Structure Variables" in message
+    assert "timestamps=1 rows=2" in message
+    assert str(hdf_path) not in message
+    assert timeseries.coords["time"].values.tolist() == [0, 1]

--- a/tests/test_hdf_results_breach_logging.py
+++ b/tests/test_hdf_results_breach_logging.py
@@ -1,0 +1,126 @@
+import logging
+from pathlib import Path
+
+import h5py
+import pandas as pd
+import pytest
+
+from ras_commander.hdf.HdfResultsBreach import HdfResultsBreach
+
+
+LOGGER_NAME = "ras_commander.hdf.HdfResultsBreach"
+
+
+def _empty_hdf(path: Path) -> None:
+    with h5py.File(path, "w"):
+        pass
+
+
+def _structure_dataframe() -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "datetime": pd.to_datetime(["2024-01-01 00:00"]),
+            "total_flow": [100.0],
+            "weir_flow": [25.0],
+            "hw": [20.0],
+            "tw": [10.0],
+        }
+    )
+
+
+def test_direct_missing_sa2d_connection_warns(tmp_path, caplog):
+    """Direct breach data requests should stay visible when required data is absent."""
+    hdf_path = tmp_path / "no_sa_conn.p01.hdf"
+    _empty_hdf(hdf_path)
+
+    with caplog.at_level(logging.WARNING, logger=LOGGER_NAME):
+        result = HdfResultsBreach.get_breaching_variables(hdf_path)
+
+    assert result.empty
+    messages = [
+        record.getMessage()
+        for record in caplog.records
+        if record.name == LOGGER_NAME and record.levelno >= logging.WARNING
+    ]
+    assert messages == [f"No SA 2D Area Conn data in {hdf_path.name}"]
+
+
+def test_breach_timeseries_partial_result_is_debug_only(
+    tmp_path,
+    caplog,
+    monkeypatch,
+):
+    """Fallback from missing breach variables to structure data should not warn."""
+    hdf_path = tmp_path / "structure_only.p01.hdf"
+    _empty_hdf(hdf_path)
+
+    def fake_structure_variables(hdf_path, structure_name=None, *, ras_object=None):
+        return _structure_dataframe()
+
+    def fake_breaching_variables(hdf_path, structure_name=None, *, ras_object=None):
+        return pd.DataFrame()
+
+    monkeypatch.setattr(
+        HdfResultsBreach,
+        "get_structure_variables",
+        staticmethod(fake_structure_variables),
+    )
+    monkeypatch.setattr(
+        HdfResultsBreach,
+        "get_breaching_variables",
+        staticmethod(fake_breaching_variables),
+    )
+
+    with caplog.at_level(logging.WARNING, logger=LOGGER_NAME):
+        result = HdfResultsBreach.get_breach_timeseries(hdf_path)
+
+    assert not result.empty
+    assert not [
+        record
+        for record in caplog.records
+        if record.name == LOGGER_NAME and record.levelno >= logging.WARNING
+    ]
+
+    caplog.clear()
+    with caplog.at_level(logging.DEBUG, logger=LOGGER_NAME):
+        HdfResultsBreach.get_breach_timeseries(hdf_path)
+
+    assert any(
+        record.name == LOGGER_NAME
+        and record.levelno == logging.DEBUG
+        and "No breach data available, returning structure data only"
+        in record.getMessage()
+        for record in caplog.records
+    )
+
+
+def test_breach_timeseries_error_log_includes_hdf_path(
+    tmp_path,
+    caplog,
+    monkeypatch,
+):
+    hdf_path = tmp_path / "failure.p01.hdf"
+    _empty_hdf(hdf_path)
+
+    def fake_structure_variables(hdf_path, structure_name=None, *, ras_object=None):
+        raise RuntimeError("synthetic failure")
+
+    monkeypatch.setattr(
+        HdfResultsBreach,
+        "get_structure_variables",
+        staticmethod(fake_structure_variables),
+    )
+
+    with caplog.at_level(logging.ERROR, logger=LOGGER_NAME):
+        with pytest.raises(RuntimeError):
+            HdfResultsBreach.get_breach_timeseries(hdf_path)
+
+    messages = [
+        record.getMessage()
+        for record in caplog.records
+        if record.name == LOGGER_NAME and record.levelno >= logging.ERROR
+    ]
+    assert len(messages) == 1
+    assert "Error creating combined breach timeseries" in messages[0]
+    assert str(hdf_path) in messages[0]
+    assert "synthetic failure" in messages[0]

--- a/tests/test_hdf_results_mesh.py
+++ b/tests/test_hdf_results_mesh.py
@@ -1,3 +1,6 @@
+import logging
+import warnings
+
 import numpy as np
 import h5py
 
@@ -5,6 +8,7 @@ from ras_commander.hdf.HdfResultsMesh import HdfResultsMesh
 
 
 MESH_NAME = "Test Mesh"
+LOGGER_NAME = "ras_commander.hdf.HdfResultsMesh"
 BASE_TS_PATH = (
     "Results/Unsteady/Output/Output Blocks/Base Output/"
     "Unsteady Time Series"
@@ -196,6 +200,41 @@ def test_get_mesh_faces_timeseries_can_preserve_full_time_axis(tmp_path):
     )
 
 
+def test_get_mesh_faces_timeseries_merges_mixed_time_axes_without_future_warning(
+    tmp_path,
+):
+    hdf_path = tmp_path / "synthetic.p01.hdf"
+    _create_synthetic_face_results_hdf(hdf_path)
+
+    with h5py.File(hdf_path, "a") as hdf:
+        del hdf[f"{BASE_TS_PATH}/2D Flow Areas/{MESH_NAME}/Face Area"]
+        dataset = hdf.create_dataset(
+            f"{BASE_TS_PATH}/2D Flow Areas/{MESH_NAME}/Face Area",
+            data=np.array([[0.0, 0.0], [10.0, 20.0], [0.0, 0.0]]),
+        )
+        dataset.attrs["Units"] = np.bytes_("ft2")
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        result = HdfResultsMesh.get_mesh_faces_timeseries(
+            hdf_path,
+            MESH_NAME,
+            truncate=True,
+        )
+
+    assert not [
+        warning
+        for warning in caught
+        if issubclass(warning.category, FutureWarning)
+        and "default value for join" in str(warning.message)
+    ]
+    assert result.sizes["time"] == 3
+    np.testing.assert_allclose(
+        result["face_area"].values[:, 0],
+        np.array([np.nan, 10.0, np.nan]),
+    )
+
+
 def test_get_mesh_cells_timeseries_treats_new_outputs_as_face_indexed(tmp_path):
     hdf_path = tmp_path / "synthetic.p01.hdf"
     _create_synthetic_face_results_hdf(hdf_path)
@@ -208,6 +247,78 @@ def test_get_mesh_cells_timeseries_treats_new_outputs_as_face_indexed(tmp_path):
 
     assert MESH_NAME in result
     assert result[MESH_NAME]["Face Manning's n"].dims == ("time", "face_id")
+
+
+def test_get_mesh_cells_timeseries_aggregate_missing_outputs_are_debug_only(
+    tmp_path,
+    caplog,
+):
+    hdf_path = tmp_path / "synthetic.p01.hdf"
+    _create_synthetic_face_results_hdf(hdf_path)
+
+    with caplog.at_level(logging.DEBUG, logger=LOGGER_NAME):
+        result = HdfResultsMesh.get_mesh_cells_timeseries(
+            hdf_path,
+            mesh_names=MESH_NAME,
+        )
+
+    assert MESH_NAME in result
+    assert "Face Area" in result[MESH_NAME].data_vars
+    assert "Face Manning's n" in result[MESH_NAME].data_vars
+
+    hdf_result_records = [
+        record for record in caplog.records if record.name == LOGGER_NAME
+    ]
+    warning_messages = [
+        record.getMessage()
+        for record in hdf_result_records
+        if record.levelno >= logging.WARNING
+    ]
+    assert not any("not found in the HDF file" in msg for msg in warning_messages)
+
+    debug_messages = [
+        record.getMessage()
+        for record in hdf_result_records
+        if record.levelno == logging.DEBUG
+    ]
+    summary_messages = [
+        msg for msg in debug_messages
+        if "time-series probe found" in msg
+    ]
+    assert len(summary_messages) == 1
+    assert "skipped" in summary_messages[0]
+    assert "Depth" in summary_messages[0]
+    assert "Face Area" in summary_messages[0]
+
+
+def test_get_mesh_cells_timeseries_explicit_missing_output_logs_error(
+    tmp_path,
+    caplog,
+):
+    hdf_path = tmp_path / "synthetic.p01.hdf"
+    _create_synthetic_face_results_hdf(hdf_path)
+
+    with caplog.at_level(logging.ERROR, logger=LOGGER_NAME):
+        result = HdfResultsMesh.get_mesh_cells_timeseries(
+            hdf_path,
+            mesh_names=MESH_NAME,
+            var="Depth",
+        )
+
+    assert result == {}
+    error_messages = [
+        record.getMessage()
+        for record in caplog.records
+        if record.name == LOGGER_NAME and record.levelno >= logging.ERROR
+    ]
+    assert any(
+        "Requested mesh time-series variable 'Depth' was not found" in msg
+        for msg in error_messages
+    )
+    assert any(
+        "No valid data variables found" in msg
+        for msg in error_messages
+    )
 
 
 def test_get_mesh_cells_timeseries_truncate_uses_time_axis(tmp_path):

--- a/tests/test_hdf_results_plan_logging.py
+++ b/tests/test_hdf_results_plan_logging.py
@@ -1,0 +1,115 @@
+import logging
+from pathlib import Path
+
+import h5py
+import numpy as np
+
+from ras_commander.hdf.HdfResultsPlan import HdfResultsPlan
+
+
+LOGGER_NAME = "ras_commander.hdf.HdfResultsPlan"
+
+
+def _empty_hdf(path: Path) -> None:
+    with h5py.File(path, "w"):
+        pass
+
+
+def _runtime_hdf_with_unknown_times(path: Path) -> None:
+    with h5py.File(path, "w") as hdf:
+        plan_info = hdf.require_group("Plan Data/Plan Information")
+        plan_info.attrs["Plan Name"] = np.bytes_("Steady plan")
+        plan_info.attrs["Simulation Start Time"] = np.bytes_("Unknown")
+        plan_info.attrs["Simulation End Time"] = np.bytes_("Unknown")
+
+
+def test_runtime_unknown_times_are_debug_only(tmp_path, caplog):
+    hdf_path = tmp_path / "steady_unknown_times.p01.hdf"
+    _runtime_hdf_with_unknown_times(hdf_path)
+
+    with caplog.at_level(logging.ERROR, logger=LOGGER_NAME):
+        result = HdfResultsPlan.get_runtime_data(hdf_path)
+
+    assert result is None
+    assert not [
+        record for record in caplog.records
+        if record.name == LOGGER_NAME and record.levelno >= logging.ERROR
+    ]
+
+    caplog.clear()
+    with caplog.at_level(logging.DEBUG, logger=LOGGER_NAME):
+        HdfResultsPlan.get_runtime_data(hdf_path)
+
+    assert any(
+        record.name == LOGGER_NAME
+        and record.levelno == logging.DEBUG
+        and "Runtime metadata unavailable" in record.getMessage()
+        for record in caplog.records
+    )
+
+
+def test_reference_output_absence_is_debug_only(tmp_path, caplog):
+    hdf_path = tmp_path / "no_reference_outputs.p01.hdf"
+    _empty_hdf(hdf_path)
+
+    with caplog.at_level(logging.WARNING, logger=LOGGER_NAME):
+        result = HdfResultsPlan.get_reference_timeseries(hdf_path, "lines")
+
+    assert result.empty
+    assert not [
+        record for record in caplog.records
+        if record.name == LOGGER_NAME and record.levelno >= logging.WARNING
+    ]
+
+
+def test_compute_messages_txt_fallback_success_is_debug_only(
+    tmp_path,
+    caplog,
+    monkeypatch,
+):
+    from ras_commander.RasControl import RasControl
+
+    hdf_path = tmp_path / "missing_compute_messages.p01.hdf"
+    _empty_hdf(hdf_path)
+
+    def fake_comp_msgs(_hdf_path):
+        return "messages from txt fallback"
+
+    monkeypatch.setattr(RasControl, "get_comp_msgs", staticmethod(fake_comp_msgs))
+
+    with caplog.at_level(logging.WARNING, logger=LOGGER_NAME):
+        result = HdfResultsPlan.get_compute_messages(hdf_path)
+
+    assert result == "messages from txt fallback"
+    assert not [
+        record for record in caplog.records
+        if record.name == LOGGER_NAME and record.levelno >= logging.WARNING
+    ]
+
+
+def test_is_steady_plan_failure_is_debug_only(tmp_path, caplog):
+    hdf_path = tmp_path / "not_hdf.p01.hdf"
+    hdf_path.write_text("not an HDF file", encoding="utf-8")
+
+    with caplog.at_level(logging.ERROR, logger=LOGGER_NAME):
+        result = HdfResultsPlan.is_steady_plan(hdf_path)
+
+    assert result is False
+    assert not [
+        record for record in caplog.records
+        if record.name == LOGGER_NAME and record.levelno >= logging.ERROR
+    ]
+
+
+def test_list_steady_variables_on_nonsteady_hdf_is_debug_only(tmp_path, caplog):
+    hdf_path = tmp_path / "unsteady_only.p01.hdf"
+    _empty_hdf(hdf_path)
+
+    with caplog.at_level(logging.WARNING, logger=LOGGER_NAME):
+        result = HdfResultsPlan.list_steady_variables(hdf_path)
+
+    assert result == {"cross_sections": [], "additional": [], "structures": []}
+    assert not [
+        record for record in caplog.records
+        if record.name == LOGGER_NAME and record.levelno >= logging.WARNING
+    ]

--- a/tests/test_hdf_results_plot_logging.py
+++ b/tests/test_hdf_results_plot_logging.py
@@ -1,0 +1,188 @@
+from __future__ import annotations
+
+import logging
+
+import matplotlib
+
+matplotlib.use("Agg", force=True)
+
+import matplotlib.pyplot as plt
+import pandas as pd
+import pytest
+from shapely.geometry import Point
+
+from ras_commander.hdf.HdfResultsPlot import HdfResultsPlot
+
+
+LOGGER_NAME = "ras_commander.hdf.HdfResultsPlot"
+
+
+def _records(caplog: pytest.LogCaptureFixture):
+    return [record for record in caplog.records if record.name == LOGGER_NAME]
+
+
+@pytest.fixture(autouse=True)
+def _disable_show(monkeypatch):
+    monkeypatch.setattr(plt, "show", lambda: None)
+    yield
+    plt.close("all")
+
+
+def _max_ws_df() -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "geometry": [Point(0.0, 0.0), Point(1.0, 1.0)],
+            "maximum_water_surface": [101.2, 103.4],
+            "maximum_water_surface_time": [
+                "2018-09-09 00:00:00",
+                "2018-09-09 06:00:00",
+            ],
+        }
+    )
+
+
+def test_plot_results_max_wsel_success_has_no_stdout_or_default_logs(
+    capsys,
+    caplog,
+):
+    data = _max_ws_df()
+
+    with caplog.at_level(logging.INFO, logger=LOGGER_NAME):
+        HdfResultsPlot.plot_results_max_wsel(data)
+
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert _records(caplog) == []
+    assert "x" not in data.columns
+    assert "y" not in data.columns
+
+
+def test_plot_results_max_wsel_missing_columns_are_actionable(capsys, caplog):
+    data = pd.DataFrame({"geometry": [Point(0.0, 0.0)]})
+
+    with caplog.at_level(logging.ERROR, logger=LOGGER_NAME):
+        with pytest.raises(ValueError) as exc_info:
+            HdfResultsPlot.plot_results_max_wsel(data)
+
+    captured = capsys.readouterr()
+    message = str(exc_info.value)
+    assert captured.out == ""
+    assert "missing column(s): ['maximum_water_surface']" in message
+    assert "Available columns: ['geometry']" in message
+    assert _records(caplog) == []
+
+
+def test_plot_results_max_wsel_all_null_geometry_is_actionable(capsys, caplog):
+    data = pd.DataFrame(
+        {
+            "geometry": [None],
+            "maximum_water_surface": [101.2],
+        }
+    )
+
+    with caplog.at_level(logging.ERROR, logger=LOGGER_NAME):
+        with pytest.raises(ValueError) as exc_info:
+            HdfResultsPlot.plot_results_max_wsel(data)
+
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert "no valid point geometries" in str(exc_info.value)
+    assert _records(caplog) == []
+
+
+def test_plot_results_max_wsel_time_default_has_no_stdout_or_default_logs(
+    capsys,
+    caplog,
+):
+    with caplog.at_level(logging.INFO, logger=LOGGER_NAME):
+        result = HdfResultsPlot.plot_results_max_wsel_time(_max_ws_df())
+
+    captured = capsys.readouterr()
+    assert result is None
+    assert captured.out == ""
+    assert _records(caplog) == []
+
+
+def test_plot_results_max_wsel_time_show_stats_returns_concise_dict(
+    capsys,
+    caplog,
+):
+    with caplog.at_level(logging.INFO, logger=LOGGER_NAME):
+        stats = HdfResultsPlot.plot_results_max_wsel_time(
+            _max_ws_df(),
+            show_stats=True,
+        )
+
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert stats["time_range_hours"] == pytest.approx(6.0)
+    assert stats["count"] == 2
+    assert stats["min_hours"] == pytest.approx(0.0)
+    assert stats["max_hours"] == pytest.approx(6.0)
+    assert _records(caplog) == []
+
+
+def test_plot_results_max_wsel_time_invalid_time_column_is_actionable(
+    capsys,
+    caplog,
+):
+    data = _max_ws_df()
+    data.loc[0, "maximum_water_surface_time"] = "not a date"
+
+    with caplog.at_level(logging.ERROR, logger=LOGGER_NAME):
+        with pytest.raises(ValueError) as exc_info:
+            HdfResultsPlot.plot_results_max_wsel_time(data)
+
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert "could not be parsed as datetimes" in str(exc_info.value)
+    assert _records(caplog) == []
+
+
+def test_plot_results_mesh_variable_success_has_no_stdout_or_default_logs(
+    capsys,
+    caplog,
+):
+    data = pd.DataFrame(
+        {
+            "geometry": [Point(0.0, 0.0), Point(1.0, 1.0)],
+            "Velocity": [2.0, 3.5],
+        }
+    )
+
+    with caplog.at_level(logging.INFO, logger=LOGGER_NAME):
+        HdfResultsPlot.plot_results_mesh_variable(data, "Velocity")
+
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert _records(caplog) == []
+
+
+def test_plot_results_mesh_variable_requires_geometry_column(capsys, caplog):
+    data = pd.DataFrame({"Velocity": [2.0, 3.5]})
+
+    with caplog.at_level(logging.ERROR, logger=LOGGER_NAME):
+        with pytest.raises(ValueError) as exc_info:
+            HdfResultsPlot.plot_results_mesh_variable(data, "Velocity")
+
+    captured = capsys.readouterr()
+    message = str(exc_info.value)
+    assert captured.out == ""
+    assert "missing column(s): ['geometry']" in message
+    assert "Available columns: ['Velocity']" in message
+    assert _records(caplog) == []
+
+
+def test_plot_results_mesh_variable_requires_variable_column(capsys, caplog):
+    data = pd.DataFrame({"geometry": [Point(0.0, 0.0)]})
+
+    with caplog.at_level(logging.ERROR, logger=LOGGER_NAME):
+        with pytest.raises(ValueError) as exc_info:
+            HdfResultsPlot.plot_results_mesh_variable(data, "Velocity")
+
+    captured = capsys.readouterr()
+    message = str(exc_info.value)
+    assert captured.out == ""
+    assert "missing column(s): ['Velocity']" in message
+    assert "Available columns: ['geometry']" in message
+    assert _records(caplog) == []

--- a/tests/test_hdf_results_query_logging.py
+++ b/tests/test_hdf_results_query_logging.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+import importlib
+import logging
+from types import SimpleNamespace
+
+import h5py
+import numpy as np
+import pandas as pd
+import pytest
+
+from ras_commander.hdf.HdfResultsQuery import HdfResultsQuery
+
+
+hdf_results_query_module = importlib.import_module(
+    "ras_commander.hdf.HdfResultsQuery"
+)
+LOGGER_NAME = "ras_commander.hdf.HdfResultsQuery"
+
+
+def _records(caplog: pytest.LogCaptureFixture):
+    return [record for record in caplog.records if record.name == LOGGER_NAME]
+
+
+def test_large_distance_warning_uses_query_context(caplog):
+    distances = np.array([20.0, 1001.0, 1054.85])
+
+    with caplog.at_level(logging.WARNING, logger=LOGGER_NAME):
+        hdf_results_query_module._warn_on_large_distances(
+            distances,
+            point_label="profile sample point",
+        )
+
+    records = _records(caplog)
+    assert len(records) == 1
+    message = records[0].getMessage()
+    assert "2 profile sample points" in message
+    assert "max distance 1054.85" in message
+    assert "Verify CRS/units" in message
+    assert "outside the 2D mesh" in message
+    assert "This often indicates a CRS mismatch" not in message
+
+
+def test_large_distance_warning_is_silent_below_threshold(caplog):
+    distances = np.array([20.0, 999.99])
+
+    with caplog.at_level(logging.WARNING, logger=LOGGER_NAME):
+        hdf_results_query_module._warn_on_large_distances(distances)
+
+    assert _records(caplog) == []
+
+
+def test_query_profile_labels_distance_warnings_as_profile_samples(
+    tmp_path,
+    monkeypatch,
+):
+    plan_hdf = tmp_path / "Example.p01.hdf"
+    with h5py.File(plan_hdf, "w"):
+        pass
+
+    captured = {}
+
+    def fake_query_points_core(
+        plan_hdf_path,
+        points_df,
+        variable,
+        time_index,
+        method,
+        ras_object=None,
+        point_label="query point",
+    ):
+        captured["plan_hdf_path"] = plan_hdf_path
+        captured["point_label"] = point_label
+        captured["method"] = method
+        return pd.DataFrame(
+            {
+                "x": points_df["x"].to_numpy(dtype=float),
+                "y": points_df["y"].to_numpy(dtype=float),
+                "value": np.arange(len(points_df), dtype=float),
+                "cell_id": np.arange(len(points_df), dtype=int),
+                "mesh_name": ["Mesh"] * len(points_df),
+                "distance": np.zeros(len(points_df), dtype=float),
+            }
+        )
+
+    monkeypatch.setattr(
+        hdf_results_query_module,
+        "_query_points_core",
+        fake_query_points_core,
+    )
+
+    result = HdfResultsQuery.query_profile(
+        plan_hdf,
+        x1=0.0,
+        y1=0.0,
+        x2=100.0,
+        y2=0.0,
+        n_points=3,
+    )
+
+    assert captured["plan_hdf_path"] == plan_hdf
+    assert captured["point_label"] == "profile sample point"
+    assert captured["method"] == "nearest"
+    assert result["station"].tolist() == [0.0, 50.0, 100.0]
+
+
+def test_resolve_geometry_hdf_preserves_plan_metadata_missing_path(tmp_path):
+    plan_hdf = tmp_path / "Example.p01.hdf"
+    with h5py.File(plan_hdf, "w") as hdf:
+        plan_info = hdf.require_group("Plan Data/Plan Information")
+        plan_info.attrs["Geometry File"] = np.bytes_("Example.g09")
+
+    ras_object = SimpleNamespace(
+        plan_df=pd.DataFrame(),
+        geom_df=pd.DataFrame(),
+    )
+
+    with pytest.raises(FileNotFoundError) as exc_info:
+        hdf_results_query_module._resolve_geometry_hdf(
+            plan_hdf,
+            ras_object=ras_object,
+        )
+
+    message = str(exc_info.value)
+    assert "Geometry HDF referenced by plan metadata was not found" in message
+    assert "Example.g09.hdf" in message
+    assert "Could not resolve geometry HDF" not in message

--- a/tests/test_hdf_results_xsec.py
+++ b/tests/test_hdf_results_xsec.py
@@ -1,15 +1,89 @@
 """Tests for reference line and point time-series extraction."""
 
+import logging
 from pathlib import Path
+from types import SimpleNamespace
 
 import h5py
 import numpy as np
+import pandas as pd
+import pytest
 
 
 BASE_TS_PATH = (
     "Results/Unsteady/Output/Output Blocks/Base Output/"
     "Unsteady Time Series"
 )
+XSEC_PATH = f"{BASE_TS_PATH}/Cross Sections"
+LOGGER_NAME = "ras_commander.hdf.HdfResultsXsec"
+
+
+def _write_xsec_results_hdf(path: Path, omit_dataset: str | None = None) -> None:
+    with h5py.File(path, "w") as hdf:
+        hdf.create_dataset(
+            f"{BASE_TS_PATH}/Time Date Stamp (ms)",
+            data=np.array(
+                [
+                    b"01Jan2020 00:00:00:000",
+                    b"01Jan2020 01:00:00:000",
+                    b"01Jan2020 02:00:00:000",
+                ],
+            ),
+        )
+
+        attrs_dtype = np.dtype(
+            [
+                ("River", "S32"),
+                ("Reach", "S32"),
+                ("Station", "S32"),
+                ("Name", "S32"),
+            ]
+        )
+        hdf.create_dataset(
+            f"{XSEC_PATH}/Cross Section Attributes",
+            data=np.array(
+                [
+                    (b"River A", b"Reach A", b"1000", b"XS 1000"),
+                    (b"River A", b"Reach A", b"2000", b"XS 2000"),
+                ],
+                dtype=attrs_dtype,
+            ),
+        )
+        hdf.create_dataset(
+            f"{XSEC_PATH}/Cross Section Only",
+            data=np.array([b"XS 1000", b"XS 2000"]),
+        )
+
+        values = np.arange(6, dtype=float).reshape(3, 2)
+        for i, dataset_name in enumerate(
+            [
+                "Water Surface",
+                "Velocity Total",
+                "Velocity Channel",
+                "Flow Lateral",
+                "Flow",
+            ],
+            start=1,
+        ):
+            if dataset_name != omit_dataset:
+                hdf.create_dataset(f"{XSEC_PATH}/{dataset_name}", data=values + i)
+
+
+def _write_minimal_plan_hdf(path: Path, program_version: str | None = None) -> None:
+    with h5py.File(path, "w") as hdf:
+        if program_version is not None:
+            plan_info = hdf.create_group("Plan Data/Plan Information")
+            plan_info.attrs["Program Version"] = program_version.encode("utf-8")
+
+
+def _write_steady_results_hdf(path: Path) -> None:
+    with h5py.File(path, "w") as hdf:
+        hdf.create_group("Results/Steady")
+
+
+def _write_unsteady_without_xsec_hdf(path: Path) -> None:
+    with h5py.File(path, "w") as hdf:
+        hdf.create_group(BASE_TS_PATH)
 
 
 def _write_reference_group(hdf: h5py.File, group_name: str) -> None:
@@ -58,6 +132,278 @@ def _write_reference_hdf(path: Path) -> None:
         )
         _write_reference_group(hdf, "Reference Lines")
         _write_reference_group(hdf, "Reference Points")
+
+
+def _assert_source_file_is_filename_only(ds, hdf_path: Path) -> None:
+    """Notebook display of returned datasets should not expose local paths."""
+    assert ds.attrs["source_file"] == hdf_path.name
+    assert str(hdf_path.parent) not in ds.attrs["source_file"]
+    assert str(hdf_path.parent) not in repr(ds)
+
+
+def test_xsec_timeseries_success_emits_no_default_logs(tmp_path, caplog):
+    """Successful direct cross-section extraction should stay quiet by default."""
+    from ras_commander.hdf import HdfResultsXsec
+
+    hdf_path = tmp_path / "xsec_results.p01.hdf"
+    _write_xsec_results_hdf(hdf_path)
+
+    with caplog.at_level(logging.INFO, logger=LOGGER_NAME):
+        ds = HdfResultsXsec.get_xsec_timeseries(hdf_path)
+
+    assert set(ds.data_vars) == {
+        "Water_Surface",
+        "Velocity_Total",
+        "Velocity_Channel",
+        "Flow_Lateral",
+        "Flow",
+    }
+    assert ds["Water_Surface"].shape == (3, 2)
+    _assert_source_file_is_filename_only(ds, hdf_path)
+    assert not [
+        record for record in caplog.records
+        if record.name == LOGGER_NAME and record.levelno >= logging.INFO
+    ]
+
+
+def test_xsec_timeseries_string_path_success_emits_no_default_logs(tmp_path, caplog):
+    """Notebook-style direct string paths should not emit default logs."""
+    from ras_commander.hdf import HdfResultsXsec
+
+    hdf_path = tmp_path / "xsec_results.p01.hdf"
+    _write_xsec_results_hdf(hdf_path)
+
+    with caplog.at_level(logging.INFO, logger=LOGGER_NAME):
+        ds = HdfResultsXsec.get_xsec_timeseries(str(hdf_path))
+
+    assert ds["Water_Surface"].shape == (3, 2)
+    _assert_source_file_is_filename_only(ds, hdf_path)
+    assert not [
+        record for record in caplog.records
+        if record.name == LOGGER_NAME and record.levelno >= logging.INFO
+    ]
+
+
+def test_xsec_timeseries_plan_number_uses_standardize_input(tmp_path, caplog):
+    """Plan-number inputs should be resolved by @standardize_input."""
+    from ras_commander.hdf import HdfResultsXsec
+
+    hdf_path = tmp_path / "xsec_results.p01.hdf"
+    _write_xsec_results_hdf(hdf_path)
+    ras_object = SimpleNamespace(
+        plan_df=pd.DataFrame(
+            {
+                "plan_number": ["01"],
+                "HDF_Results_Path": [str(hdf_path)],
+            }
+        ),
+        check_initialized=lambda: True,
+    )
+
+    with caplog.at_level(logging.INFO, logger=LOGGER_NAME):
+        ds = HdfResultsXsec.get_xsec_timeseries("01", ras_object=ras_object)
+
+    assert ds["Water_Surface"].shape == (3, 2)
+    _assert_source_file_is_filename_only(ds, hdf_path)
+    assert not [
+        record for record in caplog.records
+        if record.name == LOGGER_NAME and record.levelno >= logging.INFO
+    ]
+
+
+def test_xsec_timeseries_missing_required_dataset_logs_error(tmp_path, caplog):
+    """Missing requested cross-section outputs are direct API failures."""
+    from ras_commander.hdf import HdfResultsXsec
+
+    hdf_path = tmp_path / "xsec_missing.p01.hdf"
+    _write_xsec_results_hdf(hdf_path, omit_dataset="Water Surface")
+
+    with caplog.at_level(logging.ERROR, logger=LOGGER_NAME):
+        with pytest.raises(KeyError):
+            HdfResultsXsec.get_xsec_timeseries(hdf_path)
+
+    messages = [
+        record.getMessage()
+        for record in caplog.records
+        if record.name == LOGGER_NAME and record.levelno >= logging.ERROR
+    ]
+    assert len(messages) == 1
+    assert "Missing required 1D cross-section result dataset in xsec_missing.p01.hdf" in messages[0]
+    assert f"{XSEC_PATH}/Water Surface" in messages[0]
+    assert str(tmp_path) not in messages[0]
+
+
+def test_xsec_timeseries_minimal_hdf_logs_actionable_error(tmp_path, caplog):
+    """A geometry-only or uncomputed HDF should fail with concise guidance."""
+    from ras_commander.hdf import HdfResultsXsec
+
+    hdf_path = tmp_path / "minimal.p01.hdf"
+    _write_minimal_plan_hdf(hdf_path)
+
+    with caplog.at_level(logging.ERROR, logger=LOGGER_NAME):
+        with pytest.raises(KeyError):
+            HdfResultsXsec.get_xsec_timeseries(hdf_path)
+
+    messages = [
+        record.getMessage()
+        for record in caplog.records
+        if record.name == LOGGER_NAME and record.levelno >= logging.ERROR
+    ]
+    assert len(messages) == 1
+    assert "Cannot extract 1D cross-section time series from minimal.p01.hdf" in messages[0]
+    assert "/Results is absent" in messages[0]
+    assert "minimal, geometry-only, or uncomputed HDF" in messages[0]
+    assert str(tmp_path) not in messages[0]
+
+
+def test_xsec_timeseries_steady_hdf_points_to_steady_api(tmp_path, caplog):
+    """Steady plan HDFs should direct users to the steady results API."""
+    from ras_commander.hdf import HdfResultsXsec
+
+    hdf_path = tmp_path / "steady.p02.hdf"
+    _write_steady_results_hdf(hdf_path)
+
+    with caplog.at_level(logging.ERROR, logger=LOGGER_NAME):
+        with pytest.raises(KeyError):
+            HdfResultsXsec.get_xsec_timeseries(hdf_path)
+
+    message = next(
+        record.getMessage()
+        for record in caplog.records
+        if record.name == LOGGER_NAME and record.levelno >= logging.ERROR
+    )
+    assert "Cannot extract 1D unsteady cross-section time series from steady.p02.hdf" in message
+    assert "file contains steady results" in message
+    assert "HdfResultsPlan.get_steady_wse()" in message
+    assert str(tmp_path) not in message
+
+
+def test_xsec_timeseries_unsteady_without_cross_sections_logs_error(tmp_path, caplog):
+    """Unsteady output without 1D cross sections should fail specifically."""
+    from ras_commander.hdf import HdfResultsXsec
+
+    hdf_path = tmp_path / "unsteady_no_xs.p01.hdf"
+    _write_unsteady_without_xsec_hdf(hdf_path)
+
+    with caplog.at_level(logging.ERROR, logger=LOGGER_NAME):
+        with pytest.raises(KeyError):
+            HdfResultsXsec.get_xsec_timeseries(hdf_path)
+
+    message = next(
+        record.getMessage()
+        for record in caplog.records
+        if record.name == LOGGER_NAME and record.levelno >= logging.ERROR
+    )
+    assert "Cannot extract 1D cross-section time series from unsteady_no_xs.p01.hdf" in message
+    assert "unsteady results exist but Cross Sections output is absent" in message
+    assert str(tmp_path) not in message
+
+
+def test_ref_lines_missing_group_is_debug_only(tmp_path, caplog):
+    """Reference outputs are optional probes and should not warn by default."""
+    from ras_commander.hdf import HdfResultsXsec
+
+    hdf_path = tmp_path / "no_reference_lines.p01.hdf"
+    with h5py.File(hdf_path, "w"):
+        pass
+
+    with caplog.at_level(logging.WARNING, logger=LOGGER_NAME):
+        ds = HdfResultsXsec.get_ref_lines_timeseries(hdf_path)
+
+    assert not ds.data_vars
+    assert not [
+        record for record in caplog.records
+        if record.name == LOGGER_NAME and record.levelno >= logging.WARNING
+    ]
+
+    caplog.clear()
+    with caplog.at_level(logging.DEBUG, logger=LOGGER_NAME):
+        HdfResultsXsec.get_ref_lines_timeseries(hdf_path)
+
+    assert any(
+        record.name == LOGGER_NAME
+        and record.levelno == logging.DEBUG
+        and "Reference line time-series group not found in no_reference_lines.p01.hdf" in record.getMessage()
+        and str(tmp_path) not in record.getMessage()
+        for record in caplog.records
+    )
+
+
+def test_ref_lines_missing_name_dataset_logs_error(tmp_path, caplog):
+    """A present reference group without Name is malformed output."""
+    from ras_commander.hdf import HdfResultsXsec
+
+    hdf_path = tmp_path / "reference_missing_name.p01.hdf"
+    with h5py.File(hdf_path, "w") as hdf:
+        hdf.create_dataset(
+            f"{BASE_TS_PATH}/Time Date Stamp (ms)",
+            data=np.array([b"01Jan2020 00:00:00.000"]),
+        )
+        hdf.create_group(f"{BASE_TS_PATH}/Reference Lines")
+
+    with caplog.at_level(logging.ERROR, logger=LOGGER_NAME):
+        with pytest.raises(KeyError):
+            HdfResultsXsec.get_ref_lines_timeseries(hdf_path)
+
+    message = next(
+        record.getMessage()
+        for record in caplog.records
+        if record.name == LOGGER_NAME and record.levelno >= logging.ERROR
+    )
+    assert "Reference line time-series group in reference_missing_name.p01.hdf" in message
+    assert "missing required dataset 'Name'" in message
+    assert str(tmp_path) not in message
+
+
+def test_ref_points_missing_timestamps_logs_error(tmp_path, caplog):
+    """Reference output without unsteady timestamps is incomplete results output."""
+    from ras_commander.hdf import HdfResultsXsec
+
+    hdf_path = tmp_path / "reference_missing_time.p01.hdf"
+    with h5py.File(hdf_path, "w") as hdf:
+        group = hdf.create_group(f"{BASE_TS_PATH}/Reference Points")
+        group.create_dataset("Name", data=np.array([b"Point 1|Mesh A"]))
+
+    with caplog.at_level(logging.ERROR, logger=LOGGER_NAME):
+        with pytest.raises(KeyError):
+            HdfResultsXsec.get_ref_points_timeseries(hdf_path)
+
+    message = next(
+        record.getMessage()
+        for record in caplog.records
+        if record.name == LOGGER_NAME and record.levelno >= logging.ERROR
+    )
+    assert "Reference point time-series group in reference_missing_time.p01.hdf exists" in message
+    assert "unsteady timestamps are missing" in message
+    assert str(tmp_path) not in message
+
+
+def test_ref_lines_no_matching_numeric_datasets_is_debug_only(tmp_path, caplog):
+    """A reference group can exist while containing no selected numeric variables."""
+    from ras_commander.hdf import HdfResultsXsec
+
+    hdf_path = tmp_path / "reference_no_numeric.p01.hdf"
+    with h5py.File(hdf_path, "w") as hdf:
+        hdf.create_dataset(
+            f"{BASE_TS_PATH}/Time Date Stamp (ms)",
+            data=np.array([b"01Jan2020 00:00:00.000"]),
+        )
+        group = hdf.create_group(f"{BASE_TS_PATH}/Reference Lines")
+        group.create_dataset("Name", data=np.array([b"Line 1|Mesh A"]))
+        group.create_dataset("Notes", data=np.array([[b"text"]]))
+
+    with caplog.at_level(logging.DEBUG, logger=LOGGER_NAME):
+        ds = HdfResultsXsec.get_ref_lines_timeseries(hdf_path)
+
+    assert not ds.data_vars
+    assert any(
+        record.name == LOGGER_NAME
+        and record.levelno == logging.DEBUG
+        and "Reference line group found in reference_no_numeric.p01.hdf" in record.getMessage()
+        and "no numeric datasets matched expected shape" in record.getMessage()
+        and str(tmp_path) not in record.getMessage()
+        for record in caplog.records
+    )
 
 
 def test_ref_lines_timeseries_reads_all_numeric_matching_datasets(tmp_path):

--- a/tests/test_hdf_storage_area.py
+++ b/tests/test_hdf_storage_area.py
@@ -81,7 +81,14 @@ def test_compute_stage_storage_curve_returns_dataframe_and_metadata(
     assert curve["storage"].is_monotonic_increasing
     assert metadata["storage_area_name"] == "190"
     assert curve.attrs["storage_area"] == "190"
-    assert metadata["storage_units"] == "cubic project units"
+    assert metadata["units_system"] == "US Customary"
+    assert metadata["storage_units"] == "acre-ft"
+    assert metadata["raw_storage_units"] == "cubic ft"
+    assert metadata["storage_conversion_factor"] == pytest.approx(1.0 / 43560.0)
+    assert metadata["storage_area_area_units"] == "sq ft"
+    assert metadata["storage_area_acres"] == pytest.approx(
+        metadata["storage_area_area"] / 43560.0
+    )
 
 
 def test_get_volume_elevation_curve_matches_raw_hdf(storage_geom_hdf: Path):
@@ -114,6 +121,16 @@ def test_computed_volume_matches_hdf_storage_curve_with_unit_conversion(
     computed_acre_ft = computed_cubic_ft / 43560.0
 
     assert computed_acre_ft == pytest.approx(hdf_volume_acre_ft, rel=0.05)
+
+    curve, metadata = HdfStorageArea.compute_stage_storage_curve(
+        storage_geom_hdf,
+        "190",
+        elevation_interval=5.0,
+        min_elevation=hdf_elevation,
+        max_elevation=hdf_elevation,
+    )
+    assert metadata["storage_units"] == "acre-ft"
+    assert curve["storage"].iloc[0] == pytest.approx(hdf_volume_acre_ft, rel=0.05)
 
 
 def test_storage_area_for_structure_matches_structure_attributes(

--- a/tests/test_hdf_storage_area_logging.py
+++ b/tests/test_hdf_storage_area_logging.py
@@ -1,0 +1,407 @@
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import h5py
+import numpy as np
+import pytest
+
+from ras_commander import HdfStorageArea
+
+
+LOGGER_NAME = "ras_commander.hdf.HdfStorageArea"
+
+
+def _hdf_storage_records(caplog):
+    return [record for record in caplog.records if record.name == LOGGER_NAME]
+
+
+def _write_empty_geometry_hdf(
+    path: Path,
+    *,
+    units_system: str | None = None,
+    si_units: str | None = None,
+) -> Path:
+    with h5py.File(path, "w") as hdf:
+        if units_system is not None:
+            hdf.attrs["Units System"] = units_system
+        geom = hdf.create_group("Geometry")
+        if si_units is not None:
+            geom.attrs["SI Units"] = si_units
+    return path
+
+
+def _write_storage_area_hdf(path: Path, *, terrain_filename: str | None = None) -> Path:
+    with h5py.File(path, "w") as hdf:
+        geom = hdf.create_group("Geometry")
+        if terrain_filename is not None:
+            geom.attrs["Terrain Filename"] = terrain_filename
+
+        storage = geom.create_group("Storage Areas")
+        attrs_dtype = np.dtype([("Name", "S16"), ("Mode", "S24")])
+        storage.create_dataset(
+            "Attributes",
+            data=np.array([(b"SA-1", b"Elev Vol RC")], dtype=attrs_dtype),
+        )
+    return path
+
+
+def _patch_stage_storage_dependencies(
+    monkeypatch,
+    terrain_path: Path,
+    *,
+    polygon_area: float,
+    raw_volume: float,
+    min_elevation: float = 100.0,
+):
+    class _Polygon:
+        pass
+
+    _Polygon.area = polygon_area
+
+    monkeypatch.setattr(
+        HdfStorageArea,
+        "_get_perimeter_polygon",
+        staticmethod(lambda *args, **kwargs: _Polygon()),
+    )
+    monkeypatch.setattr(
+        HdfStorageArea,
+        "get_terrain_path_from_geom_hdf",
+        staticmethod(lambda *args, **kwargs: terrain_path),
+    )
+    monkeypatch.setattr(
+        HdfStorageArea,
+        "_extract_terrain_stats_in_polygon",
+        staticmethod(
+            lambda *args, **kwargs: {
+                "min_interior": min_elevation,
+                "max_interior": min_elevation,
+                "mean_interior": min_elevation,
+                "min_perimeter": min_elevation,
+                "max_perimeter": min_elevation,
+                "valid_cell_count": 1,
+                "cell_area": 1.0,
+            }
+        ),
+    )
+    monkeypatch.setattr(
+        HdfStorageArea,
+        "_compute_volume_below_elevation_from_terrain",
+        staticmethod(lambda *args, **kwargs: raw_volume),
+    )
+
+
+def _compute_single_stage_storage(hdf_path: Path):
+    return HdfStorageArea.compute_stage_storage_curve(
+        hdf_path,
+        "SA-1",
+        elevation_interval=5.0,
+        min_elevation=100.0,
+        max_elevation=100.0,
+    )
+
+
+def test_optional_storage_metadata_absence_quiet_by_default(tmp_path, caplog):
+    hdf_path = _write_empty_geometry_hdf(tmp_path / "empty.g01.hdf")
+
+    with caplog.at_level(logging.WARNING, logger=LOGGER_NAME):
+        assert HdfStorageArea.get_storage_area_names(hdf_path) == []
+        assert HdfStorageArea.get_storage_area_properties(hdf_path, "SA-1") == {}
+
+    assert _hdf_storage_records(caplog) == []
+
+
+def test_optional_storage_metadata_absence_has_debug_context(tmp_path, caplog):
+    hdf_path = _write_empty_geometry_hdf(tmp_path / "empty.g01.hdf")
+
+    with caplog.at_level(logging.DEBUG, logger=LOGGER_NAME):
+        assert HdfStorageArea.get_storage_area_names(hdf_path) == []
+
+    messages = [record.getMessage() for record in _hdf_storage_records(caplog)]
+    assert any(
+        "Storage areas group 'Geometry/Storage Areas' not found" in message
+        for message in messages
+    )
+    assert any("empty.g01.hdf" in message for message in messages)
+
+
+def test_missing_volume_elevation_curve_logs_preprocessor_guidance(tmp_path, caplog):
+    hdf_path = _write_storage_area_hdf(tmp_path / "storage.g01.hdf")
+
+    with caplog.at_level(logging.ERROR, logger=LOGGER_NAME):
+        curve = HdfStorageArea.get_volume_elevation_curve(hdf_path, "SA-1")
+
+    assert curve.empty
+    records = _hdf_storage_records(caplog)
+    assert len(records) == 1
+    message = records[0].getMessage()
+    assert records[0].levelno == logging.ERROR
+    assert "storage area 'SA-1'" in message
+    assert "storage.g01.hdf" in message
+    assert "created by the HEC-RAS geometry preprocessor" in message
+    assert "run the geometry preprocessor first" in message
+    assert "Geometry/Storage Areas/Volume Elevation Info" in message
+    assert "Geometry/Storage Areas/Volume Elevation Values" in message
+    assert str(tmp_path) not in message
+
+
+def test_missing_terrain_reference_is_debug_only(tmp_path, caplog):
+    hdf_path = _write_storage_area_hdf(
+        tmp_path / "storage.g01.hdf",
+        terrain_filename="Terrain/MissingTerrain.hdf",
+    )
+
+    with caplog.at_level(logging.WARNING, logger=LOGGER_NAME):
+        assert HdfStorageArea.get_terrain_path_from_geom_hdf(hdf_path) is None
+
+    assert _hdf_storage_records(caplog) == []
+
+    caplog.clear()
+    with caplog.at_level(logging.DEBUG, logger=LOGGER_NAME):
+        assert HdfStorageArea.get_terrain_path_from_geom_hdf(hdf_path) is None
+
+    messages = [record.getMessage() for record in _hdf_storage_records(caplog)]
+    assert any(
+        "Terrain referenced by storage.g01.hdf was not found" in message
+        for message in messages
+    )
+    assert any("MissingTerrain" in message for message in messages)
+    assert any("Checked candidate path(s)" in message for message in messages)
+
+
+def test_compute_stage_storage_curve_uses_private_volume_helper(monkeypatch, tmp_path):
+    hdf_path = _write_empty_geometry_hdf(tmp_path / "storage.g01.hdf")
+    terrain_path = tmp_path / "terrain.vrt"
+    terrain_path.touch()
+
+    class _Polygon:
+        area = 43560.0
+
+    def _public_helper_should_not_be_called(*args, **kwargs):
+        raise AssertionError("compute_stage_storage_curve should use the private helper")
+
+    monkeypatch.setattr(
+        HdfStorageArea,
+        "_get_perimeter_polygon",
+        staticmethod(lambda *args, **kwargs: _Polygon()),
+    )
+    monkeypatch.setattr(
+        HdfStorageArea,
+        "get_terrain_path_from_geom_hdf",
+        staticmethod(lambda *args, **kwargs: terrain_path),
+    )
+    monkeypatch.setattr(
+        HdfStorageArea,
+        "_extract_terrain_stats_in_polygon",
+        staticmethod(
+            lambda *args, **kwargs: {
+                "min_interior": 100.0,
+                "max_interior": 110.0,
+                "mean_interior": 105.0,
+                "min_perimeter": 100.0,
+                "max_perimeter": 110.0,
+                "valid_cell_count": 2,
+                "cell_area": 1.0,
+            }
+        ),
+    )
+    monkeypatch.setattr(
+        HdfStorageArea,
+        "compute_volume_below_elevation",
+        staticmethod(_public_helper_should_not_be_called),
+    )
+    monkeypatch.setattr(
+        HdfStorageArea,
+        "_compute_volume_below_elevation_from_terrain",
+        staticmethod(lambda *args, **kwargs: 123.0),
+    )
+
+    curve, metadata = HdfStorageArea.compute_stage_storage_curve(
+        hdf_path,
+        "SA-1",
+        elevation_interval=5.0,
+        min_elevation=100.0,
+        max_elevation=110.0,
+    )
+
+    assert curve["storage"].tolist() == [123.0, 123.0, 123.0]
+    assert metadata["num_elevation_points"] == 3
+    assert metadata["storage_units"] == "cubic project units"
+
+
+def test_compute_stage_storage_curve_converts_us_customary_storage_units(
+    monkeypatch,
+    tmp_path,
+):
+    hdf_path = _write_empty_geometry_hdf(
+        tmp_path / "storage.g01.hdf",
+        units_system="US Customary",
+    )
+    terrain_path = tmp_path / "terrain.vrt"
+    terrain_path.touch()
+    _patch_stage_storage_dependencies(
+        monkeypatch,
+        terrain_path,
+        polygon_area=43560.0,
+        raw_volume=43560.0,
+    )
+
+    curve, metadata = _compute_single_stage_storage(hdf_path)
+    assert curve["storage"].tolist() == [1.0]
+    assert metadata["units_system"] == "US Customary"
+    assert metadata["storage_units"] == "acre-ft"
+    assert metadata["raw_storage_units"] == "cubic ft"
+    assert metadata["storage_conversion_factor"] == pytest.approx(1.0 / 43560.0)
+    assert metadata["storage_area_area_units"] == "sq ft"
+    assert metadata["storage_area_acres"] == 1.0
+
+
+def test_compute_stage_storage_curve_keeps_metric_storage_units(
+    monkeypatch,
+    tmp_path,
+):
+    hdf_path = _write_empty_geometry_hdf(
+        tmp_path / "storage.g01.hdf",
+        si_units="True",
+    )
+    terrain_path = tmp_path / "terrain.vrt"
+    terrain_path.touch()
+    _patch_stage_storage_dependencies(
+        monkeypatch,
+        terrain_path,
+        polygon_area=4046.8564224,
+        raw_volume=250.0,
+    )
+
+    curve, metadata = _compute_single_stage_storage(hdf_path)
+    assert curve["storage"].tolist() == [250.0]
+    assert metadata["units_system"] == "SI"
+    assert metadata["storage_units"] == "m^3"
+    assert metadata["raw_storage_units"] == "m^3"
+    assert metadata["storage_conversion_factor"] == 1.0
+    assert metadata["storage_area_area_units"] == "m^2"
+    assert metadata["storage_area_acres"] == pytest.approx(1.0)
+
+
+def test_compute_stage_storage_curve_uses_geometry_si_units_precedence(
+    monkeypatch,
+    tmp_path,
+):
+    hdf_path = _write_empty_geometry_hdf(
+        tmp_path / "storage.g01.hdf",
+        units_system="US Customary",
+        si_units="True",
+    )
+    terrain_path = tmp_path / "terrain.vrt"
+    terrain_path.touch()
+    _patch_stage_storage_dependencies(
+        monkeypatch,
+        terrain_path,
+        polygon_area=4046.8564224,
+        raw_volume=43560.0,
+    )
+
+    curve, metadata = _compute_single_stage_storage(hdf_path)
+    assert curve["storage"].tolist() == [43560.0]
+    assert metadata["units_system"] == "SI"
+    assert metadata["storage_units"] == "m^3"
+
+
+def test_compute_stage_storage_curve_uses_root_metric_when_si_flag_absent(
+    monkeypatch,
+    tmp_path,
+):
+    hdf_path = _write_empty_geometry_hdf(
+        tmp_path / "storage.g01.hdf",
+        units_system="Metric",
+    )
+    terrain_path = tmp_path / "terrain.vrt"
+    terrain_path.touch()
+    _patch_stage_storage_dependencies(
+        monkeypatch,
+        terrain_path,
+        polygon_area=4046.8564224,
+        raw_volume=250.0,
+    )
+
+    curve, metadata = _compute_single_stage_storage(hdf_path)
+    assert curve["storage"].tolist() == [250.0]
+    assert metadata["units_system"] == "SI"
+    assert metadata["storage_units"] == "m^3"
+
+
+def test_compute_stage_storage_curve_keeps_unknown_project_area_units(
+    monkeypatch,
+    tmp_path,
+):
+    hdf_path = _write_empty_geometry_hdf(tmp_path / "storage.g01.hdf")
+    terrain_path = tmp_path / "terrain.vrt"
+    terrain_path.touch()
+    _patch_stage_storage_dependencies(
+        monkeypatch,
+        terrain_path,
+        polygon_area=12345.0,
+        raw_volume=678.0,
+    )
+
+    curve, metadata = _compute_single_stage_storage(hdf_path)
+    assert curve["storage"].tolist() == [678.0]
+    assert metadata["units_system"] == "unknown"
+    assert metadata["storage_units"] == "cubic project units"
+    assert metadata["storage_area_area_units"] == "square project units"
+    assert metadata["storage_area_acres"] is None
+
+
+def test_compute_stage_storage_curve_unexpected_failure_debug_only(monkeypatch, tmp_path, caplog):
+    hdf_path = _write_empty_geometry_hdf(tmp_path / "storage.g01.hdf")
+    terrain_path = tmp_path / "terrain.vrt"
+    terrain_path.touch()
+
+    class _Polygon:
+        area = 43560.0
+
+    monkeypatch.setattr(
+        HdfStorageArea,
+        "_get_perimeter_polygon",
+        staticmethod(lambda *args, **kwargs: _Polygon()),
+    )
+    monkeypatch.setattr(
+        HdfStorageArea,
+        "get_terrain_path_from_geom_hdf",
+        staticmethod(lambda *args, **kwargs: terrain_path),
+    )
+    monkeypatch.setattr(
+        HdfStorageArea,
+        "_extract_terrain_stats_in_polygon",
+        staticmethod(
+            lambda *args, **kwargs: {
+                "min_interior": 100.0,
+                "max_interior": 110.0,
+                "mean_interior": 105.0,
+                "min_perimeter": 100.0,
+                "max_perimeter": 110.0,
+                "valid_cell_count": 2,
+                "cell_area": 1.0,
+            }
+        ),
+    )
+    monkeypatch.setattr(
+        HdfStorageArea,
+        "_compute_volume_below_elevation_from_terrain",
+        staticmethod(
+            lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError("boom"))
+        ),
+    )
+
+    with caplog.at_level(logging.ERROR, logger=LOGGER_NAME):
+        with pytest.raises(IOError, match="storage area 'SA-1' in storage.g01.hdf"):
+            HdfStorageArea.compute_stage_storage_curve(
+                hdf_path,
+                "SA-1",
+                elevation_interval=5.0,
+                min_elevation=100.0,
+                max_elevation=110.0,
+            )
+
+    assert _hdf_storage_records(caplog) == []

--- a/tests/test_hdf_struc1d_logging.py
+++ b/tests/test_hdf_struc1d_logging.py
@@ -1,0 +1,238 @@
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import h5py
+import numpy as np
+import pytest
+
+from ras_commander.hdf.HdfStruc1D import HdfStruc1D
+
+
+LOGGER_NAME = "ras_commander.hdf.HdfStruc1D"
+
+
+def _records(caplog: pytest.LogCaptureFixture):
+    return [record for record in caplog.records if record.name == LOGGER_NAME]
+
+
+def _write_empty_hdf(path: Path) -> Path:
+    with h5py.File(path, "w"):
+        pass
+    return path
+
+
+def _write_steady_shell(path: Path) -> Path:
+    base_path = (
+        "Results/Steady/Output/Output Blocks/Base Output/"
+        "Steady Profiles/Cross Sections"
+    )
+    with h5py.File(path, "w") as hdf:
+        hdf.require_group(base_path)
+    return path
+
+
+def _write_unsteady_shell(path: Path) -> Path:
+    with h5py.File(path, "w") as hdf:
+        hdf.require_group("Results/Unsteady")
+    return path
+
+
+def _write_steady_flanking_structure_hdf(path: Path) -> Path:
+    base_path = (
+        "Results/Steady/Output/Output Blocks/Base Output/"
+        "Steady Profiles/Cross Sections"
+    )
+    attrs_dtype = np.dtype(
+        [
+            ("River", "S32"),
+            ("Reach", "S32"),
+            ("Station", "S16"),
+        ]
+    )
+    attrs = np.array(
+        [
+            (b"River A", b"Reach A", b"52.38"),
+            (b"River A", b"Reach A", b"52.00"),
+        ],
+        dtype=attrs_dtype,
+    )
+    water_surface = np.array(
+        [
+            [573.13, 334.44],
+            [570.00, 330.00],
+        ],
+        dtype=np.float32,
+    )
+    flow = np.array(
+        [
+            [31500.0, 100.0],
+            [30000.0, 95.0],
+        ],
+        dtype=np.float32,
+    )
+
+    with h5py.File(path, "w") as hdf:
+        base = hdf.require_group(base_path)
+        base.create_dataset("Attributes", data=attrs)
+        base.create_dataset("Water Surface", data=water_surface)
+        base.create_dataset("Flow", data=flow)
+
+        geom_info = hdf.require_group("Results/Steady/Output/Geometry Info")
+        geom_info.create_dataset("Node Info", data=np.array([b"RiverA ReachA 52.37 BR"]))
+
+    return path
+
+
+def _write_malformed_structure_list_hdf(path: Path) -> Path:
+    attrs_path = (
+        "Results/Unsteady/Output/Output Blocks/Base Output/Unsteady Time Series/"
+        "Cross Sections/Cross Section Attributes"
+    )
+    attrs = np.array([(b"BR U",)], dtype=np.dtype([("Name", "S16")]))
+    with h5py.File(path, "w") as hdf:
+        hdf.create_dataset(attrs_path, data=attrs)
+    return path
+
+
+def test_empty_hdf_raises_actionable_error_without_warning_log(tmp_path, caplog):
+    hdf_path = _write_empty_hdf(tmp_path / "no_results.p01.hdf")
+
+    with caplog.at_level(logging.WARNING, logger=LOGGER_NAME):
+        with pytest.raises(ValueError) as exc_info:
+            HdfStruc1D.get_structure_max_values(
+                hdf_path,
+                "River A",
+                "Reach A",
+                "52.37",
+            )
+
+    message = str(exc_info.value)
+    assert "No steady or unsteady results were found" in message
+    assert "no_results.p01.hdf" in message
+    assert str(tmp_path) not in message
+    assert [record for record in _records(caplog) if record.levelno >= logging.WARNING] == []
+
+
+def test_unsteady_missing_cross_sections_raises_without_warning_log(tmp_path, caplog):
+    hdf_path = _write_unsteady_shell(tmp_path / "missing_unsteady_xs.p01.hdf")
+
+    with caplog.at_level(logging.WARNING, logger=LOGGER_NAME):
+        with pytest.raises(ValueError) as exc_info:
+            HdfStruc1D.get_structure_max_values(
+                hdf_path,
+                "River A",
+                "Reach A",
+                "52.37",
+            )
+
+    message = str(exc_info.value)
+    assert "Unsteady 1D structure extraction requires cross-section results" in message
+    assert "Results/Unsteady/Output/Output Blocks" in message
+    assert [record for record in _records(caplog) if record.levelno >= logging.WARNING] == []
+
+
+def test_steady_missing_cross_section_attributes_raises_without_warning_log(
+    tmp_path,
+    caplog,
+):
+    hdf_path = _write_steady_shell(tmp_path / "missing_steady_attrs.p01.hdf")
+
+    with caplog.at_level(logging.WARNING, logger=LOGGER_NAME):
+        with pytest.raises(ValueError) as exc_info:
+            HdfStruc1D.get_structure_max_values(
+                hdf_path,
+                "River A",
+                "Reach A",
+                "52.37",
+            )
+
+    message = str(exc_info.value)
+    assert "Steady 1D structure extraction requires cross-section attributes" in message
+    assert "Cross Section Attributes" in message
+    assert [record for record in _records(caplog) if record.levelno >= logging.WARNING] == []
+
+
+def test_steady_flanking_structure_success_has_no_default_log_noise(
+    tmp_path,
+    caplog,
+):
+    hdf_path = _write_steady_flanking_structure_hdf(tmp_path / "bridge.p01.hdf")
+
+    with caplog.at_level(logging.INFO, logger=LOGGER_NAME):
+        result = HdfStruc1D.get_structure_max_values(
+            hdf_path,
+            "River A",
+            "Reach A",
+            "52.37",
+        )
+
+    assert result["found"] is True
+    assert result["max_hw"] == pytest.approx(573.13, abs=0.01)
+    assert result["max_tw"] == pytest.approx(334.44, abs=0.01)
+    assert result["max_flow"] == pytest.approx(31500.0)
+    assert result["hw_source"] == "River A/Reach A/52.38 (US of 52.37)"
+    assert result["tw_source"] == "River A/Reach A/52.00 (DS of 52.37)"
+    assert _records(caplog) == []
+
+
+def test_steady_flanking_structure_debug_retains_source_detail(tmp_path, caplog):
+    hdf_path = _write_steady_flanking_structure_hdf(tmp_path / "bridge.p01.hdf")
+
+    with caplog.at_level(logging.DEBUG, logger=LOGGER_NAME):
+        HdfStruc1D.get_structure_max_values(
+            hdf_path,
+            "River A",
+            "Reach A",
+            "52.37",
+        )
+
+    messages = [record.getMessage() for record in _records(caplog)]
+    assert any(
+        "Steady structure 52.37: using flanking XS US=52.38, DS=52.00" in message
+        for message in messages
+    )
+    assert [record for record in _records(caplog) if record.levelno >= logging.INFO] == []
+
+
+def test_missing_target_structure_raises_without_error_log(tmp_path, caplog):
+    hdf_path = _write_steady_flanking_structure_hdf(tmp_path / "bridge.p01.hdf")
+
+    with caplog.at_level(logging.ERROR, logger=LOGGER_NAME):
+        with pytest.raises(ValueError) as exc_info:
+            HdfStruc1D.get_structure_max_values(
+                hdf_path,
+                "River A",
+                "Reach A",
+                "99.99",
+            )
+
+    message = str(exc_info.value)
+    assert "No 1D structure results were found for River A/Reach A/RS 99.99" in message
+    assert "bridge.p01.hdf" in message
+    assert str(tmp_path) not in message
+    assert _records(caplog) == []
+
+
+def test_list_1d_structures_empty_hdf_is_quiet_by_default(tmp_path, caplog):
+    hdf_path = _write_empty_hdf(tmp_path / "empty.p01.hdf")
+
+    with caplog.at_level(logging.WARNING, logger=LOGGER_NAME):
+        structures = HdfStruc1D.list_1d_structures(hdf_path)
+
+    assert structures.empty
+    assert [record for record in _records(caplog) if record.levelno >= logging.WARNING] == []
+
+
+def test_list_1d_structures_malformed_schema_raises_without_error_log(
+    tmp_path,
+    caplog,
+):
+    hdf_path = _write_malformed_structure_list_hdf(tmp_path / "malformed.p01.hdf")
+
+    with caplog.at_level(logging.ERROR, logger=LOGGER_NAME):
+        with pytest.raises((KeyError, ValueError)):
+            HdfStruc1D.list_1d_structures(hdf_path)
+
+    assert _records(caplog) == []

--- a/tests/test_hdf_struc_logging.py
+++ b/tests/test_hdf_struc_logging.py
@@ -1,0 +1,201 @@
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import h5py
+import numpy as np
+import pytest
+
+from ras_commander.hdf.HdfStruc import HdfStruc
+from ras_commander.hdf.HdfBase import HdfBase
+
+
+LOGGER_NAME = "ras_commander.hdf.HdfStruc"
+
+
+def _hdf_struc_records(caplog: pytest.LogCaptureFixture):
+    return [record for record in caplog.records if record.name == LOGGER_NAME]
+
+
+def _write_structure_hdf(
+    path: Path,
+    *,
+    point_counts: tuple[int, ...] = (2,),
+    include_centerline_points: bool = True,
+) -> Path:
+    attrs_dtype = np.dtype(
+        [
+            ("Type", "S16"),
+            ("River", "S32"),
+            ("Reach", "S32"),
+            ("RS", "S16"),
+        ]
+    )
+    attrs = np.array(
+        [
+            (b"Culvert", b"River A", b"Reach A", f"{1000 + i}".encode("utf-8"))
+            for i in range(len(point_counts))
+        ],
+        dtype=attrs_dtype,
+    )
+
+    starts = []
+    cursor = 0
+    points = []
+    for count in point_counts:
+        starts.append(cursor)
+        for offset in range(count):
+            points.append((float(cursor + offset), float(offset)))
+        cursor += count
+
+    centerline_info = np.array(
+        list(zip(starts, point_counts)),
+        dtype=np.int32,
+    )
+
+    with h5py.File(path, "w") as hdf:
+        structures = hdf.create_group("Geometry/Structures")
+        structures.create_dataset("Attributes", data=attrs)
+        structures.create_dataset("Centerline Info", data=centerline_info)
+        if include_centerline_points:
+            structures.create_dataset(
+                "Centerline Points",
+                data=np.array(points, dtype=np.float64),
+            )
+    return path
+
+
+def _write_empty_plan_hdf(path: Path) -> Path:
+    with h5py.File(path, "w"):
+        pass
+    return path
+
+
+def test_optional_structure_datasets_absence_quiet_by_default(
+    tmp_path,
+    caplog,
+    monkeypatch,
+):
+    hdf_path = _write_structure_hdf(tmp_path / "structures.g01.hdf")
+    monkeypatch.setattr(HdfBase, "get_projection", staticmethod(lambda *_args, **_kwargs: None))
+
+    with caplog.at_level(logging.WARNING, logger=LOGGER_NAME):
+        structures = HdfStruc.get_structures(hdf_path)
+
+    assert len(structures) == 1
+    assert [
+        record for record in _hdf_struc_records(caplog)
+        if record.levelno >= logging.WARNING
+    ] == []
+
+    caplog.clear()
+    with caplog.at_level(logging.DEBUG, logger=LOGGER_NAME):
+        HdfStruc.get_structures(hdf_path)
+
+    messages = [record.getMessage() for record in _hdf_struc_records(caplog)]
+    assert any("Bridge Coefficient Attributes dataset absent" in msg for msg in messages)
+    assert any("Table Info dataset is absent" in msg for msg in messages)
+    assert any("Skipping Profile Data processing" in msg for msg in messages)
+    assert any("structures.g01.hdf" in msg for msg in messages)
+
+
+def test_missing_required_structure_dataset_warns_with_filename(
+    tmp_path,
+    caplog,
+):
+    hdf_path = _write_structure_hdf(
+        tmp_path / "malformed.g01.hdf",
+        include_centerline_points=False,
+    )
+
+    with caplog.at_level(logging.WARNING, logger=LOGGER_NAME):
+        structures = HdfStruc.get_structures(hdf_path)
+
+    assert structures.empty
+    records = [
+        record for record in _hdf_struc_records(caplog)
+        if record.levelno >= logging.WARNING
+    ]
+    assert len(records) == 1
+    message = records[0].getMessage()
+    assert "Required structure dataset missing" in message
+    assert "Geometry/Structures/Centerline Points" in message
+    assert "malformed.g01.hdf" in message
+    assert str(tmp_path) not in message
+
+
+def test_invalid_centerline_geometry_logs_one_aggregate_warning(
+    tmp_path,
+    caplog,
+    monkeypatch,
+):
+    hdf_path = _write_structure_hdf(
+        tmp_path / "invalid_centerline.g01.hdf",
+        point_counts=(2, 1),
+    )
+    monkeypatch.setattr(HdfBase, "get_projection", staticmethod(lambda *_args, **_kwargs: None))
+
+    with caplog.at_level(logging.WARNING, logger=LOGGER_NAME):
+        structures = HdfStruc.get_structures(hdf_path)
+
+    assert len(structures) == 1
+    records = [
+        record for record in _hdf_struc_records(caplog)
+        if record.levelno >= logging.WARNING
+    ]
+    assert len(records) == 1
+    message = records[0].getMessage()
+    assert "Dropped 1 structure(s)" in message
+    assert "invalid_centerline.g01.hdf" in message
+    assert "indices: [1]" in message
+
+
+def test_culvert_hydraulics_decodes_byte_type_values(
+    tmp_path,
+    caplog,
+):
+    hdf_path = _write_structure_hdf(tmp_path / "culvert.g02.hdf")
+
+    with caplog.at_level(logging.WARNING, logger=LOGGER_NAME):
+        culverts = HdfStruc.get_culvert_hydraulics(hdf_path)
+
+    assert len(culverts) == 1
+    assert culverts.iloc[0]["Type"] == "Culvert"
+    assert culverts.iloc[0]["Structure_ID"] == 1
+
+    records = [
+        record for record in _hdf_struc_records(caplog)
+        if record.levelno >= logging.WARNING
+    ]
+    assert len(records) == 1
+    message = records[0].getMessage()
+    assert "Culvert structures found in culvert.g02.hdf" in message
+    assert "Geometry/Structures/Culvert Data is absent" in message
+    assert "returning structure attributes only" in message
+    assert str(tmp_path) not in message
+
+
+def test_list_sa2d_connections_missing_group_is_debug_only(
+    tmp_path,
+    caplog,
+):
+    hdf_path = _write_empty_plan_hdf(tmp_path / "no_sa2d.p01.hdf")
+
+    with caplog.at_level(logging.WARNING, logger=LOGGER_NAME):
+        assert HdfStruc.list_sa2d_connections(hdf_path) == []
+
+    assert [
+        record for record in _hdf_struc_records(caplog)
+        if record.levelno >= logging.WARNING
+    ] == []
+
+    caplog.clear()
+    with caplog.at_level(logging.DEBUG, logger=LOGGER_NAME):
+        assert HdfStruc.list_sa2d_connections(hdf_path) == []
+
+    assert any(
+        record.levelno == logging.DEBUG
+        and "No SA 2D Area Conn data found in no_sa2d.p01.hdf" in record.getMessage()
+        for record in _hdf_struc_records(caplog)
+    )

--- a/tests/test_hdf_utils.py
+++ b/tests/test_hdf_utils.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timedelta
+
+import pytest
+
+from ras_commander.hdf.HdfUtils import HdfUtils
+
+
+LOGGER_NAME = "ras_commander.hdf.HdfUtils"
+
+
+def _records(caplog: pytest.LogCaptureFixture):
+    return [record for record in caplog.records if record.name == LOGGER_NAME]
+
+
+def test_convert_ras_string_duration_uses_public_duration_parser(caplog):
+    with caplog.at_level(logging.DEBUG, logger=LOGGER_NAME):
+        value = HdfUtils.convert_ras_string("01:02:03")
+
+    assert value == timedelta(hours=1, minutes=2, seconds=3)
+    assert _records(caplog) == []
+
+
+def test_convert_ras_string_datetime_range():
+    value = HdfUtils.convert_ras_string(
+        "01JAN2024 00:00:00 to 02JAN2024 12:30:45"
+    )
+
+    assert value == [
+        datetime(2024, 1, 1, 0, 0, 0),
+        datetime(2024, 1, 2, 12, 30, 45),
+    ]
+
+
+def test_parse_run_time_window_returns_start_and_end_without_logs(caplog):
+    with caplog.at_level(logging.DEBUG, logger=LOGGER_NAME):
+        begin, end = HdfUtils.parse_run_time_window(
+            "01JAN2024 00:00:00 to 02JAN2024 12:30:45"
+        )
+
+    assert begin == datetime(2024, 1, 1, 0, 0, 0)
+    assert end == datetime(2024, 1, 2, 12, 30, 45)
+    assert _records(caplog) == []
+
+
+def test_parse_run_time_window_invalid_format_is_actionable():
+    with pytest.raises(ValueError) as exc_info:
+        HdfUtils.parse_run_time_window("01JAN2024 00:00:00")
+
+    assert "DDMMMYYYY HH:MM:SS to DDMMMYYYY HH:MM:SS" in str(exc_info.value)
+
+
+def test_parse_ras_datetime_ms_single_public_definition_is_silent(caplog):
+    with caplog.at_level(logging.DEBUG, logger=LOGGER_NAME):
+        value = HdfUtils.parse_ras_datetime_ms("01JAN2024 00:00:00:123")
+
+    assert value == datetime(2024, 1, 1, 0, 0, 0, 123000)
+    assert _records(caplog) == []
+
+
+def test_parse_duration_public_method():
+    assert HdfUtils.parse_duration("24:00:01") == timedelta(
+        days=1,
+        seconds=1,
+    )

--- a/tests/test_hdf_xsec_logging.py
+++ b/tests/test_hdf_xsec_logging.py
@@ -1,0 +1,249 @@
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import geopandas as gpd
+import h5py
+import numpy as np
+import pytest
+from pyproj import CRS
+
+from ras_commander.hdf.HdfBase import HdfBase
+from ras_commander.hdf.HdfXsec import HdfXsec
+
+
+LOGGER_NAME = "ras_commander.hdf.HdfXsec"
+
+
+def _hdf_xsec_records(caplog: pytest.LogCaptureFixture):
+    return [record for record in caplog.records if record.name == LOGGER_NAME]
+
+
+def _write_empty_geometry_hdf(path: Path) -> Path:
+    with h5py.File(path, "w") as hdf:
+        hdf.create_group("Geometry")
+    return path
+
+
+def _write_2d_style_partial_xsec_hdf(path: Path) -> Path:
+    with h5py.File(path, "w") as hdf:
+        xsecs = hdf.create_group("Geometry/Cross Sections")
+        xsecs.create_group("Flow Distribution")
+        xsecs.create_group("Hyd Property Tables")
+    return path
+
+
+def _write_malformed_xsec_hdf(path: Path) -> Path:
+    with h5py.File(path, "w") as hdf:
+        xsecs = hdf.create_group("Geometry/Cross Sections")
+        xsecs.create_dataset("Polyline Info", data=np.array([[0, 2, 0, 1]], dtype=np.int32))
+    return path
+
+
+def _write_minimal_xsec_hdf(path: Path) -> Path:
+    attrs_dtype = np.dtype(
+        [
+            ("Left Bank", "f8"),
+            ("Right Bank", "f8"),
+            ("River", "S16"),
+            ("Reach", "S16"),
+            ("RS", "S16"),
+        ]
+    )
+    attrs = np.array([(2.0, 8.0, b"River A", b"Reach A", b"1000")], dtype=attrs_dtype)
+
+    with h5py.File(path, "w") as hdf:
+        geometry = hdf.create_group("Geometry")
+        geometry.attrs["Projection"] = CRS.from_epsg(4326).to_wkt()
+        xsecs = geometry.create_group("Cross Sections")
+        xsecs.create_dataset("Polyline Info", data=np.array([[0, 2, 0, 1]], dtype=np.int32))
+        xsecs.create_dataset("Polyline Parts", data=np.array([[0, 2]], dtype=np.int32))
+        xsecs.create_dataset("Polyline Points", data=np.array([[0.0, 0.0], [10.0, 0.0]]))
+        xsecs.create_dataset("Station Elevation Info", data=np.array([[0, 2]], dtype=np.int32))
+        xsecs.create_dataset("Station Elevation Values", data=np.array([[0.0, 100.0], [10.0, 101.0]]))
+        xsecs.create_dataset("Attributes", data=attrs)
+        xsecs.create_dataset("Manning's n Info", data=np.array([[0, 3]], dtype=np.int32))
+        xsecs.create_dataset("Manning's n Values", data=np.array([[0.0, 0.05], [3.0, 0.04], [9.0, 0.06]]))
+    return path
+
+
+def _write_polyline_group(parent, group_name: str, count: int):
+    group = parent.create_group(group_name)
+    poly_info = []
+    poly_parts = []
+    points = []
+    point_cursor = 0
+    for idx in range(count):
+        poly_info.append((point_cursor, 2, idx, 1))
+        poly_parts.append((0, 2))
+        points.extend([(float(idx), 0.0), (float(idx), 1.0)])
+        point_cursor += 2
+    group.create_dataset("Polyline Info", data=np.array(poly_info, dtype=np.int32))
+    group.create_dataset("Polyline Parts", data=np.array(poly_parts, dtype=np.int32))
+    group.create_dataset("Polyline Points", data=np.array(points, dtype=np.float64))
+    return group
+
+
+def _write_centerline_hdf(path: Path) -> Path:
+    attrs_dtype = np.dtype(
+        [
+            ("River Name", "S16"),
+            ("Reach Name", "S16"),
+            ("US Type", "S16"),
+            ("US Name", "S16"),
+            ("DS Type", "S16"),
+            ("DS Name", "S16"),
+            ("Junction to US XS", "f8"),
+            ("DS XS to Junction", "f8"),
+        ]
+    )
+    attrs = np.array(
+        [(b"River A", b"Reach A", b"External", b"", b"External", b"", 0.0, 1.5)],
+        dtype=attrs_dtype,
+    )
+    with h5py.File(path, "w") as hdf:
+        geometry = hdf.create_group("Geometry")
+        group = _write_polyline_group(geometry, "River Centerlines", 1)
+        group.create_dataset("Attributes", data=attrs)
+    return path
+
+
+def _write_edge_lines_hdf(path: Path, count: int = 3) -> Path:
+    attrs_dtype = np.dtype([("Last Edited", "S24"), ("Float Field", "f8")])
+    attrs = np.array(
+        [(b"01Jan2024 0100", float(idx)) for idx in range(count)],
+        dtype=attrs_dtype,
+    )
+    with h5py.File(path, "w") as hdf:
+        geometry = hdf.create_group("Geometry")
+        group = _write_polyline_group(geometry, "River Edge Lines", count)
+        group.create_dataset("Attributes", data=attrs)
+    return path
+
+
+def _write_bank_lines_hdf(path: Path, count: int = 3) -> Path:
+    with h5py.File(path, "w") as hdf:
+        geometry = hdf.create_group("Geometry")
+        _write_polyline_group(geometry, "River Bank Lines", count)
+    return path
+
+
+def test_2d_style_cross_sections_absence_is_debug_only(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+):
+    hdf_path = _write_2d_style_partial_xsec_hdf(tmp_path / "partial_2d.g01.hdf")
+
+    with caplog.at_level(logging.WARNING, logger=LOGGER_NAME):
+        xsecs = HdfXsec.get_cross_sections(hdf_path)
+
+    assert xsecs.empty
+    assert [
+        record for record in _hdf_xsec_records(caplog)
+        if record.levelno >= logging.WARNING
+    ] == []
+
+    caplog.clear()
+    with caplog.at_level(logging.DEBUG, logger=LOGGER_NAME):
+        HdfXsec.get_cross_sections(hdf_path)
+
+    assert any(
+        "No cross-section geometry datasets found in partial_2d.g01.hdf" in record.getMessage()
+        for record in _hdf_xsec_records(caplog)
+    )
+
+
+def test_malformed_cross_sections_warn_once_with_filename(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+):
+    hdf_path = _write_malformed_xsec_hdf(tmp_path / "malformed.g01.hdf")
+
+    with caplog.at_level(logging.WARNING, logger=LOGGER_NAME):
+        xsecs = HdfXsec.get_cross_sections(hdf_path)
+
+    assert xsecs.empty
+    records = [
+        record for record in _hdf_xsec_records(caplog)
+        if record.levelno >= logging.WARNING
+    ]
+    assert len(records) == 1
+    message = records[0].getMessage()
+    assert "Cross-section geometry in malformed.g01.hdf is missing required dataset(s)" in message
+    assert "Geometry/Cross Sections/Polyline Parts" in message
+    assert str(tmp_path) not in message
+
+
+def test_optional_river_geometry_absence_quiet_by_default(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+):
+    hdf_path = _write_empty_geometry_hdf(tmp_path / "empty.g01.hdf")
+
+    with caplog.at_level(logging.WARNING, logger=LOGGER_NAME):
+        assert HdfXsec.get_river_centerlines(hdf_path).empty
+        assert HdfXsec.get_river_edge_lines(hdf_path).empty
+        assert HdfXsec.get_river_bank_lines(hdf_path).empty
+        assert HdfXsec.get_river_stationing(gpd.GeoDataFrame()).empty
+
+    assert [
+        record for record in _hdf_xsec_records(caplog)
+        if record.levelno >= logging.WARNING
+    ] == []
+
+
+def test_river_reaches_handles_mixed_byte_and_numeric_attributes(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    hdf_path = _write_centerline_hdf(tmp_path / "centerlines.g01.hdf")
+    monkeypatch.setattr(HdfBase, "get_projection", staticmethod(lambda *_args, **_kwargs: "EPSG:4326"))
+
+    with caplog.at_level(logging.ERROR, logger=LOGGER_NAME):
+        reaches = HdfXsec.get_river_reaches(hdf_path)
+
+    assert len(reaches) == 1
+    assert reaches.iloc[0]["River Name"] == "River A"
+    assert reaches.iloc[0]["DS XS to Junction"] == pytest.approx(1.5)
+    assert [
+        record for record in _hdf_xsec_records(caplog)
+        if record.levelno >= logging.ERROR
+    ] == []
+
+
+def test_river_edge_lines_handles_attributes_and_odd_counts(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    hdf_path = _write_edge_lines_hdf(tmp_path / "edges.g01.hdf", count=3)
+    monkeypatch.setattr(HdfBase, "get_projection", staticmethod(lambda *_args, **_kwargs: "EPSG:4326"))
+
+    edges = HdfXsec.get_river_edge_lines(hdf_path)
+
+    assert len(edges) == 3
+    assert edges["bank_side"].tolist() == ["Left", "Right", "Left"]
+    assert edges["Float Field"].tolist() == [0.0, 1.0, 2.0]
+
+
+def test_river_bank_lines_handles_odd_counts(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    hdf_path = _write_bank_lines_hdf(tmp_path / "banks.g01.hdf", count=3)
+    monkeypatch.setattr(HdfBase, "get_projection", staticmethod(lambda *_args, **_kwargs: "EPSG:4326"))
+
+    banks = HdfXsec.get_river_bank_lines(hdf_path)
+
+    assert len(banks) == 3
+    assert banks["bank_side"].tolist() == ["Left", "Right", "Left"]
+
+
+def test_cross_sections_assigns_geometry_crs(tmp_path: Path):
+    hdf_path = _write_minimal_xsec_hdf(tmp_path / "xsecs.g01.hdf")
+
+    xsecs = HdfXsec.get_cross_sections(hdf_path)
+
+    assert len(xsecs) == 1
+    assert xsecs.crs == CRS.from_epsg(4326)

--- a/tests/test_hdfplan_geometry_information.py
+++ b/tests/test_hdfplan_geometry_information.py
@@ -1,0 +1,26 @@
+"""Tests for geometry metadata extraction from HDF files."""
+
+from datetime import datetime
+
+import h5py
+import numpy as np
+
+from ras_commander.hdf.HdfPlan import HdfPlan
+
+
+def test_get_geometry_information_handles_mixed_attribute_shapes(tmp_path):
+    hdf_path = tmp_path / "Project.g09.hdf"
+    with h5py.File(hdf_path, "w") as hdf:
+        geometry = hdf.create_group("Geometry")
+        geometry.attrs["Extents"] = np.array([1.0, 2.0, 3.0, 4.0])
+        geometry.attrs["Geometry Time"] = np.bytes_("27Jun2026 12:04:02")
+        geometry.attrs["Title"] = np.bytes_("Single 2D Area - Internal Dam Structure")
+        geometry.attrs["Version"] = np.bytes_("1.0.22 (07Apr2026)")
+
+    attrs_df = HdfPlan.get_geometry_information(hdf_path)
+
+    assert list(attrs_df.columns) == ["Value"]
+    assert np.array_equal(attrs_df.loc["Extents", "Value"], np.array([1.0, 2.0, 3.0, 4.0]))
+    assert attrs_df.loc["Geometry Time", "Value"] == datetime(2026, 6, 27, 12, 4, 2)
+    assert attrs_df.loc["Title", "Value"] == "Single 2D Area - Internal Dam Structure"
+    assert attrs_df.loc["Version", "Value"] == "1.0.22 (07Apr2026)"

--- a/tests/test_ras_terrain_create_hdf.py
+++ b/tests/test_ras_terrain_create_hdf.py
@@ -6,6 +6,7 @@ import pytest
 
 ras_terrain_module = import_module("ras_commander.terrain.RasTerrain")
 RasTerrain = ras_terrain_module.RasTerrain
+h5py = pytest.importorskip("h5py")
 
 
 def test_create_terrain_hdf_passes_custom_timeout(monkeypatch, tmp_path):
@@ -17,21 +18,27 @@ def test_create_terrain_hdf_passes_custom_timeout(monkeypatch, tmp_path):
 
     rasprocess = tmp_path / "RasProcess.exe"
     rasprocess.write_text("", encoding="utf-8")
+    gdal_bin = tmp_path / "GDAL" / "bin64"
+    gdal_bin.mkdir(parents=True)
+    (gdal_bin / "gdal_translate.exe").write_text("", encoding="utf-8")
 
     calls = []
 
-    def fake_run(cmd_str, shell, capture_output, text, timeout):
+    def fake_run(cmd, capture_output, text, timeout, cwd, env):
         calls.append(
             {
-                "cmd_str": cmd_str,
-                "shell": shell,
+                "cmd": cmd,
                 "capture_output": capture_output,
                 "text": text,
                 "timeout": timeout,
+                "cwd": cwd,
+                "env_path": env["PATH"],
             }
         )
-        output_hdf.write_text("hdf", encoding="utf-8")
-        return subprocess.CompletedProcess(cmd_str, 0, stdout="", stderr="")
+        with h5py.File(output_hdf, "w") as hdf:
+            terrain = hdf.create_group("Terrain")
+            terrain.create_dataset("Elevation", data=[1.0])
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
 
     monkeypatch.setattr(
         RasTerrain,
@@ -49,21 +56,20 @@ def test_create_terrain_hdf_passes_custom_timeout(monkeypatch, tmp_path):
     )
 
     assert result == output_hdf
-    assert calls == [
-        {
-            "cmd_str": (
-                f'"{rasprocess}" CreateTerrain '
-                f'units=Feet stitch=true '
-                f'prj="{projection_prj}" '
-                f'out="{output_hdf}" '
-                f'"{input_raster}"'
-            ),
-            "shell": True,
-            "capture_output": True,
-            "text": True,
-            "timeout": 7200,
-        }
+    assert calls[0]["cmd"] == [
+        str(rasprocess),
+        "CreateTerrain",
+        "units=Feet",
+        "stitch=true",
+        f"prj={projection_prj}",
+        f"out={output_hdf}",
+        str(input_raster),
     ]
+    assert calls[0]["capture_output"] is True
+    assert calls[0]["text"] is True
+    assert calls[0]["timeout"] == 7200
+    assert calls[0]["cwd"] == str(tmp_path)
+    assert str(gdal_bin) in calls[0]["env_path"]
 
 
 def test_create_terrain_hdf_rejects_non_positive_timeout(tmp_path):


### PR DESCRIPTION
## Summary

Improves HDF API diagnostics and logging consistency for direct API users and notebook examples. The HDF readers now provide clearer actionable errors/warnings for missing datasets, older/minimal HDF layouts, and geometry-preprocessor-derived products while keeping routine extraction chatter concise.

Highlights:
- converts duplicate/read-only INFO logs to DEBUG where returned DataFrames already show counts
- adds actionable warnings/errors for missing HDF groups and preprocessor-derived datasets
- improves HDF utility/path diagnostics and geometry information compatibility
- documents HDF API behavior and adds focused HDF logging/diagnostic regression tests

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Documentation update
- [ ] Performance improvement
- [x] Refactoring (no functional changes)
- [ ] Example notebook

---

## LLM Self-Review

### Style Compliance

- [x] Static class pattern followed (`.claude/rules/python/static-classes.md`)
- [x] `@staticmethod` + `@log_call` on public methods (`.claude/rules/python/decorators.md`)
- [x] Naming conventions followed (`.claude/rules/python/naming-conventions.md`)
- [x] `pathlib.Path` used, accepts both `str` and `Path` (`.claude/rules/python/path-handling.md`)
- [x] DataFrames used for project metadata, not glob (`.claude/rules/python/dataframe-first-principle.md`)

### Code Quality

- [x] Google-style docstrings with Args, Returns, Raises
- [x] Tested with real HEC-RAS project (`RasExamples.extract_project()`)
- [x] No hardcoded file paths
- [x] Uses logging, not `print()`
- [x] Proper error handling with informative messages

### API Changes (if applicable)

- [x] `ras_object=None` parameter included for multi-project support
- [x] Standard parameter names (`plan_number`, `geom_file`)
- [x] API consistency auditor 5 rules followed (`.claude/agents/api-consistency-auditor.md`)
- [x] Return types consistent (DataFrames for tabular data)

### Notebooks (if applicable)

- [ ] First cell is markdown with H1 title
- [ ] Uses `RasExamples.extract_project()` for data
- [ ] Development toggle cell included (`USE_LOCAL_SOURCE`)

---

## Test Plan

- `git diff --check --cached`
- `python -m py_compile` on staged `ras_commander/**/*.py`
- `pytest tests/test_hdf*.py tests/test_ras_terrain_create_hdf.py -q`: 280 passed, 14 skipped, 2 warnings

## LLM Attribution

**Model/Tool used**: Codex CLI (GPT-5)
