### PR TITLE
fix: accept polygon extents in raster workflows

### DIFF
--- a/docs/user-guide/spatial-data.md
+++ b/docs/user-guide/spatial-data.md
@@ -6,6 +6,87 @@ RAS Commander provides comprehensive tools for working with HEC-RAS spatial data
 
 When you initialize a RAS project, the library automatically parses the RASMapper file (`.rasmap`) and populates the `rasmap_df` DataFrame with paths to all spatial datasets. This provides programmatic access to terrain models, land cover layers, soil data, and more.
 
+## Authoritative Extents for Raster Inputs
+
+Raster and acquisition workflows that accept an analysis/model extent use one
+shared validation contract. You can pass:
+
+- a non-empty, valid Shapely `Polygon`;
+- a `MultiPolygon` only when removing empty parts leaves exactly one polygon;
+- a GeoSeries or GeoDataFrame with exactly one effective polygonal part;
+- a legacy `(minx, miny, maxx, maxy)` tuple/list;
+- a bounds dict or object using `left/bottom/right/top`,
+  `xmin/ymin/xmax/ymax`, or `minx/miny/maxx/maxy`; or
+- `RasMapperLib.Extent`.
+
+True multipart geometry is ambiguous for lower-level raster/native APIs and
+fails closed. Empty, invalid, `Point`, `LineString`, `GeometryCollection`, and
+other non-polygon geometries also raise `ValueError`; ras-commander does not
+silently repair or replace the authoritative geometry.
+
+`buffer_distance` defaults to `0.0`, preserving existing raster bounds. The
+buffer is applied before bounds are derived and uses the units of the supplied
+geometry:
+
+- `RasMap.add_landcover_layer()` and `RasMap.add_soils_layer()` expect the
+  geometry and buffer in the project CRS.
+- `Usgs3depAws` acquisition methods and `PrecipAorc` methods expect WGS84, so
+  their buffer distance is in decimal degrees.
+
+No CRS transformation is inferred from a Shapely geometry. Reproject a
+GeoSeries/GeoDataFrame to the workflow's documented CRS before passing it.
+Legacy bounds inputs remain supported.
+
+```python
+from ras_commander import RasMap
+
+# basin_polygon is already in the HEC-RAS project CRS.
+landcover_hdf = RasMap.add_landcover_layer(
+    ras_project_path=project_path,
+    source_path=landcover_source,
+    classification_table=classification_table,
+    cell_size=30.0,
+    restrict_to_extent=basin_polygon,
+    buffer_distance=300.0,
+)
+
+soils_hdf = RasMap.add_soils_layer(
+    ras_project_path=project_path,
+    gssurgo_path=gssurgo_path,
+    cell_size=30.0,
+    restrict_to_extent=basin_polygon,
+    buffer_distance=300.0,
+)
+```
+
+### Extent API Audit
+
+| Workflow | Extent behavior |
+|----------|-----------------|
+| `RasMap.add_landcover_layer()` | Normalizes polygon or legacy bounds, applies a project-CRS buffer, then derives raster bounds. |
+| `RasMap.add_soils_layer()` | Uses the same normalization and buffer contract as land cover. |
+| `Usgs3depAws.query_tiles_api()`, `find_tiles_for_bbox()`, `list_projects_for_bbox()`, `download_tiles()` | Use the shared contract for WGS84 terrain acquisition; polygon intersection is preserved where the tile workflow supports it. |
+| `PrecipAorc.download()`, `check_availability()`, `get_storm_catalog()`, `create_storm_plans()` | Normalize a WGS84 polygon/legacy extent and optional degree buffer before precipitation subsetting. |
+| `RasMap.add_infiltration_layer()` | Registration/combination only. Its raster extent comes from the prepared land-cover and soils inputs, so no artificial extent parameter is added. |
+| `RasMap.add_terrain_layer()` | Registration only for an existing terrain HDF; terrain acquisition owns the analysis extent. |
+| `RasUnsteady.set_gridded_precipitation()` and `configure_gridded_dss_precipitation()` | Registration only for an existing NetCDF/DSS input; precipitation preparation owns the analysis extent. |
+
+### Downstream Spring Creek Validation
+
+Before treating the Commander change as consumable downstream:
+
+1. Update the reviewed ras-commander pin or capability evidence to a release or
+   commit containing this extent contract.
+2. Run the fresh Spring Creek HEC-RAS 6.6 workflow with the authoritative basin
+   polygon passed unchanged to land-cover and soils preparation.
+3. Confirm the derived raster bounds include the explicit purpose-specific
+   buffer and that legacy bounds calls still produce their prior extents.
+4. Rebuild/associate infiltration inputs and prove the final Manning's n and
+   curve-number arrays are populated, aligned to the 2D mesh, and solver-ready.
+
+Do not unblock the downstream adoption solely from source changes; use a
+released or otherwise reviewed, consumable ras-commander revision.
+
 ## Understanding rasmap_df
 
 The `rasmap_df` DataFrame is automatically populated when you call `init_ras_project()`. It contains paths and metadata for all spatial datasets referenced in your RASMapper configuration.

--- a/ras_commander/RasMap.py
+++ b/ras_commander/RasMap.py
@@ -748,10 +748,20 @@ class RasMap:
         output_hdf_path: Optional[Union[str, Path]] = None,
         restrict_to_extent: Optional[Any] = None,
         layer_name: str = "LandCover",
+        buffer_distance: float = 0.0,
         ras_object=None,
     ) -> Path:
         """
         Create and register a land-cover classification layer for a RAS project.
+
+        ``restrict_to_extent`` may be a valid Shapely ``Polygon``, a
+        ``MultiPolygon`` containing exactly one non-empty polygonal part, a
+        one-effective-geometry GeoSeries/GeoDataFrame, a four-value bounds
+        tuple/list, a bounds dict/object, or ``RasMapperLib.Extent``.
+        ``buffer_distance`` is applied before raster bounds are derived, in
+        project CRS units, and defaults to ``0.0``. Callers are responsible for
+        supplying geometry in the project CRS. Empty, invalid, non-polygon, and
+        true multipart geometry inputs raise ``ValueError``.
         """
         ras_project_path = Path(ras_project_path)
         source_path = Path(source_path)
