### PR TITLE
Fix legacy geometry reach classification

### DIFF
--- a/ras_commander/geom/GeomCrossSection.py
+++ b/ras_commander/geom/GeomCrossSection.py
@@ -2120,13 +2120,11 @@ class GeomCrossSection:
             while i < len(lines):
                 line = lines[i].strip()
 
-                # Track current river/reach
-                if line.startswith("River Reach="):
-                    values = GeomParser.extract_comma_list(lines[i], "River Reach")
-                    if len(values) >= 2:
-                        current_river = values[0]
-                        current_reach = values[1]
-                        logger.debug(f"Parsing {current_river} / {current_reach}")
+                # Track current river/reach, including legacy ``Reach=`` files.
+                river_reach = GeomParser.extract_river_reach(lines[i])
+                if river_reach is not None:
+                    current_river, current_reach = river_reach
+                    logger.debug(f"Parsing {current_river} / {current_reach}")
 
                 # Parse cross section metadata
                 elif line.startswith("Type RM Length L Ch R ="):
@@ -2152,7 +2150,9 @@ class GeomCrossSection:
                                 next_line = lines[j].strip()
                                 if next_line.startswith("Node Name="):
                                     node_name = GeomParser.extract_keyword_value(lines[j], "Node Name")
-                                if next_line.startswith("Type RM Length") or next_line.startswith("River Reach="):
+                                if next_line.startswith(
+                                    "Type RM Length"
+                                ) or GeomParser.extract_river_reach(next_line) is not None:
                                     break
                                 j += 1
 

--- a/ras_commander/geom/GeomParser.py
+++ b/ras_commander/geom/GeomParser.py
@@ -14,6 +14,7 @@ List of Functions:
 - identify_section() - Find section boundaries by keyword marker
 - extract_keyword_value() - Extract value following keyword
 - extract_comma_list() - Extract comma-separated list
+- extract_river_reach() - Parse modern and legacy 1D reach headers
 - create_backup() - Create .bak backup before modification
 - validate_river_reach_rs() - Validate river/reach/RS exists
 - get_geom_title() - Read the Geom Title from a geometry file
@@ -383,6 +384,32 @@ class GeomParser:
         values = [v.strip().strip('"\'') for v in value_str.split(',')]
 
         return values
+
+    @staticmethod
+    def extract_river_reach(line: str) -> Optional[Tuple[str, str]]:
+        """Parse modern and legacy 1D reach headers.
+
+        HEC-RAS 5+ writes ``River Reach=<river>,<reach>``. Older projects can
+        instead contain the single-name ``Reach=<name>`` form; when HEC-RAS
+        upgrades those projects it materializes that name as both River and
+        Reach. Mirror that vendor conversion so legacy projects classify as
+        1D before they are opened or mutated by HEC-RAS.
+
+        Returns:
+            ``(river, reach)`` for a recognized non-empty header, otherwise
+            ``None``.
+        """
+        stripped = line.strip()
+        if stripped.startswith("River Reach="):
+            values = GeomParser.extract_comma_list(stripped, "River Reach")
+            if len(values) >= 2 and values[0] and values[1]:
+                return values[0], values[1]
+            return None
+        if stripped.startswith("Reach="):
+            name = GeomParser.extract_keyword_value(stripped, "Reach").strip()
+            if name:
+                return name, name
+        return None
 
     @staticmethod
     @log_call

