### PR TITLE
Add lean compute integration and steady HDF parity

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -13,7 +13,7 @@ authors:
 abstract: >-
   RAS Commander is an open-source Python library for reproducible HEC-RAS
   automation, project inspection, execution, and results analysis.
-version: 0.99.0
+version: 0.99.1
 license: MIT
 repository-code: https://github.com/gpt-cmdr/ras-commander
 url: https://rascommander.info/ras/

--- a/README.md
+++ b/README.md
@@ -165,6 +165,18 @@ pip install ras-commander[all]
 pip install --upgrade ras-commander
 ```
 
+The standard install provides project inventory and direct HDF access. For a
+lean batch runner that also executes plans through `RasCmdr.compute_plan()`, use:
+
+```bash
+pip install --upgrade "ras-commander[compute]"
+```
+
+The `compute` surface excludes RasControl/COM and the geospatial and plotting
+stacks. It does not bypass ras-commander: `RasCmdr` still constructs and owns
+the HEC-RAS command-line execution, message handling, verification options, and
+normal post-compute DataFrame refreshes.
+
 If you have dependency issues with pip (especially if you have errors with numpy), try clearing your local pip packages `C:\Users\your_username\AppData\Roaming\Python\` and then creating a new virtual environment.
 
 ### Extras
@@ -173,7 +185,10 @@ Install only what you need using pip extras:
 
 | Extra | What it adds | Install command |
 |-------|-------------|-----------------|
-| `all` | Everything below | `pip install ras-commander[all]` |
+| `compute` | Lean command-line plan execution and process supervision (no RasControl/COM) | `pip install ras-commander[compute]` |
+| `execution` | Alias for `compute` | `pip install ras-commander[execution]` |
+| `full` | Historical ras-commander feature dependency set | `pip install ras-commander[full]` |
+| `all` | Full feature set plus every optional integration below | `pip install ras-commander[all]` |
 | `remote-all` | All remote backends (SSH, WinRM, Docker, AWS, Azure) | `pip install ras-commander[remote-all]` |
 | `gui` | GUI automation & screenshots (Pillow) | `pip install ras-commander[gui]` |
 | `usgs` | USGS gauge data (dataretrieval) | `pip install ras-commander[usgs]` |
@@ -185,7 +200,9 @@ Combine extras as needed: `pip install ras-commander[notebooks,usgs,dss]`
 
 ### Core Dependencies (installed automatically)
 
-h5py, numpy, pandas, requests, tqdm, scipy, xarray, geopandas, matplotlib, shapely, rasterstats, rtree, fsspec, hms-commander, psutil, and pywin32 (Windows only).
+h5py, numpy, and pandas. The `compute` extra adds psutil and pywin32 on
+Windows for process and dialog supervision. Install `full` or `all` for the
+geospatial, plotting, scientific, precipitation, and remote-data feature stack.
 
 Note: `pathlib` is built into Python 3.4+ and does not need to be installed separately.
 

--- a/docs/development/hec-ras-6302-wine-compute-plan-qualification.md
+++ b/docs/development/hec-ras-6302-wine-compute-plan-qualification.md
@@ -1,0 +1,177 @@
+# HEC-RAS 6.3.0.2 Wine `compute_plan` qualification
+
+## Outcome
+
+The lean `ras_commander.compute` facade is qualified for one real HEC-RAS
+6.3.0.2 1D steady plan under Wine without RasControl or another Controller/COM
+call. `RasCmdr.compute_plan()` launched the normal HEC-RAS command-line path,
+HEC-RAS materialized its own steady run files, and ras-commander extracted the
+completed result HDF directly.
+
+This is a bounded integration qualification, not a claim that every HEC-RAS
+6.3 model is qualified or that a downstream ras2fim container is production
+ready. The downstream container still needs to pin this wheel, clone an
+accepted task-local Wine prefix, preserve its supervisor and receipt gates, and
+repeat the acceptance tests through its public runner interface.
+
+## Qualified identities
+
+| Component | Qualified identity |
+|---|---|
+| HEC-RAS release | `6.3.0.2` (`HEC-RAS 6.3 August 2022` in HDF provenance) |
+| Installer SHA-256 | `869e5455de14f23abfba1c9b73e7ef15b7c1b5cca3af12e8b95cb61e69832e57` |
+| `Ras.exe` SHA-256 | `3a8f683961dcad82cfb15bbb68ec3df62c6510711dd89c37e3e09f52c9d8b860` |
+| `x64/RasSteady.exe` SHA-256 | `b3e110ad72e74901e40622379828d95188d646e79a6c96f206c64e996bbecf6b` |
+| ras-commander source | `bbddd42c4966967ab6967de4fbc3c4079ab13d10` |
+| Qualification wheel SHA-256 | `fb36090e14634dfd584b309bf649e8b0673fcac9d2f03121c8ba42defa89ef5d` |
+| Wine | `wine-11.0` |
+| Container image | `localhost/ras2fim-hecras:6.3.0.2-ras-commander-69871c81` |
+| Guest | isolated CT217 on CLB01; network disabled for compute |
+| CPU allocation | affinity set `{0, 2}`; one HEC-RAS plan core |
+
+The existing container was reused to isolate the code-path question. The PR
+wheel was force-installed without dependency resolution from the local
+wheelhouse. A downstream image must rebuild from pinned inputs rather than
+relying on this qualification image.
+
+## Exact execution path
+
+The probe imported only the narrow integration facade:
+
+```python
+from ras_commander.compute import RasCmdr, RasPrj, init_ras_project
+
+project = RasPrj()
+init_ras_project(
+    r"Z:\work\project\MIXED.PRJ",
+    r"C:\Program Files (x86)\HEC\HEC-RAS\6.3\Ras.exe",
+    ras_object=project,
+    load_results_summary=False,
+    hide_intro=True,
+    accept_tcu=False,
+    load_hdf_metadata=True,
+)
+result = RasCmdr.compute_plan(
+    "01",
+    ras_object=project,
+    force_rerun=True,
+    num_cores=1,
+    verify=True,
+    dialog_watchdog=False,
+)
+```
+
+ras-commander constructed the HEC-RAS-owned command:
+
+```text
+C:\Program Files (x86)\HEC\HEC-RAS\6.3\Ras.exe \
+  -c Z:\work\project\MIXED.PRJ Z:\work\project\MIXED.p01
+```
+
+HEC-RAS then performed the full vendor workflow. Process and file-transition
+capture showed it:
+
+1. create the steady `.r01` input;
+2. create the plan `.p01.tmp.hdf` skeleton;
+3. run `RasProcess.exe CompleteGeometry` and promote the refreshed geometry
+   HDF;
+4. launch `x64/RasSteady.exe` with the absolute `.r01` path;
+5. grow the temporary result HDF and promote it to `.p01.hdf`.
+
+No ras-commander or ras2fim code authored `.r01` or `.tmp.hdf` content.
+
+## Terms acceptance boundary
+
+HEC-RAS `Ras.exe -c` displays the release-specific Terms and Conditions for
+Use dialog when the exact Windows user and install path lack accepted state.
+The original probe correctly blocked there. Earlier acceptance artifacts were
+failed receipts and were not treated as authorization evidence.
+
+After explicit authorization for exact HEC-RAS 6.3.0.2, the visible dialog was
+accepted for the task-local `runner` prefix only. The application was closed
+cleanly so its VB6 user settings were persisted, and `RasTcu.status()` then
+reported `accepted=True`. The successful receipt pins the same `Ras.exe` hash
+shown above. Acceptance was not inferred, copied from a different release, or
+performed by `init_ras_project()`.
+
+Production images must provision that already-authorized state into the
+immutable base prefix and clone it per task. They must fail closed if the exact
+release, executable hash, user, or acceptance state differs.
+
+## Real-result parity
+
+The immutable `MIXED` fixture contains two steady profiles and 19 cross
+sections. The no-COM run completed in 5.421 seconds as measured around
+initialization, `compute_plan()`, verification, and DataFrame refresh.
+
+`HdfResultsPlan.get_steady_results()` returned 38 rows. Mapping its steady HDF
+fields to the ras2fim contract produced:
+
+```text
+fid_xs, modelid, Xsection_name, wse, discharge, max_depth, channel_length
+```
+
+| Gate | Result |
+|---|---|
+| Rows | `38` |
+| Profiles × cross sections | `2 × 19` |
+| `max_depth` source | `Maximum Depth Total` |
+| `channel_length` source | `Geometry/Cross Sections/Attributes/Len Channel` |
+| Result HDF SHA-256 | `316fb01821d099c9043f4554b869f2dc4a2dea825a3a0a7bc647ea35bc2fc920` |
+| Linux-hosted ras2fim CSV SHA-256 | `6453f93e6ff40eae7842f73de42b0a6b0ff0fe25689b4673636595f826a98d5f` |
+| Windows Controller CSV SHA-256 | `6453f93e6ff40eae7842f73de42b0a6b0ff0fe25689b4673636595f826a98d5f` |
+| Maximum numeric difference | `4.440892098500626e-16` (`max_depth`) |
+
+WSE, discharge, and channel length were exact. Text identities and ordering
+were exact. The sub-machine-precision depth difference passed the `1e-6`
+absolute-tolerance gate, and the serialized result CSVs were byte-identical.
+
+## Supervision gate
+
+A separate run forced the container-level timeout while the compute worker was
+still active. The named container was stopped and removed, the task-local Wine
+server was terminated, and post-cleanup inspection found:
+
+- no owned HEC-RAS or Wine survivor processes;
+- no matching container;
+- a machine-readable timeout receipt with `stop_reason="timed_out"` and
+  `success=true`.
+
+The fixture solves very quickly, so its HDF may already be complete before a
+short outer timeout interrupts post-compute inventory refresh. The gate proves
+owned-process cleanup; downstream runner tests should retain their synthetic
+long-running timeout fixture to exercise termination during active work too.
+
+## Preserved failed experiments
+
+The following results constrain future implementations:
+
+- Direct `RasSteady.exe MIXED.r01` without `.p01.tmp.hdf` exits with an HDF5
+  diagnostic stating that the temporary result HDF is missing.
+- Copying a completed `.p01.hdf` to `.p01.tmp.hdf` is invalid; the solver
+  reports that the output must not already exist.
+- Replaying captured `.r01`, temporary HDF, and geometry HDF artifacts through
+  a separately launched Windows `RasSteady.exe` reached 10% progress and then
+  failed in `READ_HDF`. Do not advertise direct Windows-engine replay as a
+  supported path from this evidence.
+- The first `compute_plan()` probes timed out before creating run artifacts
+  because the TCU dialog was visible. After exact-version acceptance, the same
+  `Ras.exe -c` path completed. Those timeouts are not evidence that
+  `compute_plan()` is incompatible with Wine.
+
+## Remaining downstream gates
+
+Before calling the ras2fim lane production-ready:
+
+1. merge the ras-commander integration PR and pin the resulting immutable
+   wheel in ras2fim;
+2. rebuild the lean batch image from pinned dependencies and record its digest
+   and final size;
+3. replace the ras2fim steady bridge's `RasControl.run_plan()` call with normal
+   `RasCmdr.compute_plan()` while retaining task-local prefix/project cloning,
+   CPU affinity, supervision, semantic HDF validation, and receipts;
+4. rerun terrain, steady parity, concurrency, and forced-timeout smoke tests
+   through the ras2fim public container command;
+5. qualify additional immutable model families. The current steady-result HDF
+   fixture matrix covers 6.0.0, 6.3.1, 6.4.1, 6.6, and 7.0; no computed steady
+   HDF fixture was available for 6.1, 6.2, or 6.5.

--- a/docs/development/release-notes.md
+++ b/docs/development/release-notes.md
@@ -28,6 +28,12 @@
   not align. Immutable HEC-RAS 6.0.0, 6.3.1, 6.4.1, 6.6, and 7.0 fixtures
   cover the available 6.x-to-7.0 steady-result schemas and sentinel
   normalization behavior.
+- Qualify the narrow `RasCmdr.compute_plan()` path against exact HEC-RAS
+  6.3.0.2 under Wine without RasControl/COM. The real 38-row ras2fim result CSV
+  is byte-identical to the immutable Windows Controller baseline; the
+  [qualification report](hec-ras-6302-wine-compute-plan-qualification.md)
+  records identities, TCU handling, failed experiments, parity, and remaining
+  downstream gates.
 
 **C01-C06 Reliability Hardening**
 

--- a/docs/development/release-notes.md
+++ b/docs/development/release-notes.md
@@ -4,6 +4,31 @@
 
 ### Unreleased
 
+**Lean Command-Line Compute Integration**
+
+- Add `ras-commander[compute]` (and the `execution` alias) for command-line
+  `RasCmdr.compute_plan()` workers without RasControl/COM or the geospatial and
+  plotting dependency stack.
+- Add `ras_commander.compute` as a narrow integration facade for project
+  inventory, plan execution, compute-message parsing, and direct steady-result
+  HDF extraction.
+- Preserve normal compute semantics, including ras-commander-owned command
+  construction and post-compute DataFrame refreshes; no reduced-refresh flags
+  were added.
+- Lazy-load optional top-level and HDF exports so the lean install remains
+  import-safe, while retaining the historical public import names. The `full`
+  extra restores the previous broad dependency surface.
+- Keep lightweight map option types available from their historical modules,
+  including their documented and pickle-visible module identities, without
+  importing the optional geospatial stack into a compute-only worker.
+- Correct HDF steady `max_depth` extraction to use `Maximum Depth Total`
+  instead of `Hydraulic Depth Channel`, expose hydraulic depth separately, and
+  join downstream channel reach length by full river/reach/station identity.
+  Result arrays now fail closed when profile or cross-section dimensions do
+  not align. Immutable HEC-RAS 6.0.0, 6.3.1, 6.4.1, 6.6, and 7.0 fixtures
+  cover the available 6.x-to-7.0 steady-result schemas and sentinel
+  normalization behavior.
+
 **C01-C06 Reliability Hardening**
 
 - Preserve the existing precipitation-file line endings and surrounding bytes
@@ -21,6 +46,16 @@
 - Require exact legacy completion evidence before exporting result products,
   exclude nonfinite result samples from raster interpolation, and omit
   unavailable hydrograph variables from exported Parquet metadata.
+- Treat equivalent HRRR timestamps as equal across differing NumPy datetime
+  storage resolutions, avoiding false cycle-plus-step validation failures.
+- Allow initial-condition method mutation against an explicit unsteady-flow
+  path without requiring unrelated global project initialization.
+- Match 1D and 2D unsteady boundary blocks with exact semantic selectors and
+  fail closed on ambiguous or index-mismatched DSS-link mutations.
+- Restore the concise plan-geometry mutation summary at INFO while retaining
+  file paths and refreshed DataFrames at DEBUG.
+- Normalize relative components in mapped-drive fallbacks without converting
+  HEC-RAS-compatible drive-letter paths to UNC paths.
 
 ### v0.99.1 (Current published release — July 2026)
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -74,13 +74,40 @@ python -m ipykernel install --user --name RasCommander --display-name "Python (R
     pip install --upgrade ras-commander
     ```
 
