### PR TITLE
feat: native arrival time / duration / percent-inundated stored maps

### DIFF
--- a/examples/125_rasmapper_stored_maps_arrival_duration.ipynb
+++ b/examples/125_rasmapper_stored_maps_arrival_duration.ipynb
@@ -1,0 +1,232 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# RASMapper Stored Maps: Arrival Time, Duration, and Percent Time Inundated\n",
+    "\n",
+    "`RasProcess.store_maps()` generates rendered result rasters through the HEC-RAS\n",
+    "mapping engine (RasMapperLib via the bundled `RasStoreMapHelper.exe`). This notebook\n",
+    "covers the **whole-simulation** map types added alongside the profile-based ones\n",
+    "(WSE, Depth, Velocity, ...):\n",
+    "\n",
+    "| Parameter | RasMapperLib MapType | Output label |\n",
+    "|---|---|---|\n",
+    "| `arrival_time=True` | `arrival time` | `Arrival Time (0.5ft hrs).tif` |\n",
+    "| `duration=True` | `duration` | `Duration (0.5ft hrs).tif` |\n",
+    "| `percent_inundated=True` | `fraction inundated` | `Percent Time Inundated (0.5ft).tif` |\n",
+    "\n",
+    "Key behaviors:\n",
+    "\n",
+    "- These types are computed over the **entire simulation** — the `profile` argument\n",
+    "  does not apply to them (profile-based types in the same call still honor it).\n",
+    "- `arrival_depth` sets the wet/dry depth threshold (model vertical units) and\n",
+    "  appears in the output filenames instead of a profile name.\n",
+    "- RasMapperLib builds a `PostProcessing.hdf` cache for these products that can\n",
+    "  exceed the plan HDF in size — plan disk space accordingly.\n",
+    "- There is **no recession MapType** in RasMapperLib (verified against the 6.6 and\n",
+    "  7.0.1 MapTypes tables); only RasMapperLib-native products are offered.\n",
+    "\n",
+    "**Requirements:** Windows, HEC-RAS 6.6+, and a computed plan HDF."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Install ras-commander if needed (uncomment)\n",
+    "# %pip install ras-commander\n",
+    "\n",
+    "from pathlib import Path\n",
+    "\n",
+    "from ras_commander import RasExamples, init_ras_project, RasCmdr, RasProcess"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Extract the example project and compute a plan\n",
+    "\n",
+    "`BaldEagleCrkMulti2D` ships without results, so we compute plan 07 first\n",
+    "(a 2D dam-break run — takes several minutes). Skip the compute cell if the\n",
+    "plan HDF already exists from a previous session."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "project_path = RasExamples.extract_project(\"BaldEagleCrkMulti2D\")\n",
+    "ras = init_ras_project(project_path, ras_object=\"new\")\n",
+    "\n",
+    "plan_hdf = project_path / \"BaldEagleDamBrk.p07.hdf\"\n",
+    "print(f\"Plan HDF exists: {plan_hdf.exists()}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if not plan_hdf.exists():\n",
+    "    RasCmdr.compute_plan(\"07\", ras_object=ras)\n",
+    "    print(f\"Computed. Plan HDF exists: {plan_hdf.exists()}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Generate arrival time, duration, and percent-inundated maps\n",
+    "\n",
+    "A single `store_maps()` call injects the stored-map definitions into the\n",
+    "`.rasmap` (restored afterwards from backup), runs `StoreAllMaps` once, and\n",
+    "moves the outputs to `output_path`. Here we use a 0.5 ft wet/dry threshold."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "output_dir = project_path / \"whole_simulation_maps\"\n",
+    "\n",
+    "results = RasProcess.store_maps(\n",
+    "    plan_number=\"07\",\n",
+    "    output_path=output_dir,\n",
+    "    wse=False,\n",
+    "    depth=False,\n",
+    "    velocity=False,\n",
+    "    arrival_time=True,\n",
+    "    duration=True,\n",
+    "    percent_inundated=True,\n",
+    "    arrival_depth=0.5,\n",
+    "    render_mode=\"sloping\",\n",
+    "    ras_object=ras,\n",
+    "    timeout=3600,\n",
+    ")\n",
+    "\n",
+    "for map_type, paths in results.items():\n",
+    "    print(f\"{map_type}:\")\n",
+    "    for p in paths:\n",
+    "        print(f\"  {Path(p).name}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. Validate the outputs\n",
+    "\n",
+    "Physically sensible ranges for a 72-hour dam-break simulation: arrival within\n",
+    "0–72 hrs, duration up to 72 hrs (still inundated at the end of the run), and\n",
+    "percent time inundated within 0–100%."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import rasterio\n",
+    "\n",
+    "for map_type, paths in results.items():\n",
+    "    for p in paths:\n",
+    "        with rasterio.open(p) as ds:\n",
+    "            data = ds.read(1, masked=True)\n",
+    "            print(\n",
+    "                f\"{Path(p).name}: crs={ds.crs}, \"\n",
+    "                f\"wet_px={data.count():,}, \"\n",
+    "                f\"range={data.min():.2f} to {data.max():.2f}\"\n",
+    "            )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. Visualize arrival time\n",
+    "\n",
+    "Hours (from simulation start) for water to first reach the 0.5 ft depth\n",
+    "threshold — the propagation of the dam-break wave down the valley."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "fig, axes = plt.subplots(1, 3, figsize=(18, 6))\n",
+    "titles = [\"arrival_time\", \"duration\", \"percent_inundated\"]\n",
+    "cmaps = [\"viridis\", \"plasma\", \"cividis\"]\n",
+    "units = [\"hours\", \"hours\", \"%\"]\n",
+    "\n",
+    "for ax, key, cmap, unit in zip(axes, titles, cmaps, units):\n",
+    "    if not results.get(key):\n",
+    "        ax.set_title(f\"{key} (not generated)\")\n",
+    "        continue\n",
+    "    with rasterio.open(results[key][0]) as ds:\n",
+    "        data = ds.read(1, masked=True)\n",
+    "    im = ax.imshow(data, cmap=cmap)\n",
+    "    ax.set_title(key)\n",
+    "    ax.set_axis_off()\n",
+    "    fig.colorbar(im, ax=ax, shrink=0.7, label=unit)\n",
+    "\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Notes\n",
+    "\n",
+    "- Combine whole-simulation and profile-based types in one call — e.g.\n",
+    "  `wse=True, depth=True, arrival_time=True, profile=\"Max\"` renders WSE/Depth\n",
+    "  at Max while arrival time still spans the full simulation.\n",
+    "- The `ArrivalDepth` threshold is written into the rasmap `MapParameters`;\n",
+    "  RASMapper's own UI exposes additional start-time controls\n",
+    "  (`ArrivalStartMode`, `ArrivalAbsDateTime`, ...) that are not yet wrapped.\n",
+    "- For **project-free** mapping (only a plan HDF + terrain TIFF on hand), see\n",
+    "  [ras2cng](https://github.com/gpt-cmdr/ras2cng)'s `map-hdf` command, which\n",
+    "  scaffolds a minimal project around the HDF and calls `store_maps()`.\n",
+    "- Clean up `PostProcessing.hdf` from the output folder when done — it is a\n",
+    "  RasMapperLib cache, not a deliverable."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/ras_commander/RasProcess.py
+++ b/ras_commander/RasProcess.py
@@ -35,6 +35,7 @@ import os
 import sys
 import subprocess
 import tempfile
