### PR TITLE
Fix HEC-RAS TCU acceptance false positives

### DIFF
--- a/ras_commander/RasTcu.py
+++ b/ras_commander/RasTcu.py
@@ -56,6 +56,7 @@ _VB_ROOT = r"Software\VB and VBA Program Settings"
 # Direct child sections of the per-version node that hold user-specific data.
 # Cleared when copying a donor unless keep_personal=True.
 _PERSONAL_SECTIONS = ("Projects", "Form Position")
+_PERSONAL_SECTION_NAMES = {section.casefold() for section in _PERSONAL_SECTIONS}
 
 HEC_TERMS_URL = "https://www.hec.usace.army.mil/software/hec-ras/"
 
@@ -71,7 +72,8 @@ class TcuStatus:
         install_dir: Folder containing Ras.exe, if resolved.
         registry_key: The per-version HKCU subkey that gates the TCU.
         reason: Short machine-readable reason
-            ("accepted" | "no-vb6-subtree" | "not-windows" | "version-unresolved").
+            ("accepted" | "no-vb6-subtree" | "personal-only-vb6-subtree" |
+            "seeded-unverified" | "not-windows" | "version-unresolved").
     """
 
     accepted: Optional[bool]
@@ -126,12 +128,37 @@ class RasTcu:
         return "ras" if str(label).strip().startswith("4") else "ras.exe"
 
     @staticmethod
-    def _node_has_subkeys(hive, subkey: str) -> bool:
+    def _node_exists(hive, subkey: str) -> bool:
+        import winreg
+
+        try:
+            with winreg.OpenKey(hive, subkey):
+                return True
+        except OSError:
+            return False
+
+    @staticmethod
+    def _node_has_acceptance_state(hive, subkey: str) -> bool:
+        """Return True only for a VB6 settings node that is not merely personal MRU state.
+
+        HEC-RAS stores recent projects and window layout under child sections such as
+        ``Projects`` and ``Form Position``. Those sections can exist without the TCU
+        having been accepted for the target version, and copying only those sections
+        can produce a false positive. Treat a node as acceptance-bearing only when it
+        has root values or at least one non-personal child section.
+        """
         import winreg
 
         try:
             with winreg.OpenKey(hive, subkey) as key:
-                return winreg.QueryInfoKey(key)[0] > 0
+                n_sub, n_val, _ = winreg.QueryInfoKey(key)
+                if n_val > 0:
+                    return True
+                for idx in range(n_sub):
+                    child = winreg.EnumKey(key, idx)
+                    if child.casefold() not in _PERSONAL_SECTION_NAMES:
+                        return True
+                return False
         except OSError:
             return False
 
@@ -174,8 +201,10 @@ class RasTcu:
 
         for node in ("ras.exe", "ras"):
             subkey = f"{_VB_ROOT}\\{install_dir}\\{node}"
-            if RasTcu._node_has_subkeys(winreg.HKEY_CURRENT_USER, subkey):
+            if RasTcu._node_has_acceptance_state(winreg.HKEY_CURRENT_USER, subkey):
                 return TcuStatus(True, version, install_dir, subkey, "accepted")
+            if RasTcu._node_exists(winreg.HKEY_CURRENT_USER, subkey):
+                return TcuStatus(False, version, install_dir, subkey, "personal-only-vb6-subtree")
 
         target = f"{_VB_ROOT}\\{install_dir}\\{RasTcu._node_name_for(version, install_dir)}"
         return TcuStatus(False, version, install_dir, target, "no-vb6-subtree")
@@ -204,7 +233,7 @@ class RasTcu:
                     idx += 1
                     for node in ("ras.exe", "ras"):
                         candidate = f"{vb_parent}\\{ver}\\{node}"
-                        if RasTcu._node_has_subkeys(hive, candidate):
+                        if RasTcu._node_has_acceptance_state(hive, candidate):
                             yield candidate
         except OSError:
             return
@@ -307,7 +336,8 @@ class RasTcu:
         Returns:
             TcuStatus reflecting the state after the operation (``reason`` is
             "accepted", "already-accepted", "no-donor-available", "not-windows",
-            or "version-unresolved").
+            "version-unresolved", "personal-only-vb6-subtree", or
+            "seeded-unverified").
         """
         pre = RasTcu.status(ras_object, ras_version)
         if pre.accepted is True:
@@ -326,7 +356,9 @@ class RasTcu:
         if donor_key is None:
             logger.warning(
                 "Cannot auto-accept the HEC-RAS %s TCU: no already-accepted HEC-RAS "
-                "settings exist on this machine to replicate. Open HEC-RAS %s once and "
+                "settings exist on this machine to replicate. MRU-only settings such as "
+                "Projects/Form Position are intentionally ignored because they do not "
+                "prove TCU acceptance. Open HEC-RAS %s once and "
                 "click \"I Agree\" (see RasTcu.open_gui_to_accept), or run the provisioning "
                 "script Set-HecRasTcuAccepted.ps1. Terms: %s",
                 pre.version, pre.version, HEC_TERMS_URL,
@@ -349,6 +381,16 @@ class RasTcu:
                 "acceptance into HKCU\\%s", pre.version, len(writes), target_key,
             )
             return TcuStatus(False, pre.version, install_dir, target_key, "no-vb6-subtree")
+
+        if not RasTcu._node_has_acceptance_state(winreg.HKEY_CURRENT_USER, target_key):
+            logger.warning(
+                "Seeded HEC-RAS %s TCU registry data, but the target key still does not "
+                "contain acceptance-bearing state. Refusing to report accepted for "
+                "HKCU\\%s.",
+                pre.version,
+                target_key,
+            )
+            return TcuStatus(None, pre.version, install_dir, target_key, "seeded-unverified")
 
         if write_ack:
             RasTcu._write_ack(pre.version, install_dir, target_key)