-## Core Dependencies
+## Installation Profiles
 
 These are installed automatically with `pip install ras-commander`:
 
 ```bash
-h5py numpy pandas requests tqdm scipy xarray geopandas matplotlib shapely rasterstats rtree pywin32 psutil
+h5py numpy pandas
 ```
+
+For command-line HEC-RAS execution, compute-message parsing, and direct HDF
+result extraction without RasControl/COM or the full geospatial stack:
+
+```bash
+pip install "ras-commander[compute]"
+```
+
+The `execution` extra is an alias for `compute`. Both add psutil and, on
+Windows, pywin32 for the normal process and dialog supervision used by
+`RasCmdr.compute_plan()`.
+
+For the historical complete feature dependency set, including geospatial,
+plotting, scientific, precipitation, and remote-data dependencies:
+
+```bash
+pip install "ras-commander[full]"
+```
+
+Use `ras-commander[all]` when you also want every optional backend and
+integration. Extras are additive and can be combined.
+
+!!! note "Compute extra scope"
+    The extra controls Python dependencies only; it does not install HEC-RAS or
+    Wine. It preserves the normal `RasCmdr.compute_plan()` behavior, including
+    project/result DataFrame refresh after execution. It does not expose a
+    reduced-refresh execution mode and does not route computation through COM.
 
 ## Optional Dependencies
 

--- a/docs/user-guide/plan-execution.md
+++ b/docs/user-guide/plan-execution.md
@@ -2,6 +2,33 @@
 
 RAS Commander provides three modes for executing HEC-RAS plans, each optimized for different workflows.
 
+## Lean Batch Installation
+
+Batch workers that only need project inventory, plan computation, computation
+messages, and HDF result extraction can install the compute dependency profile:
+
+```bash
+pip install "ras-commander[compute]"
+```
+
+Use the intentionally narrow facade in integration code:
+
+```python
+from ras_commander.compute import (
+    HdfResultsPlan,
+    RasCmdr,
+    ResultsParser,
+    init_ras_project,
+)
+```
+
+This facade does not export `RasControl` or `RasControlResult`. Call
+`RasCmdr.compute_plan()` rather than constructing a `Ras.exe -c` command in the
+integrating application. The method retains normal ras-commander behavior:
+command construction, process and dialog supervision, compute-message handling,
+caller-controlled semantic verification, and post-compute project/result
+DataFrame refresh.
+
 ## Single Plan Execution
 
 Execute one plan with full parameter control using `RasCmdr.compute_plan()`.

--- a/docs/user-guide/steady-flow-analysis.md
+++ b/docs/user-guide/steady-flow-analysis.md
@@ -74,6 +74,37 @@ print(info)
 # - reach_names: List of reach names
 ```
 
+## Complete Cross-Section Results Without COM
+
+`get_steady_results()` reads the modern plan HDF directly and returns one row
+per profile and cross section:
+
+```python
+results = HdfResultsPlan.get_steady_results(hdf_path)
+results = results[
+    [
+        "river", "reach", "node_id", "profile", "wsel", "flow",
+        "max_depth", "channel_length",
+    ]
+]
+```
+
+`max_depth` is the HEC-RAS `Maximum Depth Total` result. This is distinct from
+`hydraulic_depth`, which is also returned from `Hydraulic Depth Channel`.
+`channel_length` is joined from geometry cross-section attributes using the
+full `(river, reach, station)` identity; HEC-RAS non-finite terminal reach-length
+sentinels are normalized to zero.
+
+The selected sources are recorded on the returned DataFrame:
+
+```python
+print(results.attrs["max_depth_source"])
+print(results.attrs["channel_length_source"])
+```
+
+HEC-RAS layouts without `Maximum Depth Total` use `Hydraulic Depth Channel` as
+an explicit legacy fallback and record that fallback in `max_depth_source`.
+
 ## Complete Workflow
 
 ```python
@@ -160,5 +191,9 @@ See [Legacy COM Interface](legacy-com-interface.md) for complete RasControl docu
 
 - Steady flow support was added in v0.80.3+
 - Works with HEC-RAS 6.x+ HDF files
+- `Maximum Depth Total` and geometry `Len Channel` semantics are regression
+  tested against immutable HEC-RAS 6.0.0, 6.3.1, 6.4.1, 6.6, and 7.0 fixtures.
+  The current CLB catalog contains no computed steady-result HDF from 6.1,
+  6.2, or 6.5, so those exact releases remain explicit fixture gaps.
 - For legacy versions (3.x-5.x), use `RasControl.get_steady_results()`
 - See `examples/19_steady_flow_analysis.ipynb` for complete examples

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -238,6 +238,7 @@ nav:
     - Multi-Harness Agent Contract: development/multi-harness-agent-contract.md
     - Contributing: development/contributing.md
     - Architecture: development/architecture.md
+    - HEC-RAS 6.3.0.2 Wine Compute Qualification: development/hec-ras-6302-wine-compute-plan-qualification.md
     - Release Notes: development/release-notes.md
   - About:
     - Cite and Support RAS Commander: cite.md

--- a/ras_commander/RasBenefits.py
+++ b/ras_commander/RasBenefits.py
@@ -37,6 +37,7 @@ from shapely.ops import unary_union
 
 from .Decorators import log_call
 from .LoggingConfig import get_logger
+from ._execution_types import BenefitAreaConfig
 
 logger = get_logger(__name__)
 
@@ -177,44 +178,6 @@ BENEFIT_COLORMAP = {
     BenefitCategory.PARTIALLY_BENEFITED: (255, 191, 0, 255),
     BenefitCategory.FULLY_BENEFITED: (35, 139, 69, 255),
 }
-
-
-@dataclass(frozen=True)
-class BenefitAreaConfig:
-    """Pair-aware configuration used by :meth:`RasProcess.store_maps`.
-
-    ``pre_plan_number`` is the baseline plan; the ``plan_number`` supplied to
-    ``store_maps`` is the post-project plan.
-    """
-
-    pre_plan_number: str
-    terrain_tif: Union[str, Path]
-    terrain_name: Optional[str] = None
-    include_wse: bool = False
-    flood_min_depth: float = 0.05
-    benefit_min_depth: float = 0.25
-    minimum_region_pixels: Optional[int] = 16
-    analysis_boundary: Any = None
-    improvement_boundary: Any = None
-    polygon_output: Optional[Union[bool, str, Path]] = None
-    polygon_simplify_tolerance: Optional[float] = None
-
-    def __post_init__(self) -> None:
-        if self.pre_plan_number is None or not str(self.pre_plan_number).strip():
-            raise ValueError("pre_plan_number is required for BenefitArea mapping")
-        if self.terrain_tif is None or not str(self.terrain_tif).strip():
-            raise ValueError(
-                "terrain_tif is required for BenefitArea mapping. "
-                f"{RasBenefits.TERRAIN_REMEDIATION}"
-            )
-        RasBenefits._validate_thresholds(
-            self.flood_min_depth,
-            self.benefit_min_depth,
-        )
-        RasBenefits._validate_minimum_region_pixels(self.minimum_region_pixels)
-        RasBenefits._validate_polygon_simplify_tolerance(
-            self.polygon_simplify_tolerance
-        )
 
 
 @dataclass(frozen=True)

--- a/ras_commander/RasMap.py
+++ b/ras_commander/RasMap.py
@@ -92,15 +92,13 @@ from typing import (
 from .RasPrj import ras
 from .RasPlan import RasPlan
 from .RasUtils import RasUtils
-from .RasGuiAutomation import RasGuiAutomation
-from .RasBenefits import BenefitAreaConfig
-from .RasterPerformance import StoreMapPerformanceOptions
 from .LoggingConfig import get_logger
 from .Decorators import log_call
 from ._native_helper import (
     normalize_store_map_render_mode,
     run_store_all_maps_helper,
 )
+from ._execution_types import BenefitAreaConfig, StoreMapPerformanceOptions
 
 if TYPE_CHECKING:
     from geopandas import GeoDataFrame
@@ -3270,6 +3268,8 @@ class RasMap:
                 # Note: For multiple plans, we run the first plan's automation
                 # The user can manually run additional plans if needed
                 first_plan = plan_number_list[0]
+
+                from .RasGuiAutomation import RasGuiAutomation
 
                 success = RasGuiAutomation.open_and_compute(
                     plan_number=first_plan,

--- a/ras_commander/RasPlan.py
+++ b/ras_commander/RasPlan.py
@@ -387,6 +387,12 @@ class RasPlan:
                 f"Plan reference verification failed for {plan_file_path}: "
                 f"expected {key}={value}, found {actual}"
             )
+        logger.debug(
+            "Updated %s in plan file %s to %s",
+            key,
+            plan_file_path.name,
+            value,
+        )
 
     @staticmethod
     def _refresh_classification(ras_obj, *, refresh_flows: bool = False) -> None:
@@ -449,7 +455,7 @@ class RasPlan:
             logger.error(f"Error updating plan file: {e}")
             raise
 
-        logger.debug("Set geometry for plan p%s to g%s", plan_number, new_geom)
+        logger.info("Set geometry for plan p%s to g%s", plan_number, new_geom)
         logger.debug("Updated plan DataFrame:")
         logger.debug(ras_obj.plan_df)
 
@@ -3997,6 +4003,11 @@ class RasPlan:
                     logger.debug(f"Plan {plan_num}: {flow_type} (from plan_df)")
                     return flow_type
 
+            if 'unsteady_number' not in plan_row.columns:
+                logger.debug(
+                    "plan_df missing unsteady_number column for plan %s",
+                    plan_num,
+                )
             flow_type = RasPrj._classify_plan_flow(plan_row.iloc[0])
             logger.debug(f"Plan {plan_num}: {flow_type} (from flow references)")
             return flow_type

--- a/ras_commander/RasUnsteady.py
+++ b/ras_commander/RasUnsteady.py
@@ -2752,10 +2752,9 @@ class RasUnsteady:
             Dict[str, Optional[Any]]: Parsed usage settings and raw values.
         """
         ras_obj = ras_object or ras
-        ras_obj.check_initialized()
-
         unsteady_path = Path(unsteady_file)
         if not unsteady_path.is_file():
+            ras_obj.check_initialized()
             from .RasPlan import RasPlan
             resolved_path = RasPlan.get_unsteady_path(unsteady_file, ras_obj)
             if resolved_path:
@@ -2831,11 +2830,10 @@ class RasUnsteady:
               ``Initial RRR Elev`` lines present
             - ``raw_use_restart`` (str or None): Raw value from file
         """
-        ras_obj = ras_object or ras
-        ras_obj.check_initialized()
-
         unsteady_path = Path(unsteady_file)
         if not unsteady_path.is_file():
+            ras_obj = ras_object or ras
+            ras_obj.check_initialized()
             from .RasPlan import RasPlan
             resolved_path = RasPlan.get_unsteady_path(unsteady_file, ras_obj)
             if resolved_path:
@@ -2951,10 +2949,9 @@ class RasUnsteady:
             raise ValueError("prior_ws_filename is required when method is 'prior_ws'")
 
         ras_obj = ras_object or ras
-        ras_obj.check_initialized()
-
         unsteady_path = Path(unsteady_file)
         if not unsteady_path.is_file():
+            ras_obj.check_initialized()
             from .RasPlan import RasPlan
             resolved_path = RasPlan.get_unsteady_path(unsteady_file, ras_obj)
             if resolved_path:
@@ -3010,7 +3007,10 @@ class RasUnsteady:
 
         logger.info(f"Set IC method to '{method}' in {unsteady_path.name}")
 
-        if hasattr(ras_obj, "get_unsteady_entries"):
+        if (
+            getattr(ras_obj, "initialized", False)
+            and hasattr(ras_obj, "get_unsteady_entries")
+        ):
             ras_obj.unsteady_df = ras_obj.get_unsteady_entries()
 
     @staticmethod
@@ -4083,6 +4083,55 @@ class RasUnsteady:
             })
 
         return blocks