@@ -767,6 +777,7 @@ class RasMap:
             output_hdf_path=output_hdf_path,
             restrict_to_extent=restrict_to_extent,
             layer_name=layer_name,
+            buffer_distance=buffer_distance,
         )
 
     @staticmethod
@@ -777,10 +788,16 @@ class RasMap:
         cell_size: float,
         output_hdf_path: Optional[Union[str, Path]] = None,
         restrict_to_extent: Optional[Any] = None,
+        buffer_distance: float = 0.0,
         ras_object=None,
     ) -> Path:
         """
         Create and register a soils layer from direct GSSURGO input.
+
+        ``restrict_to_extent`` accepts the same polygon and legacy bounds inputs
+        as :meth:`add_landcover_layer`. ``buffer_distance`` is applied in project
+        CRS units before raster bounds are derived and defaults to ``0.0``.
+        Multipart, empty, invalid, and non-polygon geometry inputs fail closed.
         """
         ras_project_path = Path(ras_project_path)
         gssurgo_path = Path(gssurgo_path)
@@ -793,6 +810,7 @@ class RasMap:
             cell_size=cell_size,
             output_hdf_path=output_hdf_path,
             restrict_to_extent=restrict_to_extent,
+            buffer_distance=buffer_distance,
         )
 
     @staticmethod

--- a/ras_commander/_land_classification_helper.py
+++ b/ras_commander/_land_classification_helper.py
@@ -25,6 +25,7 @@ import pandas as pd
 
 from .LoggingConfig import get_logger
 from .RasUtils import RasUtils
+from ._spatial_extent import _normalize_extent_bounds
 
 logger = get_logger(__name__)
 
