### PR TITLE
Correct parallel execution documentation

### DIFF
--- a/agent_tasks/2026-07-10_remaining_landing_work.md
+++ b/agent_tasks/2026-07-10_remaining_landing_work.md
@@ -2,10 +2,11 @@
 
 Date: 2026-07-10
 
-Status: **Precipitation replay completed.** PR #275 merged the selective DSS,
-MRMS, stored-map, and notebook payload on 2026-07-11. The subsequent HRRR
-temporal-contract correction described below was validated from current
-`main`; the remaining items are independent backlogs.
+Status: **Precipitation replay and HRRR hydraulic follow-up completed.** PR
+#275 merged the selective DSS, MRMS, stored-map, and notebook payload on
+2026-07-11. PR #276 merged the HRRR temporal contract and end-to-end HEC-RAS
+forecast demonstration as `6c8090c7` on 2026-07-12. No precipitation replay
+PR remains open; the remaining items are independent backlogs.
 
 ## Goal
 
@@ -16,8 +17,8 @@ independently validated.
 
 ## Main State At HRRR Follow-Up Start
 
-- `origin/main` is `f814a9e0`, including PR #275.
-- There are no open pull requests.
+- `origin/main` was `f814a9e0`, including PR #275.
+- There were no open pull requests.
 - PR #260 was closed and its approved slices landed through PRs #262-#273.
 - PR #251 was superseded by PR #274.
 - The notebook 710 and 711 follow-ups were closed by PRs #272 and #271.
@@ -95,7 +96,9 @@ The user approved this full scope, including notebook 926, on 2026-07-10:
   default Tk backend in the local UV Python is incomplete, and the successful
   run still emits the known netCDF/numpy binary warning plus a post-exit
   Windows `0xc0000139` diagnostic; pytest itself exits 0.
-- Notebook 916: 13/13 code cells executed; independent review PASS.
+- Notebook 916 as merged in PR #275: 13/13 code cells executed; independent
+  review PASS. PR #276 later superseded this forcing-only execution with the
+  end-to-end hydraulic workflow recorded below.
 - Notebook 926: 5/5 code cells executed; independent review PASS.
 - Notebook 917: 8/8 code cells executed from source in 4,040.7 seconds;
   independent review PASS. The executed notebook, terminal log, and six MP4s
@@ -158,7 +161,7 @@ The user approved this full scope, including notebook 926, on 2026-07-10:
 - Real-file smoke tests passed for both projects before execution. The final
   source-matching execution and independent artifact review also passed.
 
-## HRRR Temporal-Contract Follow-Up
+## Completed HRRR Temporal Contract And Hydraulic Follow-Up
 
 `PrecipHrrr.get_basin_average()` previously labeled its sequential row index
 as `forecast_hour` and logged every record as one hour. That was incorrect for
@@ -178,23 +181,34 @@ The focused correction:
 Validation evidence:
 
 - focused HRRR basin-average suite: 10 passed;
-- combined HRRR, MRMS, and unsteady precipitation suite: 52 passed with the
-  established headless Matplotlib backend and one pre-existing `slow` marker
-  warning;
-- notebook 916: 13/13 code cells executed from source in 1,505.56 seconds with
-  no errors or warning output and one embedded two-panel figure;
-- live extraction: 72 quarter-hour records covering lead hours 0.25-18.00,
-  with 0.047 inches total and a 0.006-inch peak 15-minute depth;
-- qpkit verification: seven GRIB2 files downloaded, six hourly `PER-CUM` grids
-  written and cataloged at 3,000 m resolution with exact pathname agreement;
-  and
-- independent notebook review: PASS (model context Partial, hydraulic
-  relevancy Pass for the forcing-data scope, visual quality Acceptable, and
-  demonstration completeness Complete).
+- notebook 916: 12/12 code cells executed from source in 961.01 seconds with
+  no errors or warning output and four embedded figures;
+- live `wrfsubhf` timing analysis: 72 quarter-hour records covering lead hours
+  0.25-18.00, with 0.066 inches over the rectangular analysis window;
+- qpkit `v0.1.0` used hourly `wrfsfc` APCP from the same forecast cycle to
+  write and catalog 18 contiguous hourly `PER-CUM` SHG grids over the exact
+  simulation period; `wrfsubhf` and `wrfsfc` are related but distinct products,
+  so the 0.066-inch analysis average is not the DSS forcing total;
+- the DSS footprint covered all 19,597 result/cell centers and all 37,594 mesh
+  faces;
+- HEC-RAS 7.0 completed both the no-rain `p07` and live-HRRR `p08` plans at a
+  10-second computation interval;
+- both plans reported `Complete Process`, maximum cell WSEL error of 0.0099
+  feet, zero cells above 0.01 feet WSEL error, and approximately 0.000002
+  percent volume error;
+- the selected live cycle was dry over the hydraulic model, so HEC-RAS applied
+  zero precipitation at model cells and the verified hydraulic difference was
+  zero; and
+- independent notebook review, hydraulic consistency audit, and notebook
+  schema/metadata validation all passed.
 
