### PR TITLE
Fix sparse gridded precipitation logging

### DIFF
--- a/agent_tasks/2026-07-07_pr251_notebook_rerun_findings.md
+++ b/agent_tasks/2026-07-07_pr251_notebook_rerun_findings.md
@@ -1,0 +1,77 @@
+# PR 251 Notebook Rerun Findings
+
+Date: 2026-07-07
+
+Context: PR #251 (`linear/CLB-899`) was replayed onto current `origin/main`
+after the logging PRs and dependency updates landed. The PR source edits were
+limited to notebook plotting/result-reporting cells:
+
+- `examples/901_aorc_precipitation_catalog.ipynb`: code cells 21 and 23.
+- `examples/914_historical_event_validation.ipynb`: code cell 8.
+
+Both notebooks were rerun in `G:\GH\ras-commander-pr251-update` using the
+repo-local `uv` environment with the notebook extras installed.
+
+## 901 AORC Precipitation Catalog
+
+Verdict: **REVISE / hold PR output**.
+
+Findings:
+
+- The notebook ran without Python exceptions.
+- HEC-RAS reported `12/12` storm plan executions successful.
+- No plan result HDFs were produced for the storm plans (`p07`, `p08`, `p09`,
+  `p10`, `p11`, `p12`, `p14`, `p16`, `p20`, `p21`, `p22`, `p23`).
+- The notebook result summary correctly reported `HDF NOT FOUND` for all
+  storm plans and `Plan HDF files found: 0 of 12 storms`.
+- Generated `.data_errors.txt` files report the same model issue:
+  `Boundary at SA Conn: Sayers Dam ... Time series data ends before the end of
+  the simulation.`
+- The rerun exposed repeated `RasUnsteady` warnings from configuring gridded
+  precipitation in sparse cloned unsteady files. A separate narrow API fix can
+  create the missing precipitation block instead of logging repeated missing-line
+  warnings.
+
+Recommended next action:
+
+- Do not publish the rerun output.
+- Fix the storm-plan workflow before accepting this notebook output: either
+  constrain simulation periods so the SA connection gate time series covers the
+  event or make the notebook explicitly a precipitation-catalog-only example.
+- Treat compute success as incomplete when the expected plan HDF is absent.
+
+## 914 Historical Event Validation
+
+Verdict: **REVISE / hold PR output**.
+
+Findings:
+
+- The notebook ran without Python exceptions.
+- The improved coverage map plotting cell rendered and is materially better
+  than the original.
+- The model execution did not produce usable modeled results.
+- `BaldEagleDamBrk.p07.hdf` contained compute messages and plan/geometry
+  metadata but no `/Results/Unsteady` result group.
+- Compute messages indicate the active event-condition precipitation does not
+  overlap the 2020 validation plan period:
+  the plan period is `2020-12-22` to `2020-12-27`, while the gridded
+  precipitation metadata still points at the 2018 example event.
+- Result extraction falls back from 1D cross-section results to 2D reference
+  lines, then reports no available modeled flow time series.
+- Metrics and comparison plots are skipped because aligned modeled data is not
+  available.
+
+Recommended next action:
+
+- Do not publish the rerun output.
+- Fix the precipitation/event-condition configuration so the 2020 plan uses
+  the downloaded 2020 AORC NetCDF.
+- Add or automate a usable modeled result extraction path, such as a reference
+  line or stage extraction workflow, before presenting the notebook as an
+  end-to-end validation example.
+
+## PR Recommendation
+
+Do not merge PR #251 as-is. The source edits are narrow and generally
+reasonable, but the notebooks fail the executed-notebook review standard because
+the published outputs do not demonstrate successful hydraulic results.

--- a/ras_commander/RasUnsteady.py
+++ b/ras_commander/RasUnsteady.py
@@ -5722,15 +5722,92 @@ class RasUnsteady:
                 gdal_group_updated = True
                 logger.debug(f"Inserted GDAL Group at line {insert_at+1}")
 
-        # Verify all updates were made
+        # Some older/minimal unsteady files omit the meteorologic
+        # precipitation block entirely. Create only the missing managed keys
+        # instead of warning after a successful configuration request.
         if not precip_mode_updated:
-            logger.warning("Could not find 'Precipitation Mode=' line")
+            insert_at = RasUnsteady._get_default_met_insert_index(lines)
+            lines.insert(insert_at, "Precipitation Mode=Enable\n")
+            precip_mode_updated = True
+
         if not mode_updated:
-            logger.warning("Could not find 'Met BC=Precipitation|Mode=' line")
+            insert_at = next(
+                (
+                    i + 1
+                    for i, line in enumerate(lines)
+                    if line.startswith("Precipitation Mode=")
+                ),
+                RasUnsteady._get_default_met_insert_index(lines),
+            )
+            lines.insert(insert_at, "Met BC=Precipitation|Mode=Gridded\n")
+            mode_updated = True
+
         if not source_updated:
-            logger.warning("Could not find 'Met BC=Precipitation|Gridded Source=' line")
+            insert_at = next(
+                (
+                    i + 1
+                    for i, line in enumerate(lines)
+                    if line.startswith("Met BC=Precipitation|Mode=")
+                ),
+                RasUnsteady._get_default_met_insert_index(lines),
+            )
+            lines.insert(
+                insert_at,
+                "Met BC=Precipitation|Gridded Source=GDAL Raster File(s)\n",
+            )
+            source_updated = True
+
+        if not interp_updated:
+            insert_at = next(
+                (
+                    i + 1
+                    for i, line in enumerate(lines)
+                    if line.startswith("Met BC=Precipitation|Gridded Source=")
+                ),
+                RasUnsteady._get_default_met_insert_index(lines),
+            )
+            lines.insert(
+                insert_at,
+                f"Met BC=Precipitation|Gridded Interpolation={interpolation}\n",
+            )
+            interp_updated = True
+
         if not gdal_filename_updated:
-            logger.warning("Could not add GDAL Filename line")
+            insert_at = next(
+                (
+                    i + 1
+                    for i, line in enumerate(lines)
+                    if line.startswith("Met BC=Precipitation|Gridded Interpolation=")
+                ),
+                next(
+                    (
+                        i + 1
+                        for i, line in enumerate(lines)
+                        if line.startswith("Met BC=Precipitation|Gridded Source=")
+                    ),
+                    RasUnsteady._get_default_met_insert_index(lines),
+                ),
+            )
+            lines.insert(
+                insert_at,
+                f"Met BC=Precipitation|Gridded GDAL Filename={netcdf_str}\n",
+            )
+            gdal_filename_updated = True
+
+        if dataset_name and not gdal_group_updated:
+            insert_at = next(
+                (
+                    i + 1
+                    for i, line in enumerate(lines)
+                    if line.startswith("Met BC=Precipitation|Gridded GDAL Filename=")
+                ),
+                RasUnsteady._get_default_met_insert_index(lines),
+            )
+            lines.insert(
+                insert_at,
+                f"Met BC=Precipitation|Gridded GDAL Group={dataset_name}\n",
+            )
+            gdal_group_updated = True
 
         # Write the updated file
         with open(unsteady_path, 'w', encoding='utf-8', errors='replace', newline='\r\n') as f:

--- a/tests/test_rasunsteady_logging.py
+++ b/tests/test_rasunsteady_logging.py
@@ -159,8 +159,23 @@ def test_gridded_precipitation_configuration_info_is_concise(tmp_path, caplog):
         "Configured gridded precipitation in Model.u01: "
         "source=.\\Precipitation\\storm.nc, interpolation=Bilinear"
     ) in info_messages
+    warning_messages = _messages(caplog, logging.WARNING)
+    assert not any(
+        "Could not find 'Precipitation Mode='" in message
+        for message in warning_messages
+    )
+    assert not any(
+        "Could not find 'Met BC=Precipitation|Mode='" in message
+        for message in warning_messages
+    )
+    assert not any("Could not add GDAL Filename line" in message for message in warning_messages)
     assert not any(str(tmp_path) in message for message in info_messages)
     assert any(str(unsteady_file) in message for message in _messages(caplog, logging.DEBUG))
+
+    updated_text = unsteady_file.read_text(encoding="utf-8")
+    assert "Precipitation Mode=Enable" in updated_text
+    assert "Met BC=Precipitation|Mode=Gridded" in updated_text
+    assert "Met BC=Precipitation|Gridded GDAL Filename=.\\Precipitation\\storm.nc" in updated_text
 
 
 def test_gridded_precipitation_hdf_import_logs_one_concise_info(tmp_path, caplog, monkeypatch):


### PR DESCRIPTION
## Summary

Fixes `RasUnsteady.set_gridded_precipitation()` for older/minimal unsteady files that do not already contain a full meteorologic precipitation block. Instead of emitting repeated missing-line warnings after a valid configuration request, the API now inserts the missing managed gridded precipitation keys while preserving the existing line-preserving update path used by GUI-authored fixtures.

Also records the PR #251 notebook rerun findings in `agent_tasks/` so the AORC and historical-validation notebook issues can be fixed separately instead of publishing failed rerun outputs.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)
- [ ] Example notebook

---

## LLM Self-Review

> **ras-commander encourages LLM-assisted contributions.** If your agent prepared this code, confirm it reviewed the style guide. See [CONTRIBUTING.md](../CONTRIBUTING.md) for details.

### Style Compliance

- [x] Static class pattern followed (`.claude/rules/python/static-classes.md`)
- [x] `@staticmethod` + `@log_call` on public methods (`.claude/rules/python/decorators.md`)
- [x] Naming conventions followed (`.claude/rules/python/naming-conventions.md`)
- [x] `pathlib.Path` used, accepts both `str` and `Path` (`.claude/rules/python/path-handling.md`)
- [x] DataFrames used for project metadata, not glob (`.claude/rules/python/dataframe-first-principle.md`)

### Code Quality

- [x] Google-style docstrings with Args, Returns, Raises
- [ ] Tested with real HEC-RAS project (`RasExamples.extract_project()`)
- [x] No hardcoded file paths
- [x] Uses logging, not `print()`
- [x] Proper error handling with informative messages

### API Changes (if applicable)

- [x] `ras_object=None` parameter included for multi-project support
- [x] Standard parameter names (`plan_number`, `geom_file`)
- [x] API consistency auditor 5 rules followed (`.claude/agents/api-consistency-auditor.md`)
- [x] Return types consistent (DataFrames for tabular data)

### Notebooks (if applicable)

- [ ] First cell is markdown with H1 title
- [ ] Uses `RasExamples.extract_project()` for data
- [ ] Development toggle cell included (`USE_LOCAL_SOURCE`)

---

## Test Plan

- [x] `uv run --with pytest pytest tests/test_rasunsteady_gridded_precipitation_fixture.py::test_set_gridded_precipitation_matches_gui_imported_u01 tests/test_rasunsteady_logging.py::test_gridded_precipitation_configuration_info_is_concise tests/test_rasunsteady_met_precip_config.py::test_set_met_precipitation_mode_creates_precipitation_block_from_scratch -q`

## LLM Attribution

**Model/Tool used**: Codex CLI (GPT-5)