@@ -556,44 +557,22 @@ def require_projection_path(
 def normalize_restrict_to_extent(
     restrict_to_extent: Any,
     extent_cls: Any = None,
+    buffer_distance: float = 0.0,
 ) -> Any:
-    """Normalize restrict_to_extent to bounds tuple or RasMapperLib.Extent."""
+    """Normalize an authoritative raster extent to bounds or RasMapperLib.Extent.
+
+    ``buffer_distance`` is applied in the input/project CRS units before bounds
+    are derived. Polygon inputs must resolve to exactly one valid, non-empty
+    polygonal part.
+    """
     if restrict_to_extent is None:
         return None
-
-    if hasattr(restrict_to_extent, "MinX") and hasattr(restrict_to_extent, "MaxX"):
-        return restrict_to_extent
-
-    bounds: Optional[tuple[float, float, float, float]] = None
-
-    if isinstance(restrict_to_extent, dict):
-        left = restrict_to_extent.get("left", restrict_to_extent.get("xmin"))
-        bottom = restrict_to_extent.get("bottom", restrict_to_extent.get("ymin"))
-        right = restrict_to_extent.get("right", restrict_to_extent.get("xmax"))
-        top = restrict_to_extent.get("top", restrict_to_extent.get("ymax"))
-        bounds = (left, bottom, right, top)
-    elif isinstance(restrict_to_extent, (list, tuple)) and len(restrict_to_extent) == 4:
-        bounds = tuple(restrict_to_extent)
-    else:
-        for attrs in (
-            ("left", "bottom", "right", "top"),
-            ("xmin", "ymin", "xmax", "ymax"),
-            ("minx", "miny", "maxx", "maxy"),
-        ):
-            if all(hasattr(restrict_to_extent, attr) for attr in attrs):
-                bounds = tuple(getattr(restrict_to_extent, attr) for attr in attrs)
-                break
-
-    if bounds is None:
-        raise ValueError(
-            "restrict_to_extent must be a 4-tuple/list, a dict with xmin/ymin/xmax/ymax "
-            "or left/bottom/right/top, or an object exposing those attributes."
-        )
-
-    left, bottom, right, top = (float(value) for value in bounds)
-    if extent_cls is None:
-        return (left, bottom, right, top)
-    return extent_cls(left, bottom, right, top)
+    return _normalize_extent_bounds(
+        restrict_to_extent,
+        buffer_distance=buffer_distance,
+        extent_cls=extent_cls,
+        parameter_name="restrict_to_extent",
+    )
 
 
 def normalize_gssurgo_path(gssurgo_path: Union[str, Path]) -> Path:
@@ -952,6 +931,7 @@ def _rasterize_landcover_source(
     cell_size: float,
     project_crs: Any,
     restrict_to_extent: Optional[Any],
+    buffer_distance: float,
     source_field: Optional[str],
 ) -> tuple[np.ndarray, Any, list[tuple[int, str]], list[tuple[str, float, float]]]:
     try:
@@ -965,7 +945,10 @@ def _rasterize_landcover_source(
             "Install the geospatial dependencies before calling this API."
         ) from exc
 
-    restrict_bounds = normalize_restrict_to_extent(restrict_to_extent)
+    restrict_bounds = normalize_restrict_to_extent(
+        restrict_to_extent,
+        buffer_distance=buffer_distance,
+    )
 
     raster_map_rows = [(0, "NoData")] + [
         (int(row.class_id), str(row.class_name))
@@ -1209,6 +1192,7 @@ def _rasterize_soils_source(
     cell_size: float,
     project_crs: Any,
     restrict_to_extent: Optional[Any],
+    buffer_distance: float,
 ) -> tuple[np.ndarray, Any, list[tuple[int, str]]]:
     try:
         import geopandas as gpd
@@ -1225,7 +1209,10 @@ def _rasterize_soils_source(
 
     gdf = gdf.to_crs(project_crs)
     bounds = tuple(gdf.total_bounds.tolist())
-    restrict_bounds = normalize_restrict_to_extent(restrict_to_extent)
+    restrict_bounds = normalize_restrict_to_extent(
+        restrict_to_extent,
+        buffer_distance=buffer_distance,
+    )
     if restrict_bounds is not None:
         bounds = restrict_bounds
 
@@ -2721,8 +2708,14 @@ def add_landcover_layer(
     output_hdf_path: Optional[Union[str, Path]] = None,
     restrict_to_extent: Optional[Any] = None,
     layer_name: str = "LandCover",
+    buffer_distance: float = 0.0,
 ) -> Path:
-    """Create and register a land-cover classification layer."""
+    """Create and register a land-cover classification layer.
+
+    ``restrict_to_extent`` accepts one valid Polygon, a single-effective-part
+    MultiPolygon, or a legacy bounds-shaped input. ``buffer_distance`` is in
+    project CRS units and defaults to no buffer.
+    """
     project_paths = resolve_project_paths(ras_project_path)
     source_path = RasUtils.safe_resolve(Path(source_path))
     if not source_path.exists():
@@ -2749,6 +2742,7 @@ def add_landcover_layer(
         cell_size=float(cell_size),
         project_crs=project_crs,
         restrict_to_extent=restrict_to_extent,
+        buffer_distance=buffer_distance,
         source_field=source_field,
     )
 
@@ -2780,8 +2774,14 @@ def add_soils_layer(
     cell_size: float,
     output_hdf_path: Optional[Union[str, Path]] = None,
     restrict_to_extent: Optional[Any] = None,
+    buffer_distance: float = 0.0,
 ) -> Path:
-    """Create and register a hydrologic soil group layer from direct GSSURGO input."""
+    """Create and register a hydrologic soil group layer from direct GSSURGO input.
+
+    ``restrict_to_extent`` accepts one valid Polygon, a single-effective-part
+    MultiPolygon, or a legacy bounds-shaped input. ``buffer_distance`` is in
+    project CRS units and defaults to no buffer.
+    """
     project_paths = resolve_project_paths(ras_project_path)
     gssurgo_path = normalize_gssurgo_path(gssurgo_path)
 
@@ -2804,6 +2804,7 @@ def add_soils_layer(
         cell_size=float(cell_size),
         project_crs=project_crs,
         restrict_to_extent=restrict_to_extent,
+        buffer_distance=buffer_distance,
     )
 
     _create_output_raster(

--- a/ras_commander/_spatial_extent.py
+++ b/ras_commander/_spatial_extent.py
@@ -1,0 +1,212 @@
+"""Shared normalization for authoritative spatial extent inputs.
+
+The helpers in this module keep polygon validation and multipart behavior
+consistent before raster, terrain, and precipitation workflows reduce an
+authoritative area of interest to lower-level bounds.
+"""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Iterable, Mapping
+from typing import Any, Optional
+
+
+def _coerce_buffer_distance(buffer_distance: float, parameter_name: str) -> float:
+    """Return a finite buffer distance in the input extent's CRS units."""
+    try:
+        distance = float(buffer_distance)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(
+            f"buffer_distance for {parameter_name} must be a finite number"
+        ) from exc
+
+    if not math.isfinite(distance):
+        raise ValueError(
+            f"buffer_distance for {parameter_name} must be a finite number"
+        )
+    return distance
+
+
+def _extract_bounds(
+    extent: Any,
+    parameter_name: str,
+) -> Optional[tuple[float, float, float, float]]:
+    """Extract a legacy bounds-shaped input without treating geometry as bounds."""
+    values: Optional[Iterable[Any]] = None
+
+    if isinstance(extent, Mapping):
+        normalized = {
+            str(key).lower(): value
+            for key, value in extent.items()
+        }
+        for keys in (
+            ("left", "bottom", "right", "top"),
+            ("xmin", "ymin", "xmax", "ymax"),
+            ("minx", "miny", "maxx", "maxy"),
+        ):
+            if all(key in normalized for key in keys):
+                values = (normalized[key] for key in keys)
+                break
+    elif isinstance(extent, (list, tuple)):
+        if len(extent) == 4:
+            values = extent
+    else:
+        for attributes in (
+            ("left", "bottom", "right", "top"),
+            ("xmin", "ymin", "xmax", "ymax"),
+            ("minx", "miny", "maxx", "maxy"),
+            ("MinX", "MinY", "MaxX", "MaxY"),
+        ):
+            if all(hasattr(extent, attribute) for attribute in attributes):
+                values = (getattr(extent, attribute) for attribute in attributes)
+                break
+
+    if values is None:
+        return None
+
+    try:
+        bounds = tuple(float(value) for value in values)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(
+            f"{parameter_name} bounds must contain four finite numeric values"
+        ) from exc
+
+    if len(bounds) != 4 or not all(math.isfinite(value) for value in bounds):
+        raise ValueError(
+            f"{parameter_name} bounds must contain four finite numeric values"
+        )
+
+    left, bottom, right, top = bounds
+    if left >= right or bottom >= top:
+        raise ValueError(
+            f"{parameter_name} bounds must satisfy minx < maxx and miny < maxy; "
+            f"got {bounds}"
+        )
+    return bounds
+
+
+def _geopandas_geometry_values(extent: Any) -> Optional[list[Any]]:
+    """Return geometries from a GeoSeries/GeoDataFrame without a hard dependency."""
+    try:
+        import geopandas as gpd
+    except ImportError:  # pragma: no cover - geopandas is an optional runtime extra
+        return None
+
+    if isinstance(extent, gpd.GeoDataFrame):
+        return list(extent.geometry)
+    if isinstance(extent, gpd.GeoSeries):
+        return list(extent)
+    return None
+
+
+def _single_polygon(
+    geometry_values: Iterable[Any],
+    parameter_name: str,
+) -> Any:
+    """Validate and collapse geometry input to exactly one non-empty Polygon."""
+    from shapely.geometry import MultiPolygon, Polygon
+    from shapely.validation import explain_validity
+
+    polygon_parts: list[Any] = []
+    saw_geometry = False
+
+    for geometry in geometry_values:
+        if geometry is None:
+            continue
+        saw_geometry = True
+        if geometry.is_empty:
+            continue
+        if not geometry.is_valid:
+            raise ValueError(
+                f"{parameter_name} geometry is invalid: "
+                f"{explain_validity(geometry)}"
+            )
+        if isinstance(geometry, Polygon):
+            polygon_parts.append(geometry)
+            continue
+        if isinstance(geometry, MultiPolygon):
+            polygon_parts.extend(part for part in geometry.geoms if not part.is_empty)
+            continue
+        raise ValueError(
+            f"{parameter_name} must be a Polygon or a single-effective-part "
+            f"MultiPolygon; got {geometry.geom_type}"
+        )
+
+    if not polygon_parts:
+        detail = "contains no geometry" if not saw_geometry else "is empty"
+        raise ValueError(
+            f"{parameter_name} geometry {detail}; expected one non-empty Polygon"
+        )
+    if len(polygon_parts) != 1:
+        raise ValueError(
+            f"{parameter_name} geometry is ambiguous: expected exactly one "
+            f"non-empty polygonal part, found {len(polygon_parts)}"
+        )
+    return polygon_parts[0]
+
+
+def _normalize_extent_geometry(
+    extent: Any,
+    *,
+    buffer_distance: float = 0.0,
+    parameter_name: str = "extent",
+) -> Any:
+    """Normalize an extent input to one valid Shapely ``Polygon``.
+
+    Accepted inputs are a Shapely ``Polygon``, a single-effective-part
+    ``MultiPolygon``, a one-effective-geometry GeoSeries/GeoDataFrame, legacy
+    four-value bounds, bounds dictionaries/objects, and RasMapper-style
+    ``Extent`` objects exposing ``MinX``, ``MinY``, ``MaxX``, and ``MaxY``.
+    """
+    from shapely.geometry import box
+    from shapely.geometry.base import BaseGeometry
+
+    distance = _coerce_buffer_distance(buffer_distance, parameter_name)
+
+    if isinstance(extent, BaseGeometry):
+        polygon = _single_polygon([extent], parameter_name)
+    else:
+        bounds = _extract_bounds(extent, parameter_name)
+        if bounds is not None:
+            polygon = box(*bounds)
+        else:
+            geometry_values = _geopandas_geometry_values(extent)
+            if geometry_values is None:
+                raise ValueError(
+                    f"{parameter_name} must be a Polygon, a single-effective-part "
+                    "MultiPolygon, a one-effective-geometry GeoSeries/GeoDataFrame, "
+                    "a 4-tuple/list, a bounds dict/object, or a RasMapperLib.Extent"
+                )
+            polygon = _single_polygon(geometry_values, parameter_name)
+
+    if distance == 0.0:
+        return polygon
+
+    buffered = polygon.buffer(distance)
+    try:
+        return _single_polygon([buffered], parameter_name)
+    except ValueError as exc:
+        raise ValueError(
+            f"buffer_distance={distance} produced an unusable {parameter_name} "
+            f"geometry: {exc}"
+        ) from exc
+
+
+def _normalize_extent_bounds(
+    extent: Any,
+    *,
+    buffer_distance: float = 0.0,
+    extent_cls: Any = None,
+    parameter_name: str = "extent",
+) -> Any:
+    """Normalize an authoritative extent to bounds or a requested Extent class."""
+    polygon = _normalize_extent_geometry(
+        extent,
+        buffer_distance=buffer_distance,
+        parameter_name=parameter_name,
+    )
+    bounds = tuple(float(value) for value in polygon.bounds)
+    if extent_cls is None:
+        return bounds
+    return extent_cls(*bounds)

--- a/ras_commander/precip/PrecipAorc.py
+++ b/ras_commander/precip/PrecipAorc.py
@@ -35,12 +35,13 @@ Example Usage:
     >>> print(f"Downloaded to: {output}")
 """
 
-from pathlib import Path
-from typing import Tuple, Optional, Union, List
 from datetime import datetime
 import logging
+from pathlib import Path
+from typing import Any, List, Optional, Union
 
 from ..LoggingConfig import get_logger
+from .._spatial_extent import _normalize_extent_bounds
 
 logger = get_logger(__name__)
 
@@ -97,13 +98,14 @@ class PrecipAorc:
 
     @staticmethod
     def download(
-        bounds: Tuple[float, float, float, float],
+        bounds: Any,
         start_time: Union[str, datetime],
         end_time: Union[str, datetime],
         output_path: Union[str, Path],
         variable: str = "APCP_surface",
         target_crs: Optional[str] = "EPSG:5070",
-        resolution: Optional[float] = 2000.0
+        resolution: Optional[float] = 2000.0,
+        buffer_distance: float = 0.0,
     ) -> Path:
         """
         Download AORC precipitation data for specified bounds and time range.
@@ -113,9 +115,10 @@ class PrecipAorc:
 
         Parameters
         ----------
-        bounds : Tuple[float, float, float, float]
-            Bounding box in WGS84 as (west, south, east, north) in decimal degrees.
-            Use HdfProject.get_project_bounds_latlon() to get these from a HEC-RAS model.
+        bounds : extent-like
+            One valid Polygon, a single-effective-part MultiPolygon, or a legacy
+            bounds-shaped input in WGS84. Use
+            HdfProject.get_project_bounds_latlon() to get bounds from a HEC-RAS model.
         start_time : str or datetime
             Start of time window. String format: "YYYY-MM-DD" or "YYYY-MM-DD HH:MM"
         end_time : str or datetime
@@ -131,6 +134,8 @@ class PrecipAorc:
         resolution : float, optional, default 2000.0
             Grid cell resolution in target CRS units (meters for EPSG:5070).
             Standard HEC SHG resolution is 2000m. Only used if target_crs is set.
+        buffer_distance : float, default 0.0
+            Buffer applied before bounds are derived, in WGS84 degrees.
 
         Returns
         -------
@@ -177,6 +182,11 @@ class PrecipAorc:
         - Default output is reprojected to SHG (EPSG:5070) for HEC-RAS compatibility
         - SHG (Standard Hydrologic Grid) is required for HEC-RAS GDAL Raster import
         """
+        bounds = _normalize_extent_bounds(
+            bounds,
+            buffer_distance=buffer_distance,
+            parameter_name="bounds",
+        )
         _check_precip_dependencies()
 
         import xarray as xr
@@ -348,21 +358,25 @@ class PrecipAorc:
 
     @staticmethod
     def check_availability(
-        bounds: Tuple[float, float, float, float],
+        bounds: Any,
         start_time: Union[str, datetime],
-        end_time: Union[str, datetime]
+        end_time: Union[str, datetime],
+        buffer_distance: float = 0.0,
     ) -> dict:
         """
         Check if AORC data is available for the specified region and time.
 
         Parameters
         ----------
-        bounds : Tuple[float, float, float, float]
-            Bounding box as (west, south, east, north)
+        bounds : extent-like
+            One valid Polygon, a single-effective-part MultiPolygon, or a legacy
+            bounds-shaped input in WGS84.
         start_time : str or datetime
             Start of time window
         end_time : str or datetime
             End of time window
+        buffer_distance : float, default 0.0
+            Buffer applied before bounds are derived, in WGS84 degrees.
 
         Returns
         -------
@@ -373,6 +387,12 @@ class PrecipAorc:
             - message: str with details
         """
         import pandas as pd
+
+        bounds = _normalize_extent_bounds(
+            bounds,
+            buffer_distance=buffer_distance,
+            parameter_name="bounds",
+        )
 
         if isinstance(start_time, str):
             start_dt = pd.to_datetime(start_time)
@@ -456,13 +476,14 @@ class PrecipAorc:
 
     @staticmethod
     def get_storm_catalog(
-        bounds: Tuple[float, float, float, float],
+        bounds: Any,
         year: int,
         inter_event_hours: float = 8.0,
         min_depth_inches: float = 0.5,
         min_wet_hours: int = 1,
         buffer_hours: int = 48,
-        percentile_threshold: Optional[float] = None
+        percentile_threshold: Optional[float] = None,
+        buffer_distance: float = 0.0,
     ) -> 'pd.DataFrame':
         """
         Analyze AORC precipitation data and generate a catalog of storm events.
@@ -473,9 +494,10 @@ class PrecipAorc:
 
         Parameters
         ----------
-        bounds : Tuple[float, float, float, float]
-            Bounding box in WGS84 as (west, south, east, north) in decimal degrees.
-            Use HdfProject.get_project_bounds_latlon() to get from HEC-RAS model.
+        bounds : extent-like
+            One valid Polygon, a single-effective-part MultiPolygon, or a legacy
+            bounds-shaped input in WGS84. Use
+            HdfProject.get_project_bounds_latlon() to get bounds from a HEC-RAS model.
         year : int
             Year to analyze (1979+).
         inter_event_hours : float, default 8.0
@@ -493,6 +515,8 @@ class PrecipAorc:
         percentile_threshold : float, optional
             If specified (0-100), only return storms above this percentile
             by total depth. E.g., 95 returns only top 5% storms. Default: None
+        buffer_distance : float, default 0.0
+            Buffer applied before bounds are derived, in WGS84 degrees.
 
         Returns
         -------
@@ -543,6 +567,11 @@ class PrecipAorc:
         - Inter-event period of 8 hours is USGS standard for storm separation
         - Buffer of 48 hours allows hydraulic model spin-up and recession
         """
+        bounds = _normalize_extent_bounds(
+            bounds,
+            buffer_distance=buffer_distance,
+            parameter_name="bounds",
+        )
         _check_precip_dependencies()
 
         import xarray as xr
@@ -735,13 +764,14 @@ class PrecipAorc:
     @staticmethod
     def create_storm_plans(
         storm_catalog: 'pd.DataFrame',
-        bounds: Tuple[float, float, float, float],
+        bounds: Any,
         template_plan: str,
         precip_folder: Union[str, Path] = "Precipitation",
         ras_object: Optional['RasPrj'] = None,
         download_data: bool = True,
         max_storms: Optional[int] = None,
-        enable_timeseries: bool = True
+        enable_timeseries: bool = True,
+        buffer_distance: float = 0.0,
     ) -> 'pd.DataFrame':
         """
         Create HEC-RAS plan and unsteady files for each storm in a catalog.
@@ -758,9 +788,10 @@ class PrecipAorc:
         storm_catalog : pd.DataFrame
             Storm catalog from get_storm_catalog() with columns:
             storm_id, start_time, end_time, sim_start, sim_end, etc.
-        bounds : Tuple[float, float, float, float]
-            Bounding box in WGS84 as (west, south, east, north).
-            Same bounds used for get_storm_catalog().
+        bounds : extent-like
+            One valid Polygon, a single-effective-part MultiPolygon, or a legacy
+            bounds-shaped input in WGS84. Use the same extent passed to
+            get_storm_catalog().
         template_plan : str
             Plan number to use as template (e.g., "06").
             Must be an unsteady plan with precipitation enabled.
@@ -777,6 +808,8 @@ class PrecipAorc:
         enable_timeseries : bool, default True
             If True, enable HDF time series output (HDF Write Time Slices=-1).
             Required for extracting cell-level time series from results.
+        buffer_distance : float, default 0.0
+            Buffer applied before bounds are derived, in WGS84 degrees.
 
         Returns
         -------
@@ -816,6 +849,12 @@ class PrecipAorc:
         - All files are created in the project folder
         """
         import pandas as pd
+
+        bounds = _normalize_extent_bounds(
+            bounds,
+            buffer_distance=buffer_distance,
+            parameter_name="bounds",
+        )
 
         # Import RAS modules (avoid circular imports)
         from ..RasPlan import RasPlan

--- a/ras_commander/terrain/Usgs3depAws.py
+++ b/ras_commander/terrain/Usgs3depAws.py
@@ -45,11 +45,17 @@ import re
 import subprocess
 import tempfile
 from pathlib import Path
-from typing import Union, List, Tuple, Optional
-import geopandas as gpd
-from shapely.geometry import box, Polygon
-import requests
+from typing import Any, List, Optional, Tuple, Union
 from urllib.parse import urlparse
+
+import geopandas as gpd
+import requests
+from shapely.geometry import box
+
+from .._spatial_extent import (
+    _normalize_extent_bounds,
+    _normalize_extent_geometry,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -143,8 +149,9 @@ class Usgs3depAws:
 
     @staticmethod
     def query_tiles_api(
-        bbox: Union[Polygon, Tuple[float, float, float, float]],
-        resolution: int
+        bbox: Any,
+        resolution: int,
+        buffer_distance: float = 0.0,
     ) -> gpd.GeoDataFrame:
         """
         Query USGS 3DEP Tile Index API for tiles intersecting a bounding box.
@@ -152,17 +159,18 @@ class Usgs3depAws:
         Uses the National Map ArcGIS REST API to get tile information.
 
         Args:
-            bbox: Bounding box as (minx, miny, maxx, maxy) in WGS84 or Polygon
+            bbox: One valid Polygon or a legacy bounds-shaped input in WGS84.
             resolution: DEM resolution in meters (1, 3, 10, or 30)
+            buffer_distance: Optional buffer in WGS84 degrees. Default is 0.0.
 
         Returns:
             GeoDataFrame with tile information including download URLs
         """
-        # Convert bbox to tuple if Polygon
-        if isinstance(bbox, Polygon):
-            bbox_tuple = bbox.bounds
-        else:
-            bbox_tuple = bbox
+        bbox_tuple = _normalize_extent_bounds(
+            bbox,
+            buffer_distance=buffer_distance,
+            parameter_name="bbox",
+        )
 
         # Get layer ID for resolution
         if resolution not in Usgs3depAws.LAYER_IDS:
@@ -208,9 +216,10 @@ class Usgs3depAws:
 
     @staticmethod
     def find_tiles_for_bbox(
-        bbox: Union[Polygon, Tuple[float, float, float, float]],
+        bbox: Any,
         resolution: int,
-        cache_folder: Optional[Union[str, Path]] = None
+        cache_folder: Optional[Union[str, Path]] = None,
+        buffer_distance: float = 0.0,
     ) -> gpd.GeoDataFrame:
         """
         Find all tiles that intersect with a bounding box.
@@ -218,16 +227,19 @@ class Usgs3depAws:
         Uses GeoPackage tile index (more reliable than API).
 
         Args:
-            bbox: Bounding box as (minx, miny, maxx, maxy) in WGS84 or Polygon
+            bbox: One valid Polygon or a legacy bounds-shaped input in WGS84.
             resolution: DEM resolution in meters (1, 10, or 30)
             cache_folder: Optional folder to cache tile index
+            buffer_distance: Optional buffer in WGS84 degrees. Default is 0.0.
 
         Returns:
             GeoDataFrame with intersecting projects
         """
-        # Convert bbox to Polygon if tuple
-        if isinstance(bbox, tuple):
-            bbox = box(*bbox)
+        bbox = _normalize_extent_geometry(
+            bbox,
+            buffer_distance=buffer_distance,
+            parameter_name="bbox",
+        )
 
         # Download tile index (GeoPackage)
         tile_index = Usgs3depAws.download_tile_index(resolution, cache_folder)
@@ -253,9 +265,10 @@ class Usgs3depAws:
 
     @staticmethod
     def list_projects_for_bbox(
-        bbox: Union[Polygon, Tuple[float, float, float, float]],
+        bbox: Any,
         resolution: int,
-        cache_folder: Optional[Union[str, Path]] = None
+        cache_folder: Optional[Union[str, Path]] = None,
+        buffer_distance: float = 0.0,
     ) -> gpd.GeoDataFrame:
         """
         List all USGS 3DEP projects that intersect with a bounding box.
@@ -264,9 +277,10 @@ class Usgs3depAws:
         specific projects by name or year.
 
         Args:
-            bbox: Bounding box as (minx, miny, maxx, maxy) in WGS84 or Polygon
+            bbox: One valid Polygon or a legacy bounds-shaped input in WGS84.
             resolution: DEM resolution in meters (1, 10, or 30)
             cache_folder: Optional folder to cache tile index
+            buffer_distance: Optional buffer in WGS84 degrees. Default is 0.0.
 
         Returns:
             GeoDataFrame with project information including:
@@ -286,12 +300,13 @@ class Usgs3depAws:
         """
         import re
 
-        # Convert bbox to Polygon if tuple
-        if isinstance(bbox, tuple):
-            bbox = box(*bbox)
-
         # Find intersecting projects (from tile index)
-        projects = Usgs3depAws.find_tiles_for_bbox(bbox, resolution, cache_folder)
+        projects = Usgs3depAws.find_tiles_for_bbox(
+            bbox,
+            resolution,
+            cache_folder,
+            buffer_distance=buffer_distance,
+        )
 
         if len(projects) == 0:
             logger.debug("No USGS 3DEP projects found for bbox")
@@ -589,14 +604,15 @@ class Usgs3depAws:
 
     @staticmethod
     def download_tiles(
-        bbox: Union[Polygon, Tuple[float, float, float, float]],
+        bbox: Any,
         resolution: int,
         output_folder: Union[str, Path],
         cache_folder: Optional[Union[str, Path]] = None,
         overwrite_dest: bool = False,
         max_workers: int = 3,
         project_name: Optional[str] = None,
-        min_year: Optional[int] = None
+        min_year: Optional[int] = None,
+        buffer_distance: float = 0.0,
     ) -> List[Path]:
         """
         Download all DEM tiles for a bounding box with concurrent downloads.
@@ -609,7 +625,7 @@ class Usgs3depAws:
         performance (default 3 concurrent downloads).
 
         Args:
-            bbox: Bounding box as (minx, miny, maxx, maxy) in WGS84 or Polygon
+            bbox: One valid Polygon or a legacy bounds-shaped input in WGS84.
             resolution: DEM resolution in meters (1, 10, or 30)
             output_folder: Folder to save downloaded tiles
             cache_folder: Optional folder to cache tile index
@@ -623,6 +639,8 @@ class Usgs3depAws:
             min_year: Optional minimum year filter (e.g., 2019).
                      Only considers projects from this year or newer.
                      Ignored if project_name is specified.
+            buffer_distance: Optional buffer in WGS84 degrees, applied before
+                tile discovery and intersection. Default is 0.0.
 
         Returns:
             List of paths to downloaded TIFF files
@@ -659,11 +677,11 @@ class Usgs3depAws:
         output_folder = Path(output_folder)
         output_folder.mkdir(parents=True, exist_ok=True)
 
-        # Convert bbox to Polygon if tuple
-        if isinstance(bbox, tuple):
-            bbox_poly = box(*bbox)
-        else:
-            bbox_poly = bbox
+        bbox_poly = _normalize_extent_geometry(
+            bbox,
+            buffer_distance=buffer_distance,
+            parameter_name="bbox",
+        )
 
         # Find intersecting projects (from tile index)
         projects = Usgs3depAws.find_tiles_for_bbox(bbox_poly, resolution, cache_folder)

--- a/tests/test_precip_aorc_logging.py
+++ b/tests/test_precip_aorc_logging.py
@@ -140,6 +140,21 @@ def test_download_info_is_concise_and_debug_keeps_paths(monkeypatch, tmp_path, c
     assert "AORC output grid shape" in debug_text
 
 
+def test_check_availability_accepts_polygon_and_explicit_buffer():
+    aorc_module = importlib.import_module("ras_commander.precip.PrecipAorc")
+    from shapely.geometry import box
+
+    result = aorc_module.PrecipAorc.check_availability(
+        bounds=box(-78.0, 40.0, -77.0, 42.0),
+        start_time="2020-01-01",
+        end_time="2020-01-02",
+        buffer_distance=0.25,
+    )
+
+    assert result["bounds"] == (-78.25, 39.75, -76.75, 42.25)
+    assert result["in_conus"] is True
+
+
 def test_get_storm_catalog_collapses_info_and_keeps_debug_details(monkeypatch, caplog):
     aorc_module = importlib.import_module("ras_commander.precip.PrecipAorc")
     monkeypatch.setattr(aorc_module, "_check_precip_dependencies", lambda: None)

--- a/tests/test_rasmap_land_classification.py
+++ b/tests/test_rasmap_land_classification.py
@@ -307,6 +307,7 @@ class TestLayerCreation:
         rasterio = pytest.importorskip("rasterio")
         pytest.importorskip("pyproj")
         from rasterio.transform import from_origin
+        from shapely.geometry import box
 
         project_dir = _make_temp_project(tmp_path, "LandcoverProject")
         source_raster = tmp_path / "landcover_source.tif"
@@ -348,10 +349,14 @@ class TestLayerCreation:
             source_raster,
             classification_table,
             cell_size=10.0,
+            restrict_to_extent=box(10, 10, 20, 20),
+            buffer_distance=10.0,
         )
 
         assert output_hdf.exists()
         assert output_hdf.with_suffix(".tif").exists()
+        with rasterio.open(output_hdf.with_suffix(".tif")) as raster:
+            assert tuple(raster.bounds) == (0.0, 0.0, 30.0, 30.0)
 
         with h5py.File(output_hdf, "r") as hdf_file:
             raster_map = hdf_file["Raster Map"][()]
@@ -369,9 +374,22 @@ class TestLayerCreation:
         parsed = RasMap.parse_rasmap(project_dir / "LandcoverProject.rasmap")
         assert parsed.at[0, "landcover_hdf_path"] == [str(output_hdf)]
 
+        legacy_output = RasMap.add_landcover_layer(
+            project_dir,
+            source_raster,
+            classification_table,
+            cell_size=10.0,
+            output_hdf_path=tmp_path / "legacy_landcover.hdf",
+            restrict_to_extent=(10, 10, 30, 30),
+            layer_name="Legacy Bounds",
+        )
+        with rasterio.open(legacy_output.with_suffix(".tif")) as raster:
+            assert tuple(raster.bounds) == (10.0, 10.0, 30.0, 30.0)
+
     def test_add_soils_layer_creates_outputs_and_registers_rasmap(self, tmp_path):
         pytest.importorskip("geopandas")
         pytest.importorskip("pyproj")
+        rasterio = pytest.importorskip("rasterio")
         from shapely.geometry import box
         import geopandas as gpd
 
@@ -402,10 +420,14 @@ class TestLayerCreation:
             project_dir,
             gssurgo_dir,
             cell_size=10.0,
+            restrict_to_extent=box(10, 0, 20, 10),
+            buffer_distance=10.0,
         )
 
         assert output_hdf.exists()
         assert output_hdf.with_suffix(".tif").exists()
+        with rasterio.open(output_hdf.with_suffix(".tif")) as raster:
+            assert tuple(raster.bounds) == (0.0, -10.0, 30.0, 20.0)
 
         with h5py.File(output_hdf, "r") as hdf_file:
             raster_map = hdf_file["Raster Map"][()]
@@ -418,6 +440,16 @@ class TestLayerCreation:
         assert set(layers["classification_kind"]) == {"soils"}
         parsed = RasMap.parse_rasmap(project_dir / "SoilsProject.rasmap")
         assert parsed.at[0, "soil_layer_path"] == [str(output_hdf)]
+
+        legacy_output = RasMap.add_soils_layer(
+            project_dir,
+            gssurgo_dir,
+            cell_size=10.0,
+            output_hdf_path=tmp_path / "legacy_soils.hdf",
+            restrict_to_extent=[0, 0, 40, 20],
+        )
+        with rasterio.open(legacy_output.with_suffix(".tif")) as raster:
+            assert tuple(raster.bounds) == (0.0, 0.0, 40.0, 20.0)
 
     @pytest.mark.parametrize(
         ("infiltration_method", "expected_fields"),

--- a/tests/test_spatial_extent.py
+++ b/tests/test_spatial_extent.py
@@ -1,0 +1,168 @@
+"""Unit coverage for the shared authoritative-extent contract."""
+
+from dataclasses import dataclass
+
+import pytest
+
+from ras_commander._spatial_extent import (
+    _normalize_extent_bounds,
+    _normalize_extent_geometry,
+)
+from ras_commander._land_classification_helper import normalize_restrict_to_extent
+
+
+@dataclass
+class _BoundsObject:
+    left: float
+    bottom: float
+    right: float
+    top: float
+
+
+class _FakeRasMapperExtent:
+    """Portable stand-in exposing the RasMapperLib.Extent coordinate contract."""
+
+    def __init__(self, min_x, min_y, max_x, max_y):
+        self.MinX = min_x
+        self.MinY = min_y
+        self.MaxX = max_x
+        self.MaxY = max_y
+
+
+@pytest.mark.parametrize(
+    "extent",
+    [
+        (1, 2, 5, 8),
+        [1, 2, 5, 8],
+        {"xmin": 1, "ymin": 2, "xmax": 5, "ymax": 8},
+        {"left": 1, "bottom": 2, "right": 5, "top": 8},
+        _BoundsObject(1, 2, 5, 8),
+        _FakeRasMapperExtent(1, 2, 5, 8),
+    ],
+)
+def test_legacy_bounds_shapes_normalize_consistently(extent):
+    assert _normalize_extent_bounds(extent) == (1.0, 2.0, 5.0, 8.0)
+
+
+def test_polygon_and_buffer_derive_expected_bounds():
+    from shapely.geometry import box
+
+    polygon = box(10, 20, 30, 50)
+
+    assert _normalize_extent_bounds(
+        polygon,
+        buffer_distance=5.0,
+    ) == (5.0, 15.0, 35.0, 55.0)
+
+
+def test_land_classification_regression_normalizer_accepts_polygon_unchanged():
+    from shapely.geometry import box
+
+    assert normalize_restrict_to_extent(box(0, 0, 1, 1)) == (
+        0.0,
+        0.0,
+        1.0,
+        1.0,
+    )
+
+
+def test_single_effective_part_multipolygon_normalizes_to_polygon():
+    from shapely import from_wkt
+
+    extent = from_wkt(
+        "MULTIPOLYGON (EMPTY, ((0 0, 4 0, 4 3, 0 3, 0 0)))"
+    )
+
+    normalized = _normalize_extent_geometry(extent)
+
+    assert normalized.geom_type == "Polygon"
+    assert normalized.bounds == (0.0, 0.0, 4.0, 3.0)
+
+
+def test_true_multipart_geometry_fails_closed():
+    from shapely.geometry import MultiPolygon, box
+
+    extent = MultiPolygon([box(0, 0, 1, 1), box(3, 3, 4, 4)])
+
+    with pytest.raises(ValueError, match="ambiguous.*found 2"):
+        _normalize_extent_bounds(extent)
+
+
+def test_empty_polygon_fails_explicitly():
+    from shapely.geometry import Polygon
+
+    with pytest.raises(ValueError, match="geometry is empty"):
+        _normalize_extent_bounds(Polygon())
+
+
+def test_invalid_polygon_fails_explicitly():
+    from shapely.geometry import Polygon
+
+    bowtie = Polygon([(0, 0), (2, 2), (0, 2), (2, 0), (0, 0)])
+
+    with pytest.raises(ValueError, match="geometry is invalid"):
+        _normalize_extent_bounds(bowtie)
+
+
+@pytest.mark.parametrize("geometry_type", ["Point", "LineString", "GeometryCollection"])
+def test_non_polygon_geometry_fails_explicitly(geometry_type):
+    from shapely.geometry import GeometryCollection, LineString, Point
+
+    geometries = {
+        "Point": Point(0, 0),
+        "LineString": LineString([(0, 0), (1, 1)]),
+        "GeometryCollection": GeometryCollection([Point(0, 0)]),
+    }
+
+    with pytest.raises(ValueError, match=rf"got {geometry_type}"):
+        _normalize_extent_bounds(geometries[geometry_type])
+
+
+def test_one_effective_geodataframe_geometry_is_supported():
+    geopandas = pytest.importorskip("geopandas")
+    from shapely.geometry import Polygon, box
+
+    extent = geopandas.GeoDataFrame(
+        geometry=[Polygon(), box(1, 2, 5, 8)],
+        crs="EPSG:2271",
+    )
+
+    assert _normalize_extent_bounds(extent) == (1.0, 2.0, 5.0, 8.0)
+
+
+def test_rasmapper_extent_can_be_rebuilt_after_buffering():
+    source = _FakeRasMapperExtent(1, 2, 5, 8)
+
+    normalized = _normalize_extent_bounds(
+        source,
+        buffer_distance=1.0,
+        extent_cls=_FakeRasMapperExtent,
+    )
+
+    assert isinstance(normalized, _FakeRasMapperExtent)
+    assert (normalized.MinX, normalized.MinY, normalized.MaxX, normalized.MaxY) == (
+        0.0,
+        1.0,
+        6.0,
+        9.0,
+    )
+
+
+@pytest.mark.parametrize(
+    "extent",
+    [
+        (0, 0, 0, 1),
+        (0, 0, float("nan"), 1),
+        {"xmin": 0, "ymin": 0, "xmax": 1},
+    ],
+)
+def test_invalid_legacy_bounds_fail_explicitly(extent):
+    with pytest.raises(ValueError, match="bounds|must be"):
+        _normalize_extent_bounds(extent)
+
+
+def test_buffer_that_erases_polygon_fails_explicitly():
+    from shapely.geometry import box
+
+    with pytest.raises(ValueError, match="buffer_distance=-1.0 produced an unusable"):
+        _normalize_extent_bounds(box(0, 0, 1, 1), buffer_distance=-1.0)

--- a/tests/test_usgs3dep_logging.py
+++ b/tests/test_usgs3dep_logging.py
@@ -81,7 +81,12 @@ def test_list_projects_logs_summary_and_projects_at_debug(monkeypatch, caplog):
     monkeypatch.setattr(
         Usgs3depAws,
         "find_tiles_for_bbox",
-        staticmethod(lambda bbox, resolution, cache_folder=None: projects.copy()),
+        staticmethod(
+            lambda bbox,
+            resolution,
+            cache_folder=None,
+            buffer_distance=0.0: projects.copy()
+        ),
     )
     caplog.set_level(logging.DEBUG, logger=usgs_module.logger.name)
 


### PR DESCRIPTION
## Summary

- Adds shared polygon-aware extent normalization for raster/input workflows.
- Preserves legacy tuple/list, dict/object, and RasMapper-style `Extent` inputs.
- Accepts valid single polygons and single-effective-part multipolygons; fails closed on true multipart, empty, invalid, or non-polygon geometries.
- Adds explicit `buffer_distance=0.0` defaults and routes land-cover, soils, terrain/3DEP, and AORC precipitation extent handling through the shared contract.
- Documents registration-only APIs as out of scope and includes the downstream ras-agent / Spring Creek validation plan for CLB-903.

## Root cause and impact

`normalize_restrict_to_extent()` only recognized bounds-shaped values, so an authoritative Shapely basin polygon failed before rasterization. Callers can now preserve that polygon through Commander while lower-level raster/native operations receive deterministic buffered bounds.

## Validation

- Targeted acceptance suite: **121 passed, 5 skipped, 2 unrelated xarray/NumPy deprecation warnings**.
- Land-cover and soils integration assertions verify polygon + buffer output bounds and legacy bounds compatibility.
- Production-style `mkdocs build`: exit 0; existing unprepared-notebook link warnings remain.
- Strict docs mode reaches the known repository-wide notebook-link warning debt (139 warnings); no warning originates from the changed spatial-data page.
- Full `python -m pytest -q` exceeded the local 10-minute capture window, so its final result was unavailable; GitHub CI is the authoritative full-suite gate.

## Downstream CLB-903 gate

CLB-903 should remain blocked until ras-agent consumes this Commander fix and Spring Creek is rerun with the basin polygon passed unchanged into the Commander API, proving final Manning/CN arrays are solver-ready.

Closes #295.
Refs CLB-958.
Blocks CLB-903.