### PR TITLE
Restore Example Project explorer prominence

### DIFF
--- a/docs/examples/example-projects.md
+++ b/docs/examples/example-projects.md
@@ -28,7 +28,8 @@ Only projects with a verified coordinate reference system are eligible for the
 web map viewer. Projects without a CRS can remain useful for notebook examples,
 but they are not published as map-review targets until their CRS is resolved.
 
-## ScienceBase Model Archives
+<details class="ras-library-details" markdown="1">
+<summary>ScienceBase model acquisition and validation details</summary>
 
 `RasExamples` exposes only ScienceBase HEC-RAS archives explicitly promoted as
 runnable. Every execution dependency must exist and be portable. Promotion
@@ -137,6 +138,8 @@ facade.
 
 SRH-2D, CE-QUAL-W2, and derived raster inundation collections are outside this
 catalog regardless of whether their source archives are otherwise useful.
+
+</details>
 
 ## Project Explorer
 


### PR DESCRIPTION
## Summary

- collapse the detailed ScienceBase acquisition and validation material by default
- return the Project Explorer map and complete linked project table to the primary landing-page flow
- preserve all Fox River and Silver Creek documentation added by #289

## Root cause

PR #289 inserted 116 lines of ScienceBase documentation before the Project Explorer. The 15-project map and table still loaded correctly, but they were pushed far below the fold and appeared to be missing.

## Validation

- rendered MkDocs site successfully with the existing ras-commander environment
- browser-verified the collapsed details state
- browser-verified 15 project markers, 15 project table rows, and the `15 published MapLibre project extents` status

`mkdocs build --strict` remains blocked by the checkout's pre-existing missing generated notebook pages (137 warnings); the same warnings occur at the merged baseline.