### PR TITLE
Publish Example Library as immutable WebGIS releases

### DIFF
--- a/docs/assets/javascripts/ras-example-library.js
+++ b/docs/assets/javascripts/ras-example-library.js
@@ -405,7 +405,7 @@
 
     registerPmtilesProtocol();
     const dataUrl = root.dataset.index ||
-      "https://rascommander.info/data/rasexamples/hec-ras-7.0/example-projects.geojson";
+      "https://rascommander.info/data/rasexamples/hec-ras-7.0/current/example-projects.geojson";
     const sourceCollection = await loadProjectIndex(dataUrl);
     const features = (sourceCollection.features || [])
       .filter((feature) => feature.geometry)

--- a/docs/examples/example-projects.md
+++ b/docs/examples/example-projects.md
@@ -9,7 +9,7 @@ below to review its geometry, terrain, and results.
 
 ## Project Explorer
 
-<div class="ras-example-library" data-ras-example-library data-index="https://rascommander.info/data/rasexamples/hec-ras-7.0/example-projects.geojson?v=20260724Tlibrary-final03">
+<div class="ras-example-library" data-ras-example-library data-index="https://rascommander.info/data/rasexamples/hec-ras-7.0/current/example-projects.geojson">
   <div class="ras-library-map-shell">
     <div class="ras-library-map" data-library-map></div>
   </div>

--- a/scripts/example_library/AGENTS.md
+++ b/scripts/example_library/AGENTS.md
@@ -16,6 +16,13 @@ be copied onto the public Example Project Library page.
 - Publish artifacts to the dedicated RAS Commander WebGIS service, then link the
   docs viewer to its hosted catalog and manifest.
 - The public artifact namespace is `/data/rasexamples/hec-ras-7.0/`.
+- Publish complete snapshots beneath
+  `/data/rasexamples/hec-ras-7.0/releases/<release-id>/`. Never overwrite a
+  completed release. The mutable `current` symlink is the only active-release
+  pointer and must be switched atomically after validation.
+- Project manifests and all absolute artifact URLs must reference their
+  immutable release path. Numeric-service asset IDs are release-qualified so
+  cached or already-open viewers remain valid across publication.
 - `rascommander.info` reverse-proxies `/data/*` to the isolated WebGIS artifact
   service. Do not put local file paths in public manifests.
 
@@ -134,6 +141,9 @@ Add projects one at a time only after all checks pass:
 - each 2D model has a consolidated, validated terrain COG;
 - manifests use hosted URLs and contain no local paths;
 - PMTiles and COG endpoints support HTTP range requests;
+- successful immutable release artifacts use a one-year immutable cache policy,
+  mutable current/catalog paths revalidate, and every `4xx` or `5xx` response
+  uses `Cache-Control: no-store`;
 - large layers have sensible default visibility;
 - desktop and mobile viewers open from the public docs URL;
 - Identify distinguishes raw HDF values from RASMapper raster values;
@@ -175,7 +185,13 @@ After publishing a manifest v2 release with numeric COGs, install or upgrade the
 bounded runtime inside CT230 with `provision_webgis_raster_service.sh`. Keep its
 application listener on `127.0.0.1:8087`; CT230 Nginx and the docs-origin proxy
 are the only public route to `/ras-raster/`.
-Run `provision_rasdocs_raster_proxy.sh` inside CLB-Web01 CT210 and the active
-serve-only rasdocs replica CT213 only after the CT230 health check passes. It
-adds the path-scoped Caddy proxy without changing the existing `/data/*`
-artifact route.
+The service readiness response must identify the active release and catalog,
+must be non-cacheable, and must report zero missing assets. The publisher must
+run `validate_public_webgis_release.py` after switching `current`; this validates
+public PMTiles and COG ranges, numeric sample/statistics/tile routes, cache
+headers, and non-cacheable API/static errors.
+Run `provision_rasdocs_raster_proxy.sh` inside the active CT210 `clb-rasdocs`
+guest on CLB-WebGIS and the serve-only rasdocs replica CT213 only after the
+CT230 readiness check passes. Former CLB-Web01 was retired on 2026-07-24. The
+script adds the path-scoped Caddy proxy without changing the existing
+`/data/*` artifact route.

--- a/scripts/example_library/clb03_rascommander_webgis_publisher.sh
+++ b/scripts/example_library/clb03_rascommander_webgis_publisher.sh
@@ -8,13 +8,15 @@ readonly KEY_PATH="/root/.ssh/rascommander-webgis-publish-ed25519"
 readonly KNOWN_HOSTS="/root/.ssh/rascommander-webgis-known_hosts"
 readonly WEBGIS_HOST="192.168.3.3"
 readonly WEBGIS_USER="rascommander-publish"
-readonly PUBLISHER="/usr/local/sbin/rascommander-webgis-publish"
 readonly SERVICE_KEY_PATH="/root/.ssh/clb-webgis-promote-ed25519"
 readonly RASTER_CT_ID="230"
 readonly VERSION_ROOT="hec-ras-7.0"
 readonly WEBGIS_DATA_ROOT="/webgis_ssd_mirror/rascommander-webgis/data/rasexamples/${VERSION_ROOT}"
 readonly CT_DATA_ROOT="/var/www/rascommander-webgis/data/rasexamples/${VERSION_ROOT}"
