### PR TITLE
Restore complete MIT license text

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -2,4 +2,20 @@ MIT License
 
 Copyright (c) 2024 William M. Katzenmeyer
 
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so.
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
## Summary

- Restores the complete canonical MIT license text.
- Preserves the existing 2024 copyright, copyright holder, and MIT licensing
  choice.
- Adds the required notice-retention condition and warranty/liability
  disclaimer so automated license detection can recognize the repository.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)
- [ ] Example notebook

---

## LLM Self-Review

### Style Compliance

Not applicable; this PR changes only the root license text.

### Code Quality

- [x] Exactly one tracked file changed
- [x] No API, test, documentation, or notebook behavior changed
- [x] Existing copyright identity and licensing choice preserved

### API Changes (if applicable)

Not applicable.

### Notebooks (if applicable)

Not applicable.

---

## Test Plan

- Compared the completed file exactly against GitHub's canonical MIT license
  template after substituting the existing copyright line.
- `git diff --check`

## LLM Attribution

**Model/Tool used**: OpenAI Codex (`gpt-5.6-terra`).
