### PR TITLE
Finalize Example Project Library viewer and publisher

### DIFF
--- a/docs/assets/javascripts/ras-maplibre-viewer.js
+++ b/docs/assets/javascripts/ras-maplibre-viewer.js
@@ -5,7 +5,7 @@
   }
 
   const DEFAULT_BOUNDS = [-85.3942, 40.1896, -85.3601, 40.2057];
-  const VIEWER_MANIFEST_REFRESH = "20260723Tvector-results01";
+  const VIEWER_MANIFEST_REFRESH = "20260724Tlibrary-final03";
   const SATELLITE_ATTRIBUTION = "Tiles &copy; Esri";
   const SATELLITE_IMAGERY_TILES = [
     "https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}",
@@ -16,6 +16,11 @@
   const HYBRID_TRANSPORTATION_TILES = [
     "https://server.arcgisonline.com/ArcGIS/rest/services/Reference/World_Transportation/MapServer/tile/{z}/{y}/{x}",
   ];
+  const OPTIONAL_BASEMAP_SOURCE_IDS = new Set([
+    "satellite-imagery",
+    "hybrid-boundaries",
+    "hybrid-transportation",
+  ]);
   const DEFAULT_STYLES = {
     model_extents: { fill: "#f59e0b", fillOpacity: 0.08, line: "#ea580c", lineWidth: 2 },
     mesh_areas: { fill: "#60a5fa", fillOpacity: 0.1, line: "#1d4ed8", lineWidth: 1 },
@@ -2082,6 +2087,21 @@
       return semanticTreeLayerIds(node).includes(interactionState.activeLayerId);
     }
 
+    function shouldOpenNode(node, isRoot) {
+      if (openNodeIds.has(node.id)) {
+        return true;
+      }
+      if (!containsActive(node)) {
+        return false;
+      }
+      if (!isRoot || !window.matchMedia("(max-width: 760px)").matches) {
+        return true;
+      }
+      return !Array.from(rootIds).some((rootId) => (
+        rootId !== node.id && openNodeIds.has(rootId)
+      ));
+    }
+
     function initializeOpenState(node, depth) {
       if (containsActive(node) || (depth === 0 && node.id === "geometries")) {
         openNodeIds.add(node.id);
@@ -2279,7 +2299,8 @@
       const details = document.createElement("details");
       details.className = isRoot ? "ras-tree-root" : "ras-tree-branch";
       details.dataset.treeNodeId = node.id;
-      details.open = openNodeIds.has(node.id) || containsActive(node);
+      details.dataset.treeCurrent = "true";
+      details.open = shouldOpenNode(node, isRoot);
 
       const summary = document.createElement("summary");
       const disclosure = document.createElement("span");
@@ -2328,13 +2349,33 @@
         children.append(renderBranch(child, depth + 1, false));
       }
       details.append(summary, children);
+      summary.addEventListener("click", () => {
+        if (details.open) {
+          openNodeIds.delete(node.id);
+          return;
+        }
+        openNodeIds.add(node.id);
+        if (isRoot && window.matchMedia("(max-width: 760px)").matches) {
+          for (const sibling of list.querySelectorAll("details.ras-tree-root[open]")) {
+            if (sibling !== details && sibling.dataset.treeNodeId) {
+              openNodeIds.delete(sibling.dataset.treeNodeId);
+            }
+          }
+        }
+      });
       details.addEventListener("toggle", () => {
+        if (details.dataset.treeCurrent !== "true" || !details.isConnected) {
+          return;
+        }
         if (details.open) {
           openNodeIds.add(node.id);
           if (isRoot && window.matchMedia("(max-width: 760px)").matches) {
             for (const sibling of list.querySelectorAll("details.ras-tree-root[open]")) {
               if (sibling !== details) {
                 sibling.open = false;
+                if (sibling.dataset.treeNodeId) {
+                  openNodeIds.delete(sibling.dataset.treeNodeId);
+                }
               }
             }
           }
@@ -2357,6 +2398,9 @@
     }
 
     function render() {
+      for (const details of list.querySelectorAll("details[data-tree-node-id]")) {
+        details.dataset.treeCurrent = "false";
+      }
       list.replaceChildren();
       const modelColumn = makeColumn("model", "Model Data");
       const resultColumn = makeColumn("results", "Surfaces and Results");
@@ -2637,6 +2681,10 @@
 
     map.on("error", (event) => {
       const message = event && event.error ? event.error.message : "Map error";
+      if (OPTIONAL_BASEMAP_SOURCE_IDS.has(event?.sourceId)) {
+        console.warn(`Optional basemap tile unavailable: ${event.sourceId}`, event.error);
+        return;
+      }
       status(root, message);
     });
   }

--- a/docs/assets/stylesheets/ras-example-library.css
+++ b/docs/assets/stylesheets/ras-example-library.css
@@ -162,4 +162,62 @@
     align-items: flex-start;
     flex-direction: column;
   }
+
+  .ras-library-table-wrap {
+    overflow: visible;
+    border: 0;
+    border-radius: 0;
+  }
+
+  .ras-library-table,
+  .ras-library-table tbody,
+  .ras-library-table tr,
+  .ras-library-table td {
+    display: block;
+    width: 100%;
+    min-width: 0;
+  }
+
+  .ras-library-table {
+    min-width: 0;
+  }
+
+  .ras-library-table thead {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0 0 0 0);
+    clip-path: inset(50%);
+    white-space: nowrap;
+    border: 0;
+  }
+
+  .ras-library-table tbody tr {
+    margin-bottom: 0.65rem;
+    padding: 0.65rem 0.7rem;
+    border: 1px solid var(--ras-library-border);
+    border-radius: 6px;
+  }
+
+  .ras-library-table th,
+  .ras-library-table td,
+  .ras-library-table td:first-child,
+  .ras-library-table td:nth-child(3) {
+    width: 100%;
+    min-width: 0;
+    padding: 0;
+    border: 0;
+  }
+
+  .ras-library-table td + td {
+    margin-top: 0.45rem;
+  }
+
+  .ras-library-table td:nth-child(3)::before {
+    content: "HEC-RAS version: ";
+    font-weight: 700;
+  }
 }

--- a/docs/assets/stylesheets/ras-maplibre-viewer.css
+++ b/docs/assets/stylesheets/ras-maplibre-viewer.css
@@ -795,9 +795,12 @@ details[open] > summary > .ras-tree-node__disclosure::before {
 
 .ras-layer-status {
   flex: 0 0 auto;
+  max-width: 18rem;
+  overflow: hidden;
   color: var(--ras-muted);
   font-size: 0.7rem;
   line-height: 1.25;
+  text-overflow: ellipsis;
   white-space: nowrap;
 }
 
@@ -952,6 +955,25 @@ details[open] > summary > .ras-tree-node__disclosure::before {
   justify-content: space-between;
   gap: 0.45rem;
   font-weight: 700;
+}
+
+.ras-identify-popup dl.ras-identify-raster-list {
+  grid-template-columns: minmax(0, 1fr);
+  gap: 0.08rem;
+}
+
+.ras-identify-raster-list dt:not(:first-child) {
+  margin-top: 0.32rem;
+}
+
+.ras-identify-raster-list dd > span:first-child {
+  flex: 0 0 auto;
+  white-space: nowrap;
+}
+
+.ras-identify-raster-list dd .ras-identify-source {
+  min-width: 0;
+  overflow-wrap: normal;
 }
 
 .ras-identify-source {

--- a/docs/examples/example-project-viewer.md
+++ b/docs/examples/example-project-viewer.md
@@ -6,9 +6,9 @@ hide:
 ---
 
 <link rel="stylesheet" href="https://unpkg.com/maplibre-gl@5.6.0/dist/maplibre-gl.css">
-<link rel="stylesheet" href="../../assets/stylesheets/ras-maplibre-viewer.css?v=20260723Tvector-results01">
+<link rel="stylesheet" href="../../assets/stylesheets/ras-maplibre-viewer.css?v=20260724Tlibrary-final03">
 
-<div class="ras-maplibre-viewer" data-ras-maplibre-viewer data-manifest="https://rascommander.info/data/rasexamples/hec-ras-7.0/projects/muncie-muncie-rerun-7-0-20260628-193916-4120d261/viewer/manifest.json?v=20260723Tvector-results01">
+<div class="ras-maplibre-viewer" data-ras-maplibre-viewer data-manifest="https://rascommander.info/data/rasexamples/hec-ras-7.0/projects/muncie-muncie-rerun-7-0-20260628-193916-4120d261/viewer/manifest.json?v=20260724Tlibrary-final03">
   <div class="ras-viewer-topbar">
     <a class="ras-back-link" href="../example-projects/">&larr; Example Projects</a>
     <div class="ras-viewer-title">
@@ -38,4 +38,4 @@ hide:
 <script src="https://unpkg.com/pmtiles@4.3.0/dist/pmtiles.js"></script>
 <script src="https://unpkg.com/proj4@2.11.0/dist/proj4.js"></script>
 <script src="https://unpkg.com/geotiff@2.1.3/dist-browser/geotiff.js"></script>
-<script src="../../assets/javascripts/ras-maplibre-viewer.js?v=20260723Tvector-results01"></script>
+<script src="../../assets/javascripts/ras-maplibre-viewer.js?v=20260724Tlibrary-final03"></script>

--- a/docs/examples/example-projects.md
+++ b/docs/examples/example-projects.md
@@ -1,7 +1,7 @@
 # Example Project Library
 
 <link rel="stylesheet" href="https://unpkg.com/maplibre-gl@5.6.0/dist/maplibre-gl.css">
-<link rel="stylesheet" href="../../assets/stylesheets/ras-example-library.css?v=20260723Ttechnical-library01">
+<link rel="stylesheet" href="../../assets/stylesheets/ras-example-library.css?v=20260724Tlibrary-final03">
 
 Explore HEC tutorial projects and organized public model releases used throughout
 the RAS Commander examples. Select a model area on the map or open a project
@@ -9,7 +9,7 @@ below to review its geometry, terrain, and results.
 
 ## Project Explorer
 
-<div class="ras-example-library" data-ras-example-library data-index="https://rascommander.info/data/rasexamples/hec-ras-7.0/example-projects.geojson?v=20260723Ttechnical-library01">
+<div class="ras-example-library" data-ras-example-library data-index="https://rascommander.info/data/rasexamples/hec-ras-7.0/example-projects.geojson?v=20260724Tlibrary-final03">
   <div class="ras-library-map-shell">
     <div class="ras-library-map" data-library-map></div>
   </div>
@@ -32,9 +32,9 @@ below to review its geometry, terrain, and results.
 
 <script src="https://unpkg.com/maplibre-gl@5.6.0/dist/maplibre-gl.js"></script>
 <script src="https://unpkg.com/pmtiles@4.3.0/dist/pmtiles.js"></script>
-<script src="../../assets/javascripts/ras-example-project-profiles.js?v=20260723Ttechnical-library01"></script>
-<script src="../../assets/javascripts/ras-example-projects-data.js?v=20260723Ttechnical-library01"></script>
-<script src="../../assets/javascripts/ras-example-library.js?v=20260723Tscale-aware-pins01"></script>
+<script src="../../assets/javascripts/ras-example-project-profiles.js?v=20260724Tlibrary-final03"></script>
+<script src="../../assets/javascripts/ras-example-projects-data.js?v=20260724Tlibrary-final03"></script>
+<script src="../../assets/javascripts/ras-example-library.js?v=20260724Tlibrary-final03"></script>
 
 ## Related Workflows
 

--- a/scripts/example_library/clb03_rascommander_webgis_publisher.sh
+++ b/scripts/example_library/clb03_rascommander_webgis_publisher.sh
@@ -9,6 +9,12 @@ readonly KNOWN_HOSTS="/root/.ssh/rascommander-webgis-known_hosts"
 readonly WEBGIS_HOST="192.168.3.3"
 readonly WEBGIS_USER="rascommander-publish"
 readonly PUBLISHER="/usr/local/sbin/rascommander-webgis-publish"
+readonly SERVICE_KEY_PATH="/root/.ssh/clb-webgis-promote-ed25519"
+readonly RASTER_CT_ID="230"
+readonly VERSION_ROOT="hec-ras-7.0"
+readonly WEBGIS_DATA_ROOT="/webgis_ssd_mirror/rascommander-webgis/data/rasexamples/${VERSION_ROOT}"
+readonly CT_DATA_ROOT="/var/www/rascommander-webgis/data/rasexamples/${VERSION_ROOT}"
+readonly RASTER_SERVICE_URL="http://127.0.0.1:8087/ras-raster/health"
 
 usage() {
     printf 'Usage: %s --release-dir /mnt/pool_12tb/rascommander-webgis-staging/<release>\n' "$0" >&2
@@ -29,7 +35,6 @@ require_release_dir() {
 verify_manifest() {
     local release_dir="$1"
     python3 - "$release_dir" <<'PY'
-import hashlib
 import json
 import sys
 from pathlib import Path, PurePosixPath
@@ -43,12 +48,21 @@ if not payload_root.is_dir() or payload_root.is_symlink():
     raise SystemExit(f"Missing regular payload directory: {payload_root}")
 
 manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
-if manifest.get("schemaVersion") != 1 or not isinstance(manifest.get("files"), list):
+schema_version = manifest.get("schemaVersion")
+if schema_version == 1:
+    integrity = "sha256"
+elif schema_version == 2:
+    integrity = manifest.get("integrity")
+else:
+    raise SystemExit("Unsupported or malformed release manifest")
+if integrity not in {"size", "sha256"} or not isinstance(manifest.get("files"), list):
     raise SystemExit("Unsupported or malformed release manifest")
 
 expected: set[Path] = set()
 
 def sha256(path: Path) -> str:
+    import hashlib
+
     digest = hashlib.sha256()
     with path.open("rb") as file_handle:
         for block in iter(lambda: file_handle.read(1024 * 1024), b""):
@@ -66,8 +80,9 @@ for entry in manifest["files"]:
     path = release_dir.joinpath(*relative.parts)
     if not path.is_file() or path.is_symlink():
         raise SystemExit(f"Missing regular artifact file: {relative}")
-    digest = sha256(path)
-    if digest != entry.get("sha256") or path.stat().st_size != entry.get("bytes"):
+    if path.stat().st_size != entry.get("bytes"):
+        raise SystemExit(f"Artifact does not match manifest: {relative}")
+    if integrity == "sha256" and sha256(path) != entry.get("sha256"):
         raise SystemExit(f"Artifact does not match manifest: {relative}")
     expected.add(path.relative_to(release_dir))
 
@@ -80,8 +95,175 @@ if actual != expected:
     missing = sorted(str(path) for path in expected - actual)
     unexpected = sorted(str(path) for path in actual - expected)
     raise SystemExit(f"Manifest mismatch; missing={missing}, unexpected={unexpected}")
-print(f"Verified {len(expected)} RAS example artifacts against the release manifest.")
+print(
+    f"Verified {len(expected)} RAS example artifacts "
+    f"against the {integrity} release inventory."
+)
 PY
+}
+
+rsync_artifacts() {
+    rsync \
+        --archive \
+        --no-owner \
+        --no-group \
+        --no-perms \
+        --chmod=Du=rwx,Dg=rwx,Do=rx,Fu=rw,Fg=rw,Fo=r \
+        --omit-dir-times \
+        --itemize-changes \
+        -e "ssh -i ${KEY_PATH} -o IdentitiesOnly=yes -o BatchMode=yes -o StrictHostKeyChecking=yes -o UserKnownHostsFile=${KNOWN_HOSTS}" \
+        "$@"
+}
+
+webgis_exec() {
+    local remote_command
+    printf -v remote_command '%q ' "$@"
+    if [[ ! -s $SERVICE_KEY_PATH ]]; then
+        printf 'Missing WebGIS service-control key: %s\n' "$SERVICE_KEY_PATH" >&2
+        return 1
+    fi
+    ssh \
+        -i "$SERVICE_KEY_PATH" \
+        -o IdentitiesOnly=yes \
+        -o BatchMode=yes \
+        -o StrictHostKeyChecking=yes \
+        -o UserKnownHostsFile="$KNOWN_HOSTS" \
+        "root@${WEBGIS_HOST}" \
+        "$remote_command"
+}
+
+raster_catalog_asset_count() {
+    python3 - "$1" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+document = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+assets = document.get("assets")
+if document.get("schema") != "rascommander.raster-assets/v1" or not isinstance(assets, dict):
+    raise SystemExit("Unsupported or malformed raster asset catalog")
+print(len(assets))
+PY
+}
+
+validate_raster_catalog_candidate() {
+    local expected_assets="$1"
+    local observed_assets
+    observed_assets="$(
+        webgis_exec \
+            pct exec "$RASTER_CT_ID" -- \
+            /opt/ras2cng/.venv/bin/python -c \
+            'from pathlib import Path; from ras2cng.webgis_service import RasterAssetCatalog; print(len(RasterAssetCatalog.load(Path(__import__("sys").argv[1]), Path(__import__("sys").argv[2])).assets))' \
+            "${CT_DATA_ROOT}/raster-assets.json.candidate" \
+            "$CT_DATA_ROOT"
+    )"
+    if [[ $observed_assets != "$expected_assets" ]]; then
+        printf 'Candidate raster catalog exposes %s assets; expected %s.\n' \
+            "$observed_assets" "$expected_assets" >&2
+        return 1
+    fi
+    printf 'Validated candidate raster catalog and %s referenced COGs.\n' \
+        "$expected_assets"
+}
+
+raster_service_ready() {
+    local expected_assets="$1"
+    local health
+    health="$(
+        webgis_exec \
+            pct exec "$RASTER_CT_ID" -- \
+            curl --fail --silent --show-error "$RASTER_SERVICE_URL" \
+            2>/dev/null
+    )" || return 1
+    python3 - "$expected_assets" "$health" <<'PY'
+import json
+import sys
+
+expected = int(sys.argv[1])
+try:
+    health = json.loads(sys.argv[2])
+except json.JSONDecodeError:
+    raise SystemExit(1)
+if health.get("status") != "ok" or health.get("assets") != expected:
+    raise SystemExit(1)
+PY
+}
+
+wait_for_raster_service() {
+    local expected_assets="$1"
+    local attempt
+    for attempt in $(seq 1 30); do
+        if raster_service_ready "$expected_assets"; then
+            printf 'Numeric raster service is ready with %s assets.\n' \
+                "$expected_assets"
+            return 0
+        fi
+        sleep 1
+    done
+    return 1
+}
+
+restart_raster_service() {
+    webgis_exec \
+        pct exec "$RASTER_CT_ID" -- \
+        systemctl restart ras2cng-raster.service
+}
+
+report_raster_service_failure() {
+    printf 'Numeric raster service did not become ready; service diagnostics follow.\n' >&2
+    webgis_exec \
+        pct exec "$RASTER_CT_ID" -- \
+        systemctl status ras2cng-raster.service --no-pager --lines=20 \
+        >&2 || true
+    webgis_exec \
+        pct exec "$RASTER_CT_ID" -- \
+        journalctl -u ras2cng-raster.service --no-pager --lines=40 \
+        >&2 || true
+}
+
+promote_raster_catalog() {
+    local raster_catalog="$1"
+    local expected_assets candidate_path live_path backup_path
+    expected_assets="$(raster_catalog_asset_count "$raster_catalog")"
+    candidate_path="${WEBGIS_DATA_ROOT}/raster-assets.json.candidate"
+    live_path="${WEBGIS_DATA_ROOT}/raster-assets.json"
+    backup_path="${WEBGIS_DATA_ROOT}/raster-assets.json.rollback.$$"
+
+    rsync_artifacts \
+        "$raster_catalog" \
+        "${WEBGIS_USER}@${WEBGIS_HOST}:./${VERSION_ROOT}/raster-assets.json.candidate"
+
+    if ! validate_raster_catalog_candidate "$expected_assets"; then
+        webgis_exec rm -f -- "$candidate_path" || true
+        return 1
+    fi
+
+    if webgis_exec test -f "$live_path"; then
+        webgis_exec cp --preserve=mode,ownership,timestamps -- \
+            "$live_path" "$backup_path"
+    else
+        backup_path=""
+    fi
+    webgis_exec mv -f -- "$candidate_path" "$live_path"
+    restart_raster_service
+
+    if wait_for_raster_service "$expected_assets"; then
+        if [[ -n $backup_path ]]; then
+            webgis_exec rm -f -- "$backup_path"
+        fi
+        return 0
+    fi
+
+    report_raster_service_failure
+    if [[ -n $backup_path ]]; then
+        webgis_exec mv -f -- "$backup_path" "$live_path"
+        restart_raster_service || true
+    else
+        webgis_exec rm -f -- "$live_path"
+        restart_raster_service || true
+    fi
+    printf 'Restored the previous raster catalog after failed readiness.\n' >&2
+    return 1
 }
 
 if [[ $# -ne 2 || $1 != "--release-dir" ]]; then
@@ -91,15 +273,33 @@ fi
 release_dir="$(require_release_dir "$2")"
 verify_manifest "$release_dir"
 
-exec rsync \
-    --archive \
-    --checksum \
-    --no-owner \
-    --no-group \
-    --no-perms \
-    --chmod=Du=rwx,Dg=rwx,Do=rx,Fu=rw,Fg=rw,Fo=r \
-    --omit-dir-times \
-    --itemize-changes \
-    -e "ssh -i ${KEY_PATH} -o IdentitiesOnly=yes -o BatchMode=yes -o StrictHostKeyChecking=yes -o UserKnownHostsFile=${KNOWN_HOSTS}" \
+# Publish immutable project artifacts before exposing their catalog entries.
+rsync_artifacts \
+    --exclude="/${VERSION_ROOT}/raster-assets.json" \
+    --exclude="/${VERSION_ROOT}/catalog.json" \
+    --exclude="/${VERSION_ROOT}/example-projects.geojson" \
+    --exclude="/${VERSION_ROOT}/snapshot.json" \
     "${release_dir}/data/rasexamples/" \
     "${WEBGIS_USER}@${WEBGIS_HOST}:./"
+
+raster_catalog="${release_dir}/data/rasexamples/${VERSION_ROOT}/raster-assets.json"
+if [[ -f $raster_catalog ]]; then
+    promote_raster_catalog "$raster_catalog"
+fi
+
+# Expose landing-page metadata only after the raster service recognizes the
+# newly published numeric assets.
+for catalog_name in catalog.json example-projects.geojson snapshot.json; do
+    catalog_path="${release_dir}/data/rasexamples/${VERSION_ROOT}/${catalog_name}"
+    if [[ -f $catalog_path ]]; then
+        rsync_artifacts \
+            "$catalog_path" \
+            "${WEBGIS_USER}@${WEBGIS_HOST}:./${VERSION_ROOT}/${catalog_name}"
+    fi
+done
+
+if [[ -f $raster_catalog ]]; then
+    printf 'Published RAS example artifacts and validated the numeric raster service.\n'
+else
+    printf 'Published RAS example artifacts without changing the numeric raster catalog.\n'
+fi

--- a/scripts/example_library/provision_webgis_raster_service.sh
+++ b/scripts/example_library/provision_webgis_raster_service.sh
@@ -58,6 +58,7 @@ RAS2CNG_RASTER_ROUTE_PREFIX=/ras-raster
 RAS2CNG_RASTER_MAX_VIEW_PIXELS=2097152
 RAS2CNG_RASTER_MAX_VIEW_DIMENSION=4096
 RAS2CNG_RASTER_CACHE_ENTRIES=512
+RAS2CNG_RASTER_MAX_COG_RANGE_BYTES=67108864
 MPLCONFIGDIR=/tmp/matplotlib
 XDG_CACHE_HOME=/tmp/cache
 EOF
@@ -99,6 +100,14 @@ from pathlib import Path
 
 path = Path(sys.argv[1])
 source = path.read_text(encoding="utf-8")
+cache_header = 'add_header Cache-Control "public, max-age=3600" always;'
+range_safe_cache_header = (
+    'add_header Cache-Control "public, max-age=3600, no-transform" always;'
+)
+if range_safe_cache_header not in source:
+    if cache_header not in source:
+        raise SystemExit(f"Expected the artifact cache header in {path}")
+    source = source.replace(cache_header, range_safe_cache_header, 1)
 marker = "# ras2cng numeric raster service"
 if marker not in source:
     needle = "    location / {\n"

--- a/scripts/example_library/publish_webgis_artifacts.py
+++ b/scripts/example_library/publish_webgis_artifacts.py
@@ -9,13 +9,15 @@ promote that release.
 
 The CLB03 publisher is responsible for authenticating to WebGIS with its
 dedicated key.  This script never carries deployment keys, never uses a remote
-shell on WebGIS, and deliberately does not pass ``--delete`` to rsync.
+shell on WebGIS, and deliberately does not pass ``--delete`` to rsync. Release
+inventories validate file sizes by default so large COGs and PMTiles are not
+reread unnecessarily; ``--integrity sha256`` is available for untrusted
+transfers.
 """
 
 from __future__ import annotations
 
 import argparse
-import hashlib
 import json
 import re
 import subprocess
@@ -68,6 +70,8 @@ def validate_remote_path(path: str, *, label: str) -> str:
 
 
 def file_sha256(path: Path) -> str:
+    import hashlib
+
     digest = hashlib.sha256()
     with path.open("rb") as file_handle:
         for block in iter(lambda: file_handle.read(1024 * 1024), b""):
@@ -75,27 +79,35 @@ def file_sha256(path: Path) -> str:
     return digest.hexdigest()
 
 
-def build_manifest(webgis_root: Path, release_id: str) -> dict[str, Any]:
+def build_manifest(
+    webgis_root: Path,
+    release_id: str,
+    *,
+    integrity: str = "size",
+) -> dict[str, Any]:
     """Describe every regular file in the immutable candidate release."""
+    if integrity not in {"size", "sha256"}:
+        raise ValueError(f"Unsupported manifest integrity mode: {integrity!r}")
     files: list[dict[str, Any]] = []
     for path in sorted(webgis_root.rglob("*")):
         if path.is_symlink():
             raise ValueError(f"Symlinks are not publishable WebGIS artifacts: {path}")
         if path.is_file():
             relative_path = (Path("data") / "rasexamples" / webgis_root.name / path.relative_to(webgis_root)).as_posix()
-            files.append(
-                {
-                    "path": relative_path,
-                    "bytes": path.stat().st_size,
-                    "sha256": file_sha256(path),
-                }
-            )
+            entry: dict[str, Any] = {
+                "path": relative_path,
+                "bytes": path.stat().st_size,
+            }
+            if integrity == "sha256":
+                entry["sha256"] = file_sha256(path)
+            files.append(entry)
     if not files:
         raise ValueError(f"No files found beneath WebGIS release root: {webgis_root}")
     return {
-        "schemaVersion": 1,
+        "schemaVersion": 2,
         "releaseId": validate_release_id(release_id),
         "generatedAt": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+        "integrity": integrity,
         "files": files,
     }
 
@@ -136,6 +148,15 @@ def parse_args() -> argparse.Namespace:
         help="Root-owned CLB03 command that validates and promotes one release directory.",
     )
     parser.add_argument(
+        "--integrity",
+        choices=("size", "sha256"),
+        default="size",
+        help=(
+            "Staging inventory validation mode. Size avoids rereading large COGs and PMTiles; "
+            "sha256 is available for untrusted transfers."
+        ),
+    )
+    parser.add_argument(
         "--dry-run",
         action="store_true",
         help="Validate and print commands without changing either remote host.",
@@ -153,7 +174,7 @@ def main() -> None:
         args.release_id
         or f"rasexamples-{datetime.now(timezone.utc).strftime('%Y%m%dT%H%M%SZ')}"
     )
-    manifest = build_manifest(webgis_root, release_id)
+    manifest = build_manifest(webgis_root, release_id, integrity=args.integrity)
     remote_release = f"{clb03_stage_root}/{release_id}"
     with tempfile.TemporaryDirectory(prefix="rascommander-webgis-") as temporary_directory:
         manifest_path = Path(temporary_directory) / "manifest.json"

--- a/tests/test_publish_webgis_artifacts.py
+++ b/tests/test_publish_webgis_artifacts.py
@@ -6,8 +6,16 @@ from pathlib import Path
 import pytest
 
 
-SCRIPT_PATH = Path(__file__).parents[1] / "scripts" / "example_library" / "publish_webgis_artifacts.py"
-SPEC = importlib.util.spec_from_file_location("publish_webgis_artifacts", SCRIPT_PATH)
+SCRIPT_PATH = (
+    Path(__file__).parents[1]
+    / "scripts"
+    / "example_library"
+    / "publish_webgis_artifacts.py"
+)
+SPEC = importlib.util.spec_from_file_location(
+    "publish_webgis_artifacts",
+    SCRIPT_PATH,
+)
 assert SPEC and SPEC.loader
 publisher = importlib.util.module_from_spec(SPEC)
 SPEC.loader.exec_module(publisher)
@@ -16,7 +24,10 @@ SPEC.loader.exec_module(publisher)
 def make_webgis_root(tmp_path: Path) -> Path:
     root = tmp_path / "data" / "rasexamples" / "hec-ras-7.0"
     root.mkdir(parents=True)
-    (root / "example-projects.geojson").write_text('{"type":"FeatureCollection"}\n', encoding="utf-8")
+    (root / "example-projects.geojson").write_text(
+        '{"type":"FeatureCollection"}\n',
+        encoding="utf-8",
+    )
     extent = root / "projects" / "muncie" / "viewer" / "model_extent.geojson"
     extent.parent.mkdir(parents=True)
     extent.write_text('{"type":"FeatureCollection"}\n', encoding="utf-8")
@@ -33,7 +44,10 @@ def test_validate_webgis_root_requires_expected_namespace(tmp_path: Path) -> Non
         publisher.validate_webgis_root(invalid_root)
 
 
-@pytest.mark.parametrize("host", ["CLB03", "clb03.example.internal", "192.168.3.20"])
+@pytest.mark.parametrize(
+    "host",
+    ["CLB03", "clb03.example.internal", "192.168.3.20"],
+)
 def test_validate_remote_host_accepts_hostnames_and_addresses(host: str) -> None:
     assert publisher.validate_remote_host(host) == host
 
@@ -44,7 +58,10 @@ def test_validate_remote_host_rejects_remote_shell_syntax(host: str) -> None:
         publisher.validate_remote_host(host)
 
 
-@pytest.mark.parametrize("path", ["/mnt/pool_12tb/staging", "/usr/local/sbin/publisher"])
+@pytest.mark.parametrize(
+    "path",
+    ["/mnt/pool_12tb/staging", "/usr/local/sbin/publisher"],
+)
 def test_validate_remote_path_accepts_absolute_paths(path: str) -> None:
     assert publisher.validate_remote_path(path, label="test") == path
 
@@ -55,27 +72,66 @@ def test_validate_remote_path_rejects_shell_syntax_and_traversal(path: str) -> N
         publisher.validate_remote_path(path, label="test")
 
 
-@pytest.mark.parametrize("release_id", ["a", "rasexamples-20260713T203000Z", "v1.2_3"])
+@pytest.mark.parametrize(
+    "release_id",
+    ["a", "rasexamples-20260713T203000Z", "v1.2_3"],
+)
 def test_validate_release_id_accepts_safe_values(release_id: str) -> None:
     assert publisher.validate_release_id(release_id) == release_id
 
 
-@pytest.mark.parametrize("release_id", ["", "../escape", "bad space", "-starts-with-punctuation"])
+@pytest.mark.parametrize(
+    "release_id",
+    ["", "../escape", "bad space", "-starts-with-punctuation"],
+)
 def test_validate_release_id_rejects_unsafe_values(release_id: str) -> None:
     with pytest.raises(ValueError):
         publisher.validate_release_id(release_id)
 
 
-def test_build_manifest_is_scoped_to_rasexamples(tmp_path: Path) -> None:
+def test_build_manifest_uses_size_inventory_by_default(tmp_path: Path) -> None:
     root = make_webgis_root(tmp_path)
     manifest = publisher.build_manifest(root, "rasexamples-test")
 
+    assert manifest["schemaVersion"] == 2
     assert manifest["releaseId"] == "rasexamples-test"
+    assert manifest["integrity"] == "size"
     assert [item["path"] for item in manifest["files"]] == [
         "data/rasexamples/hec-ras-7.0/example-projects.geojson",
         "data/rasexamples/hec-ras-7.0/projects/muncie/viewer/model_extent.geojson",
     ]
-    assert all(len(item["sha256"]) == 64 for item in manifest["files"])
+    assert all("sha256" not in item for item in manifest["files"])
+
+
+def test_build_manifest_can_include_sha256(tmp_path: Path) -> None:
+    root = make_webgis_root(tmp_path)
+    manifest = publisher.build_manifest(
+        root,
+        "rasexamples-test",
+        integrity="sha256",
+    )
+
+    assert manifest["integrity"] == "sha256"
+    by_path = {item["path"]: item for item in manifest["files"]}
+    assert by_path[
+        "data/rasexamples/hec-ras-7.0/example-projects.geojson"
+    ]["sha256"] == publisher.file_sha256(root / "example-projects.geojson")
+    assert by_path[
+        "data/rasexamples/hec-ras-7.0/projects/muncie/viewer/model_extent.geojson"
+    ]["sha256"] == publisher.file_sha256(
+        root / "projects" / "muncie" / "viewer" / "model_extent.geojson"
+    )
+
+
+def test_build_manifest_rejects_unknown_integrity_mode(tmp_path: Path) -> None:
+    root = make_webgis_root(tmp_path)
+
+    with pytest.raises(ValueError, match="integrity mode"):
+        publisher.build_manifest(
+            root,
+            "rasexamples-test",
+            integrity="crc32",
+        )
 
 
 def test_build_manifest_rejects_symlinks(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- finalize mobile/desktop Example Project Library and content-aware viewer behavior
- preserve RASMapper-style tree state and improve Identify layout
- make WebGIS publication catalog-first safe with raster readiness and rollback
- use size inventories by default, with optional SHA-256 for untrusted transfers

## Verification
- 22 publisher tests passed, 1 skipped
- JavaScript and shell syntax checks passed
- MkDocs build passed
- Claude Code read-only QA findings were reviewed and addressed or explicitly dispositioned