+import time
 import xml.etree.ElementTree as ET
 from dataclasses import dataclass
 from pathlib import Path, PurePosixPath, PureWindowsPath
@@ -147,9 +148,16 @@ class RasProcess:
         'depth_x_velocity': ('depth and velocity', 'D * V', True),
         'depth_x_velocity_sq': ('depth and velocity squared', 'D * V^2', True),
         'flow': ('flow', 'Flow', True),
-        'arrival_time': ('arrivaltime', 'Arrival Time', False),
+        # XML names verified against the RasMapperLib.dll MapTypes table
+        # (identical in 6.6 and 7.0.1): "arrival time" (with space) and
+        # "fraction inundated". These types use the ArrivalDepth threshold
+        # attribute and label outputs "(<depth><unit> hrs)" instead of the
+        # profile name.
+        'arrival_time': ('arrival time', 'Arrival Time', False),
         'duration': ('duration', 'Duration', False),
-        'recession': ('recession', 'Recession', False),
+        'percent_inundated': ('fraction inundated', 'Percent Time Inundated', False),
+        # NOTE: RasMapperLib has no 'recession' MapType (verified 6.6/7.0.1).
+        # Recession time = arrival_time + duration; derive it downstream.
         'inundation_boundary': ('depth', 'Inundation Boundary', False),
     }
 