-readonly RASTER_SERVICE_URL="http://127.0.0.1:8087/ras-raster/health"
+readonly RASTER_SERVICE_URL="http://127.0.0.1:8087/ras-raster/ready"
+readonly VERSIONER="/usr/local/libexec/rascommander-version-webgis-release.py"
+readonly PUBLIC_VALIDATOR="/usr/local/libexec/rascommander-validate-public-webgis-release.py"
+readonly PUBLIC_ORIGIN="https://rascommander.info"
 
 usage() {
     printf 'Usage: %s --release-dir /mnt/pool_12tb/rascommander-webgis-staging/<release>\n' "$0" >&2
@@ -102,6 +104,20 @@ print(
 PY
 }
 
+release_id_from_manifest() {
+    python3 - "$1/manifest.json" <<'PY'
+import json
+import re
+import sys
+from pathlib import Path
+
+release_id = str(json.loads(Path(sys.argv[1]).read_text(encoding="utf-8")).get("releaseId") or "")
+if not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9._-]{0,79}", release_id):
+    raise SystemExit("Release manifest has an unsafe or missing releaseId")
+print(release_id)
+PY
+}
+
 rsync_artifacts() {
     rsync \
         --archive \
@@ -132,42 +148,53 @@ webgis_exec() {
         "$remote_command"
 }
 
-raster_catalog_asset_count() {
-    python3 - "$1" <<'PY'
-import json
-import sys
-from pathlib import Path
-
-document = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
-assets = document.get("assets")
-if document.get("schema") != "rascommander.raster-assets/v1" or not isinstance(assets, dict):
-    raise SystemExit("Unsupported or malformed raster asset catalog")
-print(len(assets))
-PY
-}
-
 validate_raster_catalog_candidate() {
-    local expected_assets="$1"
-    local observed_assets
-    observed_assets="$(
+    local release_id="$1"
+    local validation
+    validation="$(
         webgis_exec \
             pct exec "$RASTER_CT_ID" -- \
             /opt/ras2cng/.venv/bin/python -c \
-            'from pathlib import Path; from ras2cng.webgis_service import RasterAssetCatalog; print(len(RasterAssetCatalog.load(Path(__import__("sys").argv[1]), Path(__import__("sys").argv[2])).assets))' \
+            'from pathlib import Path; import json,sys; from ras2cng.webgis_service import RasterAssetCatalog; catalog=RasterAssetCatalog.load(Path(sys.argv[1]), Path(sys.argv[2])); print(json.dumps({"assets":len(catalog.assets),"releaseId":catalog.release_id}))' \
             "${CT_DATA_ROOT}/raster-assets.json.candidate" \
             "$CT_DATA_ROOT"
     )"
-    if [[ $observed_assets != "$expected_assets" ]]; then
-        printf 'Candidate raster catalog exposes %s assets; expected %s.\n' \
-            "$observed_assets" "$expected_assets" >&2
-        return 1
+    python3 - "$release_id" "$validation" <<'PY'
+import json
+import sys
+
+release_id = sys.argv[1]
+validation = json.loads(sys.argv[2])
+if validation.get("releaseId") != release_id:
+    raise SystemExit("Candidate raster catalog has the wrong active release")
+assets = int(validation.get("assets") or 0)
+if assets < 1:
+    raise SystemExit("Candidate raster catalog contains no assets")
+print(assets)
+PY
+}
+
+merge_raster_catalog_candidate() {
+    local release_id="$1"
+    local release_catalog="${CT_DATA_ROOT}/releases/${release_id}/raster-assets.json"
+    local candidate="${CT_DATA_ROOT}/raster-assets.json.candidate"
+    local live="${CT_DATA_ROOT}/raster-assets.json"
+    local -a command=(
+        pct exec "$RASTER_CT_ID" --
+        /opt/ras2cng/.venv/bin/ras2cng
+        raster-service-catalog-merge "$candidate"
+        --catalog "$release_catalog"
+        --release-id "$release_id"
+    )
+    if webgis_exec test -f "${WEBGIS_DATA_ROOT}/raster-assets.json"; then
+        command+=(--catalog "$live")
     fi
-    printf 'Validated candidate raster catalog and %s referenced COGs.\n' \
-        "$expected_assets"
+    webgis_exec "${command[@]}"
 }
 
 raster_service_ready() {
     local expected_assets="$1"
+    local release_id="$2"
     local health
     health="$(
         webgis_exec \
@@ -175,27 +202,34 @@ raster_service_ready() {
             curl --fail --silent --show-error "$RASTER_SERVICE_URL" \
             2>/dev/null
     )" || return 1
-    python3 - "$expected_assets" "$health" <<'PY'
+    python3 - "$expected_assets" "$release_id" "$health" <<'PY'
 import json
 import sys
 
 expected = int(sys.argv[1])
+release_id = sys.argv[2]
 try:
-    health = json.loads(sys.argv[2])
+    health = json.loads(sys.argv[3])
 except json.JSONDecodeError:
     raise SystemExit(1)
-if health.get("status") != "ok" or health.get("assets") != expected:
+if (
+    health.get("status") != "ready"
+    or health.get("assets") != expected
+    or health.get("releaseId") != release_id
+    or health.get("missingAssets") != 0
+):
     raise SystemExit(1)
 PY
 }
 
 wait_for_raster_service() {
     local expected_assets="$1"
+    local release_id="$2"
     local attempt
     for attempt in $(seq 1 30); do
-        if raster_service_ready "$expected_assets"; then
-            printf 'Numeric raster service is ready with %s assets.\n' \
-                "$expected_assets"
+        if raster_service_ready "$expected_assets" "$release_id"; then
+            printf 'Numeric raster service is ready for %s with %s assets.\n' \
+                "$release_id" "$expected_assets"
             return 0
         fi
         sleep 1
@@ -222,18 +256,14 @@ report_raster_service_failure() {
 }
 
 promote_raster_catalog() {
-    local raster_catalog="$1"
+    local release_id="$1"
     local expected_assets candidate_path live_path backup_path
-    expected_assets="$(raster_catalog_asset_count "$raster_catalog")"
     candidate_path="${WEBGIS_DATA_ROOT}/raster-assets.json.candidate"
     live_path="${WEBGIS_DATA_ROOT}/raster-assets.json"
     backup_path="${WEBGIS_DATA_ROOT}/raster-assets.json.rollback.$$"
 
-    rsync_artifacts \
-        "$raster_catalog" \
-        "${WEBGIS_USER}@${WEBGIS_HOST}:./${VERSION_ROOT}/raster-assets.json.candidate"
-
-    if ! validate_raster_catalog_candidate "$expected_assets"; then
+    merge_raster_catalog_candidate "$release_id"
+    if ! expected_assets="$(validate_raster_catalog_candidate "$release_id")"; then
         webgis_exec rm -f -- "$candidate_path" || true
         return 1
     fi
@@ -241,22 +271,22 @@ promote_raster_catalog() {
     if webgis_exec test -f "$live_path"; then
         webgis_exec cp --preserve=mode,ownership,timestamps -- \
             "$live_path" "$backup_path"
+        RASTER_CATALOG_BACKUP="$backup_path"
     else
         backup_path=""
+        RASTER_CATALOG_BACKUP=""
     fi
     webgis_exec mv -f -- "$candidate_path" "$live_path"
     restart_raster_service
 
-    if wait_for_raster_service "$expected_assets"; then
-        if [[ -n $backup_path ]]; then
-            webgis_exec rm -f -- "$backup_path"
-        fi
+    if wait_for_raster_service "$expected_assets" "$release_id"; then
         return 0
     fi
 
     report_raster_service_failure
     if [[ -n $backup_path ]]; then
         webgis_exec mv -f -- "$backup_path" "$live_path"
+        RASTER_CATALOG_BACKUP=""
         restart_raster_service || true
     else
         webgis_exec rm -f -- "$live_path"
@@ -266,40 +296,217 @@ promote_raster_catalog() {
     return 1
 }
 
+finalize_raster_catalog() {
+    if [[ -n ${RASTER_CATALOG_BACKUP:-} ]]; then
+        webgis_exec rm -f -- "$RASTER_CATALOG_BACKUP"
+        RASTER_CATALOG_BACKUP=""
+    fi
+}
+
+rollback_raster_catalog() {
+    local live_path="${WEBGIS_DATA_ROOT}/raster-assets.json"
+    if [[ -z ${RASTER_CATALOG_BACKUP:-} ]]; then
+        return 0
+    fi
+    webgis_exec mv -f -- "$RASTER_CATALOG_BACKUP" "$live_path"
+    RASTER_CATALOG_BACKUP=""
+    restart_raster_service
+    printf 'Restored the previous raster catalog.\n' >&2
+}
+
+remote_path_exists() {
+    webgis_exec test -e "$1" || webgis_exec test -L "$1"
+}
+
+prepare_pointer_backup() {
+    local release_id="$1"
+    local name live_path
+    POINTER_BACKUP_DIR="${WEBGIS_DATA_ROOT}/.pointer-rollback.${release_id}.$$"
+    webgis_exec install -d -o root -g root -m 0700 "$POINTER_BACKUP_DIR" \
+        || return 1
+    for name in \
+        current \
+        catalog.json \
+        example-projects.geojson \
+        snapshot.json \
+        current-release.json; do
+        live_path="${WEBGIS_DATA_ROOT}/${name}"
+        if remote_path_exists "$live_path"; then
+            webgis_exec cp -a -- \
+                "$live_path" "${POINTER_BACKUP_DIR}/${name}" \
+                || return 1
+        fi
+    done
+}
+
+promote_current_release() {
+    local release_id="$1"
+    local current_path="${WEBGIS_DATA_ROOT}/current"
+    local temporary_current="${WEBGIS_DATA_ROOT}/.current.${release_id}.$$"
+    local metadata temporary_metadata
+
+    PREVIOUS_CURRENT_TARGET="$(
+        webgis_exec readlink "$current_path" 2>/dev/null || true
+    )"
+    case "$PREVIOUS_CURRENT_TARGET" in
+        ""|releases/*) ;;
+        *)
+            printf 'Unsafe existing current-release target: %s\n' \
+                "$PREVIOUS_CURRENT_TARGET" >&2
+            return 1
+            ;;
+    esac
+
+    prepare_pointer_backup "$release_id" || return 1
+    webgis_exec ln -s -- "releases/${release_id}" "$temporary_current" \
+        || return 1
+    webgis_exec mv -Tf -- "$temporary_current" "$current_path" \
+        || return 1
+    CURRENT_SWITCHED=1
+
+    for metadata in catalog.json example-projects.geojson snapshot.json; do
+        temporary_metadata="${WEBGIS_DATA_ROOT}/.${metadata}.${release_id}.$$"
+        webgis_exec ln -s -- "current/${metadata}" "$temporary_metadata" \
+            || return 1
+        webgis_exec mv -Tf -- \
+            "$temporary_metadata" "${WEBGIS_DATA_ROOT}/${metadata}" \
+            || return 1
+    done
+    temporary_metadata="${WEBGIS_DATA_ROOT}/.current-release.json.${release_id}.$$"
+    webgis_exec ln -s -- "current/release.json" "$temporary_metadata" \
+        || return 1
+    webgis_exec mv -Tf -- \
+        "$temporary_metadata" "${WEBGIS_DATA_ROOT}/current-release.json" \
+        || return 1
+}
+
+rollback_current_release() {
+    local release_id="$1"
+    local backup_path live_path name
+    if [[ ${CURRENT_SWITCHED:-0} != 1 ]]; then
+        if [[ -n ${POINTER_BACKUP_DIR:-} ]]; then
+            webgis_exec rm -rf -- "$POINTER_BACKUP_DIR"
+            POINTER_BACKUP_DIR=""
+        fi
+        return 0
+    fi
+    if [[ -z ${POINTER_BACKUP_DIR:-} ]]; then
+        printf 'No public-pointer rollback snapshot is available for %s.\n' \
+            "$release_id" >&2
+        return 1
+    fi
+    for name in \
+        current \
+        catalog.json \
+        example-projects.geojson \
+        snapshot.json \
+        current-release.json; do
+        live_path="${WEBGIS_DATA_ROOT}/${name}"
+        backup_path="${POINTER_BACKUP_DIR}/${name}"
+        webgis_exec rm -rf -- "$live_path"
+        if remote_path_exists "$backup_path"; then
+            webgis_exec mv -T -- "$backup_path" "$live_path"
+        fi
+    done
+    webgis_exec rm -rf -- "$POINTER_BACKUP_DIR"
+    POINTER_BACKUP_DIR=""
+    CURRENT_SWITCHED=0
+    printf 'Restored the previous public release pointers.\n' >&2
+}
+
+finalize_current_release() {
+    if [[ -n ${POINTER_BACKUP_DIR:-} ]]; then
+        webgis_exec rm -rf -- "$POINTER_BACKUP_DIR"
+        POINTER_BACKUP_DIR=""
+    fi
+}
+
 if [[ $# -ne 2 || $1 != "--release-dir" ]]; then
     usage
 fi
 
 release_dir="$(require_release_dir "$2")"
 verify_manifest "$release_dir"
+release_id="$(release_id_from_manifest "$release_dir")"
+source_root="${release_dir}/data/rasexamples/${VERSION_ROOT}"
+remote_release_path="${WEBGIS_DATA_ROOT}/releases/${release_id}"
+incoming_name="${release_id}.$$"
+remote_incoming_path="${WEBGIS_DATA_ROOT}/.incoming/${incoming_name}"
+remote_incoming_destination="./${VERSION_ROOT}/.incoming/${incoming_name}/"
 
-# Publish immutable project artifacts before exposing their catalog entries.
-rsync_artifacts \
-    --exclude="/${VERSION_ROOT}/raster-assets.json" \
-    --exclude="/${VERSION_ROOT}/catalog.json" \
-    --exclude="/${VERSION_ROOT}/example-projects.geojson" \
-    --exclude="/${VERSION_ROOT}/snapshot.json" \
-    "${release_dir}/data/rasexamples/" \
-    "${WEBGIS_USER}@${WEBGIS_HOST}:./"
-
-raster_catalog="${release_dir}/data/rasexamples/${VERSION_ROOT}/raster-assets.json"
-if [[ -f $raster_catalog ]]; then
-    promote_raster_catalog "$raster_catalog"
+if [[ ! -x $VERSIONER || ! -x $PUBLIC_VALIDATOR ]]; then
+    printf 'Required publication helpers are not installed under /usr/local/libexec.\n' >&2
+    exit 1
+fi
+if webgis_exec test -e "$remote_release_path"; then
+    printf 'Immutable WebGIS release already exists: %s\n' "$remote_release_path" >&2
+    exit 1
 fi
 
-# Expose landing-page metadata only after the raster service recognizes the
-# newly published numeric assets.
-for catalog_name in catalog.json example-projects.geojson snapshot.json; do
-    catalog_path="${release_dir}/data/rasexamples/${VERSION_ROOT}/${catalog_name}"
-    if [[ -f $catalog_path ]]; then
-        rsync_artifacts \
-            "$catalog_path" \
-            "${WEBGIS_USER}@${WEBGIS_HOST}:./${VERSION_ROOT}/${catalog_name}"
+overlay_dir="$(mktemp -d "${STAGE_ROOT}/.versioned-overlay.XXXXXX")"
+incoming_active=1
+cleanup() {
+    rm -rf -- "$overlay_dir"
+    if [[ ${incoming_active:-0} == 1 ]]; then
+        webgis_exec rm -rf -- "$remote_incoming_path" || true
     fi
-done
+}
+trap cleanup EXIT
+python3 "$VERSIONER" \
+    --source-root "$source_root" \
+    --output-root "$overlay_dir" \
+    --release-id "$release_id"
 
-if [[ -f $raster_catalog ]]; then
-    printf 'Published RAS example artifacts and validated the numeric raster service.\n'
-else
-    printf 'Published RAS example artifacts without changing the numeric raster catalog.\n'
+current_target="$(
+    webgis_exec readlink "${WEBGIS_DATA_ROOT}/current" 2>/dev/null || true
+)"
+case "$current_target" in
+    releases/*) link_destination="../../${current_target}" ;;
+    "") link_destination="../.." ;;
+    *)
+        printf 'Unsafe existing current-release target: %s\n' "$current_target" >&2
+        exit 1
+        ;;
+esac
+
+webgis_exec install -d -o "$WEBGIS_USER" -g "$WEBGIS_USER" -m 2775 \
+    "${WEBGIS_DATA_ROOT}/releases" \
+    "${WEBGIS_DATA_ROOT}/.incoming" \
+    "$remote_incoming_path"
+if ! rsync_artifacts \
+    --link-dest="$link_destination" \
+    "${source_root}/" \
+    "${WEBGIS_USER}@${WEBGIS_HOST}:${remote_incoming_destination}"; then
+    printf 'Hard-link reuse was unavailable; retrying the staged transfer without it.\n' >&2
+    rsync_artifacts \
+        "${source_root}/" \
+        "${WEBGIS_USER}@${WEBGIS_HOST}:${remote_incoming_destination}"
 fi
+rsync_artifacts \
+    "${overlay_dir}/" \
+    "${WEBGIS_USER}@${WEBGIS_HOST}:${remote_incoming_destination}"
+webgis_exec mv -T -- "$remote_incoming_path" "$remote_release_path"
+incoming_active=0
+
+promote_raster_catalog "$release_id"
+CURRENT_SWITCHED=0
+if ! promote_current_release "$release_id"; then
+    rollback_current_release "$release_id"
+    rollback_raster_catalog
+    exit 1
+fi
+
+if ! python3 "$PUBLIC_VALIDATOR" \
+    --origin "$PUBLIC_ORIGIN" \
+    --release-id "$release_id"; then
+    rollback_current_release "$release_id"
+    rollback_raster_catalog
+    exit 1
+fi
+
+finalize_current_release
+finalize_raster_catalog
+rm -rf -- "$overlay_dir"
+trap - EXIT
+printf 'Published and publicly validated immutable WebGIS release %s.\n' \
+    "$release_id"

--- a/scripts/example_library/install_clb03_rascommander_webgis_publisher.sh
+++ b/scripts/example_library/install_clb03_rascommander_webgis_publisher.sh
@@ -8,6 +8,9 @@ readonly KEY_PATH="/root/.ssh/rascommander-webgis-publish-ed25519"
 readonly KNOWN_HOSTS="/root/.ssh/rascommander-webgis-known_hosts"
 readonly WEBGIS_HOST="192.168.3.3"
 readonly INSTALL_PATH="/usr/local/sbin/rascommander-webgis-publish"
+readonly LIBEXEC_ROOT="/usr/local/libexec"
+readonly VERSIONER_INSTALL_PATH="${LIBEXEC_ROOT}/rascommander-version-webgis-release.py"
+readonly VALIDATOR_INSTALL_PATH="${LIBEXEC_ROOT}/rascommander-validate-public-webgis-release.py"
 
 usage() {
     printf 'Usage: %s --publisher-script /absolute/path/to/clb03_rascommander_webgis_publisher.sh\n' "$0" >&2
@@ -20,6 +23,14 @@ if [[ $EUID -ne 0 ]]; then
 fi
 if [[ $# -ne 2 || $1 != "--publisher-script" || $2 != /* || ! -f $2 ]]; then
     usage
+fi
+publisher_script="$(realpath -e "$2")"
+script_root="$(dirname "$publisher_script")"
+versioner_script="${script_root}/version_webgis_release.py"
+validator_script="${script_root}/validate_public_webgis_release.py"
+if [[ ! -f $versioner_script || ! -f $validator_script ]]; then
+    printf 'Publisher helpers must be located beside %s.\n' "$publisher_script" >&2
+    exit 1
 fi
 
 install -d -o root -g root -m 0750 "$STAGE_ROOT"
@@ -35,7 +46,10 @@ if ! ssh-keygen -F "$WEBGIS_HOST" -f /root/.ssh/known_hosts > "$KNOWN_HOSTS"; th
     exit 1
 fi
 
-install -o root -g root -m 0750 "$2" "$INSTALL_PATH"
+install -d -o root -g root -m 0755 "$LIBEXEC_ROOT"
+install -o root -g root -m 0750 "$publisher_script" "$INSTALL_PATH"
+install -o root -g root -m 0750 "$versioner_script" "$VERSIONER_INSTALL_PATH"
+install -o root -g root -m 0750 "$validator_script" "$VALIDATOR_INSTALL_PATH"
 printf 'Installed CLB03 publisher bridge. Public-key fingerprint: '
 ssh-keygen -lf "${KEY_PATH}.pub" | awk '{print $2}'
 printf 'WebGIS host authorization remains required before the bridge can publish.\n'

--- a/scripts/example_library/provision_rasdocs_raster_proxy.sh
+++ b/scripts/example_library/provision_rasdocs_raster_proxy.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
-# Run inside CT210 (builder) and active CT213 (serve-only replica) as root
-# after CT230 is healthy.
+# Run inside CT210 (builder on CLB-WebGIS) and active CT213 (serve-only
+# replica) as root after CT230 is ready.
 set -euo pipefail
 
 readonly CADDYFILE="/etc/caddy/Caddyfile"
@@ -16,7 +16,9 @@ if [[ ! -f $CADDYFILE ]]; then
     exit 1
 fi
 
-curl -fsS "${WEBGIS_ORIGIN}/ras-raster/health" >/dev/null
+curl -fsS "${WEBGIS_ORIGIN}/ras-raster/ready" >/dev/null
+curl -fsS -D - -o /dev/null "${WEBGIS_ORIGIN}/ras-raster/health" \
+    | grep -qi '^cache-control: no-store'
 
 python3 - "$CADDYFILE" "$MARKER" <<'PY'
 import os
@@ -58,5 +60,8 @@ caddy validate --config "$CADDYFILE"
 # This origin intentionally has Caddy's admin endpoint disabled, so reload
 # cannot reach localhost:2019. A validated restart is the supported path.
 systemctl restart caddy
-curl -fsS -H 'Host: rascommander.info' http://127.0.0.1/ras-raster/health
+curl -fsS -D - -o /dev/null -H 'Host: rascommander.info' \
+    http://127.0.0.1/ras-raster/health \
+    | grep -qi '^cache-control: no-store'
+curl -fsS -H 'Host: rascommander.info' http://127.0.0.1/ras-raster/ready
 printf '\nProvisioned the rasdocs numeric raster reverse proxy.\n'

--- a/scripts/example_library/provision_webgis_raster_service.sh
+++ b/scripts/example_library/provision_webgis_raster_service.sh
@@ -59,6 +59,7 @@ RAS2CNG_RASTER_MAX_VIEW_PIXELS=2097152
 RAS2CNG_RASTER_MAX_VIEW_DIMENSION=4096
 RAS2CNG_RASTER_CACHE_ENTRIES=512
 RAS2CNG_RASTER_MAX_COG_RANGE_BYTES=67108864
+RAS2CNG_RASTER_MAX_CONCURRENT_OPERATIONS=8
 MPLCONFIGDIR=/tmp/matplotlib
 XDG_CACHE_HOME=/tmp/cache
 EOF
@@ -87,33 +88,60 @@ ReadOnlyPaths=/var/www/rascommander-webgis
 MemoryHigh=6G
 MemoryMax=8G
 TasksMax=128
+LimitNOFILE=4096
+TimeoutStartSec=45
+TimeoutStopSec=30
 
 [Install]
 WantedBy=multi-user.target
 EOF
 chmod 0644 /etc/systemd/system/ras2cng-raster.service
 
+cat > /etc/nginx/conf.d/rascommander-webgis-cache.conf <<'EOF'
+# Successful immutable releases may be cached indefinitely. Mutable pointers
+# revalidate, and every generated or static error remains non-cacheable.
+map "$status:$uri" $ras_artifact_cache_control {
+    default "no-store";
+    ~"^[23][0-9][0-9]:/data/rasexamples/hec-ras-7\.0/releases/[A-Za-z0-9._-]+/" "public, max-age=31536000, immutable, no-transform";
+    ~"^[23][0-9][0-9]:/data/rasexamples/hec-ras-7\.0/(current/|catalog\.json$|example-projects\.geojson$|snapshot\.json$|current-release\.json$|raster-assets\.json$)" "no-cache, no-transform";
+    ~"^[23][0-9][0-9]:" "public, max-age=3600, no-transform";
+}
+
+# The API supplies its successful cache policy. This variable only covers
+# Nginx-generated errors such as request or connection limiting.
+map $status $ras_api_error_cache_control {
+    default "";
+    ~^[45] "no-store";
+}
+
+limit_req_zone $binary_remote_addr zone=ras_raster_requests:10m rate=40r/s;
+limit_conn_zone $binary_remote_addr zone=ras_raster_connections:10m;
+EOF
+chmod 0644 /etc/nginx/conf.d/rascommander-webgis-cache.conf
+
 python3 - "$SITE_CONFIG" <<'PY'
 import os
+import re
 import sys
 from pathlib import Path
 
 path = Path(sys.argv[1])
 source = path.read_text(encoding="utf-8")
-cache_header = 'add_header Cache-Control "public, max-age=3600" always;'
-range_safe_cache_header = (
-    'add_header Cache-Control "public, max-age=3600, no-transform" always;'
+original = source
+cache_headers = (
+    'add_header Cache-Control "public, max-age=3600" always;',
+    'add_header Cache-Control "public, max-age=3600, no-transform" always;',
 )
-if range_safe_cache_header not in source:
-    if cache_header not in source:
+status_aware_cache_header = (
+    "add_header Cache-Control $ras_artifact_cache_control always;"
+)
+if status_aware_cache_header not in source:
+    matches = [header for header in cache_headers if header in source]
+    if len(matches) != 1:
         raise SystemExit(f"Expected the artifact cache header in {path}")
-    source = source.replace(cache_header, range_safe_cache_header, 1)
+    source = source.replace(matches[0], status_aware_cache_header, 1)
 marker = "# ras2cng numeric raster service"
-if marker not in source:
-    needle = "    location / {\n"
-    if source.count(needle) != 1:
-        raise SystemExit(f"Expected one default location in {path}")
-    block = """    # ras2cng numeric raster service
+block = """    # ras2cng numeric raster service
     location /ras-raster/ {
         proxy_pass http://127.0.0.1:8087/ras-raster/;
         proxy_http_version 1.1;
@@ -122,12 +150,35 @@ if marker not in source:
         proxy_set_header X-Forwarded-Proto $scheme;
         proxy_connect_timeout 5s;
         proxy_read_timeout 60s;
+        proxy_send_timeout 15s;
         proxy_buffering on;
+        proxy_next_upstream off;
+        limit_req zone=ras_raster_requests burst=80 nodelay;
+        limit_req_status 429;
+        limit_conn ras_raster_connections 16;
+        limit_conn_status 429;
+        add_header Cache-Control $ras_api_error_cache_control always;
     }
 
 """
+if marker in source:
+    pattern = re.compile(
+        r"    # ras2cng numeric raster service\n"
+        r"    location /ras-raster/ \{\n.*?^    \}\n\n",
+        re.MULTILINE | re.DOTALL,
+    )
+    source, replacements = pattern.subn(block, source)
+    if replacements != 1:
+        raise SystemExit(f"Expected one numeric raster service block in {path}")
+else:
+    needle = "    location / {\n"
+    if source.count(needle) != 1:
+        raise SystemExit(f"Expected one default location in {path}")
+    source = source.replace(needle, block + needle)
+
+if source != original:
     temporary = path.with_name(f".{path.name}.ras2cng.tmp")
-    temporary.write_text(source.replace(needle, block + needle), encoding="utf-8")
+    temporary.write_text(source, encoding="utf-8")
     os.chmod(temporary, path.stat().st_mode)
     temporary.replace(path)
 PY
@@ -139,11 +190,13 @@ nginx -t
 systemctl reload nginx
 
 for _ in $(seq 1 30); do
-    if curl -fsS http://127.0.0.1:8087/ras-raster/health >/dev/null; then
+    if curl -fsS http://127.0.0.1:8087/ras-raster/ready >/dev/null; then
         break
     fi
     sleep 1
 done
-curl -fsS http://127.0.0.1:8087/ras-raster/health
-curl -fsS http://127.0.0.1/ras-raster/health
+curl -fsS -D - -o /dev/null http://127.0.0.1:8087/ras-raster/health \
+    | grep -qi '^cache-control: no-store'
+curl -fsS http://127.0.0.1:8087/ras-raster/ready
+curl -fsS http://127.0.0.1/ras-raster/ready
 printf '\nProvisioned the isolated numeric raster service.\n'

--- a/scripts/example_library/validate_public_webgis_release.py
+++ b/scripts/example_library/validate_public_webgis_release.py
@@ -1,0 +1,265 @@
+#!/usr/bin/env python
+"""Exercise one immutable Example Library release through the public origin."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+from dataclasses import dataclass
+from typing import Any
+from urllib.error import HTTPError
+from urllib.parse import urlencode, urljoin
+from urllib.request import Request, urlopen
+
+
+@dataclass(frozen=True)
+class HttpResult:
+    status: int
+    headers: dict[str, str]
+    content: bytes
+
+    def json(self) -> Any:
+        return json.loads(self.content.decode("utf-8"))
+
+
+def request(
+    url: str,
+    *,
+    headers: dict[str, str] | None = None,
+    timeout: float = 30,
+) -> HttpResult:
+    """Return both success and expected HTTP error responses."""
+
+    request_object = Request(url, headers=headers or {}, method="GET")
+    try:
+        response = urlopen(request_object, timeout=timeout)
+    except HTTPError as error:
+        response = error
+    with response:
+        return HttpResult(
+            status=response.status,
+            headers={key.lower(): value for key, value in response.headers.items()},
+            content=response.read(),
+        )
+
+
+def require_status(result: HttpResult, expected: int, label: str) -> None:
+    if result.status != expected:
+        raise RuntimeError(f"{label} returned HTTP {result.status}, expected {expected}")
+
+
+def require_cache_token(result: HttpResult, token: str, label: str) -> None:
+    cache_control = result.headers.get("cache-control", "").lower()
+    if token.lower() not in cache_control:
+        raise RuntimeError(
+            f"{label} cache policy {cache_control!r} does not contain {token!r}"
+        )
+
+
+def tile_for_point(longitude: float, latitude: float, zoom: int) -> tuple[int, int]:
+    latitude = max(-85.05112878, min(85.05112878, latitude))
+    scale = 2**zoom
+    x = int((longitude + 180.0) / 360.0 * scale)
+    latitude_radians = math.radians(latitude)
+    y = int(
+        (
+            1.0
+            - math.asinh(math.tan(latitude_radians)) / math.pi
+        )
+        / 2.0
+        * scale
+    )
+    return max(0, min(scale - 1, x)), max(0, min(scale - 1, y))
+
+
+def find_muncie_manifest(index: dict[str, Any], needle: str) -> str:
+    for feature in index.get("features") or []:
+        properties = feature.get("properties") or {}
+        project_id = str(properties.get("projectId") or "")
+        title = str(properties.get("title") or "")
+        if needle.lower() in f"{project_id} {title}".lower():
+            manifest = properties.get("manifest")
+            if manifest:
+                return str(manifest)
+    raise RuntimeError(f"No project matching {needle!r} has a manifest URL")
+
+
+def find_numeric_resource(manifest: dict[str, Any]) -> tuple[str, dict[str, Any]]:
+    for resource_id, resource in (manifest.get("resources") or {}).items():
+        if (
+            resource.get("type") == "cog"
+            and resource.get("serviceAsset")
+            and resource.get("serviceRevision")
+            and resource.get("bounds")
+        ):
+            return resource_id, resource
+    raise RuntimeError("The validation project has no queryable numeric COG")
+
+
+def find_pmtiles_resource(manifest: dict[str, Any]) -> dict[str, Any]:
+    for resource in (manifest.get("resources") or {}).values():
+        if str(resource.get("type") or "").endswith("pmtiles") and resource.get(
+            "href"
+        ):
+            return resource
+    raise RuntimeError("The validation project has no PMTiles resource")
+
+
+def validate_release(
+    origin: str,
+    release_id: str,
+    *,
+    project_needle: str = "muncie",
+) -> dict[str, Any]:
+    origin = origin.rstrip("/")
+    version_root = f"{origin}/data/rasexamples/hec-ras-7.0"
+    release_root = f"{version_root}/releases/{release_id}"
+
+    release_query = urlencode({"release": release_id})
+    health = request(f"{origin}/ras-raster/health?{release_query}")
+    require_status(health, 200, "Raster health")
+    require_cache_token(health, "no-store", "Raster health")
+    health_document = health.json()
+    if health_document.get("releaseId") != release_id:
+        raise RuntimeError("Raster health reports a different active release")
+
+    ready = request(f"{origin}/ras-raster/ready?{release_query}")
+    require_status(ready, 200, "Raster readiness")
+    require_cache_token(ready, "no-store", "Raster readiness")
+    if ready.json().get("status") != "ready":
+        raise RuntimeError("Raster readiness does not report ready")
+
+    current = request(f"{version_root}/current/release.json?{release_query}")
+    require_status(current, 200, "Current release pointer")
+    require_cache_token(current, "no-cache", "Current release pointer")
+    if current.json().get("releaseId") != release_id:
+        raise RuntimeError("The public current pointer has not switched releases")
+
+    index = request(f"{release_root}/example-projects.geojson")
+    require_status(index, 200, "Versioned project index")
+    require_cache_token(index, "immutable", "Versioned project index")
+    index_document = index.json()
+    if index_document.get("releaseId") != release_id:
+        raise RuntimeError("The project index has the wrong release identity")
+    manifest_url = find_muncie_manifest(index_document, project_needle)
+    if f"/releases/{release_id}/" not in manifest_url:
+        raise RuntimeError("The project index does not use immutable manifest URLs")
+
+    manifest_response = request(manifest_url)
+    require_status(manifest_response, 200, "Project manifest")
+    require_cache_token(manifest_response, "immutable", "Project manifest")
+    manifest = manifest_response.json()
+
+    pmtiles = find_pmtiles_resource(manifest)
+    pmtiles_url = urljoin(manifest_url, str(pmtiles["href"]))
+    pmtiles_range = request(pmtiles_url, headers={"Range": "bytes=0-16383"})
+    require_status(pmtiles_range, 206, "PMTiles range")
+    require_cache_token(pmtiles_range, "immutable", "PMTiles range")
+    require_cache_token(pmtiles_range, "no-transform", "PMTiles range")
+    if not pmtiles_range.headers.get("content-range", "").startswith("bytes 0-"):
+        raise RuntimeError("PMTiles response has no valid Content-Range")
+
+    _, numeric = find_numeric_resource(manifest)
+    cog_url = urljoin(manifest_url, str(numeric["href"]))
+    cog_range = request(cog_url, headers={"Range": "bytes=0-16383"})
+    require_status(cog_range, 206, "Direct COG range")
+    require_cache_token(cog_range, "immutable", "Direct COG range")
+    require_cache_token(cog_range, "no-transform", "Direct COG range")
+
+    service = (manifest.get("services") or {}).get("numericRaster") or {}
+    service_base = urljoin(manifest_url, str(service.get("baseUrl") or "/ras-raster"))
+    bounds = [float(value) for value in numeric["bounds"]]
+    longitude = (bounds[0] + bounds[2]) / 2
+    latitude = (bounds[1] + bounds[3]) / 2
+    common = {
+        "asset": numeric["serviceAsset"],
+        "revision": numeric["serviceRevision"],
+    }
+    sample = request(
+        f"{service_base.rstrip('/')}/{str(service.get('samplePath') or '/sample').lstrip('/')}?"
+        + urlencode({**common, "lng": longitude, "lat": latitude})
+    )
+    require_status(sample, 200, "Numeric raster sample")
+
+    stats = request(
+        f"{service_base.rstrip('/')}/{str(service.get('statisticsPath') or '/stats').lstrip('/')}?"
+        + urlencode(
+            {
+                **common,
+                "bbox": ",".join(str(value) for value in bounds),
+                "width": 512,
+                "height": 512,
+                "exact": "false",
+            }
+        )
+    )
+    require_status(stats, 200, "Viewport statistics")
+    domain = stats.json().get("domain") or {}
+
+    zoom = min(12, int(numeric.get("maxzoom") or 12))
+    tile_x, tile_y = tile_for_point(longitude, latitude, zoom)
+    tile_parameters: dict[str, Any] = dict(common)
+    if domain.get("minimum") is not None and domain.get("maximum") is not None:
+        tile_parameters["minimum"] = domain["minimum"]
+        tile_parameters["maximum"] = domain["maximum"]
+    tile_path = str(service.get("tilePath") or "/tiles/{z}/{x}/{y}.png").format(
+        z=zoom,
+        x=tile_x,
+        y=tile_y,
+    )
+    tile = request(
+        f"{service_base.rstrip('/')}/{tile_path.lstrip('/')}?"
+        + urlencode(tile_parameters)
+    )
+    require_status(tile, 200, "Styled raster tile")
+    if not tile.content.startswith(b"\x89PNG"):
+        raise RuntimeError("Styled raster tile is not a PNG")
+
+    bounded_cog = request(
+        f"{service_base.rstrip('/')}/{str(service.get('cogPath') or '/cog').lstrip('/')}?"
+        + urlencode({**common, "range": "bytes=0-16383"})
+    )
+    require_status(bounded_cog, 206, "Bounded COG range")
+    require_cache_token(bounded_cog, "immutable", "Bounded COG range")
+    require_cache_token(bounded_cog, "no-transform", "Bounded COG range")
+
+    missing_api = request(
+        f"{service_base.rstrip('/')}/{str(service.get('samplePath') or '/sample').lstrip('/')}?"
+        + urlencode({"asset": "__missing__", "lng": longitude, "lat": latitude})
+    )
+    require_status(missing_api, 404, "Missing API asset")
+    require_cache_token(missing_api, "no-store", "Missing API asset")
+
+    missing_static = request(f"{release_root}/__missing-validation-asset__.json")
+    require_status(missing_static, 404, "Missing static asset")
+    require_cache_token(missing_static, "no-store", "Missing static asset")
+
+    return {
+        "releaseId": release_id,
+        "assets": health_document.get("assets"),
+        "projectManifest": manifest_url,
+        "numericAsset": numeric["serviceAsset"],
+    }
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--origin", default="https://rascommander.info")
+    parser.add_argument("--release-id", required=True)
+    parser.add_argument("--project-contains", default="muncie")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    result = validate_release(
+        args.origin,
+        args.release_id,
+        project_needle=args.project_contains,
+    )
+    print(json.dumps(result, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/example_library/version_webgis_release.py
+++ b/scripts/example_library/version_webgis_release.py
@@ -1,0 +1,194 @@
+#!/usr/bin/env python
+"""Build the small JSON overlay for an immutable WebGIS release."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+RELEASE_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,79}$")
+VERSION_ROOT_NAME = "hec-ras-7.0"
+PUBLIC_VERSION_ROOT = f"/data/rasexamples/{VERSION_ROOT_NAME}"
+ENCODED_VERSION_PREFIX_RE = re.compile(
+    r"%2fdata%2frasexamples%2fhec-ras-7\.0%2f",
+    re.IGNORECASE,
+)
+RASTER_ASSET_SCHEMA = "rascommander.raster-assets/v1"
+
+
+def validate_release_id(release_id: str) -> str:
+    """Return a release identifier safe for both URLs and filesystem paths."""
+
+    if not RELEASE_ID_RE.fullmatch(release_id):
+        raise ValueError(
+            "Release ID must be 1-80 ASCII letters, digits, dots, underscores, "
+            "or hyphens and must not start with punctuation."
+        )
+    return release_id
+
+
+def release_public_root(release_id: str) -> str:
+    """Return the public root for one immutable release."""
+
+    return f"{PUBLIC_VERSION_ROOT}/releases/{validate_release_id(release_id)}"
+
+
+def version_public_string(value: str, release_id: str) -> str:
+    """Move stable project URLs into one immutable release namespace."""
+
+    release_root = release_public_root(release_id)
+    if value.rstrip("/") == PUBLIC_VERSION_ROOT:
+        suffix = "/" if value.endswith("/") else ""
+        return release_root + suffix
+    value = value.replace(f"{PUBLIC_VERSION_ROOT}/", f"{release_root}/")
+    encoded_release_prefix = (
+        f"%2Fdata%2Frasexamples%2F{VERSION_ROOT_NAME}"
+        f"%2Freleases%2F{release_id}%2F"
+    )
+    return ENCODED_VERSION_PREFIX_RE.sub(encoded_release_prefix, value)
+
+
+def version_document(value: Any, release_id: str, *, key: str | None = None) -> Any:
+    """Recursively version public URLs and numeric-service asset identifiers."""
+
+    if isinstance(value, dict):
+        return {
+            item_key: version_document(item_value, release_id, key=item_key)
+            for item_key, item_value in value.items()
+        }
+    if isinstance(value, list):
+        return [version_document(item, release_id) for item in value]
+    if isinstance(value, str):
+        if key == "serviceAsset" and not value.startswith("releases/"):
+            return f"releases/{release_id}/{value}"
+        return version_public_string(value, release_id)
+    return value
+
+
+def version_raster_catalog(document: dict[str, Any], release_id: str) -> dict[str, Any]:
+    """Qualify catalog IDs and paths so older release assets can coexist."""
+
+    if document.get("schema") != RASTER_ASSET_SCHEMA:
+        raise ValueError("The release raster-assets.json has an unsupported schema")
+    records = document.get("assets")
+    if not isinstance(records, dict):
+        raise ValueError("The release raster-assets.json has no asset mapping")
+    prefix = f"releases/{release_id}/"
+    assets: dict[str, dict[str, Any]] = {}
+    for asset_id, record in records.items():
+        if not isinstance(record, dict):
+            raise ValueError(f"Raster asset {asset_id!r} is not an object")
+        path = str(record.get("path") or "")
+        if not path or path.startswith("/") or ".." in Path(path).parts:
+            raise ValueError(f"Raster asset {asset_id!r} has an unsafe path")
+        versioned_id = asset_id if asset_id.startswith(prefix) else prefix + asset_id
+        versioned_record = dict(record)
+        if not path.startswith(prefix):
+            versioned_record["path"] = prefix + path.replace("\\", "/")
+        assets[versioned_id] = versioned_record
+    output = dict(document)
+    output["releaseId"] = release_id
+    output["dataRoot"] = "."
+    output["assets"] = assets
+    return output
+
+
+def prepare_versioned_overlay(
+    source_root: Path,
+    output_root: Path,
+    release_id: str,
+) -> dict[str, Any]:
+    """Write transformed JSON files without copying large release artifacts."""
+
+    release_id = validate_release_id(release_id)
+    source_root = Path(source_root).resolve()
+    output_root = Path(output_root).resolve()
+    if not source_root.is_dir() or source_root.name != VERSION_ROOT_NAME:
+        raise ValueError(
+            f"Source root must be an existing {VERSION_ROOT_NAME} directory"
+        )
+    if output_root == source_root or output_root.is_relative_to(source_root):
+        raise ValueError("The overlay output must be outside the source release")
+    output_root.mkdir(parents=True, exist_ok=True)
+    transformed = 0
+    metadata_paths = sorted(
+        path
+        for path in source_root.rglob("*")
+        if path.suffix.lower() in {".json", ".geojson"}
+    )
+    for source_path in metadata_paths:
+        if source_path.is_symlink():
+            raise ValueError(f"Release JSON cannot be a symlink: {source_path}")
+        relative_path = source_path.relative_to(source_root)
+        document = json.loads(source_path.read_text(encoding="utf-8"))
+        document = version_document(document, release_id)
+        if relative_path.as_posix() == "raster-assets.json":
+            document = version_raster_catalog(document, release_id)
+        elif relative_path.as_posix() in {
+            "catalog.json",
+            "example-projects.geojson",
+            "snapshot.json",
+        }:
+            if not isinstance(document, dict):
+                raise ValueError(f"Release metadata must be an object: {source_path}")
+            document["releaseId"] = release_id
+        destination = output_root / relative_path
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        destination.write_text(
+            json.dumps(document, indent=2) + "\n",
+            encoding="utf-8",
+        )
+        transformed += 1
+
+    required = (
+        "catalog.json",
+        "example-projects.geojson",
+        "raster-assets.json",
+        "snapshot.json",
+    )
+    missing = [name for name in required if not (output_root / name).is_file()]
+    if missing:
+        raise FileNotFoundError(
+            f"Release overlay is missing required metadata: {', '.join(missing)}"
+        )
+    release_document = {
+        "schema": "rascommander.webgis.release/v1",
+        "releaseId": release_id,
+        "generatedAt": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+        "baseUrl": release_public_root(release_id),
+        "catalog": "catalog.json",
+        "exampleProjects": "example-projects.geojson",
+        "rasterAssets": "raster-assets.json",
+    }
+    (output_root / "release.json").write_text(
+        json.dumps(release_document, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    return {"releaseId": release_id, "jsonFiles": transformed + 1}
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--source-root", type=Path, required=True)
+    parser.add_argument("--output-root", type=Path, required=True)
+    parser.add_argument("--release-id", required=True)
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    result = prepare_versioned_overlay(
+        args.source_root,
+        args.output_root,
+        args.release_id,
+    )
+    print(json.dumps(result, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_validate_public_webgis_release.py
+++ b/tests/test_validate_public_webgis_release.py
@@ -1,0 +1,163 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+import sys
+from urllib.parse import parse_qs, urlparse
+
+
+SCRIPT_PATH = (
+    Path(__file__).parents[1]
+    / "scripts"
+    / "example_library"
+    / "validate_public_webgis_release.py"
+)
+SPEC = importlib.util.spec_from_file_location(
+    "validate_public_webgis_release",
+    SCRIPT_PATH,
+)
+assert SPEC and SPEC.loader
+validator = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = validator
+SPEC.loader.exec_module(validator)
+
+
+def response(
+    status: int,
+    document=None,
+    *,
+    cache_control: str = "",
+    content: bytes | None = None,
+    headers: dict[str, str] | None = None,
+):
+    response_headers = dict(headers or {})
+    if cache_control:
+        response_headers["cache-control"] = cache_control
+    return validator.HttpResult(
+        status=status,
+        headers=response_headers,
+        content=content
+        if content is not None
+        else json.dumps(document or {}).encode("utf-8"),
+    )
+
+
+def test_validate_release_exercises_public_delivery_contract(monkeypatch):
+    release_id = "release-20260725"
+    release_root = (
+        "https://rascommander.info/data/rasexamples/hec-ras-7.0/"
+        f"releases/{release_id}"
+    )
+    manifest_url = f"{release_root}/projects/muncie/viewer/manifest.json"
+    requests: list[str] = []
+
+    index = {
+        "type": "FeatureCollection",
+        "releaseId": release_id,
+        "features": [
+            {
+                "properties": {
+                    "projectId": "muncie",
+                    "title": "Muncie",
+                    "manifest": manifest_url,
+                }
+            }
+        ],
+    }
+    manifest = {
+        "resources": {
+            "geometry": {"type": "vector-pmtiles", "href": "tiles/geometry.pmtiles"},
+            "depth": {
+                "type": "cog",
+                "href": "../archive/depth.tif",
+                "serviceAsset": f"releases/{release_id}/projects/muncie/depth",
+                "serviceRevision": "revision-1",
+                "bounds": [-85.1, 40.0, -84.9, 40.2],
+            },
+        },
+        "services": {
+            "numericRaster": {
+                "baseUrl": "/ras-raster",
+                "samplePath": "/sample",
+                "statisticsPath": "/stats",
+                "tilePath": "/tiles/{z}/{x}/{y}.png",
+                "cogPath": "/cog",
+            }
+        },
+    }
+
+    def fake_request(url: str, *, headers=None, timeout=30):
+        requests.append(url)
+        parsed = urlparse(url)
+        query = parse_qs(parsed.query)
+        if parsed.path == "/ras-raster/health":
+            return response(
+                200,
+                {"releaseId": release_id, "assets": 1238},
+                cache_control="no-store",
+            )
+        if parsed.path == "/ras-raster/ready":
+            return response(200, {"status": "ready"}, cache_control="no-store")
+        if parsed.path.endswith("/current/release.json"):
+            return response(
+                200,
+                {"releaseId": release_id},
+                cache_control="no-cache, no-transform",
+            )
+        if parsed.path.endswith("/example-projects.geojson"):
+            return response(200, index, cache_control="public, immutable")
+        if parsed.path.endswith("/viewer/manifest.json"):
+            return response(200, manifest, cache_control="public, immutable")
+        if parsed.path.endswith(".pmtiles"):
+            return response(
+                206,
+                cache_control="public, immutable, no-transform",
+                content=b"PMTiles",
+                headers={"content-range": "bytes 0-16383/20000"},
+            )
+        if parsed.path.endswith("/archive/depth.tif"):
+            return response(
+                206,
+                cache_control="public, immutable, no-transform",
+                content=b"TIFF",
+            )
+        if parsed.path == "/ras-raster/sample" and query.get("asset") == [
+            "__missing__"
+        ]:
+            return response(404, {"detail": "missing"}, cache_control="no-store")
+        if parsed.path == "/ras-raster/sample":
+            return response(200, {"state": "value", "value": 1.0})
+        if parsed.path == "/ras-raster/stats":
+            return response(200, {"domain": {"minimum": 0, "maximum": 10}})
+        if parsed.path.startswith("/ras-raster/tiles/"):
+            return response(200, content=b"\x89PNG\r\n")
+        if parsed.path == "/ras-raster/cog":
+            return response(
+                206,
+                cache_control="public, immutable, no-transform",
+                content=b"TIFF",
+            )
+        if parsed.path.endswith("/__missing-validation-asset__.json"):
+            return response(404, cache_control="no-store")
+        raise AssertionError(f"Unexpected request: {url}")
+
+    monkeypatch.setattr(validator, "request", fake_request)
+
+    result = validator.validate_release(
+        "https://rascommander.info",
+        release_id,
+    )
+
+    assert result["releaseId"] == release_id
+    assert result["assets"] == 1238
+    assert result["projectManifest"] == manifest_url
+    assert any("/ras-raster/health?release=release-20260725" in url for url in requests)
+    assert any("/ras-raster/ready?release=release-20260725" in url for url in requests)
+    assert any("/ras-raster/tiles/" in url for url in requests)
+    assert any("range=bytes%3D0-16383" in url for url in requests)
+
+
+def test_tile_for_point_stays_within_web_mercator_grid():
+    assert validator.tile_for_point(-180, 90, 2) == (0, 0)
+    assert validator.tile_for_point(180, -90, 2) == (3, 3)

--- a/tests/test_version_webgis_release.py
+++ b/tests/test_version_webgis_release.py
@@ -1,0 +1,170 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+
+SCRIPT_PATH = (
+    Path(__file__).parents[1]
+    / "scripts"
+    / "example_library"
+    / "version_webgis_release.py"
+)
+SPEC = importlib.util.spec_from_file_location("version_webgis_release", SCRIPT_PATH)
+assert SPEC and SPEC.loader
+versioner = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(versioner)
+
+
+def make_release(tmp_path: Path) -> Path:
+    root = tmp_path / "hec-ras-7.0"
+    viewer = root / "projects" / "muncie" / "viewer"
+    viewer.mkdir(parents=True)
+    (root / "catalog.json").write_text(
+        json.dumps(
+            {
+                "public_base": "/data/rasexamples/hec-ras-7.0",
+                "items": [
+                    {
+                        "href": (
+                            "/data/rasexamples/hec-ras-7.0/projects/"
+                            "muncie/project.json"
+                        )
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    (root / "example-projects.geojson").write_text(
+        json.dumps(
+            {
+                "type": "FeatureCollection",
+                "features": [
+                    {
+                        "type": "Feature",
+                        "properties": {
+                            "manifest": (
+                                "https://rascommander.info/data/rasexamples/"
+                                "hec-ras-7.0/projects/muncie/viewer/manifest.json"
+                            ),
+                            "webmap": (
+                                "../viewer/?manifest=https%3A%2F%2Frascommander.info"
+                                "%2Fdata%2Frasexamples%2Fhec-ras-7.0%2Fprojects"
+                                "%2Fmuncie%2Fviewer%2Fmanifest.json"
+                            ),
+                        },
+                        "geometry": None,
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    (root / "raster-assets.json").write_text(
+        json.dumps(
+            {
+                "schema": "rascommander.raster-assets/v1",
+                "assets": {
+                    "projects/muncie/depth": {
+                        "path": "projects/muncie/archive/depth.tif",
+                        "revision": "revision-1",
+                        "preset": "rasmapper.depth",
+                    }
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    (root / "snapshot.json").write_text(
+        json.dumps({"catalog": "/data/rasexamples/hec-ras-7.0/catalog.json"}),
+        encoding="utf-8",
+    )
+    (viewer / "manifest.json").write_text(
+        json.dumps(
+            {
+                "schema": "rascommander.maplibre/v2",
+                "resources": {
+                    "depth": {
+                        "type": "cog",
+                        "href": "../archive/depth.tif",
+                        "serviceAsset": "projects/muncie/depth",
+                        "serviceRevision": "revision-1",
+                    }
+                },
+                "tilesets": [
+                    {
+                        "id": "depth",
+                        "serviceAsset": "projects/muncie/depth",
+                        "serviceRevision": "revision-1",
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    return root
+
+
+def test_prepare_versioned_overlay_rewrites_only_json_metadata(tmp_path: Path):
+    source = make_release(tmp_path)
+    overlay = tmp_path / "overlay"
+
+    result = versioner.prepare_versioned_overlay(source, overlay, "release-20260725")
+
+    assert result["releaseId"] == "release-20260725"
+    catalog = json.loads((overlay / "catalog.json").read_text(encoding="utf-8"))
+    assert catalog["releaseId"] == "release-20260725"
+    assert catalog["public_base"].endswith("/releases/release-20260725")
+    assert "/releases/release-20260725/projects/" in catalog["items"][0]["href"]
+
+    geojson = json.loads(
+        (overlay / "example-projects.geojson").read_text(encoding="utf-8")
+    )
+    properties = geojson["features"][0]["properties"]
+    assert geojson["releaseId"] == "release-20260725"
+    assert "/releases/release-20260725/projects/" in properties["manifest"]
+    assert "%2Freleases%2Frelease-20260725%2Fprojects%2F" in properties["webmap"]
+
+    raster_catalog = json.loads(
+        (overlay / "raster-assets.json").read_text(encoding="utf-8")
+    )
+    asset_id = "releases/release-20260725/projects/muncie/depth"
+    assert raster_catalog["releaseId"] == "release-20260725"
+    assert list(raster_catalog["assets"]) == [asset_id]
+    assert raster_catalog["assets"][asset_id]["path"].startswith(
+        "releases/release-20260725/projects/"
+    )
+
+    manifest = json.loads(
+        (overlay / "projects/muncie/viewer/manifest.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    assert manifest["resources"]["depth"]["href"] == "../archive/depth.tif"
+    assert manifest["resources"]["depth"]["serviceAsset"] == asset_id
+    assert manifest["tilesets"][0]["serviceAsset"] == asset_id
+    assert json.loads((overlay / "release.json").read_text(encoding="utf-8"))[
+        "releaseId"
+    ] == "release-20260725"
+
+
+def test_prepare_versioned_overlay_rejects_missing_required_metadata(tmp_path: Path):
+    source = tmp_path / "hec-ras-7.0"
+    source.mkdir()
+
+    with pytest.raises(FileNotFoundError, match="required metadata"):
+        versioner.prepare_versioned_overlay(
+            source,
+            tmp_path / "overlay",
+            "release-20260725",
+        )
+
+
+@pytest.mark.parametrize("release_id", ["", "../release", "release/one", "-release"])
+def test_validate_release_id_rejects_unsafe_values(release_id: str):
+    with pytest.raises(ValueError):
+        versioner.validate_release_id(release_id)

--- a/tests/test_webgis_release_hardening.py
+++ b/tests/test_webgis_release_hardening.py
@@ -1,0 +1,61 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).parents[1]
+SCRIPTS = ROOT / "scripts" / "example_library"
+
+
+def read_script(name: str) -> str:
+    return (SCRIPTS / name).read_text(encoding="utf-8")
+
+
+def test_ct230_provisioner_uses_status_aware_cache_and_capacity_limits():
+    source = read_script("provision_webgis_raster_service.sh")
+
+    assert 'default "no-store";' in source
+    assert "max-age=31536000, immutable, no-transform" in source
+    assert "current/|catalog\\.json$|example-projects\\.geojson$" in source
+    assert "RAS2CNG_RASTER_MAX_CONCURRENT_OPERATIONS=8" in source
+    assert "limit_req zone=ras_raster_requests" in source
+    assert "limit_conn ras_raster_connections 16" in source
+    assert "/ras-raster/ready" in source
+    assert "cache-control: no-store" in source
+
+
+def test_publisher_stages_immutable_release_and_switches_current_atomically():
+    source = read_script("clb03_rascommander_webgis_publisher.sh")
+
+    assert '/.incoming/${incoming_name}' in source
+    assert "/releases/${release_id}" in source
+    assert '--link-dest="$link_destination"' in source
+    assert 'mv -T -- "$remote_incoming_path" "$remote_release_path"' in source
+    assert 'mv -Tf -- "$temporary_current" "$current_path"' in source
+    assert "raster-service-catalog-merge" in source
+    assert "--release-id \"$release_id\"" in source
+    assert 'python3 "$PUBLIC_VALIDATOR"' in source
+    assert "prepare_pointer_backup" in source
+    assert "finalize_current_release" in source
+    assert "Restored the previous public release pointers" in source
+    assert "leaving validated release" not in source
+    assert '"${release_dir}/data/rasexamples/"' not in source
+
+
+def test_clb03_installer_deploys_release_helpers():
+    source = read_script("install_clb03_rascommander_webgis_publisher.sh")
+
+    assert "version_webgis_release.py" in source
+    assert "validate_public_webgis_release.py" in source
+    assert "/usr/local/libexec" in source
+
+
+def test_library_uses_atomic_current_release_pointer():
+    page = (ROOT / "docs" / "examples" / "example-projects.md").read_text(
+        encoding="utf-8"
+    )
+    javascript = (
+        ROOT / "docs" / "assets" / "javascripts" / "ras-example-library.js"
+    ).read_text(encoding="utf-8")
+
+    expected = "hec-ras-7.0/current/example-projects.geojson"
+    assert expected in page
+    assert expected in javascript


### PR DESCRIPTION
## Summary

- publish each Example Library bundle into an immutable, release-qualified WebGIS namespace
- stage the complete transfer under `.incoming`, reuse unchanged files with hard links, and atomically switch the `current` pointer only after the numeric raster catalog is ready
- preserve and restore both public pointers and the raster allowlist on failed validation, including the first versioned release
- apply status-aware Nginx caching so immutable artifacts are long-lived while mutable metadata revalidates and all errors remain non-cacheable
- add request/connection limits, service readiness checks, and current CLB-WebGIS host guidance
- add a public synthetic validator covering the landing index, project manifest, PMTiles and COG range requests, numeric samples/statistics/tiles, bounded COG access, and error cache behavior

## Root cause

The existing publisher copied files directly into the stable live namespace before catalog promotion. A partial transfer or failed service restart could therefore expose a mixed release. Static 404 responses and service health responses also inherited cacheable headers, and the publisher had no end-to-end public validation or complete pointer rollback.

## Deployment order

1. Merge and install the companion `ras2cng` raster-service hardening PR on CT230: https://github.com/gpt-cmdr/ras2cng/pull/12
2. Run the updated CT230 and CT210 provisioners.
3. Install the updated CLB03 publisher and helper scripts.
4. Publish a new release; the publisher will create `releases/<id>`, validate CT230 readiness, switch `current`, and run the public synthetic checks.
5. Deploy the docs change after `current/example-projects.geojson` exists. The existing baked catalog remains a browser fallback during rollout.

## Validation

- `79 passed, 1 skipped` across the Example Library publishing, packaging, reconstruction, viewer-upgrade, release-versioning, and public-validation tests
- all modified Bash scripts pass `bash -n` after Windows line-ending normalization
- both new Python helpers pass `py_compile`
- `ras-example-library.js` passes `node --check`
- `mkdocs build` completes successfully; warnings are the existing missing pre-rendered notebook warnings when the CI notebook-preparation step is omitted locally