+
+    @staticmethod
+    def _clean_boundary_selector(value: Optional[Any]) -> Optional[str]:
+        """Normalize an optional exact boundary selector."""
+        if value is None:
+            return None
+        normalized = str(value).strip()
+        return normalized or None
+
+    @staticmethod
+    def _boundary_block_matches(
+        block: Dict[str, Any],
+        river: Optional[str],
+        reach: Optional[str],
+        station: Optional[str],
+        area_2d: Optional[str],
+        bc_line_name: Optional[str],
+    ) -> bool:
+        """Return whether one parsed block exactly matches supplied fields."""
+        parts = list(block.get("parts", ()))
+        if len(parts) < 8:
+            parts.extend([""] * (8 - len(parts)))
+
+        selectors = (
+            (river, parts[0]),
+            (reach, parts[1]),
+            (station, parts[2]),
+            (area_2d, parts[5]),
+            (bc_line_name, parts[7]),
+        )
+        return all(
+            selector is None or candidate == selector
+            for selector, candidate in selectors
+        )
+
+    @staticmethod
+    def _boundary_block_name(block: Dict[str, Any]) -> str:
+        """Return a concise semantic identity for logs and errors."""
+        parts = list(block.get("parts", ()))
+        if len(parts) < 8:
+            parts.extend([""] * (8 - len(parts)))
+
+        if parts[5] or parts[7]:
+            identity = f"2D {parts[5]!r}/{parts[7]!r}"
+        elif any(parts[:3]):
+            identity = f"1D {parts[0]!r}/{parts[1]!r}/{parts[2]!r}"
+        else:
+            identity = repr(block.get("location", ""))
+        return f"index {block.get('boundary_index', '?')} ({identity})"
 
     @staticmethod
     @log_call

--- a/ras_commander/RasUtils.py
+++ b/ras_commander/RasUtils.py
@@ -71,7 +71,6 @@ import pandas as pd
 import numpy as np
 import shutil
 import re
-from scipy.spatial import KDTree
 import datetime
 import time
 import h5py
@@ -169,7 +168,11 @@ class RasUtils:
                 f"Mapped drive detected: {original_str} would resolve to UNC {resolved}. "
                 f"Using absolute() to preserve drive letter."
             )
-            return path.absolute()
+            # ``Path.absolute()`` intentionally avoids resolving the mapped
+            # drive, but on Windows it can retain ``.`` and ``..`` segments.
+            # Normalize those segments lexically without another filesystem
+            # lookup that could convert the drive back to UNC.
+            return Path(os.path.normpath(str(path.absolute())))
 
         return resolved
 
@@ -1157,6 +1160,8 @@ class RasUtils:
             >>> print(result)
             array([ 0, -1])
         """
+        from scipy.spatial import KDTree
+
         dist, snap = KDTree(reference_points).query(query_points, distance_upper_bound=max_distance)
         snap[dist > max_distance] = -1
         return snap
@@ -1183,6 +1188,8 @@ class RasUtils:
             >>> print(result)
             array([1, 0, 1, -1])
         """
+        from scipy.spatial import KDTree
+
         dist, snap = KDTree(points).query(points, k=2, distance_upper_bound=max_distance)
         snap[dist > max_distance] = -1
         

--- a/ras_commander/RasterPerformance.py
+++ b/ras_commander/RasterPerformance.py
@@ -10,98 +10,17 @@ import time
 from collections import defaultdict
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
-from typing import Any, Dict, Literal, Optional, Tuple, Union
+from typing import Any, Dict, Optional, Tuple, Union
 
 import psutil
 
-MemoryPolicy = Literal["enforce", "warn", "ignore"]
-GdalThreadSetting = Optional[Union[int, Literal["ALL_CPUS"]]]
-
-
-def _is_strict_int(value: Any) -> bool:
-    return isinstance(value, int) and not isinstance(value, bool)
-
-
-def _normalize_gdal_threads(value: GdalThreadSetting) -> GdalThreadSetting:
-    if value is None:
-        return None
-    if isinstance(value, bool):
-        raise ValueError("GDAL thread count must not be boolean")
-    if isinstance(value, int):
-        if value < 1:
-            raise ValueError("GDAL thread count must be positive")
-        return value
-    normalized = str(value).strip().upper()
-    if normalized == "ALL_CPUS":
-        return "ALL_CPUS"
-    if normalized.isdigit() and int(normalized) >= 1:
-        return int(normalized)
-    raise ValueError("GDAL thread count must be positive, ALL_CPUS, or None")
-
-
-@dataclass(frozen=True)
-class StoreMapPerformanceOptions:
-    """Execution and resource policy for independent stored-map helpers.
-
-    ``max_workers`` is always a ceiling. ``None`` requests automatic selection.
-    The default of one preserves the legacy StoreAllMaps execution path.
-    """
-
-    max_workers: Optional[int] = 1
-    memory_policy: MemoryPolicy = "enforce"
-    minimum_worker_memory_mb: int = 600
-    worker_memory_override_mb: Optional[int] = None
-    reserve_memory_mb: int = 4096
-    reserve_memory_fraction: float = 0.25
-    gdal_num_threads_per_helper: GdalThreadSetting = 1
-    gdal_cachemax_mb: Optional[int] = None
-    admission_wait_timeout_seconds: float = 300.0
-    admission_poll_interval_seconds: float = 1.0
-
-    def __post_init__(self) -> None:
-        if self.max_workers is not None and (
-            not _is_strict_int(self.max_workers) or self.max_workers < 1
-        ):
-            raise ValueError("max_workers must be positive or None")
-        if self.memory_policy not in {"enforce", "warn", "ignore"}:
-            raise ValueError("memory_policy must be enforce, warn, or ignore")
-        if (
-            not _is_strict_int(self.minimum_worker_memory_mb)
-            or self.minimum_worker_memory_mb < 1
-        ):
-            raise ValueError("minimum_worker_memory_mb must be positive")
-        if self.worker_memory_override_mb is not None and (
-            not _is_strict_int(self.worker_memory_override_mb)
-            or self.worker_memory_override_mb < 1
-        ):
-            raise ValueError("worker_memory_override_mb must be positive")
-        if (
-            self.worker_memory_override_mb is not None
-            and self.memory_policy == "enforce"
-        ):
-            raise ValueError(
-                "worker_memory_override_mb requires memory_policy='warn' or 'ignore'"
-            )
-        if not _is_strict_int(self.reserve_memory_mb) or self.reserve_memory_mb < 0:
-            raise ValueError("reserve_memory_mb must be non-negative")
-        if not 0 <= self.reserve_memory_fraction < 1:
-            raise ValueError("reserve_memory_fraction must be in [0, 1)")
-        if self.gdal_cachemax_mb is not None and (
-            not _is_strict_int(self.gdal_cachemax_mb) or self.gdal_cachemax_mb < 1
-        ):
-            raise ValueError("gdal_cachemax_mb must be positive")
-        if self.admission_wait_timeout_seconds < 0:
-            raise ValueError("admission_wait_timeout_seconds must be non-negative")
-        if self.admission_poll_interval_seconds <= 0:
-            raise ValueError("admission_poll_interval_seconds must be positive")
-        object.__setattr__(
-            self,
-            "gdal_num_threads_per_helper",
-            _normalize_gdal_threads(self.gdal_num_threads_per_helper),
-        )
-
-    def to_dict(self) -> Dict[str, Any]:
-        return asdict(self)
+from ._execution_types import (
+    GdalThreadSetting,
+    MemoryPolicy,
+    StoreMapPerformanceOptions,
+    _is_strict_int,
+    _normalize_gdal_threads,
+)
 
 
 @dataclass(frozen=True)