@@ -1146,6 +1154,7 @@ Step 5: Configure (optional — auto-detection usually works)
         output_folder: str,
         profile_index: int = 2147483647,
         output_mode: str = "Stored Current Terrain",
+        extra_attrs: Optional[Dict[str, str]] = None,
     ) -> bool:
         """
         Add a stored map configuration to the .rasmap file.
@@ -1162,6 +1171,9 @@ Step 5: Configure (optional — auto-detection usually works)
             output_mode: OutputMode for MapParameters. Use "Stored Current Terrain"
                 for raster outputs (default), or "Stored Polygon Specified Depth"
                 for inundation boundary shapefile output.
+            extra_attrs: Additional attributes set on the MapParameters element
+                (e.g. {"ArrivalDepth": "0.1"} for arrival time / duration /
+                percent-inundated maps).
 
         Returns:
             True if successful, False otherwise
@@ -1243,6 +1255,8 @@ Step 5: Configure (optional — auto-detection usually works)
             map_params.set("StoredFilename", output_filename)
             map_params.set("ProfileIndex", str(profile_index))
             map_params.set("ProfileName", profile_name)
+            for attr_name, attr_value in (extra_attrs or {}).items():
+                map_params.set(attr_name, str(attr_value))
 
             # Write back
             tree.write(rasmap_path, encoding='utf-8', xml_declaration=True)
@@ -1326,6 +1340,10 @@ Step 5: Configure (optional — auto-detection usually works)
         depth_x_velocity: bool = False,
         depth_x_velocity_sq: bool = False,
         inundation_boundary: bool = False,
+        arrival_time: bool = False,
+        duration: bool = False,
+        percent_inundated: bool = False,
+        arrival_depth: float = 0.0,
         clear_existing: bool = True,
         fix_georef: bool = True,
         ras_object=None,
@@ -1376,6 +1394,15 @@ Step 5: Configure (optional — auto-detection usually works)
             depth_x_velocity: Generate D*V hazard map (default: False)
             depth_x_velocity_sq: Generate D*V² impact map (default: False)
             inundation_boundary: Generate inundation boundary polygon (default: False)
+            arrival_time: Generate flood Arrival Time map in hours (default: False).
+                Whole-simulation product; ignores the ``profile`` argument.
+            duration: Generate inundation Duration map in hours (default: False).
+                Whole-simulation product; ignores the ``profile`` argument.
+            percent_inundated: Generate Percent Time Inundated map (default: False).
+                Whole-simulation product; ignores the ``profile`` argument.
+            arrival_depth: Wet/dry depth threshold (model vertical units) for
+                arrival_time / duration / percent_inundated maps (default: 0.0).
+                Appears in output filenames, e.g. "Arrival Time (0.1ft hrs)".
             clear_existing: Clear existing stored maps before adding new ones (default: True)
             fix_georef: Apply georeferencing fix to output TIFs (default: True)
             ras_object: Optional RAS object instance
@@ -1523,6 +1550,21 @@ Step 5: Configure (optional — auto-detection usually works)
             if depth_x_velocity_sq:
                 maps_to_add.append(('depth and velocity squared', 'depth_x_velocity_sq'))
 
+            # Whole-simulation map types: always Max profile, labeled by the
+            # ArrivalDepth threshold (e.g. "Arrival Time (0.1ft hrs)") rather
+            # than the profile name. XML names come from MAP_TYPES — the
+            # single source of truth for RasMapperLib name strings.
+            adr_flags = {
+                'arrival_time': arrival_time,
+                'duration': duration,
+                'percent_inundated': percent_inundated,
+            }
+            adr_maps_to_add = [
+                (RasProcess.MAP_TYPES[key][0], key)
+                for key, enabled in adr_flags.items()
+                if enabled
+            ]
+
             # Add stored maps to rasmap
             for map_type, _ in maps_to_add:
                 RasProcess._add_stored_map_to_rasmap(
@@ -1532,6 +1574,17 @@ Step 5: Configure (optional — auto-detection usually works)
                     profile_name,
                     output_folder,
                     profile_index
+                )
+
+            for map_type, _ in adr_maps_to_add:
+                RasProcess._add_stored_map_to_rasmap(
+                    rasmap_path,
+                    plan_hdf,
+                    map_type,
+                    "Max",
+                    output_folder,
+                    2147483647,
+                    extra_attrs={"ArrivalDepth": str(arrival_depth)},
                 )
 
             # Add inundation boundary if requested (shapefile polygon output)
@@ -1586,6 +1639,10 @@ Step 5: Configure (optional — auto-detection usually works)
 
             logger.debug("Running StoreAllMaps for plan %s (mode=%s)", plan_num, helper_mode)
 
+            # Files created by this run have mtime >= now (moves preserve
+            # mtime); 2s slack covers coarse filesystem timestamp granularity.
+            run_started = time.time() - 2
+
             result = run_store_all_maps_helper(
                 hecras_dir=hecras_dir,
                 render_mode=helper_mode,
@@ -1626,6 +1683,12 @@ Step 5: Configure (optional — auto-detection usually works)
                         stat = item.stat()
                     except FileNotFoundError:
                         continue
+                    # PostProcessing.hdf is RasMapperLib's derived-map cache
+                    # (can exceed the plan HDF in size): leave it beside the
+                    # plan so reruns reuse it instead of paying a potentially
+                    # cross-volume move of a multi-GB scratch file.
+                    if item.name == "PostProcessing.hdf":
+                        continue
                     previous_signature = pre_existing_files.get(item.name)
                     current_signature = (stat.st_mtime_ns, stat.st_size)
                     if previous_signature != current_signature:
@@ -1663,6 +1726,25 @@ Step 5: Configure (optional — auto-detection usually works)
                 if tif_files:
                     generated_files[map_key] = tif_files
                     logger.debug("Generated %d %s TIF(s)", len(tif_files), map_key)
+                else:
+                    logger.debug(f"No TIF files found for {map_key} with pattern: {pattern}")
+
+            # Whole-simulation types label outputs by threshold, not profile
+            # (e.g. "Arrival Time (0.1ft hrs).Terrain.tile.tif") — glob by
+            # display-name prefix, restricted to files produced by this run
+            # (mtime survives shutil.move) so a rerun at a different
+            # arrival_depth never collects the previous threshold's rasters.
+            for map_type, map_key in adr_maps_to_add:
+                display_name_used = RasProcess.MAP_TYPES[map_key][1]
+
+                pattern = f"{display_name_used} (*.tif"
+                tif_files = [
+                    p for p in search_dir.glob(pattern)
+                    if p.stat().st_mtime >= run_started
+                ]
+                if tif_files:
+                    generated_files[map_key] = tif_files
+                    logger.info(f"Generated {len(tif_files)} {map_key} TIF(s)")
                 else:
                     logger.debug(f"No TIF files found for {map_key} with pattern: {pattern}")
 

--- a/tests/ras_process_store_maps_adr_test.py
+++ b/tests/ras_process_store_maps_adr_test.py
@@ -1,0 +1,173 @@
+"""Tests for arrival time / duration / percent-inundated stored maps.
+
+These map types are whole-simulation products: RasMapperLib names them by the
+ArrivalDepth threshold (e.g. "Arrival Time (0.1ft hrs)") instead of the profile,
+always uses the Max profile, and requires the correct MapType XML names
+("arrival time", "duration", "fraction inundated") verified against the
+RasMapperLib.dll MapTypes table for 6.6 and 7.0.1.
+"""
+
+import subprocess
+import xml.etree.ElementTree as ET
+from importlib import import_module
+from pathlib import Path
+
+
+ras_process_module = import_module("ras_commander.RasProcess")
+RasProcess = ras_process_module.RasProcess
+
+
+class _DummyRas:
+    def __init__(self, project_folder: Path, project_name: str = "Demo"):
+        self.project_folder = project_folder
+        self.project_name = project_name
+        self.ras_exe_path = project_folder / "hecras" / "Ras.exe"
+
+    def check_initialized(self):
+        return None
+
+
+def _write_minimal_rasmap(rasmap_path: Path):
+    rasmap_path.write_text(
+        """<?xml version="1.0" encoding="utf-8"?>
+<RASMapper>
+  <Results>
+    <Layer Name="PlanShort" Type="RASResults" Filename=".\\Demo.p01.hdf" />
+  </Results>
+</RASMapper>
+""",
+        encoding="utf-8",
+    )
+
+
+def test_add_stored_map_extra_attrs_set_on_map_parameters(tmp_path):
+    rasmap_path = tmp_path / "Demo.rasmap"
+    _write_minimal_rasmap(rasmap_path)
+
+    ok = RasProcess._add_stored_map_to_rasmap(
+        rasmap_path,
+        "Demo.p01.hdf",
+        "arrival time",
+        "Max",
+        "PlanShort",
+        2147483647,
+        extra_attrs={"ArrivalDepth": "0.25"},
+    )
+    assert ok
+
+    root = ET.parse(rasmap_path).getroot()
+    params = root.findall(".//MapParameters")
+    assert len(params) == 1
+    assert params[0].get("MapType") == "arrival time"
+    assert params[0].get("ArrivalDepth") == "0.25"
+    assert params[0].get("ProfileIndex") == "2147483647"
+
+
+def test_map_types_use_verified_xml_names():
+    assert RasProcess.MAP_TYPES["arrival_time"][0] == "arrival time"
+    assert RasProcess.MAP_TYPES["duration"][0] == "duration"
+    assert RasProcess.MAP_TYPES["percent_inundated"][0] == "fraction inundated"
+    # RasMapperLib has no recession MapType; it must not be offered.
+    assert "recession" not in RasProcess.MAP_TYPES
+
+
+def test_store_maps_adr_types_injected_and_collected(monkeypatch, tmp_path):
+    project_folder = tmp_path
+    project_name = "Demo"
+    output_dir = project_folder / "PlanShort"
+    rasmap_path = project_folder / f"{project_name}.rasmap"
+    plan_hdf_path = project_folder / f"{project_name}.p01.hdf"
+
+    (project_folder / "hecras").mkdir()
+    (project_folder / "hecras" / "Ras.exe").write_text("", encoding="utf-8")
+    plan_hdf_path.write_text("", encoding="utf-8")
+    _write_minimal_rasmap(rasmap_path)
+    output_dir.mkdir()
+
+    ras_obj = _DummyRas(project_folder=project_folder, project_name=project_name)
+
+    monkeypatch.setattr(
+        ras_process_module.RasMap,
+        "get_rasmap_path",
+        staticmethod(lambda ras_object=None: rasmap_path),
+    )
+    monkeypatch.setattr(
+        RasProcess,
+        "_get_plan_short_id",
+        staticmethod(lambda hdf_path: "PlanShort"),
+    )
+    monkeypatch.setattr(
+        RasProcess,
+        "_remove_stored_maps_from_rasmap",
+        staticmethod(lambda *args, **kwargs: 0),
+    )
+    monkeypatch.setattr(
+        ras_process_module.RasMap,
+        "get_water_surface_render_mode",
+        staticmethod(lambda ras_object=None: "horizontal"),
+    )
+
+    injected_rasmap = {}
+
+    def fake_run_store_all_maps_helper(**kwargs):
+        # Capture the rasmap as the helper sees it (before the finally-restore)
+        injected_rasmap["xml"] = rasmap_path.read_text(encoding="utf-8")
+        (output_dir / "Arrival Time (0.1ft hrs).Terrain.tile.tif").write_text(
+            "arrival", encoding="utf-8"
+        )
+        (output_dir / "Duration (0.1ft hrs).Terrain.tile.tif").write_text(
+            "duration", encoding="utf-8"
+        )
+        (output_dir / "Percent Time Inundated (0.1ft).Terrain.tile.tif").write_text(
+            "percent", encoding="utf-8"
+        )
+        return subprocess.CompletedProcess(
+            args=["RasStoreMapHelper.exe"],
+            returncode=0,
+            stdout="Maps generated: 3",
+            stderr="",
+        )
+
+    monkeypatch.setattr(
+        ras_process_module,
+        "run_store_all_maps_helper",
+        fake_run_store_all_maps_helper,
+    )
+
+    results = RasProcess.store_maps(
+        plan_number="01",
+        profile="Max",
+        wse=False,
+        depth=False,
+        velocity=False,
+        arrival_time=True,
+        duration=True,
+        percent_inundated=True,
+        arrival_depth=0.1,
+        clear_existing=False,
+        fix_georef=False,
+        ras_object=ras_obj,
+    )
+
+    # Injected entries carried the verified XML names + threshold, Max profile
+    root = ET.fromstring(injected_rasmap["xml"])
+    params = root.findall(".//MapParameters")
+    map_types = {p.get("MapType") for p in params}
+    assert map_types == {"arrival time", "duration", "fraction inundated"}
+    assert all(p.get("ArrivalDepth") == "0.1" for p in params)
+    assert all(p.get("ProfileIndex") == "2147483647" for p in params)
+
+    # Threshold-labeled outputs collected under the right keys
+    assert [p.name for p in results["arrival_time"]] == [
+        "Arrival Time (0.1ft hrs).Terrain.tile.tif"
+    ]
+    assert [p.name for p in results["duration"]] == [
+        "Duration (0.1ft hrs).Terrain.tile.tif"
+    ]
+    assert [p.name for p in results["percent_inundated"]] == [
+        "Percent Time Inundated (0.1ft).Terrain.tile.tif"
+    ]
+
+    # rasmap restored after the run (backup semantics unchanged)
+    restored = ET.parse(rasmap_path).getroot()
+    assert restored.findall(".//MapParameters") == []


### PR DESCRIPTION
## Summary

Adds native support for RASMapper's whole-simulation stored map types to
`RasProcess.store_maps()`: **Arrival Time**, **Duration**, and **Percent Time
Inundated**.

These are computed over the entire simulation (the `profile` argument does not
apply) and are labeled by an `arrival_depth` wet/dry threshold, e.g.
`Arrival Time (0.1ft hrs).tif`.

## Changes

- `store_maps()` gains `arrival_time`, `duration`, `percent_inundated`, and
  `arrival_depth` parameters.
- **Fixes `MAP_TYPES`**: the arrival-time XML name was `arrivaltime` — it must be
  `arrival time` (verified against the RasMapperLib MapTypes table in 6.6 and
  7.0.1). Adds `percent_inundated` → `fraction inundated`. Removes the
  `recession` entry — RasMapperLib has no recession MapType.
- `_add_stored_map_to_rasmap()` gains an `extra_attrs` parameter to write the
  `ArrivalDepth` threshold onto `MapParameters`.
- Output collection for these types globs by threshold-labeled display name,
  single-sourced from `MAP_TYPES`, and is filtered to files produced by the
  current run so a rerun at a different `arrival_depth` does not collect stale
  rasters.
- Excludes `PostProcessing.hdf` (RasMapperLib's derived-map cache, which can
  exceed the plan HDF in size) from the `output_path` move so it is not copied
  cross-volume and can be reused by later runs.

## Testing

- New `tests/ras_process_store_maps_adr_test.py` (3 tests): injection XML +
  `ArrivalDepth`, verified MAP_TYPES names, and end-to-end store_maps injection
  + threshold-labeled collection + rasmap-restore semantics.
- Existing `ras_process_store_maps_output_path_test.py` still passes (8 total).
- Validated live on HEC-RAS 6.6 (Bald Eagle dam-break plan): arrival 0–63 hrs,
  duration 0.33–72 hrs, percent inundated 0.46–100%, all georeferenced.

## Context

Companion to the `ras2cng` `map-hdf` feature, which generates these maps from a
plan HDF + terrain alone. `ras2cng` currently drives this via a rasmap
pre-injection shim for older ras-commander; once this lands and releases,
`ras2cng` detects the native path automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PCoSeSU2QsrLuuLvU7yxu3
