### PR TITLE
release: ras-commander 0.99.1

### DIFF
--- a/docs/development/release-notes.md
+++ b/docs/development/release-notes.md
@@ -2,7 +2,31 @@
 
 ## Version History
 
-### Unreleased (target version 0.99.0)
+### v0.99.1 (Current published release — July 2026)
+
+**Qualified Raster Processing on Linux/Wine**
+
+- Add the `hecras-setup-linux-wine-ras2cng` skill, fail-closed host preflight,
+  and notebook 511 for isolated headless deployments.
+- Serialize RASMapper stored-map helpers under Wine and constrain the inherited
+  helper process tree to one CPU, avoiding nondeterministic CLR access
+  violations and non-returning mapper calls observed with unsafe CPU topology.
+- Require one writable Wine prefix and project copy per task; scale concurrent
+  work across isolated tasks rather than sharing an active prefix or HDF model.
+- Qualify Muncie HEC-RAS 7.0.1 WSE, depth, and velocity rasters against the
+  Windows golden with exact dimensions, georeferencing, and pixel hashes.
+- Deprecate `mode="native"` in favor of `mode="configured"`; configured maps use
+  the packaged RAS Mapper helper because `RasProcess.exe StoreAllMaps` does not
+  preserve the required stored-map interpolation/render behavior.
+
+**Raster Processing Performance**
+
+- Add typed StoreMap performance policies, physical-memory and Windows-commit
+  admission, terrain-based worker estimates, and child-scoped GDAL controls.
+- Add memory-aware independent-map processing on Windows with profiling and
+  self-contained performance decision reports.
+- Preserve ordered serial handling for products that cannot safely be generated
+  as independent map-helper processes.
 
 **Raster BenefitArea Analysis**
 
@@ -28,7 +52,7 @@
 - Basin-average INFO logging now reports record count, valid-time spacing, and
   the lead-hour range instead of treating every record as one hour.
 
-### v0.96.2 (Current published release — May 2026)
+### v0.96.2 (May 2026)
 
 **Precipitation & Dependencies**
 

--- a/ras_commander/__init__.py
+++ b/ras_commander/__init__.py
@@ -14,7 +14,7 @@ try:
     __version__ = version("ras-commander")
 except PackageNotFoundError:
     # package is not installed
-    __version__ = "0.99.0"
+    __version__ = "0.99.1"
 
 # Canonical machine-readable agent index (see docs() helper below)
 __llms_txt__ = "https://rascommander.info/ras/llms.txt"

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ class CustomBuildPy(build_py):
 
 setup(
     name="ras-commander",
-    version="0.99.0",
+    version="0.99.1",
     packages=find_packages(include=['ras_commander', 'ras_commander.*']),
     include_package_data=True,
     package_data={


### PR DESCRIPTION
## Release

Bumps ras-commander from 0.99.0 to 0.99.1 and promotes the current unreleased notes to the July 2026 release.

## Validation

- focused Wine/helper/API/preflight suite: 139 passed
- wheel and source distribution built successfully
- both artifacts pass `twine check`
- wheel metadata reports 0.99.1
- packaged `RasStoreMapHelper.exe` is present in the wheel