-Notebook 916 intentionally remains an input-data/API example. Its rectangular
-averaging geometry is not a delineated watershed, and it does not claim a
-HEC-RAS hydraulic response calculation.
+Notebook 916 now demonstrates forecast acquisition through hydraulic result
+comparison. It remains an automation and hydraulic-evaluation example rather
+than an operational forecast: the averaging window is rectangular rather than
+a delineated watershed, precipitation is the only live forecast input, the
+upstream hydrograph is synthetic, Sayers Dam Gate #1 retains the supplied
+2.0-foot opening because operating data are unavailable, and the instructional
+diffusion-wave model is not calibrated for forecasting.
 
 ## Remaining Independent Backlogs
 

--- a/docs/parallel-compute/index.md
+++ b/docs/parallel-compute/index.md
@@ -51,7 +51,7 @@ result = RasCmdr.compute_plan("01")
 # Local Parallel - multiple plans on same machine
 results = RasCmdr.compute_parallel(
     plan_number=["01", "02", "03", "04"],
-    num_workers=4,
+    max_workers=4,
     num_cores=4
 )
 

--- a/docs/parallel-compute/local-parallel.md
+++ b/docs/parallel-compute/local-parallel.md
@@ -13,7 +13,7 @@ init_ras_project("/path/to/project", "6.5")
 # Run multiple plans in parallel
 results = RasCmdr.compute_parallel(
     plan_number=["01", "02", "03", "04"],
-    num_workers=4,
+    max_workers=4,
     num_cores=4
 )
 
@@ -26,56 +26,68 @@ for plan, success in results.items():
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `plan_number` | list | List of plan numbers to execute |
-| `num_workers` | int | Number of concurrent workers (parallel plans) |
+| `plan_number` | str, number, list, or None | Plan number(s) to execute; `None` selects all plans |
+| `max_workers` | int | Maximum number of concurrent workers (parallel plans) |
 | `num_cores` | int | CPU cores allocated per plan |
-| `dest_folder` | Path | Base folder for worker directories |
-| `ras_object` | RasPrj | Project object (uses global `ras` if None) |
 | `clear_geompre` | bool | Clear geometry preprocessor before run |
-| `overwrite_dest` | bool | Overwrite existing worker folders |
+| `force_geompre` | bool | Clear geometry HDF and `.c##` files before each assigned run |
+| `force_rerun` | bool | Compatibility option; assigned worker plans are already forced to execute |
+| `ras_object` | RasPrj | Project object (uses global `ras` if `None`) |
+| `dest_folder` | str, Path, or None | Final copied project directory; results are consolidated here |
+| `overwrite_dest` | bool | Remove and replace the complete `dest_folder` directory if it exists |
+| `skip_existing` | bool | Skip source plans whose HDF compute messages report `Complete Process` |
+| `verify` | bool | Require `Complete Process` verification for each assigned plan |
 
 ## How It Works
 
 ### 1. Worker Folder Creation
 
-For each worker, `compute_parallel` creates an isolated copy of the HEC-RAS project:
+`compute_parallel` first uses the original project, or copies it to
+`dest_folder` when one is supplied. Temporary worker projects are created as
+siblings of that project:
 
 ```
-dest_folder/
-├── worker_01/
+project_parent/
+├── parallel_run/
 │   ├── project.prj
 │   ├── project.g01
-│   ├── project.p01
-│   └── ...
-├── worker_02/
-│   └── ...
-└── worker_03/
-    └── ...
+│   └── project.p01
+├── parallel_run [Worker 1]/
+├── parallel_run [Worker 2]/
+└── parallel_run [Worker 3]/
 ```