--- a/ras_commander/__init__.py
+++ b/ras_commander/__init__.py
@@ -6,7 +6,10 @@ Docs: https://rascommander.info/ras
 GitHub: https://github.com/gpt-cmdr/ras-commander
 """
 
+from importlib import import_module
 from importlib.metadata import version, PackageNotFoundError
+import sys
+from types import ModuleType
 from .LoggingConfig import setup_logging, get_logger
 from .Decorators import log_call, standardize_input
 
@@ -73,100 +76,19 @@ def agent_guide_path():
     from importlib.resources import files
     return files("ras_commander").joinpath("LLM_GUIDE.md")
 
-# Core functionality
+# Lean compute/inventory surface. These imports use only the base and
+# ``compute`` dependency groups; the remainder of the historical top-level API
+# is resolved lazily below.
 from .RasPrj import RasPrj, init_ras_project, get_ras_exe, ras, create_project_from_template
 from .RasPlan import RasPlan
 from .RasGeo import RasGeo  # DEPRECATED - use geom subpackage
-from .RasGeometry import RasGeometry  # DEPRECATED - use geom subpackage
-from .RasGeometryUtils import RasGeometryUtils  # DEPRECATED - use geom subpackage
-from .RasUnsteady import RasUnsteady
-from .RasSteady import RasSteady
 from .RasUtils import RasUtils
-from .RasProject import (
-    ProjectCopyVerificationError,
-    ProjectDriftError,
-    ProjectLockedError,
-    ProjectPathAmbiguityError,
-    ProjectPopulationError,
-    ProjectPublicationError,
-    ProjectStageError,
-    StageProjectResult,
-    inspect_project_assets,
-    stage_project,
-)
-from .RasBoundary import (
-    BoundaryFormatError,
-    BoundaryMutationError,
-    BoundaryMutationResult,
-    BoundaryPostPublicationError,
-    BoundaryPublicationError,
-    BoundarySelectorError,
-    BoundaryStageOwnershipError,
-    BoundaryStaleEvidenceError,
-)
-from .RasExamples import RasExamples
-from .sources.federal import RasEbfeModels
-from .sources.county import M3Model
 from .RasCmdr import RasCmdr
-from .RasCurrency import RasCurrency
-from .RasControl import RasControl
-from .RasTcu import RasTcu, TcuStatus
 from .ComputeResults import (
     ComputeResult,
     ComputeParallelResult,
-    RasControlResult,
-    PreprocessResult,
-    GeometryPreprocessResult,
-    GeometryLayerResult,
-    GeometryCompleteResult,
 )
-from .RasPreprocess import RasPreprocess
 from .RasMap import RasMap
-from .RasDialogWatchdog import DialogWatchdog, DismissedDialog
-from .RasEncroachments import RasEncroachments
-from .RasMapValidation import RasMapValidation
-from .RasBenefits import (
-    BenefitAreaConfig,
-    BenefitAreaResult,
-    BenefitCategory,
-    RasBenefits,
-)
-from .RasProcess import RasProcess, ProjectionInfo
-from .RasterPerformance import (
-    GeoTiffWriteOptions,
-    RasterOperationProfileResult,
-    StoreMapPerformanceOptions,
-    StoreMapProfileResult,
-    StoreMapResourceEstimate,
-    StoreMapResourceSample,
-    TerrainResourceEstimate,
-)
-from .RasGeometryCompute import RasGeometryCompute
-from .RasGuiAutomation import RasGuiAutomation
-from .RasScreenshot import RasScreenshot
-from .RasBreach import RasBreach
-from .RasFloodway import RasFloodway
-from .RasHydroCompare import RasHydroCompare
-from .RasModPuls import RasModPuls
-from .RasPermutation import RasPermutation, RangeSpec
-from .RasMonteCarlo import RasMonteCarlo
-from .RasCalibrate import (
-    CalibrationPoint,
-    RasCalibrate,
-    compute_objective,
-    extract_modeled,
-    extract_steady_profile_modeled,
-    extract_steady_profile_observations,
-    make_composite_apply_fn,
-    make_infiltration_apply_fn,
-    make_mannings_apply_fn,
-    make_steady_profile_calibration_points,
-    make_xsec_mannings_apply_fn,
-)
-from .RasFlowOptimization import RasFlowOptimization
-
-# Validation framework - core validation infrastructure
-from .RasValidation import ValidationSeverity, ValidationResult, ValidationReport
 
 # Real-time execution monitoring callbacks
 from .ExecutionCallback import ExecutionCallback
@@ -178,29 +100,130 @@ from .callbacks import (
 )
 from .RasBco import BcoMonitor
 
-# Geometry handling - imported from geom subpackage
-from .geom import (
-    GeomParser, GeomPreprocessor, GeomLandCover, ManningsFromLandCover,
-    GeomCrossSection, CrossSectionBankStations, CrossSectionBuildInput,
-    CrossSectionBuildResult, CrossSectionManningsN, CrossSectionReachLengths,
-    GeomStorage, GeomProjection, GeomLateral,
-    GeomInlineWeir, GeomBridge, GeomCulvert, GeomCulvertGIS,
-    GeomReferenceFeatures, GeomBcLines, GeomMesh,
-    GeomPipeNetwork,
-    MeshResult, BCConflict, BCFixResult,
-)
-
-# HDF handling - imported from hdf subpackage
-from .hdf import (
-    HdfBase, HdfUtils, HdfPlan,
-    HdfMesh, HdfXsec, HdfBndry, HdfStruc, HdfStorageArea, HdfHydraulicTables,
-    HdfResultsPlan, HdfResultsMesh, HdfResultsQuery, HdfResultsXsec, HdfResultsBreach,
-    HdfResultsSediment, HdfResultsProducts,
-    HdfPipe, HdfPump, HdfInfiltration, HdfLandCover,
-    HdfPlot, HdfResultsPlot,
-    HdfFluvialPluvial, HdfBenefitAreas, HdfChannelCapacity, HdfResultsAnalysis,
-    HdfProject,
-)
+_LAZY_EXPORTS = {
+    # Core feature modules outside the lean compute surface.
+    'RasGeometry': ('.RasGeometry', 'RasGeometry'),
+    'RasGeometryUtils': ('.RasGeometryUtils', 'RasGeometryUtils'),
+    'RasUnsteady': ('.RasUnsteady', 'RasUnsteady'),
+    'RasSteady': ('.RasSteady', 'RasSteady'),
+    'RasExamples': ('.RasExamples', 'RasExamples'),
+    'RasEbfeModels': ('.sources.federal', 'RasEbfeModels'),
+    'M3Model': ('.sources.county', 'M3Model'),
+    'RasCurrency': ('.RasCurrency', 'RasCurrency'),
+    'RasControl': ('.RasControl', 'RasControl'),
+    'RasTcu': ('.RasTcu', 'RasTcu'),
+    'TcuStatus': ('.RasTcu', 'TcuStatus'),
+    'RasPreprocess': ('.RasPreprocess', 'RasPreprocess'),
+    'DialogWatchdog': ('.RasDialogWatchdog', 'DialogWatchdog'),
+    'DismissedDialog': ('.RasDialogWatchdog', 'DismissedDialog'),
+    'RasEncroachments': ('.RasEncroachments', 'RasEncroachments'),
+    'RasMapValidation': ('.RasMapValidation', 'RasMapValidation'),
+    'RasGeometryCompute': ('.RasGeometryCompute', 'RasGeometryCompute'),
+    'RasGuiAutomation': ('.RasGuiAutomation', 'RasGuiAutomation'),
+    'RasScreenshot': ('.RasScreenshot', 'RasScreenshot'),
+    'RasBreach': ('.RasBreach', 'RasBreach'),
+    'RasFloodway': ('.RasFloodway', 'RasFloodway'),
+    'RasHydroCompare': ('.RasHydroCompare', 'RasHydroCompare'),
+    'RasModPuls': ('.RasModPuls', 'RasModPuls'),
+    'RasMonteCarlo': ('.RasMonteCarlo', 'RasMonteCarlo'),
+    'RasFlowOptimization': ('.RasFlowOptimization', 'RasFlowOptimization'),
+    'RasProcess': ('.RasProcess', 'RasProcess'),
+    'ProjectionInfo': ('.RasProcess', 'ProjectionInfo'),
+    'RasPermutation': ('.RasPermutation', 'RasPermutation'),
+    'RangeSpec': ('.RasPermutation', 'RangeSpec'),
+    # Project staging and mutation results.
+    **{
+        name: ('.RasProject', name)
+        for name in (
+            'ProjectCopyVerificationError', 'ProjectDriftError',
+            'ProjectLockedError', 'ProjectPathAmbiguityError',
+            'ProjectPopulationError', 'ProjectPublicationError',
+            'ProjectStageError', 'StageProjectResult',
+            'inspect_project_assets', 'stage_project',
+        )
+    },
+    **{
+        name: ('.RasBoundary', name)
+        for name in (
+            'BoundaryFormatError', 'BoundaryMutationError',
+            'BoundaryMutationResult', 'BoundaryPostPublicationError',
+            'BoundaryPublicationError', 'BoundarySelectorError',
+            'BoundaryStageOwnershipError', 'BoundaryStaleEvidenceError',
+        )
+    },
+    **{
+        name: ('.ComputeResults', name)
+        for name in (
+            'RasControlResult', 'PreprocessResult',
+            'GeometryPreprocessResult', 'GeometryLayerResult',
+            'GeometryCompleteResult',
+        )
+    },
+    **{
+        name: ('.RasBenefits', name)
+        for name in (
+            'BenefitAreaResult',
+            'BenefitCategory', 'RasBenefits',
+        )
+    },
+    'BenefitAreaConfig': ('._execution_types', 'BenefitAreaConfig'),
+    **{
+        name: ('.RasterPerformance', name)
+        for name in (
+            'GeoTiffWriteOptions', 'RasterOperationProfileResult',
+            'StoreMapProfileResult',
+            'StoreMapResourceEstimate', 'StoreMapResourceSample',
+            'TerrainResourceEstimate',
+        )
+    },
+    'StoreMapPerformanceOptions': (
+        '._execution_types', 'StoreMapPerformanceOptions'
+    ),
+    **{
+        name: ('.RasCalibrate', name)
+        for name in (
+            'CalibrationPoint', 'RasCalibrate', 'compute_objective',
+            'extract_modeled', 'extract_steady_profile_modeled',
+            'extract_steady_profile_observations', 'make_composite_apply_fn',
+            'make_infiltration_apply_fn', 'make_mannings_apply_fn',
+            'make_steady_profile_calibration_points',
+            'make_xsec_mannings_apply_fn',
+        )
+    },
+    **{
+        name: ('.RasValidation', name)
+        for name in ('ValidationSeverity', 'ValidationResult', 'ValidationReport')
+    },
+    # Geometry and HDF packages retain their existing public class names while
+    # deferring optional geospatial, plotting, and scientific dependencies.
+    **{
+        name: ('.geom', name)
+        for name in (
+            'GeomParser', 'GeomPreprocessor', 'GeomLandCover',
+            'ManningsFromLandCover', 'GeomCrossSection',
+            'CrossSectionBankStations', 'CrossSectionBuildInput',
+            'CrossSectionBuildResult', 'CrossSectionManningsN',
+            'CrossSectionReachLengths', 'GeomStorage', 'GeomProjection',
+            'GeomLateral', 'GeomInlineWeir', 'GeomBridge', 'GeomCulvert',
+            'GeomCulvertGIS', 'GeomReferenceFeatures', 'GeomBcLines',
+            'GeomMesh', 'GeomPipeNetwork', 'MeshResult', 'BCConflict',
+            'BCFixResult',
+        )
+    },
+    **{
+        name: ('.hdf', name)
+        for name in (
+            'HdfBase', 'HdfUtils', 'HdfPlan', 'HdfMesh', 'HdfXsec',
+            'HdfBndry', 'HdfStruc', 'HdfStorageArea',
+            'HdfHydraulicTables', 'HdfResultsPlan', 'HdfResultsMesh',
+            'HdfResultsQuery', 'HdfResultsXsec', 'HdfResultsBreach',
+            'HdfResultsSediment', 'HdfResultsProducts', 'HdfPipe',
+            'HdfPump', 'HdfInfiltration', 'HdfLandCover', 'HdfPlot',
+            'HdfResultsPlot', 'HdfFluvialPluvial', 'HdfBenefitAreas',
+            'HdfChannelCapacity', 'HdfResultsAnalysis', 'HdfProject',
+        )
+    },
+}
 
 # Remote execution - lazy loaded to avoid importing until needed
 # This reduces import time and allows optional dependencies to be truly optional
@@ -242,30 +265,71 @@ _GUI_EXPORTS = {
     'OpenRasMapperWorkflow', 'MeshRegenerationWorkflow',
 }
 
+def _load_export(name):
+    target = _LAZY_EXPORTS.get(name)
+    if target is None:
+        raise AttributeError(f"module 'ras_commander' has no attribute '{name}'")
+    module_name, attribute_name = target
+    value = getattr(import_module(module_name, __name__), attribute_name)
+    globals()[name] = value
+    return value
+
+
 def __getattr__(name):
-    """Lazy load remote execution, DSS, check, fixit, terrain, results, and gui components on first access."""
+    """Resolve optional public features on first access and cache the result."""
+    if name in _LAZY_EXPORTS:
+        return _load_export(name)
     if name in _REMOTE_EXPORTS:
         from . import remote
-        return getattr(remote, name)
+        value = getattr(remote, name)
+        globals()[name] = value
+        return value
     if name in _DSS_EXPORTS:
         from . import dss
-        return getattr(dss, name)
+        value = getattr(dss, name)
+        globals()[name] = value
+        return value
     if name in _CHECK_EXPORTS:
         from . import check
-        return getattr(check, name)
+        value = getattr(check, name)
+        globals()[name] = value
+        return value
     if name in _FIXIT_EXPORTS:
         from . import fixit
-        return getattr(fixit, name)
+        value = getattr(fixit, name)
+        globals()[name] = value
+        return value
     if name in _TERRAIN_EXPORTS:
         from . import terrain
-        return getattr(terrain, name)
+        value = getattr(terrain, name)
+        globals()[name] = value
+        return value
     if name in _RESULTS_EXPORTS:
         from . import results
-        return getattr(results, name)
+        value = getattr(results, name)
+        globals()[name] = value
+        return value
     if name in _GUI_EXPORTS:
         from . import gui
-        return getattr(gui, name)
+        value = getattr(gui, name)
+        globals()[name] = value
+        return value
     raise AttributeError(f"module 'ras_commander' has no attribute '{name}'")
+
+
+class _LazyRasCommanderModule(ModuleType):
+    """Preserve class exports when same-named submodules are imported first."""
+
+    def __getattribute__(self, name):
+        namespace = ModuleType.__getattribute__(self, "__dict__")
+        exports = namespace.get("_LAZY_EXPORTS", {})
+        current = namespace.get(name)
+        if name in exports and (current is None or isinstance(current, ModuleType)):
+            return namespace["_load_export"](name)
+        return ModuleType.__getattribute__(self, name)
+
+
+sys.modules[__name__].__class__ = _LazyRasCommanderModule
 
 
 # Define __all__ to specify what should be imported when using "from ras_commander import *"
@@ -382,7 +446,6 @@ __all__ = [
 #   OLD: from ras_commander.validation_base import ValidationSeverity, ...
 #   NEW: from ras_commander.RasValidation import ValidationSeverity, ...
 # ======================================================================
-import sys
 import warnings
 
 

--- a/ras_commander/_execution_types.py
+++ b/ras_commander/_execution_types.py
@@ -1,0 +1,141 @@
+"""Lightweight public option types shared by execution and mapping modules."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any, Dict, Literal, Optional, Union
+
+
+MemoryPolicy = Literal["enforce", "warn", "ignore"]
+GdalThreadSetting = Optional[Union[int, Literal["ALL_CPUS"]]]
+
+
+def _is_strict_int(value: Any) -> bool:
+    return isinstance(value, int) and not isinstance(value, bool)
+
+
+def _normalize_gdal_threads(
+    value: GdalThreadSetting,
+) -> GdalThreadSetting:
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        raise ValueError("GDAL thread count must not be boolean")
+    if isinstance(value, int):
+        if value < 1:
+            raise ValueError("GDAL thread count must be positive")
+        return value
+    normalized = str(value).strip().upper()
+    if normalized == "ALL_CPUS":
+        return "ALL_CPUS"
+    if normalized.isdigit() and int(normalized) >= 1:
+        return int(normalized)
+    raise ValueError("GDAL thread count must be positive, ALL_CPUS, or None")
+
+
+@dataclass(frozen=True)
+class StoreMapPerformanceOptions:
+    """Execution and resource policy for independent stored-map helpers."""
+
+    max_workers: Optional[int] = 1
+    memory_policy: MemoryPolicy = "enforce"
+    minimum_worker_memory_mb: int = 600
+    worker_memory_override_mb: Optional[int] = None
+    reserve_memory_mb: int = 4096
+    reserve_memory_fraction: float = 0.25
+    gdal_num_threads_per_helper: GdalThreadSetting = 1
+    gdal_cachemax_mb: Optional[int] = None
+    admission_wait_timeout_seconds: float = 300.0
+    admission_poll_interval_seconds: float = 1.0
+
+    def __post_init__(self) -> None:
+        if self.max_workers is not None and (
+            not _is_strict_int(self.max_workers) or self.max_workers < 1
+        ):
+            raise ValueError("max_workers must be positive or None")
+        if self.memory_policy not in {"enforce", "warn", "ignore"}:
+            raise ValueError("memory_policy must be enforce, warn, or ignore")
+        if (
+            not _is_strict_int(self.minimum_worker_memory_mb)
+            or self.minimum_worker_memory_mb < 1
+        ):
+            raise ValueError("minimum_worker_memory_mb must be positive")
+        if self.worker_memory_override_mb is not None and (
+            not _is_strict_int(self.worker_memory_override_mb)
+            or self.worker_memory_override_mb < 1
+        ):
+            raise ValueError("worker_memory_override_mb must be positive")
+        if (
+            self.worker_memory_override_mb is not None
+            and self.memory_policy == "enforce"
+        ):
+            raise ValueError(
+                "worker_memory_override_mb requires memory_policy='warn' or 'ignore'"
+            )
+        if not _is_strict_int(self.reserve_memory_mb) or self.reserve_memory_mb < 0:
+            raise ValueError("reserve_memory_mb must be non-negative")
+        if not 0 <= self.reserve_memory_fraction < 1:
+            raise ValueError("reserve_memory_fraction must be in [0, 1)")
+        if self.gdal_cachemax_mb is not None and (
+            not _is_strict_int(self.gdal_cachemax_mb)
+            or self.gdal_cachemax_mb < 1
+        ):
+            raise ValueError("gdal_cachemax_mb must be positive")
+        if self.admission_wait_timeout_seconds < 0:
+            raise ValueError("admission_wait_timeout_seconds must be non-negative")
+        if self.admission_poll_interval_seconds <= 0:
+            raise ValueError("admission_poll_interval_seconds must be positive")
+        object.__setattr__(
+            self,
+            "gdal_num_threads_per_helper",
+            _normalize_gdal_threads(self.gdal_num_threads_per_helper),
+        )
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class BenefitAreaConfig:
+    """Pair-aware configuration used by stored-map benefit analysis."""
+
+    pre_plan_number: str
+    terrain_tif: Union[str, Path]
+    terrain_name: Optional[str] = None
+    include_wse: bool = False
+    flood_min_depth: float = 0.05
+    benefit_min_depth: float = 0.25
+    minimum_region_pixels: Optional[int] = 16
+    analysis_boundary: Any = None
+    improvement_boundary: Any = None
+    polygon_output: Optional[Union[bool, str, Path]] = None
+    polygon_simplify_tolerance: Optional[float] = None
+
+    def __post_init__(self) -> None:
+        if self.pre_plan_number is None or not str(self.pre_plan_number).strip():
+            raise ValueError("pre_plan_number is required for BenefitArea mapping")
+
+        # Benefit analysis is an optional geospatial feature. Defer importing
+        # its implementation until a configuration is actually instantiated.
+        from .RasBenefits import RasBenefits
+
+        if self.terrain_tif is None or not str(self.terrain_tif).strip():
+            raise ValueError(
+                "terrain_tif is required for BenefitArea mapping. "
+                f"{RasBenefits.TERRAIN_REMEDIATION}"
+            )
+        RasBenefits._validate_thresholds(
+            self.flood_min_depth,
+            self.benefit_min_depth,
+        )
+        RasBenefits._validate_minimum_region_pixels(self.minimum_region_pixels)
+        RasBenefits._validate_polygon_simplify_tolerance(
+            self.polygon_simplify_tolerance
+        )
+
+
+# Preserve the historical public identities for repr(), documentation, and
+# pickle compatibility even though the definitions now live in a lean module.
+StoreMapPerformanceOptions.__module__ = "ras_commander.RasterPerformance"
+BenefitAreaConfig.__module__ = "ras_commander.RasBenefits"