--- a/ras_commander/schemas.py
+++ b/ras_commander/schemas.py
@@ -28,7 +28,7 @@ Each entry of :data:`DATAFRAME_SCHEMAS`:
 """
 
 # Schema contract version -- bump when the documented column surface changes meaningfully.
-SCHEMA_VERSION = "1.4"
+SCHEMA_VERSION = "1.5"
 
 DATAFRAME_SCHEMAS = {
     "project_asset_inventory": {
@@ -138,6 +138,18 @@ DATAFRAME_SCHEMAS = {
             {"name": "unsteady_number", "dtype": "str | None", "description": "Linked unsteady-flow number, if the plan is unsteady."},
             {"name": "flow_type", "dtype": "str", "description": "Flow computation mode: 'Steady', 'Unsteady', 'Quasi-Unsteady', or 'Unknown'; orthogonal features such as sediment or dam breach are not flow types."},
             {"name": "geometry_number", "dtype": "str | None", "description": "Linked geometry number."},
+            {"name": "geometry_type", "dtype": "str", "description": "Derived geometry class: '1D', '2D', '1D/2D', or 'Unknown'."},
+            {"name": "has_1d_xs", "dtype": "boolean", "description": "Nullable flag indicating whether the linked geometry contains 1D cross sections."},
+            {"name": "has_2d_mesh", "dtype": "boolean", "description": "Nullable flag indicating whether the linked geometry contains a 2D mesh."},
+            {"name": "num_cross_sections", "dtype": "Int64", "description": "Nullable count of 1D cross sections in the linked geometry."},
+            {"name": "mesh_cell_count", "dtype": "Int64", "description": "Nullable total 2D mesh cell count in the linked geometry."},
+            {"name": "mesh_area_names", "dtype": "list[str] | None", "description": "Names of 2D flow areas in the linked geometry, when metadata is available."},
+            {"name": "geometry_metadata_source", "dtype": "str", "description": "Metadata source used for classification: 'hdf', 'text', or 'unavailable'."},
+            {"name": "geometry_metadata_valid", "dtype": "boolean", "description": "Whether linked-geometry metadata was successfully classified."},
+            {"name": "geometry_metadata_error", "dtype": "str | None", "description": "Diagnostic retained when geometry metadata inspection failed or fell back."},
+            {"name": "plan_type", "dtype": "str", "description": "Finite compute class: 'steady_1d', 'unsteady_1d', 'unsteady_2d', 'unsteady_1d_2d', 'quasi_unsteady_1d', or 'unknown'."},
+            {"name": "plan_classification_valid", "dtype": "boolean", "description": "Whether flow and geometry metadata produce a supported, unambiguous compute class."},
+            {"name": "plan_classification_reason", "dtype": "str | None", "description": "Reason an unsupported or ambiguous plan classified as 'unknown'."},
             {"name": "Geom File", "dtype": "str", "description": "Geometry file name (e.g. 'project.g01')."},
             {"name": "Geom Path", "dtype": "str", "description": "Absolute path to the geometry file."},
             {"name": "Flow File", "dtype": "str", "description": "Normalized flow-file number for steady .f##, unsteady .u##, or quasi-unsteady .q## input."},
@@ -162,18 +174,22 @@ DATAFRAME_SCHEMAS = {
             {"name": "hdf_path", "dtype": "str | None", "description": "Absolute path to the geometry HDF (.g##.hdf), if present."},
             {"name": "geom_title", "dtype": "str", "description": "Title from the 'Geom Title=' line."},
             {"name": "description", "dtype": "str", "description": "Text from the BEGIN/END DESCRIPTION block."},
-            {"name": "has_1d_xs", "dtype": "bool", "description": "Whether the geometry contains 1D cross sections."},
-            {"name": "has_2d_mesh", "dtype": "bool", "description": "Whether geometry text declares a 2D flow area or HDF metadata identifies a mesh area."},
-            {"name": "num_cross_sections", "dtype": "int", "description": "Count of 1D cross sections."},
-            {"name": "num_inline_structures", "dtype": "int", "description": "Count of inline structures."},
-            {"name": "num_bridges", "dtype": "int", "description": "Count of bridges."},
-            {"name": "num_culverts", "dtype": "int", "description": "Count of culverts."},
-            {"name": "num_weirs", "dtype": "int", "description": "Count of weirs."},
-            {"name": "num_gates", "dtype": "int", "description": "Count of gates."},
-            {"name": "num_lateral_structures", "dtype": "int", "description": "Count of lateral structures."},
-            {"name": "num_sa_2d_connections", "dtype": "int", "description": "Count of storage-area / 2D connections."},
-            {"name": "mesh_cell_count", "dtype": "int", "description": "Total 2D mesh cell count across areas."},
+            {"name": "geometry_type", "dtype": "str", "description": "Derived geometry class: '1D', '2D', '1D/2D', or 'Unknown'."},
+            {"name": "has_1d_xs", "dtype": "boolean", "description": "Nullable flag indicating whether the geometry contains 1D cross sections."},
+            {"name": "has_2d_mesh", "dtype": "boolean", "description": "Nullable flag indicating whether geometry text declares a 2D flow area or HDF metadata identifies a mesh area."},
+            {"name": "num_cross_sections", "dtype": "Int64", "description": "Nullable count of 1D cross sections."},
+            {"name": "num_inline_structures", "dtype": "Int64", "description": "Nullable count of inline structures."},
+            {"name": "num_bridges", "dtype": "Int64", "description": "Nullable count of bridges."},
+            {"name": "num_culverts", "dtype": "Int64", "description": "Nullable count of culverts."},
+            {"name": "num_weirs", "dtype": "Int64", "description": "Nullable count of weirs."},
+            {"name": "num_gates", "dtype": "Int64", "description": "Nullable count of gates."},
+            {"name": "num_lateral_structures", "dtype": "Int64", "description": "Nullable count of lateral structures."},
+            {"name": "num_sa_2d_connections", "dtype": "Int64", "description": "Nullable count of storage-area / 2D connections."},
+            {"name": "mesh_cell_count", "dtype": "Int64", "description": "Nullable total 2D mesh cell count across areas."},
             {"name": "mesh_area_names", "dtype": "list[str]", "description": "Names of the 2D flow areas."},
+            {"name": "geometry_metadata_source", "dtype": "str", "description": "Metadata source used for classification: 'hdf', 'text', or 'unavailable'."},
+            {"name": "geometry_metadata_valid", "dtype": "boolean", "description": "Whether geometry metadata was successfully classified."},
+            {"name": "geometry_metadata_error", "dtype": "str | None", "description": "Diagnostic retained when HDF or text metadata inspection failed or fell back."},
         ],
     },
     "boundaries_df": {

--- a/tests/test_geom_legacy_reach.py
+++ b/tests/test_geom_legacy_reach.py
@@ -1,0 +1,54 @@
+from ras_commander.geom.GeomCrossSection import GeomCrossSection
+from ras_commander.geom.GeomMetadata import GeomMetadata
+from ras_commander.geom.GeomParser import GeomParser
+
+
+def test_extract_river_reach_supports_modern_and_legacy_headers():
+    assert GeomParser.extract_river_reach("River Reach=River A,Reach 1\n") == (
+        "River A",
+        "Reach 1",
+    )
+    assert GeomParser.extract_river_reach("Reach=Legacy Reach\n") == (
+        "Legacy Reach",
+        "Legacy Reach",
+    )
+    assert GeomParser.extract_river_reach("Reach=\n") is None
+    assert GeomParser.extract_river_reach("Storage Area=Reach\n") is None
+
+
+def test_get_cross_sections_classifies_legacy_reach_without_mutation(tmp_path):
+    geometry = tmp_path / "legacy.g01"
+    original = (
+        "Geom Title=Legacy Geometry\r\n"
+        "ViewRect= 0, 1, 1, 0\r\n"
+        "Reach=Mixed Reach\r\n"
+        "Type RM Length L Ch R =1,0.5682,,100,,0,0,0\r\n"
+        "Node Desc=Nineteenth Cross Section\r\n"
+        "#Sta/Elev=       4\r\n"
+        "       0      80       0      70      20      70      20      80\r\n"
+        "Bank Sta=0,20\r\n"
+    )
+    geometry.write_bytes(original.encode("ascii"))
+    before = geometry.read_bytes()
+
+    cross_sections = GeomCrossSection.get_cross_sections(geometry)
+    metadata = GeomMetadata.get_geometry_counts(geometry)
+
+    assert geometry.read_bytes() == before
+    assert metadata["geometry_metadata_source"] == "text"
+    assert metadata["geometry_metadata_valid"] is True
+    assert metadata["has_1d_xs"] is True
+    assert metadata["has_2d_mesh"] is False
+    assert metadata["num_cross_sections"] == 1
+    assert cross_sections.to_dict(orient="records") == [
+        {
+            "River": "Mixed Reach",
+            "Reach": "Mixed Reach",
+            "RS": "0.5682",
+            "Type": 1,
+            "Length_Left": 0.0,
+            "Length_Channel": 100.0,
+            "Length_Right": 0.0,
+            "NodeName": "",
+        }
+    ]

--- a/tests/test_plan_classification_real_fixtures.py
+++ b/tests/test_plan_classification_real_fixtures.py
@@ -239,6 +239,35 @@ def test_clb_1106_text_only_631_2d_regression():
 
 
 @pytest.mark.qualification_critical
+def test_clb_68_legacy_reach_text_fallback_is_steady_1d_and_immutable(tmp_path):
+    database_path = _fixture_database_path()
+    if not database_path.is_file():
+        pytest.skip("CLB fixture database is not available")
+
+    project_path = _project_path_from_database(database_path, 68)
+    if not project_path.is_file():
+        pytest.skip("CLB fixture 68 is not mounted")
+
+    working_copy = tmp_path / "clb_68_legacy_reach"
+    shutil.copytree(project_path.parent, working_copy)
+    geometry_path = working_copy / "MIXED.g01"
+    geometry_hdf = working_copy / "MIXED.g01.hdf"
+    geometry_hdf.unlink()
+    before = _sha256(geometry_path)
+
+    project = _load_project(working_copy)
+    plan = project.plan_df.set_index("plan_number").loc["01"]
+
+    assert _sha256(geometry_path) == before
+    assert plan["flow_type"] == "Steady"
+    assert plan["geometry_type"] == "1D"
+    assert plan["plan_type"] == "steady_1d"
+    assert bool(plan["plan_classification_valid"])
+    assert plan["geometry_metadata_source"] == "text"
+    assert plan["num_cross_sections"] == 19
+
+
+@pytest.mark.qualification_critical
 def test_clb_670_and_700_geometry_hdf_schema_regressions():
     database_path = _fixture_database_path()
     if not database_path.is_file():

--- a/tests/test_rasprj_plan_classification.py
+++ b/tests/test_rasprj_plan_classification.py
@@ -9,6 +9,7 @@ import pytest
 from ras_commander.RasPlan import RasPlan
 from ras_commander.RasPrj import RasPrj
 from ras_commander.geom.GeomPreprocessor import GeomPreprocessor
+from ras_commander.schemas import DATAFRAME_SCHEMAS, SCHEMA_VERSION
 
 
 def _geometry_rows() -> pd.DataFrame:
@@ -82,6 +83,45 @@ def test_plan_df_uses_only_supported_compute_taxonomy():
     assert "no supported" in classified.loc[9, "plan_classification_reason"]
     assert str(classified["has_1d_xs"].dtype) == "boolean"
     assert str(classified["mesh_cell_count"].dtype) == "Int64"
+
+
+def test_classification_and_provenance_columns_are_canonical_schema() -> None:
+    expected_plan_columns = {
+        "geometry_type": "str",
+        "has_1d_xs": "boolean",
+        "has_2d_mesh": "boolean",
+        "num_cross_sections": "Int64",
+        "mesh_cell_count": "Int64",
+        "mesh_area_names": "list[str] | None",
+        "geometry_metadata_source": "str",
+        "geometry_metadata_valid": "boolean",
+        "geometry_metadata_error": "str | None",
+        "plan_type": "str",
+        "plan_classification_valid": "boolean",
+        "plan_classification_reason": "str | None",
+    }
+    expected_geom_columns = {
+        "geometry_type": "str",
+        "has_1d_xs": "boolean",
+        "has_2d_mesh": "boolean",
+        "num_cross_sections": "Int64",
+        "mesh_cell_count": "Int64",
+        "geometry_metadata_source": "str",
+        "geometry_metadata_valid": "boolean",
+        "geometry_metadata_error": "str | None",
+    }
+
+    assert SCHEMA_VERSION == "1.5"
+    for dataframe, expected in (
+        ("plan_df", expected_plan_columns),
+        ("geom_df", expected_geom_columns),
+    ):
+        schema_columns = DATAFRAME_SCHEMAS[dataframe]["columns"]
+        names = [column["name"] for column in schema_columns]
+        dtypes = {column["name"]: column["dtype"] for column in schema_columns}
+        for name, dtype in expected.items():
+            assert names.count(name) == 1
+            assert dtypes[name] == dtype
 
 
 def test_plan_parser_ignores_reference_like_text_in_description(tmp_path):


### PR DESCRIPTION
## Summary
- recognize legacy top-level `Reach=<name>` geometry headers using HEC-RAS upgrade semantics (`river=reach=name`)
- route cross-section parsing and lookahead through the shared parser without mutating geometry files
- register existing plan classification and geometry-provenance columns in the canonical dataframe schemas; bump schema contract to 1.5
- add focused modern/legacy tests and an immutable database-backed HEC-RAS 6.3 qualification fixture

## Qualification
- targeted parser/provenance/classification suite: 28 passed, 3 skipped
- CLB database-backed fixture suite: 7 passed
- full non-integration suite: 43 failed, 2289 passed, 40 skipped, 32 deselected; the 43 failures are the documented current-main baseline, with one added passing schema test
- real legacy MIXED geometry: 19 cross sections, text provenance, `steady_1d`, source SHA-256 unchanged

## Fixture audit
A read-only audit checked 5,098 distinct catalog geometry paths and cached HEC-RAS 6.6/7.0 example archives. It found no second valid top-level legacy `Reach=` geometry. Ten catalog-backed modern/2D negative controls passed with byte-identical before/after hashes and matching metadata/cross-section counts. The lack of a second real pre-upgrade fixture is retained as a qualification gap rather than replaced with invented data.