+
+If `overwrite_dest=True`, the entire `dest_folder` is removed before the
+project is copied. Use a dedicated output location, never a directory that
+contains unrelated files.
 
 ### 2. Plan Distribution
 
-Plans are distributed across workers using a queue. As each worker completes a plan, it picks up the next available one:
+Plans are assigned to worker IDs in round-robin order before execution begins.
+The thread pool may finish plans in any order, but workers do not dynamically
+dequeue the next plan:
 
 ```
 Plans: [01, 02, 03, 04, 05, 06]
 Workers: 3
 
-Time 0: Worker1=01, Worker2=02, Worker3=03
-Time 1: Worker1=04 (01 done), Worker2=02, Worker3=05 (03 done)
-Time 2: Worker1=04, Worker2=06 (02 done), Worker3=05
-...
+Worker 1: [01, 04]
+Worker 2: [02, 05]
+Worker 3: [03, 06]
 ```
 
 ### 3. Results Collection
 
-After all plans complete, results from each worker folder can be collected and analyzed.
+After all plans complete, their plan and geometry artifacts are consolidated
+into the selected project directory. Temporary worker folders are then
+removed. Review the returned result, consolidated HDF compute messages, and
+DEBUG logs when diagnosing failures.
 
 ## Optimal Configuration
 
 ### Balancing Workers vs. Cores
 
-The total CPU usage is: `num_workers × num_cores`
+The total CPU usage is: `max_workers × num_cores`
 
 For a 16-core machine:
 
@@ -109,7 +121,7 @@ all_plans = ras.plan_df['plan_number'].tolist()
 # Run all plans in parallel
 results = RasCmdr.compute_parallel(
     plan_number=all_plans,
-    num_workers=4,
+    max_workers=4,
     num_cores=4,
     dest_folder=Path("/output/parallel_run"),
     overwrite_dest=True
@@ -143,7 +155,7 @@ for n in manning_values:
 # Execute all variations in parallel
 results = RasCmdr.compute_parallel(
     plan_number=plans_created,
-    num_workers=len(plans_created),
+    max_workers=len(plans_created),
     num_cores=4
 )
 ```
@@ -157,7 +169,7 @@ init_ras_project("/path/to/project", "6.5")
 
 results = RasCmdr.compute_parallel(
     plan_number=["01", "02", "03"],
-    num_workers=2,
+    max_workers=2,
     num_cores=4
 )
 
@@ -165,7 +177,7 @@ results = RasCmdr.compute_parallel(
 failed = [plan for plan, success in results.items() if not success]
 if failed:
     print(f"Failed plans: {failed}")
-    # Investigate by checking worker folder logs
+    # Inspect consolidated HDF compute messages and DEBUG logs
 ```
 
 ## Limitations

--- a/docs/parallel-compute/scaling-strategies.md
+++ b/docs/parallel-compute/scaling-strategies.md
@@ -41,13 +41,14 @@ import os
 init_ras_project("/path/to/project", "6.5")
 
 # Determine optimal configuration
-total_cores = os.cpu_count()
-cores_per_plan = 4  # Sweet spot for most 2D models
-num_workers = total_cores // cores_per_plan
+total_cores = os.cpu_count() or 1
+cores_per_plan = min(4, total_cores)  # Up to 4 cores per plan
+max_workers = total_cores // cores_per_plan
+max_workers = max(1, max_workers)
 
 results = RasCmdr.compute_parallel(
     plan_number=plans,
-    num_workers=num_workers,
+    max_workers=max_workers,
     num_cores=cores_per_plan
 )
 ```
@@ -130,7 +131,7 @@ RasCmdr.compute_plan("01", clear_geompre=False)  # First run builds geom
 # Parallel runs use cached geometry
 results = RasCmdr.compute_parallel(
     plan_number=["02", "03", "04", "05"],
-    num_workers=4,
+    max_workers=4,
     num_cores=4,
     clear_geompre=False  # Don't clear cached geometry
 )
@@ -150,15 +151,19 @@ Worker folder creation is I/O intensive. Storage hierarchy:
 ```python
 from pathlib import Path
 
-# Use fast local storage for workers
-fast_drive = Path("D:/temp/ras_workers")  # SSD/NVMe
+# Use fast local storage for the copied project and its sibling workers
+parallel_project = Path("D:/temp/BaldEagle_parallel_results")  # SSD/NVMe
 
 results = RasCmdr.compute_parallel(
     plan_number=plans,
-    dest_folder=fast_drive,
-    num_workers=8
+    dest_folder=parallel_project,
+    max_workers=8
 )
 ```
+
+`dest_folder` is the final copied project directory, not a parent directory for
+multiple runs. If `overwrite_dest=True` is added, that complete directory is
+removed before the project is copied.
 
 ### 3. Right-size Worker Count
 
@@ -170,7 +175,7 @@ import psutil
 def optimal_worker_config(model_cells, total_cores=None):
     """Suggest optimal worker configuration."""
     if total_cores is None:
-        total_cores = psutil.cpu_count(logical=False)
+        total_cores = psutil.cpu_count(logical=False) or 1
 
     # Reserve cores for system
     available_cores = max(1, total_cores - 2)
@@ -182,17 +187,18 @@ def optimal_worker_config(model_cells, total_cores=None):
     else:
         cores_per_plan = 8
 
-    num_workers = available_cores // cores_per_plan
+    cores_per_plan = min(cores_per_plan, available_cores)
+    max_workers = available_cores // cores_per_plan
 
     return {
-        "num_workers": max(1, num_workers),
+        "max_workers": max(1, max_workers),
         "num_cores": cores_per_plan,
-        "total_utilized": num_workers * cores_per_plan
+        "total_utilized": max_workers * cores_per_plan
     }
 
 # Usage
 config = optimal_worker_config(model_cells=50000)
-print(f"Recommended: {config['num_workers']} workers, "
+print(f"Recommended: {config['max_workers']} workers, "
       f"{config['num_cores']} cores each")
 ```
 
@@ -217,14 +223,13 @@ def process_in_batches(all_plans, batch_size=20, **kwargs):
         )
         all_results.update(results)
 
