### PR TITLE
Record 710 sensitivity follow-up

### DIFF
--- a/agent_tasks/2026-07-07_710_mannings_sensitivity_followup.md
+++ b/agent_tasks/2026-07-07_710_mannings_sensitivity_followup.md
@@ -1,0 +1,63 @@
+# 710 Manning's Sensitivity Follow-Up
+
+Date: 2026-07-07
+
+## Context
+
+Notebook `examples/710_mannings_sensitivity_bulk_analysis.ipynb` was included in
+the merged sensitivity notebook refresh (`997d5ca3`, PR #265). During independent
+notebook review, the executed notebook was marked **REVISE** because the min,
+current, and max Manning's n scenarios did not show a measurable hydraulic
+response at the selected point.
+
+This document records the issue so it can be addressed in a focused follow-up
+instead of being lost in the PR 260 cleanup stream.
+
+## Evidence From Review
+
+The notebook successfully:
+
+- migrated deprecated `RasGeo` Manning's n calls to `GeomLandCover` APIs;
+- cloned the current plan/geometry into min and max roughness scenarios;
+- wrote distinct base and regional Manning's n tables for current, minimum,
+  and maximum scenarios;
+- reran the baseline and min/max plans; and
+- suppressed noisy INFO logging in committed notebook output.
+
+However, the hydraulic result comparison did not demonstrate sensitivity:
+
+- selected-cell maximum WSE was `945.89 ft` for current, minimum, and maximum
+  scenarios;
+- full-domain `HdfResultsMesh.get_mesh_max_ws()` comparison across all 5,765
+  mesh cells showed `0.0 ft` max-minus-min difference;
+- `HdfResultsMesh.get_mesh_max_face_v()` comparison across 11,164 faces also
+  showed zero difference; and
+- geometry HDF calibration tables differed, but the `Cells Center Manning's n`
+  dataset remained uniformly `0.06` across current, min, and max geometry HDFs.
+
+## Recommended Follow-Up
+
+Do not treat notebook 710 as a completed hydraulic sensitivity example until a
+follow-up proves a measurable model response.
+
+Preferred options:
+
+1. Update the workflow so geometry preprocessing propagates the changed land
+   cover calibration values into the 2D-cell Manning's n data used by the run,
+   then rerun and independently review the notebook.
+2. If the Muncie plan is genuinely insensitive to the demonstrated roughness
+   edits, switch to a project/plan/output location where the sensitivity is
+   hydraulically visible.
+3. If the example is intended only to demonstrate input editing mechanics,
+   retitle/rewrite it as a Manning's n bulk-edit verification notebook rather
+   than a hydraulic sensitivity notebook.
+
+## Validation Needed For Closure
+
+A closure PR should include:
+
+- executed notebook outputs with no tracebacks or warning spam;
+- a quantitative comparison showing a nonzero hydraulic response, such as max
+  WSE, depth, velocity, or another defensible quantity;
+- a map or table identifying where the response occurs; and
+- independent notebook-review PASS.


### PR DESCRIPTION
## Summary

Records a follow-up task for notebook `710_mannings_sensitivity_bulk_analysis.ipynb` after the sensitivity notebook refresh landed.

The task note documents that the notebook writes distinct Manning's n tables, but the executed current/min/max scenarios showed no measurable hydraulic response in max WSE or face velocity. It also records closure criteria for a future focused fix.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)
- [ ] Example notebook

---

## LLM Self-Review

> **ras-commander encourages LLM-assisted contributions.** If your agent prepared this code, confirm it reviewed the style guide. See [CONTRIBUTING.md](../CONTRIBUTING.md) for details.

### Style Compliance

Task-document-only PR; no package API or notebook implementation changed.

- [ ] Static class pattern followed (`.claude/rules/python/static-classes.md`)
- [ ] `@staticmethod` + `@log_call` on public methods (`.claude/rules/python/decorators.md`)
- [ ] Naming conventions followed (`.claude/rules/python/naming-conventions.md`)
- [ ] `pathlib.Path` used, accepts both `str` and `Path` (`.claude/rules/python/path-handling.md`)
- [ ] DataFrames used for project metadata, not glob (`.claude/rules/python/dataframe-first-principle.md`)

### Code Quality

Task-document-only PR.

- [ ] Google-style docstrings with Args, Returns, Raises
- [ ] Tested with real HEC-RAS project (`RasExamples.extract_project()`)
- [x] No hardcoded file paths
- [ ] Uses logging, not `print()`
- [ ] Proper error handling with informative messages

### API Changes (if applicable)

No API changes.

- [ ] `ras_object=None` parameter included for multi-project support
- [ ] Standard parameter names (`plan_number`, `geom_file`)
- [ ] API consistency auditor 5 rules followed (`.claude/agents/api-consistency-auditor.md`)
- [ ] Return types consistent (DataFrames for tabular data)

### Notebooks (if applicable)

No notebook changes in this PR.

- [ ] First cell is markdown with H1 title
- [ ] Uses `RasExamples.extract_project()` for data
- [ ] Development toggle cell included (`USE_LOCAL_SOURCE`)

---

## Test Plan

- `git diff --cached --check`

## LLM Attribution

**Model/Tool used**: Codex CLI