--- a/ras_commander/compute.py
+++ b/ras_commander/compute.py
@@ -1,0 +1,41 @@
+"""Lean public surface for command-line HEC-RAS plan execution.
+
+This module is intended for batch runners that need project inventory,
+``RasCmdr.compute_plan()``, compute-message parsing, and direct HDF result
+extraction. It deliberately does not export ``RasControl`` or any COM-based
+result API.
+
+The execution semantics are the normal ras-commander semantics: project and
+result DataFrames are refreshed after a compute, the caller retains the normal
+``verify`` control, and ``RasCmdr`` owns construction of the HEC-RAS command
+line.
+"""
+
+from .ComputeResults import ComputeParallelResult, ComputeResult
+from .RasCmdr import RasCmdr
+from .RasPlan import RasPlan
+from .RasPrj import (
+    RasPrj,
+    create_project_from_template,
+    get_ras_exe,
+    init_ras_project,
+    ras,
+)
+from .hdf import HdfResultsPlan
+from .results import ResultsParser, ResultsSummary
+
+
+__all__ = [
+    'RasPrj',
+    'init_ras_project',
+    'get_ras_exe',
+    'ras',
+    'create_project_from_template',
+    'RasPlan',
+    'RasCmdr',
+    'ComputeResult',
+    'ComputeParallelResult',
+    'ResultsParser',
+    'ResultsSummary',
+    'HdfResultsPlan',
+]

--- a/ras_commander/geom/GeomMesh.py
+++ b/ras_commander/geom/GeomMesh.py
@@ -3694,12 +3694,12 @@ class GeomMesh:
                     mesh_index=mesh_index,
                 )
                 if cell_size is not None:
-                    logger.info(
+                    logger.debug(
                         f"Auto-detected cell size {cell_size} from geometry text"
                     )
                 else:
                     cell_size = _read_cell_size_from_hdf(hdf_path, mesh_name)
-                    logger.info(
+                    logger.debug(
                         f"Auto-detected cell size {cell_size} from HDF Spacing dx"
                     )
 

--- a/ras_commander/geom/GeomMetadata.py
+++ b/ras_commander/geom/GeomMetadata.py
@@ -146,6 +146,9 @@ class GeomMetadata:
                 logger.debug(f"Using HDF extraction for {hdf_path.name}")
                 candidate = GeomMetadata._new_counts()
                 result = GeomMetadata._get_counts_from_hdf(hdf_path, candidate)
+                hdf_error = result.pop('_hdf_extraction_error', None)
+                if hdf_error:
+                    raise ValueError(hdf_error)
                 result['geometry_metadata_source'] = 'hdf'
                 result['geometry_metadata_valid'] = True
 
@@ -201,10 +204,22 @@ class GeomMetadata:
         Returns:
             Updated counts dict
         """
-        with h5py.File(hdf_path, 'r') as hdf:
-            counts['num_cross_sections'] = GeomMetadata._get_xs_count_hdf(hdf)
-            counts.update(GeomMetadata._get_structure_counts_hdf(hdf))
-            counts.update(GeomMetadata._get_2d_info_hdf(hdf))
+        try:
+            with h5py.File(hdf_path, 'r') as hdf:
+                counts['num_cross_sections'] = GeomMetadata._get_xs_count_hdf(hdf)
+                counts.update(GeomMetadata._get_structure_counts_hdf(hdf))
+                counts.update(GeomMetadata._get_2d_info_hdf(hdf))
+        except (OSError, KeyError, TypeError, ValueError) as exc:
+            counts['_hdf_extraction_error'] = str(exc)
+            logger.warning(
+                "HDF geometry metadata extraction failed for %s",
+                Path(hdf_path).name,
+            )
+            logger.debug(
+                "HDF geometry metadata extraction failed for %s: %s",
+                hdf_path,
+                exc,
+            )
 
         return counts
 

--- a/ras_commander/hdf/HdfBase.py
+++ b/ras_commander/hdf/HdfBase.py
@@ -44,15 +44,16 @@ from datetime import datetime, timedelta
 import h5py
 import numpy as np
 import pandas as pd
-import xarray as xr
-from typing import List, Tuple, Union, Optional, Dict, Any
+from typing import TYPE_CHECKING, List, Tuple, Union, Optional, Dict, Any
 from pathlib import Path
 import logging
-from shapely.geometry import LineString, MultiLineString
 
 from .HdfUtils import HdfUtils
 from ..Decorators import standardize_input, log_call
 from ..LoggingConfig import setup_logging, get_logger
+
+if TYPE_CHECKING:
+    from shapely.geometry import LineString
 
 logger = get_logger(__name__)
 _missing_projection_warning_paths: set[str] = set()
@@ -481,7 +482,7 @@ class HdfBase:
     @standardize_input(file_type='plan_hdf')
     def get_polylines_from_parts(hdf_path: Path, path: str, info_name: str = "Polyline Info", 
                               parts_name: str = "Polyline Parts", 
-                              points_name: str = "Polyline Points") -> List[LineString]:
+                              points_name: str = "Polyline Points") -> List["LineString"]:
         """
         Extract polylines from HDF file parts data.
 
@@ -501,6 +502,8 @@ class HdfBase:
             - Parts information for multi-part lines
             - Point coordinates
         """
+        from shapely.geometry import LineString, MultiLineString
+
         polyline_info_path = f"{path}/{info_name}"
         polyline_parts_path = f"{path}/{parts_name}"
         polyline_points_path = f"{path}/{points_name}"

--- a/ras_commander/hdf/HdfResultsPlan.py
+++ b/ras_commander/hdf/HdfResultsPlan.py
@@ -23,6 +23,7 @@ Available Functions:
         - get_steady_profile_names: Extract steady state profile names
         - get_steady_wse: Extract WSE data for steady state profiles
         - get_steady_info: Extract steady flow attributes and metadata
+        - get_steady_results: Extract profile/XS hydraulics and channel length
 
     Computation Messages:
         - get_compute_messages: Extract computation messages from HDF (with .txt fallback)
@@ -35,10 +36,8 @@ from typing import Dict, List, Optional, Tuple, Union
 from pathlib import Path
 import h5py
 import pandas as pd
-import xarray as xr
 from ..Decorators import standardize_input, log_call
 from .HdfUtils import HdfUtils
-from .HdfResultsXsec import HdfResultsXsec
 from ..LoggingConfig import get_logger
 import numpy as np
 from datetime import datetime
@@ -546,6 +545,83 @@ class HdfResultsPlan:
         raise KeyError(f"Cross section attributes not found at: {paths}")
 
     @staticmethod
+    def _get_steady_channel_lengths(
+        hdf_file: h5py.File,
+        result_attributes: np.ndarray,
+        result_fields: Dict[str, str],
+    ) -> np.ndarray:
+        """Join geometry channel reach lengths to ordered result cross sections.
+
+        HEC-RAS stores the downstream channel reach length on geometry cross
+        sections, not in the steady output block. Result rows use ``Station``
+        while geometry rows use ``RS`` in the supported 6.x layouts, so the
+        join is performed on the complete river/reach/station identity.
+
+        Non-finite and HEC-RAS sentinel lengths are normalized to zero, matching
+        the value returned by established Controller-based ras2fim workflows.
+        """
+        geometry_path = "Geometry/Cross Sections/Attributes"
+        if geometry_path not in hdf_file:
+            return np.full(len(result_attributes), np.nan, dtype=float)
+
+        geometry_attributes = hdf_file[geometry_path][()]
+        field_names = geometry_attributes.dtype.names or ()
+        field_lookup = {name.strip().lower(): name for name in field_names}
+        geometry_fields = {
+            "river": field_lookup.get("river"),
+            "reach": field_lookup.get("reach"),
+            "station": field_lookup.get("rs") or field_lookup.get("station"),
+            "length": (
+                field_lookup.get("len channel")
+                or field_lookup.get("length channel")
+                or field_lookup.get("channel length")
+            ),
+        }
+        missing = [name for name, field in geometry_fields.items() if field is None]
+        if missing:
+            logger.debug(
+                "Geometry cross-section attributes do not expose channel lengths; "
+                "missing fields: %s",
+                ", ".join(missing),
+            )
+            return np.full(len(result_attributes), np.nan, dtype=float)
+
+        def decode(value) -> str:
+            if isinstance(value, (bytes, np.bytes_)):
+                return value.decode("utf-8", errors="replace").rstrip("\x00").strip()
+            return str(value).rstrip("\x00").strip()
+
+        lengths_by_identity = {}
+        for item in geometry_attributes:
+            identity = tuple(
+                decode(item[geometry_fields[name]])
+                for name in ("river", "reach", "station")
+            )
+            if identity in lengths_by_identity:
+                raise ValueError(
+                    "Duplicate geometry cross-section identity while joining "
+                    f"channel lengths: {identity}"
+                )
+            value = float(item[geometry_fields["length"]])
+            if not np.isfinite(value) or abs(value) > 1e20:
+                value = 0.0
+            lengths_by_identity[identity] = value
+
+        ordered_lengths = []
+        for item in result_attributes:
+            identity = tuple(
+                decode(item[result_fields[name]])
+                for name in ("river", "reach", "station")
+            )
+            if identity not in lengths_by_identity:
+                raise ValueError(
+                    "Steady result cross section is absent from geometry "
+                    f"attributes: {identity}"
+                )
+            ordered_lengths.append(lengths_by_identity[identity])
+        return np.asarray(ordered_lengths, dtype=float)
+
+    @staticmethod
     @log_call
     @standardize_input(file_type='plan_hdf')
     def get_steady_wse(
@@ -1049,7 +1125,11 @@ class HdfResultsPlan:
             +----------------+----------+---------------------------------------+
             | energy         | float    | Energy grade elevation (ft or m)      |
             +----------------+----------+---------------------------------------+
-            | max_depth      | float    | Maximum channel depth (ft or m)       |
+            | max_depth      | float    | Maximum total depth (ft or m)         |
+            +----------------+----------+---------------------------------------+
+            | hydraulic_depth| float    | Channel hydraulic depth (ft or m)     |
+            +----------------+----------+---------------------------------------+
+            | channel_length | float    | Downstream channel reach length       |
             +----------------+----------+---------------------------------------+
             | min_ch_el      | float    | Minimum channel elevation (ft or m)   |
             +----------------+----------+---------------------------------------+
@@ -1072,9 +1152,13 @@ class HdfResultsPlan:
         **Comparison with RasControl.get_steady_results():**
 
         This HDF-based method provides the same schema as the COM-based
-        RasControl.get_steady_results(), plus additional hydraulic variables
-        (top_width, area, eg_slope, friction_slope) that are readily
-        available in the HDF file.
+        RasControl.get_steady_results(), plus channel reach length and
+        additional hydraulic variables (hydraulic_depth, top_width, area,
+        eg_slope, friction_slope) that are readily available in the HDF file.
+
+        ``max_depth`` is read from HEC-RAS ``Maximum Depth Total``. Older HDFs
+        without that dataset fall back to ``Hydraulic Depth Channel`` and
+        record the selected dataset in ``df.attrs['max_depth_source']``.
 
         **Performance:**
 
@@ -1132,12 +1216,34 @@ class HdfResultsPlan:
                     raise ValueError("Profile names not found in HDF file")
 
                 # Get main variables (WSE, Flow)
-                wse_data = hdf_file[f"{xs_path}/Water Surface"][()]
-                flow_data = hdf_file[f"{xs_path}/Flow"][()]
+                wse_data = np.asarray(
+                    hdf_file[f"{xs_path}/Water Surface"][()]
+                )
+                flow_data = np.asarray(hdf_file[f"{xs_path}/Flow"][()])
+                if wse_data.ndim != 2:
+                    raise ValueError(
+                        "Steady Water Surface dataset must be a 2D "
+                        "profile-by-cross-section array"
+                    )
+                if flow_data.shape != wse_data.shape:
+                    raise ValueError(
+                        "Steady Flow dataset shape does not match Water Surface: "
+                        f"{flow_data.shape} != {wse_data.shape}"
+                    )
                 num_profiles, num_xs = wse_data.shape
+                if len(profile_names) != num_profiles:
+                    raise ValueError(
+                        "Steady profile-name count does not match result rows: "
+                        f"{len(profile_names)} != {num_profiles}"
+                    )
                 xs_attrs, xs_fields = HdfResultsPlan._get_steady_cross_section_attributes(
                     hdf_file,
                     expected_count=num_xs,
+                )
+                channel_length_data = HdfResultsPlan._get_steady_channel_lengths(
+                    hdf_file,
+                    xs_attrs,
+                    xs_fields,
                 )
 
                 # Missing optional variables are returned as null values. Do
@@ -1146,13 +1252,27 @@ class HdfResultsPlan:
                 def get_additional_var(var_name, default=np.nan):
                     path = f"{add_vars_path}/{var_name}"
                     if path in hdf_file:
-                        return hdf_file[path][()]
+                        values = np.asarray(hdf_file[path][()])
+                        expected_shape = (num_profiles, num_xs)
+                        if values.shape != expected_shape:
+                            raise ValueError(
+                                f"Steady variable {var_name!r} has shape "
+                                f"{values.shape}; expected {expected_shape}"
+                            )
+                        return values
                     return np.full((num_profiles, num_xs), default)
 
                 velocity_data = get_additional_var('Velocity Channel')
                 energy_data = get_additional_var('Energy Grade')
                 froude_data = get_additional_var('Froude # Channel')
-                max_depth_data = get_additional_var('Hydraulic Depth Channel')
+                hydraulic_depth_data = get_additional_var('Hydraulic Depth Channel')
+                maximum_depth_path = f"{add_vars_path}/Maximum Depth Total"
+                if maximum_depth_path in hdf_file:
+                    max_depth_data = get_additional_var('Maximum Depth Total')
+                    max_depth_source = 'Maximum Depth Total'
+                else:
+                    max_depth_data = hydraulic_depth_data
+                    max_depth_source = 'Hydraulic Depth Channel (legacy fallback)'
                 min_ch_el_data = get_additional_var('Min Ch El')
                 top_width_data = get_additional_var('Top Width Total')
                 area_data = get_additional_var('Area Flow Total')
@@ -1183,6 +1303,8 @@ class HdfResultsPlan:
                             'froude': float(froude_data[prof_idx, xs_idx]),
                             'energy': float(energy_data[prof_idx, xs_idx]),
                             'max_depth': float(max_depth_data[prof_idx, xs_idx]),
+                            'hydraulic_depth': float(hydraulic_depth_data[prof_idx, xs_idx]),
+                            'channel_length': float(channel_length_data[xs_idx]),
                             'min_ch_el': float(min_ch_el_data[prof_idx, xs_idx]),
                             'top_width': float(top_width_data[prof_idx, xs_idx]),
                             'area': float(area_data[prof_idx, xs_idx]),
@@ -1191,6 +1313,12 @@ class HdfResultsPlan:
                         })
 
                 df = pd.DataFrame(rows)
+                df.attrs['max_depth_source'] = max_depth_source
+                df.attrs['channel_length_source'] = (
+                    'unavailable'
+                    if np.isnan(channel_length_data).all()
+                    else 'Geometry/Cross Sections/Attributes/Len Channel'
+                )
                 logger.debug(f"Extracted steady results: {len(df)} rows "
                             f"({num_profiles} profiles x {num_xs} cross sections)")
                 return df

--- a/ras_commander/hdf/HdfUtils.py
+++ b/ras_commander/hdf/HdfUtils.py
@@ -49,9 +49,7 @@ import numpy as np
 import pandas as pd
 from datetime import datetime, timedelta
 from typing import Union, Optional, Dict, List, Tuple, Any
-from scipy.spatial import KDTree
 import re
-from shapely.geometry import LineString  # Import LineString to avoid NameError
 
 from ..Decorators import standardize_input, log_call 
 from ..LoggingConfig import setup_logging, get_logger
@@ -210,6 +208,8 @@ class HdfUtils:
             >>> print(result)
             array([ 0, -1])
         """
+        from scipy.spatial import KDTree
+
         dist, snap = KDTree(reference_points).query(query_points, distance_upper_bound=max_distance)
         snap[dist > max_distance] = -1
         return snap
@@ -235,6 +235,8 @@ class HdfUtils:
             >>> print(result)
             array([1, 0, 1, -1])
         """
+        from scipy.spatial import KDTree
+
         dist, snap = KDTree(points).query(points, k=2, distance_upper_bound=max_distance)
         snap[dist > max_distance] = -1
         

--- a/ras_commander/hdf/__init__.py
+++ b/ras_commander/hdf/__init__.py
@@ -56,47 +56,63 @@ Usage:
     cells = HdfMesh.get_mesh_cell_polygons("plan.hdf")
 """
 
-# Core classes
-from .HdfBase import HdfBase
-from .HdfUtils import HdfUtils
-from .HdfPlan import HdfPlan
+from importlib import import_module
+import sys
+from types import ModuleType
 
-# Geometry classes
-from .HdfMesh import HdfMesh
-from .HdfXsec import HdfXsec
-from .HdfBndry import HdfBndry
-from .HdfStruc import HdfStruc
-from .HdfStorageArea import HdfStorageArea
-from .HdfStruc1D import HdfStruc1D
-from .HdfHydraulicTables import HdfHydraulicTables
 
-# Results classes
-from .HdfResultsPlan import HdfResultsPlan
-from .HdfResultsMesh import HdfResultsMesh
-from .HdfResultsQuery import HdfResultsQuery
-from .HdfResultsXsec import HdfResultsXsec
-from .HdfResultsBreach import HdfResultsBreach
-from .HdfResultsSediment import HdfResultsSediment
-from .HdfResultsProducts import HdfResultsProducts
+_LAZY_EXPORTS = {
+    name: (f".{name}", name)
+    for name in (
+        'HdfBase', 'HdfUtils', 'HdfPlan',
+        'HdfMesh', 'HdfXsec', 'HdfBndry', 'HdfStruc', 'HdfStorageArea',
+        'HdfStruc1D', 'HdfHydraulicTables',
+        'HdfResultsPlan', 'HdfResultsMesh', 'HdfResultsQuery',
+        'HdfResultsXsec', 'HdfResultsBreach', 'HdfResultsSediment',
+        'HdfResultsProducts',
+        'HdfPipe', 'HdfPump', 'HdfInfiltration', 'HdfLandCover',
+        'HdfPlot', 'HdfResultsPlot',
+        'HdfFluvialPluvial', 'HdfBenefitAreas', 'HdfChannelCapacity',
+        'HdfResultsAnalysis', 'HdfProject',
+    )
+}
 
-# Infrastructure classes
-from .HdfPipe import HdfPipe
-from .HdfPump import HdfPump
-from .HdfInfiltration import HdfInfiltration
-from .HdfLandCover import HdfLandCover
 
-# Visualization classes
-from .HdfPlot import HdfPlot
-from .HdfResultsPlot import HdfResultsPlot
+def _load_export(name):
+    target = _LAZY_EXPORTS.get(name)
+    if target is None:
+        raise AttributeError(f"module 'ras_commander.hdf' has no attribute '{name}'")
+    module_name, attribute_name = target
+    value = getattr(import_module(module_name, __name__), attribute_name)
+    globals()[name] = value
+    return value
 
-# Analysis classes
-from .HdfFluvialPluvial import HdfFluvialPluvial
-from .HdfBenefitAreas import HdfBenefitAreas
-from .HdfChannelCapacity import HdfChannelCapacity
-from .HdfResultsAnalysis import HdfResultsAnalysis
 
-# Project-level classes
-from .HdfProject import HdfProject
+def __getattr__(name):
+    """Import an HDF feature only when its public class is requested."""
+    return _load_export(name)
+
+
+class _LazyHdfModule(ModuleType):
+    """Keep class exports stable when Python also imports same-named modules.
+
+    Import machinery assigns ``package.HdfMesh`` to the submodule object when
+    code imports ``ras_commander.hdf.HdfMesh`` directly. Historically the HDF
+    package overwrote that name with the class during eager initialization.
+    This accessor preserves that public behavior without eagerly loading the
+    entire optional HDF stack.
+    """
+
+    def __getattribute__(self, name):
+        namespace = ModuleType.__getattribute__(self, "__dict__")
+        exports = namespace.get("_LAZY_EXPORTS", {})
+        current = namespace.get(name)
+        if name in exports and (current is None or isinstance(current, ModuleType)):
+            return namespace["_load_export"](name)
+        return ModuleType.__getattribute__(self, name)
+
+
+sys.modules[__name__].__class__ = _LazyHdfModule
 
 __all__ = [
     # Core

--- a/ras_commander/precip/PrecipHrrr.py
+++ b/ras_commander/precip/PrecipHrrr.py
@@ -715,7 +715,13 @@ class PrecipHrrr:
             expected_valid_times = pd.DatetimeIndex(
                 [forecast_reference_time] * record_count
             ) + step_deltas
-            if not valid_times.equals(expected_valid_times):
+            # Pandas 3 preserves source datetime resolutions.  Equivalent
+            # coordinates can therefore be represented as datetime64[s] and
+            # datetime64[ns], for which DatetimeIndex.equals() returns False.
+            # Compare the timestamp values rather than their storage units.
+            if not np.array_equal(
+                valid_times.to_numpy(), expected_valid_times.to_numpy()
+            ):
                 raise ValueError(
                     "HRRR valid_time must equal the forecast cycle time plus step"
                 )

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,38 @@ from setuptools.command.build_py import build_py
 import subprocess
 from pathlib import Path
 
+
+# Keep the default installation import-safe and suitable for inventory/HDF work.
+# Feature groups are additive so batch runners can install only what they use.
+CORE_DEPENDENCIES = [
+    'h5py',
+    'numpy',
+    'pandas',
+]
+
+COMPUTE_DEPENDENCIES = [
+    'psutil>=5.6.6',  # Process supervision and the default dialog watchdog
+    'pywin32>=227; sys_platform == "win32"',  # Windows dialog watchdog primitives
+]
+
+FULL_FEATURE_DEPENDENCIES = [
+    'requests',
+    'tqdm',
+    'scipy',
+    'xarray',
+    'geopandas',
+    'matplotlib',
+    'shapely>=2.0',
+    'rasterio',
+    'pyarrow>=14.0',
+    'pyproj',
+    'rasterstats',
+    'rtree',
+    'fsspec>=2023.0.0',
+    'hms-commander>=0.3.1',
+]
+
+
 class CustomBuildPy(build_py):
     def run(self):
         # Clean up __pycache__ folders
@@ -67,28 +99,16 @@ setup(
     cmdclass={
         'build_py': CustomBuildPy,
     },
-    install_requires=[
-        'h5py',
-        'numpy',
-        'pandas',
-        'requests',
-        'tqdm',
-        'scipy',
-        'xarray',
-        'geopandas',
-        'matplotlib',
-        'shapely>=2.0',
-        'rasterio',
-        'pyarrow>=14.0',
-        'pyproj',
-        'rasterstats',
-        'rtree',
-        'fsspec>=2023.0.0',  # Required for Atlas14Grid remote HTTP access
-        'pywin32>=227; sys_platform == "win32"',    # Required for RasControl COM interface (Windows only)
-        'psutil>=5.6.6',   # Required for RasControl process management
-        'hms-commander>=0.3.1',  # Storm generator updates and Atlas 14 DataFrame API
-    ],
+    install_requires=CORE_DEPENDENCIES,
     extras_require={
+        # Lean Windows/Wine batch execution through RasCmdr.compute_plan().
+        # This intentionally excludes the RasControl COM interface and the
+        # geospatial/plotting stack. "execution" is a descriptive alias.
+        'compute': COMPUTE_DEPENDENCIES,
+        'execution': COMPUTE_DEPENDENCIES,
+        # Preserve the historical default feature dependency surface for
+        # users who need every ras-commander module.
+        'full': FULL_FEATURE_DEPENDENCIES + COMPUTE_DEPENDENCIES,
         # Remote execution backends (PsExec worker has no extra deps)
         'remote': [],  # Base remote - PsExec only, no additional deps
         'remote-ssh': ['paramiko>=3.0'],
@@ -111,8 +131,8 @@ setup(
         # Precipitation enhancements
         'precip': ['zarr>=2.14.0', 's3fs>=2023.0.0', 'netCDF4>=1.6.0'],
         'precip-huc12': ['pygeohydro>=0.19.0'],  # HUC12 watershed boundaries for Atlas14Variance
-        # Compatibility alias: pyarrow is required by the core package.
-        'geoparquet': [],
+        # GeoParquet support without the rest of the full feature stack.
+        'geoparquet': ['pyarrow>=14.0'],
         # Notebook dependencies (raster visualization, coordinate systems, precipitation examples)
         'notebooks': [
             'rasterio',
@@ -131,7 +151,7 @@ setup(
         # DSS file operations (requires Java JRE/JDK 8+)
         'dss': ['pyjnius'],
         # Everything (all optional dependencies)
-        'all': [
+        'all': FULL_FEATURE_DEPENDENCIES + COMPUTE_DEPENDENCIES + [
             'paramiko>=3.0',
             'pywinrm>=0.4.3',
             'docker>=6.0',

--- a/tests/test_compute_extra.py
+++ b/tests/test_compute_extra.py
@@ -1,0 +1,171 @@
+"""Contracts for the lean RasCmdr command-line execution installation."""
+
+from pathlib import Path
+import inspect
+import json
+import runpy
+import subprocess
+import sys
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _setup_metadata(monkeypatch):
+    captured = {}
+
+    def fake_setup(**kwargs):
+        captured.update(kwargs)
+
+    monkeypatch.chdir(REPO_ROOT)
+    monkeypatch.setattr("setuptools.setup", fake_setup)
+    runpy.run_path(str(REPO_ROOT / "setup.py"), run_name="__main__")
+    return captured
+
+
+def test_compute_extra_has_only_process_supervision_dependencies(monkeypatch):
+    metadata = _setup_metadata(monkeypatch)
+
+    assert metadata["install_requires"] == ["h5py", "numpy", "pandas"]
+    expected = [
+        "psutil>=5.6.6",
+        'pywin32>=227; sys_platform == "win32"',
+    ]
+    assert metadata["extras_require"]["compute"] == expected
+    assert metadata["extras_require"]["execution"] == expected
+
+    full = metadata["extras_require"]["full"]
+    for dependency in (
+        "geopandas",
+        "rasterio",
+        "matplotlib",
+        "scipy",
+        "xarray",
+        "shapely>=2.0",
+        "pyarrow>=14.0",
+        "hms-commander>=0.3.1",
+        *expected,
+    ):
+        assert dependency in full
+
+
+def test_compute_facade_imports_without_full_feature_stack():
+    script = r'''
+import importlib.abc
+import json
+import sys
+
+forbidden = {
+    "geopandas", "rasterio", "matplotlib", "scipy", "xarray", "shapely",
+    "pyarrow", "pyproj", "rasterstats", "rtree", "requests", "tqdm",
+    "hms_commander",
+}
+
+class Blocker(importlib.abc.MetaPathFinder):
+    def find_spec(self, fullname, path=None, target=None):
+        if fullname.split(".", 1)[0] in forbidden:
+            raise ModuleNotFoundError(fullname)
+        return None
+
+sys.meta_path.insert(0, Blocker())
+from ras_commander.compute import (
+    ComputeParallelResult,
+    ComputeResult,
+    HdfResultsPlan,
+    RasCmdr,
+    RasPlan,
+    RasPrj,
+    ResultsParser,
+    ResultsSummary,
+    init_ras_project,
+    ras,
+)
+
+assert "ras_commander.RasControl" not in sys.modules
+assert all(name not in globals() for name in ("RasControl", "RasControlResult"))
+print(json.dumps({
+    "exports": [
+        RasCmdr.__name__, RasPlan.__name__, RasPrj.__name__,
+        ComputeResult.__name__, ComputeParallelResult.__name__,
+        HdfResultsPlan.__name__, ResultsParser.__name__, ResultsSummary.__name__,
+    ],
+    "project_initialized": getattr(ras, "project_folder", None) is not None,
+    "initializer_callable": callable(init_ras_project),
+}))
+'''
+    completed = subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    payload = json.loads(completed.stdout.strip().splitlines()[-1])
+
+    assert payload["exports"] == [
+        "RasCmdr",
+        "RasPlan",
+        "RasPrj",
+        "ComputeResult",
+        "ComputeParallelResult",
+        "HdfResultsPlan",
+        "ResultsParser",
+        "ResultsSummary",
+    ]
+    assert payload["initializer_callable"] is True
+
+
+def test_representative_top_level_exports_remain_available():
+    from ras_commander import (
+        BenefitAreaConfig,
+        HdfResultsPlan,
+        RasCmdr,
+        RasSteady,
+        RasUnsteady,
+        StoreMapPerformanceOptions,
+    )
+    from ras_commander.RasBenefits import BenefitAreaConfig as LegacyBenefitAreaConfig
+    from ras_commander.RasterPerformance import (
+        StoreMapPerformanceOptions as LegacyStoreMapPerformanceOptions,
+    )
+    from ras_commander.compute import RasCmdr as ComputeRasCmdr
+
+    assert HdfResultsPlan.__name__ == "HdfResultsPlan"
+    assert RasSteady.__name__ == "RasSteady"
+    assert RasUnsteady.__name__ == "RasUnsteady"
+    assert ComputeRasCmdr is RasCmdr
+    assert BenefitAreaConfig is LegacyBenefitAreaConfig
+    assert StoreMapPerformanceOptions is LegacyStoreMapPerformanceOptions
+    assert BenefitAreaConfig.__module__ == "ras_commander.RasBenefits"
+    assert (
+        StoreMapPerformanceOptions.__module__
+        == "ras_commander.RasterPerformance"
+    )
+    parameters = inspect.signature(RasCmdr.compute_plan).parameters
+    assert "refresh_inventory" not in parameters
+    assert "refresh_results" not in parameters
+
+
+def test_lazy_class_exports_survive_same_named_submodule_imports():
+    script = r'''
+import importlib
+from types import ModuleType
+
+importlib.import_module("ras_commander.RasSteady")
+importlib.import_module("ras_commander.hdf.HdfMesh")
+
+from ras_commander import RasSteady
+from ras_commander.hdf import HdfMesh
+
+assert not isinstance(RasSteady, ModuleType)
+assert not isinstance(HdfMesh, ModuleType)
+assert RasSteady.__name__ == "RasSteady"
+assert HdfMesh.__name__ == "HdfMesh"
+'''
+    subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=True,
+    )

--- a/tests/test_hdf_results_products_export.py
+++ b/tests/test_hdf_results_products_export.py
@@ -198,16 +198,13 @@ class _SliceOnlyDataset:
         return self._values[key]
 
 
-def test_pyarrow_is_a_required_core_dependency():
+def test_pyarrow_is_available_through_feature_extras():
     setup_path = Path(__file__).absolute().parents[1] / "setup.py"
     setup_text = setup_path.read_text(encoding="utf-8")
 
-    install_requires = setup_text.split("install_requires=[", 1)[1].split(
-        "],",
-        1,
-    )[0]
-    assert "'pyarrow>=14.0'" in install_requires
-    assert "'geoparquet': []" in setup_text
+    assert "'pyarrow>=14.0'" in setup_text
+    assert "'geoparquet': ['pyarrow>=14.0']" in setup_text
+    assert "'full': FULL_FEATURE_DEPENDENCIES + COMPUTE_DEPENDENCIES" in setup_text
 
 
 def test_velocity_reduction_is_bounded_slice_only():

--- a/tests/test_hdf_steady_results.py
+++ b/tests/test_hdf_steady_results.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 import h5py
 import numpy as np
+import pytest
 
 from ras_commander.hdf import HdfResultsPlan
 
@@ -18,6 +19,7 @@ def _write_legacy_steady_plan_hdf(path: Path) -> None:
             ("River", "S32"),
             ("Reach", "S32"),
             ("RS", "S32"),
+            ("Len Channel", "f4"),
         ]
     )
     with h5py.File(path, "w") as hdf:
@@ -25,8 +27,8 @@ def _write_legacy_steady_plan_hdf(path: Path) -> None:
             "Geometry/Cross Sections/Attributes",
             data=np.array(
                 [
-                    (b"River A", b"Reach A", b"1000"),
-                    (b"River A", b"Reach A", b"900"),
+                    (b"River A", b"Reach A", b"1000", 125.0),
+                    (b"River A", b"Reach A", b"900", 1.0e30),
                 ],
                 dtype=attributes_dtype,
             ),
@@ -42,6 +44,14 @@ def _write_legacy_steady_plan_hdf(path: Path) -> None:
         hdf.create_dataset(
             f"{STEADY_BASE_PATH}/Cross Sections/Flow",
             data=np.array([[1000.0, 1000.0], [1500.0, 1500.0]]),
+        )
+        hdf.create_dataset(
+            f"{STEADY_BASE_PATH}/Cross Sections/Additional Variables/Maximum Depth Total",
+            data=np.array([[5.0, 4.0], [6.0, 5.0]]),
+        )
+        hdf.create_dataset(
+            f"{STEADY_BASE_PATH}/Cross Sections/Additional Variables/Hydraulic Depth Channel",
+            data=np.array([[2.0, 1.0], [3.0, 2.0]]),
         )
 
 
@@ -116,3 +126,44 @@ def test_steady_results_uses_geometry_cross_section_attributes_when_needed(tmp_p
             "flow": 1500.0,
         },
     ]
+    assert results[["max_depth", "hydraulic_depth", "channel_length"]].to_dict("records") == [
+        {"max_depth": 5.0, "hydraulic_depth": 2.0, "channel_length": 125.0},
+        {"max_depth": 4.0, "hydraulic_depth": 1.0, "channel_length": 0.0},
+        {"max_depth": 6.0, "hydraulic_depth": 3.0, "channel_length": 125.0},
+        {"max_depth": 5.0, "hydraulic_depth": 2.0, "channel_length": 0.0},
+    ]
+    assert results.attrs["max_depth_source"] == "Maximum Depth Total"
+    assert results.attrs["channel_length_source"].endswith("Len Channel")
+
+
+def test_steady_results_records_legacy_hydraulic_depth_fallback(tmp_path):
+    hdf_path = tmp_path / "legacy_depth_fallback.p01.hdf"
+    _write_legacy_steady_plan_hdf(hdf_path)
+    maximum_depth_path = (
+        f"{STEADY_BASE_PATH}/Cross Sections/Additional Variables/"
+        "Maximum Depth Total"
+    )
+    with h5py.File(hdf_path, "a") as hdf:
+        del hdf[maximum_depth_path]
+
+    results = HdfResultsPlan.get_steady_results(hdf_path)
+
+    assert results["max_depth"].tolist() == results["hydraulic_depth"].tolist()
+    assert results.attrs["max_depth_source"] == (
+        "Hydraulic Depth Channel (legacy fallback)"
+    )
+
+
+def test_steady_results_rejects_misaligned_variable_shape(tmp_path):
+    hdf_path = tmp_path / "misaligned_steady.p01.hdf"
+    _write_legacy_steady_plan_hdf(hdf_path)
+    maximum_depth_path = (
+        f"{STEADY_BASE_PATH}/Cross Sections/Additional Variables/"
+        "Maximum Depth Total"
+    )
+    with h5py.File(hdf_path, "a") as hdf:
+        del hdf[maximum_depth_path]
+        hdf.create_dataset(maximum_depth_path, data=np.array([[5.0, 4.0]]))
+
+    with pytest.raises(ValueError, match="Maximum Depth Total.*shape"):
+        HdfResultsPlan.get_steady_results(hdf_path)

--- a/tests/test_hdf_steady_results_real_fixtures.py
+++ b/tests/test_hdf_steady_results_real_fixtures.py
@@ -1,0 +1,194 @@
+"""Qualification checks against immutable, externally mounted steady HDFs."""
+
+import hashlib
+import os
+from pathlib import Path
+import sqlite3
+
+import h5py
+import numpy as np
+import pytest
+
+from ras_commander.hdf import HdfResultsPlan
+
+
+pytestmark = [pytest.mark.integration, pytest.mark.qualification_critical]
+
+EXPECTED_631_SHA256 = (
+    "9f42e4313fa530cda0f11fce7d3e3c849b267e71cc1627c2bc988555f94ad744"
+)
+REGRESSION_FIXTURES = [
+    pytest.param(
+        570,
+        "02",
+        "7.0",
+        8,
+        178,
+        "ad2cdb4c0485505e6cc48991c1873191e48a325a8d585761709f493bef429b9a",
+        id="hecras-7.0-bald-eagle",
+    ),
+    pytest.param(
+        1498,
+        "01",
+        "6.4.1",
+        8,
+        180,
+        "d6452ee8306553f550a2749dd036da7cd49145a6f3082b84ed3ba26a7c1f5891",
+        id="hecras-6.4.1-siletz",
+    ),
+    pytest.param(
+        74,
+        "05",
+        "6.6",
+        2,
+        12,
+        "9d929783e40d5a2ed22286bbde8b18e18a63a415619de32530fef8c86d100fc7",
+        id="hecras-6.6-floodway",
+    ),
+    pytest.param(
+        96,
+        "01",
+        "6.0.0",
+        75,
+        12,
+        "597dd4ce66c8c73fa1718eec5664a373213f718d84cb5b9283f7de5b7f5bc76a",
+        id="hecras-6.0-ras2fim-si",
+    ),
+]
+STEADY_BASE = (
+    "Results/Steady/Output/Output Blocks/Base Output/Steady Profiles"
+)
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _fixture_database_path() -> Path:
+    override = os.environ.get("RAS_COMMANDER_CLB_FIXTURE_DB")
+    return (
+        Path(override)
+        if override
+        else Path("feature_dev_notes")
+        / "Database of Project Fixtures"
+        / "project_fixtures.sqlite3"
+    )
+
+
+def _clb_project_path(database_path: Path, project_id: int) -> Path:
+    connection = sqlite3.connect(
+        f"file:{database_path.as_posix()}?mode=ro",
+        uri=True,
+    )
+    try:
+        row = connection.execute(
+            "SELECT prj_file FROM projects WHERE project_id = ?",
+            (project_id,),
+        ).fetchone()
+    finally:
+        connection.close()
+    if row is None:
+        pytest.skip(f"CLB fixture database has no project_id={project_id}")
+    return Path(row[0])
+
+
+def test_hecras_631_steady_depth_and_channel_length_semantics_are_exact():
+    database_path = _fixture_database_path()
+    if not database_path.is_file():
+        pytest.skip("CLB fixture database is not available")
+
+    project_path = _clb_project_path(database_path, 616)
+    hdf_path = project_path.with_name(f"{project_path.stem}.p07.hdf")
+    if not hdf_path.is_file():
+        pytest.skip("Immutable HEC-RAS 6.3.1 steady result fixture is not mounted")
+
+    before_hash = _sha256(hdf_path)
+    assert before_hash == EXPECTED_631_SHA256
+
+    results = HdfResultsPlan.get_steady_results(hdf_path)
+
+    with h5py.File(hdf_path, "r") as hdf:
+        file_version = hdf.attrs["File Version"]
+        if isinstance(file_version, bytes):
+            file_version = file_version.decode("utf-8", errors="replace")
+        expected_maximum_depth = hdf[
+            f"{STEADY_BASE}/Cross Sections/Additional Variables/Maximum Depth Total"
+        ][()].reshape(-1)
+        hydraulic_depth = hdf[
+            f"{STEADY_BASE}/Cross Sections/Additional Variables/Hydraulic Depth Channel"
+        ][()].reshape(-1)
+
+    assert "6.3.1" in str(file_version)
+    assert len(results) == 8 * 178
+    np.testing.assert_array_equal(
+        results["max_depth"].to_numpy(),
+        expected_maximum_depth,
+    )
+    assert np.max(np.abs(expected_maximum_depth - hydraulic_depth)) > 29.0
+    assert np.isfinite(results["channel_length"]).all()
+    assert results.attrs["max_depth_source"] == "Maximum Depth Total"
+    assert results.attrs["channel_length_source"].endswith("Len Channel")
+    assert _sha256(hdf_path) == before_hash
+
+
+@pytest.mark.parametrize(
+    "project_id,plan_number,version,profile_count,xs_count,expected_hash",
+    REGRESSION_FIXTURES,
+)
+def test_steady_result_semantics_across_real_hecras_versions(
+    project_id,
+    plan_number,
+    version,
+    profile_count,
+    xs_count,
+    expected_hash,
+):
+    database_path = _fixture_database_path()
+    if not database_path.is_file():
+        pytest.skip("CLB fixture database is not available")
+
+    project_path = _clb_project_path(database_path, project_id)
+    hdf_path = project_path.with_name(
+        f"{project_path.stem}.p{plan_number}.hdf"
+    )
+    if not hdf_path.is_file():
+        pytest.skip(f"Steady result fixture {project_id} is not mounted")
+
+    before_hash = _sha256(hdf_path)
+    assert before_hash == expected_hash
+    results = HdfResultsPlan.get_steady_results(hdf_path)
+
+    with h5py.File(hdf_path, "r") as hdf:
+        file_version = hdf.attrs["File Version"]
+        if isinstance(file_version, bytes):
+            file_version = file_version.decode("utf-8", errors="replace")
+        expected_maximum_depth = hdf[
+            f"{STEADY_BASE}/Cross Sections/Additional Variables/Maximum Depth Total"
+        ][()].reshape(-1)
+        raw_lengths = np.asarray(
+            hdf["Geometry/Cross Sections/Attributes"]["Len Channel"],
+            dtype=float,
+        )
+        root_file_type = hdf.attrs.get("File Type", "")
+        if isinstance(root_file_type, bytes):
+            root_file_type = root_file_type.decode("utf-8", errors="replace")
+
+    assert version in str(file_version)
+    assert len(results) == profile_count * xs_count
+    np.testing.assert_array_equal(
+        results["max_depth"].to_numpy(),
+        expected_maximum_depth,
+    )
+    assert np.isfinite(results["channel_length"]).all()
+    assert results.attrs["max_depth_source"] == "Maximum Depth Total"
+    if project_id == 1498:
+        assert np.count_nonzero(~np.isfinite(raw_lengths) | (np.abs(raw_lengths) > 1e20)) == 1
+    if project_id == 74:
+        assert any("*" in station for station in results["node_id"].unique())
+    if project_id == 96:
+        assert "Geometry" in str(root_file_type)
+    assert _sha256(hdf_path) == before_hash

--- a/tests/test_init_intro.py
+++ b/tests/test_init_intro.py
@@ -20,11 +20,13 @@ def _stub_initialization(monkeypatch):
         ras_exe_path,
         prj_file=None,
         load_results_summary=True,
+        load_hdf_metadata=True,
     ):
         self.project_folder = Path(project_folder)
         self.project_name = "Citation Test Project"
         self.prj_file = prj_file
         self.ras_exe_path = ras_exe_path
+        self.load_hdf_metadata = load_hdf_metadata
 
     monkeypatch.setattr(RasPrj, "initialize", fake_initialize)
     monkeypatch.setattr(


### PR DESCRIPTION
## Summary

- add lean `compute`/`execution` dependency profiles and a narrow `ras_commander.compute` facade for `RasCmdr.compute_plan()`, project inventory, message parsing, and direct HDF extraction
- keep RasControl/COM and optional geospatial dependencies outside the compute-only import surface while preserving historical public imports
- reproduce Controller-equivalent steady-result semantics from HDF: `Maximum Depth Total`, separate hydraulic depth, and geometry `Len Channel` joined by full river/reach/station identity
- fail closed on result-shape, cross-section identity, parser/provenance, and ambiguous mutation conditions uncovered during qualification
- add hash-pinned real steady fixtures for HEC-RAS 6.0.0, 6.3.1, 6.4.1, 6.6, and 7.0

## Intended ras2fim boundary

ras2fim will call `RasCmdr.compute_plan()`; it will not invoke `Ras.exe -c` directly and will not use RasControl/COM. Normal ras-commander post-compute DataFrame refresh semantics remain unchanged.

## Validation

- focused qualification: 256 passed, 3 skipped
- latest focused compute/HDF rerun: 29 passed, 5 skipped
- real HDF fixture hashes checked before and after extraction
- wheel build and metadata inspection passed
- broad 2,413-test suite passed in version-compatible process partitions except one pre-existing executed-notebook hygiene failure
- documentation Markdown/YAML/navigation validation passed; strict docs remain blocked by the NAS worktree path limitation in the Git revision-date plugin

## Patch-exact HEC-RAS 6.3.0.2 Wine qualification

The PR wheel was installed into the pinned 6.3.0.2 Wine image in isolated CT217 and executed the immutable 2-profile × 19-cross-section steady fixture through `RasCmdr.compute_plan()` with no RasControl/COM.

- `Ras.exe -c` materialized `.r01` and `.p01.tmp.hdf`, refreshed geometry, launched `x64/RasSteady.exe`, and promoted the completed result HDF
- `completion_verified=true`; compute/inventory/refresh duration: 5.421 seconds
- current HDF extraction produced 38 ras2fim rows
- Linux-hosted and Windows Controller CSV SHA-256 are identical: `6453f93e6ff40eae7842f73de42b0a6b0ff0fe25689b4673636595f826a98d5f`
- maximum numeric difference: `4.440892098500626e-16`
- forced-timeout cleanup left no owned Wine/HEC-RAS processes or container
- exact-version TCU acceptance was explicit, task-local, and receipt-backed; earlier failed acceptance receipts were not treated as success

The tracked qualification report records executable/wheel hashes, exact commands, process/file transitions, parity, failed experiments, and downstream gates.

## Explicit gaps

The CLB fixture catalog contains no computed steady HDF from HEC-RAS 6.1, 6.2, or 6.5. Those releases are documented as fixture gaps. The downstream ras2fim image still must pin the merged wheel, rebuild its lean batch image, replace its existing RasControl bridge, and repeat terrain/steady/concurrency/timeout gates through the public runner before that lane is called production-ready.