-        # Optional: cleanup between batches
-        # cleanup_worker_folders(kwargs.get('dest_folder'))
+        # Worker artifacts are consolidated and temporary workers are removed.
 
     return all_results
 
 # Process 100 plans in batches of 20
 all_plans = [f"{i:02d}" for i in range(1, 101)]
-results = process_in_batches(all_plans, batch_size=20, num_workers=4, num_cores=4)
+results = process_in_batches(all_plans, batch_size=20, max_workers=4, num_cores=4)
 ```
 
 ### 5. Memory Management
@@ -234,22 +239,26 @@ Monitor memory usage to avoid swapping:
 ```python
 import psutil
 
-def check_memory_for_workers(num_workers, mem_per_plan_gb=4):
+def check_memory_for_workers(max_workers, mem_per_plan_gb=4):
     """Check if system has enough memory for planned workers."""
     available_gb = psutil.virtual_memory().available / (1024**3)
-    required_gb = num_workers * mem_per_plan_gb
+    required_gb = max_workers * mem_per_plan_gb
 
     if required_gb > available_gb * 0.8:  # 80% threshold
         suggested = int(available_gb * 0.8 / mem_per_plan_gb)
-        print(f"Warning: {num_workers} workers need ~{required_gb:.1f} GB")
+        print(f"Warning: {max_workers} workers need ~{required_gb:.1f} GB")
         print(f"Available: {available_gb:.1f} GB")
         print(f"Suggested max workers: {suggested}")
         return False
     return True
 
 # Check before running