--- a/tests/test_rastcu.py
+++ b/tests/test_rastcu.py
@@ -5,6 +5,7 @@ internal helpers that touch winreg, so they run on any platform.
 """
 
 import logging
+import sys
 
 import pytest
 
@@ -55,12 +56,15 @@ def test_status_version_unresolved(monkeypatch):
     assert status.reason == "version-unresolved"
 
 
-def test_status_accepted_when_node_has_subkeys(monkeypatch):
+def test_status_accepted_when_node_has_acceptance_state(monkeypatch):
     monkeypatch.setattr("os.name", "nt")
     monkeypatch.setattr(RasTcu, "_resolve_exe", staticmethod(lambda *a, **k: _EXE))
-    # Pretend winreg is importable and the ras.exe node has subkeys.
-    monkeypatch.setitem(__import__("sys").modules, "winreg", _FakeWinregModule())
-    monkeypatch.setattr(RasTcu, "_node_has_subkeys", staticmethod(lambda hive, sub: sub.endswith(r"\ras.exe")))
+    monkeypatch.setitem(sys.modules, "winreg", _FakeWinregModule())
+    monkeypatch.setattr(
+        RasTcu,
+        "_node_has_acceptance_state",
+        staticmethod(lambda hive, sub: sub.endswith(r"\ras.exe")),
+    )
     status = RasTcu.status(ras_version="6.6")
     assert status.accepted is True
     assert status.reason == "accepted"
@@ -70,12 +74,55 @@ def test_status_accepted_when_node_has_subkeys(monkeypatch):
 def test_status_not_accepted_when_no_subtree(monkeypatch):
     monkeypatch.setattr("os.name", "nt")
     monkeypatch.setattr(RasTcu, "_resolve_exe", staticmethod(lambda *a, **k: _EXE))
-    monkeypatch.setitem(__import__("sys").modules, "winreg", _FakeWinregModule())
-    monkeypatch.setattr(RasTcu, "_node_has_subkeys", staticmethod(lambda hive, sub: False))
+    monkeypatch.setitem(sys.modules, "winreg", _FakeWinregModule())
+    monkeypatch.setattr(RasTcu, "_node_has_acceptance_state", staticmethod(lambda hive, sub: False))
+    monkeypatch.setattr(RasTcu, "_node_exists", staticmethod(lambda hive, sub: False))
     status = RasTcu.status(ras_version="6.6")
     assert status.accepted is False
     assert status.reason == "no-vb6-subtree"
     assert status.install_dir == _INSTALL
+
+
+def test_status_rejects_personal_only_subtree(monkeypatch):
+    monkeypatch.setattr("os.name", "nt")
+    monkeypatch.setattr(RasTcu, "_resolve_exe", staticmethod(lambda *a, **k: _EXE))
+    monkeypatch.setitem(sys.modules, "winreg", _FakeWinregModule())
+    monkeypatch.setattr(RasTcu, "_node_has_acceptance_state", staticmethod(lambda hive, sub: False))
+    monkeypatch.setattr(RasTcu, "_node_exists", staticmethod(lambda hive, sub: sub.endswith(r"\ras.exe")))
+    status = RasTcu.status(ras_version="6.6")
+    assert status.accepted is False
+    assert status.reason == "personal-only-vb6-subtree"
+    assert status.registry_key.endswith(r"HEC-RAS\6.6\ras.exe")
+
+
+def test_node_has_acceptance_state_ignores_projects_only(monkeypatch):
+    fake = _FakeWinregModule(
+        {
+            (1, "node"): {"values": [], "subkeys": ["Projects", "Form Position"]},
+        }
+    )
+    monkeypatch.setitem(sys.modules, "winreg", fake)
+    assert RasTcu._node_has_acceptance_state(fake.HKEY_CURRENT_USER, "node") is False
+
+
+def test_node_has_acceptance_state_accepts_root_values(monkeypatch):
+    fake = _FakeWinregModule(
+        {
+            (1, "node"): {"values": [("Accepted", "1", 1)], "subkeys": ["Projects"]},
+        }
+    )
+    monkeypatch.setitem(sys.modules, "winreg", fake)
+    assert RasTcu._node_has_acceptance_state(fake.HKEY_CURRENT_USER, "node") is True
+
+
+def test_node_has_acceptance_state_accepts_non_personal_child(monkeypatch):
+    fake = _FakeWinregModule(
+        {
+            (1, "node"): {"values": [], "subkeys": ["Projects", "TCU"]},
+        }
+    )
+    monkeypatch.setitem(sys.modules, "winreg", fake)
+    assert RasTcu._node_has_acceptance_state(fake.HKEY_CURRENT_USER, "node") is True
 
 
 def test_is_accepted_wrapper(monkeypatch):
@@ -106,7 +153,7 @@ def test_accept_returns_unknown_off_windows(monkeypatch):
 def test_accept_warns_when_no_donor(monkeypatch, caplog):
     monkeypatch.setattr(RasTcu, "status", staticmethod(
         lambda *a, **k: TcuStatus(False, "6.6", _INSTALL, "key", "no-vb6-subtree")))
-    monkeypatch.setitem(__import__("sys").modules, "winreg", _FakeWinregModule())
+    monkeypatch.setitem(sys.modules, "winreg", _FakeWinregModule())
     monkeypatch.setattr(RasTcu, "_find_donor", staticmethod(lambda install_dir: (None, None)))
     with caplog.at_level(logging.WARNING, logger="ras_commander.RasTcu"):
         result = RasTcu.accept(ras_version="6.6")
@@ -118,7 +165,7 @@ def test_accept_dry_run_does_not_write(monkeypatch):
     monkeypatch.setattr(RasTcu, "status", staticmethod(
         lambda *a, **k: TcuStatus(False, "6.6", _INSTALL, "key", "no-vb6-subtree")))
     fake = _FakeWinregModule()
-    monkeypatch.setitem(__import__("sys").modules, "winreg", fake)
+    monkeypatch.setitem(sys.modules, "winreg", fake)
     monkeypatch.setattr(RasTcu, "_find_donor", staticmethod(lambda install_dir: (fake.HKEY_CURRENT_USER, "donor\\path")))
 
     copied = {"writes": 0}
@@ -139,11 +186,12 @@ def test_accept_success_records_acceptance(monkeypatch):
     monkeypatch.setattr(RasTcu, "status", staticmethod(
         lambda *a, **k: TcuStatus(False, "6.6", _INSTALL, "key", "no-vb6-subtree")))
     fake = _FakeWinregModule()
-    monkeypatch.setitem(__import__("sys").modules, "winreg", fake)
+    monkeypatch.setitem(sys.modules, "winreg", fake)
     monkeypatch.setattr(RasTcu, "_find_donor", staticmethod(lambda install_dir: (fake.HKEY_CURRENT_USER, "donor")))
     monkeypatch.setattr(RasTcu, "_copy_key", staticmethod(
         lambda *a, **k: a[4].append("one")))  # writes list is 5th positional arg
     monkeypatch.setattr(RasTcu, "_clear_values", staticmethod(lambda *a, **k: None))
+    monkeypatch.setattr(RasTcu, "_node_has_acceptance_state", staticmethod(lambda *a, **k: True))
     acks = []
     monkeypatch.setattr(RasTcu, "_write_ack", staticmethod(lambda *a, **k: acks.append(a)))
     result = RasTcu.accept(ras_version="6.6")
@@ -152,11 +200,64 @@ def test_accept_success_records_acceptance(monkeypatch):
     assert len(acks) == 1  # audit record written
 
 
+def test_accept_does_not_report_success_when_seeded_state_is_unverified(monkeypatch):
+    monkeypatch.setattr(RasTcu, "status", staticmethod(
+        lambda *a, **k: TcuStatus(False, "6.6", _INSTALL, "key", "personal-only-vb6-subtree")))
+    fake = _FakeWinregModule()
+    monkeypatch.setitem(sys.modules, "winreg", fake)
+    monkeypatch.setattr(RasTcu, "_find_donor", staticmethod(lambda install_dir: (fake.HKEY_CURRENT_USER, "donor")))
+    monkeypatch.setattr(RasTcu, "_copy_key", staticmethod(
+        lambda *a, **k: a[4].append("one")))  # writes list is 5th positional arg
+    monkeypatch.setattr(RasTcu, "_clear_values", staticmethod(lambda *a, **k: None))
+    monkeypatch.setattr(RasTcu, "_node_has_acceptance_state", staticmethod(lambda *a, **k: False))
+    acks = []
+    monkeypatch.setattr(RasTcu, "_write_ack", staticmethod(lambda *a, **k: acks.append(a)))
+    result = RasTcu.accept(ras_version="6.6")
+    assert result.accepted is None
+    assert result.reason == "seeded-unverified"
+    assert acks == []
+
+
 # --------------------------------------------------------------------------- #
 # Minimal fake winreg (only what RasTcu references at import points)
 # --------------------------------------------------------------------------- #
+class _FakeKey:
+    def __init__(self, data):
+        self.data = data
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        return False
+
+
 class _FakeWinregModule:
     HKEY_CURRENT_USER = 1
     HKEY_USERS = 2
     KEY_SET_VALUE = 0x0002
     KEY_ALL_ACCESS = 0xF003F
+
+    def __init__(self, registry=None):
+        self.registry = registry or {}
+
+    def OpenKey(self, hive, subkey, *_args):
+        try:
+            return _FakeKey(self.registry[(hive, subkey)])
+        except KeyError as exc:
+            raise OSError(subkey) from exc
+
+    def QueryInfoKey(self, key):
+        return (len(key.data.get("subkeys", [])), len(key.data.get("values", [])), None)
+
+    def EnumKey(self, key, index):
+        try:
+            return key.data.get("subkeys", [])[index]
+        except IndexError as exc:
+            raise OSError(index) from exc
+
+    def EnumValue(self, key, index):
+        try:
+            return key.data.get("values", [])[index]
+        except IndexError as exc:
+            raise OSError(index) from exc


### PR DESCRIPTION
## Summary
- Treat HEC-RAS VB6 registry nodes containing only `Projects` / `Form Position` as personal MRU/window-layout state, not TCU acceptance.
- Ignore those personal-only nodes when selecting an acceptance donor.
- Verify the target after seeding and refuse to report `accepted` if no acceptance-bearing state exists.

## Why
CLB-903 Spring Creek testing showed `RasTcu.accept(ras_version="6.6")` could return accepted while HEC-RAS 6.6 still opened the TCU dialog. The target registry subtree existed, but only contained personal/MRU sections, which are insufficient to suppress TCU.

## Validation
- `python -m pytest tests/test_rastcu.py -q` — 21 passed
- `python -m ruff check ras_commander/RasTcu.py tests/test_rastcu.py` — passed