### PR TITLE
feat(project): classify plan execution topology

### DIFF
--- a/docs/reference/dataframe-reference.md
+++ b/docs/reference/dataframe-reference.md
@@ -127,13 +127,16 @@ parsed from the plan text are strings unless noted:
 | `plan_number` | str | normalized two-digit plan id such as `01` |
 | `geometry_number` | str | normalized geometry id used by the plan |
 | `unsteady_number` | str / None | normalized unsteady-flow id when the plan is unsteady; `None` for steady plans |
+| `quasi_unsteady_number` | str / None | normalized quasi-unsteady id when the plan references `.q##` |
+| `flow_file_prefix` | str / None | exact normalized plan reference prefix: `f`, `u`, or `q` |
 | `Plan Title` | str | HEC-RAS plan title (`Plan Title=`) |
 | `Short Identifier` | str | HEC-RAS short id used by stored-map/result folders |
 | `Geom File` | str | geometry reference number from the plan (`Geom File=`) |
 | `Geom Path` | str | resolved absolute `.g##` path |
-| `Flow File` | str | steady/unsteady flow reference number (`Flow File=`) |
-| `Flow Path` | str | resolved absolute `.f##` / `.u##` path |
+| `Flow File` | str | normalized steady, unsteady, or quasi-unsteady reference number (`Flow File=`) |
+| `Flow Path` | str | resolved absolute `.f##`, `.u##`, or `.q##` path |
 | `Sediment File` | str / None | normalized sediment-file number such as `01`; `None` when no recognized `s##` reference is present |
+| `sediment_number` | str / None | normalized `.s##` identifier; sediment is independent of flow regime |
 | `Sediment Path` | str / None | expected absolute `.s##` path for the selected sediment file; file existence/readiness is reported separately by the asset inventory |
 | `breach_definition_count` | nullable Int64 | number of successfully parsed stored `Breach Loc` definitions; zero means none and null means inspection failed |
 | `breach_active_count` | nullable Int64 | number of stored definitions whose local `RasBreach` `is_active` flag is true; not evidence that a breach initiated during computation |
@@ -151,6 +154,13 @@ parsed from the plan text are strings unless noted:
 | `HDF_Results_Path` | str / None | resolved `.p##.hdf` path; `None` when results do not exist yet |
 | `full_path` | str | resolved absolute `.p##` path |
 | `flow_type` | str | Flow computation mode: `"Unsteady"`, `"Steady"`, `"Quasi-Unsteady"`, or `"Unknown"` (derived from the plan's `.u##`, `.f##`, or `.q##` reference). Sediment, dam breach, and topology are separate features. |
+| `geometry_type` | str | hydraulic inventory: `1D`, `2D`, `1D/2D`, or `Unknown` |
+| `plan_type` | str | finite execution class: `steady_1d`, `unsteady_1d`, `unsteady_2d`, `unsteady_1d_2d`, `quasi_unsteady_1d`, or `unknown` |
+| `plan_classification_valid` | nullable bool | whether the plan maps to a supported execution class |
+| `plan_classification_reason` | str / None | why classification failed closed |
+| `geometry_metadata_source` | str | `hdf`, `text`, or `unavailable` provenance inherited from `geom_df` |
+| `geometry_metadata_valid` | nullable bool | whether geometry metadata was successfully inspected |
+| `geometry_metadata_error` | str / None | failed-source details, including HDF-to-text fallback |
 
 !!! note
     Most source columns derive directly from `_parse_plan_file()` in
@@ -158,6 +168,18 @@ parsed from the plan text are strings unless noted:
     `Sediment File` is normalized for consistency with `Geom File` and `Flow
     File`; the two breach counts are derived through the existing `RasBreach`
     reader. Not every plan contains every source key.
+
+The execution taxonomy is deliberately finite. HEC-RAS has no steady 2D
+solver, so a steady plan that references `2D` or `1D/2D` geometry is
+`plan_type="unknown"` with `plan_classification_valid=False`; no
+`steady_2d` or `steady_1d_2d` value is emitted. Quasi-unsteady is anticipated
+as `quasi_unsteady_1d`; quasi plans with a mesh also fail closed.
+
+Sediment is orthogonal to flow classification. Both `.u##` and `.q##` plans
+can reference `.s##`. Storage-area-only geometries with no cross sections or
+2D areas currently classify as `unknown`. Pipe-network presence is also
+orthogonal: an unsteady pipe-plus-mesh plan remains `unsteady_2d` based on its
+hydraulic geometry inventory.
 
 Common patterns:
 
@@ -195,7 +217,11 @@ HDF-based extraction when `.g##.hdf` exists and falls back to plain-text parsing
 | `geom_title` | str / None | parsed `Geom Title=` value when present |
 | `description` | str / None | geometry `BEGIN DESCRIPTION` block when present |
 | `has_1d_xs` | bool | `True` if the geometry has 1D cross sections |
-| `has_2d_mesh` | bool | `True` if plain geometry text declares a 2D flow area or geometry HDF metadata identifies a mesh area |
+| `has_2d_mesh` | nullable bool | `True` if HDF metadata identifies a mesh or text pairs `Storage Area=<name>` with `Storage Area Is2D=-1`; null when no source can be inspected |
+| `geometry_type` | str | `1D`, `2D`, `1D/2D`, or `Unknown` |
+| `geometry_metadata_source` | str | successful source: `hdf`, `text`, or `unavailable` |
+| `geometry_metadata_valid` | nullable bool | whether a geometry source was successfully inspected |
+| `geometry_metadata_error` | str / None | failed source reads encountered before success, or terminal failure |
 | `num_cross_sections` | int | count of 1D cross sections |
 | `num_inline_structures` | int | total inline structures (bridges + culverts + weirs) |
 | `num_bridges` | int | count of bridge structures |
@@ -204,12 +230,27 @@ HDF-based extraction when `.g##.hdf` exists and falls back to plain-text parsing
 | `num_gates` | int | count of gate structures |
 | `num_lateral_structures` | int | count of lateral structures |
 | `num_sa_2d_connections` | int | count of SA/2D connections |
-| `mesh_cell_count` | int | total 2D mesh cells across all areas |
+| `mesh_cell_count` | nullable Int64 | total HDF mesh cells; null for text-only geometry |
 | `mesh_area_names` | list[str] | names of 2D flow areas |
 
-When metadata extraction fails for a geometry, counts default to `0`, booleans to
-`False`, and `mesh_area_names` to an empty list. Use this table for geometry
-discovery first, then move to `RasGeometry`, `Geom*`, or HDF readers for detail.
+When HDF inspection fails, `GeomMetadata` retries the plain geometry and keeps
+the HDF error in `geometry_metadata_error`. When neither source is readable,
+the classification booleans remain null and the geometry fails closed as
+`Unknown`; an unreadable geometry never masquerades as a valid empty 1D model.
+Text geometry can prove that a 2D area exists, but it cannot provide a mesh-cell
+count until preprocessing materializes the HDF.
+
+`RasPlan.set_geom()`, `set_steady()`, and `set_unsteady()` rewrite exactly one
+top-level plan reference, preserve description text and newline style, verify
+the write, and then refresh geometry, flow, and plan classification dataframes
+in dependency order.
+
+Classification tests pin the public RAS example archive by release, byte size,
+and SHA-256. Derived copies remove or corrupt HDFs without changing the
+immutable source. The private CLB qualification tier additionally covers real
+6.31 text-only 2D, 6.70 pipe-plus-2D, and 7.00 1D HDF schemas. These gates
+qualify metadata classification only; they do not claim solver execution or
+numerical-result parity.
 
 ## `flow_df` and `unsteady_df`
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,4 +5,5 @@ build-backend = "setuptools.build_meta:__legacy__"
 [tool.pytest.ini_options]
 markers = [
     "integration: opt-in real-project or external dependency smoke tests",
+    "qualification_critical: real-project classification qualification gates",
 ]

--- a/ras_commander/RasPlan.py
+++ b/ras_commander/RasPlan.py
@@ -296,6 +296,106 @@ class RasPlan:
         "plan file using Write IC File keys. Restart-file usage remains separate "
         "in the unsteady-flow file as Use Restart and Restart Filename."
     )
+
+    @staticmethod
+    def _replace_reference_in_lines(lines, key: str, value: str):
+        """Replace exactly one top-level ``key=value`` plan-file record."""
+        updated_lines = list(lines)
+        matches = []
+        in_description = False
+
+        for index, line in enumerate(updated_lines):
+            stripped = line.strip()
+            if re.match(r'^BEGIN DESCRIPTION:?$', stripped, re.IGNORECASE):
+                in_description = True
+                continue
+            if re.match(r'^END DESCRIPTION$', stripped, re.IGNORECASE):
+                in_description = False
+                continue
+            if not in_description and line.startswith(f"{key}="):
+                matches.append(index)
+
+        if len(matches) != 1:
+            raise ValueError(
+                f"Expected exactly one top-level {key}= record; found {len(matches)}"
+            )
+
+        index = matches[0]
+        original = updated_lines[index]
+        if original.endswith('\r\n'):
+            newline = '\r\n'
+        elif original.endswith('\n'):
+            newline = '\n'
+        elif original.endswith('\r'):
+            newline = '\r'
+        else:
+            newline = ''
+        updated_lines[index] = f"{key}={value}{newline}"
+        return updated_lines
+
+    @staticmethod
+    def _replace_top_level_plan_reference(
+        plan_file_path: Union[str, Path],
+        key: str,
+        value: str,
+    ) -> None:
+        """Rewrite and verify one plan reference without touching descriptions."""
+        plan_file_path = Path(plan_file_path)
+        with open(
+            plan_file_path,
+            'r',
+            encoding='utf-8',
+            errors='replace',
+            newline='',
+        ) as handle:
+            lines = handle.readlines()
+
+        updated_lines = RasPlan._replace_reference_in_lines(lines, key, value)
+        with open(
+            plan_file_path,
+            'w',
+            encoding='utf-8',
+            errors='replace',
+            newline='',
+        ) as handle:
+            handle.writelines(updated_lines)
+
+        with open(
+            plan_file_path,
+            'r',
+            encoding='utf-8',
+            errors='replace',
+            newline='',
+        ) as handle:
+            verified_lines = handle.readlines()
+
+        RasPlan._replace_reference_in_lines(verified_lines, key, value)
+        actual = []
+        in_description = False
+        for line in verified_lines:
+            stripped = line.strip()
+            if re.match(r'^BEGIN DESCRIPTION:?$', stripped, re.IGNORECASE):
+                in_description = True
+                continue
+            if re.match(r'^END DESCRIPTION$', stripped, re.IGNORECASE):
+                in_description = False
+                continue
+            if not in_description and line.startswith(f"{key}="):
+                actual.append(line.rstrip('\r\n'))
+        if actual != [f"{key}={value}"]:
+            raise IOError(
+                f"Plan reference verification failed for {plan_file_path}: "
+                f"expected {key}={value}, found {actual}"
+            )
+
+    @staticmethod
+    def _refresh_classification(ras_obj, *, refresh_flows: bool = False) -> None:
+        """Refresh DataFrames in dependency order after a plan mutation."""
+        ras_obj.geom_df = ras_obj.get_geom_entries()
+        if refresh_flows:
+            ras_obj.flow_df = ras_obj.get_flow_entries()
+            ras_obj.unsteady_df = ras_obj.get_unsteady_entries()
+        ras_obj.plan_df = ras_obj.get_plan_entries()
     
     @staticmethod
     @log_call
@@ -325,8 +425,7 @@ class RasPlan:
         plan_number = RasUtils.normalize_ras_number(plan_number)
         new_geom = RasUtils.normalize_ras_number(new_geom)
 
-        # Update all dataframes
-        ras_obj.plan_df = ras_obj.get_plan_entries()
+        # Refresh geometry inventory before validating the new reference.
         ras_obj.geom_df = ras_obj.get_geom_entries()
         
         if new_geom not in ras_obj.geom_df['geom_number'].values:
@@ -339,33 +438,16 @@ class RasPlan:
             logger.error(f"Plan file not found: {plan_file_path}")
             raise ValueError(f"Plan file not found: {plan_file_path}")
         
-        # Read the plan file and update the Geom File line
         try:
-            with open(plan_file_path, 'r', encoding='utf-8', errors='replace') as file:
-                lines = file.readlines()
-            
-            for i, line in enumerate(lines):
-                if line.startswith("Geom File="):
-                    lines[i] = f"Geom File=g{new_geom}\n"
-                    logger.debug(
-                        "Updated Geom File in plan file %s to g%s",
-                        plan_file_path.name,
-                        new_geom,
-                    )
-                    break
-                
-            with open(plan_file_path, 'w', encoding='utf-8', errors='replace') as file:
-                file.writelines(lines)
+            RasPlan._replace_top_level_plan_reference(
+                plan_file_path,
+                'Geom File',
+                f"g{new_geom}",
+            )
+            RasPlan._refresh_classification(ras_obj)
         except Exception as e:
             logger.error(f"Error updating plan file: {e}")
             raise
-        # Update the plan_df without reinitializing
-        mask = ras_obj.plan_df['plan_number'] == plan_number
-        ras_obj.plan_df.loc[mask, 'geom_number'] = new_geom
-        ras_obj.plan_df.loc[mask, 'geometry_number'] = new_geom  # Update geometry_number column
-        ras_obj.plan_df.loc[mask, 'Geom File'] = f"g{new_geom}"
-        geom_path = ras_obj.project_folder / f"{ras_obj.project_name}.g{new_geom}"
-        ras_obj.plan_df.loc[mask, 'Geom Path'] = str(geom_path)
 
         logger.debug("Set geometry for plan p%s to g%s", plan_number, new_geom)
         logger.debug("Updated plan DataFrame:")
@@ -417,29 +499,22 @@ class RasPlan:
             )
         
         try:
-            RasUtils.update_file(plan_file_path, RasPlan._update_steady_in_file, new_steady_flow_number)
-            
-            # Update all dataframes
-            ras_obj.plan_df = ras_obj.get_plan_entries()
-            
-            # Update flow-related columns
-            mask = ras_obj.plan_df['plan_number'] == plan_number
-            flow_path = ras_obj.project_folder / f"{ras_obj.project_name}.f{new_steady_flow_number}"
-            ras_obj.plan_df.loc[mask, 'Flow File'] = f"f{new_steady_flow_number}"
-            ras_obj.plan_df.loc[mask, 'Flow Path'] = str(flow_path)
-            ras_obj.plan_df.loc[mask, 'unsteady_number'] = None
-            
-            # Update remaining dataframes
-            ras_obj.geom_df = ras_obj.get_geom_entries()
-            ras_obj.flow_df = ras_obj.get_flow_entries()
-            ras_obj.unsteady_df = ras_obj.get_unsteady_entries()
-            
+            RasPlan._replace_top_level_plan_reference(
+                plan_file_path,
+                'Flow File',
+                f"f{new_steady_flow_number}",
+            )
+            RasPlan._refresh_classification(ras_obj, refresh_flows=True)
         except Exception as e:
             raise IOError(f"Failed to update steady flow file: {e}")
 
     @staticmethod
     def _update_steady_in_file(lines, new_steady_flow_number):
-        return [f"Flow File=f{new_steady_flow_number}\n" if line.startswith("Flow File=f") else line for line in lines]
+        return RasPlan._replace_reference_in_lines(
+            lines,
+            'Flow File',
+            f"f{new_steady_flow_number}",
+        )
 
     @staticmethod
     @log_call
@@ -485,41 +560,22 @@ class RasPlan:
             )
         
         try:
-            # Read the plan file
-            with open(plan_file_path, 'r', encoding='utf-8', errors='replace') as f:
-                lines = f.readlines()
-
-            # Update the Flow File line
-            for i, line in enumerate(lines):
-                if line.startswith("Flow File="):
-                    lines[i] = f"Flow File=u{new_unsteady_flow_number}\n"
-                    break
-            
-            # Write back to the plan file
-            with open(plan_file_path, 'w', encoding='utf-8', errors='replace') as f:
-                f.writelines(lines)
-            
-            # Update all dataframes
-            ras_obj.plan_df = ras_obj.get_plan_entries()
-            
-            # Update flow-related columns
-            mask = ras_obj.plan_df['plan_number'] == plan_number
-            flow_path = ras_obj.project_folder / f"{ras_obj.project_name}.u{new_unsteady_flow_number}"
-            ras_obj.plan_df.loc[mask, 'Flow File'] = f"u{new_unsteady_flow_number}"
-            ras_obj.plan_df.loc[mask, 'Flow Path'] = str(flow_path)
-            ras_obj.plan_df.loc[mask, 'unsteady_number'] = new_unsteady_flow_number
-            
-            # Update remaining dataframes
-            ras_obj.geom_df = ras_obj.get_geom_entries()
-            ras_obj.flow_df = ras_obj.get_flow_entries()
-            ras_obj.unsteady_df = ras_obj.get_unsteady_entries()
-            
+            RasPlan._replace_top_level_plan_reference(
+                plan_file_path,
+                'Flow File',
+                f"u{new_unsteady_flow_number}",
+            )
+            RasPlan._refresh_classification(ras_obj, refresh_flows=True)
         except Exception as e:
             raise IOError(f"Failed to update unsteady flow file: {e}")
 
     @staticmethod
     def _update_unsteady_in_file(lines, new_unsteady_flow_number):
-        return [f"Unsteady File=u{new_unsteady_flow_number}\n" if line.startswith("Unsteady File=u") else line for line in lines]
+        return RasPlan._replace_reference_in_lines(
+            lines,
+            'Flow File',
+            f"u{new_unsteady_flow_number}",
+        )
     
     @staticmethod
     @log_call
@@ -3935,21 +3991,14 @@ class RasPlan:
             # Use flow_type column if available (preferred)
             if 'flow_type' in plan_row.columns:
                 flow_type = plan_row.iloc[0]['flow_type']
-                logger.debug(f"Plan {plan_num}: {flow_type} (from plan_df)")
-                return flow_type
+                if pd.notna(flow_type) and flow_type in {
+                    'Steady', 'Unsteady', 'Quasi-Unsteady', 'Unknown'
+                }:
+                    logger.debug(f"Plan {plan_num}: {flow_type} (from plan_df)")
+                    return flow_type
 
-            if 'unsteady_number' not in plan_row.columns:
-                logger.debug(
-                    "Plan %s flow type unknown; plan_df missing unsteady_number column",
-                    plan_num,
-                )
-                return 'Unknown'
-
-            # Fallback: determine from unsteady_number
-            import pandas as pd
-            unsteady_num = plan_row.iloc[0]['unsteady_number']
-            flow_type = 'Unsteady' if pd.notna(unsteady_num) else 'Steady'
-            logger.debug(f"Plan {plan_num}: {flow_type} (from unsteady_number)")
+            flow_type = RasPrj._classify_plan_flow(plan_row.iloc[0])
+            logger.debug(f"Plan {plan_num}: {flow_type} (from flow references)")
             return flow_type
 
         except Exception:

--- a/ras_commander/RasPrj.py
+++ b/ras_commander/RasPrj.py
@@ -247,7 +247,13 @@ class RasPrj:
                 f"Project CRS: {self.project_crs} "
                 f"(source={self.project_crs_source})"
             )
-            logger.info(f"Geometry HDF files found: {self.plan_df['Geom_File'].notna().sum()}")
+            geometry_hdf_count = sum(
+                Path(path).is_file()
+                for path in self.geom_df.get(
+                    'hdf_path', pd.Series(dtype='object')
+                ).dropna()
+            )
+            logger.info(f"Geometry HDF files found: {geometry_hdf_count}")
             logger.info(f"RASMapper data loaded: {not self.rasmap_df.empty}")
             logger.info(f"Results summaries loaded: {len(self.results_df)} plans with HDF results")
 
@@ -271,6 +277,7 @@ class RasPrj:
             self.flow_df = self._get_prj_entries('Flow')
             self.geom_df = self.get_geom_entries()
             self.plan_df = self._enrich_plan_dataframe(self.plan_df)
+            self.plan_df = self._enrich_plan_classification(self.plan_df)
 
         except Exception as e:
             logger.error(f"Error loading project data: {e}")