-if check_memory_for_workers(num_workers=8, mem_per_plan_gb=4):
-    results = RasCmdr.compute_parallel(...)
+if check_memory_for_workers(max_workers=8, mem_per_plan_gb=4):
+    results = RasCmdr.compute_parallel(
+        plan_number=["01", "02", "03"],
+        max_workers=8,
+        num_cores=4,
+    )
 ```
 
 ## Performance Benchmarking
@@ -260,13 +269,13 @@ if check_memory_for_workers(num_workers=8, mem_per_plan_gb=4):
 import time
 from ras_commander import RasCmdr
 
-def benchmark_config(plans, num_workers, num_cores, **kwargs):
+def benchmark_config(plans, max_workers, num_cores, **kwargs):
     """Benchmark a specific configuration."""
     start = time.time()
 
     results = RasCmdr.compute_parallel(
         plan_number=plans,
-        num_workers=num_workers,
+        max_workers=max_workers,
         num_cores=num_cores,
         **kwargs
     )
@@ -275,7 +284,7 @@ def benchmark_config(plans, num_workers, num_cores, **kwargs):
     successful = sum(1 for v in results.values() if v)
 
     return {
-        "num_workers": num_workers,
+        "max_workers": max_workers,
         "num_cores": num_cores,
         "total_plans": len(plans),
         "successful": successful,
@@ -286,14 +295,14 @@ def benchmark_config(plans, num_workers, num_cores, **kwargs):
 
 # Compare configurations
 configs = [
-    {"num_workers": 2, "num_cores": 8},
-    {"num_workers": 4, "num_cores": 4},
-    {"num_workers": 8, "num_cores": 2},
+    {"max_workers": 2, "num_cores": 8},
+    {"max_workers": 4, "num_cores": 4},
+    {"max_workers": 8, "num_cores": 2},
 ]
 
 for config in configs:
     result = benchmark_config(plans[:8], **config)
-    print(f"Workers={config['num_workers']}, Cores={config['num_cores']}: "
+    print(f"Workers={config['max_workers']}, Cores={config['num_cores']}: "
           f"{result['plans_per_hour']:.1f} plans/hour")
 ```
 
@@ -301,10 +310,10 @@ for config in configs:
 
 | Symptom | Cause | Solution |
 |---------|-------|----------|
-| Low CPU usage | Too few workers | Increase num_workers |
+| Low CPU usage | Too few workers | Increase `max_workers` |
 | High CPU but slow | Too many cores/plan | Decrease num_cores |
 | Disk thrashing | HDD storage | Use SSD for workers |
-| Memory pressure | Too many workers | Reduce num_workers |
+| Memory pressure | Too many workers | Reduce `max_workers` |
 | Network bottleneck | Remote workers | Check bandwidth |
 
 ## Summary Recommendations


### PR DESCRIPTION
## Summary

Corrects the public local-parallel documentation to match the current
`RasCmdr.compute_parallel()` contract and reconciles the landing ledger with
the final notebook 916 workflow.

- replaces the removed `num_workers` keyword with `max_workers`;
- documents that `dest_folder` is the retained copied project and that
  `overwrite_dest=True` removes that complete directory;
- describes sibling worker folders, predetermined round-robin assignment,
  result consolidation, and normal worker cleanup;
- repairs worker-sizing, batching, memory-check, and benchmarking examples; and
- records PR #276's HRRR products, DSS forcing, HEC-RAS execution, hydraulic
  checks, and retained limitations without conflating `wrfsubhf` with
  `wrfsfc`.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)
- [ ] Example notebook

---

## LLM Self-Review

### Style Compliance

- [x] Static class pattern not affected; documentation was checked against the existing static API.
- [x] Decorators not affected.
- [x] Public parameter names match the inspected API signature.
- [x] Generic example paths use `Path` where appropriate.
- [x] DataFrame behavior not affected.

### Code Quality

- [x] Public behavior was checked against the implementation and docstring.
- [x] No HEC-RAS execution was required for this documentation-only change.
- [x] No machine-specific paths were introduced.
- [x] Logging behavior was not changed.
- [x] Destructive destination replacement and troubleshooting behavior are explicit.

### API Changes (if applicable)

- [x] No API changes.
- [x] Existing multi-project support is documented without modification.
- [x] Standard `compute_parallel` parameter names are used.
- [x] Return behavior was not changed.

### Notebooks (if applicable)

- [x] No notebook files or stored outputs were changed.
- [x] Notebook 916 evidence was verified against the merged artifact.
- [x] No development toggle changes were required.

---

## Test Plan

- Inspected `inspect.signature(RasCmdr.compute_parallel)`; confirmed
  `max_workers` is present and `num_workers` is absent.
- Parsed 14 normalized Python documentation snippets.
- Confirmed no `num_workers` or stale worker-cleanup guidance remains in the
  three parallel-compute pages.
- Ran the production-equivalent notebook and cognitive documentation prebuild.
- Ran `uv run mkdocs build` successfully.
- Ran `git diff --check`.
- Completed independent API-documentation and notebook-ledger reviews with no
  remaining findings.

## LLM Attribution

**Model/Tool used**: Codex
