### PR TITLE
fix: preserve RAS worker request identity

### DIFF
--- a/.claude/skills/hecras_compute_plans/SKILL.md
+++ b/.claude/skills/hecras_compute_plans/SKILL.md
@@ -18,6 +18,11 @@ description: |
 
 When the user asks to run HEC-RAS plans, use `RasCmdr.compute_plan()` for single plans or `RasCmdr.compute_parallel()` for multiple. Read the primary sources below for complete parameter details.
 
+For prepared external-forcing scenarios, do not compute until the project
+current plan, cloned flow file, simulation window, DSS references, and
+boundary-to-active-geometry crosswalk have been validated. Preserve the source
+newline convention in RAS text files; reject mixed LF/CRLF input.
+
 ## Primary Sources
 
 ### 1. Execution Patterns (AGENTS.md)
@@ -104,6 +109,18 @@ RasCmdr.compute_plan(
 - `verify` - True to check completion
 - `skip_existing` - True to resume interrupted runs
 - `stream_callback` - Real-time monitoring object
+
+The return value is an execution signal, not hydraulic acceptance. After
+compute, verify the result HDF completion flag and time axis, then use
+`hecras_parse_compute-messages` and `hecras_extract_results`. Report ignored
+inflows, raster coverage, convergence, and volume accounting as conditional
+review items.
+
+For a workspace prepared by `RasScenario.prepare_workspace()`, prefer
+`RasScenario.execute()`. Its run artifact fails closed unless the compute call,
+nonempty HDF, HDF completion flag, and exact output time window all pass. Treat
+that artifact as the execution-completion gate only; the conditional hydraulic
+review still follows.
 
 ### Parallel Execution
 

--- a/.claude/skills/hecras_extract_results/SKILL.md
+++ b/.claude/skills/hecras_extract_results/SKILL.md
@@ -9,8 +9,9 @@ description: |
   depths, velocities, and flows for both steady and unsteady simulations. Handles cross section
   time series, 2D mesh results, maximum envelopes, and dam breach results. Use when you need to
   extract, analyze, or post-process HEC-RAS simulation outputs, retrieve water levels, query
-  velocity fields, get depth grids, extract flow data, analyze breach hydrographs, or pull
-  hydraulic variables from .hdf result files.
+  velocity fields, get depth grids, extract flow data, create deterministic
+  hydraulic product manifests, analyze breach hydrographs, or pull hydraulic
+  variables from .hdf result files.
   Triggers: HDF results, extract WSE, water surface elevation, depth grid, velocity,
   flow data, mesh results, cross section time series, maximum envelope, breach results,
   HdfResultsPlan, HdfResultsMesh, HdfResultsBreach, steady results, unsteady results,
@@ -26,6 +27,14 @@ and that its first/last output timestamps match the active plan window. Result
 arrays can be populated even when individual inflows were ignored or the run
 has convergence/coverage warnings, so retain compute-message qualification
 alongside extracted values.
+
+When the user needs reusable scenario-serving assets rather than exploratory
+DataFrames, use `HdfResultsProducts.inspect_result()` and
+`HdfResultsProducts.export()`. That package-owned operation fails closed on
+completion/time inconsistencies and emits stable COG, Parquet, footprint,
+metadata, numerical-summary, preview, and manifest assets without mutating the
+source HDF. Do not recreate that contract in orchestration code, and do not
+treat extraction success as hydraulic QA/QC acceptance.
 
 **Primary Sources**:
 - **HDF Class Reference**: `ras_commander/hdf/AGENTS.md` - Canonical HDF package contract, module families, lazy loading rules, decorators
@@ -129,6 +138,7 @@ Read this notebook when you need:
 | Class | Purpose | Primary Use |
 |-------|---------|-------------|
 | **HdfResultsPlan** | Plan-level results | Steady profiles, metadata, plan info, output times, computation messages |
+| **HdfResultsProducts** | Scenario product package | Stable COG, Parquet, footprint, metadata, QAQC-summary, preview, and manifest assets |
 | **HdfResultsMesh** | 2D mesh results | Maximum envelopes, time series, spatial grids |
 | **HdfResultsXsec** | Cross section results | 1D time series, longitudinal profiles |
 | **HdfResultsBreach** | Breach results | Dam breach time series, summary statistics, geometry evolution |
@@ -238,6 +248,26 @@ max_vel = HdfResultsMesh.get_mesh_maximum("01", variable="Velocity")
 **Returns**: GeoDataFrame with columns: cell_id, max_value, max_time, geometry (Polygon)
 
 **Full Details**: `examples/410_2d_hdf_data_extraction.ipynb`
+
+---
+
+### Deterministic Scenario Product Package
+
+```python
+from ras_commander import HdfResultsProducts
+
+inspection = HdfResultsProducts.inspect_result("project.p02.hdf")
+manifest = HdfResultsProducts.export(
+    "project.p02.hdf",
+    "products/scenario-001/hydraulics",
+)
+```
+
+The output directory must not already exist. Consume
+`hydraulic-products.json` downstream instead of reopening the HDF to
+reconstruct CRS, bounds, raster, time, table, checksum, or numerical-summary
+metadata. Keep the manifest's `hydraulic_qaqc = not_evaluated` state separate
+from solver completion.
 
 ---
 

--- a/.claude/skills/hecras_extract_results/SKILL.md
+++ b/.claude/skills/hecras_extract_results/SKILL.md
@@ -21,6 +21,12 @@ description: |
 
 When the user asks to extract HEC-RAS results, use the patterns below. Read the primary sources for complete details -- do not duplicate their content here.
 
+Before interpreting values, verify that the HDF reports successful completion
+and that its first/last output timestamps match the active plan window. Result
+arrays can be populated even when individual inflows were ignored or the run
+has convergence/coverage warnings, so retain compute-message qualification
+alongside extracted values.
+
 **Primary Sources**:
 - **HDF Class Reference**: `ras_commander/hdf/AGENTS.md` - Canonical HDF package contract, module families, lazy loading rules, decorators
 - **Library Context**: `ras_commander/AGENTS.md` - HDF architecture overview, subpackage organization

--- a/.claude/skills/hecras_parse_compute-messages/SKILL.md
+++ b/.claude/skills/hecras_parse_compute-messages/SKILL.md
@@ -25,6 +25,10 @@ description: |
 
 When the user asks about execution status or compute messages, use these patterns. Read the primary sources above for implementation details.
 
+Keep `execution complete` distinct from `hydraulic QA/QC accepted`. Runtime
+data or the phrase `Complete Process` is supporting evidence, not a complete
+qualification decision.
+
 ---
 
 ## Quick Start
@@ -133,10 +137,20 @@ Use this variant in automated/parallel workflows where COM locking is problemati
 
 | Pattern | Meaning |
 |---------|---------|
-| `Complete Process` | Plan finished successfully |
+| `Complete Process` | Solver process reached completion; also verify HDF completion and time axis |
 | `Writing Results` | Output phase started |
 | `Completing Geometry` | Preprocessing successful |
 | `Completing Event Conditions` | Boundary setup successful |
+
+Also preserve conditional messages that may not stop the solver:
+
+- a lateral inflow ignored because its target is absent from geometry;
+- precipitation raster faces or cells outside forcing coverage;
+- cells reaching the maximum iteration count;
+- maximum WSEL error and volume-accounting metrics.
+
+Classify these under the study's documented thresholds. Do not silently convert
+them to either a fatal error or an unconditional pass.
 
 ---
 

--- a/.claude/skills/precip_analyze_aorc/SKILL.md
+++ b/.claude/skills/precip_analyze_aorc/SKILL.md
@@ -22,6 +22,13 @@ description: |
 
 **This skill is a NAVIGATOR** -- read the primary sources below for complete workflows and API documentation. Do not duplicate implementation details here.
 
+Treat the storm transposition/scoring domain and the hydraulic forcing-coverage
+domain as separate concepts. Before a rain-on-grid qualification, verify that
+the actual DSS grid footprint covers the active RAS mesh and report any faces
+or cells outside the precipitation raster. Do not expand a scientific
+transposition domain merely to suppress a hydraulic coverage warning without
+an approved hydrometeorologic policy.
+
 ## Primary Sources (Read These First!)
 
 ### 1. Canonical Precipitation Contract

--- a/.gitignore
+++ b/.gitignore
@@ -262,3 +262,6 @@ terminal-logs/
 .env.local
 .pypirc
 /agent_tasks/plans
+
+# Data directory
+/data/

--- a/.gitignore
+++ b/.gitignore
@@ -268,3 +268,4 @@ terminal-logs/
 
 # test temp
 .test-tmp/
+.vscode/settings.json

--- a/.gitignore
+++ b/.gitignore
@@ -265,3 +265,6 @@ terminal-logs/
 
 # Data directory
 /data/
+
+# test temp
+.test-tmp/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -128,6 +128,12 @@ This file is the canonical shared instruction contract for repository-local codi
   nonempty result HDF, HDF completion marker, and exact output time window all
   pass.
 - Keep execution completion and hydraulic qualification separate. A completed solver and populated HDF may still require review for ignored inflows, precipitation coverage, convergence, volume accounting, or other conditional warnings.
+- Use `HdfResultsProducts.export()` for deterministic client-oriented hydraulic
+  products from a completed plan HDF. Cross-repository orchestration consumes
+  its manifest and must not duplicate RAS HDF interpretation, rasterization,
+  hydrograph extraction, or numerical-summary rules.
+- A hydraulic product manifest records mechanical completion and extracted
+  evidence. It must leave hydraulic QA/QC as a separate, explicit gate.
 - Generate reviewable outputs:
   - HEC-RAS project artifacts that open in the GUI
   - plots or figures when results need visual checking

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -121,6 +121,13 @@ This file is the canonical shared instruction contract for repository-local codi
   - errors should include enough diagnostic detail to debug path issues, including discovered versions and relevant candidate paths
   - docs build scripts and committed notebook outputs must stay faithful to real output; do not sanitize or rewrite outputs during documentation generation
 - Keep original project folders immutable when practical. Prefer `dest_folder=` or separate working directories for execution outputs and experiments.
+- Preserve the existing newline convention when mutating HEC-RAS ASCII files. Reject mixed LF/CRLF input; mixed project or plan files can cause the Windows GUI to load only the Project section.
+- Scenario builders must make the cloned plan current and verify its simulation window before execution. A plan file's existence does not make it the active plan.
+- Crosswalk every external DSS boundary selector to the geometry used by the active plan. An inherited `.u##` boundary block may reference a storage area, 2D area, BC line, or cross section that no longer exists.
+- Scenario execution artifacts must fail closed unless the compute return value,
+  nonempty result HDF, HDF completion marker, and exact output time window all
+  pass.
+- Keep execution completion and hydraulic qualification separate. A completed solver and populated HDF may still require review for ignored inflows, precipitation coverage, convergence, volume accounting, or other conditional warnings.
 - Generate reviewable outputs:
   - HEC-RAS project artifacts that open in the GUI
   - plots or figures when results need visual checking

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,4 +4,7 @@ include ras_commander/native/RasStoreMapHelper.exe
 include ras_commander/native/RasStoreMapHelper.cs
 include ras_commander/resources/land_classification/*.hdf
 recursive-include ras_commander/resources/templates *
+global-exclude *.py[cod]
+prune ras_commander/resources/templates/__pycache__
+recursive-include ras_commander/contracts *.schema.json
 

--- a/README.md
+++ b/README.md
@@ -80,6 +80,13 @@ HEC-RAS Project Management & Execution
 - Progress tracking and logging
 - Execution error handling and recovery
 
+Automated execution status is not hydraulic acceptance. For externally forced
+or cloned scenarios, first verify the project current plan, cloned flow file,
+simulation window, resolvable DSS references, and boundary-to-active-geometry
+crosswalk. After compute, verify the result HDF completion flag and time axis,
+then retain ignored inflows, precipitation coverage, convergence, WSEL error,
+and volume accounting as explicit engineering review items.
+
 Legacy Version Support (NEW in v0.81.0)
 - **RasControl class** for HEC-RAS 3.x-4.x via COM interface (HECRASController)
 - ras-commander style API - use plan numbers, not file paths

--- a/docs/api/hdf.md
+++ b/docs/api/hdf.md
@@ -52,6 +52,49 @@ Mesh geometry data.
 - `get_profile_line_flow_timeseries(hdf_path, line_name, mesh_name=None, profile_lines_path=None, direction="absolute")` - Flow time series across a RAS Mapper profile/reference line
 - `get_profile_line_peak_flow(hdf_path, line_name, mesh_name=None, profile_lines_path=None, direction="absolute")` - Peak Q and peak time for a profile/reference line
 
+### HdfResultsProducts
+
+Deterministic client-oriented products from a completed unsteady plan HDF.
+
+- `inspect_result(hdf_path)` - Fail-closed completion, time-axis, mesh, CRS,
+  version, and units inspection
+- `export(hdf_path, output_directory, resolution=None, max_dimension=2048,
+  nodata=-9999, include_preview=True)` - Create checksum-pinned COG,
+  hydrograph, footprint, metadata, QAQC-summary, and optional preview assets
+
+```python
+from ras_commander import HdfResultsProducts
+
+manifest = HdfResultsProducts.export(
+    "project.p02.hdf",
+    "products/scenario-001/hydraulics",
+)
+```
+
+The output directory must not already exist. Stable assets are:
+
+- `maximum-wse.tif`
+- `maximum-depth.tif`
+- `maximum-velocity.tif`
+- `hydraulic-hydrographs.parquet`
+- `result-metadata.json`
+- `numerical-qaqc.json`
+- `result-footprint.geojson`
+- `maximum-depth-preview.png`, when the renderer is available
+- `hydraulic-products.json`
+
+The three rasters are Cloud Optimized GeoTIFFs on one grid and carry CRS,
+bounds, shape, transform, nodata, units, statistics, checksums, and sizes in
+the manifest. When the HDF does not store maximum depth directly, depth is
+derived as the maximum nonnegative difference between water-surface elevation
+and cell minimum elevation. Maximum velocity is the largest absolute adjacent
+face velocity assigned to each cell; it is not a velocity-vector product.
+
+`numerical-qaqc.json` preserves solver summaries, volume accounting, water
+surface errors, iterations, and classified compute-message findings.
+Extraction success does not imply hydraulic acceptance: the manifest keeps
+`hydraulic_qaqc` as `not_evaluated` for the owning study to decide.
+
 ## Plan Results
 
 ### HdfResultsPlan

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -36,6 +36,8 @@ Classes for reading HDF result files:
 - [`HdfPlan`](hdf.md#hdfplan) - Plan information
 - [`HdfMesh`](hdf.md#hdfmesh) - Mesh geometry
 - [`HdfResultsMesh`](hdf.md#hdfresultsmesh) - 2D mesh results
+- [`HdfResultsProducts`](hdf.md#hdfresultsproducts) - Deterministic hydraulic
+  product package
 - [`HdfResultsPlan`](hdf.md#hdfresultsplan) - Plan-level results
 - [`HdfResultsXsec`](hdf.md#hdfresultsxsec) - 1D cross-section results
 - [`HdfStruc`](hdf.md#hdfstruc) - Structure data

--- a/docs/api/scenario-worker.md
+++ b/docs/api/scenario-worker.md
@@ -1,0 +1,12 @@
+# RAS Scenario Worker
+
+::: ras_commander.RasScenarioWorker
+    options:
+      show_root_heading: true
+      show_source: true
+      members_order: source
+
+::: ras_commander.RasScenarioWorkerError
+    options:
+      show_root_heading: true
+      show_source: true

--- a/docs/user-guide/plan-execution.md
+++ b/docs/user-guide/plan-execution.md
@@ -520,9 +520,11 @@ contract before calling `compute_plan()`:
 - every river/reach/station or storage-area/2D/BC-line selector exists in the
   geometry used by the plan.
 
-Preserve one newline convention in RAS text files. Mixed LF and CRLF records can
-cause the Windows GUI to load the project while leaving Plan, Geometry, and Flow
-sections blank.
+Preserve one newline convention in authored RAS project, plan, geometry, and
+flow text files. Mixed LF and CRLF records can cause the Windows GUI to load the
+project while leaving Plan, Geometry, and Flow sections blank. Generated
+compute artifacts such as `.b##`, `.c##`, `.o##`, `.r##`, and `.x##` are not
+part of this text-file check because they may be binary.
 
 After compute, report two independent outcomes:
 

--- a/docs/user-guide/plan-execution.md
+++ b/docs/user-guide/plan-execution.md
@@ -505,3 +505,42 @@ except ValueError as e:
 3. **Clear preprocessor**: Use `clear_geompre=True` after geometry changes
 4. **Check return values**: Always verify execution success
 5. **Use logging**: Enable DEBUG level for troubleshooting
+
+## Qualification Gates for Automated Scenarios
+
+For a cloned or externally forced unsteady plan, verify the preparation
+contract before calling `compute_plan()`:
+
+- the project `Current Plan` is the cloned plan;
+- the plan references the cloned `.u##` file;
+- the `Simulation Date` equals the intended forcing window;
+- every DSS reference is absolute or begins with `.\`/`..\` and resolves to an
+  existing file;
+- every exact DSS pathname covers the plan window; and
+- every river/reach/station or storage-area/2D/BC-line selector exists in the
+  geometry used by the plan.
+
+Preserve one newline convention in RAS text files. Mixed LF and CRLF records can
+cause the Windows GUI to load the project while leaving Plan, Geometry, and Flow
+sections blank.
+
+After compute, report two independent outcomes:
+
+1. **Execution completion**: the solver completed, the result HDF is populated,
+   its completed flag is true, and its time axis matches the plan window.
+2. **Hydraulic qualification**: compute messages and results satisfy the
+   study's engineering criteria.
+
+A run can pass the first outcome and remain conditional on ignored inflows,
+rainfall-grid/mesh coverage, maximum-iteration cells, volume accounting, or
+other model-specific warnings. Preserve those messages in the qualification
+record instead of collapsing them into a single success boolean.
+
+`RasScenario.execute()` performs the first set of checks automatically for a
+prepared scenario workspace. Its `RasRunArtifact.status` is `succeeded` only
+when the compute call returns success, the result HDF is nonempty, the HDF
+`Event Conditions/Completed Successfully` attribute is true, and the first and
+last unsteady output timestamps exactly match the workspace simulation window.
+The artifact records each check separately, including any HDF inspection
+error. This execution status is intentionally not a hydraulic acceptance
+decision.

--- a/docs/user-guide/scenario-worker.md
+++ b/docs/user-guide/scenario-worker.md
@@ -1,0 +1,160 @@
+# Scenario Worker
+
+`ras-scenario-worker` is the package-owned process boundary for one isolated
+HEC-RAS scenario. It lets an orchestrator invoke RAS Commander from a dedicated
+RAS environment without importing RAS Commander into the orchestrator.
+
+The versioned request binds the scenario to:
+
+- the source project checksum, full model-manifest identity, and exact template
+  plan;
+- the HMS result DSS and hydrologic product-manifest identities;
+- every exact DSS boundary selector;
+- the run-local gridded `EXCESS` DSS and provenance identity;
+- the local model window, RAS executable, core count, and timeout; and
+- new workspace and hydraulic-product destinations.
+
+Run a request with either entry point:
+
+```powershell
+ras-scenario-worker --request request.json --result result.json
+
+python -m ras_commander.RasScenarioWorker `
+  --request request.json `
+  --result result.json
+```
+
+The worker calls `RasScenario.prepare_workspace()`, `RasScenario.execute()`,
+and `HdfResultsProducts.export()`. The original model is not mutated. A
+successful result includes current-plan, simulation-window, newline,
+geometry-crosswalk, DSS-link, HDF-completion, time-axis, product, numerical
+QA/QC, and timing evidence.
+
+Newline evidence covers authored project, plan, geometry, and flow text files;
+generated `.b##`, `.c##`, `.o##`, `.r##`, and `.x##` compute artifacts are
+excluded because they may be binary.
+
+Scenario clones omit source-project generated outputs: the project-named DSS,
+plan and temporary plan HDF files, and RAS Mapper `PostProcessing.hdf` caches.
+Geometry HDF inputs remain in the clone. The preparation result records every
+excluded path and byte count so the reduced clone is auditable.
+
+Mechanical execution and hydraulic acceptance remain separate. Compute-message
+findings such as ignored boundaries, precipitation coverage, maximum
+iterations, water-surface error, and volume accounting are returned under
+`conditional_findings`; their presence does not rewrite a mechanically
+successful execution as a failure.
+
+## Repeat and failure behavior
+
+A verified successful result for the identical normalized request is returned
+without rerunning RAS. The worker refuses an existing workspace, product
+directory, conflicting result, or changed completed output. Timeout and failed
+attempt workspaces are retained for diagnosis and GUI review, and failure
+results are written atomically when possible.
+
+## Shared linked-asset cache and preparation retry
+
+Large immutable linked directories such as `Terrain`, `Land Cover`, and
+`Hydrologic Input` do not need a private copy for every scenario. Set
+`source_model.linked_asset_mode` to `shared-cache` and place scenario workspace
+directories directly below one stable cache root. The first request copies or
+adopts the linked directories beside the workspace, content-compares them with
+their declared sources, records an identity manifest, and marks cached files
+read-only. Later sibling workspaces verify the cache metadata and reuse it
+without copying the large assets again.
+
+```json
+{
+  "source_model": {
+    "linked_asset_mode": "shared-cache",
+    "linked_asset_directories": [
+      "C:/models/release/Terrain",
+      "C:/models/release/Land Cover"
+    ]
+  },
+  "workspace": "C:/ras-cache/model-manifest-sha/scenario-001"
+}
+```
+
+The cache key is the request's verified RAS model-manifest SHA-256. A different
+key, source path, file population, size, or modification time fails closed.
+Cache adoption may read both large trees once to establish their content
+identity, but it does not allocate another copy.
+
+A corrected retry after a preparation-only failure may reference the preserved
+prior request and result:
+
+```json
+{
+  "retry": {
+    "prior_request": "C:/evidence/failed-request.json",
+    "prior_result": "C:/evidence/failed-result.json"
+  }
+}
+```
+
+The worker authenticates the prior request/result binding, requires execution
+to remain `not_started`, preserves the failed workspace, and requires the new
+workspace to be a sibling under the same cache root. Scenario, source-model,
+hydrology, forcing-excess, and model-window identities cannot change; corrected
+boundary selectors and execution options may change.
+
+The packaged contracts are:
+
+- `ras-commander/scenario-worker-request/1.0`
+- `ras-commander/scenario-worker-result/1.0`
+
+## Configure the installed-engine test
+
+The installed-engine test is opt-in through the `integration` pytest marker.
+Configure its inputs with environment variables in the shell that launches
+pytest:
+
+| Variable | Required | Value |
+| --- | --- | --- |
+| `RAS_WORKER_TEST_SOURCE_PROJECT` | Yes | Source `.prj` file or directory containing one project |
+| `RAS_WORKER_TEST_SOURCE_PLAN` | Yes | Template plan number, such as `01` |
+| `RAS_WORKER_TEST_MODEL_MANIFEST` | Yes | JSON model manifest whose `stage` is `ras` |
+| `RAS_WORKER_TEST_HYDROLOGY_DSS` | Yes | HMS result DSS used by the boundary links |
+| `RAS_WORKER_TEST_HYDROLOGY_MANIFEST` | Yes | `hms-commander/hydrologic-product-manifest/1.0` JSON that identifies the HMS DSS checksum |
+| `RAS_WORKER_TEST_BOUNDARY_LINKS_JSON` | Yes | JSON array of worker boundary-link objects |
+| `RAS_WORKER_TEST_EXCESS_DSS` | Yes | Run-local gridded excess DSS |
+| `RAS_WORKER_TEST_EXCESS_MANIFEST` | Yes | JSON provenance manifest for the excess DSS |
+| `RAS_WORKER_TEST_EXCESS_PATHNAME` | Yes | Six-part DSS pathname family, ending with `/` |
+| `RAS_WORKER_TEST_EXECUTABLE` | Yes | Installed `Ras.exe` path |
+| `RAS_WORKER_TEST_START` / `RAS_WORKER_TEST_END` | No | Naive local model timestamps; defaults cover the DeLoutre canary window |
+| `RAS_WORKER_TEST_TIME_ZONE` | No | IANA time-zone identity; default `America/Chicago` |
+| `RAS_WORKER_TEST_TIMEOUT_SECONDS` | No | Positive worker timeout; default `7200` |
+| `RAS_WORKER_TEST_CORES` | No | Positive RAS core count; default `2` |
+| `RAS_WORKER_TEST_WORKSPACE` | No | New, nonexistent workspace path |
+| `RAS_WORKER_TEST_LINKED_ASSETS_JSON` | No | JSON array of immutable linked-asset directories |
+| `RAS_WORKER_TEST_LINKED_ASSET_MODE` | No | `copy` or `shared-cache`; default `copy` |
+| `RAS_WORKER_TEST_RETRY_REQUEST` / `RAS_WORKER_TEST_RETRY_RESULT` | No | Authenticated preparation-only retry evidence; configure both or neither |
+
+For example:
+
+```powershell
+$env:RAS_WORKER_TEST_SOURCE_PROJECT = 'C:\models\release\Model.prj'
+$env:RAS_WORKER_TEST_SOURCE_PLAN = '01'
+$env:RAS_WORKER_TEST_MODEL_MANIFEST = 'C:\evidence\ras-model.json'
+$env:RAS_WORKER_TEST_HYDROLOGY_DSS = 'C:\inputs\hms-output.dss'
+$env:RAS_WORKER_TEST_HYDROLOGY_MANIFEST = 'C:\inputs\hydrologic-products.json'
+$env:RAS_WORKER_TEST_BOUNDARY_LINKS_JSON = Get-Content -Raw '.\boundary-links.json'
+$env:RAS_WORKER_TEST_EXCESS_DSS = 'C:\inputs\ras-excess.dss'
+$env:RAS_WORKER_TEST_EXCESS_MANIFEST = 'C:\inputs\ras-excess.json'
+$env:RAS_WORKER_TEST_EXCESS_PATHNAME = '/SHG/BASIN/PRECIPITATION///EXCESS/'
+$env:RAS_WORKER_TEST_EXECUTABLE = 'C:\Program Files (x86)\HEC\HEC-RAS\6.6\Ras.exe'
+$env:RAS_WORKER_TEST_WORKSPACE = 'C:\ras-cache\model-hash\canary-001'
+$env:RAS_WORKER_TEST_LINKED_ASSETS_JSON = '["C:/models/release/Terrain"]'
+$env:RAS_WORKER_TEST_LINKED_ASSET_MODE = 'shared-cache'
+
+python -m pytest tests\test_scenario_worker.py `
+  -m integration `
+  -k installed_engine_executes_one_scenario `
+  --basetemp .\working\pytest-scenario-worker-installed
+```
+
+Use a fresh `--basetemp` and workspace for each new attempt. A shared cache
+can adopt an existing directory only when its content matches the declared
+canonical source; otherwise the worker fails closed before RAS execution.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -71,6 +71,7 @@ plugins:
         User Guide:
           - user-guide/overview.md
           - user-guide/plan-execution.md
+          - user-guide/scenario-worker.md
           - user-guide/workflows-and-patterns.md
           - user-guide/hdf-data-extraction.md
           - user-guide/geometry-operations.md
@@ -171,6 +172,7 @@ nav:
       - Project Initialization: getting-started/project-initialization.md
     - Architecture Overview: user-guide/overview.md
     - Plan Execution: user-guide/plan-execution.md
+    - Scenario Worker: user-guide/scenario-worker.md
     - Workflows & Patterns: user-guide/workflows-and-patterns.md
     - Boundary Conditions: user-guide/boundary-conditions.md
     - Spatial Data & RASMapper: user-guide/spatial-data.md
@@ -210,6 +212,7 @@ nav:
   - API Reference:
     - Overview: api/index.md
     - Core Classes: api/core.md
+    - Scenario Worker: api/scenario-worker.md
     - Benefits Analysis: api/benefits.md
     - HDF Modules: api/hdf.md
     - Geometry Modules: api/geometry.md

--- a/ras_commander/AGENTS.md
+++ b/ras_commander/AGENTS.md
@@ -57,6 +57,10 @@ This file is the canonical local instruction file for the `ras_commander/` packa
   nonempty result HDF, HDF completion marker, and exact output time window all
   pass.
 - Record solver completion separately from hydraulic QA/QC. Ignored inflows, mesh/raster coverage warnings, convergence limits, and volume-accounting metrics remain explicit review items even when the HDF reports successful completion.
+- `HdfResultsProducts` owns deterministic scenario serving products. It must
+  fail closed on incomplete results or inconsistent time axes, preserve the
+  source HDF, use stable asset keys and filenames, and emit checksum-pinned
+  metadata sufficient for STAC assembly without reopening the HDF.
 
 ## Testing Rules
 

--- a/ras_commander/AGENTS.md
+++ b/ras_commander/AGENTS.md
@@ -50,6 +50,13 @@ This file is the canonical local instruction file for the `ras_commander/` packa
 - Preserve originals when practical. Prefer `dest_folder=` for plan execution and isolated working directories for derived artifacts.
 - Be conservative with `max_workers * num_cores` when parallelizing runs.
 - Remote execution details live in [ras_commander/remote/AGENTS.md](remote/AGENTS.md).
+- RAS `.prj`, `.p##`, `.u##`, and related ASCII mutators must preserve the file's single newline convention. Fail closed on mixed LF/CRLF input instead of writing a hybrid file.
+- When cloning a scenario plan, set it as `Current Plan`, preserve the source plan's time-token style, and validate the active plan plus exact simulation window before compute.
+- Validate external boundary selectors against the cloned plan's geometry. Updating a matching unsteady-flow block alone is not proof that RAS will apply the boundary.
+- `RasScenario.execute()` must fail closed unless the compute return value,
+  nonempty result HDF, HDF completion marker, and exact output time window all
+  pass.
+- Record solver completion separately from hydraulic QA/QC. Ignored inflows, mesh/raster coverage warnings, convergence limits, and volume-accounting metrics remain explicit review items even when the HDF reports successful completion.
 
 ## Testing Rules
 

--- a/ras_commander/RasPlan.py
+++ b/ras_commander/RasPlan.py
@@ -1889,19 +1889,29 @@ class RasPlan:
             if plan_file_path is None or not Path(plan_file_path).exists():
                 raise ValueError(f"Plan file not found for plan number: {plan_number_or_path!r}")
 
-        # Format the dates
-        formatted_date = f"{start_date.strftime('%d%b%Y').upper()},{start_date.strftime('%H%M')},{end_date.strftime('%d%b%Y').upper()},{end_date.strftime('%H%M')}"
-
         try:
-            # Read the file
-            with open(plan_file_path, 'r', encoding='utf-8', errors='replace') as file:
-                lines = file.readlines()
+            lines, newline = RasUtils._read_text_lines_preserving_newline(
+                plan_file_path
+            )
 
             # Update the Simulation Date line
             updated = False
             for i, line in enumerate(lines):
                 if line.startswith("Simulation Date="):
-                    lines[i] = f"Simulation Date={formatted_date}\n"
+                    existing = line.rstrip("\r\n").split("=", 1)[1]
+                    time_tokens = existing.split(",")[1::2]
+                    time_format = (
+                        "%H:%M"
+                        if any(":" in token for token in time_tokens)
+                        else "%H%M"
+                    )
+                    formatted_date = (
+                        f"{start_date:%d%b%Y},"
+                        f"{start_date.strftime(time_format)},"
+                        f"{end_date:%d%b%Y},"
+                        f"{end_date.strftime(time_format)}"
+                    ).upper()
+                    lines[i] = f"Simulation Date={formatted_date}{newline}"
                     updated = True
                     break
 
@@ -1912,9 +1922,9 @@ class RasPlan:
                     "Cannot update simulation date."
                 )
 
-            # Write the updated content back to the file
-            with open(plan_file_path, 'w', encoding='utf-8', errors='replace') as file:
-                file.writelines(lines)
+            RasUtils._write_text_lines_with_newline(
+                plan_file_path, lines, newline
+            )
 
             logger.info("Updated simulation date in plan file: %s", plan_file_path.name)
             logger.debug("Updated simulation date in plan file path: %s", plan_file_path)

--- a/ras_commander/RasPrj.py
+++ b/ras_commander/RasPrj.py
@@ -1109,15 +1109,16 @@ class RasPrj:
             )
 
         try:
-            # Read the project file
-            with open(self.prj_file, 'r', encoding='utf-8', errors='replace') as f:
-                lines = f.readlines()
+            # Preserve the one newline convention used by the project file.
+            lines, newline = RasUtils._read_text_lines_preserving_newline(
+                self.prj_file
+            )
 
             # Find and update the Current Plan line
             updated = False
             for i, line in enumerate(lines):
                 if line.strip().startswith('Current Plan='):
-                    lines[i] = f"Current Plan=p{plan_number_str}\n"
+                    lines[i] = f"Current Plan=p{plan_number_str}{newline}"
                     updated = True
                     break
 
@@ -1125,16 +1126,19 @@ class RasPrj:
             if not updated:
                 for i, line in enumerate(lines):
                     if line.strip().startswith('Proj Title='):
-                        lines.insert(i + 1, f"Current Plan=p{plan_number_str}\n")
+                        lines.insert(
+                            i + 1,
+                            f"Current Plan=p{plan_number_str}{newline}",
+                        )
                         updated = True
                         break
 
             if not updated:
                 raise ValueError("Could not find 'Proj Title=' or 'Current Plan=' in project file")
 
-            # Write back to file
-            with open(self.prj_file, 'w', encoding='utf-8', errors='replace') as f:
-                f.writelines(lines)
+            RasUtils._write_text_lines_with_newline(
+                self.prj_file, lines, newline
+            )
 
             logger.info(f"Set current plan to p{plan_number_str} in {self.prj_file}")
 

--- a/ras_commander/RasScenario.py
+++ b/ras_commander/RasScenario.py
@@ -5,10 +5,16 @@ from __future__ import annotations
 import json
 import re
 import shutil
-from dataclasses import asdict, dataclass
+from concurrent.futures import (
+    ThreadPoolExecutor,
+    TimeoutError as FutureTimeoutError,
+)
+from dataclasses import asdict, dataclass, replace
 from datetime import datetime, timezone
-from pathlib import Path
+from pathlib import Path, PureWindowsPath
 from typing import Any, Dict, Iterable, Mapping, Optional, Union
+
+import h5py
 
 from .Decorators import log_call
 from .LoggingConfig import get_logger
@@ -17,6 +23,8 @@ from .RasPlan import RasPlan
 from .RasPrj import RasPrj, init_ras_project
 from .RasUnsteady import RasUnsteady
 from .RasUtils import RasUtils
+from .geom import GeomCrossSection, GeomStorage
+from .hdf.HdfBase import HdfBase
 
 logger = get_logger(__name__)
 
@@ -74,6 +82,8 @@ class RasScenarioWorkspace:
     hydrology_file: Path
     result_hdf: Path
     boundary_mapping_ids: tuple[str, ...]
+    simulation_start: Optional[str] = None
+    simulation_end: Optional[str] = None
 
     def to_dict(self) -> Dict[str, Any]:
         """Return a JSON-serializable workspace record."""
@@ -104,8 +114,14 @@ class RasRunArtifact:
     result_hdf: Path
     started_at: str
     finished_at: str
+    compute_returned_successfully: bool
     result_exists: bool
     result_size_bytes: int
+    hdf_completed_successfully: bool
+    output_start: Optional[str]
+    output_end: Optional[str]
+    time_window_matches: bool
+    hdf_inspection_error: Optional[str]
 
     def to_dict(self) -> Dict[str, Any]:
         """Return a JSON-serializable run artifact."""
@@ -136,6 +152,35 @@ class RasScenario:
 
     @staticmethod
     @log_call
+    def format_dss_pathname_for_window(
+        pathname: str,
+        start_time: datetime,
+        end_time: datetime,
+    ) -> str:
+        """Materialize a deterministic DSS D-part for the requested window.
+
+        HEC-DSS stores regular series in physical blocks and clients may display
+        a blank D-part after resolving them. Writing the requested model window
+        into the boundary link makes the prepared contract explicit and was
+        validated with HEC-RAS 6.6; it does not rewrite the source DSS catalog.
+        """
+        if end_time <= start_time:
+            raise ValueError("end_time must be later than start_time")
+        if not pathname.startswith("/") or not pathname.endswith("/"):
+            raise ValueError(f"Invalid DSS pathname: {pathname!r}")
+        parts = pathname.split("/")[1:-1]
+        if len(parts) != 6:
+            raise ValueError(
+                "DSS pathname must contain six A-F parts: "
+                f"{pathname!r}"
+            )
+        parts[3] = (
+            f"{start_time:%d%b%Y}-{end_time:%d%b%Y}".upper()
+        )
+        return "/" + "/".join(parts) + "/"
+
+    @staticmethod
+    @log_call
     def prepare_workspace(
         source_project: Union[str, Path],
         workspace: Union[str, Path],
@@ -147,19 +192,43 @@ class RasScenario:
         end_time: datetime,
         *,
         ras_exe_path: Union[str, Path],
+        linked_asset_directories: Optional[
+            Iterable[Union[str, Path]]
+        ] = None,
         copy_hydrology: bool = True,
         overwrite: bool = False,
     ) -> RasScenarioWorkspace:
-        """Clone a RAS project, plan, and unsteady file for one HMS result."""
+        """Clone a RAS project and its declared linked assets for one HMS result.
+
+        ``workspace`` is the destination project directory. Directories passed
+        through ``linked_asset_directories`` are copied beside that directory,
+        preserving the sibling layout used by relative paths in ``.prj`` and
+        ``.rasmap`` files.
+        """
         source_file = RasScenario._resolve_project_file(source_project)
         source_folder = source_file.parent.resolve()
         destination = Path(workspace).resolve()
         hydrology_source = Path(hydrology_dss).resolve()
-        links = tuple(
+        linked_sources = tuple(
+            Path(path).resolve()
+            for path in (linked_asset_directories or ())
+        )
+        raw_links = tuple(
             link
             if isinstance(link, RasBoundaryLink)
             else RasBoundaryLink.from_mapping(link)
             for link in boundary_links
+        )
+        links = tuple(
+            replace(
+                link,
+                dss_path=RasScenario.format_dss_pathname_for_window(
+                    link.dss_path,
+                    start_time,
+                    end_time,
+                ),
+            )
+            for link in raw_links
         )
 
         if not links:
@@ -178,6 +247,30 @@ class RasScenario:
             )
 
         RasScenario._validate_copy_boundaries(source_folder, destination)
+        linked_destinations = tuple(
+            destination.parent / source.name for source in linked_sources
+        )
+        if len({path.name.casefold() for path in linked_sources}) != len(
+            linked_sources
+        ):
+            raise ValueError("linked asset directory names must be unique")
+        for source, linked_destination in zip(
+            linked_sources,
+            linked_destinations,
+        ):
+            if not source.is_dir():
+                raise FileNotFoundError(
+                    f"Linked asset directory not found: {source}"
+                )
+            RasScenario._validate_copy_boundaries(
+                source,
+                linked_destination,
+            )
+            if linked_destination.exists():
+                raise FileExistsError(
+                    "Linked asset destination already exists: "
+                    f"{linked_destination}"
+                )
         if destination.exists():
             if not overwrite:
                 raise FileExistsError(f"Workspace already exists: {destination}")
@@ -188,6 +281,15 @@ class RasScenario:
             destination,
             ignore=RasUtils.ignore_windows_reserved,
         )
+        for source, linked_destination in zip(
+            linked_sources,
+            linked_destinations,
+        ):
+            shutil.copytree(
+                source,
+                linked_destination,
+                ignore=RasUtils.ignore_windows_reserved,
+            )
 
         copied_project = destination / source_file.name
         project = init_ras_project(
@@ -233,6 +335,7 @@ class RasScenario:
             end_time,
             ras_object=project,
         )
+        project.set_current_plan(plan_number)
 
         hydrology_dir = destination / "hydrology"
         hydrology_dir.mkdir(parents=True, exist_ok=True)
@@ -289,6 +392,8 @@ class RasScenario:
             hydrology_file=hydrology_file,
             result_hdf=destination / f"{project.project_name}.p{plan_number}.hdf",
             boundary_mapping_ids=tuple(link.mapping_id for link in links),
+            simulation_start=start_time.isoformat(),
+            simulation_end=end_time.isoformat(),
         )
         RasScenario.validate_workspace(prepared, links)
         logger.info("Prepared RAS scenario workspace: %s", destination)
@@ -310,6 +415,73 @@ class RasScenario:
             errors="replace",
         )
         links = tuple(boundary_links)
+        if workspace.simulation_start and workspace.simulation_end:
+            start_time = datetime.fromisoformat(workspace.simulation_start)
+            end_time = datetime.fromisoformat(workspace.simulation_end)
+            links = tuple(
+                replace(
+                    link,
+                    dss_path=RasScenario.format_dss_pathname_for_window(
+                        link.dss_path,
+                        start_time,
+                        end_time,
+                    ),
+                )
+                for link in links
+            )
+        boundaries = RasUnsteady.get_dss_boundaries(
+            workspace.unsteady_file,
+        )
+        linked_pathnames = {link.dss_path for link in links}
+        mapped_boundaries = boundaries[
+            boundaries["dss_path"].isin(linked_pathnames)
+        ]
+        dss_references = tuple(
+            str(reference).strip()
+            for reference in mapped_boundaries["dss_file"]
+            if str(reference).strip()
+        )
+
+        def is_resolvable_reference(reference: str) -> bool:
+            windows_path = PureWindowsPath(reference)
+            return (
+                Path(reference).is_absolute()
+                or windows_path.is_absolute()
+                or reference.replace("/", "\\").startswith((".\\", "..\\"))
+            )
+
+        def resolve_reference(reference: str) -> Path:
+            native_path = Path(reference)
+            if native_path.is_absolute():
+                return native_path
+            windows_path = PureWindowsPath(reference)
+            if windows_path.is_absolute():
+                return Path(str(windows_path))
+            return workspace.project_folder.joinpath(*windows_path.parts)
+
+        current_plan_match = re.search(
+            r"^Current Plan=p(\w+)\s*$",
+            workspace.project_file.read_text(
+                encoding="utf-8",
+                errors="replace",
+            ),
+            flags=re.MULTILINE,
+        )
+        actual_window = RasScenario._parse_simulation_window(plan_text)
+        expected_window = (
+            (
+                datetime.fromisoformat(workspace.simulation_start),
+                datetime.fromisoformat(workspace.simulation_end),
+            )
+            if workspace.simulation_start and workspace.simulation_end
+            else None
+        )
+        geometry_crosswalk = RasScenario._geometry_boundary_crosswalk(
+            workspace,
+            links,
+            plan_text,
+        )
+
         checks = {
             "project_file_exists": workspace.project_file.is_file(),
             "plan_file_exists": workspace.plan_file.is_file(),
@@ -318,12 +490,38 @@ class RasScenario:
             "plan_uses_cloned_unsteady": (
                 f"Flow File=u{workspace.unsteady_number}" in plan_text
             ),
+            "project_uses_cloned_plan": (
+                current_plan_match is not None
+                and current_plan_match.group(1).zfill(2)
+                == workspace.plan_number
+            ),
+            "plan_window_matches_contract": (
+                expected_window is None or actual_window == expected_window
+            ),
             "all_dss_paths_present": all(
                 f"DSS Path={link.dss_path}" in unsteady_text for link in links
+            ),
+            "all_dss_file_references_resolvable": (
+                bool(dss_references)
+                and all(
+                    is_resolvable_reference(reference)
+                    for reference in dss_references
+                )
+            ),
+            "all_dss_files_exist": (
+                bool(dss_references)
+                and all(
+                    resolve_reference(reference).is_file()
+                    for reference in dss_references
+                )
             ),
             "all_mappings_recorded": (
                 tuple(link.mapping_id for link in links)
                 == workspace.boundary_mapping_ids
+            ),
+            "all_boundaries_exist_in_active_geometry": (
+                bool(geometry_crosswalk)
+                and all(geometry_crosswalk.values())
             ),
         }
         if not all(checks.values()):
@@ -332,6 +530,109 @@ class RasScenario:
                 "Prepared RAS workspace failed validation: " + ", ".join(failed)
             )
         return checks
+
+    @staticmethod
+    def _parse_simulation_window(
+        plan_text: str,
+    ) -> Optional[tuple[datetime, datetime]]:
+        """Parse a HEC-RAS ``Simulation Date`` line."""
+        match = re.search(
+            r"^Simulation Date=([^,\r\n]+),([^,\r\n]+),"
+            r"([^,\r\n]+),([^,\r\n]+)\s*$",
+            plan_text,
+            flags=re.MULTILINE,
+        )
+        if match is None:
+            return None
+
+        def parse(date_token: str, time_token: str) -> datetime:
+            date_value = datetime.strptime(
+                date_token.strip().upper(),
+                "%d%b%Y",
+            )
+            time_format = "%H:%M" if ":" in time_token else "%H%M"
+            time_value = datetime.strptime(time_token.strip(), time_format)
+            return date_value.replace(
+                hour=time_value.hour,
+                minute=time_value.minute,
+            )
+
+        return (
+            parse(match.group(1), match.group(2)),
+            parse(match.group(3), match.group(4)),
+        )
+
+    @staticmethod
+    def _geometry_boundary_crosswalk(
+        workspace: RasScenarioWorkspace,
+        links: tuple[RasBoundaryLink, ...],
+        plan_text: str,
+    ) -> Dict[str, bool]:
+        """Check each boundary selector against the plan's active geometry."""
+        geometry_match = re.search(
+            r"^Geom File=g(\w+)\s*$",
+            plan_text,
+            flags=re.MULTILINE,
+        )
+        if geometry_match is None:
+            return {link.mapping_id: False for link in links}
+        geometry_file = (
+            workspace.project_folder
+            / f"{workspace.project_file.stem}.g{geometry_match.group(1)}"
+        )
+        if not geometry_file.is_file():
+            return {link.mapping_id: False for link in links}
+
+        cross_sections = GeomCrossSection.get_cross_sections(geometry_file)
+        storage_areas = GeomStorage.get_storage_areas(
+            geometry_file,
+            exclude_2d=False,
+        )
+        geometry_text = geometry_file.read_text(
+            encoding="utf-8",
+            errors="replace",
+        )
+        area_names = {
+            str(value).strip().casefold()
+            for value in storage_areas.get("Name", ())
+        }
+        bc_line_names = {
+            value.strip().casefold()
+            for value in re.findall(
+                r"^BC Line Name=([^\r\n,]+)",
+                geometry_text,
+                flags=re.MULTILINE,
+            )
+        }
+
+        def same_station(left: Any, right: Any) -> bool:
+            try:
+                return float(left) == float(right)
+            except (TypeError, ValueError):
+                return str(left).strip().casefold() == str(right).strip().casefold()
+
+        results: Dict[str, bool] = {}
+        for link in links:
+            if link.river or link.reach or link.station:
+                results[link.mapping_id] = any(
+                    str(row["River"]).strip().casefold()
+                    == str(link.river).strip().casefold()
+                    and str(row["Reach"]).strip().casefold()
+                    == str(link.reach).strip().casefold()
+                    and same_station(row["RS"], link.station)
+                    for _, row in cross_sections.iterrows()
+                )
+                continue
+            area_exists = (
+                str(link.sa_2d_name).strip().casefold() in area_names
+            )
+            bc_line_exists = (
+                True
+                if not link.bc_line
+                else str(link.bc_line).strip().casefold() in bc_line_names
+            )
+            results[link.mapping_id] = area_exists and bc_line_exists
+        return results
 
     @staticmethod
     @log_call
@@ -343,6 +644,8 @@ class RasScenario:
         num_cores: Optional[int] = None,
     ) -> RasRunArtifact:
         """Execute a prepared scenario through RasCmdr and record its result."""
+        if timeout <= 0:
+            raise ValueError("timeout must be positive")
         project = init_ras_project(
             workspace.project_file,
             ras_version=str(Path(ras_exe_path)),
@@ -351,19 +654,46 @@ class RasScenario:
             hide_intro=True,
         )
         started = datetime.now(timezone.utc)
-        result = RasCmdr.compute_plan(
+        executor = ThreadPoolExecutor(
+            max_workers=1,
+            thread_name_prefix="ras-scenario",
+        )
+        future = executor.submit(
+            RasCmdr.compute_plan,
             workspace.plan_number,
             ras_object=project,
-            timeout=timeout,
             num_cores=num_cores,
             verify=True,
         )
+        try:
+            result = future.result(timeout=timeout)
+        except FutureTimeoutError as exc:
+            cancelled = RasCmdr.cancel_plan(
+                workspace.plan_number,
+                ras_object=project,
+            )
+            raise TimeoutError(
+                f"RAS plan {workspace.plan_number} exceeded "
+                f"{timeout} seconds; cancellation requested={cancelled}"
+            ) from exc
+        finally:
+            executor.shutdown(wait=False, cancel_futures=True)
         finished = datetime.now(timezone.utc)
         result_exists = workspace.result_hdf.is_file()
         result_size = (
             workspace.result_hdf.stat().st_size if result_exists else 0
         )
-        status = "succeeded" if bool(result) and result_size > 0 else "failed"
+        hdf_check = RasScenario._inspect_result_hdf(workspace)
+        status = (
+            "succeeded"
+            if (
+                bool(result)
+                and result_size > 0
+                and hdf_check["completed_successfully"]
+                and hdf_check["time_window_matches"]
+            )
+            else "failed"
+        )
         return RasRunArtifact(
             scenario_id=workspace.scenario_id,
             status=status,
@@ -372,9 +702,70 @@ class RasScenario:
             result_hdf=workspace.result_hdf,
             started_at=started.isoformat().replace("+00:00", "Z"),
             finished_at=finished.isoformat().replace("+00:00", "Z"),
+            compute_returned_successfully=bool(result),
             result_exists=result_exists,
             result_size_bytes=result_size,
+            hdf_completed_successfully=hdf_check["completed_successfully"],
+            output_start=hdf_check["output_start"],
+            output_end=hdf_check["output_end"],
+            time_window_matches=hdf_check["time_window_matches"],
+            hdf_inspection_error=hdf_check["error"],
         )
+
+    @staticmethod
+    def _inspect_result_hdf(
+        workspace: RasScenarioWorkspace,
+    ) -> Dict[str, Any]:
+        """Verify the HDF completion marker and exact scenario time axis."""
+        result = {
+            "completed_successfully": False,
+            "output_start": None,
+            "output_end": None,
+            "time_window_matches": False,
+            "error": None,
+        }
+        if not workspace.result_hdf.is_file():
+            result["error"] = "result HDF does not exist"
+            return result
+        if not workspace.simulation_start or not workspace.simulation_end:
+            result["error"] = "workspace simulation window is not recorded"
+            return result
+
+        try:
+            with h5py.File(workspace.result_hdf, "r") as hdf_file:
+                event_conditions = hdf_file.get("Event Conditions")
+                if event_conditions is None:
+                    raise ValueError("Event Conditions group is missing")
+                completed = event_conditions.attrs.get(
+                    "Completed Successfully",
+                )
+                if isinstance(completed, bytes):
+                    completed = completed.decode("utf-8", errors="replace")
+                result["completed_successfully"] = (
+                    str(completed).strip().casefold() == "true"
+                )
+
+                timestamps = HdfBase.get_unsteady_timestamps(hdf_file)
+                if not timestamps:
+                    raise ValueError("unsteady output time axis is empty")
+                output_start = timestamps[0]
+                output_end = timestamps[-1]
+                result["output_start"] = output_start.isoformat()
+                result["output_end"] = output_end.isoformat()
+
+                expected_start = datetime.fromisoformat(
+                    workspace.simulation_start,
+                ).replace(tzinfo=None)
+                expected_end = datetime.fromisoformat(
+                    workspace.simulation_end,
+                ).replace(tzinfo=None)
+                result["time_window_matches"] = (
+                    output_start.replace(tzinfo=None) == expected_start
+                    and output_end.replace(tzinfo=None) == expected_end
+                )
+        except (OSError, KeyError, TypeError, ValueError) as exc:
+            result["error"] = str(exc)
+        return result
 
     @staticmethod
     def _resolve_project_file(source_project: Union[str, Path]) -> Path:

--- a/ras_commander/RasScenario.py
+++ b/ras_commander/RasScenario.py
@@ -1,0 +1,413 @@
+"""Isolated HEC-RAS scenario preparation for external hydrologic DSS inputs."""
+
+from __future__ import annotations
+
+import json
+import re
+import shutil
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, Iterable, Mapping, Optional, Union
+
+from .Decorators import log_call
+from .LoggingConfig import get_logger
+from .RasCmdr import RasCmdr
+from .RasPlan import RasPlan
+from .RasPrj import RasPrj, init_ras_project
+from .RasUnsteady import RasUnsteady
+from .RasUtils import RasUtils
+
+logger = get_logger(__name__)
+
+
+@dataclass(frozen=True)
+class RasBoundaryLink:
+    """One exact HMS DSS pathname to HEC-RAS boundary mapping."""
+
+    mapping_id: str
+    dss_path: str
+    expected_bc_type: str
+    interval: str = "5MIN"
+    river: Optional[str] = None
+    reach: Optional[str] = None
+    station: Optional[str] = None
+    sa_2d_name: Optional[str] = None
+    bc_line: Optional[str] = None
+    boundary_index: Optional[int] = None
+
+    def __post_init__(self) -> None:
+        if not self.mapping_id.strip():
+            raise ValueError("mapping_id must be non-empty")
+        if not self.dss_path.startswith("/") or not self.dss_path.endswith("/"):
+            raise ValueError(f"Invalid DSS pathname: {self.dss_path!r}")
+        if len(self.dss_path.split("/")) < 8:
+            raise ValueError(f"Invalid DSS pathname: {self.dss_path!r}")
+        has_1d = any(value for value in (self.river, self.reach, self.station))
+        has_2d = any(value for value in (self.sa_2d_name, self.bc_line))
+        if has_1d and has_2d:
+            raise ValueError(
+                "A boundary link cannot mix 1D and 2D selectors"
+            )
+        if not (has_1d or has_2d or self.boundary_index is not None):
+            raise ValueError("A boundary link requires an exact boundary selector")
+
+    @classmethod
+    def from_mapping(cls, value: Mapping[str, Any]) -> "RasBoundaryLink":
+        """Build a link from a contract or CSV-derived mapping."""
+        return cls(**dict(value))
+
+
+@dataclass(frozen=True)
+class RasScenarioWorkspace:
+    """Prepared, GUI-verifiable RAS scenario workspace."""
+
+    scenario_id: str
+    source_project: Path
+    project_folder: Path
+    project_file: Path
+    plan_number: str
+    plan_file: Path
+    unsteady_number: str
+    unsteady_file: Path
+    hydrology_source: Path
+    hydrology_file: Path
+    result_hdf: Path
+    boundary_mapping_ids: tuple[str, ...]
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Return a JSON-serializable workspace record."""
+        return {
+            key: (
+                str(value)
+                if isinstance(value, Path)
+                else list(value)
+                if isinstance(value, tuple)
+                else value
+            )
+            for key, value in asdict(self).items()
+        }
+
+    def write_manifest(self, path: Union[str, Path]) -> Path:
+        """Write the workspace record atomically."""
+        return _write_json(path, self.to_dict())
+
+
+@dataclass(frozen=True)
+class RasRunArtifact:
+    """Result of one RAS scenario execution."""
+
+    scenario_id: str
+    status: str
+    plan_number: str
+    project_folder: Path
+    result_hdf: Path
+    started_at: str
+    finished_at: str
+    result_exists: bool
+    result_size_bytes: int
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Return a JSON-serializable run artifact."""
+        return {
+            key: str(value) if isinstance(value, Path) else value
+            for key, value in asdict(self).items()
+        }
+
+    def write_manifest(self, path: Union[str, Path]) -> Path:
+        """Write the execution record atomically."""
+        return _write_json(path, self.to_dict())
+
+
+def _write_json(path: Union[str, Path], payload: Dict[str, Any]) -> Path:
+    output = Path(path)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    temporary = output.with_suffix(output.suffix + ".tmp")
+    temporary.write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    temporary.replace(output)
+    return output
+
+
+class RasScenario:
+    """Static namespace for HMS-to-RAS scenario preparation and execution."""
+
+    @staticmethod
+    @log_call
+    def prepare_workspace(
+        source_project: Union[str, Path],
+        workspace: Union[str, Path],
+        scenario_id: str,
+        source_plan: Union[str, int],
+        hydrology_dss: Union[str, Path],
+        boundary_links: Iterable[Union[RasBoundaryLink, Mapping[str, Any]]],
+        start_time: datetime,
+        end_time: datetime,
+        *,
+        ras_exe_path: Union[str, Path],
+        copy_hydrology: bool = True,
+        overwrite: bool = False,
+    ) -> RasScenarioWorkspace:
+        """Clone a RAS project, plan, and unsteady file for one HMS result."""
+        source_file = RasScenario._resolve_project_file(source_project)
+        source_folder = source_file.parent.resolve()
+        destination = Path(workspace).resolve()
+        hydrology_source = Path(hydrology_dss).resolve()
+        links = tuple(
+            link
+            if isinstance(link, RasBoundaryLink)
+            else RasBoundaryLink.from_mapping(link)
+            for link in boundary_links
+        )
+
+        if not links:
+            raise ValueError("At least one boundary link is required")
+        if len({link.mapping_id for link in links}) != len(links):
+            raise ValueError("boundary mapping IDs must be unique")
+        if not hydrology_source.is_file():
+            raise FileNotFoundError(
+                f"Hydrology DSS file not found: {hydrology_source}"
+            )
+        if end_time <= start_time:
+            raise ValueError("end_time must be later than start_time")
+        if start_time.tzinfo is not None or end_time.tzinfo is not None:
+            raise ValueError(
+                "start_time and end_time must be naive datetimes in RAS model time"
+            )
+
+        RasScenario._validate_copy_boundaries(source_folder, destination)
+        if destination.exists():
+            if not overwrite:
+                raise FileExistsError(f"Workspace already exists: {destination}")
+            shutil.rmtree(destination)
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copytree(
+            source_folder,
+            destination,
+            ignore=RasUtils.ignore_windows_reserved,
+        )
+
+        copied_project = destination / source_file.name
+        project = init_ras_project(
+            copied_project,
+            ras_version=str(Path(ras_exe_path)),
+            ras_object=RasPrj(),
+            load_results_summary=False,
+            hide_intro=True,
+        )
+
+        slug = RasScenario._scenario_slug(scenario_id)
+        source_plan_path = RasPlan.get_plan_path(source_plan, ras_object=project)
+        if source_plan_path is None:
+            raise ValueError(f"Source plan {source_plan!r} was not found")
+        source_plan_number = RasUtils.normalize_ras_number(source_plan)
+        plan_matches = project.plan_df[
+            project.plan_df["plan_number"] == source_plan_number
+        ]
+        if plan_matches.empty:
+            raise ValueError(f"Source plan {source_plan!r} was not found")
+        source_unsteady_number = str(
+            plan_matches.iloc[0].get("unsteady_number", "")
+        ).lower().removeprefix("u")
+        if not source_unsteady_number:
+            raise ValueError(f"Source plan {source_plan!r} has no unsteady flow file")
+
+        unsteady_number = RasPlan.clone_unsteady(
+            source_unsteady_number,
+            new_title=f"FloodForecast {slug}"[:32],
+            ras_object=project,
+        )
+        plan_number = RasPlan.clone_plan(
+            source_plan,
+            new_plan_shortid=f"FF_{slug}"[:24],
+            new_title=f"FloodForecast {slug}"[:32],
+            unsteady_flow=unsteady_number,
+            description=f"FloodForecast scenario {scenario_id}",
+            ras_object=project,
+        )
+        RasPlan.update_simulation_date(
+            plan_number,
+            start_time,
+            end_time,
+            ras_object=project,
+        )
+
+        hydrology_dir = destination / "hydrology"
+        hydrology_dir.mkdir(parents=True, exist_ok=True)
+        if copy_hydrology:
+            hydrology_file = hydrology_dir / hydrology_source.name
+            shutil.copy2(hydrology_source, hydrology_file)
+            dss_reference = str(
+                hydrology_file.relative_to(destination)
+            ).replace("/", "\\")
+        else:
+            hydrology_file = hydrology_source
+            dss_reference = str(hydrology_source)
+
+        unsteady_file = RasPlan.get_unsteady_path(
+            unsteady_number,
+            ras_object=project,
+        )
+        if unsteady_file is None:
+            raise RuntimeError("Cloned unsteady flow file could not be resolved")
+
+        for link in links:
+            changed = RasUnsteady.set_boundary_dss_link(
+                unsteady_file,
+                river=link.river,
+                reach=link.reach,
+                station=link.station,
+                dss_file=dss_reference,
+                dss_path=link.dss_path,
+                interval=link.interval,
+                ras_object=project,
+                sa_2d_name=link.sa_2d_name,
+                bc_line=link.bc_line,
+                boundary_index=link.boundary_index,
+                expected_bc_type=link.expected_bc_type,
+            )
+            if not changed:
+                raise ValueError(
+                    f"Boundary mapping {link.mapping_id!r} did not match"
+                )
+
+        plan_file = RasPlan.get_plan_path(plan_number, ras_object=project)
+        if plan_file is None:
+            raise RuntimeError("Cloned plan file could not be resolved")
+        prepared = RasScenarioWorkspace(
+            scenario_id=scenario_id,
+            source_project=source_file,
+            project_folder=destination,
+            project_file=copied_project,
+            plan_number=plan_number,
+            plan_file=plan_file,
+            unsteady_number=unsteady_number,
+            unsteady_file=unsteady_file,
+            hydrology_source=hydrology_source,
+            hydrology_file=hydrology_file,
+            result_hdf=destination / f"{project.project_name}.p{plan_number}.hdf",
+            boundary_mapping_ids=tuple(link.mapping_id for link in links),
+        )
+        RasScenario.validate_workspace(prepared, links)
+        logger.info("Prepared RAS scenario workspace: %s", destination)
+        return prepared
+
+    @staticmethod
+    @log_call
+    def validate_workspace(
+        workspace: RasScenarioWorkspace,
+        boundary_links: Iterable[RasBoundaryLink],
+    ) -> Dict[str, bool]:
+        """Validate the plan/unsteady references and all exact DSS links."""
+        plan_text = workspace.plan_file.read_text(
+            encoding="utf-8",
+            errors="replace",
+        )
+        unsteady_text = workspace.unsteady_file.read_text(
+            encoding="utf-8",
+            errors="replace",
+        )
+        links = tuple(boundary_links)
+        checks = {
+            "project_file_exists": workspace.project_file.is_file(),
+            "plan_file_exists": workspace.plan_file.is_file(),
+            "unsteady_file_exists": workspace.unsteady_file.is_file(),
+            "hydrology_file_exists": workspace.hydrology_file.is_file(),
+            "plan_uses_cloned_unsteady": (
+                f"Flow File=u{workspace.unsteady_number}" in plan_text
+            ),
+            "all_dss_paths_present": all(
+                f"DSS Path={link.dss_path}" in unsteady_text for link in links
+            ),
+            "all_mappings_recorded": (
+                tuple(link.mapping_id for link in links)
+                == workspace.boundary_mapping_ids
+            ),
+        }
+        if not all(checks.values()):
+            failed = [name for name, passed in checks.items() if not passed]
+            raise ValueError(
+                "Prepared RAS workspace failed validation: " + ", ".join(failed)
+            )
+        return checks
+
+    @staticmethod
+    @log_call
+    def execute(
+        workspace: RasScenarioWorkspace,
+        *,
+        ras_exe_path: Union[str, Path],
+        timeout: int = 3600,
+        num_cores: Optional[int] = None,
+    ) -> RasRunArtifact:
+        """Execute a prepared scenario through RasCmdr and record its result."""
+        project = init_ras_project(
+            workspace.project_file,
+            ras_version=str(Path(ras_exe_path)),
+            ras_object=RasPrj(),
+            load_results_summary=False,
+            hide_intro=True,
+        )
+        started = datetime.now(timezone.utc)
+        result = RasCmdr.compute_plan(
+            workspace.plan_number,
+            ras_object=project,
+            timeout=timeout,
+            num_cores=num_cores,
+            verify=True,
+        )
+        finished = datetime.now(timezone.utc)
+        result_exists = workspace.result_hdf.is_file()
+        result_size = (
+            workspace.result_hdf.stat().st_size if result_exists else 0
+        )
+        status = "succeeded" if bool(result) and result_size > 0 else "failed"
+        return RasRunArtifact(
+            scenario_id=workspace.scenario_id,
+            status=status,
+            plan_number=workspace.plan_number,
+            project_folder=workspace.project_folder,
+            result_hdf=workspace.result_hdf,
+            started_at=started.isoformat().replace("+00:00", "Z"),
+            finished_at=finished.isoformat().replace("+00:00", "Z"),
+            result_exists=result_exists,
+            result_size_bytes=result_size,
+        )
+
+    @staticmethod
+    def _resolve_project_file(source_project: Union[str, Path]) -> Path:
+        source = Path(source_project).resolve()
+        if source.is_file():
+            if source.suffix.lower() != ".prj":
+                raise ValueError(f"Not a HEC-RAS project file: {source}")
+            return source
+        if not source.is_dir():
+            raise FileNotFoundError(f"RAS project not found: {source}")
+        candidates = sorted(source.glob("*.prj"))
+        if len(candidates) != 1:
+            raise ValueError(
+                f"Expected one .prj file in {source}, found {len(candidates)}"
+            )
+        return candidates[0]
+
+    @staticmethod
+    def _scenario_slug(scenario_id: str) -> str:
+        slug = re.sub(r"[^A-Za-z0-9_-]+", "_", str(scenario_id)).strip("_")
+        if not slug:
+            raise ValueError("scenario_id must contain at least one letter or number")
+        return slug[:40]
+
+    @staticmethod
+    def _validate_copy_boundaries(source: Path, destination: Path) -> None:
+        source = source.resolve()
+        destination = destination.resolve()
+        if (
+            source == destination
+            or source in destination.parents
+            or destination in source.parents
+        ):
+            raise ValueError(
+                "Source project and scenario workspace must not overlap"
+            )

--- a/ras_commander/RasScenario.py
+++ b/ras_commander/RasScenario.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
+import os
 import re
 import shutil
+import stat
 from concurrent.futures import (
     ThreadPoolExecutor,
     TimeoutError as FutureTimeoutError,
@@ -27,6 +30,12 @@ from .geom import GeomCrossSection, GeomStorage
 from .hdf.HdfBase import HdfBase
 
 logger = get_logger(__name__)
+
+
+_RAS_AUTHORED_TEXT_SUFFIX = re.compile(
+    r"\.(?:f|g|p|q|s|u|w)\d+\Z",
+    re.IGNORECASE,
+)
 
 
 @dataclass(frozen=True)
@@ -54,9 +63,7 @@ class RasBoundaryLink:
         has_1d = any(value for value in (self.river, self.reach, self.station))
         has_2d = any(value for value in (self.sa_2d_name, self.bc_line))
         if has_1d and has_2d:
-            raise ValueError(
-                "A boundary link cannot mix 1D and 2D selectors"
-            )
+            raise ValueError("A boundary link cannot mix 1D and 2D selectors")
         if not (has_1d or has_2d or self.boundary_index is not None):
             raise ValueError("A boundary link requires an exact boundary selector")
 
@@ -84,6 +91,12 @@ class RasScenarioWorkspace:
     boundary_mapping_ids: tuple[str, ...]
     simulation_start: Optional[str] = None
     simulation_end: Optional[str] = None
+    forcing_excess_source: Optional[Path] = None
+    forcing_excess_file: Optional[Path] = None
+    forcing_excess_pathname: Optional[str] = None
+    linked_asset_cache: Optional[Dict[str, Any]] = None
+    source_output_exclusions: Optional[Dict[str, Any]] = None
+    inactive_inherited_boundaries: tuple[Dict[str, Any], ...] = ()
 
     def to_dict(self) -> Dict[str, Any]:
         """Return a JSON-serializable workspace record."""
@@ -91,9 +104,7 @@ class RasScenarioWorkspace:
             key: (
                 str(value)
                 if isinstance(value, Path)
-                else list(value)
-                if isinstance(value, tuple)
-                else value
+                else list(value) if isinstance(value, tuple) else value
             )
             for key, value in asdict(self).items()
         }
@@ -150,6 +161,273 @@ def _write_json(path: Union[str, Path], payload: Dict[str, Any]) -> Path:
 class RasScenario:
     """Static namespace for HMS-to-RAS scenario preparation and execution."""
 
+    LINKED_ASSET_CACHE_SCHEMA = "ras-commander/linked-asset-cache/1.0"
+    LINKED_ASSET_CACHE_MANIFEST = ".ras-commander-linked-assets.json"
+    LINKED_ASSET_CACHE_LOCK = ".ras-commander-linked-assets.lock"
+
+    @staticmethod
+    def _scenario_output_exclusions(
+        source_folder: Path,
+        project_name: str,
+    ) -> Dict[str, Any]:
+        patterns = (
+            re.compile(re.escape(project_name) + r"\.dss$", re.IGNORECASE),
+            re.compile(
+                re.escape(project_name) + r"\.p\d+(?:\.tmp)?\.hdf$",
+                re.IGNORECASE,
+            ),
+            re.compile(r"PostProcessing\.hdf$", re.IGNORECASE),
+        )
+        excluded = []
+        for path in source_folder.rglob("*"):
+            if path.is_file() and any(
+                pattern.fullmatch(path.name) for pattern in patterns
+            ):
+                excluded.append(
+                    {
+                        "path": path.relative_to(source_folder).as_posix(),
+                        "size_bytes": path.stat().st_size,
+                    }
+                )
+        excluded.sort(key=lambda value: value["path"])
+        return {
+            "files": excluded,
+            "file_count": len(excluded),
+            "size_bytes": sum(value["size_bytes"] for value in excluded),
+        }
+
+    @staticmethod
+    def _scenario_copy_ignore(project_name: str):
+        output_patterns = (
+            re.compile(re.escape(project_name) + r"\.dss$", re.IGNORECASE),
+            re.compile(
+                re.escape(project_name) + r"\.p\d+(?:\.tmp)?\.hdf$",
+                re.IGNORECASE,
+            ),
+            re.compile(r"PostProcessing\.hdf$", re.IGNORECASE),
+        )
+
+        def ignore(directory: str, contents: list[str]) -> list[str]:
+            skipped = set(RasUtils.ignore_windows_reserved(directory, contents))
+            skipped.update(
+                name
+                for name in contents
+                if any(pattern.fullmatch(name) for pattern in output_patterns)
+            )
+            return sorted(skipped)
+
+        return ignore
+
+    @staticmethod
+    def _sha256_file(path: Path) -> str:
+        digest = hashlib.sha256()
+        with path.open("rb") as stream:
+            for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+                digest.update(chunk)
+        return digest.hexdigest()
+
+    @staticmethod
+    def _tree_snapshot(root: Path) -> Dict[str, Any]:
+        """Return a content and metadata identity for one asset directory."""
+        records = []
+        tree_digest = hashlib.sha256()
+        total_size = 0
+        for path in sorted(
+            (candidate for candidate in root.rglob("*") if candidate.is_file()),
+            key=lambda candidate: candidate.relative_to(root).as_posix(),
+        ):
+            relative = path.relative_to(root).as_posix()
+            file_stat = path.stat()
+            file_sha256 = RasScenario._sha256_file(path)
+            record = {
+                "path": relative,
+                "size_bytes": file_stat.st_size,
+                "mtime_ns": file_stat.st_mtime_ns,
+                "sha256": file_sha256,
+            }
+            records.append(record)
+            total_size += file_stat.st_size
+            tree_digest.update(relative.encode("utf-8"))
+            tree_digest.update(b"\0")
+            tree_digest.update(str(file_stat.st_size).encode("ascii"))
+            tree_digest.update(b"\0")
+            tree_digest.update(file_sha256.encode("ascii"))
+            tree_digest.update(b"\n")
+        return {
+            "file_count": len(records),
+            "size_bytes": total_size,
+            "tree_sha256": tree_digest.hexdigest(),
+            "files": records,
+        }
+
+    @staticmethod
+    def _verify_tree_snapshot(
+        root: Path,
+        snapshot: Mapping[str, Any],
+        *,
+        label: str,
+    ) -> None:
+        """Fail closed when a cached or source tree changed after priming."""
+        expected = {str(record["path"]): record for record in snapshot.get("files", [])}
+        actual_paths = {
+            path.relative_to(root).as_posix(): path
+            for path in root.rglob("*")
+            if path.is_file()
+        }
+        if set(actual_paths) != set(expected):
+            raise ValueError(f"Linked asset cache {label} file population drifted")
+        for relative, record in expected.items():
+            file_stat = actual_paths[relative].stat()
+            if file_stat.st_size != record.get(
+                "size_bytes"
+            ) or file_stat.st_mtime_ns != record.get("mtime_ns"):
+                raise ValueError(
+                    f"Linked asset cache {label} metadata drifted: {relative}"
+                )
+
+    @staticmethod
+    def _set_tree_read_only(root: Path) -> None:
+        for path in root.rglob("*"):
+            if path.is_file():
+                path.chmod(stat.S_IREAD)
+
+    @staticmethod
+    def _prepare_linked_asset_cache(
+        cache_root: Path,
+        linked_sources: tuple[Path, ...],
+        cache_key: str,
+    ) -> Dict[str, Any]:
+        """Create, adopt, or verify shared immutable linked RAS assets.
+
+        Workspaces placed directly below ``cache_root`` retain the model's
+        ``..\\Terrain``-style relative references while sharing one authenticated
+        copy of large immutable assets.
+        """
+        if re.fullmatch(r"[0-9a-f]{64}", cache_key) is None:
+            raise ValueError("Linked asset cache key must be a SHA-256 digest")
+        cache_root.mkdir(parents=True, exist_ok=True)
+        manifest_path = cache_root / RasScenario.LINKED_ASSET_CACHE_MANIFEST
+        lock_path = cache_root / RasScenario.LINKED_ASSET_CACHE_LOCK
+        expected_names = [source.name for source in linked_sources]
+
+        if manifest_path.exists():
+            try:
+                manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+            except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+                raise ValueError(
+                    f"Linked asset cache manifest is unreadable: {manifest_path}"
+                ) from exc
+            if manifest.get("schema") != RasScenario.LINKED_ASSET_CACHE_SCHEMA:
+                raise ValueError("Linked asset cache manifest schema is unsupported")
+            if manifest.get("cache_key") != cache_key:
+                raise ValueError("Linked asset cache key does not match the request")
+            assets = manifest.get("assets")
+            if not isinstance(assets, list):
+                raise ValueError("Linked asset cache manifest assets are invalid")
+            if [asset.get("name") for asset in assets] != expected_names:
+                raise ValueError(
+                    "Linked asset cache population does not match the request"
+                )
+            for source, asset in zip(linked_sources, assets):
+                cached = cache_root / source.name
+                if str(source) != asset.get("source"):
+                    raise ValueError(
+                        f"Linked asset cache source changed for {source.name}"
+                    )
+                if not source.is_dir() or not cached.is_dir():
+                    raise ValueError(
+                        f"Linked asset cache directory is missing: {source.name}"
+                    )
+                RasScenario._verify_tree_snapshot(
+                    source,
+                    asset.get("source_snapshot", {}),
+                    label=f"source {source.name}",
+                )
+                RasScenario._verify_tree_snapshot(
+                    cached,
+                    asset.get("cache_snapshot", {}),
+                    label=f"copy {source.name}",
+                )
+            return {
+                "status": "reused",
+                "root": str(cache_root),
+                "manifest": str(manifest_path),
+                "cache_key": cache_key,
+                "asset_count": len(assets),
+                "size_bytes": sum(
+                    int(asset["cache_snapshot"]["size_bytes"]) for asset in assets
+                ),
+            }
+
+        try:
+            lock_fd = os.open(lock_path, os.O_CREAT | os.O_EXCL | os.O_WRONLY)
+        except FileExistsError as exc:
+            raise FileExistsError(f"Linked asset cache is locked: {lock_path}") from exc
+        os.close(lock_fd)
+        statuses = []
+        assets = []
+        try:
+            for source in linked_sources:
+                if not source.is_dir():
+                    raise FileNotFoundError(
+                        f"Linked asset directory not found: {source}"
+                    )
+                cached = cache_root / source.name
+                source_snapshot = RasScenario._tree_snapshot(source)
+                if cached.exists():
+                    if not cached.is_dir():
+                        raise ValueError(
+                            f"Linked asset cache target is not a directory: {cached}"
+                        )
+                    statuses.append("adopted")
+                else:
+                    shutil.copytree(
+                        source,
+                        cached,
+                        ignore=RasUtils.ignore_windows_reserved,
+                    )
+                    statuses.append("created")
+                cache_snapshot = RasScenario._tree_snapshot(cached)
+                if (
+                    source_snapshot["file_count"] != cache_snapshot["file_count"]
+                    or source_snapshot["size_bytes"] != cache_snapshot["size_bytes"]
+                    or source_snapshot["tree_sha256"] != cache_snapshot["tree_sha256"]
+                ):
+                    raise ValueError(
+                        f"Linked asset cache content mismatch: {source.name}"
+                    )
+                RasScenario._set_tree_read_only(cached)
+                assets.append(
+                    {
+                        "name": source.name,
+                        "source": str(source),
+                        "source_snapshot": source_snapshot,
+                        "cache_snapshot": cache_snapshot,
+                    }
+                )
+            manifest = {
+                "schema": RasScenario.LINKED_ASSET_CACHE_SCHEMA,
+                "cache_key": cache_key,
+                "assets": assets,
+            }
+            _write_json(manifest_path, manifest)
+        finally:
+            lock_path.unlink(missing_ok=True)
+
+        status = "adopted" if statuses and set(statuses) == {"adopted"} else "created"
+        if len(set(statuses)) > 1:
+            status = "recovered"
+        return {
+            "status": status,
+            "root": str(cache_root),
+            "manifest": str(manifest_path),
+            "cache_key": cache_key,
+            "asset_count": len(assets),
+            "size_bytes": sum(
+                int(asset["cache_snapshot"]["size_bytes"]) for asset in assets
+            ),
+        }
+
     @staticmethod
     @log_call
     def format_dss_pathname_for_window(
@@ -171,12 +449,9 @@ class RasScenario:
         parts = pathname.split("/")[1:-1]
         if len(parts) != 6:
             raise ValueError(
-                "DSS pathname must contain six A-F parts: "
-                f"{pathname!r}"
+                "DSS pathname must contain six A-F parts: " f"{pathname!r}"
             )
-        parts[3] = (
-            f"{start_time:%d%b%Y}-{end_time:%d%b%Y}".upper()
-        )
+        parts[3] = f"{start_time:%d%b%Y}-{end_time:%d%b%Y}".upper()
         return "/" + "/".join(parts) + "/"
 
     @staticmethod
@@ -192,9 +467,11 @@ class RasScenario:
         end_time: datetime,
         *,
         ras_exe_path: Union[str, Path],
-        linked_asset_directories: Optional[
-            Iterable[Union[str, Path]]
-        ] = None,
+        linked_asset_directories: Optional[Iterable[Union[str, Path]]] = None,
+        linked_asset_cache_key: Optional[str] = None,
+        forcing_excess_dss: Optional[Union[str, Path]] = None,
+        forcing_excess_pathname: Optional[str] = None,
+        forcing_excess_interpolation: str = "Bilinear",
         copy_hydrology: bool = True,
         overwrite: bool = False,
     ) -> RasScenarioWorkspace:
@@ -203,20 +480,28 @@ class RasScenario:
         ``workspace`` is the destination project directory. Directories passed
         through ``linked_asset_directories`` are copied beside that directory,
         preserving the sibling layout used by relative paths in ``.prj`` and
-        ``.rasmap`` files.
+        ``.rasmap`` files. When ``linked_asset_cache_key`` is supplied, those
+        sibling copies are authenticated and reused by other workspaces under
+        the same parent directory.
         """
         source_file = RasScenario._resolve_project_file(source_project)
         source_folder = source_file.parent.resolve()
         destination = Path(workspace).resolve()
         hydrology_source = Path(hydrology_dss).resolve()
+        excess_source = (
+            Path(forcing_excess_dss).resolve()
+            if forcing_excess_dss is not None
+            else None
+        )
         linked_sources = tuple(
-            Path(path).resolve()
-            for path in (linked_asset_directories or ())
+            Path(path).resolve() for path in (linked_asset_directories or ())
         )
         raw_links = tuple(
-            link
-            if isinstance(link, RasBoundaryLink)
-            else RasBoundaryLink.from_mapping(link)
+            (
+                link
+                if isinstance(link, RasBoundaryLink)
+                else RasBoundaryLink.from_mapping(link)
+            )
             for link in boundary_links
         )
         links = tuple(
@@ -236,8 +521,15 @@ class RasScenario:
         if len({link.mapping_id for link in links}) != len(links):
             raise ValueError("boundary mapping IDs must be unique")
         if not hydrology_source.is_file():
+            raise FileNotFoundError(f"Hydrology DSS file not found: {hydrology_source}")
+        if (excess_source is None) != (forcing_excess_pathname is None):
+            raise ValueError(
+                "forcing_excess_dss and forcing_excess_pathname must be "
+                "provided together"
+            )
+        if excess_source is not None and not excess_source.is_file():
             raise FileNotFoundError(
-                f"Hydrology DSS file not found: {hydrology_source}"
+                f"Forcing-excess DSS file not found: {excess_source}"
             )
         if end_time <= start_time:
             raise ValueError("end_time must be later than start_time")
@@ -254,42 +546,48 @@ class RasScenario:
             linked_sources
         ):
             raise ValueError("linked asset directory names must be unique")
-        for source, linked_destination in zip(
-            linked_sources,
-            linked_destinations,
-        ):
+        for source, linked_destination in zip(linked_sources, linked_destinations):
             if not source.is_dir():
-                raise FileNotFoundError(
-                    f"Linked asset directory not found: {source}"
-                )
+                raise FileNotFoundError(f"Linked asset directory not found: {source}")
             RasScenario._validate_copy_boundaries(
                 source,
                 linked_destination,
             )
-            if linked_destination.exists():
+            if linked_asset_cache_key is None and linked_destination.exists():
                 raise FileExistsError(
-                    "Linked asset destination already exists: "
-                    f"{linked_destination}"
+                    "Linked asset destination already exists: " f"{linked_destination}"
                 )
         if destination.exists():
             if not overwrite:
                 raise FileExistsError(f"Workspace already exists: {destination}")
             shutil.rmtree(destination)
         destination.parent.mkdir(parents=True, exist_ok=True)
+        source_output_exclusions = RasScenario._scenario_output_exclusions(
+            source_folder,
+            source_file.stem,
+        )
+        linked_asset_cache = None
+        if linked_asset_cache_key is not None:
+            linked_asset_cache = RasScenario._prepare_linked_asset_cache(
+                destination.parent,
+                linked_sources,
+                linked_asset_cache_key,
+            )
         shutil.copytree(
             source_folder,
             destination,
-            ignore=RasUtils.ignore_windows_reserved,
+            ignore=RasScenario._scenario_copy_ignore(source_file.stem),
         )
-        for source, linked_destination in zip(
-            linked_sources,
-            linked_destinations,
-        ):
-            shutil.copytree(
-                source,
-                linked_destination,
-                ignore=RasUtils.ignore_windows_reserved,
-            )
+        if linked_asset_cache_key is None:
+            for source, linked_destination in zip(
+                linked_sources,
+                linked_destinations,
+            ):
+                shutil.copytree(
+                    source,
+                    linked_destination,
+                    ignore=RasUtils.ignore_windows_reserved,
+                )
 
         copied_project = destination / source_file.name
         project = init_ras_project(
@@ -310,9 +608,11 @@ class RasScenario:
         ]
         if plan_matches.empty:
             raise ValueError(f"Source plan {source_plan!r} was not found")
-        source_unsteady_number = str(
-            plan_matches.iloc[0].get("unsteady_number", "")
-        ).lower().removeprefix("u")
+        source_unsteady_number = (
+            str(plan_matches.iloc[0].get("unsteady_number", ""))
+            .lower()
+            .removeprefix("u")
+        )
         if not source_unsteady_number:
             raise ValueError(f"Source plan {source_plan!r} has no unsteady flow file")
 
@@ -342,12 +642,21 @@ class RasScenario:
         if copy_hydrology:
             hydrology_file = hydrology_dir / hydrology_source.name
             shutil.copy2(hydrology_source, hydrology_file)
-            dss_reference = str(
-                hydrology_file.relative_to(destination)
-            ).replace("/", "\\")
+            dss_reference = str(hydrology_file.relative_to(destination)).replace(
+                "/", "\\"
+            )
         else:
             hydrology_file = hydrology_source
             dss_reference = str(hydrology_source)
+
+        excess_file: Optional[Path] = None
+        if excess_source is not None:
+            if excess_source.name.casefold() == hydrology_source.name.casefold():
+                raise ValueError(
+                    "Hydrology and forcing-excess DSS filenames must be distinct"
+                )
+            excess_file = hydrology_dir / excess_source.name
+            shutil.copy2(excess_source, excess_file)
 
         unsteady_file = RasPlan.get_unsteady_path(
             unsteady_number,
@@ -372,9 +681,18 @@ class RasScenario:
                 expected_bc_type=link.expected_bc_type,
             )
             if not changed:
-                raise ValueError(
-                    f"Boundary mapping {link.mapping_id!r} did not match"
-                )
+                raise ValueError(f"Boundary mapping {link.mapping_id!r} did not match")
+
+        if excess_file is not None:
+            RasUnsteady.set_met_precipitation_mode(
+                unsteady_file,
+                "Gridded",
+                source="DSS",
+                dss_filename=excess_file,
+                dss_pathname=forcing_excess_pathname,
+                interpolation=forcing_excess_interpolation,
+                ras_object=project,
+            )
 
         plan_file = RasPlan.get_plan_path(plan_number, ras_object=project)
         if plan_file is None:
@@ -390,14 +708,152 @@ class RasScenario:
             unsteady_file=unsteady_file,
             hydrology_source=hydrology_source,
             hydrology_file=hydrology_file,
+            forcing_excess_source=excess_source,
+            forcing_excess_file=excess_file,
+            forcing_excess_pathname=forcing_excess_pathname,
+            linked_asset_cache=linked_asset_cache,
+            source_output_exclusions=source_output_exclusions,
             result_hdf=destination / f"{project.project_name}.p{plan_number}.hdf",
             boundary_mapping_ids=tuple(link.mapping_id for link in links),
             simulation_start=start_time.isoformat(),
             simulation_end=end_time.isoformat(),
         )
+        requested_crosswalk = RasScenario._geometry_boundary_crosswalk(
+            prepared,
+            links,
+            plan_file.read_text(encoding="utf-8", errors="replace"),
+        )
+        if all(requested_crosswalk.values()):
+            inactive_inherited = RasScenario._remove_inactive_inherited_dss_boundaries(
+                prepared,
+                links,
+            )
+            prepared = replace(
+                prepared,
+                inactive_inherited_boundaries=tuple(inactive_inherited),
+            )
         RasScenario.validate_workspace(prepared, links)
         logger.info("Prepared RAS scenario workspace: %s", destination)
         return prepared
+
+    @staticmethod
+    def _remove_inactive_inherited_dss_boundaries(
+        workspace: RasScenarioWorkspace,
+        requested_links: tuple[RasBoundaryLink, ...],
+    ) -> list[Dict[str, Any]]:
+        """Remove inherited DSS blocks absent from the active geometry.
+
+        A template unsteady file can retain boundary blocks from an older
+        geometry. HEC-RAS still attempts to open their DSS records during
+        preprocessing even though the active geometry cannot apply them. Keep
+        requested mappings fail-closed, but remove non-requested inherited
+        blocks from the scenario clone and retain an explicit audit record.
+        """
+        boundaries = RasUnsteady.get_dss_boundaries(workspace.unsteady_file)
+        if boundaries.empty:
+            return []
+
+        def clean(value: Any) -> Optional[str]:
+            text = str(value).strip()
+            return text if text and text.casefold() != "nan" else None
+
+        def is_requested(row: Mapping[str, Any]) -> bool:
+            row_index = int(row["boundary_index"])
+            for link in requested_links:
+                if link.boundary_index is not None:
+                    if row_index == link.boundary_index:
+                        return True
+                    continue
+                if link.river or link.reach or link.station:
+                    if (
+                        clean(row.get("river")) == clean(link.river)
+                        and clean(row.get("reach")) == clean(link.reach)
+                        and clean(row.get("station")) == clean(link.station)
+                    ):
+                        return True
+                    continue
+                if clean(row.get("sa_2d_name")) == clean(link.sa_2d_name) and clean(
+                    row.get("bc_line")
+                ) == clean(link.bc_line):
+                    return True
+            return False
+
+        candidates: list[tuple[int, RasBoundaryLink, Dict[str, Any]]] = []
+        for _, row in boundaries.iterrows():
+            record = row.to_dict()
+            if is_requested(record):
+                continue
+            boundary_index = int(record["boundary_index"])
+            selector: Dict[str, Any]
+            if any(clean(record.get(key)) for key in ("river", "reach", "station")):
+                selector = {
+                    "river": clean(record.get("river")),
+                    "reach": clean(record.get("reach")),
+                    "station": clean(record.get("station")),
+                }
+            elif any(clean(record.get(key)) for key in ("sa_2d_name", "bc_line")):
+                selector = {
+                    "sa_2d_name": clean(record.get("sa_2d_name")),
+                    "bc_line": clean(record.get("bc_line")),
+                }
+            else:
+                selector = {"boundary_index": boundary_index}
+            link = RasBoundaryLink(
+                mapping_id=f"inherited-boundary-{boundary_index:03d}",
+                dss_path=str(record["dss_path"]),
+                expected_bc_type=clean(record.get("bc_type")) or "Unknown",
+                **selector,
+            )
+            candidates.append((boundary_index, link, record))
+
+        if not candidates:
+            return []
+        plan_text = workspace.plan_file.read_text(
+            encoding="utf-8",
+            errors="replace",
+        )
+        crosswalk = RasScenario._geometry_boundary_crosswalk(
+            workspace,
+            tuple(link for _, link, _ in candidates),
+            plan_text,
+        )
+        inactive = [
+            (boundary_index, link, record)
+            for boundary_index, link, record in candidates
+            if not crosswalk[link.mapping_id]
+        ]
+        audit: list[Dict[str, Any]] = []
+        for boundary_index, link, record in sorted(
+            inactive,
+            key=lambda value: value[0],
+            reverse=True,
+        ):
+            deletion = RasUnsteady.delete_boundary(
+                workspace.unsteady_file,
+                boundary_index=boundary_index,
+                force=True,
+                ras_object=None,
+            )
+            audit.append(
+                {
+                    "mapping_id": link.mapping_id,
+                    "boundary_index": boundary_index,
+                    "boundary_name": clean(record.get("boundary_name")),
+                    "bc_type": clean(record.get("bc_type")),
+                    "dss_file": clean(record.get("dss_file")),
+                    "dss_path": clean(record.get("dss_path")),
+                    "river": clean(record.get("river")),
+                    "reach": clean(record.get("reach")),
+                    "station": clean(record.get("station")),
+                    "sa_2d_name": clean(record.get("sa_2d_name")),
+                    "bc_line": clean(record.get("bc_line")),
+                    "geometry_crosswalk": False,
+                    "disposition": "removed_from_clone_inactive_in_active_geometry",
+                    "lines_removed": deletion["lines_removed"],
+                }
+            )
+        audit.sort(key=lambda value: value["boundary_index"])
+        return audit
 
     @staticmethod
     @log_call
@@ -433,9 +889,7 @@ class RasScenario:
             workspace.unsteady_file,
         )
         linked_pathnames = {link.dss_path for link in links}
-        mapped_boundaries = boundaries[
-            boundaries["dss_path"].isin(linked_pathnames)
-        ]
+        mapped_boundaries = boundaries[boundaries["dss_path"].isin(linked_pathnames)]
         dss_references = tuple(
             str(reference).strip()
             for reference in mapped_boundaries["dss_file"]
@@ -481,6 +935,18 @@ class RasScenario:
             links,
             plan_text,
         )
+        newline_evidence = RasScenario.inspect_newlines(workspace.project_folder)
+        forcing_config = RasUnsteady.get_met_precipitation_config(
+            workspace.unsteady_file
+        )
+        forcing_expected = workspace.forcing_excess_file is not None
+        forcing_reference = (
+            str(
+                workspace.forcing_excess_file.relative_to(workspace.project_folder)
+            ).replace("/", "\\")
+            if workspace.forcing_excess_file is not None
+            else None
+        )
 
         checks = {
             "project_file_exists": workspace.project_file.is_file(),
@@ -492,8 +958,7 @@ class RasScenario:
             ),
             "project_uses_cloned_plan": (
                 current_plan_match is not None
-                and current_plan_match.group(1).zfill(2)
-                == workspace.plan_number
+                and current_plan_match.group(1).zfill(2) == workspace.plan_number
             ),
             "plan_window_matches_contract": (
                 expected_window is None or actual_window == expected_window
@@ -504,8 +969,7 @@ class RasScenario:
             "all_dss_file_references_resolvable": (
                 bool(dss_references)
                 and all(
-                    is_resolvable_reference(reference)
-                    for reference in dss_references
+                    is_resolvable_reference(reference) for reference in dss_references
                 )
             ),
             "all_dss_files_exist": (
@@ -520,16 +984,133 @@ class RasScenario:
                 == workspace.boundary_mapping_ids
             ),
             "all_boundaries_exist_in_active_geometry": (
-                bool(geometry_crosswalk)
-                and all(geometry_crosswalk.values())
+                bool(geometry_crosswalk) and all(geometry_crosswalk.values())
+            ),
+            "one_newline_convention": newline_evidence["consistent"],
+            "forcing_excess_file_exists": (
+                not forcing_expected
+                or (
+                    workspace.forcing_excess_file is not None
+                    and workspace.forcing_excess_file.is_file()
+                )
+            ),
+            "forcing_excess_link_matches": (
+                not forcing_expected
+                or (
+                    forcing_config["enabled"] is True
+                    and forcing_config["mode"] == "Gridded"
+                    and forcing_config["source"] == "DSS"
+                    and forcing_config["dss_filename"]
+                    in {forcing_reference, f".\\{forcing_reference}"}
+                    and forcing_config["dss_pathname"]
+                    == workspace.forcing_excess_pathname
+                )
             ),
         }
         if not all(checks.values()):
             failed = [name for name, passed in checks.items() if not passed]
+            details = []
+            if not checks["all_boundaries_exist_in_active_geometry"]:
+                inactive_mappings = [
+                    mapping_id
+                    for mapping_id, exists in geometry_crosswalk.items()
+                    if not exists
+                ]
+                if inactive_mappings:
+                    details.append("inactive mappings: " + ", ".join(inactive_mappings))
+            detail_suffix = f" ({'; '.join(details)})" if details else ""
             raise ValueError(
-                "Prepared RAS workspace failed validation: " + ", ".join(failed)
+                "Prepared RAS workspace failed validation: "
+                + ", ".join(failed)
+                + detail_suffix
             )
         return checks
+
+    @staticmethod
+    @log_call
+    def inspect_newlines(project_folder: Union[str, Path]) -> Dict[str, Any]:
+        """Return newline evidence for top-level HEC-RAS text files.
+
+        Each file must use exactly one line-ending style, and all recognized
+        authored project text files must agree. Generated compute artifacts
+        such as ``.b##``, ``.c##``, ``.o##``, ``.r##``, and ``.x##`` are not
+        authored project text and may be binary, so they are intentionally
+        excluded along with HDF, DSS, and XML rasmap files.
+        """
+        folder = Path(project_folder)
+        files = sorted(
+            path
+            for path in folder.iterdir()
+            if path.is_file()
+            and (
+                path.suffix.casefold() == ".prj"
+                or _RAS_AUTHORED_TEXT_SUFFIX.fullmatch(path.suffix)
+            )
+        )
+        conventions = {str(path): RasUtils._detect_text_newline(path) for path in files}
+        unique = sorted(set(conventions.values()))
+        return {
+            "consistent": bool(conventions) and len(unique) == 1,
+            "convention": unique[0] if len(unique) == 1 else None,
+            "files": conventions,
+        }
+
+    @staticmethod
+    @log_call
+    def inspect_workspace_evidence(
+        workspace: RasScenarioWorkspace,
+        boundary_links: Iterable[RasBoundaryLink],
+    ) -> Dict[str, Any]:
+        """Return read-only evidence for a prepared scenario workspace."""
+        plan_text = workspace.plan_file.read_text(
+            encoding="utf-8",
+            errors="replace",
+        )
+        links = tuple(boundary_links)
+        if workspace.simulation_start and workspace.simulation_end:
+            start_time = datetime.fromisoformat(workspace.simulation_start)
+            end_time = datetime.fromisoformat(workspace.simulation_end)
+            links = tuple(
+                replace(
+                    link,
+                    dss_path=RasScenario.format_dss_pathname_for_window(
+                        link.dss_path,
+                        start_time,
+                        end_time,
+                    ),
+                )
+                for link in links
+            )
+        current_plan = re.search(
+            r"^Current Plan=p(\w+)\s*$",
+            workspace.project_file.read_text(
+                encoding="utf-8",
+                errors="replace",
+            ),
+            flags=re.MULTILINE,
+        )
+        window = RasScenario._parse_simulation_window(plan_text)
+        return {
+            "current_plan": (
+                current_plan.group(1).zfill(2) if current_plan is not None else None
+            ),
+            "simulation_window": {
+                "start": window[0].isoformat() if window else None,
+                "end": window[1].isoformat() if window else None,
+            },
+            "geometry_crosswalk": RasScenario._geometry_boundary_crosswalk(
+                workspace,
+                links,
+                plan_text,
+            ),
+            "inactive_inherited_boundaries": list(
+                workspace.inactive_inherited_boundaries
+            ),
+            "newline": RasScenario.inspect_newlines(workspace.project_folder),
+            "forcing_excess": RasUnsteady.get_met_precipitation_config(
+                workspace.unsteady_file
+            ),
+        }
 
     @staticmethod
     def _parse_simulation_window(
@@ -537,8 +1118,7 @@ class RasScenario:
     ) -> Optional[tuple[datetime, datetime]]:
         """Parse a HEC-RAS ``Simulation Date`` line."""
         match = re.search(
-            r"^Simulation Date=([^,\r\n]+),([^,\r\n]+),"
-            r"([^,\r\n]+),([^,\r\n]+)\s*$",
+            r"^Simulation Date=([^,\r\n]+),([^,\r\n]+)," r"([^,\r\n]+),([^,\r\n]+)\s*$",
             plan_text,
             flags=re.MULTILINE,
         )
@@ -593,8 +1173,7 @@ class RasScenario:
             errors="replace",
         )
         area_names = {
-            str(value).strip().casefold()
-            for value in storage_areas.get("Name", ())
+            str(value).strip().casefold() for value in storage_areas.get("Name", ())
         }
         bc_line_names = {
             value.strip().casefold()
@@ -623,9 +1202,7 @@ class RasScenario:
                     for _, row in cross_sections.iterrows()
                 )
                 continue
-            area_exists = (
-                str(link.sa_2d_name).strip().casefold() in area_names
-            )
+            area_exists = str(link.sa_2d_name).strip().casefold() in area_names
             bc_line_exists = (
                 True
                 if not link.bc_line
@@ -680,9 +1257,7 @@ class RasScenario:
             executor.shutdown(wait=False, cancel_futures=True)
         finished = datetime.now(timezone.utc)
         result_exists = workspace.result_hdf.is_file()
-        result_size = (
-            workspace.result_hdf.stat().st_size if result_exists else 0
-        )
+        result_size = workspace.result_hdf.stat().st_size if result_exists else 0
         hdf_check = RasScenario._inspect_result_hdf(workspace)
         status = (
             "succeeded"
@@ -799,6 +1374,4 @@ class RasScenario:
             or source in destination.parents
             or destination in source.parents
         ):
-            raise ValueError(
-                "Source project and scenario workspace must not overlap"
-            )
+            raise ValueError("Source project and scenario workspace must not overlap")

--- a/ras_commander/RasScenarioWorker.py
+++ b/ras_commander/RasScenarioWorker.py
@@ -16,9 +16,9 @@ from pathlib import Path
 from typing import Any, Dict, Mapping, Optional, Sequence, Union
 
 from .Decorators import log_call
+from .hdf.HdfResultsProducts import HdfResultsProducts
 from .LoggingConfig import get_logger
 from .RasScenario import RasBoundaryLink, RasRunArtifact, RasScenario
-from .hdf.HdfResultsProducts import HdfResultsProducts
 
 logger = get_logger(__name__)
 
@@ -73,10 +73,9 @@ class RasScenarioWorker:
         warnings: list[str] = []
 
         try:
-            request = RasScenarioWorker._validate_request(
-                RasScenarioWorker._load_request(request_file)
-            )
-            request_sha256 = _json_sha256(request)
+            retained_request = RasScenarioWorker._load_request(request_file)
+            request_sha256 = _json_sha256(retained_request)
+            request = RasScenarioWorker._validate_request(retained_request)
             if result_file.exists():
                 RasScenarioWorker._verify_completed_result(
                     result_file,
@@ -528,7 +527,7 @@ class RasScenarioWorker:
                 ),
             }
 
-        return {
+        normalized_request = {
             "schema": RasScenarioWorker.REQUEST_SCHEMA,
             "scenario": normalized_scenario,
             "source_model": normalized_source,
@@ -555,8 +554,10 @@ class RasScenarioWorker:
                 ),
                 "cores": _positive_int(execution["cores"], "execution.cores"),
             },
-            "retry": retry,
         }
+        if retry is not None:
+            normalized_request["retry"] = retry
+        return normalized_request
 
     @staticmethod
     def _verify_input_identities(request: Mapping[str, Any]) -> None:
@@ -671,8 +672,12 @@ class RasScenarioWorker:
             reject(f"Prior worker result does not exist: {prior_result_path}")
 
         try:
+            retained_prior_request = RasScenarioWorker._load_request(
+                prior_request_path
+            )
+            retained_prior_hash = _json_sha256(retained_prior_request)
             prior_request = RasScenarioWorker._validate_request(
-                RasScenarioWorker._load_request(prior_request_path)
+                retained_prior_request
             )
             prior_result = json.loads(prior_result_path.read_text(encoding="utf-8"))
         except RasScenarioWorkerError:
@@ -687,6 +692,7 @@ class RasScenarioWorker:
         legacy_prior_request.pop("retry", None)
         legacy_prior_request["source_model"].pop("linked_asset_mode", None)
         accepted_prior_hashes = {
+            retained_prior_hash,
             prior_request_sha256,
             _json_sha256(legacy_prior_request),
         }

--- a/ras_commander/RasScenarioWorker.py
+++ b/ras_commander/RasScenarioWorker.py
@@ -1,0 +1,1174 @@
+"""Versioned process boundary for one HEC-RAS scenario execution."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+import re
+import subprocess
+import sys
+import tempfile
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, Mapping, Optional, Sequence, Union
+
+from .Decorators import log_call
+from .LoggingConfig import get_logger
+from .RasScenario import RasBoundaryLink, RasRunArtifact, RasScenario
+from .hdf.HdfResultsProducts import HdfResultsProducts
+
+logger = get_logger(__name__)
+
+_SHA256_PATTERN = re.compile(r"^[0-9a-f]{64}$")
+_HYDROLOGIC_PRODUCTS_SCHEMA = "hms-commander/hydrologic-product-manifest/1.0"
+
+
+class RasScenarioWorkerError(RuntimeError):
+    """Classified worker failure suitable for a machine-readable result."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        classification: str,
+        exit_code: int,
+        retryable: bool = False,
+    ) -> None:
+        super().__init__(message)
+        self.classification = classification
+        self.exit_code = exit_code
+        self.retryable = retryable
+
+
+class RasScenarioWorker:
+    """Static namespace for the RAS scenario-worker request/result contract."""
+
+    REQUEST_SCHEMA = "ras-commander/scenario-worker-request/1.0"
+    RESULT_SCHEMA = "ras-commander/scenario-worker-result/1.0"
+
+    @staticmethod
+    @log_call
+    def run(
+        request_path: Union[str, Path],
+        result_path: Union[str, Path],
+    ) -> int:
+        """Execute one request and atomically write identity-bound evidence."""
+        request_file = Path(request_path).resolve()
+        result_file = Path(result_path).resolve()
+        started_at = _utc_now()
+        started_clock = time.perf_counter()
+        request: Optional[Dict[str, Any]] = None
+        request_sha256: Optional[str] = None
+        preparation: Dict[str, Any] = {"status": "not_started"}
+        execution: Dict[str, Any] = {"status": "not_started"}
+        result_hdf: Optional[Dict[str, Any]] = None
+        products: Optional[Dict[str, Any]] = None
+        numerical_qaqc: Optional[Dict[str, Any]] = None
+        conditional_findings: Optional[Dict[str, Any]] = None
+        retry_evidence: Optional[Dict[str, Any]] = None
+        timings: Dict[str, Any] = {}
+        warnings: list[str] = []
+
+        try:
+            request = RasScenarioWorker._validate_request(
+                RasScenarioWorker._load_request(request_file)
+            )
+            request_sha256 = _json_sha256(request)
+            if result_file.exists():
+                RasScenarioWorker._verify_completed_result(
+                    result_file,
+                    request_sha256=request_sha256,
+                    specification_sha256=request["scenario"]["specification_sha256"],
+                )
+                logger.info(
+                    "Verified existing RAS worker result for request %s",
+                    request_sha256,
+                )
+                return 0
+
+            retry_evidence = RasScenarioWorker._verify_retry_evidence(request)
+            preparation = {
+                "status": "not_started",
+                "retry": retry_evidence,
+            }
+
+            workspace_path = Path(request["workspace"])
+            product_directory = Path(request["products"]["directory"])
+            if workspace_path.exists():
+                raise RasScenarioWorkerError(
+                    f"RAS scenario workspace already exists: {workspace_path}",
+                    classification="existing_workspace",
+                    exit_code=3,
+                )
+            if product_directory.exists():
+                raise RasScenarioWorkerError(
+                    "Hydraulic product destination already exists: "
+                    f"{product_directory}",
+                    classification="existing_product_destination",
+                    exit_code=3,
+                )
+
+            RasScenarioWorker._verify_input_identities(request)
+            links = tuple(
+                RasBoundaryLink.from_mapping(value)
+                for value in request["boundary_links"]
+            )
+            model_window = request["model_window"]
+            source_model = request["source_model"]
+            forcing_excess = request["forcing_excess"]
+            execution_options = request["execution"]
+
+            preparation_started = time.perf_counter()
+            preparation = {"status": "in_progress"}
+            try:
+                workspace = RasScenario.prepare_workspace(
+                    source_model["project"],
+                    request["workspace"],
+                    request["scenario"]["scenario_id"],
+                    source_model["template_plan"],
+                    request["hydrology"]["dss"],
+                    links,
+                    _parse_model_time(model_window["start"]),
+                    _parse_model_time(model_window["end"]),
+                    ras_exe_path=execution_options["ras_executable"],
+                    linked_asset_directories=source_model["linked_asset_directories"],
+                    linked_asset_cache_key=(
+                        source_model["model_manifest_sha256"]
+                        if source_model["linked_asset_mode"] == "shared-cache"
+                        else None
+                    ),
+                    forcing_excess_dss=forcing_excess["dss"],
+                    forcing_excess_pathname=forcing_excess["pathname"],
+                    forcing_excess_interpolation=forcing_excess["interpolation"],
+                    copy_hydrology=True,
+                    overwrite=False,
+                )
+                checks = RasScenario.validate_workspace(workspace, links)
+                evidence = RasScenario.inspect_workspace_evidence(
+                    workspace,
+                    links,
+                )
+            finally:
+                timings["preparation_seconds"] = _elapsed(preparation_started)
+            preparation = {
+                "status": "passed",
+                "checks": checks,
+                "evidence": evidence,
+                "workspace": workspace.to_dict(),
+                "retry": retry_evidence,
+            }
+
+            execution_started = time.perf_counter()
+            execution = {"status": "in_progress"}
+            try:
+                artifact = RasScenario.execute(
+                    workspace,
+                    ras_exe_path=execution_options["ras_executable"],
+                    timeout=execution_options["timeout_seconds"],
+                    num_cores=execution_options["cores"],
+                )
+            finally:
+                timings["execution_seconds"] = _elapsed(execution_started)
+            execution = artifact.to_dict()
+            if artifact.status != "succeeded":
+                raise RasScenarioWorker._artifact_failure(artifact)
+            if source_model["linked_asset_mode"] == "shared-cache":
+                preparation["linked_asset_cache_post_execution"] = (
+                    RasScenario._prepare_linked_asset_cache(
+                        workspace.project_folder.parent,
+                        tuple(
+                            Path(path)
+                            for path in source_model["linked_asset_directories"]
+                        ),
+                        source_model["model_manifest_sha256"],
+                    )
+                )
+
+            result_hdf = _file_identity(artifact.result_hdf)
+            product_options = request["products"]
+            product_started = time.perf_counter()
+            try:
+                try:
+                    manifest = HdfResultsProducts.export(
+                        artifact.result_hdf,
+                        product_directory,
+                        resolution=product_options["resolution"],
+                        max_dimension=product_options["max_dimension"],
+                        nodata=product_options["nodata"],
+                        include_preview=product_options["include_preview"],
+                    )
+                except Exception as exc:
+                    raise RasScenarioWorkerError(
+                        f"Hydraulic product export failed: {exc}",
+                        classification="product_export_failed",
+                        exit_code=4,
+                        retryable=isinstance(exc, OSError),
+                    ) from exc
+            finally:
+                timings["product_export_seconds"] = _elapsed(product_started)
+
+            product_manifest_path = (
+                product_directory / HdfResultsProducts.MANIFEST_FILENAME
+            )
+            numerical_path = (
+                product_directory / HdfResultsProducts.FILENAMES["numerical-qaqc"]
+            )
+            numerical_qaqc = json.loads(numerical_path.read_text(encoding="utf-8"))
+            conditional_findings = dict(
+                numerical_qaqc.get("compute_message_findings", {})
+            )
+            warnings = _conditional_warning_lines(conditional_findings)
+            products = {
+                "directory": str(product_directory),
+                "manifest": _file_identity(product_manifest_path),
+                "schema": manifest["schema"],
+                "status": manifest["status"],
+            }
+
+            result = RasScenarioWorker._result_payload(
+                request=request,
+                request_sha256=request_sha256,
+                status="succeeded",
+                started_at=started_at,
+                started_clock=started_clock,
+                preparation=preparation,
+                execution=execution,
+                result_hdf=result_hdf,
+                products=products,
+                numerical_qaqc=numerical_qaqc,
+                conditional_findings=conditional_findings,
+                timings=timings,
+                warnings=warnings,
+                error=None,
+            )
+            _write_json_new(result_file, result)
+            logger.info("Completed RAS scenario worker request %s", request_sha256)
+            return 0
+        except Exception as exc:
+            failure = RasScenarioWorker._classify_exception(exc)
+            result = RasScenarioWorker._result_payload(
+                request=request,
+                request_sha256=request_sha256,
+                status="failed",
+                started_at=started_at,
+                started_clock=started_clock,
+                preparation=preparation,
+                execution=execution,
+                result_hdf=result_hdf,
+                products=products,
+                numerical_qaqc=numerical_qaqc,
+                conditional_findings=conditional_findings,
+                timings=timings,
+                warnings=warnings,
+                error={
+                    "classification": failure.classification,
+                    "exception_type": type(exc).__name__,
+                    "message": str(exc),
+                    "retryable": failure.retryable,
+                },
+            )
+            try:
+                _write_json_new(result_file, result)
+            except FileExistsError:
+                logger.error(
+                    "Refusing to replace existing RAS worker result: %s",
+                    result_file,
+                )
+            except OSError as write_error:
+                logger.error(
+                    "Could not write RAS worker failure result %s: %s",
+                    result_file,
+                    write_error,
+                )
+            logger.error(
+                "RAS scenario worker failed (%s): %s",
+                failure.classification,
+                exc,
+            )
+            return failure.exit_code
+
+    @staticmethod
+    def _load_request(path: Path) -> Dict[str, Any]:
+        if not path.is_file():
+            raise RasScenarioWorkerError(
+                f"RAS worker request does not exist: {path}",
+                classification="invalid_request",
+                exit_code=2,
+            )
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+            raise RasScenarioWorkerError(
+                f"Could not read RAS worker request {path}: {exc}",
+                classification="invalid_request",
+                exit_code=2,
+            ) from exc
+        if not isinstance(payload, dict):
+            raise RasScenarioWorkerError(
+                "RAS worker request root must be a JSON object",
+                classification="invalid_request",
+                exit_code=2,
+            )
+        return payload
+
+    @staticmethod
+    def _validate_request(payload: Mapping[str, Any]) -> Dict[str, Any]:
+        _require_keys(
+            payload,
+            required={
+                "schema",
+                "scenario",
+                "source_model",
+                "hydrology",
+                "boundary_links",
+                "forcing_excess",
+                "model_window",
+                "workspace",
+                "products",
+                "execution",
+            },
+            optional={"retry"},
+            label="request",
+        )
+        if payload["schema"] != RasScenarioWorker.REQUEST_SCHEMA:
+            raise RasScenarioWorkerError(
+                f"Unsupported RAS worker request schema: {payload['schema']!r}",
+                classification="invalid_request",
+                exit_code=2,
+            )
+
+        scenario = _object(payload["scenario"], "scenario")
+        _require_keys(
+            scenario,
+            required={"scenario_id", "specification_sha256"},
+            optional=set(),
+            label="scenario",
+        )
+        normalized_scenario = {
+            "scenario_id": _nonempty_string(
+                scenario["scenario_id"], "scenario.scenario_id"
+            ),
+            "specification_sha256": _sha256_string(
+                scenario["specification_sha256"],
+                "scenario.specification_sha256",
+            ),
+        }
+
+        source = _object(payload["source_model"], "source_model")
+        _require_keys(
+            source,
+            required={
+                "project",
+                "project_file_sha256",
+                "template_plan",
+                "model_manifest",
+                "model_manifest_sha256",
+            },
+            optional={"linked_asset_directories", "linked_asset_mode"},
+            label="source_model",
+        )
+        linked_assets = source.get("linked_asset_directories", [])
+        if not isinstance(linked_assets, list):
+            _invalid("source_model.linked_asset_directories must be an array")
+        normalized_source = {
+            "project": _resolved_path(source["project"], "source_model.project"),
+            "project_file_sha256": _sha256_string(
+                source["project_file_sha256"],
+                "source_model.project_file_sha256",
+            ),
+            "template_plan": _nonempty_string(
+                str(source["template_plan"]), "source_model.template_plan"
+            ),
+            "model_manifest": _resolved_path(
+                source["model_manifest"], "source_model.model_manifest"
+            ),
+            "model_manifest_sha256": _sha256_string(
+                source["model_manifest_sha256"],
+                "source_model.model_manifest_sha256",
+            ),
+            "linked_asset_directories": [
+                _resolved_path(value, f"source_model.linked_asset_directories[{i}]")
+                for i, value in enumerate(linked_assets)
+            ],
+            "linked_asset_mode": _choice(
+                source.get("linked_asset_mode", "copy"),
+                "source_model.linked_asset_mode",
+                {"copy", "shared-cache"},
+            ),
+        }
+
+        hydrology = _identity_input(
+            payload["hydrology"],
+            label="hydrology",
+            file_key="dss",
+            manifest_key="product_manifest",
+        )
+        forcing = _identity_input(
+            payload["forcing_excess"],
+            label="forcing_excess",
+            file_key="dss",
+            manifest_key="provenance_manifest",
+            extra_required={"pathname"},
+            extra_optional={"interpolation"},
+        )
+        forcing["pathname"] = _dss_pathname(
+            payload["forcing_excess"]["pathname"],
+            "forcing_excess.pathname",
+        )
+        forcing["interpolation"] = _choice(
+            payload["forcing_excess"].get("interpolation", "Bilinear"),
+            "forcing_excess.interpolation",
+            {"Nearest", "Bilinear"},
+        )
+
+        raw_links = payload["boundary_links"]
+        if not isinstance(raw_links, list) or not raw_links:
+            _invalid("boundary_links must be a non-empty array")
+        links: list[Dict[str, Any]] = []
+        allowed_link_fields = set(RasBoundaryLink.__dataclass_fields__)
+        for index, raw_link in enumerate(raw_links):
+            link = _object(raw_link, f"boundary_links[{index}]")
+            unknown = sorted(set(link) - allowed_link_fields)
+            if unknown:
+                _invalid(
+                    f"Invalid boundary_links[{index}] fields: unknown "
+                    + ", ".join(unknown)
+                )
+            try:
+                normalized_link = RasBoundaryLink.from_mapping(link)
+            except (TypeError, ValueError) as exc:
+                raise RasScenarioWorkerError(
+                    f"Invalid boundary_links[{index}]: {exc}",
+                    classification="invalid_request",
+                    exit_code=2,
+                ) from exc
+            links.append(
+                {
+                    name: value
+                    for name, value in normalized_link.__dict__.items()
+                    if value is not None
+                }
+            )
+        if len({link["mapping_id"] for link in links}) != len(links):
+            _invalid("boundary_links mapping_id values must be unique")
+
+        window = _object(payload["model_window"], "model_window")
+        _require_keys(
+            window,
+            required={"start", "end", "time_zone"},
+            optional=set(),
+            label="model_window",
+        )
+        start = _parse_model_time(window["start"])
+        end = _parse_model_time(window["end"])
+        if end <= start:
+            _invalid("model_window.end must be later than model_window.start")
+        normalized_window = {
+            "start": start.isoformat(timespec="seconds"),
+            "end": end.isoformat(timespec="seconds"),
+            "time_zone": _nonempty_string(
+                window["time_zone"], "model_window.time_zone"
+            ),
+        }
+
+        product_config = _object(payload["products"], "products")
+        _require_keys(
+            product_config,
+            required={"directory"},
+            optional={"resolution", "max_dimension", "nodata", "include_preview"},
+            label="products",
+        )
+        resolution = product_config.get("resolution")
+        if resolution is not None:
+            resolution = _positive_number(resolution, "products.resolution")
+        max_dimension = product_config.get("max_dimension", 2048)
+        if (
+            isinstance(max_dimension, bool)
+            or not isinstance(max_dimension, int)
+            or max_dimension < 64
+        ):
+            _invalid("products.max_dimension must be an integer of at least 64")
+        nodata = product_config.get("nodata", -9999.0)
+        if (
+            isinstance(nodata, bool)
+            or not isinstance(nodata, (int, float))
+            or not math.isfinite(nodata)
+        ):
+            _invalid("products.nodata must be finite and numeric")
+        include_preview = product_config.get("include_preview", True)
+        if not isinstance(include_preview, bool):
+            _invalid("products.include_preview must be boolean")
+
+        execution = _object(payload["execution"], "execution")
+        _require_keys(
+            execution,
+            required={"ras_executable", "timeout_seconds", "cores"},
+            optional=set(),
+            label="execution",
+        )
+
+        retry = None
+        if payload.get("retry") is not None:
+            retry_config = _object(payload["retry"], "retry")
+            _require_keys(
+                retry_config,
+                required={"prior_request", "prior_result"},
+                optional=set(),
+                label="retry",
+            )
+            retry = {
+                "prior_request": _resolved_path(
+                    retry_config["prior_request"], "retry.prior_request"
+                ),
+                "prior_result": _resolved_path(
+                    retry_config["prior_result"], "retry.prior_result"
+                ),
+            }
+
+        return {
+            "schema": RasScenarioWorker.REQUEST_SCHEMA,
+            "scenario": normalized_scenario,
+            "source_model": normalized_source,
+            "hydrology": hydrology,
+            "boundary_links": links,
+            "forcing_excess": forcing,
+            "model_window": normalized_window,
+            "workspace": _resolved_path(payload["workspace"], "workspace"),
+            "products": {
+                "directory": _resolved_path(
+                    product_config["directory"], "products.directory"
+                ),
+                "resolution": resolution,
+                "max_dimension": max_dimension,
+                "nodata": float(nodata),
+                "include_preview": include_preview,
+            },
+            "execution": {
+                "ras_executable": _resolved_path(
+                    execution["ras_executable"], "execution.ras_executable"
+                ),
+                "timeout_seconds": _positive_int(
+                    execution["timeout_seconds"], "execution.timeout_seconds"
+                ),
+                "cores": _positive_int(execution["cores"], "execution.cores"),
+            },
+            "retry": retry,
+        }
+
+    @staticmethod
+    def _verify_input_identities(request: Mapping[str, Any]) -> None:
+        project = Path(request["source_model"]["project"])
+        try:
+            project_file = RasScenario._resolve_project_file(project)
+        except (FileNotFoundError, ValueError) as exc:
+            raise RasScenarioWorkerError(
+                str(exc),
+                classification="source_model_identity",
+                exit_code=2,
+            ) from exc
+        _verify_file_sha256(
+            project_file,
+            request["source_model"]["project_file_sha256"],
+            "source RAS project",
+            "source_model_identity",
+        )
+        model_manifest = _verify_json_identity(
+            request["source_model"]["model_manifest"],
+            request["source_model"]["model_manifest_sha256"],
+            "source RAS model manifest",
+            "source_model_identity",
+        )
+        if str(model_manifest.get("stage", "")).casefold() != "ras":
+            raise RasScenarioWorkerError(
+                "Source model manifest is not a RAS-stage manifest",
+                classification="source_model_identity",
+                exit_code=2,
+            )
+        for directory in request["source_model"]["linked_asset_directories"]:
+            if not Path(directory).is_dir():
+                raise RasScenarioWorkerError(
+                    f"Linked asset directory does not exist: {directory}",
+                    classification="source_model_identity",
+                    exit_code=2,
+                )
+
+        _verify_file_sha256(
+            Path(request["hydrology"]["dss"]),
+            request["hydrology"]["sha256"],
+            "hydrology DSS",
+            "hydrology_identity",
+        )
+        hydrology_manifest = _verify_json_identity(
+            request["hydrology"]["product_manifest"],
+            request["hydrology"]["product_manifest_sha256"],
+            "hydrologic product manifest",
+            "hydrology_identity",
+        )
+        if hydrology_manifest.get("schema") != _HYDROLOGIC_PRODUCTS_SCHEMA:
+            raise RasScenarioWorkerError(
+                "Hydrologic product manifest has an unsupported schema",
+                classification="hydrology_identity",
+                exit_code=2,
+            )
+        if (
+            hydrology_manifest.get("source", {}).get("sha256")
+            != request["hydrology"]["sha256"]
+        ):
+            raise RasScenarioWorkerError(
+                "Hydrologic product manifest does not identify the supplied DSS",
+                classification="hydrology_identity",
+                exit_code=2,
+            )
+
+        _verify_file_sha256(
+            Path(request["forcing_excess"]["dss"]),
+            request["forcing_excess"]["sha256"],
+            "forcing-excess DSS",
+            "forcing_excess_identity",
+        )
+        _verify_json_identity(
+            request["forcing_excess"]["provenance_manifest"],
+            request["forcing_excess"]["provenance_manifest_sha256"],
+            "forcing-excess provenance manifest",
+            "forcing_excess_identity",
+        )
+        executable = Path(request["execution"]["ras_executable"])
+        if not executable.is_file():
+            raise RasScenarioWorkerError(
+                f"HEC-RAS executable reference does not exist: {executable}",
+                classification="invalid_request",
+                exit_code=2,
+            )
+
+    @staticmethod
+    def _verify_retry_evidence(
+        request: Mapping[str, Any],
+    ) -> Optional[Dict[str, Any]]:
+        """Authenticate a preparation-only failure before sharing its cache."""
+        retry = request.get("retry")
+        if retry is None:
+            return None
+
+        def reject(message: str) -> None:
+            raise RasScenarioWorkerError(
+                message,
+                classification="retry_evidence",
+                exit_code=2,
+            )
+
+        if request["source_model"]["linked_asset_mode"] != "shared-cache":
+            reject(
+                "Retry requests must use source_model.linked_asset_mode=shared-cache"
+            )
+        prior_request_path = Path(retry["prior_request"])
+        prior_result_path = Path(retry["prior_result"])
+        if not prior_request_path.is_file():
+            reject(f"Prior worker request does not exist: {prior_request_path}")
+        if not prior_result_path.is_file():
+            reject(f"Prior worker result does not exist: {prior_result_path}")
+
+        try:
+            prior_request = RasScenarioWorker._validate_request(
+                RasScenarioWorker._load_request(prior_request_path)
+            )
+            prior_result = json.loads(prior_result_path.read_text(encoding="utf-8"))
+        except RasScenarioWorkerError:
+            raise
+        except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+            reject(f"Prior worker evidence is unreadable: {exc}")
+        if not isinstance(prior_result, dict):
+            reject("Prior worker result root must be an object")
+
+        prior_request_sha256 = _json_sha256(prior_request)
+        legacy_prior_request = json.loads(json.dumps(prior_request))
+        legacy_prior_request.pop("retry", None)
+        legacy_prior_request["source_model"].pop("linked_asset_mode", None)
+        accepted_prior_hashes = {
+            prior_request_sha256,
+            _json_sha256(legacy_prior_request),
+        }
+        if prior_result.get("schema") != RasScenarioWorker.RESULT_SCHEMA:
+            reject("Prior worker result schema does not match")
+        if prior_result.get("status") != "failed":
+            reject("Prior worker result is not a failed attempt")
+        bound_prior_hash = prior_result.get("request", {}).get("sha256")
+        if bound_prior_hash not in accepted_prior_hashes:
+            reject("Prior worker result does not bind the prior request")
+        if prior_result.get("preparation", {}).get("status") != "in_progress":
+            reject("Prior worker failure did not occur during preparation")
+        if prior_result.get("execution", {}).get("status") != "not_started":
+            reject("Prior worker failure started HEC-RAS execution")
+        error = prior_result.get("error")
+        if not isinstance(error, dict) or not error.get("classification"):
+            reject("Prior worker failure classification is missing")
+
+        for field in ("scenario", "hydrology", "forcing_excess", "model_window"):
+            if prior_request[field] != request[field]:
+                reject(f"Retry changed immutable {field} inputs")
+        source_identity_fields = (
+            "project",
+            "project_file_sha256",
+            "template_plan",
+            "model_manifest",
+            "model_manifest_sha256",
+            "linked_asset_directories",
+        )
+        for field in source_identity_fields:
+            if prior_request["source_model"][field] != request["source_model"][field]:
+                reject(f"Retry changed immutable source_model.{field}")
+
+        prior_workspace = Path(prior_request["workspace"])
+        current_workspace = Path(request["workspace"])
+        if not prior_workspace.is_dir():
+            reject(f"Prior failed workspace does not exist: {prior_workspace}")
+        if prior_workspace == current_workspace:
+            reject("Retry must use a new workspace and preserve the failed workspace")
+        if prior_workspace.parent != current_workspace.parent:
+            reject("Retry workspace must share the prior linked-asset cache parent")
+
+        return {
+            "status": "authenticated",
+            "prior_request": _file_identity(prior_request_path),
+            "prior_result": _file_identity(prior_result_path),
+            "prior_request_sha256": bound_prior_hash,
+            "prior_workspace": str(prior_workspace),
+            "failure_classification": error["classification"],
+            "cache_root": str(prior_workspace.parent),
+        }
+
+    @staticmethod
+    def _artifact_failure(artifact: RasRunArtifact) -> RasScenarioWorkerError:
+        if not artifact.result_exists:
+            classification = "missing_hdf"
+            message = "HEC-RAS result HDF is missing"
+        elif artifact.result_size_bytes <= 0:
+            classification = "empty_hdf"
+            message = "HEC-RAS result HDF is empty"
+        elif not artifact.hdf_completed_successfully:
+            classification = "incomplete_hdf"
+            message = "HEC-RAS result HDF has no successful completion marker"
+        elif not artifact.time_window_matches:
+            classification = "mismatched_result_time"
+            message = "HEC-RAS result time axis does not match the request"
+        elif not artifact.compute_returned_successfully:
+            classification = "execution_failed"
+            message = "HEC-RAS compute did not return success"
+        else:
+            classification = "execution_failed"
+            message = "HEC-RAS execution artifact failed validation"
+        if artifact.hdf_inspection_error:
+            message += f": {artifact.hdf_inspection_error}"
+        return RasScenarioWorkerError(
+            message,
+            classification=classification,
+            exit_code=4,
+            retryable=True,
+        )
+
+    @staticmethod
+    def _verify_completed_result(
+        result_path: Path,
+        *,
+        request_sha256: str,
+        specification_sha256: str,
+    ) -> Dict[str, Any]:
+        try:
+            result = json.loads(result_path.read_text(encoding="utf-8"))
+        except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+            raise RasScenarioWorkerError(
+                f"Existing RAS worker result is unreadable: {result_path}",
+                classification="existing_result_conflict",
+                exit_code=3,
+            ) from exc
+        matches = (
+            isinstance(result, dict)
+            and result.get("schema") == RasScenarioWorker.RESULT_SCHEMA
+            and result.get("status") == "succeeded"
+            and result.get("request", {}).get("sha256") == request_sha256
+            and result.get("scenario", {}).get("specification_sha256")
+            == specification_sha256
+        )
+        if not matches:
+            raise RasScenarioWorkerError(
+                "Existing RAS worker result is not an identical completed request",
+                classification="existing_result_conflict",
+                exit_code=3,
+            )
+        for label, identity in (
+            ("result HDF", result.get("result_hdf")),
+            ("product manifest", result.get("products", {}).get("manifest")),
+        ):
+            if not isinstance(identity, dict):
+                raise RasScenarioWorkerError(
+                    f"Existing RAS worker result has no {label} identity",
+                    classification="existing_result_conflict",
+                    exit_code=3,
+                )
+            path = Path(str(identity.get("path", "")))
+            if (
+                not path.is_file()
+                or path.stat().st_size != identity.get("size_bytes")
+                or _sha256(path) != identity.get("sha256")
+            ):
+                raise RasScenarioWorkerError(
+                    f"Existing RAS worker {label} failed identity verification",
+                    classification="existing_result_conflict",
+                    exit_code=3,
+                )
+        return result
+
+    @staticmethod
+    def _classify_exception(exc: Exception) -> RasScenarioWorkerError:
+        if isinstance(exc, RasScenarioWorkerError):
+            return exc
+        if isinstance(exc, (TimeoutError, subprocess.TimeoutExpired)):
+            return RasScenarioWorkerError(
+                str(exc), classification="timeout", exit_code=4, retryable=True
+            )
+        if isinstance(exc, FileExistsError):
+            if "linked asset cache" in str(exc).casefold():
+                return RasScenarioWorkerError(
+                    str(exc),
+                    classification="linked_asset_cache",
+                    exit_code=4,
+                    retryable=True,
+                )
+            return RasScenarioWorkerError(
+                str(exc), classification="existing_destination", exit_code=3
+            )
+        message = str(exc)
+        lower = message.casefold()
+        if "mixed newline" in lower:
+            classification = "mixed_newlines"
+        elif "project_uses_cloned_plan" in lower:
+            classification = "wrong_current_plan"
+        elif "plan_window_matches_contract" in lower:
+            classification = "wrong_window"
+        elif "all_boundaries_exist_in_active_geometry" in lower:
+            classification = "inactive_geometry"
+        elif "boundary mapping" in lower or "boundary selector" in lower:
+            classification = "invalid_boundary_selector"
+        elif "forcing_excess_link_matches" in lower:
+            classification = "forcing_excess_link"
+        elif "linked asset cache" in lower:
+            classification = "linked_asset_cache"
+        elif isinstance(exc, (ValueError, FileNotFoundError, TypeError)):
+            classification = "preparation_failed"
+        else:
+            return RasScenarioWorkerError(
+                message,
+                classification="worker_error",
+                exit_code=5,
+                retryable=isinstance(exc, OSError),
+            )
+        return RasScenarioWorkerError(
+            message, classification=classification, exit_code=4
+        )
+
+    @staticmethod
+    def _result_payload(
+        *,
+        request: Optional[Mapping[str, Any]],
+        request_sha256: Optional[str],
+        status: str,
+        started_at: str,
+        started_clock: float,
+        preparation: Mapping[str, Any],
+        execution: Mapping[str, Any],
+        result_hdf: Optional[Mapping[str, Any]],
+        products: Optional[Mapping[str, Any]],
+        numerical_qaqc: Optional[Mapping[str, Any]],
+        conditional_findings: Optional[Mapping[str, Any]],
+        timings: Mapping[str, Any],
+        warnings: Sequence[str],
+        error: Optional[Mapping[str, Any]],
+    ) -> Dict[str, Any]:
+        scenario = request.get("scenario", {}) if request else {}
+        complete_timings = dict(timings)
+        complete_timings["total_seconds"] = _elapsed(started_clock)
+        return {
+            "schema": RasScenarioWorker.RESULT_SCHEMA,
+            "status": status,
+            "scenario": {
+                "scenario_id": scenario.get("scenario_id"),
+                "specification_sha256": scenario.get("specification_sha256"),
+            },
+            "request": {
+                "schema": request.get("schema") if request else None,
+                "sha256": request_sha256,
+            },
+            "preparation": dict(preparation),
+            "execution": dict(execution),
+            "result_hdf": dict(result_hdf) if result_hdf else None,
+            "products": dict(products) if products else None,
+            "numerical_qaqc": (dict(numerical_qaqc) if numerical_qaqc else None),
+            "conditional_findings": (
+                dict(conditional_findings) if conditional_findings else None
+            ),
+            "timings": {
+                "started_at": started_at,
+                "finished_at": _utc_now(),
+                **complete_timings,
+            },
+            "warnings": list(warnings),
+            "error": dict(error) if error else None,
+        }
+
+
+def _identity_input(
+    value: Any,
+    *,
+    label: str,
+    file_key: str,
+    manifest_key: str,
+    extra_required: Optional[set[str]] = None,
+    extra_optional: Optional[set[str]] = None,
+) -> Dict[str, Any]:
+    payload = _object(value, label)
+    required = {
+        file_key,
+        "sha256",
+        manifest_key,
+        f"{manifest_key}_sha256",
+    } | (extra_required or set())
+    _require_keys(
+        payload,
+        required=required,
+        optional=extra_optional or set(),
+        label=label,
+    )
+    return {
+        file_key: _resolved_path(payload[file_key], f"{label}.{file_key}"),
+        "sha256": _sha256_string(payload["sha256"], f"{label}.sha256"),
+        manifest_key: _resolved_path(payload[manifest_key], f"{label}.{manifest_key}"),
+        f"{manifest_key}_sha256": _sha256_string(
+            payload[f"{manifest_key}_sha256"],
+            f"{label}.{manifest_key}_sha256",
+        ),
+    }
+
+
+def _object(value: Any, label: str) -> Dict[str, Any]:
+    if not isinstance(value, dict):
+        _invalid(f"{label} must be a JSON object")
+    return dict(value)
+
+
+def _require_keys(
+    value: Mapping[str, Any],
+    *,
+    required: set[str],
+    optional: set[str],
+    label: str,
+) -> None:
+    missing = sorted(required - set(value))
+    unknown = sorted(set(value) - required - optional)
+    if missing or unknown:
+        details = []
+        if missing:
+            details.append("missing " + ", ".join(missing))
+        if unknown:
+            details.append("unknown " + ", ".join(unknown))
+        _invalid(f"Invalid {label} fields: " + "; ".join(details))
+
+
+def _invalid(message: str) -> None:
+    raise RasScenarioWorkerError(message, classification="invalid_request", exit_code=2)
+
+
+def _nonempty_string(value: Any, label: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        _invalid(f"{label} must be a non-empty string")
+    return value.strip()
+
+
+def _resolved_path(value: Any, label: str) -> str:
+    return str(Path(_nonempty_string(value, label)).resolve())
+
+
+def _sha256_string(value: Any, label: str) -> str:
+    normalized = _nonempty_string(value, label)
+    if _SHA256_PATTERN.fullmatch(normalized) is None:
+        _invalid(f"{label} must be a lowercase SHA-256 hexadecimal digest")
+    return normalized
+
+
+def _dss_pathname(value: Any, label: str) -> str:
+    pathname = _nonempty_string(value, label)
+    if not pathname.startswith("/") or not pathname.endswith("/"):
+        _invalid(f"{label} must begin and end with '/'")
+    return pathname
+
+
+def _choice(value: Any, label: str, choices: set[str]) -> str:
+    selected = _nonempty_string(value, label)
+    if selected not in choices:
+        _invalid(f"{label} must be one of: {', '.join(sorted(choices))}")
+    return selected
+
+
+def _positive_int(value: Any, label: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+        _invalid(f"{label} must be a positive integer")
+    return value
+
+
+def _positive_number(value: Any, label: str) -> float:
+    if (
+        isinstance(value, bool)
+        or not isinstance(value, (int, float))
+        or not math.isfinite(value)
+        or value <= 0
+    ):
+        _invalid(f"{label} must be a positive number")
+    return float(value)
+
+
+def _parse_model_time(value: Any) -> datetime:
+    text = _nonempty_string(value, "model window timestamp")
+    try:
+        parsed = datetime.fromisoformat(text)
+    except ValueError as exc:
+        raise RasScenarioWorkerError(
+            f"Invalid model window timestamp: {text!r}",
+            classification="invalid_request",
+            exit_code=2,
+        ) from exc
+    if parsed.tzinfo is not None:
+        _invalid("Model window timestamps must be naive local/model times")
+    return parsed
+
+
+def _verify_file_sha256(
+    path: Path,
+    expected: str,
+    label: str,
+    classification: str,
+) -> None:
+    if not path.is_file() or path.stat().st_size <= 0:
+        raise RasScenarioWorkerError(
+            f"{label} does not exist or is empty: {path}",
+            classification=classification,
+            exit_code=2,
+        )
+    if _sha256(path) != expected:
+        raise RasScenarioWorkerError(
+            f"{label} checksum does not match the worker request",
+            classification=classification,
+            exit_code=2,
+        )
+
+
+def _verify_json_identity(
+    path_value: str,
+    expected: str,
+    label: str,
+    classification: str,
+) -> Dict[str, Any]:
+    path = Path(path_value)
+    _verify_file_sha256(path, expected, label, classification)
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        raise RasScenarioWorkerError(
+            f"{label} is not readable JSON: {path}",
+            classification=classification,
+            exit_code=2,
+        ) from exc
+    if not isinstance(payload, dict):
+        raise RasScenarioWorkerError(
+            f"{label} root must be a JSON object",
+            classification=classification,
+            exit_code=2,
+        )
+    return payload
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _json_sha256(payload: Mapping[str, Any]) -> str:
+    canonical = json.dumps(
+        payload,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+    return hashlib.sha256(canonical).hexdigest()
+
+
+def _file_identity(path: Union[str, Path]) -> Dict[str, Any]:
+    file_path = Path(path).resolve()
+    if not file_path.is_file():
+        raise FileNotFoundError(f"Expected output file does not exist: {file_path}")
+    return {
+        "path": str(file_path),
+        "size_bytes": file_path.stat().st_size,
+        "sha256": _sha256(file_path),
+    }
+
+
+def _write_json_new(path: Path, payload: Mapping[str, Any]) -> Path:
+    if path.exists():
+        raise FileExistsError(f"RAS worker result already exists: {path}")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.NamedTemporaryFile(
+        mode="w",
+        encoding="utf-8",
+        prefix=f".{path.name}.",
+        suffix=".tmp",
+        dir=path.parent,
+        delete=False,
+    ) as stream:
+        json.dump(payload, stream, indent=2, sort_keys=True)
+        stream.write("\n")
+        temporary = Path(stream.name)
+    try:
+        if path.exists():
+            raise FileExistsError(f"RAS worker result already exists: {path}")
+        temporary.rename(path)
+    finally:
+        temporary.unlink(missing_ok=True)
+    return path
+
+
+def _conditional_warning_lines(findings: Mapping[str, Any]) -> list[str]:
+    return [
+        f"{name}: {value.get('count')} finding(s)"
+        for name, value in sorted(findings.items())
+        if isinstance(value, dict) and value.get("count", 0) > 0
+    ]
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _elapsed(started: float) -> float:
+    return round(time.perf_counter() - started, 6)
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    """Run the ``ras-scenario-worker`` command-line interface."""
+    parser = argparse.ArgumentParser(
+        description="Execute one versioned ras-commander scenario-worker request."
+    )
+    parser.add_argument("--request", required=True, type=Path)
+    parser.add_argument("--result", required=True, type=Path)
+    args = parser.parse_args(argv)
+    exit_code = RasScenarioWorker.run(args.request, args.result)
+    if exit_code != 0:
+        sys.stderr.write(f"RAS scenario worker failed; result: {args.result}\n")
+    return exit_code
+
+
+if __name__ == "__main__":  # pragma: no cover - subprocess boundary
+    raise SystemExit(main())

--- a/ras_commander/RasUnsteady.py
+++ b/ras_commander/RasUnsteady.py
@@ -5252,6 +5252,19 @@ class RasUnsteady:
         paths under the unsteady file folder are converted to project-relative
         paths; absolute paths elsewhere are preserved.
         """
+        return RasUnsteady._format_dss_filename(dss_filename, unsteady_path)
+
+    @staticmethod
+    def _format_dss_filename(
+        dss_filename: Union[str, Path],
+        unsteady_path: Path,
+    ) -> str:
+        """Normalize a DSS filename for an HEC-RAS unsteady-flow file.
+
+        HEC-RAS requires project-relative DSS references to begin with ``.\\``
+        or ``..\\``. A bare relative directory such as ``hydrology\\input.dss``
+        is resolved as only ``input.dss`` in the project folder by HEC-RAS 6.6.
+        """
         raw_filename = str(dss_filename).strip()
         if not raw_filename:
             raise ValueError("dss_filename must not be empty")
@@ -7178,6 +7191,10 @@ class RasUnsteady:
         unsteady_path = Path(unsteady_file)
         if not unsteady_path.exists():
             raise FileNotFoundError(f"Unsteady flow file not found: {unsteady_path}")
+        dss_file = RasUnsteady._format_dss_filename(
+            dss_file,
+            unsteady_path,
+        )
 
         with open(unsteady_path, 'r', encoding='utf-8', errors='ignore') as f:
             lines = f.readlines()

--- a/ras_commander/RasUnsteady.py
+++ b/ras_commander/RasUnsteady.py
@@ -113,6 +113,7 @@ import tempfile
 from datetime import datetime
 from pathlib import Path
 from .RasPrj import ras
+from .RasUtils import RasUtils
 from .LoggingConfig import get_logger
 from .Decorators import log_call
 import pandas as pd
@@ -3342,16 +3343,9 @@ class RasUnsteady:
         before inserting the requested state so transitions cannot leave stale
         Constant, Point, DSS, GDAL Group, or legacy GDAL Datasetname values.
         """
-        with open(
-            unsteady_path,
-            "r",
-            encoding="utf-8",
-            errors="replace",
-            newline="",
-        ) as file:
-            lines = file.readlines()
-
-        newline = RasUnsteady._detect_line_ending(lines)
+        lines, newline = RasUtils._read_text_lines_preserving_newline(
+            unsteady_path
+        )
         desired_lines = [
             f"{key}={value}{newline}" for key, value in desired_entries
         ]

--- a/ras_commander/RasUnsteady.py
+++ b/ras_commander/RasUnsteady.py
@@ -6631,12 +6631,15 @@ class RasUnsteady:
 
         boundaries = []
         i = 0
+        boundary_index = -1
         while i < len(lines):
             line = lines[i]
 
             if line.startswith('Boundary Location='):
+                boundary_index += 1
                 bc = RasUnsteady._parse_boundary_block_dss(lines, i)
                 if bc.get('use_dss') == 'True':
+                    bc['boundary_index'] = boundary_index
                     bc['line_number'] = i + 1  # 1-indexed for user reference
                     boundaries.append(bc)
             i += 1
@@ -6652,6 +6655,10 @@ class RasUnsteady:
             'river': '',
             'reach': '',
             'station': '',
+            'downstream_station': '',
+            'sa_2d_name': '',
+            'bc_line': '',
+            'boundary_name': '',
             'bc_type': '',
             'interval': '',
             'dss_file': '',
@@ -6675,6 +6682,12 @@ class RasUnsteady:
             bc['reach'] = parts[1]
         if len(parts) >= 3:
             bc['station'] = parts[2]
+        if len(parts) >= 4:
+            bc['downstream_station'] = parts[3]
+        if len(parts) >= 6:
+            bc['sa_2d_name'] = parts[5]
+        if len(parts) >= 8:
+            bc['bc_line'] = parts[7]
 
         # Scan following lines for DSS info
         i = start_idx + 1
@@ -6683,6 +6696,10 @@ class RasUnsteady:
 
             if line.startswith('Boundary Location='):
                 break
+            elif line.startswith('Boundary Name='):
+                bc['boundary_name'] = line.replace(
+                    'Boundary Name=', ''
+                ).strip()
             elif line.startswith('Interval='):
                 bc['interval'] = line.replace('Interval=', '').strip()
             elif line.startswith('Flow Hydrograph='):
@@ -6696,6 +6713,16 @@ class RasUnsteady:
                 try:
                     bc['data_count'] = int(line.replace('Lateral Inflow Hydrograph=', '').strip())
                 except:
+                    pass
+            elif line.startswith('Uniform Lateral Inflow Hydrograph='):
+                bc['bc_type'] = 'Uniform Lateral Inflow Hydrograph'
+                try:
+                    bc['data_count'] = int(
+                        line.replace(
+                            'Uniform Lateral Inflow Hydrograph=', ''
+                        ).strip()
+                    )
+                except ValueError:
                     pass
             elif line.startswith('Uniform Lateral Inflow='):
                 bc['bc_type'] = 'Uniform Lateral Inflow'
@@ -6742,22 +6769,18 @@ class RasUnsteady:
             'dss_part_f': ''
         }
 
-        # Remove leading slashes and split
-        clean_path = dss_path.strip('/')
-        segments = clean_path.split('/')
+        # Preserve an empty A-part when only B-F are present.  Some RAS files
+        # serialize all six populated parts with a double leading slash, while
+        # HMS output commonly uses ``//LOCATION/FLOW/D/E/F/`` (five populated
+        # parts, intentionally empty A).  The populated-part count resolves
+        # those two conventions without shifting B-F.
+        segments = dss_path.strip('/').split('/') if dss_path else []
+        if dss_path.startswith('//') and len(segments) == 5:
+            segments.insert(0, '')
+        segments = (segments + [''] * 6)[:6]
 
-        if len(segments) >= 1:
-            parts['dss_part_a'] = segments[0]
-        if len(segments) >= 2:
-            parts['dss_part_b'] = segments[1]
-        if len(segments) >= 3:
-            parts['dss_part_c'] = segments[2]
-        if len(segments) >= 4:
-            parts['dss_part_d'] = segments[3]
-        if len(segments) >= 5:
-            parts['dss_part_e'] = segments[4]
-        if len(segments) >= 6:
-            parts['dss_part_f'] = segments[5]
+        for key, value in zip(parts, segments):
+            parts[key] = value
 
         return parts
 
@@ -7076,13 +7099,18 @@ class RasUnsteady:
     @log_call
     def set_boundary_dss_link(
         unsteady_file: Union[str, Path],
-        river: str,
-        reach: str,
-        station: str,
+        river: Optional[str],
+        reach: Optional[str],
+        station: Optional[str],
         dss_file: str,
         dss_path: str,
         interval: str = "5MIN",
-        ras_object: Optional[Any] = None
+        ras_object: Optional[Any] = None,
+        *,
+        sa_2d_name: Optional[str] = None,
+        bc_line: Optional[str] = None,
+        boundary_index: Optional[int] = None,
+        expected_bc_type: Optional[str] = None,
     ) -> bool:
         """
         Convert an inline hydrograph boundary to use DSS linkage.
@@ -7110,6 +7138,17 @@ class RasUnsteady:
             Time interval for the boundary condition
         ras_object : optional
             Custom RAS object to use instead of the global one
+        sa_2d_name, bc_line : str, optional
+            Exact 2D/storage-area boundary selectors. ``sa_2d_name`` matches
+            field index 5 and ``bc_line`` matches field index 7 of the
+            ``Boundary Location=`` record. Pass ``river``, ``reach``, and
+            ``station`` as ``None`` when using these selectors.
+        boundary_index : int, optional
+            Zero-based boundary block index used alone or to disambiguate a
+            partial selector.
+        expected_bc_type : str, optional
+            Require the selected block to have this boundary type before
+            changing it.
 
         Returns
         -------
@@ -7143,22 +7182,97 @@ class RasUnsteady:
         with open(unsteady_path, 'r', encoding='utf-8', errors='ignore') as f:
             lines = f.readlines()
 
-        # Find the boundary location
-        boundary_idx = None
-        for i, line in enumerate(lines):
-            if line.startswith('Boundary Location='):
-                loc_line = line.replace('Boundary Location=', '')
-                parts = [p.strip() for p in loc_line.split(',')]
-                if (len(parts) >= 3 and
-                    parts[0] == river and
-                    parts[1] == reach and
-                    parts[2] == station):
-                    boundary_idx = i
-                    break
+        river = RasUnsteady._clean_boundary_selector(river)
+        reach = RasUnsteady._clean_boundary_selector(reach)
+        station = RasUnsteady._clean_boundary_selector(station)
+        sa_2d_name = RasUnsteady._clean_boundary_selector(sa_2d_name)
+        bc_line = RasUnsteady._clean_boundary_selector(bc_line)
 
-        if boundary_idx is None:
-            logger.warning(f"Boundary not found: {river}/{reach}/{station}")
-            return False
+        has_1d_selector = any(
+            selector is not None for selector in (river, reach, station)
+        )
+        has_2d_selector = any(
+            selector is not None for selector in (sa_2d_name, bc_line)
+        )
+        if has_1d_selector and has_2d_selector:
+            raise ValueError(
+                "Provide either 1D selectors (river, reach, station) "
+                "or 2D selectors (sa_2d_name, bc_line), not both"
+            )
+        if boundary_index is not None:
+            if isinstance(boundary_index, bool) or not isinstance(boundary_index, int):
+                raise ValueError("boundary_index must be a zero-based integer")
+            if boundary_index < 0:
+                raise ValueError("boundary_index must be >= 0")
+        if boundary_index is None and not (has_1d_selector or has_2d_selector):
+            raise ValueError(
+                "Provide a boundary selector or boundary_index"
+            )
+
+        blocks = RasUnsteady._find_boundary_blocks(lines)
+        matches = [
+            block
+            for block in blocks
+            if RasUnsteady._boundary_block_matches(
+                block,
+                river,
+                reach,
+                station,
+                sa_2d_name,
+                bc_line,
+            )
+        ] if (has_1d_selector or has_2d_selector) else blocks
+
+        if boundary_index is not None:
+            selected = next(
+                (
+                    block
+                    for block in blocks
+                    if block["boundary_index"] == boundary_index
+                ),
+                None,
+            )
+            if selected is None:
+                raise ValueError(
+                    f"boundary_index {boundary_index} is out of range; "
+                    f"{len(blocks)} boundary blocks found"
+                )
+            if (has_1d_selector or has_2d_selector) and selected not in matches:
+                raise ValueError(
+                    f"boundary_index {boundary_index} does not match the "
+                    "provided boundary selectors"
+                )
+            target_block = selected
+        else:
+            if not matches:
+                logger.warning(
+                    "Boundary not found for selectors: "
+                    "river=%r, reach=%r, station=%r, sa_2d_name=%r, bc_line=%r",
+                    river,
+                    reach,
+                    station,
+                    sa_2d_name,
+                    bc_line,
+                )
+                return False
+            if len(matches) > 1:
+                choices = ", ".join(
+                    f"{block['boundary_index']}:"
+                    f"{RasUnsteady._boundary_block_name(block)}"
+                    for block in matches
+                )
+                raise ValueError(
+                    "Boundary selector is ambiguous. Provide boundary_index "
+                    f"to disambiguate one of: {choices}"
+                )
+            target_block = matches[0]
+
+        if expected_bc_type is not None and target_block["bc_type"] != expected_bc_type:
+            raise ValueError(
+                f"Selected boundary type is {target_block['bc_type']!r}, "
+                f"expected {expected_bc_type!r}"
+            )
+        boundary_idx = target_block["start_idx"]
 
         # Inline table type keywords that may have data to remove
         TABLE_KEYWORDS = [
@@ -7284,8 +7398,11 @@ class RasUnsteady:
         with open(unsteady_path, 'w', encoding='utf-8') as f:
             f.writelines(lines)
 
-        logger.info(f"Updated boundary {river}/{reach}/{station} to use DSS link "
-                     f"(removed {lines_removed} inline data lines)")
+        logger.info(
+            "Updated boundary %s to use DSS link (removed %d inline data lines)",
+            RasUnsteady._boundary_block_name(target_block),
+            lines_removed,
+        )
         return True
 
     @staticmethod

--- a/ras_commander/RasUtils.py
+++ b/ras_commander/RasUtils.py
@@ -856,6 +856,69 @@ class RasUtils:
         logger.debug(f"Calculated error metrics: {metrics}")
         return metrics
 
+    @staticmethod
+    def _detect_text_newline(file_path: Path) -> str:
+        """Return the one newline convention used by a RAS text file.
+
+        HEC-RAS project text files can become unreadable in the GUI when an
+        editor introduces mixed LF and CRLF records. Mutators use this helper
+        to preserve the source convention and fail closed on mixed input.
+        """
+        content = Path(file_path).read_bytes()
+        without_crlf = content.replace(b"\r\n", b"")
+        styles = []
+        if b"\r\n" in content:
+            styles.append("\r\n")
+        if b"\n" in without_crlf:
+            styles.append("\n")
+        if b"\r" in without_crlf:
+            styles.append("\r")
+        if len(styles) > 1:
+            raise ValueError(
+                f"Mixed newline conventions in HEC-RAS text file: {file_path}"
+            )
+        return styles[0] if styles else "\r\n"
+
+    @staticmethod
+    def _read_text_lines_preserving_newline(
+        file_path: Path,
+    ) -> tuple[list[str], str]:
+        """Read a RAS text file without translating its newline characters."""
+        newline = RasUtils._detect_text_newline(file_path)
+        with open(
+            file_path,
+            "r",
+            encoding="utf-8",
+            errors="replace",
+            newline="",
+        ) as handle:
+            return handle.readlines(), newline
+
+    @staticmethod
+    def _write_text_lines_with_newline(
+        file_path: Path,
+        lines: list[str],
+        newline: str,
+    ) -> None:
+        """Write lines using one explicit newline convention."""
+        normalized = []
+        for line in lines:
+            had_newline = line.endswith(("\r\n", "\n", "\r"))
+            value = line.rstrip("\r\n")
+            normalized.append(value + newline if had_newline else value)
+        with open(
+            file_path,
+            "w",
+            encoding="utf-8",
+            errors="replace",
+            newline="",
+        ) as handle:
+            handle.writelines(normalized)
+        if RasUtils._detect_text_newline(file_path) != newline:
+            raise RuntimeError(
+                f"Failed to preserve newline convention in {file_path}"
+            )
+
     
     @staticmethod
     @log_call
@@ -878,13 +941,15 @@ class RasUtils:
         >>> RasUtils.update_file(Path("example.txt"), update_content, "Hello")
         """
         try:
-            with open(file_path, 'r', encoding='utf-8', errors='replace') as f:
-                lines = f.readlines()
+            lines, newline = RasUtils._read_text_lines_preserving_newline(
+                file_path
+            )
 
             updated_lines = update_function(lines, *args) if args else update_function(lines)
 
-            with open(file_path, 'w', encoding='utf-8', errors='replace') as f:
-                f.writelines(updated_lines)
+            RasUtils._write_text_lines_with_newline(
+                file_path, updated_lines, newline
+            )
             logger.debug("Successfully updated file: %s", Path(file_path).name)
             logger.debug(f"Successfully updated file path: {file_path}")
         except Exception as e:
@@ -961,14 +1026,16 @@ class RasUtils:
         ras_obj.check_initialized()
         
         try:
-            with open(prj_file, 'r', encoding='utf-8', errors='replace') as f:
-                lines = f.readlines()
+            lines, newline = RasUtils._read_text_lines_preserving_newline(
+                prj_file
+            )
 
-            new_line = f"{file_type} File={file_type[0].lower()}{new_num}\n"
+            new_line = (
+                f"{file_type} File={file_type[0].lower()}{new_num}{newline}"
+            )
             lines.append(new_line)
 
-            with open(prj_file, 'w', encoding='utf-8', errors='replace') as f:
-                f.writelines(lines)
+            RasUtils._write_text_lines_with_newline(prj_file, lines, newline)
             logger.debug(f"Project file updated with new {file_type} entry: {new_num}")
         except Exception as e:
             logger.exception(f"Failed to update project file {prj_file}")

--- a/ras_commander/__init__.py
+++ b/ras_commander/__init__.py
@@ -92,6 +92,7 @@ from .RasScenario import (
     RasScenario,
     RasScenarioWorkspace,
 )
+from .RasScenarioWorker import RasScenarioWorker, RasScenarioWorkerError
 from .RasCurrency import RasCurrency
 from .RasControl import RasControl
 from .RasTcu import RasTcu, TcuStatus
@@ -264,6 +265,7 @@ __all__ = [
     'RasPreprocess',
     'RasExamples', 'RasEbfeModels', 'M3Model', 'RasCmdr', 'RasCurrency', 'RasControl', 'RasTcu', 'TcuStatus', 'RasMap', 'RasEncroachments', 'RasProcess', 'ProjectionInfo', 'GeoTiffWriteOptions', 'RasterOperationProfileResult', 'StoreMapPerformanceOptions', 'StoreMapProfileResult', 'StoreMapResourceEstimate', 'StoreMapResourceSample', 'TerrainResourceEstimate', 'RasGuiAutomation', 'RasScreenshot', 'HdfFluvialPluvial',
     'RasBoundaryLink', 'RasRunArtifact', 'RasScenario', 'RasScenarioWorkspace',
+    'RasScenarioWorker', 'RasScenarioWorkerError',
     'RasBenefits', 'BenefitAreaConfig', 'BenefitAreaResult', 'BenefitCategory',
     'RasFloodway', 'RasFlowOptimization', 'RasModPuls', 'RasPermutation', 'RangeSpec', 'RasMonteCarlo',
     'CalibrationPoint', 'RasCalibrate',

--- a/ras_commander/__init__.py
+++ b/ras_commander/__init__.py
@@ -86,6 +86,12 @@ from .RasExamples import RasExamples
 from .sources.federal import RasEbfeModels
 from .sources.county import M3Model
 from .RasCmdr import RasCmdr
+from .RasScenario import (
+    RasBoundaryLink,
+    RasRunArtifact,
+    RasScenario,
+    RasScenarioWorkspace,
+)
 from .RasCurrency import RasCurrency
 from .RasControl import RasControl
 from .RasTcu import RasTcu, TcuStatus
@@ -257,6 +263,7 @@ __all__ = [
     'RasGeometryCompute',
     'RasPreprocess',
     'RasExamples', 'RasEbfeModels', 'M3Model', 'RasCmdr', 'RasCurrency', 'RasControl', 'RasTcu', 'TcuStatus', 'RasMap', 'RasEncroachments', 'RasProcess', 'ProjectionInfo', 'GeoTiffWriteOptions', 'RasterOperationProfileResult', 'StoreMapPerformanceOptions', 'StoreMapProfileResult', 'StoreMapResourceEstimate', 'StoreMapResourceSample', 'TerrainResourceEstimate', 'RasGuiAutomation', 'RasScreenshot', 'HdfFluvialPluvial',
+    'RasBoundaryLink', 'RasRunArtifact', 'RasScenario', 'RasScenarioWorkspace',
     'RasBenefits', 'BenefitAreaConfig', 'BenefitAreaResult', 'BenefitCategory',
     'RasFloodway', 'RasFlowOptimization', 'RasModPuls', 'RasPermutation', 'RangeSpec', 'RasMonteCarlo',
     'CalibrationPoint', 'RasCalibrate',

--- a/ras_commander/__init__.py
+++ b/ras_commander/__init__.py
@@ -179,7 +179,7 @@ from .hdf import (
     HdfBase, HdfUtils, HdfPlan,
     HdfMesh, HdfXsec, HdfBndry, HdfStruc, HdfStorageArea, HdfHydraulicTables,
     HdfResultsPlan, HdfResultsMesh, HdfResultsQuery, HdfResultsXsec, HdfResultsBreach,
-    HdfResultsSediment,
+    HdfResultsSediment, HdfResultsProducts,
     HdfPipe, HdfPump, HdfInfiltration, HdfLandCover,
     HdfPlot, HdfResultsPlot,
     HdfFluvialPluvial, HdfBenefitAreas, HdfChannelCapacity, HdfResultsAnalysis,
@@ -318,7 +318,8 @@ __all__ = [
 
     # HDF handling
     'HdfBase', 'HdfBndry', 'HdfMesh', 'HdfPlan', 'HdfProject',
-    'HdfResultsMesh', 'HdfResultsPlan', 'HdfResultsQuery', 'HdfResultsXsec', 'HdfResultsSediment',
+    'HdfResultsMesh', 'HdfResultsPlan', 'HdfResultsProducts', 'HdfResultsQuery',
+    'HdfResultsXsec', 'HdfResultsSediment',
     'HdfStruc', 'HdfStorageArea', 'HdfUtils', 'HdfXsec', 'HdfPump',
     'HdfPipe', 'HdfInfiltration', 'HdfLandCover', 'HdfHydraulicTables', 'HdfResultsBreach', 'RasBreach',
     'HdfBenefitAreas', 'HdfChannelCapacity', 'HdfResultsAnalysis',

--- a/ras_commander/contracts/__init__.py
+++ b/ras_commander/contracts/__init__.py
@@ -1,0 +1,1 @@
+"""Packaged JSON contracts for the RAS scenario-worker boundary."""

--- a/ras_commander/contracts/scenario-worker-request-v1.0.schema.json
+++ b/ras_commander/contracts/scenario-worker-request-v1.0.schema.json
@@ -1,0 +1,159 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "ras-commander/scenario-worker-request/1.0",
+  "title": "RAS Commander scenario worker request 1.0",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema",
+    "scenario",
+    "source_model",
+    "hydrology",
+    "boundary_links",
+    "forcing_excess",
+    "model_window",
+    "workspace",
+    "products",
+    "execution"
+  ],
+  "properties": {
+    "schema": {"const": "ras-commander/scenario-worker-request/1.0"},
+    "scenario": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["scenario_id", "specification_sha256"],
+      "properties": {
+        "scenario_id": {"type": "string", "minLength": 1},
+        "specification_sha256": {"$ref": "#/$defs/sha256"}
+      }
+    },
+    "source_model": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "project",
+        "project_file_sha256",
+        "template_plan",
+        "model_manifest",
+        "model_manifest_sha256"
+      ],
+      "properties": {
+        "project": {"type": "string", "minLength": 1},
+        "project_file_sha256": {"$ref": "#/$defs/sha256"},
+        "template_plan": {"type": "string", "minLength": 1},
+        "model_manifest": {"type": "string", "minLength": 1},
+        "model_manifest_sha256": {"$ref": "#/$defs/sha256"},
+        "linked_asset_directories": {
+          "type": "array",
+          "items": {"type": "string", "minLength": 1},
+          "uniqueItems": true
+        },
+        "linked_asset_mode": {"enum": ["copy", "shared-cache"]}
+      }
+    },
+    "hydrology": {
+      "allOf": [{"$ref": "#/$defs/identityInput"}],
+      "properties": {
+        "dss": {"type": "string", "minLength": 1},
+        "product_manifest": {"type": "string", "minLength": 1},
+        "product_manifest_sha256": {"$ref": "#/$defs/sha256"}
+      },
+      "required": ["dss", "sha256", "product_manifest", "product_manifest_sha256"],
+      "unevaluatedProperties": false
+    },
+    "boundary_links": {
+      "type": "array",
+      "minItems": 1,
+      "items": {"$ref": "#/$defs/boundaryLink"}
+    },
+    "forcing_excess": {
+      "allOf": [{"$ref": "#/$defs/identityInput"}],
+      "properties": {
+        "dss": {"type": "string", "minLength": 1},
+        "provenance_manifest": {"type": "string", "minLength": 1},
+        "provenance_manifest_sha256": {"$ref": "#/$defs/sha256"},
+        "pathname": {"type": "string", "pattern": "^/.+/$"},
+        "interpolation": {"enum": ["Nearest", "Bilinear"]}
+      },
+      "required": [
+        "dss",
+        "sha256",
+        "provenance_manifest",
+        "provenance_manifest_sha256",
+        "pathname"
+      ],
+      "unevaluatedProperties": false
+    },
+    "model_window": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["start", "end", "time_zone"],
+      "properties": {
+        "start": {"type": "string", "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}$"},
+        "end": {"type": "string", "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}$"},
+        "time_zone": {"type": "string", "minLength": 1}
+      }
+    },
+    "workspace": {"type": "string", "minLength": 1},
+    "products": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["directory"],
+      "properties": {
+        "directory": {"type": "string", "minLength": 1},
+        "resolution": {"type": ["number", "null"], "exclusiveMinimum": 0},
+        "max_dimension": {"type": "integer", "minimum": 64},
+        "nodata": {"type": "number"},
+        "include_preview": {"type": "boolean"}
+      }
+    },
+    "execution": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["ras_executable", "timeout_seconds", "cores"],
+      "properties": {
+        "ras_executable": {"type": "string", "minLength": 1},
+        "timeout_seconds": {"type": "integer", "minimum": 1},
+        "cores": {"type": "integer", "minimum": 1}
+      }
+    },
+    "retry": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["prior_request", "prior_result"],
+      "properties": {
+        "prior_request": {"type": "string", "minLength": 1},
+        "prior_result": {"type": "string", "minLength": 1}
+      }
+    }
+  },
+  "$defs": {
+    "sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
+    "identityInput": {
+      "type": "object",
+      "properties": {"sha256": {"$ref": "#/$defs/sha256"}}
+    },
+    "boundaryLink": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["mapping_id", "dss_path", "expected_bc_type"],
+      "properties": {
+        "mapping_id": {"type": "string", "minLength": 1},
+        "dss_path": {"type": "string", "pattern": "^/.+/$"},
+        "expected_bc_type": {"type": "string", "minLength": 1},
+        "interval": {"type": "string", "minLength": 1},
+        "river": {"type": "string"},
+        "reach": {"type": "string"},
+        "station": {"type": "string"},
+        "sa_2d_name": {"type": "string"},
+        "bc_line": {"type": "string"},
+        "boundary_index": {"type": "integer", "minimum": 0}
+      },
+      "anyOf": [
+        {"required": ["river", "reach", "station"]},
+        {"required": ["sa_2d_name"]},
+        {"required": ["boundary_index"]}
+      ]
+    }
+  }
+}

--- a/ras_commander/contracts/scenario-worker-result-v1.0.schema.json
+++ b/ras_commander/contracts/scenario-worker-result-v1.0.schema.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "ras-commander/scenario-worker-result/1.0",
+  "title": "RAS Commander scenario worker result 1.0",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema",
+    "status",
+    "scenario",
+    "request",
+    "preparation",
+    "execution",
+    "result_hdf",
+    "products",
+    "numerical_qaqc",
+    "conditional_findings",
+    "timings",
+    "warnings",
+    "error"
+  ],
+  "properties": {
+    "schema": {"const": "ras-commander/scenario-worker-result/1.0"},
+    "status": {"enum": ["succeeded", "failed"]},
+    "scenario": {"type": "object"},
+    "request": {"type": "object"},
+    "preparation": {"type": "object"},
+    "execution": {"type": "object"},
+    "result_hdf": {"type": ["object", "null"]},
+    "products": {"type": ["object", "null"]},
+    "numerical_qaqc": {"type": ["object", "null"]},
+    "conditional_findings": {"type": ["object", "null"]},
+    "timings": {"type": "object"},
+    "warnings": {"type": "array", "items": {"type": "string"}},
+    "error": {"type": ["object", "null"]}
+  }
+}

--- a/ras_commander/dss/RasDss.py
+++ b/ras_commander/dss/RasDss.py
@@ -47,6 +47,8 @@ Lazy Loading:
 
 import sys
 import os
+import shutil
+from numbers import Real
 from pathlib import Path
 from typing import Any, List, Dict, Optional, Tuple, Union
 import logging
@@ -217,7 +219,7 @@ class RasDss:
         RasDss._configure_jvm()
 
         # Import Java classes via pyjnius (lazy)
-        from jnius import autoclass
+        from jnius import autoclass, cast
         from ras_commander.RasUtils import RasUtils
 
         HecDss = autoclass('hec.heclib.dss.HecDss')
@@ -1499,6 +1501,300 @@ class RasDss:
 
     @staticmethod
     @log_call
+    def copy_grid_with_zero_tail(
+        source_dss: Union[str, Path],
+        output_dss: Union[str, Path],
+        pathname: str,
+        tail_intervals: int,
+        *,
+        time_shift_minutes: int = 0,
+        output_pathname: Optional[str] = None,
+        x_shift: float = 0.0,
+        y_shift: float = 0.0,
+        overwrite: bool = False,
+    ) -> Dict[str, Any]:
+        """Create a translated grid derivative with an explicit zero tail.
+
+        With no time, spatial, or pathname-family transform, the source file
+        is copied before HEC-DSS opens the derivative and only the zero tail is
+        appended. Otherwise, the matching source grid family is rewritten with
+        translated metadata before the tail is appended. Grid values are not
+        spatially resampled or time-distributed.
+
+        Args:
+            source_dss: Existing source DSS file.
+            output_dss: New writable derivative DSS file.
+            pathname: Six-part grid family selector with blank D and E parts,
+                such as ``/SHG/BASIN/PRECIPITATION///VERSION/``.
+            tail_intervals: Number of zero-valued intervals to append.
+            time_shift_minutes: Signed offset applied to all source grid
+                pathname windows. For example, ``-300`` expresses UTC source
+                records on an America/Chicago CDT model clock.
+            output_pathname: Optional six-part grid family for the derivative.
+                D and E must be blank. Defaults to ``pathname``.
+            x_shift: Signed spatial translation in the grid projection's
+                horizontal units. Must be a whole-cell increment.
+            y_shift: Signed spatial translation in the grid projection's
+                vertical units. Must be a whole-cell increment.
+            overwrite: Replace an existing output file when ``True``.
+
+        Returns:
+            Summary of source coverage, interval, and appended records.
+
+        Raises:
+            FileNotFoundError: If the source DSS does not exist.
+            FileExistsError: If output exists and overwrite is false.
+            ValueError: If the selector, timing, or grid metadata is invalid.
+        """
+        source = Path(source_dss).resolve()
+        output = Path(output_dss).resolve()
+        if not source.is_file():
+            raise FileNotFoundError(f"DSS file not found: {source}")
+        if source == output:
+            raise ValueError("output_dss must differ from source_dss")
+        if not isinstance(tail_intervals, int) or tail_intervals <= 0:
+            raise ValueError("tail_intervals must be a positive integer")
+        if isinstance(time_shift_minutes, bool) or not isinstance(
+            time_shift_minutes,
+            int,
+        ):
+            raise ValueError("time_shift_minutes must be an integer")
+        for label, value in (("x_shift", x_shift), ("y_shift", y_shift)):
+            if (
+                isinstance(value, bool)
+                or not isinstance(value, Real)
+                or not np.isfinite(value)
+            ):
+                raise ValueError(f"{label} must be a finite number")
+        x_shift = float(x_shift)
+        y_shift = float(y_shift)
+
+        _, selector_parts = RasDss._split_dss_pathname(pathname)
+        if selector_parts[3] or selector_parts[4]:
+            raise ValueError(
+                "pathname must select a grid family with blank D and E parts"
+            )
+        derivative_pathname = output_pathname or pathname
+        _, derivative_parts = RasDss._split_dss_pathname(derivative_pathname)
+        if derivative_parts[3] or derivative_parts[4]:
+            raise ValueError(
+                "output_pathname must select a grid family with blank D and E parts"
+            )
+        rewrite_source = (
+            time_shift_minutes != 0
+            or x_shift != 0
+            or y_shift != 0
+            or tuple(part.upper() for part in derivative_parts)
+            != tuple(part.upper() for part in selector_parts)
+        )
+
+        if output.exists():
+            if not overwrite:
+                raise FileExistsError(f"Output DSS already exists: {output}")
+            output.unlink()
+        output.parent.mkdir(parents=True, exist_ok=True)
+        catalog_dss = source
+        if not rewrite_source:
+            shutil.copy2(source, output)
+            catalog_dss = output
+
+        catalog = RasDss.get_catalog(catalog_dss)
+        records: List[Tuple[pd.Timestamp, pd.Timestamp, str]] = []
+        selector_key = tuple(
+            selector_parts[index].upper() for index in (0, 1, 2, 5)
+        )
+        for candidate in catalog["pathname"].astype(str):
+            try:
+                _, candidate_parts = RasDss._split_dss_pathname(candidate)
+            except ValueError:
+                continue
+            candidate_key = tuple(
+                candidate_parts[index].upper() for index in (0, 1, 2, 5)
+            )
+            if candidate_key != selector_key:
+                continue
+            start = RasDss._parse_grid_dss_datetime(candidate_parts[3])
+            end = RasDss._parse_grid_dss_datetime(candidate_parts[4])
+            if start is None or end is None or end <= start:
+                raise ValueError(
+                    f"Grid record has an invalid time window: {candidate}"
+                )
+            records.append((start, end, candidate))
+
+        if not records:
+            raise ValueError(
+                f"No grid records matched pathname family {pathname} in {catalog_dss}"
+            )
+        records.sort(key=lambda item: (item[0], item[1], item[2]))
+        intervals = {end - start for start, end, _ in records}
+        if len(intervals) != 1:
+            raise ValueError("Matched grid records do not use one uniform interval")
+        interval = intervals.pop()
+        for previous, current in zip(records, records[1:]):
+            if current[0] != previous[1]:
+                raise ValueError(
+                    "Matched grid records are not contiguous: "
+                    f"{previous[2]} then {current[2]}"
+                )
+
+        last_grid = RasDss.read_grid(catalog_dss, records[-1][2])
+        metadata = last_grid["metadata"]
+        projection = metadata.get("projection", {})
+        lower_left = metadata.get("lower_left_cell")
+        if not lower_left or len(lower_left) != 2:
+            raise ValueError("Last grid record has no lower-left cell metadata")
+        cell_size = float(last_grid["cell_size"])
+        x_shift_cells = round(x_shift / cell_size)
+        y_shift_cells = round(y_shift / cell_size)
+        if not np.isclose(x_shift, x_shift_cells * cell_size):
+            raise ValueError("x_shift must be a whole grid-cell increment")
+        if not np.isclose(y_shift, y_shift_cells * cell_size):
+            raise ValueError("y_shift must be a whole grid-cell increment")
+        output_lower_left = (
+            int(lower_left[0]) + x_shift_cells,
+            int(lower_left[1]) + y_shift_cells,
+        )
+
+        zero_frame = np.where(
+            np.isfinite(last_grid["data"]),
+            np.float32(0.0),
+            np.float32(np.nan),
+        )
+        zero_data = np.repeat(
+            zero_frame[np.newaxis, :, :],
+            tail_intervals,
+            axis=0,
+        )
+        shift = pd.Timedelta(minutes=time_shift_minutes)
+        output_start = records[0][0] + shift
+        output_source_end = records[-1][1] + shift
+        grid_info = {
+            "cell_size": cell_size,
+            "lower_left_cell_x": output_lower_left[0],
+            "lower_left_cell_y": output_lower_left[1],
+            "x_coord_cell_zero": projection.get("x_coord_cell_zero", 0.0),
+            "y_coord_cell_zero": projection.get("y_coord_cell_zero", 0.0),
+            "crs": last_grid["crs"],
+            "grid_type": last_grid["grid_type"],
+            "units": last_grid["units"],
+            "data_type": last_grid["data_type"],
+            "nodata_value": metadata.get("nodata_value"),
+            "compression": "PRECIP_2_BYTE",
+            "projection_datum": projection.get("datum_code", "NAD83"),
+            "projection_units": projection.get("units", "METERS"),
+            "standard_parallel_1": projection.get("standard_parallel_1", 29.5),
+            "standard_parallel_2": projection.get("standard_parallel_2", 45.5),
+            "central_meridian": projection.get("central_meridian", -96.0),
+            "latitude_of_origin": projection.get("latitude_of_origin", 23.0),
+            "false_easting": projection.get("false_easting", 0.0),
+            "false_northing": projection.get("false_northing", 0.0),
+        }
+        shifted_pathnames: List[str] = []
+        if not rewrite_source:
+            tail_boundaries = [
+                output_source_end + index * interval
+                for index in range(tail_intervals + 1)
+            ]
+            appended_pathnames = RasDss.write_grid_timeseries(
+                dss_file=output,
+                pathname=derivative_pathname,
+                data=zero_data,
+                times=[value.to_pydatetime() for value in tail_boundaries],
+                grid_info=grid_info,
+                create_if_missing=False,
+            )
+            padded_end = tail_boundaries[-1]
+        else:
+            source_grids = [
+                RasDss.read_grid(catalog_dss, record_path)
+                for _, _, record_path in records
+            ]
+            source_shape = source_grids[0]["data"].shape
+            if any(grid["data"].shape != source_shape for grid in source_grids):
+                raise ValueError("Matched grid records do not use one grid shape")
+            shifted_data = np.stack(
+                [grid["data"] for grid in source_grids],
+                axis=0,
+            )
+            output_data = np.concatenate([shifted_data, zero_data], axis=0)
+            source_boundaries = [records[0][0]] + [
+                end for _, end, _ in records
+            ]
+            output_boundaries = [
+                boundary + shift for boundary in source_boundaries
+            ]
+            output_boundaries.extend(
+                output_source_end + index * interval
+                for index in range(1, tail_intervals + 1)
+            )
+            written = RasDss.write_grid_timeseries(
+                dss_file=output,
+                pathname=derivative_pathname,
+                data=output_data,
+                times=[
+                    value.to_pydatetime()
+                    for value in output_boundaries
+                ],
+                grid_info=grid_info,
+                create_if_missing=True,
+            )
+            shifted_pathnames = written[: len(records)]
+            appended_pathnames = written[len(records) :]
+            padded_end = output_boundaries[-1]
+
+        return {
+            "source_dss": str(source),
+            "output_dss": str(output),
+            "pathname": pathname,
+            "output_pathname": derivative_pathname,
+            "source_record_count": len(records),
+            "appended_record_count": len(appended_pathnames),
+            "interval_minutes": int(interval.total_seconds() // 60),
+            "time_shift_minutes": time_shift_minutes,
+            "x_shift": x_shift,
+            "y_shift": y_shift,
+            "output_lower_left_cell": output_lower_left,
+            "source_start": records[0][0].isoformat(),
+            "source_end": records[-1][1].isoformat(),
+            "output_start": output_start.isoformat(),
+            "output_source_end": output_source_end.isoformat(),
+            "padded_end": padded_end.isoformat(),
+            "shifted_pathnames": shifted_pathnames,
+            "appended_pathnames": appended_pathnames,
+        }
+
+    @staticmethod
+    @log_call
+    def get_file_version(dss_file: Union[str, Path]) -> int:
+        """Return the major HEC-DSS file version (6 or 7).
+
+        Parameters
+        ----------
+        dss_file : str or Path
+            Existing DSS file to inspect.
+        """
+        RasDss._configure_jvm()
+
+        from jnius import autoclass
+        from ras_commander.RasUtils import RasUtils
+
+        dss_path = Path(dss_file)
+        if not dss_path.is_file():
+            raise FileNotFoundError(f"DSS file not found: {dss_path}")
+        HecDataManager = autoclass("hec.heclib.dss.HecDataManager")
+        version = int(
+            HecDataManager.getDssFileVersion(
+                str(RasUtils.safe_resolve(dss_path))
+            )
+        )
+        if version not in (6, 7):
+            raise ValueError(
+                f"File is not a supported HEC-DSS database: {dss_path}"
+            )
+        return version
+
+    @staticmethod
+    @log_call
     def write_timeseries(
         dss_file: Union[str, Path],
         pathname: str,
@@ -1507,6 +1803,7 @@ class RasDss:
         units: str = "CFS",
         data_type: str = "INST-VAL",
         create_if_missing: bool = True,
+        dss_version: Optional[int] = None,
     ) -> None:
         """
         Write a time series to a DSS file.
@@ -1527,6 +1824,8 @@ class RasDss:
                 - "PER-CUM"  - Period cumulative
                 - "INST-CUM" - Instantaneous cumulative
             create_if_missing: Create DSS file if it doesn't exist (default True)
+            dss_version: Major version (6 or 7) to use when creating a new
+                DSS file. Existing files must match when this is specified.
 
         Raises:
             FileNotFoundError: If DSS file doesn't exist and create_if_missing=False
@@ -1559,10 +1858,12 @@ class RasDss:
         """
         RasDss._configure_jvm()
 
-        from jnius import autoclass
+        from jnius import autoclass, cast
         from ras_commander.RasUtils import RasUtils
 
         # Validate inputs
+        if dss_version not in (None, 6, 7):
+            raise ValueError("dss_version must be 6, 7, or None")
         values = np.asarray(values, dtype=np.float64)
         if len(times) != len(values):
             raise ValueError(
@@ -1573,6 +1874,13 @@ class RasDss:
 
         # Resolve DSS file path
         dss_path = Path(dss_file)
+        if dss_path.exists() and dss_version is not None:
+            existing_version = RasDss.get_file_version(dss_path)
+            if existing_version != dss_version:
+                raise ValueError(
+                    f"Existing DSS file is version {existing_version}, "
+                    f"not requested version {dss_version}: {dss_path}"
+                )
         if not dss_path.exists():
             if not create_if_missing:
                 raise FileNotFoundError(f"DSS file not found: {dss_path}")
@@ -1596,6 +1904,7 @@ class RasDss:
         # Load Java classes
         HecDss = autoclass('hec.heclib.dss.HecDss')
         TimeSeriesContainer = autoclass('hec.io.TimeSeriesContainer')
+        HecTimeArray = autoclass('hec.heclib.util.HecTimeArray')
 
         # Create TimeSeriesContainer
         tsc = TimeSeriesContainer()
@@ -1603,21 +1912,33 @@ class RasDss:
         tsc.units = units
         tsc.type = data_type
         tsc.interval = interval_minutes
+        tsc.setStoreAsDoubles(True)
 
-        # Set times array (Java int[])
+        # PyJNIus cannot assign primitive Java array fields directly. Use the
+        # container's typed setter methods so Python sequences are converted
+        # through the declared int[] and double[] method signatures.
         n = len(values)
+        time_status = tsc.setTimes(HecTimeArray(hec_times.tolist()))
+        value_status = tsc.setValues(values.tolist())
+        if time_status != 0 or value_status != 0:
+            raise RuntimeError(
+                "HEC time-series container rejected input arrays: "
+                f"times={time_status}, values={value_status}"
+            )
         tsc.numberValues = n
-
-        # Convert numpy arrays to Java-compatible arrays
-        # pyjnius handles int[] and double[] conversion from Python lists
-        tsc.times = hec_times.tolist()
-        tsc.values = values.tolist()
 
         # Open DSS file and write
         dss = None
         try:
-            dss = HecDss.open(dss_file_str)
-            dss.put(tsc)
+            dss = (
+                HecDss.open(dss_file_str, dss_version)
+                if dss_version is not None
+                else HecDss.open(dss_file_str)
+            )
+            # HecDss.put is overloaded for DataContainer and
+            # DataContainerTransformer. Cast explicitly so PyJNIus does not
+            # select the transformer overload for a TimeSeriesContainer.
+            dss.put(cast('hec.io.DataContainer', tsc))
             logger.info(f"Wrote {n} values to {Path(dss_file_str).name}")
             logger.debug(
                 f"DSS write details: file={dss_file_str}, pathname={pathname}, "
@@ -1644,6 +1965,7 @@ class RasDss:
         units: str = "CFS",
         data_type: str = "INST-VAL",
         create_if_missing: bool = True,
+        dss_version: Optional[int] = None,
     ) -> None:
         """
         Write a time series DataFrame to a DSS file.
@@ -1659,6 +1981,8 @@ class RasDss:
             units: Data units string
             data_type: DSS data type string
             create_if_missing: Create DSS file if it doesn't exist
+            dss_version: Major version (6 or 7) to use when creating a new
+                DSS file. Existing files must match when this is specified.
 
         Example:
             >>> # Read from one DSS file, write to another
@@ -1684,6 +2008,7 @@ class RasDss:
             units=units,
             data_type=data_type,
             create_if_missing=create_if_missing,
+            dss_version=dss_version,
         )
 
     @staticmethod
@@ -2012,7 +2337,7 @@ class RasDss:
         Returns:
             numpy int array of minutes since HEC epoch (1899-12-31 00:00:00)
         """
-        HEC_EPOCH = np.datetime64('1899-12-31T00:00:00')
+        HEC_EPOCH = np.datetime64('1899-12-31T00:00:00', 'm')
 
         if isinstance(times, pd.DatetimeIndex):
             dt64 = times.values.astype('datetime64[m]')
@@ -2024,13 +2349,8 @@ class RasDss:
 
         # Calculate minutes since HEC epoch
         delta = dt64 - HEC_EPOCH
-        minutes = delta.astype(np.int64)
+        minutes = delta.astype('timedelta64[m]').astype(np.int32)
 
-        if minutes.max() > np.iinfo(np.int32).max:
-            logger.warning(
-                f"HEC epoch minutes ({minutes.max()}) exceeds int32 range; "
-                "passing as int64 — verify HEC-DSS Java bridge accepts int64"
-            )
         return minutes
 
 

--- a/ras_commander/hdf/AGENTS.md
+++ b/ras_commander/hdf/AGENTS.md
@@ -13,6 +13,7 @@ This file is the canonical local instruction file for `ras_commander/hdf/`.
 - Geometry readers: `HdfMesh`, `HdfXsec`, `HdfBndry`, `HdfStruc`, `HdfHydraulicTables`
 - Project extent / footprint: `HdfProject`
 - Results readers: `HdfResultsPlan`, `HdfResultsMesh`, `HdfResultsXsec`, `HdfResultsBreach`, `HdfResultsSediment`
+- Scenario product extraction: `HdfResultsProducts`
 - Infrastructure and land surface: `HdfPipe`, `HdfPump`, `HdfInfiltration`, `HdfLandCover`
 - Plotting and analysis: `HdfPlot`, `HdfResultsPlot`, `HdfBenefitAreas`, `HdfChannelCapacity`, `HdfFluvialPluvial`
 
@@ -34,6 +35,10 @@ This file is the canonical local instruction file for `ras_commander/hdf/`.
 - Accept the flexible HDF-facing input forms already used in this package: plan numbers, prefixed plan numbers, paths, and open HDF handles where the decorator pattern already allows them.
 - Return pandas or GeoPandas objects in the shapes established by nearby code. Do not invent a new container style for one method unless the surrounding API also changes.
 - Log read failures with enough file context to debug the issue.
+- Keep `HdfResultsProducts` asset keys and deterministic filenames stable.
+  Its COG, Parquet, footprint, metadata, preview, and numerical-summary assets
+  are a package-owned contract for downstream catalogs, not an engineering
+  acceptance decision.
 
 ## Common Entry Points
 
@@ -47,6 +52,8 @@ This file is the canonical local instruction file for `ras_commander/hdf/`.
 - 2D face spatial filtering (polygon mask): `HdfMesh.get_face_ids_in_polygon()`, `get_face_ids_in_calibration_region()`
 - Both `extend_face_property_tables()` and `set_face_mannings_n_values()` accept optional `polygon` and `region_name` parameters for selective face application (precedence: `face_ids` > `region_name` > `polygon` > all faces)
 - 2D results extraction: `HdfResultsMesh`
+- Deterministic client-oriented result package:
+  `HdfResultsProducts.inspect_result()` and `HdfResultsProducts.export()`
 - 2D mobile-bed (sediment) results: `HdfResultsSediment` (`is_sediment_plan()`, `get_sediment_mesh_areas()`, `get_cell_bed_change()`/`get_cell_bed_elevation()`/`get_active_layer_grain_class()` -> GeoDataFrame, `get_bed_change_volumes()` -> erosion/deposition/net volume per area, `get_cell_bed_change_timeseries()` -> xr.DataArray). Reads the `Sediment Bed` output block; per-cell arrays align with computed `Cells Surface Area` (zero-area ghost cells drop out of volume integrals). Covered by `examples/230_mesh_sensitivity_analysis.ipynb`.
 - 1D cross section geometry and results: `HdfXsec`, `HdfResultsXsec`
 - 1D river edge lines: `HdfXsec.get_river_edge_lines()` (stored `Geometry/River Edge Lines`);

--- a/ras_commander/hdf/HdfResultsMesh.py
+++ b/ras_commander/hdf/HdfResultsMesh.py
@@ -1387,8 +1387,14 @@ class HdfResultsMesh:
     @standardize_input(file_type='plan_hdf')
     def get_mesh_max_depth(hdf_path: Path) -> gpd.GeoDataFrame:
         """
-        Get the maximum depth for each 2D mesh cell by reading the full Depth
-        time series and computing np.max(axis=0) per cell.
+        Get the maximum depth for each 2D mesh cell.
+
+        The preferred source is the stored ``Depth`` time series. HEC-RAS
+        projects may omit that optional output while retaining ``Water
+        Surface`` and ``Cells Minimum Elevation``. In that case this method
+        computes depth at every timestep as water surface minus minimum cell
+        elevation, clips negative values to zero, and then takes the temporal
+        maximum.
 
         Attribution: Implementation pattern derived from ras-agent
         (https://github.com/gheistand/ras-agent) by Glenn Heistand / CHAMP —
@@ -1409,10 +1415,15 @@ class HdfResultsMesh:
         try:
             dfs = []
             with h5py.File(hdf_path, 'r') as hdf_file:
+                crs = HdfBase.get_projection(hdf_file)
                 d2_flow_areas = hdf_file.get("Geometry/2D Flow Areas/Attributes")
                 if d2_flow_areas is None:
                     logger.debug("No 2D Flow Areas found in HDF file")
-                    return gpd.GeoDataFrame()
+                    return gpd.GeoDataFrame(
+                        columns=["mesh_name", "cell_id", "maximum_depth", "geometry"],
+                        geometry="geometry",
+                        crs=crs,
+                    )
 
                 for d2_flow_area in d2_flow_areas[:]:
                     mesh_name = HdfUtils.convert_ras_string(d2_flow_area[0])
@@ -1431,12 +1442,64 @@ class HdfResultsMesh:
                         f"Unsteady Time Series/2D Flow Areas/{mesh_name}/Depth"
                     )
                     depth_ds = hdf_file.get(depth_path)
-                    if depth_ds is None:
-                        logger.warning(f"Depth dataset not found for mesh '{mesh_name}'")
-                        continue
+                    if depth_ds is not None:
+                        depths = np.asarray(depth_ds, dtype=np.float32)
+                    else:
+                        wse_path = (
+                            f"Results/Unsteady/Output/Output Blocks/Base Output/"
+                            f"Unsteady Time Series/2D Flow Areas/{mesh_name}/"
+                            "Water Surface"
+                        )
+                        minimum_elevation_path = (
+                            f"Geometry/2D Flow Areas/{mesh_name}/"
+                            "Cells Minimum Elevation"
+                        )
+                        wse_ds = hdf_file.get(wse_path)
+                        minimum_elevation_ds = hdf_file.get(
+                            minimum_elevation_path
+                        )
+                        if wse_ds is None or minimum_elevation_ds is None:
+                            raise ValueError(
+                                f"Depth is absent for mesh '{mesh_name}' and "
+                                "Water Surface plus Cells Minimum Elevation "
+                                "are not both available"
+                            )
+                        water_surface = np.asarray(wse_ds, dtype=np.float32)
+                        minimum_elevation = np.asarray(
+                            minimum_elevation_ds,
+                            dtype=np.float32,
+                        )
+                        if (
+                            water_surface.ndim != 2
+                            or water_surface.shape[1] != len(minimum_elevation)
+                        ):
+                            raise ValueError(
+                                f"Water Surface shape {water_surface.shape} "
+                                "does not align with Cells Minimum Elevation "
+                                f"count {len(minimum_elevation)} for mesh "
+                                f"'{mesh_name}'"
+                            )
+                        depths = np.maximum(
+                            water_surface - minimum_elevation[np.newaxis, :],
+                            0.0,
+                        )
+                        logger.debug(
+                            "Computed depth from Water Surface and Cells "
+                            "Minimum Elevation for mesh '%s'",
+                            mesh_name,
+                        )
 
-                    depths = np.array(depth_ds, dtype=np.float32)  # (T, N)
-                    max_depth = np.max(depths, axis=0)  # (N,)
+                    if depths.ndim != 2 or depths.shape[1] != len(xy):
+                        raise ValueError(
+                            f"Depth shape {depths.shape} does not align with "
+                            f"cell-center count {len(xy)} for mesh '{mesh_name}'"
+                        )
+                    finite_cells = np.any(np.isfinite(depths), axis=0)
+                    max_depth = np.full(depths.shape[1], np.nan, dtype=np.float32)
+                    max_depth[finite_cells] = np.nanmax(
+                        depths[:, finite_cells],
+                        axis=0,
+                    )
 
                     geom = [Point(x, y) for x, y in xy]
                     df = gpd.GeoDataFrame({
@@ -1447,13 +1510,17 @@ class HdfResultsMesh:
                     dfs.append(df)
 
             if not dfs:
-                return gpd.GeoDataFrame()
+                return gpd.GeoDataFrame(
+                    columns=["mesh_name", "cell_id", "maximum_depth", "geometry"],
+                    geometry="geometry",
+                    crs=crs,
+                )
 
-            result = pd.concat(dfs, ignore_index=True)
-
-            # Set CRS
-            with h5py.File(hdf_path, 'r') as hdf_file:
-                crs = HdfBase.get_projection(hdf_file)
+            result = gpd.GeoDataFrame(
+                pd.concat(dfs, ignore_index=True),
+                geometry="geometry",
+                crs=crs,
+            )
             if crs:
                 result.set_crs(crs, inplace=True)
 
@@ -2548,11 +2615,25 @@ class HdfResultsMesh:
                 )
                 
                 # Add metadata as coordinates
+                coordinate_names = {
+                    "flow": "flow_units",
+                    "stage": "stage_units",
+                    "2d area": "area_2d",
+                }
                 for key in bc_metadata[bc_names[0]]:
                     if key != 'Columns':  # Skip Columns attribute as it's used for Stage/Flow
                         try:
                             values = [bc_metadata[bc].get(key, '') for bc in bc_names]
-                            ds = ds.assign_coords({f'{key.lower()}': ('bc_name', values)})
+                            normalized_key = str(key).strip().lower()
+                            coordinate_name = coordinate_names.get(
+                                normalized_key,
+                                normalized_key.replace(" ", "_"),
+                            )
+                            if coordinate_name in ds.data_vars:
+                                coordinate_name = f"bc_{coordinate_name}"
+                            ds = ds.assign_coords(
+                                {coordinate_name: ('bc_name', values)}
+                            )
                         except Exception as e:
                             logger.debug(f"Could not add metadata coordinate '{key}': {str(e)}")
                 

--- a/ras_commander/hdf/HdfResultsProducts.py
+++ b/ras_commander/hdf/HdfResultsProducts.py
@@ -1,0 +1,1101 @@
+"""Deterministic client-oriented products from a qualified RAS result HDF."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import tempfile
+from pathlib import Path
+from typing import Any, Dict, Optional, Union
+
+import h5py
+import numpy as np
+import pandas as pd
+
+from ..Decorators import log_call
+from ..LoggingConfig import get_logger
+from .HdfBase import HdfBase
+from .HdfMesh import HdfMesh
+from .HdfProject import HdfProject
+from .HdfResultsMesh import HdfResultsMesh
+from .HdfResultsPlan import HdfResultsPlan
+from .HdfUtils import HdfUtils
+
+logger = get_logger(__name__)
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _json_value(value: Any) -> Any:
+    if value is None:
+        return None
+    if isinstance(value, (str, bool, int)):
+        return value
+    if isinstance(value, float):
+        return value if np.isfinite(value) else None
+    if isinstance(value, (np.integer,)):
+        return int(value)
+    if isinstance(value, (np.floating,)):
+        numeric = float(value)
+        return numeric if np.isfinite(numeric) else None
+    if isinstance(value, (pd.Timestamp,)):
+        return value.isoformat()
+    if isinstance(value, np.datetime64):
+        return pd.Timestamp(value).isoformat()
+    if isinstance(value, np.ndarray):
+        return [_json_value(item) for item in value.tolist()]
+    if isinstance(value, dict):
+        return {str(key): _json_value(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_json_value(item) for item in value]
+    return str(value)
+
+
+def _write_json(path: Path, payload: Dict[str, Any]) -> Path:
+    path.write_text(
+        json.dumps(_json_value(payload), indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    return path
+
+
+def _frame_records(frame: Optional[pd.DataFrame]) -> list[Dict[str, Any]]:
+    if frame is None or frame.empty:
+        return []
+    return [_json_value(record) for record in frame.to_dict(orient="records")]
+
+
+class HdfResultsProducts:
+    """Static namespace for deterministic hydraulic product extraction."""
+
+    SCHEMA = "ras-commander/hydraulic-product-manifest/1.0"
+    FILENAMES = {
+        "maximum-wse": "maximum-wse.tif",
+        "maximum-depth": "maximum-depth.tif",
+        "maximum-velocity": "maximum-velocity.tif",
+        "hydraulic-hydrographs": "hydraulic-hydrographs.parquet",
+        "result-metadata": "result-metadata.json",
+        "numerical-qaqc": "numerical-qaqc.json",
+        "result-footprint": "result-footprint.geojson",
+        "preview": "maximum-depth-preview.png",
+    }
+    MANIFEST_FILENAME = "hydraulic-products.json"
+
+    @staticmethod
+    @log_call
+    def inspect_result(
+        hdf_path: Union[str, Path],
+    ) -> Dict[str, Any]:
+        """Validate completion and required result time axes without mutation."""
+        source = Path(hdf_path).resolve()
+        if not source.is_file():
+            raise FileNotFoundError(f"Result HDF does not exist: {source}")
+        if source.stat().st_size <= 0:
+            raise ValueError(f"Result HDF is empty: {source}")
+
+        with h5py.File(source, "r") as hdf_file:
+            event_conditions = hdf_file.get("Event Conditions")
+            if event_conditions is None:
+                raise ValueError("Event Conditions group is missing")
+            completed = HdfResultsProducts._decode(
+                event_conditions.attrs.get("Completed Successfully")
+            )
+            if str(completed).strip().casefold() != "true":
+                raise ValueError(
+                    "Result HDF does not report Completed Successfully=True"
+                )
+
+            timestamps = HdfBase.get_unsteady_timestamps(hdf_file)
+            if len(timestamps) < 2:
+                raise ValueError(
+                    "Result HDF must contain at least two unsteady timestamps"
+                )
+            timestamp_index = pd.DatetimeIndex(timestamps)
+            if not timestamp_index.is_monotonic_increasing:
+                raise ValueError("Result HDF time axis is not increasing")
+            if timestamp_index.has_duplicates:
+                raise ValueError("Result HDF time axis contains duplicates")
+
+            mesh_names = HdfMesh.get_mesh_area_names(hdf_file)
+            if not mesh_names:
+                raise ValueError("Result HDF contains no 2D flow areas")
+
+            base = (
+                "Results/Unsteady/Output/Output Blocks/Base Output/"
+                "Unsteady Time Series"
+            )
+            checked_datasets: list[str] = []
+            for mesh_name in mesh_names:
+                for variable in ("Water Surface", "Face Velocity"):
+                    dataset_path = (
+                        f"{base}/2D Flow Areas/{mesh_name}/{variable}"
+                    )
+                    if dataset_path not in hdf_file:
+                        raise ValueError(
+                            f"Required result dataset is missing: {dataset_path}"
+                        )
+                    dataset = hdf_file[dataset_path]
+                    if dataset.ndim != 2:
+                        raise ValueError(
+                            f"Required result dataset is not two-dimensional: "
+                            f"{dataset_path}"
+                        )
+                    if dataset.shape[0] != len(timestamps):
+                        raise ValueError(
+                            f"Time-axis mismatch for {dataset_path}: "
+                            f"{dataset.shape[0]} rows != {len(timestamps)} "
+                            "timestamps"
+                        )
+                    checked_datasets.append(dataset_path)
+
+            intervals = (
+                timestamp_index.to_series(index=range(len(timestamp_index)))
+                .diff()
+                .dropna()
+                .dt.total_seconds()
+                .to_numpy(dtype=float)
+            )
+            regular = bool(np.allclose(intervals, intervals[0]))
+            interval_seconds = (
+                float(intervals[0]) if regular and len(intervals) else None
+            )
+            projection = HdfBase.get_projection(hdf_file)
+            unit_metadata = HdfResultsProducts._unit_metadata(hdf_file)
+            program_version = HdfResultsProducts._first_attribute(
+                hdf_file,
+                (
+                    ("Results/Unsteady", "Program Version"),
+                    ("", "Program Version"),
+                    ("", "File Version"),
+                ),
+            )
+
+        return {
+            "completed_successfully": True,
+            "time_axis_consistent": True,
+            "time": {
+                "start": timestamp_index[0].isoformat(),
+                "end": timestamp_index[-1].isoformat(),
+                "count": len(timestamp_index),
+                "regular": regular,
+                "interval_seconds": interval_seconds,
+            },
+            "mesh_names": mesh_names,
+            "checked_datasets": checked_datasets,
+            "crs": str(projection) if projection else None,
+            "program_version": program_version,
+            **unit_metadata,
+        }
+
+    @staticmethod
+    @log_call
+    def export(
+        hdf_path: Union[str, Path],
+        output_directory: Union[str, Path],
+        *,
+        resolution: Optional[float] = None,
+        max_dimension: int = 2048,
+        nodata: float = -9999.0,
+        include_preview: bool = True,
+    ) -> Dict[str, Any]:
+        """Export a deterministic hydraulic product package.
+
+        Args:
+            hdf_path: Qualified HEC-RAS plan-result HDF.
+            output_directory: New directory for the product package. It must
+                not already exist.
+            resolution: Optional raster cell size in model CRS units.
+            max_dimension: Maximum raster width or height when resolution is
+                inferred.
+            nodata: Nodata value for all raster products.
+            include_preview: Create a deterministic depth PNG when matplotlib
+                is available.
+
+        Returns:
+            JSON-serializable hydraulic product manifest.
+
+        Raises:
+            ValueError: If completion, time axes, result variables, CRS, or
+                product metadata are incomplete.
+            FileExistsError: If the output directory already exists.
+        """
+        source = Path(hdf_path).resolve()
+        output = Path(output_directory).resolve()
+        if output.exists():
+            raise FileExistsError(
+                f"Hydraulic product directory already exists: {output}"
+            )
+        if max_dimension < 64:
+            raise ValueError("max_dimension must be at least 64")
+        if resolution is not None and resolution <= 0:
+            raise ValueError("resolution must be positive")
+        if not np.isfinite(nodata):
+            raise ValueError("nodata must be finite")
+
+        inspection = HdfResultsProducts.inspect_result(source)
+        if not inspection["crs"]:
+            raise ValueError("Result HDF does not contain a resolvable CRS")
+
+        source_size = source.stat().st_size
+        source_hash = _sha256(source)
+        output.parent.mkdir(parents=True, exist_ok=True)
+
+        with tempfile.TemporaryDirectory(
+            prefix=f".{output.name}-",
+            dir=output.parent,
+        ) as stage_name:
+            stage = Path(stage_name)
+            manifest = HdfResultsProducts._build_products(
+                source,
+                stage,
+                inspection,
+                source_size=source_size,
+                source_hash=source_hash,
+                resolution=resolution,
+                max_dimension=max_dimension,
+                nodata=nodata,
+                include_preview=include_preview,
+            )
+            current_size = source.stat().st_size
+            current_hash = _sha256(source)
+            if current_size != source_size or current_hash != source_hash:
+                raise RuntimeError(
+                    "Source result HDF changed during product extraction"
+                )
+            _write_json(stage / HdfResultsProducts.MANIFEST_FILENAME, manifest)
+            stage.replace(output)
+
+        logger.info(
+            "Exported %s hydraulic products to %s",
+            len(manifest["assets"]),
+            output.name,
+        )
+        logger.debug("Hydraulic product directory: %s", output)
+        return manifest
+
+    @staticmethod
+    def _build_products(
+        source: Path,
+        stage: Path,
+        inspection: Dict[str, Any],
+        *,
+        source_size: int,
+        source_hash: str,
+        resolution: Optional[float],
+        max_dimension: int,
+        nodata: float,
+        include_preview: bool,
+    ) -> Dict[str, Any]:
+        import geopandas as gpd
+        from shapely.geometry import mapping
+
+        footprint, bbox = HdfProject.get_project_extent(
+            source,
+            buffer_percent=0.0,
+            fill_holes=False,
+        )
+        if footprint.empty or footprint.geometry.is_empty.all():
+            raise ValueError("Result HDF produced an empty project footprint")
+        footprint_geometry = footprint.geometry.union_all()
+        if footprint_geometry.is_empty:
+            raise ValueError("Result HDF produced an empty project footprint")
+
+        wse = HdfResultsMesh.get_mesh_max_ws(source)
+        depth = HdfResultsMesh.get_mesh_max_depth(source)
+        velocity = HdfResultsProducts._maximum_velocity_points(source)
+        required_frames = {
+            "maximum WSE": wse,
+            "maximum depth": depth,
+            "maximum velocity": velocity,
+        }
+        for label, frame in required_frames.items():
+            if frame.empty:
+                raise ValueError(f"Result HDF produced no {label} values")
+            if frame.crs is None:
+                raise ValueError(f"Result HDF produced {label} without a CRS")
+
+        depth = depth.copy()
+        depth["maximum_depth"] = depth["maximum_depth"].clip(lower=0.0)
+        wse = wse.merge(
+            depth[["mesh_name", "cell_id", "maximum_depth"]],
+            on=["mesh_name", "cell_id"],
+            how="left",
+            validate="one_to_one",
+        )
+        wse = gpd.GeoDataFrame(wse, geometry="geometry", crs=depth.crs)
+        invalid_wse = (
+            (wse["maximum_depth"] <= 0.0)
+            | (wse["maximum_water_surface"] <= 0.0)
+        )
+        wse.loc[invalid_wse, "maximum_water_surface"] = np.nan
+
+        grid = HdfResultsProducts._grid_spec(
+            bbox,
+            resolution=resolution,
+            max_dimension=max_dimension,
+        )
+        depth_grid = HdfResultsProducts._interpolate_points(
+            depth,
+            "maximum_depth",
+            grid,
+        )
+        wet_mask = np.isfinite(depth_grid) & (depth_grid > 0.0)
+
+        raster_specs = {
+            "maximum-wse": (
+                wse,
+                "maximum_water_surface",
+                inspection["length_units"],
+                "maximum cell water-surface elevation; dry cells are nodata",
+            ),
+            "maximum-depth": (
+                depth,
+                "maximum_depth",
+                inspection["depth_units"],
+                "maximum of stored Depth or WSE minus cell minimum elevation",
+            ),
+            "maximum-velocity": (
+                velocity,
+                "maximum_velocity",
+                inspection["velocity_units"],
+                "maximum absolute adjacent-face velocity across time",
+            ),
+        }
+        assets: Dict[str, Any] = {}
+        for key, (frame, column, units, derivation) in raster_specs.items():
+            values = (
+                depth_grid
+                if key == "maximum-depth"
+                else HdfResultsProducts._interpolate_points(frame, column, grid)
+            )
+            values = HdfResultsProducts._apply_masks(
+                values,
+                footprint_geometry,
+                grid,
+                wet_mask=wet_mask if key != "maximum-depth" else None,
+                nodata=nodata,
+            )
+            raster_path = stage / HdfResultsProducts.FILENAMES[key]
+            HdfResultsProducts._write_cog(
+                raster_path,
+                values,
+                grid,
+                crs=inspection["crs"],
+                nodata=nodata,
+                units=units,
+                product_key=key,
+                derivation=derivation,
+            )
+            assets[key] = HdfResultsProducts._raster_asset(
+                raster_path,
+                units=units,
+            )
+
+        hydrograph_path = (
+            stage / HdfResultsProducts.FILENAMES["hydraulic-hydrographs"]
+        )
+        hydrograph_metadata = HdfResultsProducts._write_hydrographs(
+            source,
+            hydrograph_path,
+        )
+        assets["hydraulic-hydrographs"] = HdfResultsProducts._file_asset(
+            hydrograph_path,
+            media_type="application/vnd.apache.parquet",
+            roles=["data", "hydrograph"],
+            extra={"table": hydrograph_metadata},
+        )
+
+        metadata = HdfResultsProducts._result_metadata(
+            source,
+            inspection,
+            bbox,
+            source_size=source_size,
+            source_hash=source_hash,
+        )
+        metadata_path = stage / HdfResultsProducts.FILENAMES["result-metadata"]
+        _write_json(metadata_path, metadata)
+        assets["result-metadata"] = HdfResultsProducts._file_asset(
+            metadata_path,
+            media_type="application/json",
+            roles=["metadata"],
+        )
+
+        qaqc = HdfResultsProducts._numerical_qaqc(source)
+        qaqc_path = stage / HdfResultsProducts.FILENAMES["numerical-qaqc"]
+        _write_json(qaqc_path, qaqc)
+        assets["numerical-qaqc"] = HdfResultsProducts._file_asset(
+            qaqc_path,
+            media_type="application/json",
+            roles=["metadata", "quality"],
+        )
+
+        footprint_payload = {
+            "type": "FeatureCollection",
+            "features": [
+                {
+                    "type": "Feature",
+                    "id": "result-footprint",
+                    "properties": {
+                        "crs": inspection["crs"],
+                        "source": source.name,
+                    },
+                    "geometry": mapping(footprint_geometry),
+                }
+            ],
+        }
+        footprint_path = stage / HdfResultsProducts.FILENAMES["result-footprint"]
+        _write_json(footprint_path, footprint_payload)
+        assets["result-footprint"] = HdfResultsProducts._file_asset(
+            footprint_path,
+            media_type="application/geo+json",
+            roles=["metadata", "footprint"],
+            extra={
+                "proj:bbox": [float(value) for value in bbox],
+                "proj:code": inspection["crs"],
+            },
+        )
+
+        omissions: list[Dict[str, str]] = []
+        if include_preview:
+            preview_path = stage / HdfResultsProducts.FILENAMES["preview"]
+            try:
+                HdfResultsProducts._write_preview(
+                    stage / HdfResultsProducts.FILENAMES["maximum-depth"],
+                    preview_path,
+                    units=inspection["depth_units"],
+                )
+                assets["preview"] = HdfResultsProducts._file_asset(
+                    preview_path,
+                    media_type="image/png",
+                    roles=["overview", "visual"],
+                )
+            except ImportError as exc:
+                omissions.append(
+                    {
+                        "asset_key": "preview",
+                        "reason": f"renderer unavailable: {exc}",
+                    }
+                )
+
+        return {
+            "schema": HdfResultsProducts.SCHEMA,
+            "source": {
+                "href": source.name,
+                "size_bytes": source_size,
+                "sha256": source_hash,
+                "roles": ["source", "engineering-result"],
+            },
+            "status": {
+                "completed_successfully": inspection["completed_successfully"],
+                "time_axis_consistent": inspection["time_axis_consistent"],
+                "hydraulic_qaqc": "not_evaluated",
+            },
+            "time": inspection["time"],
+            "spatial": {
+                "crs": inspection["crs"],
+                "bbox": [float(value) for value in bbox],
+                "footprint_asset": "result-footprint",
+            },
+            "assets": dict(sorted(assets.items())),
+            "omissions": omissions,
+        }
+
+    @staticmethod
+    def _maximum_velocity_points(source: Path):
+        import geopandas as gpd
+
+        points = HdfMesh.get_mesh_cell_points(source)
+        if points.empty:
+            return gpd.GeoDataFrame(
+                columns=[
+                    "mesh_name",
+                    "cell_id",
+                    "maximum_velocity",
+                    "geometry",
+                ],
+                geometry="geometry",
+            )
+
+        frames = []
+        base = (
+            "Results/Unsteady/Output/Output Blocks/Base Output/"
+            "Unsteady Time Series/2D Flow Areas"
+        )
+        with h5py.File(source, "r") as hdf_file:
+            for mesh_name in HdfMesh.get_mesh_area_names(hdf_file):
+                velocity_path = f"{base}/{mesh_name}/Face Velocity"
+                info_path = (
+                    f"Geometry/2D Flow Areas/{mesh_name}/"
+                    "Cells Face and Orientation Info"
+                )
+                values_path = (
+                    f"Geometry/2D Flow Areas/{mesh_name}/"
+                    "Cells Face and Orientation Values"
+                )
+                for required in (velocity_path, info_path, values_path):
+                    if required not in hdf_file:
+                        raise ValueError(
+                            f"Maximum velocity input is missing: {required}"
+                        )
+
+                face_timeseries = np.asarray(
+                    hdf_file[velocity_path],
+                    dtype=float,
+                )
+                finite_face = np.any(np.isfinite(face_timeseries), axis=0)
+                maximum_face = np.full(face_timeseries.shape[1], np.nan)
+                maximum_face[finite_face] = np.nanmax(
+                    np.abs(face_timeseries[:, finite_face]),
+                    axis=0,
+                )
+
+                cell_face_info = np.asarray(hdf_file[info_path])
+                cell_face_values = np.asarray(hdf_file[values_path])[:, 0].astype(
+                    int
+                )
+                maximum_cell = np.full(len(cell_face_info), np.nan)
+                for cell_id, (start, count) in enumerate(
+                    cell_face_info[:, :2]
+                ):
+                    face_ids = cell_face_values[start : start + count]
+                    face_ids = face_ids[
+                        (face_ids >= 0) & (face_ids < len(maximum_face))
+                    ]
+                    finite = maximum_face[face_ids]
+                    finite = finite[np.isfinite(finite)]
+                    if finite.size:
+                        maximum_cell[cell_id] = float(np.max(finite))
+
+                mesh_points = (
+                    points[points["mesh_name"] == mesh_name]
+                    .sort_values("cell_id")
+                    .copy()
+                )
+                if len(mesh_points) != len(maximum_cell):
+                    raise ValueError(
+                        f"Velocity cell count mismatch for mesh '{mesh_name}': "
+                        f"{len(maximum_cell)} values != {len(mesh_points)} "
+                        "cell points"
+                    )
+                mesh_points["maximum_velocity"] = maximum_cell
+                frames.append(
+                    mesh_points[
+                        ["mesh_name", "cell_id", "maximum_velocity", "geometry"]
+                    ]
+                )
+
+        return gpd.GeoDataFrame(
+            pd.concat(frames, ignore_index=True),
+            geometry="geometry",
+            crs=points.crs,
+        )
+
+    @staticmethod
+    def _grid_spec(
+        bbox: tuple[float, float, float, float],
+        *,
+        resolution: Optional[float],
+        max_dimension: int,
+    ) -> Dict[str, Any]:
+        from rasterio.transform import from_bounds
+
+        minx, miny, maxx, maxy = (float(value) for value in bbox)
+        width = maxx - minx
+        height = maxy - miny
+        if width <= 0 or height <= 0:
+            raise ValueError(f"Result footprint has invalid bounds: {bbox}")
+        if resolution is None:
+            resolution = max(width, height) / float(max_dimension)
+        columns = max(2, int(np.ceil(width / resolution)))
+        rows = max(2, int(np.ceil(height / resolution)))
+        transform = from_bounds(minx, miny, maxx, maxy, columns, rows)
+        return {
+            "bbox": (minx, miny, maxx, maxy),
+            "width": columns,
+            "height": rows,
+            "transform": transform,
+            "resolution": (
+                float(transform.a),
+                float(abs(transform.e)),
+            ),
+        }
+
+    @staticmethod
+    def _interpolate_points(
+        frame,
+        value_column: str,
+        grid: Dict[str, Any],
+    ) -> np.ndarray:
+        from scipy.spatial import cKDTree
+
+        valid = (
+            frame.geometry.notna()
+            & ~frame.geometry.is_empty
+            & np.isfinite(frame[value_column].to_numpy(dtype=float))
+        )
+        source = frame.loc[valid]
+        if source.empty:
+            raise ValueError(f"No finite values available for {value_column}")
+        xy = np.column_stack(
+            [
+                source.geometry.x.to_numpy(dtype=float),
+                source.geometry.y.to_numpy(dtype=float),
+            ]
+        )
+        values = source[value_column].to_numpy(dtype=float)
+        minx, miny, maxx, maxy = grid["bbox"]
+        width = grid["width"]
+        height = grid["height"]
+        x_resolution, y_resolution = grid["resolution"]
+        x = np.linspace(
+            minx + x_resolution / 2.0,
+            maxx - x_resolution / 2.0,
+            width,
+        )
+        y = np.linspace(
+            maxy - y_resolution / 2.0,
+            miny + y_resolution / 2.0,
+            height,
+        )
+        gx, gy = np.meshgrid(x, y)
+        tree = cKDTree(xy)
+        _, nearest = tree.query(np.column_stack([gx.ravel(), gy.ravel()]))
+        return values[nearest].reshape((height, width)).astype(np.float32)
+
+    @staticmethod
+    def _apply_masks(
+        values: np.ndarray,
+        footprint,
+        grid: Dict[str, Any],
+        *,
+        wet_mask: Optional[np.ndarray],
+        nodata: float,
+    ) -> np.ndarray:
+        from rasterio.features import geometry_mask
+
+        valid_footprint = geometry_mask(
+            [footprint],
+            out_shape=(grid["height"], grid["width"]),
+            transform=grid["transform"],
+            invert=True,
+        )
+        valid = valid_footprint & np.isfinite(values)
+        if wet_mask is not None:
+            valid &= wet_mask
+        return np.where(valid, values, nodata).astype(np.float32)
+
+    @staticmethod
+    def _write_cog(
+        path: Path,
+        values: np.ndarray,
+        grid: Dict[str, Any],
+        *,
+        crs: str,
+        nodata: float,
+        units: str,
+        product_key: str,
+        derivation: str,
+    ) -> None:
+        import rasterio
+
+        with rasterio.open(
+            path,
+            "w",
+            driver="COG",
+            height=grid["height"],
+            width=grid["width"],
+            count=1,
+            dtype="float32",
+            crs=crs,
+            transform=grid["transform"],
+            nodata=nodata,
+            compress="DEFLATE",
+            blocksize=512,
+            overview_resampling="average",
+            num_threads=1,
+            BIGTIFF="IF_SAFER",
+        ) as destination:
+            destination.write(values, 1)
+            destination.update_tags(
+                product_key=product_key,
+                units=units,
+                derivation=derivation,
+            )
+
+        with rasterio.open(path) as source:
+            layout = source.tags(ns="IMAGE_STRUCTURE").get("LAYOUT")
+            if layout != "COG":
+                raise RuntimeError(
+                    f"Raster driver did not produce a COG for {path.name}"
+                )
+
+    @staticmethod
+    def _write_hydrographs(
+        source: Path,
+        path: Path,
+    ) -> Dict[str, Any]:
+        dataset = HdfResultsMesh.get_boundary_conditions_timeseries(source)
+        required = {"flow", "stage"}
+        missing = required - set(dataset.data_vars)
+        if missing:
+            raise ValueError(
+                "Boundary hydrograph variables are missing: "
+                + ", ".join(sorted(missing))
+            )
+
+        frames = []
+        units_by_variable: Dict[str, list[str]] = {}
+        for variable in ("flow", "stage"):
+            frame = (
+                dataset[variable]
+                .to_dataframe(name="value")
+                .reset_index()
+            )
+            frame.insert(2, "variable", variable)
+            units_coordinate = f"{variable}_units"
+            if units_coordinate in dataset.coords:
+                unit_lookup = {
+                    str(name): str(unit)
+                    for name, unit in zip(
+                        dataset["bc_name"].values,
+                        dataset[units_coordinate].values,
+                    )
+                }
+                frame["units"] = frame["bc_name"].map(unit_lookup)
+            else:
+                frame["units"] = ""
+            if "area_2d" in dataset.coords:
+                area_lookup = {
+                    str(name): str(area)
+                    for name, area in zip(
+                        dataset["bc_name"].values,
+                        dataset["area_2d"].values,
+                    )
+                }
+                frame["area_2d"] = frame["bc_name"].map(area_lookup)
+            else:
+                frame["area_2d"] = ""
+            frames.append(frame)
+            units_by_variable[variable] = sorted(
+                {
+                    value
+                    for value in frame["units"].astype(str)
+                    if value.strip()
+                }
+            )
+
+        table = pd.concat(frames, ignore_index=True)
+        table = table[
+            ["time", "bc_name", "variable", "value", "units", "area_2d"]
+        ].sort_values(
+            ["time", "bc_name", "variable"],
+            kind="stable",
+        )
+        table.reset_index(drop=True, inplace=True)
+        table.to_parquet(
+            path,
+            index=False,
+            engine="pyarrow",
+            compression="zstd",
+        )
+        return {
+            "row_count": len(table),
+            "columns": [
+                {"name": "time", "type": "timestamp"},
+                {"name": "bc_name", "type": "string"},
+                {"name": "variable", "type": "string"},
+                {"name": "value", "type": "float64"},
+                {"name": "units", "type": "string"},
+                {"name": "area_2d", "type": "string"},
+            ],
+            "variables": ["flow", "stage"],
+            "units": units_by_variable,
+            "missing_value_count": int(table["value"].isna().sum()),
+            "time_start": pd.Timestamp(table["time"].min()).isoformat(),
+            "time_end": pd.Timestamp(table["time"].max()).isoformat(),
+        }
+
+    @staticmethod
+    def _result_metadata(
+        source: Path,
+        inspection: Dict[str, Any],
+        bbox: tuple[float, float, float, float],
+        *,
+        source_size: int,
+        source_hash: str,
+    ) -> Dict[str, Any]:
+        return {
+            "schema": "ras-commander/result-hdf-metadata/1.0",
+            "source": {
+                "href": source.name,
+                "size_bytes": source_size,
+                "sha256": source_hash,
+            },
+            "completion": {
+                "completed_successfully": inspection[
+                    "completed_successfully"
+                ],
+                "time_axis_consistent": inspection["time_axis_consistent"],
+            },
+            "time": inspection["time"],
+            "spatial": {
+                "crs": inspection["crs"],
+                "bbox": [float(value) for value in bbox],
+                "mesh_names": inspection["mesh_names"],
+            },
+            "units": {
+                "system": inspection["unit_system"],
+                "length": inspection["length_units"],
+                "depth": inspection["depth_units"],
+                "velocity": inspection["velocity_units"],
+            },
+            "program_version": inspection["program_version"],
+            "checked_datasets": inspection["checked_datasets"],
+            "derivations": {
+                "maximum-wse": "HEC-RAS Maximum Water Surface summary",
+                "maximum-depth": (
+                    "maximum stored Depth or Water Surface minus Cells "
+                    "Minimum Elevation, clipped at zero"
+                ),
+                "maximum-velocity": (
+                    "maximum absolute adjacent-face velocity across time"
+                ),
+            },
+        }
+
+    @staticmethod
+    def _numerical_qaqc(source: Path) -> Dict[str, Any]:
+        unsteady_summary = HdfResultsPlan.get_unsteady_summary(source)
+        volume_accounting = HdfResultsPlan.get_volume_accounting(source)
+        maximum_wse_error = HdfResultsMesh.get_mesh_max_ws_err(source)
+        messages = HdfResultsPlan.get_compute_messages_hdf_only(source)
+
+        patterns = {
+            "ignored_boundary": r"not used because",
+            "precipitation_out_of_bounds": r"out-of-bounds",
+            "maximum_iteration": r"maximum iteration",
+            "volume_accounting": r"volume accounting",
+            "wsel_error": r"(?:wsel|water surface).*error",
+        }
+        message_lines = [line.strip() for line in messages.splitlines()]
+        iteration_counts = []
+        for line in message_lines:
+            match = re.match(
+                r"^\d{2}[A-Za-z]{3}\d{4}\s+\d{2}:\d{2}:\d{2}"
+                r".*\s(\d+)\s*$",
+                line,
+            )
+            if match:
+                iteration_counts.append(int(match.group(1)))
+        findings: Dict[str, Any] = {}
+        for key, pattern in patterns.items():
+            matches = [
+                line
+                for line in message_lines
+                if line and re.search(pattern, line, flags=re.IGNORECASE)
+            ]
+            findings[key] = {
+                "count": len(matches),
+                "messages": list(dict.fromkeys(matches)),
+            }
+
+        return {
+            "schema": "ras-commander/numerical-qaqc-summary/1.0",
+            "acceptance": "not_evaluated",
+            "unsteady_summary": _frame_records(unsteady_summary),
+            "volume_accounting": _frame_records(volume_accounting),
+            "mesh": {
+                "maximum_iterations_observed": {
+                    "maximum": (
+                        max(iteration_counts) if iteration_counts else None
+                    ),
+                    "reported_row_count": len(iteration_counts),
+                    "source": "compute messages",
+                },
+                "maximum_water_surface_error": {
+                    "row_count": len(maximum_wse_error),
+                    "maximum": HdfResultsProducts._numeric_max(
+                        maximum_wse_error,
+                        "cell_maximum_water_surface_error",
+                    ),
+                },
+            },
+            "compute_message_findings": findings,
+            "compute_message_sha256": hashlib.sha256(
+                messages.encode("utf-8")
+            ).hexdigest(),
+        }
+
+    @staticmethod
+    def _numeric_max(frame: pd.DataFrame, column: str) -> Optional[float]:
+        if frame.empty or column not in frame:
+            return None
+        values = pd.to_numeric(frame[column], errors="coerce")
+        if not values.notna().any():
+            return None
+        return float(values.max())
+
+    @staticmethod
+    def _raster_asset(path: Path, *, units: str) -> Dict[str, Any]:
+        import rasterio
+
+        with rasterio.open(path) as source:
+            band = source.read(1, masked=True)
+            finite = band.compressed()
+            asset = HdfResultsProducts._file_asset(
+                path,
+                media_type=(
+                    "image/tiff; application=geotiff; "
+                    "profile=cloud-optimized"
+                ),
+                roles=["data", "visual"],
+                extra={
+                    "proj:code": source.crs.to_string(),
+                    "proj:bbox": [float(value) for value in source.bounds],
+                    "proj:shape": [source.height, source.width],
+                    "proj:transform": [
+                        float(value) for value in source.transform[:6]
+                    ],
+                    "raster:bands": [
+                        {
+                            "data_type": source.dtypes[0],
+                            "nodata": source.nodata,
+                            "unit": units,
+                            "spatial_resolution": float(abs(source.transform.a)),
+                            "statistics": {
+                                "minimum": (
+                                    float(np.min(finite))
+                                    if finite.size
+                                    else None
+                                ),
+                                "maximum": (
+                                    float(np.max(finite))
+                                    if finite.size
+                                    else None
+                                ),
+                            },
+                        }
+                    ],
+                    "cog": {
+                        "layout": source.tags(
+                            ns="IMAGE_STRUCTURE"
+                        ).get("LAYOUT"),
+                        "overviews": source.overviews(1),
+                    },
+                },
+            )
+        return asset
+
+    @staticmethod
+    def _file_asset(
+        path: Path,
+        *,
+        media_type: str,
+        roles: list[str],
+        extra: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        asset = {
+            "href": path.name,
+            "type": media_type,
+            "roles": roles,
+            "size_bytes": path.stat().st_size,
+            "sha256": _sha256(path),
+        }
+        if extra:
+            asset.update(extra)
+        return asset
+
+    @staticmethod
+    def _write_preview(
+        depth_path: Path,
+        preview_path: Path,
+        *,
+        units: str,
+    ) -> None:
+        import matplotlib
+
+        matplotlib.use("Agg")
+        import matplotlib.pyplot as plt
+        import rasterio
+
+        with rasterio.open(depth_path) as source:
+            depth = source.read(1, masked=True)
+            extent = (
+                source.bounds.left,
+                source.bounds.right,
+                source.bounds.bottom,
+                source.bounds.top,
+            )
+        figure, axis = plt.subplots(figsize=(10, 7), dpi=120)
+        image = axis.imshow(
+            depth,
+            extent=extent,
+            cmap="Blues",
+            origin="upper",
+        )
+        axis.set_title("Maximum Depth")
+        axis.set_xlabel("Model X")
+        axis.set_ylabel("Model Y")
+        colorbar = figure.colorbar(image, ax=axis, shrink=0.82)
+        colorbar.set_label(f"Depth ({units})")
+        figure.tight_layout()
+        figure.savefig(
+            preview_path,
+            metadata={"Software": "ras-commander"},
+        )
+        plt.close(figure)
+
+    @staticmethod
+    def _unit_metadata(hdf_file: h5py.File) -> Dict[str, str]:
+        geometry = hdf_file.get("Geometry")
+        raw_si = (
+            HdfResultsProducts._decode(geometry.attrs.get("SI Units"))
+            if geometry is not None
+            else None
+        )
+        raw_system = HdfResultsProducts._decode(
+            hdf_file.attrs.get("Units System")
+        )
+        text = str(raw_system or "").strip().casefold()
+        si_units = str(raw_si or "").strip().casefold() in {
+            "true",
+            "1",
+            "yes",
+            "si",
+        } or text.startswith("si")
+        length = "m" if si_units else "ft"
+        return {
+            "unit_system": "SI" if si_units else "US Customary",
+            "length_units": length,
+            "depth_units": length,
+            "velocity_units": "m/s" if si_units else "ft/s",
+        }
+
+    @staticmethod
+    def _first_attribute(
+        hdf_file: h5py.File,
+        candidates: tuple[tuple[str, str], ...],
+    ) -> Optional[str]:
+        for group_path, attribute in candidates:
+            group = hdf_file if not group_path else hdf_file.get(group_path)
+            if group is None:
+                continue
+            value = HdfResultsProducts._decode(group.attrs.get(attribute))
+            if value is not None and str(value).strip():
+                return str(value).strip()
+        return None
+
+    @staticmethod
+    def _decode(value: Any) -> Any:
+        if isinstance(value, (bytes, np.bytes_)):
+            return value.decode("utf-8", errors="replace")
+        if isinstance(value, np.ndarray) and value.size == 1:
+            return HdfResultsProducts._decode(value.flat[0])
+        return value

--- a/ras_commander/hdf/__init__.py
+++ b/ras_commander/hdf/__init__.py
@@ -77,6 +77,7 @@ from .HdfResultsQuery import HdfResultsQuery
 from .HdfResultsXsec import HdfResultsXsec
 from .HdfResultsBreach import HdfResultsBreach
 from .HdfResultsSediment import HdfResultsSediment
+from .HdfResultsProducts import HdfResultsProducts
 
 # Infrastructure classes
 from .HdfPipe import HdfPipe
@@ -104,7 +105,7 @@ __all__ = [
     'HdfMesh', 'HdfXsec', 'HdfBndry', 'HdfStruc', 'HdfStorageArea', 'HdfStruc1D', 'HdfHydraulicTables',
     # Results
     'HdfResultsPlan', 'HdfResultsMesh', 'HdfResultsQuery', 'HdfResultsXsec', 'HdfResultsBreach',
-    'HdfResultsSediment',
+    'HdfResultsSediment', 'HdfResultsProducts',
     # Infrastructure
     'HdfPipe', 'HdfPump', 'HdfInfiltration', 'HdfLandCover',
     # Visualization

--- a/setup.py
+++ b/setup.py
@@ -78,6 +78,7 @@ setup(
         'matplotlib',
         'shapely>=2.0',
         'rasterio',
+        'pyarrow>=14.0',
         'pyproj',
         'rasterstats',
         'rtree',
@@ -109,8 +110,9 @@ setup(
         # Precipitation enhancements
         'precip': ['zarr>=2.14.0', 's3fs>=2023.0.0', 'netCDF4>=1.6.0'],
         'precip-huc12': ['pygeohydro>=0.19.0'],  # HUC12 watershed boundaries for Atlas14Variance
-        # Optional GeoParquet polygon output for raster benefits analysis
-        'geoparquet': ['pyarrow>=14.0'],
+        # Kept for installation-command compatibility; pyarrow is now core
+        # because deterministic hydraulic product manifests include Parquet.
+        'geoparquet': [],
         # Notebook dependencies (raster visualization, coordinate systems, precipitation examples)
         'notebooks': [
             'rasterio',

--- a/setup.py
+++ b/setup.py
@@ -40,9 +40,11 @@ setup(
     package_data={
         "ras_commander": [
             "LLM_GUIDE.md",
+            "contracts/*.schema.json",
             "resources/*.json",
             "resources/land_classification/*.hdf",
-            "resources/templates/*/*",
+            "resources/templates/RAS_6.6/*",
+            "resources/templates/RAS_7.0/*",
         ],
         "ras_commander.native": [
             "RasStoreMapHelper.exe",
@@ -65,6 +67,11 @@ setup(
     },
     cmdclass={
         'build_py': CustomBuildPy,
+    },
+    entry_points={
+        'console_scripts': [
+            'ras-scenario-worker=ras_commander.RasScenarioWorker:main',
+        ],
     },
     install_requires=[
         'h5py',

--- a/tests/test_hdf_results_products.py
+++ b/tests/test_hdf_results_products.py
@@ -1,0 +1,171 @@
+"""Tests for deterministic hydraulic product contracts."""
+
+from pathlib import Path
+
+import h5py
+import numpy as np
+import pytest
+from pyproj import CRS
+
+from ras_commander import HdfResultsMesh, HdfResultsProducts
+
+
+BASE = (
+    "Results/Unsteady/Output/Output Blocks/Base Output/"
+    "Unsteady Time Series"
+)
+
+
+def _write_product_hdf(
+    path: Path,
+    *,
+    completed: bool = True,
+    velocity_time_count: int = 2,
+) -> None:
+    with h5py.File(path, "w") as hdf_file:
+        hdf_file.attrs["Projection"] = CRS.from_epsg(3451).to_wkt()
+        hdf_file.attrs["Units System"] = "English"
+        geometry = hdf_file.create_group("Geometry")
+        geometry.attrs["SI Units"] = False
+        event_conditions = hdf_file.create_group("Event Conditions")
+        event_conditions.attrs["Completed Successfully"] = (
+            b"True" if completed else b"False"
+        )
+        attributes = np.asarray(
+            [(b"Mesh", 2)],
+            dtype=[("Name", "S16"), ("Cell Count", "i4")],
+        )
+        hdf_file.create_dataset(
+            "Geometry/2D Flow Areas/Attributes",
+            data=attributes,
+        )
+        hdf_file.create_dataset(
+            f"{BASE}/Time Date Stamp (ms)",
+            data=np.asarray(
+                [
+                    b"18Sep2019 13:00:00.000",
+                    b"18Sep2019 14:00:00.000",
+                ],
+                dtype="S24",
+            ),
+        )
+        hdf_file.create_dataset(
+            f"{BASE}/2D Flow Areas/Mesh/Water Surface",
+            data=np.asarray([[10.0, 20.0], [12.0, 21.0]], dtype=np.float32),
+        )
+        hdf_file.create_dataset(
+            f"{BASE}/2D Flow Areas/Mesh/Face Velocity",
+            data=np.ones((velocity_time_count, 3), dtype=np.float32),
+        )
+
+
+def test_inspect_result_requires_completion_marker(tmp_path):
+    hdf_path = tmp_path / "incomplete.p01.hdf"
+    _write_product_hdf(hdf_path, completed=False)
+
+    with pytest.raises(ValueError, match="Completed Successfully"):
+        HdfResultsProducts.inspect_result(hdf_path)
+
+
+def test_inspect_result_rejects_inconsistent_required_time_axis(tmp_path):
+    hdf_path = tmp_path / "mismatch.p01.hdf"
+    _write_product_hdf(hdf_path, velocity_time_count=1)
+
+    with pytest.raises(ValueError, match="Time-axis mismatch"):
+        HdfResultsProducts.inspect_result(hdf_path)
+
+
+def test_inspect_result_reports_stac_ready_metadata(tmp_path):
+    hdf_path = tmp_path / "complete.p01.hdf"
+    _write_product_hdf(hdf_path)
+
+    result = HdfResultsProducts.inspect_result(hdf_path)
+
+    assert result["completed_successfully"] is True
+    assert result["time_axis_consistent"] is True
+    assert result["time"] == {
+        "start": "2019-09-18T13:00:00",
+        "end": "2019-09-18T14:00:00",
+        "count": 2,
+        "regular": True,
+        "interval_seconds": 3600.0,
+    }
+    assert result["mesh_names"] == ["Mesh"]
+    assert result["crs"] == "EPSG:3451"
+    assert result["unit_system"] == "US Customary"
+    assert result["depth_units"] == "ft"
+
+
+def test_maximum_depth_falls_back_to_wse_minus_minimum_elevation(tmp_path):
+    hdf_path = tmp_path / "depth-fallback.p01.hdf"
+    with h5py.File(hdf_path, "w") as hdf_file:
+        hdf_file.attrs["Projection"] = CRS.from_epsg(3451).to_wkt()
+        hdf_file.create_dataset(
+            "Geometry/2D Flow Areas/Attributes",
+            data=np.asarray(
+                [(b"Mesh", 2)],
+                dtype=[("Name", "S16"), ("Cell Count", "i4")],
+            ),
+        )
+        hdf_file.create_dataset(
+            "Geometry/2D Flow Areas/Mesh/Cells Center Coordinate",
+            data=np.asarray([[0.0, 0.0], [1.0, 1.0]]),
+        )
+        hdf_file.create_dataset(
+            "Geometry/2D Flow Areas/Mesh/Cells Minimum Elevation",
+            data=np.asarray([8.0, 20.0], dtype=np.float32),
+        )
+        hdf_file.create_dataset(
+            f"{BASE}/2D Flow Areas/Mesh/Water Surface",
+            data=np.asarray([[10.0, 19.0], [12.0, 21.0]], dtype=np.float32),
+        )
+
+    result = HdfResultsMesh.get_mesh_max_depth(hdf_path)
+
+    assert result["maximum_depth"].tolist() == pytest.approx([4.0, 1.0])
+    assert result.crs.to_epsg() == 3451
+
+
+def test_boundary_metadata_does_not_overwrite_hydrograph_variables(tmp_path):
+    hdf_path = tmp_path / "boundaries.p01.hdf"
+    with h5py.File(hdf_path, "w") as hdf_file:
+        plan_information = hdf_file.create_group(
+            "Plan Data/Plan Information"
+        )
+        plan_information.attrs["Simulation Start Time"] = (
+            b"18Sep2019 13:00:00"
+        )
+        hdf_file.create_dataset(
+            f"{BASE}/Time",
+            data=np.asarray([0.0, 1.0 / 24.0]),
+        )
+        boundary = hdf_file.create_dataset(
+            f"{BASE}/Boundary Conditions/Inflow",
+            data=np.asarray([[10.0, 100.0], [11.0, 120.0]]),
+        )
+        boundary.attrs["Columns"] = np.asarray([b"Stage", b"Flow"])
+        boundary.attrs["Stage"] = b"ft"
+        boundary.attrs["Flow"] = b"cfs"
+        boundary.attrs["2D Area"] = b"Mesh"
+
+    dataset = HdfResultsMesh.get_boundary_conditions_timeseries(hdf_path)
+
+    assert {"stage", "flow"} <= set(dataset.data_vars)
+    assert dataset["flow"].values.tolist() == [[100.0], [120.0]]
+    assert dataset["stage"].values.tolist() == [[10.0], [11.0]]
+    assert dataset["flow_units"].values.tolist() == ["cfs"]
+    assert dataset["stage_units"].values.tolist() == ["ft"]
+    assert dataset["area_2d"].values.tolist() == ["Mesh"]
+
+
+def test_product_filenames_and_keys_are_stable():
+    assert HdfResultsProducts.FILENAMES == {
+        "maximum-wse": "maximum-wse.tif",
+        "maximum-depth": "maximum-depth.tif",
+        "maximum-velocity": "maximum-velocity.tif",
+        "hydraulic-hydrographs": "hydraulic-hydrographs.parquet",
+        "result-metadata": "result-metadata.json",
+        "numerical-qaqc": "numerical-qaqc.json",
+        "result-footprint": "result-footprint.geojson",
+        "preview": "maximum-depth-preview.png",
+    }

--- a/tests/test_ras_scenario.py
+++ b/tests/test_ras_scenario.py
@@ -1,0 +1,157 @@
+"""Tests for isolated HMS-to-RAS scenario workspaces."""
+
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+
+from ras_commander import RasBoundaryLink, RasScenario
+
+
+RAS_EXE = Path(r"C:\Program Files (x86)\HEC\HEC-RAS\6.6\Ras.exe")
+
+
+def _write_project(folder: Path) -> Path:
+    folder.mkdir()
+    (folder / "Example.prj").write_text(
+        """Proj Title=Example
+Current Plan=p01
+Geom File=g01
+Unsteady File=u01
+Plan File=p01
+""",
+        encoding="utf-8",
+    )
+    (folder / "Example.p01").write_text(
+        """Plan Title=Baseline
+Program Version=6.60
+Short Identifier=Baseline
+Simulation Date=01JAN2020,0000,02JAN2020,0000
+Geom File=g01
+Flow File=u01
+Unsteady Flow
+""",
+        encoding="utf-8",
+    )
+    (folder / "Example.g01").write_text(
+        "Geom Title=Geometry\nProgram Version=6.60\n",
+        encoding="utf-8",
+    )
+    (folder / "Example.u01").write_text(
+        """Flow Title=Baseline
+Program Version=6.60
+Boundary Location=River           ,Reach           ,1000    ,        ,                ,                ,                ,                                ,
+Boundary Name=Tributary
+Interval=1HOUR
+Lateral Inflow Hydrograph= 0
+DSS File=baseline.dss
+DSS Path=//TRIBUTARY/FLOW/DATE/1HOUR/RUN:BASE/
+Use DSS=True
+Boundary Location=                ,                ,        ,        ,                ,Area2D          ,                ,Junction                        ,
+Boundary Name=Junction
+Interval=1HOUR
+Flow Hydrograph= 0
+DSS File=baseline.dss
+DSS Path=//JUNCTION/FLOW/DATE/1HOUR/RUN:BASE/
+Use DSS=True
+Met Point Raster Parameters=,,,,
+""",
+        encoding="utf-8",
+    )
+    return folder / "Example.prj"
+
+
+@pytest.mark.skipif(not RAS_EXE.is_file(), reason="HEC-RAS 6.6 not installed")
+def test_prepare_workspace_clones_plan_and_links_boundaries(tmp_path):
+    source_project = _write_project(tmp_path / "source")
+    hydrology = tmp_path / "hms-output.dss"
+    hydrology.write_bytes(b"not-a-real-dss")
+    original = {
+        path.name: path.read_bytes()
+        for path in source_project.parent.iterdir()
+        if path.is_file()
+    }
+    links = [
+        RasBoundaryLink(
+            mapping_id="tributary",
+            dss_path="//TRIBUTARY/FLOW/01JAN2020-02JAN2020/5MIN/RUN:FF_TEST/",
+            expected_bc_type="Lateral Inflow Hydrograph",
+            river="River",
+            reach="Reach",
+            station="1000",
+        ),
+        RasBoundaryLink(
+            mapping_id="junction",
+            dss_path="//JUNCTION/FLOW/01JAN2020-02JAN2020/5MIN/RUN:FF_TEST/",
+            expected_bc_type="Flow Hydrograph",
+            sa_2d_name="Area2D",
+            bc_line="Junction",
+        ),
+    ]
+
+    prepared = RasScenario.prepare_workspace(
+        source_project,
+        tmp_path / "workspace",
+        "scenario-001",
+        "01",
+        hydrology,
+        links,
+        datetime(2020, 1, 1),
+        datetime(2020, 1, 2),
+        ras_exe_path=RAS_EXE,
+    )
+
+    plan_text = prepared.plan_file.read_text(encoding="utf-8")
+    unsteady_text = prepared.unsteady_file.read_text(encoding="utf-8")
+    assert prepared.plan_number == "02"
+    assert prepared.unsteady_number == "02"
+    assert "Flow File=u02" in plan_text
+    assert "Simulation Date=01JAN2020,0000,02JAN2020,0000" in plan_text
+    assert unsteady_text.count("DSS File=hydrology\\hms-output.dss") == 2
+    assert all(f"DSS Path={link.dss_path}" in unsteady_text for link in links)
+    assert {
+        path.name: path.read_bytes()
+        for path in source_project.parent.iterdir()
+        if path.is_file()
+    } == original
+
+
+def test_boundary_link_rejects_mixed_selector_groups():
+    with pytest.raises(ValueError, match="cannot mix"):
+        RasBoundaryLink(
+            mapping_id="bad",
+            dss_path="//A/FLOW/DATE/5MIN/RUN/",
+            expected_bc_type="Flow Hydrograph",
+            river="River",
+            sa_2d_name="Area2D",
+        )
+
+
+def test_prepare_workspace_is_non_destructive_by_default(tmp_path):
+    source_project = _write_project(tmp_path / "source")
+    hydrology = tmp_path / "hms-output.dss"
+    hydrology.write_bytes(b"dss")
+    destination = tmp_path / "workspace"
+    destination.mkdir()
+
+    with pytest.raises(FileExistsError, match="Workspace already exists"):
+        RasScenario.prepare_workspace(
+            source_project,
+            destination,
+            "scenario",
+            "01",
+            hydrology,
+            [
+                RasBoundaryLink(
+                    mapping_id="mapping",
+                    dss_path="//A/FLOW/DATE/5MIN/RUN/",
+                    expected_bc_type="Lateral Inflow Hydrograph",
+                    river="River",
+                    reach="Reach",
+                    station="1000",
+                )
+            ],
+            datetime(2020, 1, 1),
+            datetime(2020, 1, 2),
+            ras_exe_path=RAS_EXE,
+        )

--- a/tests/test_ras_scenario.py
+++ b/tests/test_ras_scenario.py
@@ -1,14 +1,44 @@
 """Tests for isolated HMS-to-RAS scenario workspaces."""
 
+import importlib
+import threading
 from datetime import datetime
 from pathlib import Path
 
+import h5py
+import numpy as np
 import pytest
 
-from ras_commander import RasBoundaryLink, RasScenario
+from ras_commander import (
+    RasBoundaryLink,
+    RasScenario,
+    RasScenarioWorkspace,
+)
 
 
 RAS_EXE = Path(r"C:\Program Files (x86)\HEC\HEC-RAS\6.6\Ras.exe")
+
+
+def _write_result_hdf(
+    path: Path,
+    *,
+    completed: bool = True,
+    start: str = "18Sep2019 13:00:00.000",
+    end: str = "22Sep2019 13:00:00.000",
+) -> None:
+    with h5py.File(path, "w") as hdf_file:
+        event_conditions = hdf_file.create_group("Event Conditions")
+        event_conditions.attrs["Completed Successfully"] = (
+            b"True" if completed else b"False"
+        )
+        timestamps = hdf_file.create_group(
+            "Results/Unsteady/Output/Output Blocks/Base Output/"
+            "Unsteady Time Series"
+        )
+        timestamps.create_dataset(
+            "Time Date Stamp (ms)",
+            data=np.asarray([start, end], dtype="S24"),
+        )
 
 
 def _write_project(folder: Path) -> Path:
@@ -34,7 +64,14 @@ Unsteady Flow
         encoding="utf-8",
     )
     (folder / "Example.g01").write_text(
-        "Geom Title=Geometry\nProgram Version=6.60\n",
+        """Geom Title=Geometry
+Program Version=6.60
+River Reach=River           ,Reach
+Type RM Length L Ch R = 1 ,1000,0,0,0
+Storage Area=Area2D,0,0
+Storage Area Is2D=-1
+BC Line Name=Junction
+""",
         encoding="utf-8",
     )
     (folder / "Example.u01").write_text(
@@ -53,6 +90,13 @@ Interval=1HOUR
 Flow Hydrograph= 0
 DSS File=baseline.dss
 DSS Path=//JUNCTION/FLOW/DATE/1HOUR/RUN:BASE/
+Use DSS=True
+Boundary Location=                ,                ,        ,        ,                ,SA_NotInGeometry,                ,                                ,
+Boundary Name=Missing Storage
+Interval=1HOUR
+Flow Hydrograph= 0
+DSS File=baseline.dss
+DSS Path=//MISSING/FLOW/DATE/1HOUR/RUN:BASE/
 Use DSS=True
 Met Point Raster Parameters=,,,,
 """,
@@ -74,7 +118,7 @@ def test_prepare_workspace_clones_plan_and_links_boundaries(tmp_path):
     links = [
         RasBoundaryLink(
             mapping_id="tributary",
-            dss_path="//TRIBUTARY/FLOW/01JAN2020-02JAN2020/5MIN/RUN:FF_TEST/",
+            dss_path="//TRIBUTARY/FLOW//5MIN/RUN:FF_TEST/",
             expected_bc_type="Lateral Inflow Hydrograph",
             river="River",
             reach="Reach",
@@ -82,7 +126,7 @@ def test_prepare_workspace_clones_plan_and_links_boundaries(tmp_path):
         ),
         RasBoundaryLink(
             mapping_id="junction",
-            dss_path="//JUNCTION/FLOW/01JAN2020-02JAN2020/5MIN/RUN:FF_TEST/",
+            dss_path="//JUNCTION/FLOW//5MIN/RUN:FF_TEST/",
             expected_bc_type="Flow Hydrograph",
             sa_2d_name="Area2D",
             bc_line="Junction",
@@ -105,15 +149,55 @@ def test_prepare_workspace_clones_plan_and_links_boundaries(tmp_path):
     unsteady_text = prepared.unsteady_file.read_text(encoding="utf-8")
     assert prepared.plan_number == "02"
     assert prepared.unsteady_number == "02"
+    assert "Current Plan=p02" in prepared.project_file.read_text(
+        encoding="utf-8"
+    )
     assert "Flow File=u02" in plan_text
     assert "Simulation Date=01JAN2020,0000,02JAN2020,0000" in plan_text
-    assert unsteady_text.count("DSS File=hydrology\\hms-output.dss") == 2
-    assert all(f"DSS Path={link.dss_path}" in unsteady_text for link in links)
+    assert unsteady_text.count("DSS File=.\\hydrology\\hms-output.dss") == 2
+    assert (
+        "DSS Path=//TRIBUTARY/FLOW/01JAN2020-02JAN2020/5MIN/"
+        "RUN:FF_TEST/"
+    ) in unsteady_text
+    assert (
+        "DSS Path=//JUNCTION/FLOW/01JAN2020-02JAN2020/5MIN/"
+        "RUN:FF_TEST/"
+    ) in unsteady_text
     assert {
         path.name: path.read_bytes()
         for path in source_project.parent.iterdir()
         if path.is_file()
     } == original
+
+
+@pytest.mark.skipif(not RAS_EXE.is_file(), reason="HEC-RAS 6.6 not installed")
+def test_validate_workspace_rejects_inactive_geometry_boundary(tmp_path):
+    source_project = _write_project(tmp_path / "source")
+    hydrology = tmp_path / "hms-output.dss"
+    hydrology.write_bytes(b"not-a-real-dss")
+
+    with pytest.raises(
+        ValueError,
+        match="all_boundaries_exist_in_active_geometry",
+    ):
+        RasScenario.prepare_workspace(
+            source_project,
+            tmp_path / "workspace",
+            "scenario-001",
+            "01",
+            hydrology,
+            [
+                RasBoundaryLink(
+                    mapping_id="missing-storage",
+                    dss_path="//MISSING/FLOW//5MIN/RUN:FF_TEST/",
+                    expected_bc_type="Flow Hydrograph",
+                    sa_2d_name="SA_NotInGeometry",
+                )
+            ],
+            datetime(2020, 1, 1),
+            datetime(2020, 1, 2),
+            ras_exe_path=RAS_EXE,
+        )
 
 
 def test_boundary_link_rejects_mixed_selector_groups():
@@ -125,6 +209,18 @@ def test_boundary_link_rejects_mixed_selector_groups():
             river="River",
             sa_2d_name="Area2D",
         )
+
+
+def test_format_dss_pathname_for_window_materializes_blank_d_part():
+    pathname = RasScenario.format_dss_pathname_for_window(
+        "//OUTLET/FLOW//5Minute/RUN:TEST/",
+        datetime(2019, 9, 18, 13),
+        datetime(2019, 9, 22, 13),
+    )
+
+    assert pathname == (
+        "//OUTLET/FLOW/18SEP2019-22SEP2019/5Minute/RUN:TEST/"
+    )
 
 
 def test_prepare_workspace_is_non_destructive_by_default(tmp_path):
@@ -155,3 +251,259 @@ def test_prepare_workspace_is_non_destructive_by_default(tmp_path):
             datetime(2020, 1, 2),
             ras_exe_path=RAS_EXE,
         )
+
+
+@pytest.mark.skipif(not RAS_EXE.is_file(), reason="HEC-RAS 6.6 not installed")
+def test_validate_workspace_rejects_bare_relative_dss_reference(tmp_path):
+    source_project = _write_project(tmp_path / "source")
+    hydrology = tmp_path / "hms-output.dss"
+    hydrology.write_bytes(b"not-a-real-dss")
+    links = [
+        RasBoundaryLink(
+            mapping_id="tributary",
+            dss_path="//TRIBUTARY/FLOW/DATE/5MIN/RUN:FF_TEST/",
+            expected_bc_type="Lateral Inflow Hydrograph",
+            river="River",
+            reach="Reach",
+            station="1000",
+        ),
+        RasBoundaryLink(
+            mapping_id="junction",
+            dss_path="//JUNCTION/FLOW/DATE/5MIN/RUN:FF_TEST/",
+            expected_bc_type="Flow Hydrograph",
+            sa_2d_name="Area2D",
+            bc_line="Junction",
+        ),
+    ]
+    prepared = RasScenario.prepare_workspace(
+        source_project,
+        tmp_path / "workspace",
+        "scenario-001",
+        "01",
+        hydrology,
+        links,
+        datetime(2020, 1, 1),
+        datetime(2020, 1, 2),
+        ras_exe_path=RAS_EXE,
+    )
+    text = prepared.unsteady_file.read_text(encoding="utf-8")
+    prepared.unsteady_file.write_text(
+        text.replace(
+            r"DSS File=.\hydrology\hms-output.dss",
+            r"DSS File=hydrology\hms-output.dss",
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="all_dss_file_references_resolvable",
+    ):
+        RasScenario.validate_workspace(prepared, links)
+
+
+@pytest.mark.skipif(not RAS_EXE.is_file(), reason="HEC-RAS 6.6 not installed")
+def test_prepare_workspace_preserves_linked_asset_sibling_layout(tmp_path):
+    source_package = tmp_path / "source-package"
+    source_package.mkdir()
+    source_project = _write_project(source_package / "project")
+    terrain = source_package / "Terrain"
+    terrain.mkdir()
+    (terrain / "terrain.hdf").write_bytes(b"terrain")
+    hydrology = tmp_path / "hms-output.dss"
+    hydrology.write_bytes(b"dss")
+
+    prepared = RasScenario.prepare_workspace(
+        source_project,
+        tmp_path / "attempt" / "project",
+        "scenario",
+        "01",
+        hydrology,
+        [
+            RasBoundaryLink(
+                mapping_id="mapping",
+                dss_path="//A/FLOW/DATE/5MIN/RUN/",
+                expected_bc_type="Lateral Inflow Hydrograph",
+                river="River",
+                reach="Reach",
+                station="1000",
+            )
+        ],
+        datetime(2020, 1, 1),
+        datetime(2020, 1, 2),
+        ras_exe_path=RAS_EXE,
+        linked_asset_directories=[terrain],
+    )
+
+    assert prepared.project_folder == tmp_path / "attempt" / "project"
+    assert (
+        prepared.project_folder.parent / "Terrain" / "terrain.hdf"
+    ).read_bytes() == b"terrain"
+    assert (terrain / "terrain.hdf").read_bytes() == b"terrain"
+
+
+def test_execute_cancels_plan_after_timeout(monkeypatch, tmp_path):
+    project = tmp_path / "project"
+    project.mkdir()
+    workspace = RasScenarioWorkspace(
+        scenario_id="scenario",
+        source_project=project / "source.prj",
+        project_folder=project,
+        project_file=project / "Example.prj",
+        plan_number="02",
+        plan_file=project / "Example.p02",
+        unsteady_number="02",
+        unsteady_file=project / "Example.u02",
+        hydrology_source=tmp_path / "source.dss",
+        hydrology_file=project / "hydrology.dss",
+        result_hdf=project / "Example.p02.hdf",
+        boundary_mapping_ids=("mapping",),
+    )
+    project_object = object()
+    released = threading.Event()
+    calls = {}
+    scenario_module = importlib.import_module("ras_commander.RasScenario")
+
+    monkeypatch.setattr(
+        scenario_module,
+        "init_ras_project",
+        lambda *args, **kwargs: project_object,
+    )
+
+    def compute_plan(plan_number, **kwargs):
+        calls["compute"] = (plan_number, kwargs)
+        released.wait(timeout=1)
+        return False
+
+    def cancel_plan(plan_number, **kwargs):
+        calls["cancel"] = (plan_number, kwargs)
+        released.set()
+        return True
+
+    monkeypatch.setattr(
+        scenario_module.RasCmdr,
+        "compute_plan",
+        compute_plan,
+    )
+    monkeypatch.setattr(
+        scenario_module.RasCmdr,
+        "cancel_plan",
+        cancel_plan,
+    )
+
+    with pytest.raises(TimeoutError, match="cancellation requested=True"):
+        RasScenario.execute(
+            workspace,
+            ras_exe_path=RAS_EXE,
+            timeout=0.01,
+            num_cores=4,
+        )
+
+    assert calls["compute"] == (
+        "02",
+        {
+            "ras_object": project_object,
+            "num_cores": 4,
+            "verify": True,
+        },
+    )
+    assert calls["cancel"] == (
+        "02",
+        {"ras_object": project_object},
+    )
+
+
+def test_execute_requires_hdf_completion_and_matching_time_axis(
+    monkeypatch,
+    tmp_path,
+):
+    project = tmp_path / "project"
+    project.mkdir()
+    result_hdf = project / "Example.p02.hdf"
+    _write_result_hdf(result_hdf)
+    workspace = RasScenarioWorkspace(
+        scenario_id="scenario",
+        source_project=project / "source.prj",
+        project_folder=project,
+        project_file=project / "Example.prj",
+        plan_number="02",
+        plan_file=project / "Example.p02",
+        unsteady_number="02",
+        unsteady_file=project / "Example.u02",
+        hydrology_source=tmp_path / "source.dss",
+        hydrology_file=project / "hydrology.dss",
+        result_hdf=result_hdf,
+        boundary_mapping_ids=("mapping",),
+        simulation_start="2019-09-18T13:00:00-05:00",
+        simulation_end="2019-09-22T13:00:00-05:00",
+    )
+    scenario_module = importlib.import_module("ras_commander.RasScenario")
+    monkeypatch.setattr(
+        scenario_module,
+        "init_ras_project",
+        lambda *args, **kwargs: object(),
+    )
+    monkeypatch.setattr(
+        scenario_module.RasCmdr,
+        "compute_plan",
+        lambda *args, **kwargs: True,
+    )
+
+    artifact = RasScenario.execute(
+        workspace,
+        ras_exe_path=RAS_EXE,
+    )
+
+    assert artifact.status == "succeeded"
+    assert artifact.compute_returned_successfully
+    assert artifact.hdf_completed_successfully
+    assert artifact.time_window_matches
+    assert artifact.output_start == "2019-09-18T13:00:00"
+    assert artifact.output_end == "2019-09-22T13:00:00"
+    assert artifact.hdf_inspection_error is None
+
+
+def test_execute_fails_when_hdf_time_axis_does_not_match(
+    monkeypatch,
+    tmp_path,
+):
+    project = tmp_path / "project"
+    project.mkdir()
+    result_hdf = project / "Example.p02.hdf"
+    _write_result_hdf(result_hdf, end="22Sep2019 12:00:00.000")
+    workspace = RasScenarioWorkspace(
+        scenario_id="scenario",
+        source_project=project / "source.prj",
+        project_folder=project,
+        project_file=project / "Example.prj",
+        plan_number="02",
+        plan_file=project / "Example.p02",
+        unsteady_number="02",
+        unsteady_file=project / "Example.u02",
+        hydrology_source=tmp_path / "source.dss",
+        hydrology_file=project / "hydrology.dss",
+        result_hdf=result_hdf,
+        boundary_mapping_ids=("mapping",),
+        simulation_start="2019-09-18T13:00:00",
+        simulation_end="2019-09-22T13:00:00",
+    )
+    scenario_module = importlib.import_module("ras_commander.RasScenario")
+    monkeypatch.setattr(
+        scenario_module,
+        "init_ras_project",
+        lambda *args, **kwargs: object(),
+    )
+    monkeypatch.setattr(
+        scenario_module.RasCmdr,
+        "compute_plan",
+        lambda *args, **kwargs: True,
+    )
+
+    artifact = RasScenario.execute(
+        workspace,
+        ras_exe_path=RAS_EXE,
+    )
+
+    assert artifact.status == "failed"
+    assert artifact.hdf_completed_successfully
+    assert not artifact.time_window_matches

--- a/tests/test_ras_scenario.py
+++ b/tests/test_ras_scenario.py
@@ -1,6 +1,7 @@
 """Tests for isolated HMS-to-RAS scenario workspaces."""
 
 import importlib
+import stat
 import threading
 from datetime import datetime
 from pathlib import Path
@@ -32,8 +33,7 @@ def _write_result_hdf(
             b"True" if completed else b"False"
         )
         timestamps = hdf_file.create_group(
-            "Results/Unsteady/Output/Output Blocks/Base Output/"
-            "Unsteady Time Series"
+            "Results/Unsteady/Output/Output Blocks/Base Output/" "Unsteady Time Series"
         )
         timestamps.create_dataset(
             "Time Date Stamp (ms)",
@@ -149,25 +149,84 @@ def test_prepare_workspace_clones_plan_and_links_boundaries(tmp_path):
     unsteady_text = prepared.unsteady_file.read_text(encoding="utf-8")
     assert prepared.plan_number == "02"
     assert prepared.unsteady_number == "02"
-    assert "Current Plan=p02" in prepared.project_file.read_text(
-        encoding="utf-8"
-    )
+    assert "Current Plan=p02" in prepared.project_file.read_text(encoding="utf-8")
     assert "Flow File=u02" in plan_text
     assert "Simulation Date=01JAN2020,0000,02JAN2020,0000" in plan_text
     assert unsteady_text.count("DSS File=.\\hydrology\\hms-output.dss") == 2
     assert (
-        "DSS Path=//TRIBUTARY/FLOW/01JAN2020-02JAN2020/5MIN/"
-        "RUN:FF_TEST/"
+        "DSS Path=//TRIBUTARY/FLOW/01JAN2020-02JAN2020/5MIN/" "RUN:FF_TEST/"
     ) in unsteady_text
     assert (
-        "DSS Path=//JUNCTION/FLOW/01JAN2020-02JAN2020/5MIN/"
-        "RUN:FF_TEST/"
+        "DSS Path=//JUNCTION/FLOW/01JAN2020-02JAN2020/5MIN/" "RUN:FF_TEST/"
     ) in unsteady_text
+    assert "//MISSING/FLOW/DATE/1HOUR/RUN:BASE/" not in unsteady_text
+    assert prepared.inactive_inherited_boundaries == (
+        {
+            "mapping_id": "inherited-boundary-002",
+            "boundary_index": 2,
+            "boundary_name": "Missing Storage",
+            "bc_type": "Flow Hydrograph",
+            "dss_file": "baseline.dss",
+            "dss_path": "//MISSING/FLOW/DATE/1HOUR/RUN:BASE/",
+            "river": None,
+            "reach": None,
+            "station": None,
+            "sa_2d_name": "SA_NotInGeometry",
+            "bc_line": None,
+            "geometry_crosswalk": False,
+            "disposition": "removed_from_clone_inactive_in_active_geometry",
+            "lines_removed": 7,
+        },
+    )
     assert {
         path.name: path.read_bytes()
         for path in source_project.parent.iterdir()
         if path.is_file()
     } == original
+
+
+@pytest.mark.skipif(not RAS_EXE.is_file(), reason="HEC-RAS 6.6 not installed")
+def test_prepare_workspace_stages_and_validates_forcing_excess(tmp_path):
+    source_project = _write_project(tmp_path / "source")
+    hydrology = tmp_path / "hms-output.dss"
+    hydrology.write_bytes(b"hydrology")
+    excess = tmp_path / "ras-excess.dss"
+    excess.write_bytes(b"excess")
+    link = RasBoundaryLink(
+        mapping_id="tributary",
+        dss_path="//TRIBUTARY/FLOW//5MIN/RUN:FF_TEST/",
+        expected_bc_type="Lateral Inflow Hydrograph",
+        river="River",
+        reach="Reach",
+        station="1000",
+    )
+
+    prepared = RasScenario.prepare_workspace(
+        source_project,
+        tmp_path / "workspace",
+        "scenario-001",
+        "01",
+        hydrology,
+        [link],
+        datetime(2020, 1, 1),
+        datetime(2020, 1, 2),
+        ras_exe_path=RAS_EXE,
+        forcing_excess_dss=excess,
+        forcing_excess_pathname="/SHG/BASIN/PRECIPITATION///EXCESS/",
+        forcing_excess_interpolation="Nearest",
+    )
+
+    assert prepared.forcing_excess_file is not None
+    assert prepared.forcing_excess_file.read_bytes() == b"excess"
+    checks = RasScenario.validate_workspace(prepared, [link])
+    evidence = RasScenario.inspect_workspace_evidence(prepared, [link])
+    assert checks["forcing_excess_link_matches"] is True
+    assert checks["one_newline_convention"] is True
+    assert evidence["forcing_excess"]["dss_pathname"] == (
+        "/SHG/BASIN/PRECIPITATION///EXCESS/"
+    )
+    assert evidence["forcing_excess"]["interpolation"] == "Nearest"
+    assert evidence["geometry_crosswalk"] == {"tributary": True}
 
 
 @pytest.mark.skipif(not RAS_EXE.is_file(), reason="HEC-RAS 6.6 not installed")
@@ -179,7 +238,7 @@ def test_validate_workspace_rejects_inactive_geometry_boundary(tmp_path):
     with pytest.raises(
         ValueError,
         match="all_boundaries_exist_in_active_geometry",
-    ):
+    ) as error:
         RasScenario.prepare_workspace(
             source_project,
             tmp_path / "workspace",
@@ -198,6 +257,7 @@ def test_validate_workspace_rejects_inactive_geometry_boundary(tmp_path):
             datetime(2020, 1, 2),
             ras_exe_path=RAS_EXE,
         )
+    assert "inactive mappings: missing-storage" in str(error.value)
 
 
 def test_boundary_link_rejects_mixed_selector_groups():
@@ -218,9 +278,7 @@ def test_format_dss_pathname_for_window_materializes_blank_d_part():
         datetime(2019, 9, 22, 13),
     )
 
-    assert pathname == (
-        "//OUTLET/FLOW/18SEP2019-22SEP2019/5Minute/RUN:TEST/"
-    )
+    assert pathname == ("//OUTLET/FLOW/18SEP2019-22SEP2019/5Minute/RUN:TEST/")
 
 
 def test_prepare_workspace_is_non_destructive_by_default(tmp_path):
@@ -507,3 +565,98 @@ def test_execute_fails_when_hdf_time_axis_does_not_match(
     assert artifact.status == "failed"
     assert artifact.hdf_completed_successfully
     assert not artifact.time_window_matches
+
+
+def test_linked_asset_cache_adopts_existing_copy_and_reuses_it(tmp_path, monkeypatch):
+    source = tmp_path / "source" / "Terrain"
+    source.mkdir(parents=True)
+    (source / "terrain.hdf").write_bytes(b"immutable terrain")
+    cache_root = tmp_path / "cache"
+    cached = cache_root / "Terrain"
+    cached.mkdir(parents=True)
+    (cached / "terrain.hdf").write_bytes(b"immutable terrain")
+    cache_key = "a" * 64
+
+    adopted = RasScenario._prepare_linked_asset_cache(
+        cache_root, (source.resolve(),), cache_key
+    )
+
+    assert adopted["status"] == "adopted"
+    assert adopted["size_bytes"] == len(b"immutable terrain")
+    manifest = cache_root / RasScenario.LINKED_ASSET_CACHE_MANIFEST
+    assert manifest.is_file()
+
+    scenario_module = importlib.import_module("ras_commander.RasScenario")
+    monkeypatch.setattr(
+        scenario_module.shutil,
+        "copytree",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("cache reuse must not copy linked assets")
+        ),
+    )
+    reused = RasScenario._prepare_linked_asset_cache(
+        cache_root, (source.resolve(),), cache_key
+    )
+
+    assert reused["status"] == "reused"
+    assert reused["manifest"] == str(manifest)
+
+
+def test_linked_asset_cache_refuses_cached_file_drift(tmp_path):
+    source = tmp_path / "source" / "Terrain"
+    source.mkdir(parents=True)
+    (source / "terrain.hdf").write_bytes(b"immutable terrain")
+    cache_root = tmp_path / "cache"
+    RasScenario._prepare_linked_asset_cache(cache_root, (source.resolve(),), "b" * 64)
+    cached_file = cache_root / "Terrain" / "terrain.hdf"
+    cached_file.chmod(stat.S_IREAD | stat.S_IWRITE)
+    cached_file.write_bytes(b"tampered terrain")
+
+    with pytest.raises(ValueError, match="cache copy Terrain metadata drifted"):
+        RasScenario._prepare_linked_asset_cache(
+            cache_root, (source.resolve(),), "b" * 64
+        )
+
+
+def test_scenario_clone_excludes_generated_outputs_but_keeps_geometry_hdf(tmp_path):
+    source = tmp_path / "Model"
+    nested = source / "Maps"
+    nested.mkdir(parents=True)
+    files = {
+        source / "Model.dss": 10,
+        source / "Model.p01.hdf": 20,
+        source / "Model.p02.tmp.hdf": 30,
+        nested / "PostProcessing.hdf": 40,
+        source / "Model.g01.hdf": 50,
+        source / "Model.prj": 60,
+    }
+    for path, size in files.items():
+        path.write_bytes(b"x" * size)
+
+    exclusions = RasScenario._scenario_output_exclusions(source, "Model")
+    root_ignored = RasScenario._scenario_copy_ignore("Model")(
+        str(source), [path.name for path in source.iterdir()]
+    )
+    nested_ignored = RasScenario._scenario_copy_ignore("Model")(
+        str(nested), [path.name for path in nested.iterdir()]
+    )
+
+    assert exclusions["file_count"] == 4
+    assert exclusions["size_bytes"] == 100
+    assert "Model.dss" in root_ignored
+    assert "Model.p01.hdf" in root_ignored
+    assert "Model.p02.tmp.hdf" in root_ignored
+    assert "PostProcessing.hdf" in nested_ignored
+    assert "Model.g01.hdf" not in root_ignored
+    assert "Model.prj" not in root_ignored
+
+
+def test_newline_inspection_ignores_generated_compute_artifacts(tmp_path):
+    project_file = _write_project(tmp_path / "source")
+    compute_artifact = project_file.parent / "Example.c04"
+    compute_artifact.write_bytes(b"generated\r\ncompute\nartifact\x00")
+
+    evidence = RasScenario.inspect_newlines(project_file.parent)
+
+    assert evidence["consistent"] is True
+    assert str(compute_artifact) not in evidence["files"]

--- a/tests/test_ras_text_mutation_safety.py
+++ b/tests/test_ras_text_mutation_safety.py
@@ -1,0 +1,98 @@
+"""Regression tests for HEC-RAS project text mutation safety."""
+
+from datetime import datetime
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from ras_commander import RasPlan, RasPrj
+from ras_commander.RasUtils import RasUtils
+
+
+def _has_crlf_only(path: Path) -> bool:
+    content = path.read_bytes()
+    return b"\r\n" in content and b"\n" not in content.replace(b"\r\n", b"")
+
+
+def test_set_current_plan_preserves_crlf(tmp_path):
+    project_file = tmp_path / "Example.prj"
+    project_file.write_bytes(
+        b"Proj Title=Example\r\nCurrent Plan=p01\r\nPlan File=p01\r\n"
+        b"Plan File=p02\r\n"
+    )
+    project = RasPrj()
+    project.prj_file = project_file
+    project.plan_df = pd.DataFrame({"plan_number": ["01", "02"]})
+    project.check_initialized = lambda: None
+
+    project.set_current_plan("02")
+
+    assert _has_crlf_only(project_file)
+    assert b"Current Plan=p02\r\n" in project_file.read_bytes()
+
+
+@pytest.mark.parametrize(
+    ("source_time", "expected_time"),
+    [
+        (
+            "01JAN2020,0000,02JAN2020,0000",
+            "18SEP2019,1300,22SEP2019,1300",
+        ),
+        (
+            "01JAN2020,00:00,02JAN2020,00:00",
+            "18SEP2019,13:00,22SEP2019,13:00",
+        ),
+    ],
+)
+def test_update_simulation_date_preserves_crlf_and_time_style(
+    tmp_path, source_time, expected_time
+):
+    plan_file = tmp_path / "Example.p01"
+    plan_file.write_bytes(
+        (
+            "Plan Title=Example\r\n"
+            f"Simulation Date={source_time}\r\n"
+            "Geom File=g01\r\n"
+        ).encode("utf-8")
+    )
+
+    RasPlan.update_simulation_date(
+        plan_file,
+        datetime(2019, 9, 18, 13),
+        datetime(2019, 9, 22, 13),
+    )
+
+    assert _has_crlf_only(plan_file)
+    assert (
+        f"Simulation Date={expected_time}\r\n".encode("utf-8")
+        in plan_file.read_bytes()
+    )
+
+
+def test_mutators_reject_mixed_newlines(tmp_path):
+    project_file = tmp_path / "mixed.prj"
+    project_file.write_bytes(
+        b"Proj Title=Example\r\nCurrent Plan=p01\nPlan File=p01\r\n"
+    )
+    project = RasPrj()
+    project.prj_file = project_file
+    project.plan_df = pd.DataFrame({"plan_number": ["01"]})
+    project.check_initialized = lambda: None
+
+    with pytest.raises(ValueError, match="Mixed newline conventions"):
+        project.set_current_plan("01")
+
+
+def test_update_file_preserves_lf_for_linux_projects(tmp_path):
+    text_file = tmp_path / "Example.p01"
+    text_file.write_text("Plan Title=Old\nGeom File=g01\n", newline="\n")
+
+    def update(lines):
+        lines[0] = "Plan Title=New\n"
+        return lines
+
+    RasUtils.update_file(text_file, update)
+
+    assert b"\r\n" not in text_file.read_bytes()
+    assert text_file.read_bytes() == b"Plan Title=New\nGeom File=g01\n"

--- a/tests/test_ras_text_mutation_safety.py
+++ b/tests/test_ras_text_mutation_safety.py
@@ -6,7 +6,7 @@ from pathlib import Path
 import pandas as pd
 import pytest
 
-from ras_commander import RasPlan, RasPrj
+from ras_commander import RasPlan, RasPrj, RasUnsteady
 from ras_commander.RasUtils import RasUtils
 
 
@@ -65,8 +65,7 @@ def test_update_simulation_date_preserves_crlf_and_time_style(
 
     assert _has_crlf_only(plan_file)
     assert (
-        f"Simulation Date={expected_time}\r\n".encode("utf-8")
-        in plan_file.read_bytes()
+        f"Simulation Date={expected_time}\r\n".encode("utf-8") in plan_file.read_bytes()
     )
 
 
@@ -82,6 +81,23 @@ def test_mutators_reject_mixed_newlines(tmp_path):
 
     with pytest.raises(ValueError, match="Mixed newline conventions"):
         project.set_current_plan("01")
+
+
+def test_gridded_precipitation_mutator_rejects_mixed_newlines(tmp_path):
+    unsteady_file = tmp_path / "mixed.u01"
+    unsteady_file.write_bytes(
+        b"Flow Title=Example\r\nPrecipitation Mode=Disable\n"
+        b"Met Point Raster Parameters=,,,,\r\n"
+    )
+
+    with pytest.raises(ValueError, match="Mixed newline conventions"):
+        RasUnsteady.set_met_precipitation_mode(
+            unsteady_file,
+            "Gridded",
+            source="DSS",
+            dss_filename="excess.dss",
+            dss_pathname="/SHG/BASIN/PRECIPITATION///EXCESS/",
+        )
 
 
 def test_update_file_preserves_lf_for_linux_projects(tmp_path):

--- a/tests/test_rasdss_grid_write.py
+++ b/tests/test_rasdss_grid_write.py
@@ -1,7 +1,10 @@
 """Integration tests for HEC-DSS grid writing through RasDss."""
 
 from datetime import datetime
+import hashlib
 from pathlib import Path
+import subprocess
+import sys
 
 import numpy as np
 import pandas as pd
@@ -186,3 +189,319 @@ def test_parse_grid_dss_datetime_normalizes_2400():
     assert RasDss._parse_grid_dss_datetime("31DEC2022:2400") == pd.Timestamp(
         "2023-01-01 00:00"
     )
+
+
+def test_datetimes_to_hec_times_returns_int32_minutes():
+    RasDss = _configure_dss_or_skip()
+    times = pd.DatetimeIndex(
+        ["1899-12-31 00:00", "1900-01-01 00:00", "2019-09-18 13:00"]
+    )
+
+    result = RasDss._datetimes_to_hec_times(times)
+
+    assert result.dtype == np.int32
+    assert result.tolist() == [0, 1440, 62964780]
+
+
+def test_write_timeseries_round_trips_modern_dates(tmp_path):
+    RasDss = _configure_dss_or_skip()
+    dss_file = tmp_path / "modern-timeseries.dss"
+    pathname = "/BASIN/UPSTREAM/FLOW//1HOUR/QUALIFICATION/"
+    times = pd.date_range("2019-09-18 13:00", periods=4, freq="h")
+    values = np.array(
+        [52700.41850796765, 52752.45784599134, 52802.061108445996, 52849.18364664102]
+    )
+
+    RasDss.write_timeseries(
+        dss_file,
+        pathname,
+        times,
+        values,
+        units="CFS",
+        data_type="INST-VAL",
+    )
+    reread = RasDss.read_timeseries(dss_file, pathname)
+
+    assert reread.index.equals(times.rename("datetime"))
+    np.testing.assert_array_equal(reread["value"].to_numpy(), values)
+    assert reread.attrs["units"] == "CFS"
+    assert reread.attrs["type"] == "INST-VAL"
+
+
+def test_copy_grid_with_zero_tail_preserves_source_and_nodata(tmp_path):
+    RasDss = _configure_dss_or_skip()
+
+    source = tmp_path / "source.dss"
+    output = tmp_path / "padded.dss"
+    pathname = "/SHG/TEST/PRECIPITATION///AORC-TRANSPOSED/"
+    fixture_script = """
+from datetime import datetime
+from pathlib import Path
+import numpy as np
+from ras_commander import RasDss
+
+RasDss.write_grid_timeseries(
+    dss_file=Path(__import__("sys").argv[1]),
+    pathname="/SHG/TEST/PRECIPITATION///AORC-TRANSPOSED/",
+    data=np.array(
+        [
+            [[1.0, np.nan], [2.0, 3.0]],
+            [[4.0, np.nan], [5.0, 6.0]],
+        ],
+        dtype=np.float32,
+    ),
+    times=[
+        datetime(2020, 1, 1, 0),
+        datetime(2020, 1, 1, 1),
+        datetime(2020, 1, 1, 2),
+    ],
+    grid_info={
+        "cellsize": 1000,
+        "origin": (259000, 1024000),
+        "crs": "SHG",
+        "units": "MM",
+        "data_type": "PER-CUM",
+    },
+)
+"""
+    completed = subprocess.run(
+        [sys.executable, "-c", fixture_script, str(source)],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert completed.returncode == 0, completed.stderr
+    source_sha256 = hashlib.sha256(source.read_bytes()).hexdigest()
+    original_paths = [
+        "/SHG/TEST/PRECIPITATION/01JAN2020:0000/01JAN2020:0100/AORC-TRANSPOSED/",
+        "/SHG/TEST/PRECIPITATION/01JAN2020:0100/01JAN2020:0200/AORC-TRANSPOSED/",
+    ]
+
+    result = RasDss.copy_grid_with_zero_tail(
+        source,
+        output,
+        pathname,
+        tail_intervals=3,
+    )
+
+    assert hashlib.sha256(source.read_bytes()).hexdigest() == source_sha256
+    assert result["source_record_count"] == 2
+    assert result["appended_record_count"] == 3
+    assert result["interval_minutes"] == 60
+    assert result["time_shift_minutes"] == 0
+    assert result["source_start"] == "2020-01-01T00:00:00"
+    assert result["source_end"] == "2020-01-01T02:00:00"
+    assert result["output_start"] == "2020-01-01T00:00:00"
+    assert result["output_source_end"] == "2020-01-01T02:00:00"
+    assert result["padded_end"] == "2020-01-01T05:00:00"
+    assert result["shifted_pathnames"] == []
+
+    output_paths = RasDss.get_catalog(output)["pathname"].tolist()
+    assert sorted(output_paths) == sorted(
+        original_paths + result["appended_pathnames"]
+    )
+    first_tail = RasDss.read_grid(output, result["appended_pathnames"][0])
+    np.testing.assert_allclose(
+        first_tail["data"],
+        np.array([[0.0, np.nan], [0.0, 0.0]], dtype=np.float32),
+        equal_nan=True,
+    )
+    assert first_tail["units"] == "MM"
+    assert first_tail["data_type"] == "PER-CUM"
+    assert first_tail["cell_size"] == 1000.0
+
+
+def test_copy_grid_with_zero_tail_shifts_pathname_windows(tmp_path):
+    RasDss = _configure_dss_or_skip()
+
+    source = tmp_path / "source.dss"
+    output = tmp_path / "shifted.dss"
+    fixture_script = """
+from datetime import datetime
+from pathlib import Path
+import numpy as np
+from ras_commander import RasDss
+
+RasDss.write_grid_timeseries(
+    dss_file=Path(__import__("sys").argv[1]),
+    pathname="/SHG/TEST/PRECIPITATION///AORC-TRANSPOSED/",
+    data=np.array(
+        [
+            [[1.0, np.nan], [2.0, 3.0]],
+            [[4.0, np.nan], [5.0, 6.0]],
+        ],
+        dtype=np.float32,
+    ),
+    times=[
+        datetime(2020, 1, 1, 0),
+        datetime(2020, 1, 1, 1),
+        datetime(2020, 1, 1, 2),
+    ],
+    grid_info={
+        "cellsize": 1000,
+        "origin": (259000, 1024000),
+        "crs": "SHG",
+        "units": "MM",
+        "data_type": "PER-CUM",
+    },
+)
+"""
+    completed = subprocess.run(
+        [sys.executable, "-c", fixture_script, str(source)],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert completed.returncode == 0, completed.stderr
+    source_sha256 = hashlib.sha256(source.read_bytes()).hexdigest()
+
+    transform_script = """
+from pathlib import Path
+from ras_commander import RasDss
+
+RasDss.copy_grid_with_zero_tail(
+    Path(__import__("sys").argv[1]),
+    Path(__import__("sys").argv[2]),
+    "/SHG/TEST/PRECIPITATION///AORC-TRANSPOSED/",
+    tail_intervals=1,
+    time_shift_minutes=-300,
+)
+"""
+    completed = subprocess.run(
+        [sys.executable, "-c", transform_script, str(source), str(output)],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert completed.returncode == 0, completed.stderr
+    assert hashlib.sha256(source.read_bytes()).hexdigest() == source_sha256
+
+    output_paths = sorted(RasDss.get_catalog(output)["pathname"].tolist())
+    assert output_paths == [
+        "/SHG/TEST/PRECIPITATION/31DEC2019:1900/31DEC2019:2000/AORC-TRANSPOSED/",
+        "/SHG/TEST/PRECIPITATION/31DEC2019:2000/31DEC2019:2100/AORC-TRANSPOSED/",
+        "/SHG/TEST/PRECIPITATION/31DEC2019:2100/31DEC2019:2200/AORC-TRANSPOSED/",
+    ]
+    shifted_first = RasDss.read_grid(output, output_paths[0])
+    shifted_tail = RasDss.read_grid(output, output_paths[-1])
+    np.testing.assert_allclose(
+        shifted_first["data"],
+        np.array([[1.0, np.nan], [2.0, 3.0]], dtype=np.float32),
+        equal_nan=True,
+    )
+    np.testing.assert_allclose(
+        shifted_tail["data"],
+        np.array([[0.0, np.nan], [0.0, 0.0]], dtype=np.float32),
+        equal_nan=True,
+    )
+
+
+def test_copy_grid_with_zero_tail_translates_grid_without_resampling(tmp_path):
+    RasDss = _configure_dss_or_skip()
+
+    source = tmp_path / "source.dss"
+    output = tmp_path / "translated.dss"
+    fixture_script = """
+from datetime import datetime
+from pathlib import Path
+import numpy as np
+from ras_commander import RasDss
+
+RasDss.write_grid_timeseries(
+    dss_file=Path(__import__("sys").argv[1]),
+    pathname="/SHG/TEST/PRECIPITATION///AORC/",
+    data=np.array(
+        [
+            [[1.0, np.nan], [2.0, 3.0]],
+            [[4.0, np.nan], [5.0, 6.0]],
+        ],
+        dtype=np.float32,
+    ),
+    times=[
+        datetime(2020, 1, 1, 0),
+        datetime(2020, 1, 1, 1),
+        datetime(2020, 1, 1, 2),
+    ],
+    grid_info={
+        "cellsize": 1000,
+        "origin": (259000, 1024000),
+        "crs": "SHG",
+        "units": "MM",
+        "data_type": "PER-CUM",
+    },
+)
+"""
+    completed = subprocess.run(
+        [sys.executable, "-c", fixture_script, str(source)],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert completed.returncode == 0, completed.stderr
+    source_sha256 = hashlib.sha256(source.read_bytes()).hexdigest()
+
+    transform_script = """
+from pathlib import Path
+from ras_commander import RasDss
+
+result = RasDss.copy_grid_with_zero_tail(
+    Path(__import__("sys").argv[1]),
+    Path(__import__("sys").argv[2]),
+    "/SHG/TEST/PRECIPITATION///AORC/",
+    tail_intervals=1,
+    time_shift_minutes=-300,
+    output_pathname="/SHG/TEST/PRECIPITATION///AORC-TRANSPOSED/",
+    x_shift=2000,
+    y_shift=3000,
+)
+assert result["output_lower_left_cell"] == (261, 1027)
+"""
+    completed = subprocess.run(
+        [sys.executable, "-c", transform_script, str(source), str(output)],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert completed.returncode == 0, completed.stderr
+    assert hashlib.sha256(source.read_bytes()).hexdigest() == source_sha256
+
+    output_paths = sorted(RasDss.get_catalog(output)["pathname"].tolist())
+    assert output_paths == [
+        "/SHG/TEST/PRECIPITATION/31DEC2019:1900/31DEC2019:2000/AORC-TRANSPOSED/",
+        "/SHG/TEST/PRECIPITATION/31DEC2019:2000/31DEC2019:2100/AORC-TRANSPOSED/",
+        "/SHG/TEST/PRECIPITATION/31DEC2019:2100/31DEC2019:2200/AORC-TRANSPOSED/",
+    ]
+    translated = RasDss.read_grid(output, output_paths[0])
+    np.testing.assert_allclose(
+        translated["data"],
+        np.array([[1.0, np.nan], [2.0, 3.0]], dtype=np.float32),
+        equal_nan=True,
+    )
+    assert translated["metadata"]["lower_left_cell"] == (261, 1027)
+    assert translated["metadata"]["origin"] == (261000.0, 1027000.0)
+
+
+def test_copy_grid_with_zero_tail_refuses_unsafe_targets(tmp_path):
+    RasDss = _configure_dss_or_skip()
+
+    source = tmp_path / "source.dss"
+    source.write_bytes(b"placeholder")
+
+    with pytest.raises(ValueError, match="must differ"):
+        RasDss.copy_grid_with_zero_tail(
+            source,
+            source,
+            "/SHG/TEST/PRECIPITATION///TEST/",
+            1,
+        )
+
+    existing = tmp_path / "existing.dss"
+    existing.write_bytes(b"do not replace")
+    with pytest.raises(FileExistsError, match="already exists"):
+        RasDss.copy_grid_with_zero_tail(
+            source,
+            existing,
+            "/SHG/TEST/PRECIPITATION///TEST/",
+            1,
+        )
+    assert existing.read_bytes() == b"do not replace"

--- a/tests/test_rasdss_version_creation.py
+++ b/tests/test_rasdss_version_creation.py
@@ -1,0 +1,52 @@
+"""HEC-DSS major-version creation coverage."""
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from ras_commander import RasDss
+
+
+def _configure_dss_or_skip():
+    try:
+        RasDss._configure_jvm()
+    except Exception as exc:
+        pytest.skip(f"HEC-DSS Java bridge unavailable: {exc}")
+    return RasDss
+
+
+def test_write_timeseries_can_create_version_6_file(tmp_path):
+    dss = _configure_dss_or_skip()
+    output = tmp_path / "boundary-v6.dss"
+    pathname = "/BASIN/UPSTREAM/FLOW//5MIN/QUALIFICATION/"
+    times = pd.date_range("2019-09-18 13:00", periods=5, freq="5min")
+    values = np.array([100.0, 110.0, 125.0, 120.0, 115.0])
+
+    dss.write_timeseries(
+        output,
+        pathname,
+        times,
+        values,
+        units="CFS",
+        data_type="INST-VAL",
+        dss_version=6,
+    )
+
+    assert dss.get_file_version(output) == 6
+    reread = dss.read_timeseries(output, pathname)
+    assert reread.index.equals(times.rename("datetime"))
+    np.testing.assert_array_equal(reread["value"].to_numpy(), values)
+
+
+@pytest.mark.parametrize("version", [0, 5, 8])
+def test_write_timeseries_rejects_unsupported_version(tmp_path, version):
+    dss = _configure_dss_or_skip()
+
+    with pytest.raises(ValueError, match="dss_version"):
+        dss.write_timeseries(
+            tmp_path / "invalid.dss",
+            "/BASIN/UPSTREAM/FLOW//5MIN/QUALIFICATION/",
+            pd.date_range("2019-09-18", periods=2, freq="5min"),
+            [1.0, 2.0],
+            dss_version=version,
+        )

--- a/tests/test_rasunsteady_dss_link_selectors.py
+++ b/tests/test_rasunsteady_dss_link_selectors.py
@@ -75,9 +75,9 @@ def test_set_boundary_dss_link_preserves_legacy_1d_selector(tmp_path):
     )
 
     assert changed is True
-    assert "DSS Path=//S_OUACHIRI_2/FLOW/DATE/5MIN/RUN:FF_TEST/" in (
-        unsteady.read_text(encoding="utf-8")
-    )
+    content = unsteady.read_text(encoding="utf-8")
+    assert "DSS Path=//S_OUACHIRI_2/FLOW/DATE/5MIN/RUN:FF_TEST/" in content
+    assert r"DSS File=.\scenario.dss" in content
 
 
 def test_set_boundary_dss_link_rejects_ambiguous_partial_2d_selector(tmp_path):

--- a/tests/test_rasunsteady_dss_link_selectors.py
+++ b/tests/test_rasunsteady_dss_link_selectors.py
@@ -1,0 +1,129 @@
+"""Exact boundary selector coverage for HMS-to-RAS DSS links."""
+
+from pathlib import Path
+
+import pytest
+
+from ras_commander import RasUnsteady
+
+
+def _write_unsteady(path: Path) -> Path:
+    path.write_text(
+        """Flow Title=Selector Test
+Boundary Location=OuachitaRv      ,10.6            ,91744   ,        ,                ,                ,                ,                                ,
+Boundary Name=S_OuachiRi_2
+Interval=1HOUR
+Lateral Inflow Hydrograph= 0
+DSS File=old.dss
+DSS Path=//OLD/FLOW/DATE/1HOUR/RUN:OLD/
+Use DSS=True
+Boundary Location=                ,                ,        ,        ,                ,OuaRiW2         ,                ,J_ByDeLout_2                    ,
+Boundary Name=J_ByDeLout_2
+Interval=1HOUR
+Flow Hydrograph= 0
+DSS File=old.dss
+DSS Path=//OLD_JUNCTION/FLOW/DATE/1HOUR/RUN:OLD/
+Use DSS=True
+Boundary Location=                ,                ,        ,        ,                ,OuaRiW2         ,                ,Other                           ,
+Boundary Name=Other
+Flow Hydrograph= 0
+DSS File=other.dss
+DSS Path=//OTHER/FLOW/DATE/1HOUR/RUN:OLD/
+Use DSS=True
+Met Point Raster Parameters=,,,,
+""",
+        encoding="utf-8",
+    )
+    return path
+
+
+def test_set_boundary_dss_link_selects_2d_bc_line_exactly(tmp_path):
+    unsteady = _write_unsteady(tmp_path / "project.u01")
+    dss_path = "//J_BYDELOUT_2/FLOW/18SEP2019-20SEP2019/5MIN/RUN:FF_TEST/"
+
+    changed = RasUnsteady.set_boundary_dss_link(
+        unsteady,
+        river=None,
+        reach=None,
+        station=None,
+        dss_file=r".\hydrology\scenario.dss",
+        dss_path=dss_path,
+        interval="5MIN",
+        sa_2d_name="OuaRiW2",
+        bc_line="J_ByDeLout_2",
+        expected_bc_type="Flow Hydrograph",
+    )
+
+    content = unsteady.read_text(encoding="utf-8")
+    assert changed is True
+    assert f"DSS Path={dss_path}" in content
+    assert r"DSS File=.\hydrology\scenario.dss" in content
+    assert "DSS Path=//OTHER/FLOW/DATE/1HOUR/RUN:OLD/" in content
+
+
+def test_set_boundary_dss_link_preserves_legacy_1d_selector(tmp_path):
+    unsteady = _write_unsteady(tmp_path / "project.u01")
+
+    changed = RasUnsteady.set_boundary_dss_link(
+        unsteady,
+        river="OuachitaRv",
+        reach="10.6",
+        station="91744",
+        dss_file="scenario.dss",
+        dss_path="//S_OUACHIRI_2/FLOW/DATE/5MIN/RUN:FF_TEST/",
+        expected_bc_type="Lateral Inflow Hydrograph",
+    )
+
+    assert changed is True
+    assert "DSS Path=//S_OUACHIRI_2/FLOW/DATE/5MIN/RUN:FF_TEST/" in (
+        unsteady.read_text(encoding="utf-8")
+    )
+
+
+def test_set_boundary_dss_link_rejects_ambiguous_partial_2d_selector(tmp_path):
+    unsteady = _write_unsteady(tmp_path / "project.u01")
+
+    with pytest.raises(ValueError, match="ambiguous"):
+        RasUnsteady.set_boundary_dss_link(
+            unsteady,
+            river=None,
+            reach=None,
+            station=None,
+            dss_file="scenario.dss",
+            dss_path="//J/FLOW/DATE/5MIN/RUN/",
+            sa_2d_name="OuaRiW2",
+        )
+
+
+def test_set_boundary_dss_link_checks_boundary_type_before_write(tmp_path):
+    unsteady = _write_unsteady(tmp_path / "project.u01")
+    original = unsteady.read_text(encoding="utf-8")
+
+    with pytest.raises(ValueError, match="expected 'Flow Hydrograph'"):
+        RasUnsteady.set_boundary_dss_link(
+            unsteady,
+            river="OuachitaRv",
+            reach="10.6",
+            station="91744",
+            dss_file="scenario.dss",
+            dss_path="//S/FLOW/DATE/5MIN/RUN/",
+            expected_bc_type="Flow Hydrograph",
+        )
+
+    assert unsteady.read_text(encoding="utf-8") == original
+
+
+def test_get_dss_boundaries_retains_exact_2d_selectors_and_name(tmp_path):
+    unsteady = _write_unsteady(tmp_path / "project.u01")
+
+    boundaries = RasUnsteady.get_dss_boundaries(unsteady)
+    junction = boundaries[boundaries["bc_line"] == "J_ByDeLout_2"].iloc[0]
+
+    assert junction["dss_part_a"] == ""
+    assert junction["dss_part_b"] == "OLD_JUNCTION"
+    assert junction["dss_part_c"] == "FLOW"
+    assert junction["sa_2d_name"] == "OuaRiW2"
+    assert junction["bc_line"] == "J_ByDeLout_2"
+    assert junction["boundary_name"] == "J_ByDeLout_2"
+    assert junction["bc_type"] == "Flow Hydrograph"
+    assert junction["boundary_index"] == 1

--- a/tests/test_scenario_worker.py
+++ b/tests/test_scenario_worker.py
@@ -1,0 +1,697 @@
+"""Contract tests for the package-owned RAS scenario worker."""
+
+import hashlib
+import importlib
+import importlib.resources
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from ras_commander import (
+    HdfResultsProducts,
+    RasRunArtifact,
+    RasScenarioWorker,
+    RasScenarioWorkspace,
+)
+
+
+def _sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _request(tmp_path: Path):
+    source = tmp_path / "source"
+    source.mkdir()
+    project = source / "Model.prj"
+    project.write_text("Proj Title=Test\nCurrent Plan=p01\n", encoding="utf-8")
+    model_manifest = tmp_path / "ras-model.json"
+    model_manifest.write_text(
+        json.dumps({"schema_version": 1, "stage": "ras"}),
+        encoding="utf-8",
+    )
+    hydrology = tmp_path / "hms-output.dss"
+    hydrology.write_bytes(b"hydrology")
+    hydrologic_manifest = tmp_path / "hydrologic-products.json"
+    hydrologic_manifest.write_text(
+        json.dumps(
+            {
+                "schema": "hms-commander/hydrologic-product-manifest/1.0",
+                "source": {"sha256": _sha256(hydrology)},
+            }
+        ),
+        encoding="utf-8",
+    )
+    excess = tmp_path / "ras-excess.dss"
+    excess.write_bytes(b"excess")
+    excess_provenance = tmp_path / "ras-excess.json"
+    excess_provenance.write_text(
+        json.dumps({"schema": "test/excess-provenance/1.0"}),
+        encoding="utf-8",
+    )
+    executable = tmp_path / "Ras.exe"
+    executable.write_bytes(b"executable")
+    request = {
+        "schema": RasScenarioWorker.REQUEST_SCHEMA,
+        "scenario": {
+            "scenario_id": "test-scenario",
+            "specification_sha256": "1" * 64,
+        },
+        "source_model": {
+            "project": str(project),
+            "project_file_sha256": _sha256(project),
+            "template_plan": "01",
+            "model_manifest": str(model_manifest),
+            "model_manifest_sha256": _sha256(model_manifest),
+            "linked_asset_directories": [],
+        },
+        "hydrology": {
+            "dss": str(hydrology),
+            "sha256": _sha256(hydrology),
+            "product_manifest": str(hydrologic_manifest),
+            "product_manifest_sha256": _sha256(hydrologic_manifest),
+        },
+        "boundary_links": [
+            {
+                "mapping_id": "tributary",
+                "dss_path": "//TRIBUTARY/FLOW//5MIN/RUN:SCENARIO/",
+                "expected_bc_type": "Flow Hydrograph",
+                "river": "River",
+                "reach": "Reach",
+                "station": "1000",
+            }
+        ],
+        "forcing_excess": {
+            "dss": str(excess),
+            "sha256": _sha256(excess),
+            "provenance_manifest": str(excess_provenance),
+            "provenance_manifest_sha256": _sha256(excess_provenance),
+            "pathname": "/SHG/BASIN/PRECIPITATION///EXCESS/",
+            "interpolation": "Bilinear",
+        },
+        "model_window": {
+            "start": "2019-09-18T13:00:00",
+            "end": "2019-09-19T13:00:00",
+            "time_zone": "America/Chicago",
+        },
+        "workspace": str(tmp_path / "workspace"),
+        "products": {
+            "directory": str(tmp_path / "products"),
+            "include_preview": False,
+        },
+        "execution": {
+            "ras_executable": str(executable),
+            "timeout_seconds": 60,
+            "cores": 2,
+        },
+    }
+    request_path = tmp_path / "request.json"
+    result_path = tmp_path / "result.json"
+    request_path.write_text(json.dumps(request), encoding="utf-8")
+    return request, request_path, result_path
+
+
+def _write_prior_preparation_failure(request, request_path, result_path):
+    """Write the evidence shape produced before cache/retry fields existed."""
+    worker_module = importlib.import_module("ras_commander.RasScenarioWorker")
+    normalized = RasScenarioWorker._validate_request(request)
+    legacy = json.loads(json.dumps(normalized))
+    legacy.pop("retry", None)
+    legacy["source_model"].pop("linked_asset_mode", None)
+    request_sha256 = worker_module._json_sha256(legacy)
+    Path(request["workspace"]).mkdir()
+    request_path.write_text(json.dumps(request), encoding="utf-8")
+    result_path.write_text(
+        json.dumps(
+            {
+                "schema": RasScenarioWorker.RESULT_SCHEMA,
+                "status": "failed",
+                "request": {
+                    "schema": RasScenarioWorker.REQUEST_SCHEMA,
+                    "sha256": request_sha256,
+                },
+                "preparation": {"status": "in_progress"},
+                "execution": {"status": "not_started"},
+                "error": {"classification": "invalid_boundary_selector"},
+            }
+        ),
+        encoding="utf-8",
+    )
+    return request_sha256
+
+
+def _install_success_fakes(monkeypatch, request):
+    worker_module = importlib.import_module("ras_commander.RasScenarioWorker")
+    calls = {"prepare": 0, "execute": 0, "export": 0}
+
+    def prepare(*_args, **_kwargs):
+        calls["prepare"] += 1
+        folder = Path(request["workspace"])
+        folder.mkdir()
+        project_file = folder / "Model.prj"
+        plan_file = folder / "Model.p02"
+        unsteady_file = folder / "Model.u02"
+        geometry_file = folder / "Model.g01"
+        for path in (project_file, plan_file, unsteady_file, geometry_file):
+            path.write_text("test\n", encoding="utf-8")
+        hydrology_file = folder / "hydrology" / "hms-output.dss"
+        hydrology_file.parent.mkdir()
+        hydrology_file.write_bytes(b"hydrology")
+        excess_file = folder / "hydrology" / "ras-excess.dss"
+        excess_file.write_bytes(b"excess")
+        return RasScenarioWorkspace(
+            scenario_id=request["scenario"]["scenario_id"],
+            source_project=Path(request["source_model"]["project"]),
+            project_folder=folder,
+            project_file=project_file,
+            plan_number="02",
+            plan_file=plan_file,
+            unsteady_number="02",
+            unsteady_file=unsteady_file,
+            hydrology_source=Path(request["hydrology"]["dss"]),
+            hydrology_file=hydrology_file,
+            forcing_excess_source=Path(request["forcing_excess"]["dss"]),
+            forcing_excess_file=excess_file,
+            forcing_excess_pathname=request["forcing_excess"]["pathname"],
+            result_hdf=folder / "Model.p02.hdf",
+            boundary_mapping_ids=("tributary",),
+            simulation_start=request["model_window"]["start"],
+            simulation_end=request["model_window"]["end"],
+        )
+
+    def execute(workspace, **_kwargs):
+        calls["execute"] += 1
+        workspace.result_hdf.write_bytes(b"completed hdf")
+        return RasRunArtifact(
+            scenario_id=workspace.scenario_id,
+            status="succeeded",
+            plan_number=workspace.plan_number,
+            project_folder=workspace.project_folder,
+            result_hdf=workspace.result_hdf,
+            started_at="2026-08-20T12:00:00Z",
+            finished_at="2026-08-20T12:01:00Z",
+            compute_returned_successfully=True,
+            result_exists=True,
+            result_size_bytes=workspace.result_hdf.stat().st_size,
+            hdf_completed_successfully=True,
+            output_start=request["model_window"]["start"],
+            output_end=request["model_window"]["end"],
+            time_window_matches=True,
+            hdf_inspection_error=None,
+        )
+
+    def export(_hdf, output, **_kwargs):
+        calls["export"] += 1
+        output = Path(output)
+        output.mkdir()
+        numerical = {
+            "schema": "ras-commander/numerical-qaqc-summary/1.0",
+            "acceptance": "not_evaluated",
+            "compute_message_findings": {
+                "maximum_iteration": {
+                    "count": 2,
+                    "messages": ["maximum iteration"],
+                }
+            },
+        }
+        (output / HdfResultsProducts.FILENAMES["numerical-qaqc"]).write_text(
+            json.dumps(numerical), encoding="utf-8"
+        )
+        manifest = {
+            "schema": HdfResultsProducts.SCHEMA,
+            "status": {
+                "completed_successfully": True,
+                "time_axis_consistent": True,
+                "hydraulic_qaqc": "not_evaluated",
+            },
+        }
+        (output / HdfResultsProducts.MANIFEST_FILENAME).write_text(
+            json.dumps(manifest), encoding="utf-8"
+        )
+        return manifest
+
+    monkeypatch.setattr(worker_module.RasScenario, "prepare_workspace", prepare)
+    monkeypatch.setattr(
+        worker_module.RasScenario,
+        "validate_workspace",
+        lambda *_args: {
+            "project_uses_cloned_plan": True,
+            "plan_window_matches_contract": True,
+            "one_newline_convention": True,
+            "all_boundaries_exist_in_active_geometry": True,
+            "forcing_excess_link_matches": True,
+        },
+    )
+    monkeypatch.setattr(
+        worker_module.RasScenario,
+        "inspect_workspace_evidence",
+        lambda *_args: {
+            "current_plan": "02",
+            "simulation_window": {
+                "start": request["model_window"]["start"],
+                "end": request["model_window"]["end"],
+            },
+            "geometry_crosswalk": {"tributary": True},
+            "newline": {"consistent": True, "convention": "\n"},
+            "forcing_excess": {"enabled": True, "mode": "Gridded"},
+        },
+    )
+    monkeypatch.setattr(worker_module.RasScenario, "execute", execute)
+    monkeypatch.setattr(worker_module.HdfResultsProducts, "export", export)
+    return calls
+
+
+def test_worker_writes_identity_bound_success_and_verifies_repeat(
+    tmp_path, monkeypatch
+):
+    request, request_path, result_path = _request(tmp_path)
+    calls = _install_success_fakes(monkeypatch, request)
+
+    assert RasScenarioWorker.run(request_path, result_path) == 0
+    result_bytes = result_path.read_bytes()
+    result = json.loads(result_bytes)
+
+    assert result["schema"] == RasScenarioWorker.RESULT_SCHEMA
+    assert result["status"] == "succeeded"
+    assert result["preparation"]["evidence"]["current_plan"] == "02"
+    assert result["execution"]["hdf_completed_successfully"] is True
+    assert result["result_hdf"]["sha256"] == _sha256(Path(result["result_hdf"]["path"]))
+    assert result["products"]["schema"] == HdfResultsProducts.SCHEMA
+    assert result["numerical_qaqc"]["acceptance"] == "not_evaluated"
+    assert result["conditional_findings"]["maximum_iteration"]["count"] == 2
+    assert result["error"] is None
+    assert calls == {"prepare": 1, "execute": 1, "export": 1}
+
+    assert RasScenarioWorker.run(request_path, result_path) == 0
+    assert result_path.read_bytes() == result_bytes
+    assert calls == {"prepare": 1, "execute": 1, "export": 1}
+
+    Path(result["result_hdf"]["path"]).write_bytes(b"tampered")
+    assert RasScenarioWorker.run(request_path, result_path) == 3
+    assert result_path.read_bytes() == result_bytes
+
+
+def test_worker_rejects_invalid_forcing_excess_identity(tmp_path):
+    request, request_path, result_path = _request(tmp_path)
+    request["forcing_excess"]["sha256"] = "f" * 64
+    request_path.write_text(json.dumps(request), encoding="utf-8")
+
+    assert RasScenarioWorker.run(request_path, result_path) == 2
+    result = json.loads(result_path.read_text(encoding="utf-8"))
+    assert result["error"]["classification"] == "forcing_excess_identity"
+    assert not Path(request["workspace"]).exists()
+
+
+def test_worker_rejects_hydrologic_manifest_for_another_dss(tmp_path):
+    request, request_path, result_path = _request(tmp_path)
+    manifest = Path(request["hydrology"]["product_manifest"])
+    manifest.write_text(
+        json.dumps(
+            {
+                "schema": "hms-commander/hydrologic-product-manifest/1.0",
+                "source": {"sha256": "f" * 64},
+            }
+        ),
+        encoding="utf-8",
+    )
+    request["hydrology"]["product_manifest_sha256"] = _sha256(manifest)
+    request_path.write_text(json.dumps(request), encoding="utf-8")
+
+    assert RasScenarioWorker.run(request_path, result_path) == 2
+    result = json.loads(result_path.read_text(encoding="utf-8"))
+    assert result["error"]["classification"] == "hydrology_identity"
+
+
+def test_worker_rejects_non_ras_model_manifest(tmp_path):
+    request, request_path, result_path = _request(tmp_path)
+    manifest = Path(request["source_model"]["model_manifest"])
+    manifest.write_text(
+        json.dumps({"schema_version": 1, "stage": "hms"}),
+        encoding="utf-8",
+    )
+    request["source_model"]["model_manifest_sha256"] = _sha256(manifest)
+    request_path.write_text(json.dumps(request), encoding="utf-8")
+
+    assert RasScenarioWorker.run(request_path, result_path) == 2
+    result = json.loads(result_path.read_text(encoding="utf-8"))
+    assert result["error"]["classification"] == "source_model_identity"
+
+
+@pytest.mark.parametrize(
+    "link",
+    [
+        {
+            "mapping_id": "missing-selector",
+            "dss_path": "//A/FLOW//5MIN/RUN/",
+            "expected_bc_type": "Flow Hydrograph",
+        },
+        {
+            "mapping_id": "mixed-selector",
+            "dss_path": "//A/FLOW//5MIN/RUN/",
+            "expected_bc_type": "Flow Hydrograph",
+            "river": "River",
+            "sa_2d_name": "Mesh",
+        },
+    ],
+)
+def test_worker_rejects_invalid_boundary_selectors(tmp_path, link):
+    request, request_path, result_path = _request(tmp_path)
+    request["boundary_links"] = [link]
+    request_path.write_text(json.dumps(request), encoding="utf-8")
+
+    assert RasScenarioWorker.run(request_path, result_path) == 2
+    result = json.loads(result_path.read_text(encoding="utf-8"))
+    assert result["error"]["classification"] == "invalid_request"
+
+
+def test_worker_refuses_existing_workspace(tmp_path):
+    request, request_path, result_path = _request(tmp_path)
+    Path(request["workspace"]).mkdir()
+
+    assert RasScenarioWorker.run(request_path, result_path) == 3
+    result = json.loads(result_path.read_text(encoding="utf-8"))
+    assert result["error"]["classification"] == "existing_workspace"
+
+
+def test_worker_authenticates_preparation_retry_and_preserves_prior_workspace(
+    tmp_path, monkeypatch
+):
+    prior_root = tmp_path / "prior"
+    prior_root.mkdir()
+    prior_request, prior_request_path, prior_result_path = _request(prior_root)
+    prior_hash = _write_prior_preparation_failure(
+        prior_request, prior_request_path, prior_result_path
+    )
+    prior_workspace = Path(prior_request["workspace"])
+
+    request = json.loads(json.dumps(prior_request))
+    request["source_model"]["linked_asset_mode"] = "shared-cache"
+    request["boundary_links"][0]["boundary_index"] = 0
+    request["workspace"] = str(prior_root / "retry-workspace")
+    request["products"]["directory"] = str(tmp_path / "retry-products")
+    request["retry"] = {
+        "prior_request": str(prior_request_path),
+        "prior_result": str(prior_result_path),
+    }
+    request_path = tmp_path / "retry-request.json"
+    result_path = tmp_path / "retry-result.json"
+    request_path.write_text(json.dumps(request), encoding="utf-8")
+    _install_success_fakes(monkeypatch, request)
+
+    assert RasScenarioWorker.run(request_path, result_path) == 0
+
+    result = json.loads(result_path.read_text(encoding="utf-8"))
+    retry = result["preparation"]["retry"]
+    assert retry["status"] == "authenticated"
+    assert retry["prior_request_sha256"] == prior_hash
+    assert retry["failure_classification"] == "invalid_boundary_selector"
+    assert prior_workspace.is_dir()
+
+
+def test_worker_refuses_retry_when_immutable_inputs_change(tmp_path):
+    prior_root = tmp_path / "prior"
+    prior_root.mkdir()
+    prior_request, prior_request_path, prior_result_path = _request(prior_root)
+    _write_prior_preparation_failure(
+        prior_request, prior_request_path, prior_result_path
+    )
+    request = json.loads(json.dumps(prior_request))
+    request["source_model"]["linked_asset_mode"] = "shared-cache"
+    request["workspace"] = str(prior_root / "retry-workspace")
+    request["products"]["directory"] = str(tmp_path / "retry-products")
+    request["model_window"]["end"] = "2019-09-20T13:00:00"
+    request["retry"] = {
+        "prior_request": str(prior_request_path),
+        "prior_result": str(prior_result_path),
+    }
+    request_path = tmp_path / "retry-request.json"
+    result_path = tmp_path / "retry-result.json"
+    request_path.write_text(json.dumps(request), encoding="utf-8")
+
+    assert RasScenarioWorker.run(request_path, result_path) == 2
+    result = json.loads(result_path.read_text(encoding="utf-8"))
+    assert result["error"]["classification"] == "retry_evidence"
+    assert not Path(request["workspace"]).exists()
+
+
+def test_worker_writes_failure_result_for_timeout(tmp_path, monkeypatch):
+    request, request_path, result_path = _request(tmp_path)
+    _install_success_fakes(monkeypatch, request)
+    worker_module = importlib.import_module("ras_commander.RasScenarioWorker")
+    monkeypatch.setattr(
+        worker_module.RasScenario,
+        "execute",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            TimeoutError("HEC-RAS exceeded 60 seconds")
+        ),
+    )
+
+    assert RasScenarioWorker.run(request_path, result_path) == 4
+    result = json.loads(result_path.read_text(encoding="utf-8"))
+    assert result["error"]["classification"] == "timeout"
+    assert result["error"]["retryable"] is True
+    assert result["preparation"]["status"] == "passed"
+    assert result["execution"]["status"] == "in_progress"
+    assert Path(request["workspace"]).is_dir()
+
+
+@pytest.mark.parametrize(
+    ("changes", "classification"),
+    [
+        ({"result_exists": False, "result_size_bytes": 0}, "missing_hdf"),
+        ({"hdf_completed_successfully": False}, "incomplete_hdf"),
+        ({"time_window_matches": False}, "mismatched_result_time"),
+    ],
+)
+def test_worker_classifies_failed_execution_artifacts(
+    tmp_path, monkeypatch, changes, classification
+):
+    request, request_path, result_path = _request(tmp_path)
+    _install_success_fakes(monkeypatch, request)
+    worker_module = importlib.import_module("ras_commander.RasScenarioWorker")
+
+    def failed_execute(workspace, **_kwargs):
+        workspace.result_hdf.write_bytes(b"failed hdf")
+        values = {
+            "scenario_id": workspace.scenario_id,
+            "status": "failed",
+            "plan_number": workspace.plan_number,
+            "project_folder": workspace.project_folder,
+            "result_hdf": workspace.result_hdf,
+            "started_at": "2026-08-20T12:00:00Z",
+            "finished_at": "2026-08-20T12:01:00Z",
+            "compute_returned_successfully": True,
+            "result_exists": True,
+            "result_size_bytes": workspace.result_hdf.stat().st_size,
+            "hdf_completed_successfully": True,
+            "output_start": request["model_window"]["start"],
+            "output_end": request["model_window"]["end"],
+            "time_window_matches": True,
+            "hdf_inspection_error": None,
+        }
+        values.update(changes)
+        return RasRunArtifact(**values)
+
+    monkeypatch.setattr(worker_module.RasScenario, "execute", failed_execute)
+
+    assert RasScenarioWorker.run(request_path, result_path) == 4
+    result = json.loads(result_path.read_text(encoding="utf-8"))
+    assert result["error"]["classification"] == classification
+    assert result["products"] is None
+
+
+@pytest.mark.parametrize(
+    ("message", "classification"),
+    [
+        ("Mixed newline conventions in HEC-RAS text file", "mixed_newlines"),
+        (
+            "Prepared RAS workspace failed validation: project_uses_cloned_plan",
+            "wrong_current_plan",
+        ),
+        (
+            "Prepared RAS workspace failed validation: plan_window_matches_contract",
+            "wrong_window",
+        ),
+        (
+            "Prepared RAS workspace failed validation: "
+            "all_boundaries_exist_in_active_geometry",
+            "inactive_geometry",
+        ),
+    ],
+)
+def test_worker_classifies_preparation_evidence_failures(
+    tmp_path, monkeypatch, message, classification
+):
+    request, request_path, result_path = _request(tmp_path)
+    worker_module = importlib.import_module("ras_commander.RasScenarioWorker")
+    monkeypatch.setattr(
+        worker_module.RasScenario,
+        "prepare_workspace",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(ValueError(message)),
+    )
+
+    assert RasScenarioWorker.run(request_path, result_path) == 4
+    result = json.loads(result_path.read_text(encoding="utf-8"))
+    assert result["error"]["classification"] == classification
+
+
+def test_worker_rejects_request_contract_drift(tmp_path):
+    request, request_path, result_path = _request(tmp_path)
+    request["unexpected"] = True
+    request_path.write_text(json.dumps(request), encoding="utf-8")
+
+    assert RasScenarioWorker.run(request_path, result_path) == 2
+    result = json.loads(result_path.read_text(encoding="utf-8"))
+    assert result["error"]["classification"] == "invalid_request"
+    assert "unknown unexpected" in result["error"]["message"]
+
+
+def test_packaged_worker_schemas_match_public_contract_constants():
+    package = importlib.resources.files("ras_commander") / "contracts"
+    request_schema = json.loads(
+        (package / "scenario-worker-request-v1.0.schema.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    result_schema = json.loads(
+        (package / "scenario-worker-result-v1.0.schema.json").read_text(
+            encoding="utf-8"
+        )
+    )
+
+    assert request_schema["$id"] == RasScenarioWorker.REQUEST_SCHEMA
+    assert result_schema["$id"] == RasScenarioWorker.RESULT_SCHEMA
+
+
+@pytest.mark.integration
+def test_installed_engine_executes_one_scenario(tmp_path):
+    names = {
+        "project": "RAS_WORKER_TEST_SOURCE_PROJECT",
+        "plan": "RAS_WORKER_TEST_SOURCE_PLAN",
+        "model_manifest": "RAS_WORKER_TEST_MODEL_MANIFEST",
+        "hydrology": "RAS_WORKER_TEST_HYDROLOGY_DSS",
+        "hydrology_manifest": "RAS_WORKER_TEST_HYDROLOGY_MANIFEST",
+        "boundary_links": "RAS_WORKER_TEST_BOUNDARY_LINKS_JSON",
+        "excess": "RAS_WORKER_TEST_EXCESS_DSS",
+        "excess_manifest": "RAS_WORKER_TEST_EXCESS_MANIFEST",
+        "excess_pathname": "RAS_WORKER_TEST_EXCESS_PATHNAME",
+        "ras_executable": "RAS_WORKER_TEST_EXECUTABLE",
+    }
+    values = {key: os.environ.get(name) for key, name in names.items()}
+    missing = [names[key] for key, value in values.items() if not value]
+    if missing:
+        pytest.skip(
+            "Installed-engine worker inputs not configured: " + ", ".join(missing)
+        )
+
+    project = Path(values["project"])
+    source_project = (
+        project
+        if project.is_file()
+        else next(iter(sorted(project.glob("*.prj"))), None)
+    )
+    assert source_project is not None
+    hydrology = Path(values["hydrology"])
+    model_manifest = Path(values["model_manifest"])
+    hydrology_manifest = Path(values["hydrology_manifest"])
+    excess = Path(values["excess"])
+    excess_manifest = Path(values["excess_manifest"])
+    workspace = Path(
+        os.environ.get("RAS_WORKER_TEST_WORKSPACE", str(tmp_path / "workspace"))
+    )
+    request = {
+        "schema": RasScenarioWorker.REQUEST_SCHEMA,
+        "scenario": {
+            "scenario_id": "installed-engine-canary",
+            "specification_sha256": "2" * 64,
+        },
+        "source_model": {
+            "project": str(project),
+            "project_file_sha256": _sha256(source_project),
+            "template_plan": values["plan"],
+            "model_manifest": str(model_manifest),
+            "model_manifest_sha256": _sha256(model_manifest),
+            "linked_asset_directories": json.loads(
+                os.environ.get("RAS_WORKER_TEST_LINKED_ASSETS_JSON", "[]")
+            ),
+            "linked_asset_mode": os.environ.get(
+                "RAS_WORKER_TEST_LINKED_ASSET_MODE", "copy"
+            ),
+        },
+        "hydrology": {
+            "dss": str(hydrology),
+            "sha256": _sha256(hydrology),
+            "product_manifest": str(hydrology_manifest),
+            "product_manifest_sha256": _sha256(hydrology_manifest),
+        },
+        "boundary_links": json.loads(values["boundary_links"]),
+        "forcing_excess": {
+            "dss": str(excess),
+            "sha256": _sha256(excess),
+            "provenance_manifest": str(excess_manifest),
+            "provenance_manifest_sha256": _sha256(excess_manifest),
+            "pathname": values["excess_pathname"],
+        },
+        "model_window": {
+            "start": os.environ.get("RAS_WORKER_TEST_START", "2019-09-18T13:00:00"),
+            "end": os.environ.get("RAS_WORKER_TEST_END", "2019-09-22T13:00:00"),
+            "time_zone": os.environ.get("RAS_WORKER_TEST_TIME_ZONE", "America/Chicago"),
+        },
+        "workspace": str(workspace),
+        "products": {
+            "directory": str(tmp_path / "products"),
+            "include_preview": False,
+        },
+        "execution": {
+            "ras_executable": values["ras_executable"],
+            "timeout_seconds": int(
+                os.environ.get("RAS_WORKER_TEST_TIMEOUT_SECONDS", "7200")
+            ),
+            "cores": int(os.environ.get("RAS_WORKER_TEST_CORES", "2")),
+        },
+    }
+    prior_request = os.environ.get("RAS_WORKER_TEST_RETRY_REQUEST")
+    prior_result = os.environ.get("RAS_WORKER_TEST_RETRY_RESULT")
+    if bool(prior_request) != bool(prior_result):
+        pytest.fail(
+            "RAS_WORKER_TEST_RETRY_REQUEST and RAS_WORKER_TEST_RETRY_RESULT "
+            "must be configured together"
+        )
+    if prior_request and prior_result:
+        request["retry"] = {
+            "prior_request": prior_request,
+            "prior_result": prior_result,
+        }
+    request_path = tmp_path / "request.json"
+    result_path = tmp_path / "result.json"
+    request_path.write_text(json.dumps(request), encoding="utf-8")
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "ras_commander.RasScenarioWorker",
+            "--request",
+            str(request_path),
+            "--result",
+            str(result_path),
+        ],
+        capture_output=True,
+        check=False,
+        encoding="utf-8",
+        errors="replace",
+        timeout=request["execution"]["timeout_seconds"] + 120,
+    )
+    assert completed.returncode == 0, (
+        "Installed RAS scenario worker failed.\n"
+        f"stdout:\n{completed.stdout}\n"
+        f"stderr:\n{completed.stderr}"
+    )
+    result = json.loads(result_path.read_text(encoding="utf-8"))
+    assert result["status"] == "succeeded"
+    assert result["execution"]["hdf_completed_successfully"] is True
+    assert all(result["preparation"]["checks"].values())
+    assert Path(result["preparation"]["workspace"]["project_file"]).is_file()

--- a/tests/test_scenario_worker.py
+++ b/tests/test_scenario_worker.py
@@ -115,13 +115,9 @@ def _request(tmp_path: Path):
 
 
 def _write_prior_preparation_failure(request, request_path, result_path):
-    """Write the evidence shape produced before cache/retry fields existed."""
+    """Write a preparation failure bound to the exact retained request."""
     worker_module = importlib.import_module("ras_commander.RasScenarioWorker")
-    normalized = RasScenarioWorker._validate_request(request)
-    legacy = json.loads(json.dumps(normalized))
-    legacy.pop("retry", None)
-    legacy["source_model"].pop("linked_asset_mode", None)
-    request_sha256 = worker_module._json_sha256(legacy)
+    request_sha256 = worker_module._json_sha256(request)
     Path(request["workspace"]).mkdir()
     request_path.write_text(json.dumps(request), encoding="utf-8")
     result_path.write_text(
@@ -374,6 +370,21 @@ def test_worker_refuses_existing_workspace(tmp_path):
     assert RasScenarioWorker.run(request_path, result_path) == 3
     result = json.loads(result_path.read_text(encoding="utf-8"))
     assert result["error"]["classification"] == "existing_workspace"
+
+
+def test_no_retry_request_identity_survives_validation_and_result_binding(
+    tmp_path, monkeypatch
+):
+    request, request_path, result_path = _request(tmp_path)
+    normalized = RasScenarioWorker._validate_request(request)
+    assert "retry" not in normalized
+    _install_success_fakes(monkeypatch, request)
+
+    assert RasScenarioWorker.run(request_path, result_path) == 0
+
+    worker_module = importlib.import_module("ras_commander.RasScenarioWorker")
+    result = json.loads(result_path.read_text(encoding="utf-8"))
+    assert result["request"]["sha256"] == worker_module._json_sha256(request)
 
 
 def test_worker_authenticates_preparation_retry_and_preserves_prior_workspace(


### PR DESCRIPTION
## Summary

Preserves the exact retained RAS scenario-worker request identity across first-attempt results and governed retries. The worker now hashes the request as retained before normalization, omits a synthetic `retry: null` field when retry was not configured, and accepts retained, normalized, and legacy-compatible prior hashes when authenticating preparation-only retry evidence.

This fixes the Increment 8 canary failure where attempt 1 correctly failed during preparation but immutable attempt 2 was rejected because the prior result could not bind its request.

Closes #310.
Tracks harrisbienn/floodforecast#59.
Tracks harrisbienn/floodforecast#40.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)
- [ ] Example notebook

---

## LLM Self-Review

> **ras-commander encourages LLM-assisted contributions.** If your agent prepared this code, confirm it reviewed the style guide. See [CONTRIBUTING.md](../CONTRIBUTING.md) for details.

### Style Compliance

- [x] Static class pattern followed (`.claude/rules/python/static-classes.md`)
- [x] `@staticmethod` + `@log_call` on public methods (`.claude/rules/python/decorators.md`)
- [x] Naming conventions followed (`.claude/rules/python/naming-conventions.md`)
- [x] `pathlib.Path` used, accepts both `str` and `Path` (`.claude/rules/python/path-handling.md`)
- [ ] DataFrames used for project metadata, not glob (`.claude/rules/python/dataframe-first-principle.md`)

### Code Quality

- [ ] Google-style docstrings with Args, Returns, Raises
- [x] Tested with real HEC-RAS project (`RasExamples.extract_project()`)
- [x] No hardcoded file paths
- [x] Uses logging, not `print()`
- [x] Proper error handling with informative messages

### API Changes (if applicable)

- [ ] `ras_object=None` parameter included for multi-project support
- [x] Standard parameter names (`plan_number`, `geom_file`)
- [x] API consistency auditor 5 rules followed (`.claude/agents/api-consistency-auditor.md`)
- [x] Return types consistent (DataFrames for tabular data)

### Notebooks (if applicable)

- [ ] First cell is markdown with H1 title
- [ ] Uses `RasExamples.extract_project()` for data
- [ ] Development toggle cell included (`USE_LOCAL_SOURCE`)

---

## Test Plan

- `python -m ruff check ras_commander/RasScenarioWorker.py tests/test_scenario_worker.py --select E,F,I` - passed.
- `python -m pytest tests/test_scenario_worker.py` - 20 passed, 1 installed-engine skip.
- Full suite - 1,809 passed, 65 skipped, 10 unrelated baseline failures; also reproduced the existing Windows JVM/DSS access violation in `test_rasdss_grid_write.py`. None of the failures touch `RasScenarioWorker.py` or `tests/test_scenario_worker.py`.
- Live DeLoutre evidence - prior result used normalized hash `3fc3418f...` while retained request hashed to `f33e8887...`; the focused regression now proves results bind the exact retained request and retry verification accepts preparation-only failures.

## LLM Attribution

**Model/Tool used**: OpenAI Codex