@@ -283,7 +290,8 @@ class RasPrj:
     def _enrich_plan_dataframe(self, plan_df: pd.DataFrame) -> pd.DataFrame:
         """Apply the canonical plan columns, paths, dtypes, and flow type."""
         required_columns = [
-            'plan_number', 'unsteady_number', 'geometry_number',
+            'plan_number', 'unsteady_number', 'quasi_unsteady_number',
+            'geometry_number', 'sediment_number', 'flow_file_prefix',
             'Geom File', 'Geom Path', 'Flow File', 'Flow Path',
             'Sediment File', 'Sediment Path',
             'breach_definition_count', 'breach_active_count', 'full_path'
@@ -323,6 +331,238 @@ class RasPrj:
 
         return plan_df
 
+    @staticmethod
+    def _classify_plan_flow(row: pd.Series) -> str:
+        """Classify the flow regime from normalized plan-file references."""
+        prefix = row.get('flow_file_prefix')
+        if pd.notna(prefix):
+            flow_type = {
+                'f': 'Steady',
+                'u': 'Unsteady',
+                'q': 'Quasi-Unsteady',
+            }.get(str(prefix).strip().lower())
+            if flow_type:
+                return flow_type
+
+        flow_reference = row.get('Flow File')
+        if pd.notna(flow_reference):
+            reference = str(flow_reference).strip().lower()
+            if reference[:1] in {'f', 'u', 'q'}:
+                return {
+                    'f': 'Steady',
+                    'u': 'Unsteady',
+                    'q': 'Quasi-Unsteady',
+                }[reference[0]]
+
+        quasi_number = row.get('quasi_unsteady_number')
+        if pd.notna(quasi_number) and str(quasi_number).strip():
+            return 'Quasi-Unsteady'
+
+        unsteady_number = row.get('unsteady_number')
+        if pd.notna(unsteady_number) and str(unsteady_number).strip():
+            return 'Unsteady'
+
+        # Backward compatibility for DataFrames created before the normalized
+        # prefix column existed.
+        if pd.notna(flow_reference) and str(flow_reference).strip():
+            return 'Steady'
+
+        return 'Unknown'
+
+    @staticmethod
+    def _classify_geometry(row: pd.Series) -> str:
+        """Return the hydraulic inventory class for a geometry row."""
+        metadata_valid = row.get('geometry_metadata_valid')
+        if pd.isna(metadata_valid) or not bool(metadata_valid):
+            return 'Unknown'
+
+        has_1d = row.get('has_1d_xs')
+        has_2d = row.get('has_2d_mesh')
+        has_1d = False if pd.isna(has_1d) else bool(has_1d)
+        has_2d = False if pd.isna(has_2d) else bool(has_2d)
+
+        if has_1d and has_2d:
+            return '1D/2D'
+        if has_2d:
+            return '2D'
+        if has_1d:
+            return '1D'
+        return 'Unknown'
+
+    @staticmethod
+    def _classify_plan_type(row: pd.Series) -> tuple[str, bool, Optional[str]]:
+        """Map flow and geometry classes into the supported compute taxonomy."""
+        flow_type = row.get('flow_type')
+        geometry_type = row.get('geometry_type')
+
+        if flow_type == 'Unknown':
+            return 'unknown', False, 'Plan flow reference is missing or unsupported'
+
+        if geometry_type == 'Unknown':
+            metadata_error = row.get('geometry_metadata_error')
+            if pd.notna(metadata_error) and str(metadata_error).strip():
+                reason = str(metadata_error)
+            else:
+                reason = (
+                    'Geometry contains no supported 1D cross sections or '
+                    '2D flow areas'
+                )
+            return 'unknown', False, reason
+
+        if flow_type == 'Steady':
+            if geometry_type == '1D':
+                return 'steady_1d', True, None
+            return (
+                'unknown',
+                False,
+                'The HEC-RAS steady solver does not support 2D flow areas',
+            )
+
+        if flow_type == 'Quasi-Unsteady':
+            if geometry_type == '1D':
+                return 'quasi_unsteady_1d', True, None
+            return (
+                'unknown',
+                False,
+                'Quasi-unsteady plans with 2D flow areas are unsupported',
+            )
+
+        if flow_type == 'Unsteady':
+            plan_type = {
+                '1D': 'unsteady_1d',
+                '2D': 'unsteady_2d',
+                '1D/2D': 'unsteady_1d_2d',
+            }.get(geometry_type)
+            if plan_type:
+                return plan_type, True, None
+
+        return 'unknown', False, 'Unsupported flow and geometry combination'
+
+    def _enrich_plan_classification(self, plan_df: pd.DataFrame) -> pd.DataFrame:
+        """Join geometry provenance to plans and derive finite execution classes.
+
+        Stable ``plan_type`` values are ``steady_1d``, ``unsteady_1d``,
+        ``unsteady_2d``, ``unsteady_1d_2d``, ``quasi_unsteady_1d``, and
+        ``unknown``. HEC-RAS has no steady 2D solver, so those combinations
+        fail closed with an explanatory reason.
+        """
+        result = plan_df.copy()
+        geometry_columns = [
+            'has_1d_xs',
+            'has_2d_mesh',
+            'num_cross_sections',
+            'mesh_cell_count',
+            'mesh_area_names',
+            'geometry_metadata_source',
+            'geometry_metadata_valid',
+            'geometry_metadata_error',
+        ]
+        derived_columns = [
+            'geometry_type',
+            'plan_type',
+            'plan_classification_valid',
+            'plan_classification_reason',
+        ]
+
+        if result.empty:
+            for column in ['flow_type', *geometry_columns, *derived_columns]:
+                if column not in result.columns:
+                    result[column] = pd.Series(dtype='object')
+            return result
+
+        result['flow_type'] = result.apply(self._classify_plan_flow, axis=1)
+        result = result.drop(
+            columns=[
+                column for column in [*geometry_columns, *derived_columns]
+                if column in result.columns
+            ],
+            errors='ignore',
+        )
+
+        geom_df = getattr(self, 'geom_df', None)
+        if geom_df is not None and not geom_df.empty and 'geom_number' in geom_df.columns:
+            available_columns = [
+                column for column in geometry_columns if column in geom_df.columns
+            ]
+            geometry_lookup = geom_df[['geom_number', *available_columns]].copy()
+            geometry_lookup = geometry_lookup.rename(
+                columns={'geom_number': 'geometry_number'}
+            )
+            geometry_lookup['geometry_number'] = (
+                geometry_lookup['geometry_number'].astype(str).str.zfill(2)
+            )
+            geometry_lookup['_geometry_metadata_joined'] = True
+            geometry_lookup = geometry_lookup.drop_duplicates(
+                subset=['geometry_number'], keep='first'
+            )
+
+            result['geometry_number'] = result['geometry_number'].apply(
+                lambda value: str(value).zfill(2) if pd.notna(value) else value
+            )
+            result['_plan_row_order'] = range(len(result))
+            result = result.merge(
+                geometry_lookup,
+                how='left',
+                on='geometry_number',
+                validate='many_to_one',
+            )
+            result = result.sort_values('_plan_row_order').drop(
+                columns=['_plan_row_order']
+            )
+            geometry_joined = result.pop('_geometry_metadata_joined').eq(True)
+        else:
+            geometry_joined = pd.Series(False, index=result.index)
+
+        defaults = {
+            'has_1d_xs': pd.NA,
+            'has_2d_mesh': pd.NA,
+            'num_cross_sections': pd.NA,
+            'mesh_cell_count': pd.NA,
+            'mesh_area_names': None,
+            'geometry_metadata_source': 'unavailable',
+            'geometry_metadata_valid': False,
+            'geometry_metadata_error': None,
+        }
+        for column, default in defaults.items():
+            if column not in result.columns:
+                result[column] = default
+
+        missing_geometry = ~geometry_joined.astype(bool)
+        result.loc[missing_geometry, 'geometry_metadata_source'] = 'unavailable'
+        result.loc[missing_geometry, 'geometry_metadata_valid'] = False
+        result.loc[missing_geometry, ['has_1d_xs', 'has_2d_mesh']] = pd.NA
+
+        missing_reference = missing_geometry & result['geometry_number'].isna()
+        missing_lookup = missing_geometry & ~result['geometry_number'].isna()
+        result.loc[missing_reference, 'geometry_metadata_error'] = (
+            'Plan geometry reference is missing'
+        )
+        result.loc[missing_lookup, 'geometry_metadata_error'] = (
+            'Referenced geometry was not found in geom_df'
+        )
+
+        for column in ['has_1d_xs', 'has_2d_mesh', 'geometry_metadata_valid']:
+            result[column] = result[column].astype('boolean')
+        for column in ['num_cross_sections', 'mesh_cell_count']:
+            result[column] = pd.to_numeric(result[column], errors='coerce').astype('Int64')
+
+        result['geometry_type'] = result.apply(self._classify_geometry, axis=1)
+        plan_classes = result.apply(
+            self._classify_plan_type,
+            axis=1,
+            result_type='expand',
+        )
+        plan_classes.columns = [
+            'plan_type',
+            'plan_classification_valid',
+            'plan_classification_reason',
+        ]
+        result[plan_classes.columns] = plan_classes
+        result['plan_classification_valid'] = (
+            result['plan_classification_valid'].astype('boolean')
+        )
+        return result
+
     def _set_file_paths(self):
         """Set geometry and flow paths in plan_df."""
         for idx, row in self.plan_df.iterrows():
@@ -356,7 +596,11 @@ class RasPrj:
             self.plan_df.at[idx, 'Sediment Path'] = str(sediment_path)
 
     def _flow_prefix_for_plan(self, row: pd.Series) -> str:
-        """Return the f/u/q prefix declared by a plan without exposing new columns."""
+        """Return the normalized f/u/q prefix declared by a plan."""
+        prefix = row.get('flow_file_prefix')
+        if pd.notna(prefix) and str(prefix).strip().lower() in {'f', 'u', 'q'}:
+            return str(prefix).strip().lower()
+
         full_path = row.get('full_path')
         if pd.notna(full_path):
             plan_path = Path(str(full_path))
@@ -378,11 +622,7 @@ class RasPrj:
 
     def _flow_type_for_plan(self, row: pd.Series) -> str:
         """Return the mechanical plan flow type from its declared file prefix."""
-        return {
-            'f': 'Steady',
-            'u': 'Unsteady',
-            'q': 'Quasi-Unsteady',
-        }.get(self._flow_prefix_for_plan(row), 'Unknown')
+        return self._classify_plan_flow(row)
 
     def _set_plan_paths(self):
         """Set full path information for plan files and their associated geometry and flow files."""
@@ -583,6 +823,15 @@ class RasPrj:
             description_match = re.search(r'BEGIN DESCRIPTION:?\s*\n(.*?)\nEND DESCRIPTION', content, re.DOTALL | re.IGNORECASE)
             if description_match:
                 plan_info['description'] = description_match.group(1).strip()
+
+            # Description text can contain strings that look like plan keys.
+            # Remove it before reading top-level control records.
+            parse_content = re.sub(
+                r'BEGIN DESCRIPTION:?\s*\n.*?\nEND DESCRIPTION',
+                '',
+                content,
+                flags=re.DOTALL | re.IGNORECASE,
+            )
             
             # BEGIN Exception to Style Guide, this is needed to keep the key names consistent with the plan file keys.
             
@@ -626,7 +875,7 @@ class RasPrj:
                 plan_info[key] = None
             
             for key, pattern in supported_plan_keys.items():
-                match = re.search(pattern, content)
+                match = re.search(rf'^{pattern}\r?$', parse_content, re.MULTILINE)
                 if match:
                     value = match.group(1).strip()
                     # Convert core values to integers if they exist
@@ -765,10 +1014,14 @@ class RasPrj:
             prefix = flow_file[0].lower()
             return {
                 'unsteady_number': flow_file[1:] if prefix == 'u' else None,
+                'quasi_unsteady_number': flow_file[1:] if prefix == 'q' else None,
+                'flow_file_prefix': prefix,
                 'Flow File': flow_file[1:]
             }
         return {
             'unsteady_number': None,
+            'quasi_unsteady_number': None,
+            'flow_file_prefix': None,
             'Flow File': None
         }
 
@@ -791,8 +1044,15 @@ class RasPrj:
         if sediment_file:
             match = re.fullmatch(r'[sS](\d{2,3})', sediment_file.strip())
             if match:
-                return {'Sediment File': match.group(1)}
-        return {'Sediment File': None}
+                number = match.group(1)
+                return {
+                    'sediment_number': number,
+                    'Sediment File': number,
+                }
+        return {
+            'sediment_number': None,
+            'Sediment File': None,
+        }
 
     def _process_breach_summary(self, plan_path: Path) -> dict:
         """Derive nullable plan-level counts from the public breach reader."""
@@ -1309,7 +1569,8 @@ class RasPrj:
             ...     print(plan_entries.iloc[0])
         """
         self.check_initialized()
-        return self._enrich_plan_dataframe(self._get_prj_entries('Plan'))
+        entries = self._enrich_plan_dataframe(self._get_prj_entries('Plan'))
+        return self._enrich_plan_classification(entries)
 
     @log_call
     def get_flow_entries(self):
@@ -1446,7 +1707,9 @@ class RasPrj:
                     'has_1d_xs', 'has_2d_mesh', 'num_cross_sections',
                     'num_inline_structures', 'num_bridges', 'num_culverts',
                     'num_weirs', 'num_gates', 'num_lateral_structures',
-                    'num_sa_2d_connections', 'mesh_cell_count', 'mesh_area_names'
+                    'num_sa_2d_connections', 'mesh_cell_count', 'mesh_area_names',
+                    'geometry_metadata_source', 'geometry_metadata_valid',
+                    'geometry_metadata_error',
                 ]
                 for col in metadata_columns:
                     default = GeomMetadata.DEFAULT_COUNTS.get(col)
@@ -1466,7 +1729,8 @@ class RasPrj:
                             geom_path=geom_path,
                             hdf_path=(
                                 hdf_path
-                                if self.load_hdf_metadata and hdf_path.exists()
+                                if getattr(self, 'load_hdf_metadata', True)
+                                and hdf_path.exists()
                                 else None
                             ),
                         )
@@ -1506,6 +1770,25 @@ class RasPrj:
                                 geom_df.at[idx, 'description'] = desc_match.group(1).strip()
                 except Exception as e:
                     logger.debug(f"Failed to extract title/description for {row['geom_file']}: {e}")
+
+            for column in ['has_1d_xs', 'has_2d_mesh', 'geometry_metadata_valid']:
+                if column in geom_df.columns:
+                    geom_df[column] = geom_df[column].astype('boolean')
+            for column in [
+                'num_cross_sections', 'num_inline_structures', 'num_bridges',
+                'num_culverts', 'num_weirs', 'num_gates',
+                'num_lateral_structures', 'num_sa_2d_connections',
+                'mesh_cell_count',
+            ]:
+                if column in geom_df.columns:
+                    geom_df[column] = pd.to_numeric(
+                        geom_df[column], errors='coerce'
+                    ).astype('Int64')
+
+            geom_df['geometry_type'] = geom_df.apply(
+                self._classify_geometry,
+                axis=1,
+            )
 
             if not self.suppress_logging:  # Only log if suppress_logging is False
                 logger.debug(f"Found {len(geom_df)} geometry entries")
@@ -2036,7 +2319,12 @@ class RasPrj:
             entry = {
                 'plan_number': row['plan_number'],
                 'plan_title': row.get('Plan Title', row.get('plan_title', '')),
-                'flow_type': row.get('flow_type', 'Unsteady'),
+                'flow_type': row.get('flow_type', 'Unknown'),
+                'flow_file_prefix': row.get('flow_file_prefix'),
+                'unsteady_number': row.get('unsteady_number'),
+                'quasi_unsteady_number': row.get('quasi_unsteady_number'),
+                'Flow File': row.get('Flow File'),
+                'Flow Path': row.get('Flow Path'),
                 'HDF_Results_Path': row.get('HDF_Results_Path'),
                 'Program Version': row.get('Program Version'),
             }

--- a/ras_commander/geom/GeomMetadata.py
+++ b/ras_commander/geom/GeomMetadata.py
@@ -35,7 +35,8 @@ Performance Notes:
 """
 
 from pathlib import Path
-from typing import Union, Optional, Dict, Any
+from typing import Any, Dict, Optional, Union
+
 import h5py
 
 from ..LoggingConfig import get_logger
@@ -51,10 +52,11 @@ class GeomMetadata:
     All methods are static and designed to be used without instantiation.
     """
 
-    # Default return values for graceful degradation
+    # Provenance is part of the classification contract. Unknown metadata
+    # must not look like a valid geometry with zero hydraulic elements.
     DEFAULT_COUNTS = {
-        'has_1d_xs': False,
-        'has_2d_mesh': False,
+        'has_1d_xs': None,
+        'has_2d_mesh': None,
         'num_cross_sections': 0,
         'num_inline_structures': 0,
         'num_bridges': 0,
@@ -63,9 +65,22 @@ class GeomMetadata:
         'num_gates': 0,
         'num_lateral_structures': 0,
         'num_sa_2d_connections': 0,
-        'mesh_cell_count': 0,
+        # Cell counts are only materialized in the geometry HDF. A text-only
+        # geometry can prove a 2D area exists, but its cell count is unknown.
+        'mesh_cell_count': None,
         'mesh_area_names': [],
+        'geometry_metadata_source': 'unavailable',
+        'geometry_metadata_valid': False,
+        'geometry_metadata_error': None,
     }
+
+    @staticmethod
+    def _new_counts() -> Dict[str, Any]:
+        """Return independent defaults for one geometry inspection."""
+        return {
+            key: value.copy() if isinstance(value, list) else value
+            for key, value in GeomMetadata.DEFAULT_COUNTS.items()
+        }
 
     @staticmethod
     @log_call
@@ -96,58 +111,78 @@ class GeomMetadata:
                 - num_gates (int): Gate count
                 - num_lateral_structures (int): Lateral structure count
                 - num_sa_2d_connections (int): SA to 2D connections count
-                - mesh_cell_count (int): Total 2D mesh cells
+                - mesh_cell_count (int | None): Total HDF mesh cells; ``None``
+                  when only text geometry is available
                 - mesh_area_names (list[str]): Names of 2D flow areas
+                - geometry_metadata_source (str): ``hdf``, ``text``, or
+                  ``unavailable``
+                - geometry_metadata_valid (bool): Whether a geometry source
+                  was successfully inspected
+                - geometry_metadata_error (str | None): Failed source reads
+                  encountered before success, or the terminal failure
 
         Note:
-            Always returns a complete dict with all keys, using defaults on failure.
-            Graceful degradation is critical - never raises exceptions.
+            Always returns a complete dict and never raises. The two
+            ``has_*`` values remain ``None`` when no source can be inspected,
+            so dispatch cannot mistake unreadable geometry for valid 1D.
 
         Example:
             >>> counts = GeomMetadata.get_geometry_counts("model.g01", "model.g01.hdf")
             >>> if counts['has_2d_mesh']:
             ...     print(f"2D areas: {counts['mesh_area_names']}")
         """
-        # Start with default values
-        result = GeomMetadata.DEFAULT_COUNTS.copy()
+        result = GeomMetadata._new_counts()
 
         # Normalize paths
         geom_path = Path(geom_path) if geom_path else None
         hdf_path = Path(hdf_path) if hdf_path else None
 
-        try:
-            # Try HDF extraction first (fast path)
-            if hdf_path and hdf_path.exists():
-                logger.debug(f"Using HDF extraction for {hdf_path.name}")
-                result = GeomMetadata._get_counts_from_hdf(hdf_path, result)
+        errors = []
 
-                # Supplement HDF metadata with plain-text-only counts and any
-                # canonical Storage Area Is2D=-1 evidence. Older/incomplete
-                # geometry HDF files may omit a 2D area that is still declared
-                # unambiguously in the geometry text.
+        # Build HDF results into a fresh candidate so a failed read cannot
+        # leak partial counts into the text fallback.
+        if hdf_path and hdf_path.exists():
+            try:
+                logger.debug(f"Using HDF extraction for {hdf_path.name}")
+                candidate = GeomMetadata._new_counts()
+                result = GeomMetadata._get_counts_from_hdf(hdf_path, candidate)
+                result['geometry_metadata_source'] = 'hdf'
+                result['geometry_metadata_valid'] = True
+
+                # These two inventories are not stored in the geometry HDF.
                 if geom_path and geom_path.exists():
                     result = GeomMetadata._add_text_only_counts(geom_path, result)
+            except Exception as exc:
+                errors.append(f"HDF inspection failed: {exc}")
+                logger.warning(f"HDF extraction failed for {hdf_path}: {exc}")
+                result = GeomMetadata._new_counts()
 
-            # Fall back to plain text parsing
-            elif geom_path and geom_path.exists():
+        if not result['geometry_metadata_valid'] and geom_path and geom_path.exists():
+            try:
                 logger.debug(f"Using text extraction for {geom_path.name}")
-                result = GeomMetadata._get_counts_from_text(geom_path, result)
+                candidate = GeomMetadata._new_counts()
+                result = GeomMetadata._get_counts_from_text(geom_path, candidate)
+                result['geometry_metadata_source'] = 'text'
+                result['geometry_metadata_valid'] = True
+            except Exception as exc:
+                errors.append(f"Text inspection failed: {exc}")
+                logger.warning(f"Text extraction failed for {geom_path}: {exc}")
+                result = GeomMetadata._new_counts()
 
-            else:
-                logger.warning("Neither HDF nor geometry file exists")
+        if not result['geometry_metadata_valid'] and not errors:
+            errors.append("Neither HDF nor geometry file exists")
+            logger.warning(errors[-1])
 
-        except Exception as e:
-            logger.warning(f"Failed to extract geometry metadata: {e}")
-            # Keep default values on failure
-
-        # Calculate derived fields
-        result['has_1d_xs'] = result['num_cross_sections'] > 0
-        result['has_2d_mesh'] = len(result['mesh_area_names']) > 0
+        if result['geometry_metadata_valid']:
+            result['has_1d_xs'] = result['num_cross_sections'] > 0
+            if result['has_2d_mesh'] is None:
+                result['has_2d_mesh'] = bool(result['mesh_area_names'])
         result['num_inline_structures'] = (
             result['num_bridges'] +
             result['num_culverts'] +
             result['num_weirs']
         )
+        result['geometry_metadata_error'] = '; '.join(errors) if errors else None
 
         return result
 
@@ -166,34 +201,23 @@ class GeomMetadata:
         Returns:
             Updated counts dict
         """
-        try:
-            with h5py.File(hdf_path, 'r') as hdf:
-                # Cross sections
-                counts['num_cross_sections'] = GeomMetadata._get_xs_count_hdf(hdf)
-
-                # Structures (bridges, culverts, weirs, gates)
-                structure_counts = GeomMetadata._get_structure_counts_hdf(hdf)
-                counts.update(structure_counts)
-
-                # 2D mesh areas and cell counts
-                mesh_info = GeomMetadata._get_2d_info_hdf(hdf)
-                counts.update(mesh_info)
-
-        except Exception as e:
-            logger.debug("HDF metadata extraction failure for %s: %s", hdf_path, e)
+        with h5py.File(hdf_path, 'r') as hdf:
+            counts['num_cross_sections'] = GeomMetadata._get_xs_count_hdf(hdf)
+            counts.update(GeomMetadata._get_structure_counts_hdf(hdf))
+            counts.update(GeomMetadata._get_2d_info_hdf(hdf))
 
         return counts
 
     @staticmethod
     def _get_xs_count_hdf(hdf: h5py.File) -> int:
         """Get 1D cross section count from geometry HDF."""
-        try:
-            path = '/Geometry/Cross Sections/Attributes'
-            if path in hdf:
-                return hdf[path].shape[0]
-        except Exception as e:
-            logger.debug(f"XS count HDF error: {e}")
-        return 0
+        path = '/Geometry/Cross Sections/Attributes'
+        if path not in hdf:
+            return 0
+        dataset = hdf[path]
+        if not isinstance(dataset, h5py.Dataset) or not dataset.shape:
+            raise ValueError(f"Unreadable cross-section attributes dataset: {path}")
+        return int(dataset.shape[0])
 
     @staticmethod
     def _get_structure_counts_hdf(hdf: h5py.File) -> Dict[str, int]:
@@ -215,47 +239,31 @@ class GeomMetadata:
             'num_gates': 0,
         }
 
-        try:
-            path = '/Geometry/Structures/Attributes'
-            if path not in hdf:
-                return result
+        path = '/Geometry/Structures/Attributes'
+        if path not in hdf:
+            return result
 
-            attrs = hdf[path][:]
+        attrs = hdf[path][()]
+        dtype_names = attrs.dtype.names or ()
 
-            # Check if 'Type' field exists
-            if 'Type' not in attrs.dtype.names:
-                # Fall back to total count if no type breakdown
-                total = attrs.shape[0]
-                logger.debug(f"No Type field in structures, total: {total}")
-                return result
+        # Older HDFs do not always expose Type. That is a supported schema
+        # variant, not an unreadable dataset.
+        if 'Type' not in dtype_names:
+            logger.debug("No Type field in structures, total: %s", attrs.shape[0])
+            return result
 
-            types = attrs['Type']
+        for struct_type in attrs['Type']:
+            if struct_type == 2:
+                result['num_bridges'] += 1
+            elif struct_type == 4:
+                result['num_weirs'] += 1
 
-            # Count by type
-            # Based on HEC-RAS structure types:
-            # Type 2 = Bridge/Culvert structure
-            # Within Bridge/Culvert, need to look for culvert count vs bridge
-            # For simplicity, count Type 2 as potential bridge/culvert
-            # Type 4 = Inline Weir
-            for struct_type in types:
-                if struct_type == 2:
-                    # Bridge/Culvert - need more info to differentiate
-                    # For now, count as bridges (culverts are within bridge structures)
-                    result['num_bridges'] += 1
-                elif struct_type == 4:
-                    result['num_weirs'] += 1
-
-            # Gates: Check for gate groups in structures
-            if '/Geometry/Structures/Gate Groups' in hdf:
-                try:
-                    gate_groups = hdf['/Geometry/Structures/Gate Groups']
-                    if 'Attributes' in gate_groups:
-                        result['num_gates'] = gate_groups['Attributes'].shape[0]
-                except Exception:
-                    pass
-
-        except Exception as e:
-            logger.debug(f"Structure counts HDF error: {e}")
+        gate_path = '/Geometry/Structures/Gate Groups/Attributes'
+        if gate_path in hdf:
+            gate_dataset = hdf[gate_path]
+            if not isinstance(gate_dataset, h5py.Dataset) or not gate_dataset.shape:
+                raise ValueError(f"Unreadable gate-group attributes dataset: {gate_path}")
+            result['num_gates'] = int(gate_dataset.shape[0])
 
         return result
 
@@ -264,39 +272,63 @@ class GeomMetadata:
         """
         Get 2D mesh area names and cell counts from geometry HDF.
 
-        Returns dict with: mesh_area_names, mesh_cell_count
+        Returns dict with: has_2d_mesh, mesh_area_names, mesh_cell_count
         """
         result = {
+            'has_2d_mesh': False,
             'mesh_area_names': [],
             'mesh_cell_count': 0,
         }
 
-        try:
-            base_path = 'Geometry/2D Flow Areas'
-            if base_path not in hdf:
-                return result
+        base_path = 'Geometry/2D Flow Areas'
+        if base_path not in hdf:
+            return result
 
-            # Get area names
-            if f"{base_path}/Attributes" in hdf:
-                attrs = hdf[f"{base_path}/Attributes"][()]
-                if 'Name' in attrs.dtype.names:
-                    names = []
-                    for name in attrs['Name']:
-                        if isinstance(name, bytes):
-                            name = name.decode('utf-8')
-                        # Strip trailing spaces
-                        names.append(name.strip())
-                    result['mesh_area_names'] = names
+        base_group = hdf[base_path]
+        if not isinstance(base_group, h5py.Group):
+            raise ValueError(f"Expected HDF group at {base_path}")
 
-            # Get cell counts from Cell Info
-            if f"{base_path}/Cell Info" in hdf:
-                cell_info = hdf[f"{base_path}/Cell Info"][()]
-                # Cell info format: (start_index, cell_count) per area
-                total_cells = sum(info[1] for info in cell_info)
-                result['mesh_cell_count'] = int(total_cells)
+        attrs_path = f"{base_path}/Attributes"
+        attributes_present = attrs_path in hdf
+        if attributes_present:
+            attrs = hdf[attrs_path][()]
+            dtype_names = attrs.dtype.names or ()
+            if 'Name' not in dtype_names:
+                raise ValueError(f"2D area Attributes dataset has no Name field: {attrs_path}")
+            for raw_name in attrs['Name']:
+                if isinstance(raw_name, bytes):
+                    raw_name = raw_name.decode('utf-8')
+                name = str(raw_name).strip()
+                if name and name not in result['mesh_area_names']:
+                    result['mesh_area_names'].append(name)
 
-        except Exception as e:
-            logger.debug(f"2D info HDF error: {e}")
+        area_group_names = [
+            name for name, item in base_group.items()
+            if isinstance(item, h5py.Group)
+        ]
+        if not attributes_present and area_group_names:
+            result['mesh_area_names'] = area_group_names
+
+        cell_info_path = f"{base_path}/Cell Info"
+        cell_rows = 0
+        if cell_info_path in hdf:
+            cell_info = hdf[cell_info_path][()]
+            cell_rows = int(cell_info.shape[0]) if cell_info.ndim else 0
+            if cell_info.size == 0:
+                result['mesh_cell_count'] = 0
+            elif cell_info.ndim >= 2 and cell_info.shape[1] >= 2:
+                result['mesh_cell_count'] = int(cell_info[:, 1].sum())
+            else:
+                raise ValueError(f"Unexpected 2D Cell Info shape at {cell_info_path}")
+
+        if not attributes_present and cell_info_path not in hdf and not area_group_names:
+            raise ValueError(
+                f"2D Flow Areas group has no Attributes, Cell Info, or area groups: {base_path}"
+            )
+
+        result['has_2d_mesh'] = bool(
+            result['mesh_area_names'] or area_group_names or cell_rows
+        )
 
         return result
 
@@ -306,12 +338,9 @@ class GeomMetadata:
         counts: Dict[str, Any]
     ) -> Dict[str, Any]:
         """
-        Supplement HDF-derived counts with plain-text geometry evidence.
+        Add counts that are only available from plain text (not in HDF).
 
-        Adds lateral structures and SA/2D connections, and merges 2D flow-area
-        names declared by canonical ``Storage Area Is2D=-1`` records. The text
-        evidence is additive so existing HDF-derived names and cell counts are
-        preserved.
+        Specifically: lateral structures and SA/2D connections.
 
         Parameters:
             geom_path: Path to plain text geometry file
@@ -339,16 +368,6 @@ class GeomMetadata:
         except Exception as e:
             logger.debug(f"Text-only counts error: {e}")
 
-        try:
-            text_mesh_info = GeomMetadata._get_2d_info_from_text(geom_path)
-            existing_names = counts.get('mesh_area_names', [])
-            text_names = text_mesh_info['mesh_area_names']
-            counts['mesh_area_names'] = list(
-                dict.fromkeys([*existing_names, *text_names])
-            )
-        except Exception as e:
-            logger.debug(f"2D mesh text supplement error: {e}")
-
         return counts
 
     @staticmethod
@@ -367,13 +386,14 @@ class GeomMetadata:
             Updated counts dict
         """
         try:
-            # Cross sections
-            try:
-                from .GeomCrossSection import GeomCrossSection
-                xs_df = GeomCrossSection.get_cross_sections(geom_path)
-                counts['num_cross_sections'] = len(xs_df)
-            except Exception as e:
-                logger.debug(f"XS count text error: {e}")
+            # Cross sections and 2D markers are classification-critical. Let
+            # their parser errors reach the top-level provenance handler.
+            from .GeomCrossSection import GeomCrossSection
+            xs_df = GeomCrossSection.get_cross_sections(geom_path)
+            counts['num_cross_sections'] = len(xs_df)
+
+            mesh_info = GeomMetadata._get_2d_info_from_text(geom_path)
+            counts.update(mesh_info)
 
             # Bridges
             try:
@@ -419,19 +439,8 @@ class GeomMetadata:
             except Exception as e:
                 logger.debug(f"Connections count text error: {e}")
 
-            # 2D mesh areas - parse from text
-            try:
-                mesh_info = GeomMetadata._get_2d_info_from_text(geom_path)
-                counts.update(mesh_info)
-            except Exception as e:
-                logger.debug(f"2D mesh text error: {e}")
-
         except Exception as e:
-            logger.warning(
-                "Text geometry metadata extraction failed for %s",
-                geom_path.name,
-            )
-            logger.debug("Text metadata extraction failure for %s: %s", geom_path, e)
+            raise ValueError(f"Geometry text parser failed for {geom_path}: {e}") from e
 
         return counts
 
@@ -440,54 +449,39 @@ class GeomMetadata:
         """
         Extract 2D mesh info from plain text geometry file.
 
-        Returns dict with: mesh_area_names, mesh_cell_count
+        Returns dict with: has_2d_mesh, mesh_area_names, mesh_cell_count
 
         Note: Mesh cell count is not directly available in plain text,
-        only in HDF. Returns 0 for mesh_cell_count from text parsing.
+        only in HDF. Returns ``None`` for mesh_cell_count from text parsing.
         """
         result = {
+            'has_2d_mesh': False,
             'mesh_area_names': [],
-            'mesh_cell_count': 0,  # Not available in plain text
+            'mesh_cell_count': None,
         }
 
-        try:
-            # Reuse the geometry parser that understands the canonical HEC-RAS
-            # representation: a Storage Area= block containing an exact integer
-            # Storage Area Is2D=-1 record. Malformed and non-(-1) values remain
-            # ordinary storage areas and therefore cannot create false positives.
-            from .GeomStorage import GeomStorage
+        current_area = None
+        with open(geom_path, 'r', encoding='utf-8', errors='replace') as handle:
+            for raw_line in handle:
+                line = raw_line.lstrip()
+                if line.startswith('Storage Area='):
+                    current_area = line.split('=', 1)[1].split(',', 1)[0].strip()
+                    continue
 
-            storage_areas = GeomStorage.get_storage_areas(
-                geom_path,
-                exclude_2d=False,
-            )
-            required_columns = {'Name', 'Is2D'}
-            if (
-                not storage_areas.empty
-                and required_columns <= set(storage_areas.columns)
-            ):
-                names = storage_areas.loc[storage_areas['Is2D'], 'Name']
-                result['mesh_area_names'] = list(dict.fromkeys(names.tolist()))
+                if not line.startswith('Storage Area Is2D=') or current_area is None:
+                    continue
 
-            # Preserve the legacy plain-text record recognized by earlier
-            # releases. It is additive to canonical storage-area evidence.
-            with open(geom_path, 'r', encoding='utf-8', errors='replace') as file:
-                content = file.read()
+                raw_flag = line.split('=', 1)[1].split(',', 1)[0].strip()
+                try:
+                    is_2d = int(raw_flag)
+                except ValueError as exc:
+                    raise ValueError(
+                        f"Invalid Storage Area Is2D flag {raw_flag!r} for {current_area!r}"
+                    ) from exc
 
-            import re
+                if is_2d == -1 and current_area and current_area not in result['mesh_area_names']:
+                    result['mesh_area_names'].append(current_area)
 
-            pattern = r'2D Flow Area=\s*(.+?)(?:\s*,|$)'
-            legacy_names = re.findall(pattern, content, re.MULTILINE)
-            result['mesh_area_names'] = list(
-                dict.fromkeys(
-                    [
-                        *result['mesh_area_names'],
-                        *(name.strip().rstrip(',') for name in legacy_names if name.strip()),
-                    ]
-                )
-            )
-
-        except Exception as e:
-            logger.debug(f"2D info text extraction error: {e}")
+        result['has_2d_mesh'] = bool(result['mesh_area_names'])
 
         return result

--- a/ras_commander/geom/GeomPreprocessor.py
+++ b/ras_commander/geom/GeomPreprocessor.py
@@ -455,23 +455,13 @@ class GeomPreprocessor:
 
     @staticmethod
     def _resolve_flow_type(plan_num: str, ras_obj) -> str:
-        """Return the flow type recorded in plan_df when available."""
+        """Return the canonical steady, unsteady, or quasi-unsteady type."""
         try:
-            if getattr(ras_obj, "plan_df", None) is None or ras_obj.plan_df.empty:
-                return "Unknown"
-            matching = ras_obj.plan_df[
-                ras_obj.plan_df["plan_number"].apply(RasUtils.normalize_ras_number)
-                == plan_num
-            ]
-            if matching.empty:
-                return "Unknown"
-            if "flow_type" in matching.columns:
-                return str(matching.iloc[0].get("flow_type") or "Unknown")
-            if "unsteady_number" in matching.columns:
-                return "Unsteady" if matching.iloc[0].get("unsteady_number") else "Steady"
+            from ..RasPlan import RasPlan
+
+            return RasPlan.get_plan_flow_type(plan_num, ras_obj)
         except Exception:
             return "Unknown"
-        return "Unknown"
 
     @staticmethod
     def _compute_message_paths(

--- a/ras_commander/results/ResultsSummary.py
+++ b/ras_commander/results/ResultsSummary.py
@@ -115,12 +115,27 @@ class ResultsSummary:
 
         Preferred inputs:
         1. Explicit ``flow_type``
-        2. ``unsteady_number`` from ``plan_df``
-        3. Raw ``Flow Path`` or ``Flow File`` values with ``u##``/``f##``/``q##``
+        2. Normalized ``flow_file_prefix``
+        3. Quasi/unsteady number columns from ``plan_df``
+        4. Raw ``Flow Path`` or ``Flow File`` values with ``f##``/``u##``/``q##``
         """
         flow_type = entry.get('flow_type')
         if ResultsSummary._has_value(flow_type):
             return str(flow_type).strip()
+
+        prefix = entry.get('flow_file_prefix')
+        if ResultsSummary._has_value(prefix):
+            normalized = str(prefix).strip().lower()
+            inferred = {
+                'f': 'Steady',
+                'u': 'Unsteady',
+                'q': 'Quasi-Unsteady',
+            }.get(normalized)
+            if inferred:
+                return inferred
+
+        if ResultsSummary._has_value(entry.get('quasi_unsteady_number')):
+            return 'Quasi-Unsteady'
 
         if ResultsSummary._has_value(entry.get('unsteady_number')):
             return 'Unsteady'

--- a/tests/fixtures/plan_classification/rasexamples_7_0.json
+++ b/tests/fixtures/plan_classification/rasexamples_7_0.json
@@ -1,0 +1,57 @@
+{
+  "archive": {
+    "filename": "Example_Projects_7_0.zip",
+    "release_tag": "1.0.45",
+    "url": "https://github.com/HydrologicEngineeringCenter/hec-downloads/releases/download/1.0.45/Example_Projects_7_0.zip",
+    "sha256": "fac04f071e624c841b20e943e3b68f351b4531f565a0c24ab7d885cf9e38d523",
+    "size_bytes": 427304097
+  },
+  "projects": {
+    "Balde Eagle Creek": {
+      "01": "unsteady_1d",
+      "02": "steady_1d"
+    },
+    "Muncie": {
+      "01": "unsteady_1d",
+      "03": "unsteady_1d_2d"
+    },
+    "Chippewa_2D": {
+      "02": "unsteady_2d"
+    },
+    "BSTEM - Simple Example": {
+      "02": "quasi_unsteady_1d"
+    },
+    "Wailupe GeoRAS": {
+      "01": "steady_1d",
+      "02": "steady_1d"
+    }
+  },
+  "derived_cases": [
+    "Muncie p03 with g02.hdf removed",
+    "Chippewa_2D p02 with g01.hdf removed",
+    "Muncie p03 with g02 and g02.hdf removed",
+    "Muncie p03 with a corrupt g02.hdf",
+    "Muncie p03 changed to steady f01 against mixed geometry"
+  ],
+  "clb_qualification": {
+    "fixture_database_project_ids": [21, 757, 1106, 1514, 1532],
+    "text_only_2d_regression": {
+      "project_id": 1106,
+      "plan_number": "01",
+      "program_version": "6.31",
+      "expected_plan_type": "unsteady_2d"
+    },
+    "version_schema_regressions": {
+      "6.70": {
+        "project_id": 21,
+        "plan_numbers": ["01", "03"],
+        "expected_plan_type": "unsteady_2d"
+      },
+      "7.00": {
+        "project_id": 1514,
+        "plan_numbers": ["03", "17"],
+        "expected_plan_type": "unsteady_1d"
+      }
+    }
+  }
+}

--- a/tests/test_geom_metadata_2d.py
+++ b/tests/test_geom_metadata_2d.py
@@ -31,10 +31,12 @@ def test_geometry_counts_recognizes_canonical_2d_storage_area(tmp_path: Path) ->
 
     assert counts["has_2d_mesh"] is True
     assert counts["mesh_area_names"] == ["Mesh Area"]
-    assert counts["mesh_cell_count"] == 0
+    assert counts["mesh_cell_count"] is None
+    assert counts["geometry_metadata_source"] == "text"
+    assert counts["geometry_metadata_valid"] is True
 
 
-def test_geometry_counts_preserves_legacy_2d_flow_area_record(tmp_path: Path) -> None:
+def test_geometry_counts_ignores_non_hecras_2d_flow_area_record(tmp_path: Path) -> None:
     geom_path = tmp_path / "Legacy.g01"
     geom_path.write_text(
         "Geom Title=Legacy 2D metadata fixture\n"
@@ -44,12 +46,12 @@ def test_geometry_counts_preserves_legacy_2d_flow_area_record(tmp_path: Path) ->
 
     counts = GeomMetadata.get_geometry_counts(geom_path, hdf_path=None)
 
-    assert counts["has_2d_mesh"] is True
-    assert counts["mesh_area_names"] == ["Legacy Mesh"]
+    assert counts["has_2d_mesh"] is False
+    assert counts["mesh_area_names"] == []
 
 
-@pytest.mark.parametrize("is_2d_value", ["0", "1", "-1.0", "unknown", ""])
-def test_geometry_counts_rejects_noncanonical_2d_values(
+@pytest.mark.parametrize("is_2d_value", ["0", "1"])
+def test_geometry_counts_treats_non_2d_flags_as_storage_areas(
     tmp_path: Path,
     is_2d_value: str,
 ) -> None:
@@ -61,7 +63,22 @@ def test_geometry_counts_rejects_noncanonical_2d_values(
     assert counts["mesh_area_names"] == []
 
 
-def test_plain_text_2d_evidence_supplements_hdf_metadata(tmp_path: Path) -> None:
+@pytest.mark.parametrize("is_2d_value", ["-1.0", "unknown", ""])
+def test_geometry_counts_fails_closed_for_malformed_2d_values(
+    tmp_path: Path,
+    is_2d_value: str,
+) -> None:
+    geom_path = _write_geometry(tmp_path / "Model.g01", is_2d_value)
+
+    counts = GeomMetadata.get_geometry_counts(geom_path, hdf_path=None)
+
+    assert counts["has_2d_mesh"] is None
+    assert counts["geometry_metadata_source"] == "unavailable"
+    assert counts["geometry_metadata_valid"] is False
+    assert "Invalid Storage Area Is2D flag" in counts["geometry_metadata_error"]
+
+
+def test_plain_text_only_counts_do_not_mutate_hdf_mesh_metadata(tmp_path: Path) -> None:
     geom_path = _write_geometry(tmp_path / "Model.g01", "-1")
     counts = GeomMetadata.DEFAULT_COUNTS.copy()
     counts["mesh_area_names"] = ["HDF Area"]
@@ -69,5 +86,5 @@ def test_plain_text_2d_evidence_supplements_hdf_metadata(tmp_path: Path) -> None
 
     result = GeomMetadata._add_text_only_counts(geom_path, counts)
 
-    assert result["mesh_area_names"] == ["HDF Area", "Mesh Area"]
+    assert result["mesh_area_names"] == ["HDF Area"]
     assert result["mesh_cell_count"] == 123

--- a/tests/test_geom_metadata_provenance.py
+++ b/tests/test_geom_metadata_provenance.py
@@ -1,0 +1,164 @@
+from pathlib import Path
+
+import h5py
+import numpy as np
+
+from ras_commander.RasPrj import RasPrj
+from ras_commander.geom.GeomMetadata import GeomMetadata
+
+
+def _write_geometry_hdf(path: Path) -> None:
+    xs_attributes = np.array(
+        [(b"River A",), (b"River A",)],
+        dtype=np.dtype([("River", "S32")]),
+    )
+    mesh_attributes = np.array(
+        [(b"Mesh A",)],
+        dtype=np.dtype([("Name", "S32")]),
+    )
+
+    with h5py.File(path, "w") as hdf:
+        hdf.create_dataset("Geometry/Cross Sections/Attributes", data=xs_attributes)
+        hdf.create_dataset("Geometry/2D Flow Areas/Attributes", data=mesh_attributes)
+        hdf.create_dataset(
+            "Geometry/2D Flow Areas/Cell Info",
+            data=np.array([[0, 4]], dtype=np.int64),
+        )
+
+
+def _text_2d_area(name: str, flag: int = -1) -> str:
+    return (
+        f"Storage Area={name},0,0\n"
+        "Storage Area Surface Line= 4\n"
+        f"Storage Area Is2D={flag}\n"
+    )
+
+
+def test_geometry_metadata_prefers_hdf_and_records_provenance(tmp_path):
+    geom_path = tmp_path / "Model.g01"
+    hdf_path = tmp_path / "Model.g01.hdf"
+    geom_path.write_text(_text_2d_area("Text Mesh"), encoding="utf-8")
+    _write_geometry_hdf(hdf_path)
+
+    metadata = GeomMetadata.get_geometry_counts(geom_path, hdf_path)
+
+    assert metadata["geometry_metadata_source"] == "hdf"
+    assert metadata["geometry_metadata_valid"] is True
+    assert metadata["geometry_metadata_error"] is None
+    assert metadata["has_1d_xs"] is True
+    assert metadata["has_2d_mesh"] is True
+    assert metadata["num_cross_sections"] == 2
+    assert metadata["mesh_area_names"] == ["Mesh A"]
+    assert metadata["mesh_cell_count"] == 4
+
+
+def test_geometry_metadata_falls_back_to_text_after_corrupt_hdf(tmp_path):
+    geom_path = tmp_path / "Model.g02"
+    hdf_path = tmp_path / "Model.g02.hdf"
+    geom_path.write_text(
+        "Geom Title=Fallback\n" + _text_2d_area("Fallback Mesh"),
+        encoding="utf-8",
+    )
+    hdf_path.write_bytes(b"not an hdf file")
+
+    metadata = GeomMetadata.get_geometry_counts(geom_path, hdf_path)
+
+    assert metadata["geometry_metadata_source"] == "text"
+    assert metadata["geometry_metadata_valid"] is True
+    assert "HDF inspection failed" in metadata["geometry_metadata_error"]
+    assert metadata["has_1d_xs"] is False
+    assert metadata["has_2d_mesh"] is True
+    assert metadata["mesh_area_names"] == ["Fallback Mesh"]
+    assert metadata["mesh_cell_count"] is None
+
+
+def test_text_parser_pairs_storage_area_name_with_is2d_flag(tmp_path):
+    geom_path = tmp_path / "Model.g03"
+    geom_path.write_text(
+        "2D Flow Area=Fictional Marker,\n"
+        + _text_2d_area("Reservoir", flag=0)
+        + "From Storage Area=Not A Geometry Block\n"
+        + _text_2d_area("Interior Mesh", flag=-1),
+        encoding="utf-8",
+    )
+
+    metadata = GeomMetadata.get_geometry_counts(geom_path)
+
+    assert metadata["geometry_metadata_source"] == "text"
+    assert metadata["geometry_metadata_valid"] is True
+    assert metadata["has_2d_mesh"] is True
+    assert metadata["mesh_area_names"] == ["Interior Mesh"]
+    assert metadata["mesh_cell_count"] is None
+
+
+def test_hdf_cell_info_proves_2d_when_attributes_are_absent(tmp_path):
+    hdf_path = tmp_path / "Model.g04.hdf"
+    with h5py.File(hdf_path, "w") as hdf:
+        hdf.create_dataset(
+            "Geometry/2D Flow Areas/Cell Info",
+            data=np.array([[0, 12]], dtype=np.int64),
+        )
+
+    metadata = GeomMetadata.get_geometry_counts(None, hdf_path)
+
+    assert metadata["geometry_metadata_source"] == "hdf"
+    assert metadata["geometry_metadata_valid"] is True
+    assert metadata["has_2d_mesh"] is True
+    assert metadata["mesh_area_names"] == []
+    assert metadata["mesh_cell_count"] == 12
+
+
+def test_malformed_2d_attributes_fail_closed(tmp_path):
+    hdf_path = tmp_path / "Model.g05.hdf"
+    with h5py.File(hdf_path, "w") as hdf:
+        hdf.create_dataset(
+            "Geometry/2D Flow Areas/Attributes",
+            data=np.array([(1,)], dtype=np.dtype([("Unexpected", "i4")])),
+        )
+
+    metadata = GeomMetadata.get_geometry_counts(None, hdf_path)
+
+    assert metadata["geometry_metadata_source"] == "unavailable"
+    assert metadata["geometry_metadata_valid"] is False
+    assert "has no Name field" in metadata["geometry_metadata_error"]
+    assert metadata["has_1d_xs"] is None
+    assert metadata["has_2d_mesh"] is None
+
+
+def test_geometry_metadata_is_unknown_when_no_source_is_available(tmp_path):
+    metadata = GeomMetadata.get_geometry_counts(
+        tmp_path / "Missing.g06",
+        tmp_path / "Missing.g06.hdf",
+    )
+
+    assert metadata["geometry_metadata_source"] == "unavailable"
+    assert metadata["geometry_metadata_valid"] is False
+    assert metadata["geometry_metadata_error"] == (
+        "Neither HDF nor geometry file exists"
+    )
+    assert metadata["has_1d_xs"] is None
+    assert metadata["has_2d_mesh"] is None
+
+
+def test_geom_df_exposes_derived_geometry_type(tmp_path):
+    prj_path = tmp_path / "Model.prj"
+    geom_path = tmp_path / "Model.g01"
+    hdf_path = tmp_path / "Model.g01.hdf"
+    prj_path.write_text("Proj Title=Model\nGeom File=g01\n", encoding="utf-8")
+    geom_path.write_text("Geom Title=Mixed Geometry\n", encoding="utf-8")
+    _write_geometry_hdf(hdf_path)
+
+    project = RasPrj()
+    project.initialized = True
+    project.prj_file = prj_path
+    project.project_folder = tmp_path
+    project.project_name = "Model"
+    project.suppress_logging = True
+
+    geom_df = project.get_geom_entries()
+
+    assert geom_df.loc[0, "geometry_type"] == "1D/2D"
+    assert geom_df.loc[0, "geometry_metadata_source"] == "hdf"
+    assert bool(geom_df.loc[0, "geometry_metadata_valid"])
+    assert str(geom_df["has_2d_mesh"].dtype) == "boolean"
+    assert str(geom_df["mesh_cell_count"].dtype) == "Int64"

--- a/tests/test_plan_classification_real_fixtures.py
+++ b/tests/test_plan_classification_real_fixtures.py
@@ -1,0 +1,271 @@
+import hashlib
+import json
+import os
+import shutil
+import sqlite3
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from ras_commander.RasExamples import RasExamples
+from ras_commander.RasPlan import RasPlan
+from ras_commander.RasPrj import RasPrj
+
+
+pytestmark = pytest.mark.integration
+
+MANIFEST_PATH = (
+    Path(__file__).parent
+    / "fixtures"
+    / "plan_classification"
+    / "rasexamples_7_0.json"
+)
+
+
+def _load_manifest() -> dict:
+    return json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _find_project_file(project_folder: Path) -> Path:
+    candidates = []
+    for path in project_folder.rglob("*.prj"):
+        text = path.read_text(encoding="utf-8", errors="replace")
+        if "Plan File=" in text:
+            candidates.append(path)
+    assert len(candidates) == 1, (
+        f"Expected one plan-bearing project in {project_folder}, found {candidates}"
+    )
+    return candidates[0]
+
+
+def _load_project(project_folder: Path) -> RasPrj:
+    prj_path = _find_project_file(project_folder)
+    project = RasPrj()
+    project.initialized = True
+    project.prj_file = prj_path
+    project.project_folder = prj_path.parent
+    project.project_name = prj_path.stem
+    project.suppress_logging = True
+    project.geom_df = project.get_geom_entries()
+    project.plan_df = project.get_plan_entries()
+    return project
+
+
+def _fixture_database_path() -> Path:
+    database_override = os.environ.get("RAS_COMMANDER_CLB_FIXTURE_DB")
+    return (
+        Path(database_override)
+        if database_override
+        else Path("feature_dev_notes")
+        / "Database of Project Fixtures"
+        / "project_fixtures.sqlite3"
+    )
+
+
+def _project_path_from_database(database_path: Path, project_id: int) -> Path:
+    connection = sqlite3.connect(
+        f"file:{database_path.as_posix()}?mode=ro",
+        uri=True,
+    )
+    try:
+        row = connection.execute(
+            "SELECT prj_file FROM projects WHERE project_id = ?",
+            (project_id,),
+        ).fetchone()
+    finally:
+        connection.close()
+    if row is None:
+        raise LookupError(f"Fixture database has no project_id={project_id}")
+    return Path(row[0])
+
+
+@pytest.fixture(scope="module")
+def real_projects(tmp_path_factory):
+    manifest = _load_manifest()
+    archive_meta = manifest["archive"]
+    archive_override = os.environ.get("RAS_COMMANDER_EXAMPLE_ARCHIVE")
+    archive_path = (
+        Path(archive_override)
+        if archive_override
+        else RasExamples._user_data_dir / archive_meta["filename"]
+    )
+    if not archive_path.is_file():
+        pytest.skip(
+            "Pinned HEC-RAS 7.0 example archive is not cached; set "
+            "RAS_COMMANDER_EXAMPLE_ARCHIVE to run real classification fixtures"
+        )
+
+    assert archive_path.stat().st_size == archive_meta["size_bytes"]
+    assert _sha256(archive_path) == archive_meta["sha256"]
+
+    previous_archive = RasExamples._zip_file_path
+    previous_folders = RasExamples._folder_df
+    RasExamples._zip_file_path = archive_path
+    RasExamples._folder_df = None
+    RasExamples._extract_folder_structure()
+
+    project_names = list(manifest["projects"])
+    output_path = tmp_path_factory.mktemp("plan_classification_examples")
+    try:
+        extracted = RasExamples.extract_project(
+            project_names,
+            output_path=output_path,
+            suffix="plan_classification",
+        )
+        yield dict(zip(project_names, extracted))
+    finally:
+        RasExamples._zip_file_path = previous_archive
+        RasExamples._folder_df = previous_folders
+
+
+def test_portable_real_fixture_matrix(real_projects):
+    manifest = _load_manifest()
+
+    for project_name, expected_plans in manifest["projects"].items():
+        project = _load_project(real_projects[project_name])
+        rows = project.plan_df.set_index("plan_number")
+        for plan_number, expected_type in expected_plans.items():
+            assert rows.loc[plan_number, "plan_type"] == expected_type
+            assert bool(rows.loc[plan_number, "plan_classification_valid"])
+
+    chippewa = _load_project(real_projects["Chippewa_2D"])
+    chippewa_row = chippewa.plan_df.set_index("plan_number").loc["02"]
+    assert chippewa_row["flow_file_prefix"] == "u"
+    assert chippewa_row["Sediment File"] == "01"
+
+    bstem = _load_project(real_projects["BSTEM - Simple Example"])
+    bstem_row = bstem.plan_df.set_index("plan_number").loc["02"]
+    assert bstem_row["flow_file_prefix"] == "q"
+    assert bstem_row["Sediment File"] == "02"
+
+
+def test_muncie_and_chippewa_text_only_2d_detection(real_projects, tmp_path):
+    muncie_copy = tmp_path / "muncie_text"
+    shutil.copytree(real_projects["Muncie"], muncie_copy)
+    (muncie_copy / "Muncie.g02.hdf").unlink()
+    muncie = _load_project(muncie_copy)
+    muncie_row = muncie.plan_df.set_index("plan_number").loc["03"]
+    assert muncie_row["plan_type"] == "unsteady_1d_2d"
+    assert muncie_row["geometry_metadata_source"] == "text"
+    assert pd.isna(muncie_row["mesh_cell_count"])
+    assert muncie_row["mesh_area_names"] == ["2D Interior Area"]
+
+    chippewa_copy = tmp_path / "chippewa_text"
+    shutil.copytree(real_projects["Chippewa_2D"], chippewa_copy)
+    (chippewa_copy / "Chippewa_2D.g01.hdf").unlink()
+    chippewa = _load_project(chippewa_copy)
+    chippewa_row = chippewa.plan_df.set_index("plan_number").loc["02"]
+    assert chippewa_row["plan_type"] == "unsteady_2d"
+    assert chippewa_row["geometry_metadata_source"] == "text"
+    assert pd.isna(chippewa_row["mesh_cell_count"])
+
+
+def test_missing_and_corrupt_geometry_hdf_fail_or_fallback(real_projects, tmp_path):
+    missing_copy = tmp_path / "muncie_missing"
+    shutil.copytree(real_projects["Muncie"], missing_copy)
+    (missing_copy / "Muncie.g02.hdf").unlink()
+    (missing_copy / "Muncie.g02").unlink()
+    missing = _load_project(missing_copy)
+    missing_row = missing.plan_df.set_index("plan_number").loc["03"]
+    assert missing_row["plan_type"] == "unknown"
+    assert not bool(missing_row["plan_classification_valid"])
+    assert missing_row["geometry_metadata_source"] == "unavailable"
+
+    corrupt_copy = tmp_path / "muncie_corrupt"
+    shutil.copytree(real_projects["Muncie"], corrupt_copy)
+    (corrupt_copy / "Muncie.g02.hdf").write_bytes(b"not an hdf file")
+    corrupt = _load_project(corrupt_copy)
+    corrupt_row = corrupt.plan_df.set_index("plan_number").loc["03"]
+    assert corrupt_row["plan_type"] == "unsteady_1d_2d"
+    assert corrupt_row["geometry_metadata_source"] == "text"
+    assert "HDF inspection failed" in corrupt_row["geometry_metadata_error"]
+
+
+def test_real_mutations_refresh_classification_and_refuse_steady_2d(
+    real_projects,
+    tmp_path,
+):
+    muncie_copy = tmp_path / "muncie_mutation"
+    shutil.copytree(real_projects["Muncie"], muncie_copy)
+    muncie = _load_project(muncie_copy)
+    RasPlan.set_steady("03", "01", muncie)
+    row = muncie.plan_df.set_index("plan_number").loc["03"]
+    assert row["flow_type"] == "Steady"
+    assert row["geometry_type"] == "1D/2D"
+    assert row["plan_type"] == "unknown"
+    assert "steady solver" in row["plan_classification_reason"]
+
+    wailupe_copy = tmp_path / "wailupe_mutation"
+    shutil.copytree(real_projects["Wailupe GeoRAS"], wailupe_copy)
+    wailupe = _load_project(wailupe_copy)
+    before = wailupe.plan_df.set_index("plan_number").loc["01"]
+    assert before["num_cross_sections"] == 47
+    RasPlan.set_geom("01", "02", wailupe)
+    after = wailupe.plan_df.set_index("plan_number").loc["01"]
+    assert after["geometry_number"] == "02"
+    assert after["num_cross_sections"] == 209
+    assert after["plan_type"] == "steady_1d"
+    assert after["geometry_metadata_source"] == "text"
+
+
+@pytest.mark.qualification_critical
+def test_clb_1106_text_only_631_2d_regression():
+    database_path = _fixture_database_path()
+    if not database_path.is_file():
+        pytest.skip("CLB fixture database is not available")
+
+    project_path = _project_path_from_database(database_path, 1106)
+    if not project_path.is_file():
+        pytest.skip("CLB fixture 1106 is not mounted")
+
+    project = _load_project(project_path.parent)
+    plan = project.plan_df.set_index("plan_number").loc["01"]
+    assert plan["Program Version"] == "6.31"
+    assert plan["flow_type"] == "Unsteady"
+    assert plan["geometry_type"] == "2D"
+    assert plan["plan_type"] == "unsteady_2d"
+    assert plan["geometry_metadata_source"] == "text"
+    assert plan["mesh_area_names"] == ["Perimeter 1"]
+    assert pd.isna(plan["mesh_cell_count"])
+
+
+@pytest.mark.qualification_critical
+def test_clb_670_and_700_geometry_hdf_schema_regressions():
+    database_path = _fixture_database_path()
+    if not database_path.is_file():
+        pytest.skip("CLB fixture database is not available")
+
+    expected = {
+        21: {
+            "version": "6.70",
+            "plans": {"01", "03"},
+            "plan_type": "unsteady_2d",
+        },
+        1514: {
+            "version": "7.00",
+            "plans": {"03", "17"},
+            "plan_type": "unsteady_1d",
+        },
+    }
+    for project_id, contract in expected.items():
+        project_path = _project_path_from_database(database_path, project_id)
+        if not project_path.is_file():
+            pytest.skip(f"CLB fixture {project_id} is not mounted")
+        project = _load_project(project_path.parent)
+        rows = project.plan_df[
+            project.plan_df["plan_number"].isin(contract["plans"])
+        ]
+        assert set(rows["plan_number"]) == contract["plans"]
+        assert set(rows["Program Version"]) == {contract["version"]}
+        assert set(rows["plan_type"]) == {contract["plan_type"]}
+        assert set(rows["geometry_metadata_source"]) == {"hdf"}
+        assert rows["plan_classification_valid"].all()

--- a/tests/test_rasprj_plan_classification.py
+++ b/tests/test_rasprj_plan_classification.py
@@ -1,0 +1,243 @@
+from pathlib import Path
+from types import SimpleNamespace
+
+import h5py
+import numpy as np
+import pandas as pd
+import pytest
+
+from ras_commander.RasPlan import RasPlan
+from ras_commander.RasPrj import RasPrj
+from ras_commander.geom.GeomPreprocessor import GeomPreprocessor
+
+
+def _geometry_rows() -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "geom_number": ["01", "02", "03", "04", "05"],
+            "has_1d_xs": [True, False, True, None, False],
+            "has_2d_mesh": [False, True, True, None, False],
+            "num_cross_sections": [12, 0, 7, None, 0],
+            "mesh_cell_count": [0, 500, 250, None, 0],
+            "mesh_area_names": [[], ["Mesh 2D"], ["Mixed Mesh"], None, []],
+            "geometry_metadata_source": [
+                "hdf", "hdf", "text", "unavailable", "hdf"
+            ],
+            "geometry_metadata_valid": [True, True, True, False, True],
+            "geometry_metadata_error": [None, None, None, "unreadable", None],
+        }
+    )
+
+
+def test_plan_df_uses_only_supported_compute_taxonomy():
+    project = RasPrj()
+    project.geom_df = _geometry_rows()
+    plans = pd.DataFrame(
+        {
+            "plan_number": [f"{number:02d}" for number in range(1, 11)],
+            "flow_file_prefix": ["f", "u", "u", "u", None, "u", "q", "f", "q", "u"],
+            "unsteady_number": [None, "02", "03", "04", None, "06", None, None, None, "10"],
+            "quasi_unsteady_number": [None, None, None, None, None, None, "01", None, "02", None],
+            "Flow File": ["01", "02", "03", "04", None, "06", "01", "02", "02", "10"],
+            "geometry_number": ["01", "02", "03", "04", "01", "99", "01", "02", "03", "05"],
+        }
+    )
+
+    classified = project._enrich_plan_classification(plans)
+
+    assert classified["flow_type"].tolist() == [
+        "Steady",
+        "Unsteady",
+        "Unsteady",
+        "Unsteady",
+        "Unknown",
+        "Unsteady",
+        "Quasi-Unsteady",
+        "Steady",
+        "Quasi-Unsteady",
+        "Unsteady",
+    ]
+    assert classified["geometry_type"].tolist() == [
+        "1D", "2D", "1D/2D", "Unknown", "1D",
+        "Unknown", "1D", "2D", "1D/2D", "Unknown",
+    ]
+    assert classified["plan_type"].tolist() == [
+        "steady_1d",
+        "unsteady_2d",
+        "unsteady_1d_2d",
+        "unknown",
+        "unknown",
+        "unknown",
+        "quasi_unsteady_1d",
+        "unknown",
+        "unknown",
+        "unknown",
+    ]
+    assert "steady_2d" not in set(classified["plan_type"])
+    assert "steady_1d_2d" not in set(classified["plan_type"])
+    assert bool(classified.loc[0, "plan_classification_valid"])
+    assert not bool(classified.loc[7, "plan_classification_valid"])
+    assert "steady solver" in classified.loc[7, "plan_classification_reason"]
+    assert "Quasi-unsteady" in classified.loc[8, "plan_classification_reason"]
+    assert "no supported" in classified.loc[9, "plan_classification_reason"]
+    assert str(classified["has_1d_xs"].dtype) == "boolean"
+    assert str(classified["mesh_cell_count"].dtype) == "Int64"
+
+
+def test_plan_parser_ignores_reference_like_text_in_description(tmp_path):
+    plan_path = tmp_path / "Model.p01"
+    plan_path.write_text(
+        "Plan Title=Real Plan\n"
+        "Geom File=g01\n"
+        "Flow File=u01\n"
+        "BEGIN DESCRIPTION:\n"
+        "Flow File=q99\n"
+        "Geom File=g99\n"
+        "END DESCRIPTION\n",
+        encoding="utf-8",
+    )
+
+    project = RasPrj()
+    parsed = project._parse_plan_file(plan_path)
+
+    assert parsed["Flow File"] == "u01"
+    assert parsed["Geom File"] == "g01"
+
+
+def test_rasplan_flow_type_fallback_includes_quasi_unsteady():
+    project = SimpleNamespace(
+        plan_df=pd.DataFrame(
+            {
+                "plan_number": ["01", "02", "03", "04"],
+                "flow_file_prefix": ["u", "f", "q", None],
+                "unsteady_number": ["01", None, None, None],
+                "quasi_unsteady_number": [None, None, "01", None],
+                "Flow File": ["01", "02", "01", None],
+            }
+        ),
+        check_initialized=lambda: None,
+    )
+
+    assert RasPlan.get_plan_flow_type("01", project) == "Unsteady"
+    assert RasPlan.get_plan_flow_type("02", project) == "Steady"
+    assert RasPlan.get_plan_flow_type("03", project) == "Quasi-Unsteady"
+    assert RasPlan.get_plan_flow_type("04", project) == "Unknown"
+    assert RasPlan.is_plan_steady_state("03", project) is False
+    assert GeomPreprocessor._resolve_flow_type("03", project) == "Quasi-Unsteady"
+
+
+def _write_geometry_hdf(path: Path, *, one_d: bool, two_d: bool) -> None:
+    with h5py.File(path, "w") as hdf:
+        if one_d:
+            hdf.create_dataset(
+                "Geometry/Cross Sections/Attributes",
+                data=np.array([(b"River",)], dtype=np.dtype([("River", "S32")])),
+            )
+        if two_d:
+            hdf.create_dataset(
+                "Geometry/2D Flow Areas/Attributes",
+                data=np.array([(b"Mesh",)], dtype=np.dtype([("Name", "S32")])),
+            )
+            hdf.create_dataset(
+                "Geometry/2D Flow Areas/Cell Info",
+                data=np.array([[0, 4]], dtype=np.int64),
+            )
+
+
+def _mutable_project(tmp_path: Path) -> RasPrj:
+    (tmp_path / "Model.prj").write_text(
+        "Proj Title=Model\n"
+        "Current Plan=p01\n"
+        "Plan File=p01\n"
+        "Geom File=g01\n"
+        "Geom File=g02\n"
+        "Flow File=f01\n"
+        "Unsteady File=u01\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "Model.p01").write_text(
+        "Plan Title=Mutation Test\n"
+        "Geom File=g01\n"
+        "Flow File=u01\n"
+        "BEGIN DESCRIPTION:\n"
+        "Flow File=q99\n"
+        "END DESCRIPTION\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "Model.g01").write_text("Geom Title=One D\n", encoding="utf-8")
+    (tmp_path / "Model.g02").write_text("Geom Title=Two D\n", encoding="utf-8")
+    _write_geometry_hdf(tmp_path / "Model.g01.hdf", one_d=True, two_d=False)
+    _write_geometry_hdf(tmp_path / "Model.g02.hdf", one_d=False, two_d=True)
+    (tmp_path / "Model.f01").write_text("Flow Title=Steady\n", encoding="utf-8")
+    (tmp_path / "Model.u01").write_text("Flow Title=Unsteady\n", encoding="utf-8")
+
+    project = RasPrj()
+    project.initialized = True
+    project.prj_file = tmp_path / "Model.prj"
+    project.project_folder = tmp_path
+    project.project_name = "Model"
+    project.suppress_logging = True
+    project._load_project_data()
+    return project
+
+
+def test_plan_mutations_rederive_classification_and_preserve_schema(tmp_path):
+    project = _mutable_project(tmp_path)
+    assert project.plan_df.loc[0, "plan_type"] == "unsteady_1d"
+
+    RasPlan.set_geom("01", "02", project)
+    row = project.plan_df.loc[0]
+    assert row["geometry_number"] == "02"
+    assert row["Geom File"] == "02"
+    assert row["geometry_type"] == "2D"
+    assert row["plan_type"] == "unsteady_2d"
+
+    RasPlan.set_steady("01", "01", project)
+    row = project.plan_df.loc[0]
+    assert row["Flow File"] == "01"
+    assert row["flow_file_prefix"] == "f"
+    assert row["flow_type"] == "Steady"
+    assert row["plan_type"] == "unknown"
+    assert "steady solver" in row["plan_classification_reason"]
+
+    RasPlan.set_geom("01", "01", project)
+    assert project.plan_df.loc[0, "plan_type"] == "steady_1d"
+
+    RasPlan.set_unsteady("01", "01", project)
+    row = project.plan_df.loc[0]
+    assert row["Flow File"] == "01"
+    assert row["flow_file_prefix"] == "u"
+    assert row["unsteady_number"] == "01"
+    assert row["plan_type"] == "unsteady_1d"
+
+    plan_text = (tmp_path / "Model.p01").read_text(encoding="utf-8")
+    assert plan_text.count("Flow File=u01") == 1
+    assert "Flow File=q99" in plan_text
+
+
+def test_plan_reference_mutation_refuses_missing_top_level_key():
+    with pytest.raises(ValueError, match="exactly one top-level Flow File"):
+        RasPlan._update_steady_in_file(
+            ["BEGIN DESCRIPTION:\n", "Flow File=u01\n", "END DESCRIPTION\n"],
+            "02",
+        )
+
+
+def test_plan_reference_mutation_preserves_crlf_and_rejects_duplicates():
+    updated = RasPlan._update_unsteady_in_file(
+        [
+            "Flow File=f01\r\n",
+            "BEGIN DESCRIPTION:\r\n",
+            "Flow File=q99\r\n",
+            "END DESCRIPTION\r\n",
+        ],
+        "02",
+    )
+    assert updated[0] == "Flow File=u02\r\n"
+    assert updated[2] == "Flow File=q99\r\n"
+
+    with pytest.raises(ValueError, match="found 2"):
+        RasPlan._update_unsteady_in_file(
+            ["Flow File=f01\n", "Flow File=u02\n"],
+            "03",
+        )

--- a/tests/test_rasprj_quasi_unsteady.py
+++ b/tests/test_rasprj_quasi_unsteady.py
@@ -41,7 +41,7 @@ def _write_quasi_unsteady_project(root: Path) -> Path:
     return project
 
 
-def test_plan_df_resolves_quasi_unsteady_flow_without_new_contract_columns(
+def test_plan_df_resolves_quasi_unsteady_flow_with_normalized_contract_columns(
     tmp_path: Path,
 ) -> None:
     project = _write_quasi_unsteady_project(tmp_path / "quasi")
@@ -66,8 +66,9 @@ def test_plan_df_resolves_quasi_unsteady_flow_without_new_contract_columns(
     assert plan["breach_active_count"] == 0
     assert str(ras_project.plan_df["breach_definition_count"].dtype) == "Int64"
     assert str(ras_project.plan_df["breach_active_count"].dtype) == "Int64"
-    assert "quasi_unsteady_number" not in ras_project.plan_df.columns
-    assert "flow_file_prefix" not in ras_project.plan_df.columns
+    assert plan["quasi_unsteady_number"] == "01"
+    assert plan["flow_file_prefix"] == "q"
+    assert plan["sediment_number"] == "01"
 
     ras_project._plan_flow_prefixes.clear()
     assert ras_project._flow_prefix_for_plan(plan) == "q"
@@ -302,14 +303,20 @@ def test_existing_steady_and_unsteady_prefixes_remain_compatible(tmp_path: Path)
 
     assert ras_project._process_flow_file({"Flow File": "f02"}) == {
         "unsteady_number": None,
+        "quasi_unsteady_number": None,
+        "flow_file_prefix": "f",
         "Flow File": "02",
     }
     assert ras_project._process_flow_file({"Flow File": "u03"}) == {
         "unsteady_number": "03",
+        "quasi_unsteady_number": None,
+        "flow_file_prefix": "u",
         "Flow File": "03",
     }
     assert ras_project._process_flow_file({"Flow File": "Q04"}) == {
         "unsteady_number": None,
+        "quasi_unsteady_number": "04",
+        "flow_file_prefix": "q",
         "Flow File": "04",
     }
 

--- a/tests/test_results_summary_flow_type.py
+++ b/tests/test_results_summary_flow_type.py
@@ -111,6 +111,29 @@ def test_summarize_plans_infers_steady_from_raw_flow_path(
     assert captured[0]["plan_meta"]["flow_type"] == "Steady"
 
 
+def test_summarize_plans_infers_quasi_from_normalized_prefix(
+    monkeypatch,
+    tmp_path,
+):
+    df, captured = _capture_flow_types(
+        monkeypatch,
+        [
+            {
+                "plan_number": "05",
+                "plan_title": "Quasi Plan DF Row",
+                "flow_type": pd.NA,
+                "flow_file_prefix": "q",
+                "quasi_unsteady_number": "02",
+                "Flow File": "02",
+            }
+        ],
+        tmp_path,
+    )
+
+    assert df["flow_type"].tolist() == ["Quasi-Unsteady"]
+    assert captured[0]["plan_meta"]["flow_type"] == "Quasi-Unsteady"
+
+
 def test_summarize_plans_infers_quasi_unsteady_from_raw_flow_path(
     monkeypatch,
     tmp_path,


### PR DESCRIPTION
## Summary

- add normalized `flow_file_prefix`, quasi-unsteady, sediment, geometry, and finite `plan_type` columns to `RasPrj.plan_df`
- classify only supported solver topologies: steady 1D; unsteady 1D, 2D, and coupled 1D/2D; quasi-unsteady 1D; otherwise fail closed as `unknown`
- make geometry metadata provenance explicit (`hdf`, `text`, `unavailable`), parse the real `Storage Area Is2D=-1` text records, and retain HDF failure details during text fallback
- make `RasPlan` geometry/flow mutations target exactly one top-level record, preserve description blocks/newlines, verify the write, and refresh dependent DataFrames
- keep preprocessing and result-summary flow typing consistent with quasi-unsteady plans
- document the DataFrame contract and add pinned public plus opt-in CLB fixture qualifications

## Why

ras2fim needs a reliable DataFrame-level dispatch contract before it can choose Wine-only steady execution versus Wine-preprocess/native-Linux unsteady execution. The prior behavior could mistake unreadable geometry for empty 1D, accept a non-HEC-RAS `2D Flow Area=` marker, lose quasi-unsteady identity, and leave classification stale after plan mutation.

HEC-RAS has no steady 2D solver, so this intentionally never emits `steady_2d` or `steady_1d_2d`.

## Validation

- `52 passed`: focused parser, provenance, taxonomy, mutation, quasi-unsteady, results-summary, and real-fixture tests
- `127 passed, 1 deselected`: broader project/geometry/preprocessor/plan/HDF regression matrix
- pinned HEC-RAS 7.0 public archive: release `1.0.45`, byte size and SHA-256 verified
- opt-in CLB fixture database qualifications passed for real 6.31 text-only 2D, 6.70 pipe-plus-2D, and 7.00 1D schemas
- Ruff passed for touched files with existing repository-baseline `E741,F401,F541,F811` findings excluded
- cached diff check passed

The one deselected regression (`test_rasunsteady_initial_condition_wrappers_round_trip`) is an existing main-branch issue: the wrapper calls the uninitialized global `RasPrj`; this change does not touch that path.

## QA

The required API-consistency review and Fable 5 adversarial review findings were incorporated: correct text marker, fail-closed provenance, finite taxonomy, quasi-unsteady classification, mutation refresh/verification, and multi-version real fixtures.