### PR TITLE
Harden Linux/Wine unsteady preprocessing for native Linux solves

### DIFF
--- a/docs/api/core.md
+++ b/docs/api/core.md
@@ -280,6 +280,28 @@ RasCmdr.compute_plan("01", stream_callback=CustomCallback())
                 self.results[plan_number] = (success, duration)
     ```
 
+##### Linux-Hosted Unsteady Preparation
+
+::: ras_commander.RasPreprocess
+    options:
+      show_root_heading: true
+      heading_level: 6
+      members:
+        - preprocess_plan
+        - run_ras_geom_preprocess
+        - verify_preprocessing
+
+`preprocess_plan()` runs Windows HEC-RAS through native Windows Python or
+Windows Python hosted by Wine. It stops at either the detailed `.bco` signal or
+an owned `RasUnsteady.exe` descendant after `.tmp.hdf`, `.b##`, and `.x##` are
+all non-empty. The returned `PreprocessResult.signal_source` records which path
+was used. First-run legal-assent dialogs are reported as blockers and are never
+accepted automatically.
+
+`run_ras_geom_preprocess()` performs the matching vendor geometry-preprocessor
+step with a bounded timeout, executable hash, before/after HDF hashes,
+compute-message parsing, and HDF readability/`Geometry`-group validation.
+
 ##### BcoMonitor Utility
 
 ::: ras_commander.BcoMonitor

--- a/docs/development/release-notes.md
+++ b/docs/development/release-notes.md
@@ -34,6 +34,14 @@
   [qualification report](hec-ras-6302-wine-compute-plan-qualification.md)
   records identities, TCU handling, failed experiments, parity, and remaining
   downstream gates.
+- Extend the lean `ras_commander.compute` facade for Linux-hosted unsteady
+  workflows. `RasPreprocess.preprocess_plan()` now recognizes an owned
+  `RasUnsteady.exe` plus complete `.tmp.hdf`/`.b##`/`.x##` artifacts when a
+  release leaves `.bco` empty, records the exact stop or full-result-copy path,
+  fails closed on timeout and legal-assent dialogs, and supervises only the
+  launched process tree. `run_ras_geom_preprocess()` adds the matching bounded
+  vendor geometry-preprocessor step with hashes, message parsing, and semantic
+  HDF checks.
 
 **C01-C06 Reliability Hardening**
 

--- a/ras_commander/ComputeResults.py
+++ b/ras_commander/ComputeResults.py
@@ -192,6 +192,12 @@ class PreprocessResult:
         b_file_path: Path to the generated .b## file, or None on failure.
         x_file_path: Path to the generated .x## file, or None on failure.
         elapsed_seconds: Wall-clock time for preprocessing.
+        signal_source: ``bco``, ``owned_process_artifacts``,
+            ``natural_completion``, ``full_result_copy``, ``timeout``, or a
+            blocking-condition identifier.
+        full_result_copied: Whether a naturally completed ``p##.hdf`` supplied
+            the temporary HDF fallback.
+        timed_out: Whether preprocessing exceeded its bounded wait.
         error: Error message if preprocessing failed, None on success.
 
     Examples:
@@ -214,6 +220,9 @@ class PreprocessResult:
     b_file_path: Optional[Path] = None
     x_file_path: Optional[Path] = None
     elapsed_seconds: float = 0.0
+    signal_source: Optional[str] = None
+    full_result_copied: bool = False
+    timed_out: bool = False
     error: Optional[str] = None
 
     def __bool__(self) -> bool:
@@ -228,12 +237,12 @@ class PreprocessResult:
 @dataclass
 class GeometryPreprocessResult:
     """
-    Result of GeomPreprocessor.run_geometry_preprocessor().
+    Result of a HEC-RAS geometry-preprocessing operation.
 
-    This result is for delivery/assembly validation: run the HEC-RAS geometry
-    preprocessor, capture detailed compute messages, and report whether blocking
-    errors were found. It is intentionally separate from ``PreprocessResult``,
-    which is tuned for creating Linux unsteady-compute prerequisite files.
+    This result supports both delivery/assembly validation through
+    ``GeomPreprocessor`` and the standalone vendor ``RasGeomPreprocess`` action
+    used after Linux/Wine plan materialization. The optional executable and HDF
+    provenance fields are populated by the standalone action.
     """
     success: bool
     plan_number: str = ""
@@ -242,6 +251,18 @@ class GeometryPreprocessResult:
     elapsed_seconds: float = 0.0
     command: str = ""
     return_code: Optional[int] = None
+    executable_path: Optional[Path] = None
+    executable_sha256: Optional[str] = None
+    input_hdf_path: Optional[Path] = None
+    x_file_path: Optional[Path] = None
+    input_hdf_sha256_before: Optional[str] = None
+    input_hdf_sha256_after: Optional[str] = None
+    output_changed: bool = False
+    hdf_readable: bool = False
+    geometry_group_present: bool = False
+    timed_out: bool = False
+    stdout: str = ""
+    stderr: str = ""
     signal_detected: Optional[str] = None
     compute_message_paths: List[Path] = field(default_factory=list)
     artifact_paths: List[Path] = field(default_factory=list)

--- a/ras_commander/RasBco.py
+++ b/ras_commander/RasBco.py
@@ -43,6 +43,11 @@ class BcoMonitor:
         check_interval: Seconds between .bco file polls (default: 0.5)
         max_wait_seconds: Maximum wait time before timeout (default: 300)
         message_callback: Optional callback for new messages
+        blocking_condition: Optional callback returning a diagnostic when a
+            known modal condition prevents progress
+        alternate_signal_condition: Optional callback for an equivalent,
+            job-scoped readiness signal when the .bco file remains empty
+        alternate_signal_description: Human-readable alternate signal name
 
     Example:
         >>> monitor = BcoMonitor(
@@ -66,11 +71,20 @@ class BcoMonitor:
     # Optional callback for streaming messages
     message_callback: Optional[Callable[[str], None]] = None
 
+    # Optional probes used by process-owning callers such as RasPreprocess.
+    blocking_condition: Optional[Callable[[], Optional[str]]] = None
+    alternate_signal_condition: Optional[Callable[[], bool]] = None
+    alternate_signal_description: Optional[str] = None
+
     # Internal state (initialized in __post_init__)
     bco_file: Path = field(init=False)
     execution_start_time: Optional[float] = field(default=None, init=False)
     _last_file_position: int = field(default=0, init=False)
     _callback_error_logged: bool = field(default=False, init=False)
+    _blocking_probe_error_logged: bool = field(default=False, init=False)
+    _alternate_probe_error_logged: bool = field(default=False, init=False)
+    blocked_reason: Optional[str] = field(default=None, init=False)
+    signal_source: Optional[str] = field(default=None, init=False)
 
     def __post_init__(self):
         """Initialize paths and validate configuration."""
@@ -170,6 +184,36 @@ class BcoMonitor:
                     self._read_and_callback_new_content()
                 return False
 
+            if self.blocking_condition is not None:
+                try:
+                    blocked_reason = self.blocking_condition()
+                except Exception as e:
+                    if not self._blocking_probe_error_logged:
+                        logger.warning(f"Blocking-condition probe failed: {e}")
+                        self._blocking_probe_error_logged = True
+                else:
+                    if blocked_reason:
+                        self.blocked_reason = str(blocked_reason)
+                        logger.error(self.blocked_reason)
+                        return False
+
+            if self.alternate_signal_condition is not None:
+                try:
+                    alternate_detected = self.alternate_signal_condition()
+                except Exception as e:
+                    if not self._alternate_probe_error_logged:
+                        logger.warning(f"Alternate signal probe failed: {e}")
+                        self._alternate_probe_error_logged = True
+                else:
+                    if alternate_detected:
+                        description = (
+                            self.alternate_signal_description
+                            or "alternate completion condition"
+                        )
+                        self.signal_source = "alternate"
+                        logger.info(f"Detected {description}")
+                        return True
+
             # Check for .bco file with signal detection
             if self.bco_file.exists():
                 # Verify file was modified after we started execution
@@ -178,6 +222,7 @@ class BcoMonitor:
                     # Read new content and check for signal
                     content = self._read_and_callback_new_content()
                     if content and self.signal_string in content:
+                        self.signal_source = "bco"
                         logger.info(f"Detected '{self.signal_string}' in {self.bco_file.name}")
                         return True
 

--- a/ras_commander/RasPreprocess.py
+++ b/ras_commander/RasPreprocess.py
@@ -18,21 +18,29 @@ Classes:
     RasPreprocess - Static class for Windows preprocessing operations.
 """
 
+import hashlib
+import os
 import re
 import shutil
 import subprocess
+import sys
 import time
 from pathlib import Path
-from typing import Optional, Union
+from typing import Dict, List, Optional, Tuple, Union
 
 from numbers import Number
 
-from .ComputeResults import PreprocessResult
+from .ComputeResults import GeometryPreprocessResult, PreprocessResult
 from .Decorators import log_call
 from .LoggingConfig import get_logger
 from .RasBco import BcoMonitor
 from .RasPlan import RasPlan
 from .RasPrj import ras
+from ._legal_dialogs import (
+    TCU_BLOCKING_ERROR,
+    TCU_DIALOG_TITLE,
+    legal_dialog_blocking_reason,
+)
 
 logger = get_logger(__name__)
 
@@ -43,7 +51,7 @@ class RasPreprocess:
 
     Automates Phase 1 of the two-phase Linux execution workflow:
     1. Launches HEC-RAS on Windows
-    2. Monitors the .bco log for "Starting Unsteady Flow Computations"
+    2. Monitors the .bco log or owned process tree for compute-engine startup
     3. Terminates HEC-RAS at that point (preprocessing complete)
     4. Verifies .tmp.hdf, .b##, .x## files were generated
 
@@ -56,6 +64,14 @@ class RasPreprocess:
         >>> if result:
         ...     print(f"Ready for Linux in {result.elapsed_seconds:.1f}s")
     """
+
+    _TCU_DIALOG_TITLE = TCU_DIALOG_TITLE
+    _TCU_BLOCKING_ERROR = TCU_BLOCKING_ERROR
+    _TCU_SUPERVISION_ERROR = (
+        "HEC-RAS legal-dialog supervision could not establish the launched "
+        "process tree. ras-commander refused to continue without a scoped "
+        "first-run TCU check."
+    )
 
     @staticmethod
     @log_call
@@ -72,7 +88,9 @@ class RasPreprocess:
         Runs HEC-RAS with early termination to generate .tmp.hdf, .b##, and .x##
         files required by the Linux RasUnsteady binary. The process is killed when
         the .bco log indicates preprocessing is complete ("Starting Unsteady Flow
-        Computations" signal).
+        Computations" signal), or when an owned ``RasUnsteady.exe`` descendant has
+        started and all three prerequisite files are non-empty. The process-tree
+        fallback supports releases that create an empty ``.bco`` file.
 
         Args:
             plan_number: Plan number to preprocess (e.g., "01", 1).
@@ -177,28 +195,66 @@ class RasPreprocess:
                 elapsed_seconds=time.time() - start_time,
             )
 
+        supervision_error = RasPreprocess._tcu_supervision_availability_error()
+        if supervision_error:
+            return PreprocessResult(
+                success=False,
+                plan_number=plan_num,
+                geometry_number=geometry_number,
+                error=supervision_error,
+                elapsed_seconds=time.time() - start_time,
+            )
+
         # Clear existing preprocessing files
         if clear_existing:
             RasPreprocess._clear_preprocessing_files(
                 project_folder, project_name, plan_num, geometry_number
             )
 
+        artifact_baseline = {
+            path: RasPreprocess._artifact_state(path)
+            for path in (tmp_hdf, b_file, x_file)
+        }
+
         # Enable detailed logging to create .bco file
         BcoMonitor.enable_detailed_logging(plan_file)
 
-        # Build command: RAS.exe -c project.prj plan.p##
-        cmd = f'"{ras_exe}" -c "{prj_file}" "{plan_file}"'
+        # Keep a Python launcher alive while the GUI-subsystem Ras.exe runs.
+        # This provides a stable job-owned ancestry under native Windows and
+        # Windows Python hosted by Wine.
+        launcher = (
+            "import subprocess,sys; "
+            "raise SystemExit(subprocess.call(sys.argv[1:], shell=False))"
+        )
+        cmd = [
+            sys.executable,
+            "-c",
+            launcher,
+            str(ras_exe),
+            "-c",
+            str(prj_file),
+            str(plan_file),
+        ]
         logger.info("Starting HEC-RAS preprocessing for plan %s", plan_num)
         logger.debug(f"Command: {cmd}")
 
         # Launch HEC-RAS
-        process = subprocess.Popen(
-            cmd,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            cwd=str(project_folder),
-            shell=True,
-        )
+        try:
+            process = subprocess.Popen(
+                cmd,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                cwd=str(project_folder),
+                shell=False,
+            )
+        except OSError as e:
+            return PreprocessResult(
+                success=False,
+                plan_number=plan_num,
+                geometry_number=geometry_number,
+                error=f"Could not launch HEC-RAS preprocessing: {e}",
+                elapsed_seconds=time.time() - start_time,
+            )
 
         # Monitor .bco file for preprocessing completion signal
         monitor = BcoMonitor(
@@ -207,20 +263,84 @@ class RasPreprocess:
             project_name=project_name,
             signal_string="Starting Unsteady Flow Computations",
             max_wait_seconds=max_wait,
+            blocking_condition=lambda: (
+                RasPreprocess._detect_first_run_tcu_dialog(process.pid)
+            ),
+            alternate_signal_condition=lambda: (
+                RasPreprocess._unsteady_compute_started(
+                    process.pid,
+                    tmp_hdf,
+                    b_file,
+                    x_file,
+                    artifact_baseline=artifact_baseline,
+                )
+            ),
+            alternate_signal_description=(
+                "owned RasUnsteady.exe startup with complete preprocessing artifacts"
+            ),
         )
 
         signal_detected = monitor.monitor_until_signal(process)
+        blocked_reason = getattr(monitor, "blocked_reason", None)
+        monitor_source = getattr(monitor, "signal_source", None)
+        signal_source = (
+            "owned_process_artifacts"
+            if monitor_source == "alternate"
+            else monitor_source
+        )
+        if signal_detected and signal_source is None:
+            signal_source = "bco"
+
+        if blocked_reason:
+            if process.poll() is None:
+                RasPreprocess._terminate_process_tree(process)
+            return PreprocessResult(
+                success=False,
+                plan_number=plan_num,
+                geometry_number=geometry_number,
+                signal_source="blocked_legal_dialog",
+                error=blocked_reason,
+                elapsed_seconds=time.time() - start_time,
+            )
 
         # Terminate process tree
-        if process.poll() is None:
-            logger.debug("Preprocessing signal detected; terminating HEC-RAS")
+        process_was_running = process.poll() is None
+        if process_was_running:
             RasPreprocess._terminate_process_tree(process)
+            if not signal_detected:
+                return PreprocessResult(
+                    success=False,
+                    plan_number=plan_num,
+                    geometry_number=geometry_number,
+                    signal_source="timeout",
+                    timed_out=True,
+                    error=(
+                        "Preprocessing timed out after "
+                        f"{int(max_wait)} seconds before a readiness signal"
+                    ),
+                    elapsed_seconds=time.time() - start_time,
+                )
+            logger.debug("Preprocessing signal detected; terminating HEC-RAS")
         elif signal_detected:
             logger.debug("Preprocessing complete; HEC-RAS process already exited")
         else:
             logger.warning(f"Process exited with code {process.returncode} before signal detected")
+            signal_source = "natural_completion"
+            if process.returncode not in (0, None):
+                return PreprocessResult(
+                    success=False,
+                    plan_number=plan_num,
+                    geometry_number=geometry_number,
+                    signal_source=signal_source,
+                    error=(
+                        "HEC-RAS exited with code "
+                        f"{process.returncode} before a readiness signal"
+                    ),
+                    elapsed_seconds=time.time() - start_time,
+                )
 
         # If process completed fully and .hdf exists but no .tmp.hdf, copy it
+        full_result_copied = False
         if not tmp_hdf.exists() and hdf_file.exists() and hdf_file.stat().st_size > 0:
             logger.warning(
                 "Full simulation completed before early termination; copying %s to %s",
@@ -228,6 +348,8 @@ class RasPreprocess:
                 tmp_hdf.name,
             )
             shutil.copy2(hdf_file, tmp_hdf)
+            full_result_copied = True
+            signal_source = "full_result_copy"
 
         # Verify all three prerequisite files exist and are non-empty
         missing = []
@@ -242,6 +364,8 @@ class RasPreprocess:
             return PreprocessResult(
                 success=False, plan_number=plan_num,
                 geometry_number=geometry_number,
+                signal_source=signal_source,
+                full_result_copied=full_result_copied,
                 error=f"Preprocessing did not generate: {', '.join(missing)}",
                 elapsed_seconds=time.time() - start_time,
             )
@@ -275,6 +399,251 @@ class RasPreprocess:
             b_file_path=b_file,
             x_file_path=x_file,
             elapsed_seconds=elapsed,
+            signal_source=signal_source,
+            full_result_copied=full_result_copied,
+        )
+
+    @staticmethod
+    @log_call
+    def run_ras_geom_preprocess(
+        plan_number: Union[str, Number],
+        ras_object=None,
+        input_hdf_path: Optional[Union[str, Path]] = None,
+        x_file_path: Optional[Union[str, Path]] = None,
+        executable_path: Optional[Union[str, Path]] = None,
+        timeout_sec: int = 300,
+        require_hdf_change: bool = False,
+    ) -> GeometryPreprocessResult:
+        """Run vendor ``RasGeomPreprocess.exe`` for one staged plan.
+
+        :meth:`preprocess_plan` creates the plan ``*.tmp.hdf`` and geometry
+        ``.x##`` inputs. This method executes the matching standalone geometry
+        preprocessor using an argument vector, enforces a bounded timeout, and
+        records executable and before/after HDF fingerprints. It is intended for
+        Windows Python, including Windows Python hosted by Wine.
+
+        Args:
+            plan_number: Plan number (for example ``"06"``).
+            ras_object: Initialized :class:`RasPrj`; defaults to the global project.
+            input_hdf_path: Optional explicit plan ``*.tmp.hdf`` input.
+            x_file_path: Optional explicit project ``.x##`` file.
+            executable_path: Optional explicit ``RasGeomPreprocess.exe`` path.
+                The default is the ``x64`` directory beside ``Ras.exe``.
+            timeout_sec: Maximum execution time in seconds.
+            require_hdf_change: Require the input HDF fingerprint to change.
+                Leave False for idempotent reruns; qualification of a fresh input
+                should set this to True.
+
+        Returns:
+            GeometryPreprocessResult: Bool-compatible execution evidence.
+        """
+        start_time = time.time()
+        ras_obj = ras_object if ras_object is not None else ras
+
+        if isinstance(plan_number, Number):
+            plan_num = f"{int(plan_number):02d}"
+        else:
+            plan_num = str(plan_number).zfill(2)
+
+        try:
+            ras_obj.check_initialized()
+        except Exception as e:
+            return GeometryPreprocessResult(
+                success=False,
+                plan_number=plan_num,
+                error=f"Project not initialized: {e}",
+                elapsed_seconds=time.time() - start_time,
+            )
+
+        project_folder = Path(ras_obj.project_folder)
+        project_name = ras_obj.project_name
+        plan_path = project_folder / f"{project_name}.p{plan_num}"
+        geometry_number = None
+        try:
+            plan_row = ras_obj.plan_df[ras_obj.plan_df["plan_number"] == plan_num]
+            if not plan_row.empty and "Geom File" in plan_row.columns:
+                match = re.search(r"(\d+)", str(plan_row["Geom File"].iloc[0]))
+                if match:
+                    geometry_number = match.group(1)
+        except Exception:
+            pass
+        if geometry_number is None and plan_path.is_file():
+            geometry_number = RasPreprocess._extract_geometry_number(plan_path)
+        if geometry_number is None:
+            return GeometryPreprocessResult(
+                success=False,
+                plan_number=plan_num,
+                error=f"Could not determine geometry number for plan {plan_num}",
+                elapsed_seconds=time.time() - start_time,
+            )
+
+        input_hdf = (
+            Path(input_hdf_path)
+            if input_hdf_path is not None
+            else project_folder / f"{project_name}.p{plan_num}.tmp.hdf"
+        )
+        x_file = (
+            Path(x_file_path)
+            if x_file_path is not None
+            else project_folder / f"{project_name}.x{geometry_number}"
+        )
+        if executable_path is None:
+            ras_exe_path = Path(str(getattr(ras_obj, "ras_exe_path", "")))
+            executable = ras_exe_path.parent / "x64" / "RasGeomPreprocess.exe"
+        else:
+            executable = Path(executable_path)
+
+        missing = [
+            str(path)
+            for path in (executable, input_hdf, x_file)
+            if not path.is_file() or path.stat().st_size == 0
+        ]
+        if missing:
+            return GeometryPreprocessResult(
+                success=False,
+                plan_number=plan_num,
+                geometry_number=geometry_number,
+                executable_path=executable,
+                input_hdf_path=input_hdf,
+                x_file_path=x_file,
+                error=(
+                    "Missing or empty geometry-preprocessor input: "
+                    + ", ".join(missing)
+                ),
+                elapsed_seconds=time.time() - start_time,
+            )
+
+        expected_x_name = f"{project_name}.x{geometry_number}".casefold()
+        try:
+            same_parent = x_file.parent.resolve() == input_hdf.parent.resolve()
+        except OSError:
+            same_parent = x_file.parent.absolute() == input_hdf.parent.absolute()
+        if not same_parent or x_file.name.casefold() != expected_x_name:
+            return GeometryPreprocessResult(
+                success=False,
+                plan_number=plan_num,
+                geometry_number=geometry_number,
+                executable_path=executable,
+                input_hdf_path=input_hdf,
+                x_file_path=x_file,
+                error=(
+                    "RasGeomPreprocess requires the project execution file "
+                    f"{project_name}.x{geometry_number} beside the input HDF"
+                ),
+                elapsed_seconds=time.time() - start_time,
+            )
+
+        executable_sha256 = RasPreprocess._file_sha256(executable)
+        before_sha256 = RasPreprocess._file_sha256(input_hdf)
+        command = [str(executable), str(input_hdf), f"x{geometry_number}"]
+        command_text = subprocess.list2cmdline(command)
+        process = None
+        stdout = ""
+        stderr = ""
+        timed_out = False
+        launch_error = None
+
+        try:
+            process = subprocess.Popen(
+                command,
+                cwd=str(input_hdf.parent),
+                shell=False,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                encoding="utf-8",
+                errors="replace",
+            )
+            try:
+                stdout, stderr = process.communicate(timeout=int(timeout_sec))
+            except subprocess.TimeoutExpired:
+                timed_out = True
+                RasPreprocess._terminate_process_tree(process)
+                try:
+                    stdout, stderr = process.communicate(timeout=2)
+                except Exception:
+                    stdout, stderr = "", ""
+        except OSError as e:
+            launch_error = str(e)
+
+        after_sha256 = (
+            RasPreprocess._file_sha256(input_hdf)
+            if input_hdf.is_file() and input_hdf.stat().st_size > 0
+            else None
+        )
+        output_changed = bool(
+            before_sha256 and after_sha256 and before_sha256 != after_sha256
+        )
+        return_code = process.returncode if process is not None else None
+
+        hdf_readable = False
+        geometry_group_present = False
+        hdf_error = None
+        if after_sha256 is not None:
+            try:
+                import h5py
+
+                with h5py.File(input_hdf, "r") as handle:
+                    hdf_readable = True
+                    geometry_group_present = "Geometry" in handle
+            except Exception as e:
+                hdf_error = str(e)
+
+        errors = []
+        if launch_error:
+            errors.append(f"Could not launch RasGeomPreprocess: {launch_error}")
+        if timed_out:
+            errors.append(
+                f"RasGeomPreprocess timed out after {int(timeout_sec)} seconds"
+            )
+        if return_code is None:
+            errors.append("RasGeomPreprocess did not report a final return code")
+        elif return_code != 0:
+            errors.append(f"RasGeomPreprocess exited with code {return_code}")
+        if after_sha256 is None:
+            errors.append("RasGeomPreprocess did not leave a non-empty input HDF")
+        elif not hdf_readable:
+            errors.append(f"RasGeomPreprocess output HDF is unreadable: {hdf_error}")
+        elif not geometry_group_present:
+            errors.append("RasGeomPreprocess output HDF has no Geometry group")
+        if require_hdf_change and not output_changed:
+            errors.append("RasGeomPreprocess did not change the input HDF fingerprint")
+
+        combined_output = "\n".join(item for item in (stdout, stderr) if item)
+        from .results import ResultsParser
+
+        parsed = ResultsParser.parse_compute_messages(combined_output)
+        operational_error_count = len(errors)
+        if parsed["has_errors"]:
+            errors.append(
+                "RasGeomPreprocess reported an error: "
+                f"{parsed['first_error_line']}"
+            )
+
+        return GeometryPreprocessResult(
+            success=not errors,
+            plan_number=plan_num,
+            geometry_number=geometry_number,
+            elapsed_seconds=time.time() - start_time,
+            command=command_text,
+            return_code=return_code,
+            executable_path=executable,
+            executable_sha256=executable_sha256,
+            input_hdf_path=input_hdf,
+            x_file_path=x_file,
+            input_hdf_sha256_before=before_sha256,
+            input_hdf_sha256_after=after_sha256,
+            output_changed=output_changed,
+            hdf_readable=hdf_readable,
+            geometry_group_present=geometry_group_present,
+            timed_out=timed_out,
+            stdout=stdout or "",
+            stderr=stderr or "",
+            artifact_paths=[input_hdf, x_file],
+            error_count=operational_error_count + parsed["error_count"],
+            warning_count=parsed["warning_count"],
+            first_error_line=parsed["first_error_line"],
+            error="; ".join(errors) if errors else None,
         )
 
     @staticmethod
@@ -374,6 +743,191 @@ class RasPreprocess:
         return None
 
     @staticmethod
+    def _file_sha256(path: Path) -> str:
+        """Return a streaming SHA-256 digest for a preprocessing artifact."""
+        digest = hashlib.sha256()
+        with Path(path).open("rb") as handle:
+            for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+                digest.update(chunk)
+        return digest.hexdigest()
+
+    @staticmethod
+    def _artifact_state(path: Path) -> Optional[Tuple[int, int]]:
+        """Return a size/mtime fingerprint, or None when an artifact is absent."""
+        try:
+            stat = Path(path).stat()
+        except OSError:
+            return None
+        return stat.st_size, stat.st_mtime_ns
+
+    @staticmethod
+    def _detect_first_run_tcu_dialog(
+        root_pid: Optional[int] = None,
+    ) -> Optional[str]:
+        """Return a diagnostic for a TCU modal in one launched process tree."""
+        try:
+            titles = RasPreprocess._get_visible_window_titles(root_pid=root_pid)
+        except Exception as e:
+            return f"{RasPreprocess._TCU_SUPERVISION_ERROR} Detail: {e}"
+        for title in titles:
+            reason = legal_dialog_blocking_reason(title=title)
+            if reason:
+                return reason
+        return None
+
+    @staticmethod
+    def _tcu_supervision_availability_error() -> Optional[str]:
+        """Return a prelaunch diagnostic when scoped TCU detection is unavailable."""
+        if os.name != "nt":
+            return (
+                f"{RasPreprocess._TCU_SUPERVISION_ERROR} "
+                "A Windows-hosted Python process is required for this Ras.exe path."
+            )
+        try:
+            import psutil  # noqa: F401
+        except Exception as e:
+            return (
+                f"{RasPreprocess._TCU_SUPERVISION_ERROR} "
+                f"psutil is unavailable: {e}"
+            )
+        return None
+
+    @staticmethod
+    def _get_visible_window_titles(
+        root_pid: Optional[int] = None,
+    ) -> List[str]:
+        """Enumerate visible titles, optionally scoped to one process tree."""
+        if os.name != "nt":
+            return []
+
+        try:
+            import ctypes
+            from ctypes import wintypes
+
+            allowed_pids = None
+            if root_pid is not None:
+                allowed_pids = {int(root_pid)}
+                try:
+                    import psutil
+
+                    root = psutil.Process(int(root_pid))
+                    allowed_pids.update(
+                        child.pid for child in root.children(recursive=True)
+                    )
+                except Exception as e:
+                    raise RuntimeError(
+                        "Could not enumerate descendants for TCU window scope "
+                        f"PID {root_pid}: {e}"
+                    ) from e
+
+            user32 = ctypes.WinDLL("user32", use_last_error=True)
+            enum_windows_proc = ctypes.WINFUNCTYPE(
+                wintypes.BOOL,
+                wintypes.HWND,
+                wintypes.LPARAM,
+            )
+            user32.EnumWindows.argtypes = [enum_windows_proc, wintypes.LPARAM]
+            user32.EnumWindows.restype = wintypes.BOOL
+            user32.IsWindowVisible.argtypes = [wintypes.HWND]
+            user32.IsWindowVisible.restype = wintypes.BOOL
+            user32.GetWindowTextLengthW.argtypes = [wintypes.HWND]
+            user32.GetWindowTextLengthW.restype = ctypes.c_int
+            user32.GetWindowTextW.argtypes = [
+                wintypes.HWND,
+                wintypes.LPWSTR,
+                ctypes.c_int,
+            ]
+            user32.GetWindowTextW.restype = ctypes.c_int
+            user32.GetWindowThreadProcessId.argtypes = [
+                wintypes.HWND,
+                ctypes.POINTER(wintypes.DWORD),
+            ]
+            user32.GetWindowThreadProcessId.restype = wintypes.DWORD
+
+            titles: List[str] = []
+
+            @enum_windows_proc
+            def collect_title(hwnd, _lparam):
+                if not user32.IsWindowVisible(hwnd):
+                    return True
+                if allowed_pids is not None:
+                    window_pid = wintypes.DWORD()
+                    user32.GetWindowThreadProcessId(
+                        hwnd,
+                        ctypes.byref(window_pid),
+                    )
+                    if int(window_pid.value) not in allowed_pids:
+                        return True
+                length = user32.GetWindowTextLengthW(hwnd)
+                if length <= 0:
+                    return True
+                buffer = ctypes.create_unicode_buffer(length + 1)
+                if user32.GetWindowTextW(hwnd, buffer, length + 1):
+                    title = buffer.value.strip()
+                    if title:
+                        titles.append(title)
+                return True
+
+            user32.EnumWindows(collect_title, 0)
+            return titles
+        except Exception as e:
+            if root_pid is not None:
+                raise RuntimeError(
+                    f"Could not enumerate scoped visible window titles: {e}"
+                ) from e
+            logger.debug(f"Could not enumerate visible window titles: {e}")
+            return []
+
+    @staticmethod
+    def _unsteady_compute_started(
+        root_pid: int,
+        tmp_hdf: Path,
+        b_file: Path,
+        x_file: Path,
+        artifact_baseline: Optional[
+            Dict[Path, Optional[Tuple[int, int]]]
+        ] = None,
+    ) -> bool:
+        """Return True when this launch owns a ready unsteady compute process."""
+        artifacts = (Path(tmp_hdf), Path(b_file), Path(x_file))
+        if any(
+            not path.is_file() or path.stat().st_size == 0
+            for path in artifacts
+        ):
+            return False
+        if artifact_baseline is not None:
+            for path in artifacts:
+                before = artifact_baseline.get(path)
+                if before is not None and RasPreprocess._artifact_state(path) == before:
+                    return False
+
+        try:
+            import psutil
+
+            descendants = psutil.Process(int(root_pid)).children(recursive=True)
+        except Exception:
+            return False
+
+        for child in descendants:
+            candidates = []
+            try:
+                candidates.append(child.name())
+            except Exception:
+                pass
+            try:
+                command = child.cmdline()
+                if command:
+                    candidates.append(Path(command[0]).name)
+            except Exception:
+                pass
+            if any(
+                str(candidate).casefold() in {"rasunsteady", "rasunsteady.exe"}
+                for candidate in candidates
+            ):
+                return True
+        return False
+
+    @staticmethod
     def _terminate_process_tree(process: subprocess.Popen) -> None:
         """
         Kill a process and all its children.
@@ -386,18 +940,42 @@ class RasPreprocess:
         """
         try:
             import psutil
+
             parent = psutil.Process(process.pid)
             children = parent.children(recursive=True)
 
             # Kill children first, then parent
-            for child in children:
+            for child in reversed(children):
                 try:
                     child.kill()
                 except psutil.NoSuchProcess:
                     pass
 
-            parent.kill()
-            process.wait(timeout=10)
+            try:
+                parent.kill()
+            except psutil.NoSuchProcess:
+                pass
+
+            _, survivors = psutil.wait_procs(
+                [*children, parent],
+                timeout=10,
+            )
+            for survivor in survivors:
+                try:
+                    survivor.kill()
+                except psutil.NoSuchProcess:
+                    pass
+            if survivors:
+                _, survivors = psutil.wait_procs(survivors, timeout=2)
+            if survivors:
+                logger.warning(
+                    "Owned HEC-RAS processes survived termination: %s",
+                    ", ".join(str(item.pid) for item in survivors),
+                )
+            try:
+                process.wait(timeout=2)
+            except Exception:
+                pass
             logger.debug("HEC-RAS process tree terminated")
         except Exception as e:
             logger.warning(f"psutil termination failed ({e}), falling back to process.kill()")

--- a/ras_commander/RasTcu.py
+++ b/ras_commander/RasTcu.py
@@ -58,6 +58,14 @@ _VB_ROOT = r"Software\VB and VBA Program Settings"
 _PERSONAL_SECTIONS = ("Projects", "Form Position")
 _PERSONAL_SECTION_NAMES = {section.casefold() for section in _PERSONAL_SECTIONS}
 
+# HEC-RAS 6.x records the user-approved TCU state inside the otherwise-personal
+# ``Projects`` section.  ``System Statistic`` is not an MRU entry: a value such
+# as ``660`` is the release-family sentinel written after the user accepts the
+# 6.6 terms.  It must be detected and preserved while the other Projects values
+# remain excluded from acceptance inference and donor copying.
+_TCU_SENTINEL_SECTION = "Projects"
+_TCU_SENTINEL_VALUE = "System Statistic"
+
 HEC_TERMS_URL = "https://www.hec.usace.army.mil/software/hec-ras/"
 
 
@@ -139,13 +147,15 @@ class RasTcu:
 
     @staticmethod
     def _node_has_acceptance_state(hive, subkey: str) -> bool:
-        """Return True only for a VB6 settings node that is not merely personal MRU state.
+        """Return True only for a VB6 settings node with acceptance-bearing state.
 
         HEC-RAS stores recent projects and window layout under child sections such as
         ``Projects`` and ``Form Position``. Those sections can exist without the TCU
-        having been accepted for the target version, and copying only those sections
-        can produce a false positive. Treat a node as acceptance-bearing only when it
-        has root values or at least one non-personal child section.
+        having been accepted for the target version. HEC-RAS 6.x also stores its
+        ``System Statistic`` acceptance sentinel inside ``Projects``. Treat that exact,
+        non-empty value as acceptance-bearing; continue to ignore ordinary MRU values.
+        Root values and non-personal child sections remain acceptance-bearing for older
+        and future layouts.
         """
         import winreg
 
@@ -154,6 +164,8 @@ class RasTcu:
                 n_sub, n_val, _ = winreg.QueryInfoKey(key)
                 if n_val > 0:
                     return True
+                if RasTcu._has_tcu_sentinel(hive, subkey):
+                    return True
                 for idx in range(n_sub):
                     child = winreg.EnumKey(key, idx)
                     if child.casefold() not in _PERSONAL_SECTION_NAMES:
@@ -161,6 +173,28 @@ class RasTcu:
                 return False
         except OSError:
             return False
+
+    @staticmethod
+    def _has_tcu_sentinel(hive, subkey: str) -> bool:
+        """Return whether ``Projects`` contains the exact non-empty TCU sentinel."""
+        import winreg
+
+        projects_key = f"{subkey}\\{_TCU_SENTINEL_SECTION}"
+        try:
+            with winreg.OpenKey(hive, projects_key) as key:
+                _, n_val, _ = winreg.QueryInfoKey(key)
+                for idx in range(n_val):
+                    name, value, _ = winreg.EnumValue(key, idx)
+                    if name.casefold() != _TCU_SENTINEL_VALUE.casefold():
+                        continue
+                    if isinstance(value, str):
+                        return bool(value.strip())
+                    if isinstance(value, int) and not isinstance(value, bool):
+                        return value > 0
+                    return False
+        except OSError:
+            pass
+        return False
 
     # ------------------------------------------------------------------ #
     # Public: detection (read-only)
@@ -370,7 +404,16 @@ class RasTcu:
             RasTcu._copy_key(donor_hive, donor_key, winreg.HKEY_CURRENT_USER, target_key, writes, dry_run)
             if not keep_personal and not dry_run:
                 for section in _PERSONAL_SECTIONS:
-                    RasTcu._clear_values(winreg.HKEY_CURRENT_USER, f"{target_key}\\{section}")
+                    preserve_names = (
+                        (_TCU_SENTINEL_VALUE,)
+                        if section.casefold() == _TCU_SENTINEL_SECTION.casefold()
+                        else ()
+                    )
+                    RasTcu._clear_values(
+                        winreg.HKEY_CURRENT_USER,
+                        f"{target_key}\\{section}",
+                        preserve_names=preserve_names,
+                    )
         except OSError as exc:
             logger.error("Failed to seed HEC-RAS %s TCU acceptance: %s", pre.version, exc)
             return TcuStatus(False, pre.version, install_dir, target_key, "no-vb6-subtree")
@@ -402,9 +445,10 @@ class RasTcu:
         return TcuStatus(True, pre.version, install_dir, target_key, "accepted")
 
     @staticmethod
-    def _clear_values(hive, subkey: str) -> None:
+    def _clear_values(hive, subkey: str, *, preserve_names=()) -> None:
         import winreg
 
+        preserved = {name.casefold() for name in preserve_names}
         try:
             with winreg.OpenKey(hive, subkey, 0, winreg.KEY_ALL_ACCESS) as key:
                 names = []
@@ -416,6 +460,8 @@ class RasTcu:
                     except OSError:
                         break
                 for name in names:
+                    if name.casefold() in preserved:
+                        continue
                     try:
                         winreg.DeleteValue(key, name)
                     except OSError:

--- a/ras_commander/_legal_dialogs.py
+++ b/ras_commander/_legal_dialogs.py
@@ -1,0 +1,41 @@
+"""Fail-closed classification for software-assent dialogs.
+
+This module intentionally contains no UI automation. Callers may terminate
+their own process tree when a matching dialog blocks execution, but must never
+click a control or otherwise automate assent.
+"""
+
+from typing import Optional
+
+
+TCU_DIALOG_TITLE = "Terms and Conditions for Use (TCU)"
+TCU_BLOCKING_ERROR = (
+    'HEC-RAS is blocked by the first-run "Terms and Conditions for Use (TCU)" '
+    "dialog. Provision an already accepted, exact-version user state or have an "
+    "authorized user review the terms interactively; ras-commander will not "
+    "automate assent."
+)
+
+_LEGAL_ASSENT_MARKERS = (
+    "terms and conditions for use",
+    "terms and conditions of use",
+    "terms of use",
+    "license agreement",
+    "licence agreement",
+    "end user license agreement",
+    "end-user license agreement",
+    "eula",
+)
+
+
+def legal_dialog_blocking_reason(
+    title: str = "",
+    body: str = "",
+) -> Optional[str]:
+    """Return a fail-closed diagnostic for a legal-assent dialog, if any."""
+    combined = " ".join(
+        part.strip() for part in (title, body) if part
+    ).casefold()
+    if any(marker in combined for marker in _LEGAL_ASSENT_MARKERS):
+        return TCU_BLOCKING_ERROR
+    return None

--- a/ras_commander/compute.py
+++ b/ras_commander/compute.py
@@ -1,9 +1,9 @@
 """Lean public surface for command-line HEC-RAS plan execution.
 
 This module is intended for batch runners that need project inventory,
-``RasCmdr.compute_plan()``, compute-message parsing, and direct HDF result
-extraction. It deliberately does not export ``RasControl`` or any COM-based
-result API.
+``RasCmdr.compute_plan()``, Linux unsteady preparation and execution,
+compute-message parsing, and direct HDF result extraction. It deliberately
+does not export ``RasControl`` or any COM-based result API.
 
 The execution semantics are the normal ras-commander semantics: project and
 result DataFrames are refreshed after a compute, the caller retains the normal
@@ -11,9 +11,15 @@ result DataFrames are refreshed after a compute, the caller retains the normal
 line.
 """
 
-from .ComputeResults import ComputeParallelResult, ComputeResult
+from .ComputeResults import (
+    ComputeParallelResult,
+    ComputeResult,
+    GeometryPreprocessResult,
+    PreprocessResult,
+)
 from .RasCmdr import RasCmdr
 from .RasPlan import RasPlan
+from .RasPreprocess import RasPreprocess
 from .RasPrj import (
     RasPrj,
     create_project_from_template,
@@ -33,8 +39,11 @@ __all__ = [
     'create_project_from_template',
     'RasPlan',
     'RasCmdr',
+    'RasPreprocess',
     'ComputeResult',
     'ComputeParallelResult',
+    'PreprocessResult',
+    'GeometryPreprocessResult',
     'ResultsParser',
     'ResultsSummary',
     'HdfResultsPlan',

--- a/ras_commander/results/ResultsParser.py
+++ b/ras_commander/results/ResultsParser.py
@@ -60,6 +60,8 @@ class ResultsParser:
         r'\bcell\s+error\b',               # Iteration/convergence table header
         r'\berror\s+node\s+or\s+conduit\b', # Pipe network iteration table header
         r'iterations',                     # Lines with iteration counts
+        r'\b0\s+errors?\b',               # Explicit zero-error summary
+        r'\berrors?\s*[:=]\s*0\b',       # "Errors: 0" / "Error = 0"
     ]
 
     WARNING_KEYWORDS = [

--- a/tests/test_compute_extra.py
+++ b/tests/test_compute_extra.py
@@ -71,9 +71,12 @@ sys.meta_path.insert(0, Blocker())
 from ras_commander.compute import (
     ComputeParallelResult,
     ComputeResult,
+    GeometryPreprocessResult,
     HdfResultsPlan,
+    PreprocessResult,
     RasCmdr,
     RasPlan,
+    RasPreprocess,
     RasPrj,
     ResultsParser,
     ResultsSummary,
@@ -86,6 +89,8 @@ assert all(name not in globals() for name in ("RasControl", "RasControlResult"))
 print(json.dumps({
     "exports": [
         RasCmdr.__name__, RasPlan.__name__, RasPrj.__name__,
+        RasPreprocess.__name__, PreprocessResult.__name__,
+        GeometryPreprocessResult.__name__,
         ComputeResult.__name__, ComputeParallelResult.__name__,
         HdfResultsPlan.__name__, ResultsParser.__name__, ResultsSummary.__name__,
     ],
@@ -106,6 +111,9 @@ print(json.dumps({
         "RasCmdr",
         "RasPlan",
         "RasPrj",
+        "RasPreprocess",
+        "PreprocessResult",
+        "GeometryPreprocessResult",
         "ComputeResult",
         "ComputeParallelResult",
         "HdfResultsPlan",

--- a/tests/test_rasbco_logging.py
+++ b/tests/test_rasbco_logging.py
@@ -125,3 +125,30 @@ def test_callback_error_warns_once_then_debugs_repeats(tmp_path, caplog):
     ]
     assert "Repeated callback error while monitoring" in debug_text
     assert str(bco_file) in debug_text
+
+
+def test_monitor_accepts_job_scoped_alternate_signal(tmp_path):
+    monitor = BcoMonitor(
+        project_path=tmp_path,
+        plan_number="07",
+        project_name="TestProject",
+        alternate_signal_condition=lambda: True,
+        alternate_signal_description="owned RasUnsteady.exe startup",
+    )
+
+    assert monitor.monitor_until_signal(_FakeProcess(returncode=None))
+    assert monitor.signal_source == "alternate"
+    assert monitor.blocked_reason is None
+
+
+def test_monitor_stops_on_blocking_condition(tmp_path):
+    monitor = BcoMonitor(
+        project_path=tmp_path,
+        plan_number="07",
+        project_name="TestProject",
+        blocking_condition=lambda: "legal dialog requires review",
+    )
+
+    assert not monitor.monitor_until_signal(_FakeProcess(returncode=None))
+    assert monitor.blocked_reason == "legal dialog requires review"
+    assert monitor.signal_source is None

--- a/tests/test_raspreprocess_linux_hosted.py
+++ b/tests/test_raspreprocess_linux_hosted.py
@@ -1,0 +1,430 @@
+"""Focused contracts for Linux-hosted unsteady plan preparation."""
+
+import importlib
+import subprocess
+import sys
+from pathlib import Path
+
+import h5py
+import pandas as pd
+
+from ras_commander.RasPreprocess import RasPreprocess
+
+
+raspreprocess_module = importlib.import_module("ras_commander.RasPreprocess")
+
+
+class _FakeRas:
+    def __init__(self, project_folder: Path):
+        self.project_folder = project_folder
+        self.project_name = "fixture"
+        self.ras_exe_path = project_folder / "Ras.exe"
+        self.plan_df = pd.DataFrame(
+            [{"plan_number": "01", "Geom File": "g03"}]
+        )
+
+    def check_initialized(self):
+        return None
+
+
+class _RunningProcess:
+    pid = 12345
+    returncode = None
+
+    def poll(self):
+        return self.returncode
+
+
+def _seed_project(tmp_path: Path) -> _FakeRas:
+    project = _FakeRas(tmp_path)
+    project.ras_exe_path.write_bytes(b"fixture executable")
+    (tmp_path / "fixture.prj").write_text(
+        "Proj Title=fixture\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "fixture.p01").write_text(
+        "Plan Title=fixture\nGeom File=g03\n",
+        encoding="utf-8",
+    )
+    return project
+
+
+def _write_preprocess_outputs(folder: Path):
+    (folder / "fixture.p01.tmp.hdf").write_bytes(b"ready")
+    (folder / "fixture.b01").write_bytes(b"ready")
+    (folder / "fixture.x03").write_bytes(b"ready")
+
+
+def test_preprocess_uses_owned_launcher_and_records_alternate_signal(
+    tmp_path,
+    monkeypatch,
+):
+    ras_obj = _seed_project(tmp_path)
+    process = _RunningProcess()
+    launched = {}
+    terminated = []
+
+    class Monitor:
+        blocked_reason = None
+        signal_source = "alternate"
+
+        @staticmethod
+        def enable_detailed_logging(_plan_file):
+            return True
+
+        def __init__(self, **kwargs):
+            launched["monitor"] = kwargs
+
+        def monitor_until_signal(self, _process):
+            _write_preprocess_outputs(tmp_path)
+            return True
+
+    def popen(command, **kwargs):
+        launched["command"] = command
+        launched["kwargs"] = kwargs
+        return process
+
+    monkeypatch.setattr(raspreprocess_module, "BcoMonitor", Monitor)
+    monkeypatch.setattr(subprocess, "Popen", popen)
+    monkeypatch.setattr(
+        RasPreprocess,
+        "_tcu_supervision_availability_error",
+        staticmethod(lambda: None),
+    )
+    monkeypatch.setattr(
+        RasPreprocess,
+        "_terminate_process_tree",
+        staticmethod(lambda child: terminated.append(child)),
+    )
+
+    result = RasPreprocess.preprocess_plan(
+        "01",
+        ras_object=ras_obj,
+        clear_existing=False,
+        fix_line_endings=False,
+    )
+
+    assert result
+    assert result.signal_source == "owned_process_artifacts"
+    assert result.full_result_copied is False
+    assert terminated == [process]
+    assert launched["command"] == [
+        sys.executable,
+        "-c",
+        "import subprocess,sys; "
+        "raise SystemExit(subprocess.call(sys.argv[1:], shell=False))",
+        str(ras_obj.ras_exe_path),
+        "-c",
+        str(tmp_path / "fixture.prj"),
+        str(tmp_path / "fixture.p01"),
+    ]
+    assert launched["kwargs"]["shell"] is False
+    assert callable(launched["monitor"]["alternate_signal_condition"])
+    assert callable(launched["monitor"]["blocking_condition"])
+
+
+def test_preprocess_timeout_terminates_owned_tree_and_fails_closed(
+    tmp_path,
+    monkeypatch,
+):
+    ras_obj = _seed_project(tmp_path)
+    process = _RunningProcess()
+    terminated = []
+
+    class Monitor:
+        blocked_reason = None
+        signal_source = None
+
+        @staticmethod
+        def enable_detailed_logging(_plan_file):
+            return True
+
+        def __init__(self, **_kwargs):
+            pass
+
+        def monitor_until_signal(self, _process):
+            return False
+
+    monkeypatch.setattr(raspreprocess_module, "BcoMonitor", Monitor)
+    monkeypatch.setattr(subprocess, "Popen", lambda *_args, **_kwargs: process)
+    monkeypatch.setattr(
+        RasPreprocess,
+        "_tcu_supervision_availability_error",
+        staticmethod(lambda: None),
+    )
+    monkeypatch.setattr(
+        RasPreprocess,
+        "_terminate_process_tree",
+        staticmethod(lambda child: terminated.append(child)),
+    )
+
+    result = RasPreprocess.preprocess_plan(
+        "01",
+        ras_object=ras_obj,
+        max_wait=2,
+        clear_existing=False,
+    )
+
+    assert not result
+    assert result.signal_source == "timeout"
+    assert result.timed_out is True
+    assert "timed out after 2 seconds" in result.error
+    assert terminated == [process]
+
+
+def test_unsteady_signal_requires_owned_process_and_all_artifacts(
+    tmp_path,
+    monkeypatch,
+):
+    artifacts = [
+        tmp_path / "fixture.p01.tmp.hdf",
+        tmp_path / "fixture.b01",
+        tmp_path / "fixture.x03",
+    ]
+    for path in artifacts:
+        path.write_bytes(b"ready")
+
+    class Child:
+        def name(self):
+            return "RasUnsteady.exe"
+
+        def cmdline(self):
+            return [r"C:\HEC-RAS\x64\RasUnsteady.exe"]
+
+    class Root:
+        def children(self, recursive):
+            assert recursive is True
+            return [Child()]
+
+    import psutil
+
+    monkeypatch.setattr(psutil, "Process", lambda _pid: Root())
+
+    assert RasPreprocess._unsteady_compute_started(12345, *artifacts)
+    artifacts[-1].write_bytes(b"")
+    assert not RasPreprocess._unsteady_compute_started(12345, *artifacts)
+
+
+def test_unsteady_signal_rejects_unrelated_descendant(tmp_path, monkeypatch):
+    artifacts = [
+        tmp_path / "fixture.p01.tmp.hdf",
+        tmp_path / "fixture.b01",
+        tmp_path / "fixture.x03",
+    ]
+    for path in artifacts:
+        path.write_bytes(b"ready")
+
+    class Child:
+        def name(self):
+            return "Ras.exe"
+
+        def cmdline(self):
+            return [r"C:\HEC-RAS\Ras.exe"]
+
+    class Root:
+        def children(self, recursive):
+            return [Child()]
+
+    import psutil
+
+    monkeypatch.setattr(psutil, "Process", lambda _pid: Root())
+    assert not RasPreprocess._unsteady_compute_started(12345, *artifacts)
+
+
+def test_unsteady_signal_rejects_stale_preexisting_artifacts(
+    tmp_path,
+    monkeypatch,
+):
+    artifacts = [
+        tmp_path / "fixture.p01.tmp.hdf",
+        tmp_path / "fixture.b01",
+        tmp_path / "fixture.x03",
+    ]
+    for path in artifacts:
+        path.write_bytes(b"ready")
+    baseline = {
+        path: RasPreprocess._artifact_state(path)
+        for path in artifacts
+    }
+
+    class Child:
+        def name(self):
+            return "RasUnsteady.exe"
+
+        def cmdline(self):
+            return [r"C:\HEC-RAS\x64\RasUnsteady.exe"]
+
+    class Root:
+        def children(self, recursive):
+            return [Child()]
+
+    import psutil
+
+    monkeypatch.setattr(psutil, "Process", lambda _pid: Root())
+
+    assert not RasPreprocess._unsteady_compute_started(
+        12345,
+        *artifacts,
+        artifact_baseline=baseline,
+    )
+    artifacts[0].write_bytes(b"new preparation")
+    assert not RasPreprocess._unsteady_compute_started(
+        12345,
+        *artifacts,
+        artifact_baseline=baseline,
+    )
+    artifacts[1].write_bytes(b"new preparation")
+    artifacts[2].write_bytes(b"new preparation")
+    assert RasPreprocess._unsteady_compute_started(
+        12345,
+        *artifacts,
+        artifact_baseline=baseline,
+    )
+
+
+def _standalone_geometry_fixture(tmp_path: Path):
+    ras_obj = _seed_project(tmp_path)
+    executable = tmp_path / "x64" / "RasGeomPreprocess.exe"
+    executable.parent.mkdir()
+    executable.write_bytes(b"geometry preprocessor")
+    input_hdf = tmp_path / "fixture.p01.tmp.hdf"
+    with h5py.File(input_hdf, "w") as handle:
+        handle.create_group("Geometry")
+    x_file = tmp_path / "fixture.x03"
+    x_file.write_bytes(b"execution data")
+    return ras_obj, executable, input_hdf, x_file
+
+
+def test_run_ras_geom_preprocess_uses_argument_vector_and_fingerprints(
+    tmp_path,
+    monkeypatch,
+):
+    ras_obj, executable, input_hdf, _x_file = _standalone_geometry_fixture(
+        tmp_path
+    )
+    observed = {}
+
+    class Process:
+        returncode = 0
+
+        def communicate(self, timeout):
+            observed["timeout"] = timeout
+            with h5py.File(input_hdf, "a") as handle:
+                handle["Geometry"].create_dataset("Product Marker", data=[1])
+            return "Errors: 0\nFinished Processing Geometry", ""
+
+    def popen(command, **kwargs):
+        observed["command"] = command
+        observed["kwargs"] = kwargs
+        return Process()
+
+    monkeypatch.setattr(subprocess, "Popen", popen)
+
+    result = RasPreprocess.run_ras_geom_preprocess(
+        "01",
+        ras_object=ras_obj,
+        timeout_sec=45,
+        require_hdf_change=True,
+    )
+
+    assert result
+    assert result.executable_path == executable
+    assert result.executable_sha256 == RasPreprocess._file_sha256(executable)
+    assert result.output_changed is True
+    assert result.hdf_readable is True
+    assert result.geometry_group_present is True
+    assert result.error_count == 0
+    assert observed["command"] == [str(executable), str(input_hdf), "x03"]
+    assert observed["kwargs"]["shell"] is False
+    assert observed["kwargs"]["cwd"] == str(tmp_path)
+    assert observed["timeout"] == 45
+
+
+def test_run_ras_geom_preprocess_timeout_terminates_and_fails_closed(
+    tmp_path,
+    monkeypatch,
+):
+    ras_obj, _executable, _input_hdf, _x_file = (
+        _standalone_geometry_fixture(tmp_path)
+    )
+    terminated = []
+
+    class Process:
+        returncode = None
+        calls = 0
+
+        def communicate(self, timeout):
+            self.calls += 1
+            if self.calls == 1:
+                raise subprocess.TimeoutExpired("RasGeomPreprocess", timeout)
+            return "", ""
+
+    process = Process()
+    monkeypatch.setattr(subprocess, "Popen", lambda *_args, **_kwargs: process)
+
+    def terminate(child):
+        terminated.append(child)
+        child.returncode = -9
+
+    monkeypatch.setattr(
+        RasPreprocess,
+        "_terminate_process_tree",
+        staticmethod(terminate),
+    )
+
+    result = RasPreprocess.run_ras_geom_preprocess(
+        "01",
+        ras_object=ras_obj,
+        timeout_sec=2,
+        require_hdf_change=True,
+    )
+
+    assert not result
+    assert result.timed_out is True
+    assert result.return_code == -9
+    assert terminated == [process]
+    assert "timed out after 2 seconds" in result.error
+    assert "did not change" in result.error
+
+
+def test_run_ras_geom_preprocess_rejects_corrupt_hdf(tmp_path, monkeypatch):
+    ras_obj, _executable, input_hdf, _x_file = _standalone_geometry_fixture(
+        tmp_path
+    )
+
+    class Process:
+        returncode = 0
+
+        def communicate(self, timeout):
+            input_hdf.write_bytes(b"not an HDF5 file")
+            return "Finished Processing Geometry", ""
+
+    monkeypatch.setattr(subprocess, "Popen", lambda *_args, **_kwargs: Process())
+
+    result = RasPreprocess.run_ras_geom_preprocess(
+        "01",
+        ras_object=ras_obj,
+        require_hdf_change=True,
+    )
+
+    assert not result
+    assert result.output_changed is True
+    assert result.hdf_readable is False
+    assert "output HDF is unreadable" in result.error
+
+
+def test_tcu_detector_is_scoped_and_never_automates_assent(monkeypatch):
+    observed = []
+    monkeypatch.setattr(
+        RasPreprocess,
+        "_get_visible_window_titles",
+        staticmethod(
+            lambda root_pid=None: observed.append(root_pid)
+            or ["Terms and Conditions for Use (TCU)"]
+        ),
+    )
+
+    assert RasPreprocess._detect_first_run_tcu_dialog(777) == (
+        RasPreprocess._TCU_BLOCKING_ERROR
+    )
+    assert observed == [777]

--- a/tests/test_raspreprocess_logging.py
+++ b/tests/test_raspreprocess_logging.py
@@ -189,6 +189,8 @@ def test_full_simulation_fallback_warning_is_concise(
     )
 
     assert result.success is True
+    assert result.signal_source == "full_result_copy"
+    assert result.full_result_copied is True
     warning_messages = [
         record.getMessage()
         for record in _preprocess_records(caplog)

--- a/tests/test_rastcu.py
+++ b/tests/test_rastcu.py
@@ -105,6 +105,54 @@ def test_node_has_acceptance_state_ignores_projects_only(monkeypatch):
     assert RasTcu._node_has_acceptance_state(fake.HKEY_CURRENT_USER, "node") is False
 
 
+def test_node_has_acceptance_state_accepts_exact_projects_sentinel(monkeypatch):
+    fake = _FakeWinregModule(
+        {
+            (1, "node"): {"values": [], "subkeys": ["Projects"]},
+            (1, r"node\Projects"): {
+                "values": [
+                    ("Most Recent Project", r"C:\models\example.prj", 1),
+                    ("System Statistic", "660", 1),
+                ],
+                "subkeys": [],
+            },
+        }
+    )
+    monkeypatch.setitem(sys.modules, "winreg", fake)
+    assert RasTcu._node_has_acceptance_state(fake.HKEY_CURRENT_USER, "node") is True
+
+
+@pytest.mark.parametrize("sentinel", ["", "   ", 0, False, b"660"])
+def test_node_has_acceptance_state_rejects_empty_or_invalid_sentinel(monkeypatch, sentinel):
+    fake = _FakeWinregModule(
+        {
+            (1, "node"): {"values": [], "subkeys": ["Projects"]},
+            (1, r"node\Projects"): {
+                "values": [("System Statistic", sentinel, 1)],
+                "subkeys": [],
+            },
+        }
+    )
+    monkeypatch.setitem(sys.modules, "winreg", fake)
+    assert RasTcu._node_has_acceptance_state(fake.HKEY_CURRENT_USER, "node") is False
+
+
+def test_clear_values_preserves_tcu_sentinel(monkeypatch):
+    projects = {
+        "values": [
+            ("Most Recent Project", r"C:\private\model.prj", 1),
+            ("System Statistic", "660", 1),
+        ],
+        "subkeys": [],
+    }
+    fake = _FakeWinregModule({(1, "projects"): projects})
+    monkeypatch.setitem(sys.modules, "winreg", fake)
+
+    RasTcu._clear_values(1, "projects", preserve_names=("System Statistic",))
+
+    assert projects["values"] == [("System Statistic", "660", 1)]
+
+
 def test_node_has_acceptance_state_accepts_root_values(monkeypatch):
     fake = _FakeWinregModule(
         {
@@ -261,3 +309,8 @@ class _FakeWinregModule:
             return key.data.get("values", [])[index]
         except IndexError as exc:
             raise OSError(index) from exc
+
+    def DeleteValue(self, key, name):
+        key.data["values"] = [
+            value for value in key.data.get("values", []) if value[0] != name
+        ]

--- a/tests/test_results_parser.py
+++ b/tests/test_results_parser.py
@@ -37,3 +37,13 @@ def test_parse_compute_messages_ignores_new_orleans_error_columns():
     assert parsed["has_errors"] is False
     assert parsed["error_count"] == 0
     assert parsed["first_error_line"] is None
+
+
+def test_parse_compute_messages_ignores_explicit_zero_error_summaries():
+    parsed = ResultsParser.parse_compute_messages(
+        "Errors: 0\n0 Errors\nFinished Processing Geometry"
+    )
+
+    assert parsed["has_errors"] is False
+    assert parsed["error_count"] == 0
+    assert parsed["first_error_line"] is None


### PR DESCRIPTION
## Why this exists

This adds a first-class ras-commander workflow for preparing HEC-RAS unsteady projects with the matching Windows release under Wine and then computing them with the matching native Linux solver. It keeps HEC-RAS-aware process control, provenance, and validation in the library instead of requiring each downstream batch worker to reproduce that behavior.

## What changes

- Harden `RasPreprocess.preprocess_plan()` for HEC-RAS releases whose detailed `.bco` remains empty:
  - accept an owned `RasUnsteady.exe` descendant only after `.tmp.hdf`, `.b##`, and `.x##` are non-empty;
  - reject unrelated processes and unchanged pre-existing artifacts;
  - keep a stable Python → `Ras.exe` → solver ancestry under Windows and Wine;
  - fail closed on timeout and first-run legal-assent dialogs;
  - record `bco`, `owned_process_artifacts`, natural-completion, full-result-copy, blocker, and timeout provenance.
- Add bounded `RasPreprocess.run_ras_geom_preprocess()` with an argument vector, owned-process cleanup, executable SHA-256, before/after HDF SHA-256, compute-message parsing, and semantic HDF checks.
- Extend the existing lean `ras_commander.compute` facade with preprocessing APIs and result types. No COM/RasControl dependency and no DataFrame-refresh changes are introduced.
- Recognize the exact HEC-RAS 6.x `Projects\System Statistic` TCU sentinel while continuing to reject ordinary project-history state; preserve that sentinel when donor settings are sanitized.
- Treat explicit zero-error summaries such as `Errors: 0` as non-errors in `ResultsParser`.
- Document the public workflow.

## Existing real-model evidence

The behavior promoted here was exercised on immutable `BaldEagleCrkMulti2D` plan 06 (geometry 09; 18,066 cells and 37,594 faces):

- HEC-RAS 6.5: owned-process preparation signal at 20.3 s; complete Wine preparation action 39.8 s; vendor geometry preprocess 0.191 s; matching native solve 346.2 s.
- HEC-RAS 6.6: owned-process preparation signal at 22.0 s; complete Wine preparation action 43.6 s; matching native solve 220.0 s.

Those runs proved feasibility. Fresh-clone repetition, concurrency, live forced-timeout cleanup, and Windows/native hydraulic parity remain downstream qualification gates for production workers.

## Validation

- `76 passed` across focused TCU, preprocessing, compute-facade, parser, and plan-classification tests.
- Ruff: all changed Python files pass.
- Broad repository run before the final stale-artifact guard: `2,358 passed, 60 skipped, 8 failed`. All 8 failures are outside this diff (host PROJ contamination, single-process CLR rebinding between installed HEC-RAS versions, a stale sediment expectation, and a notebook with retained output).
- `mkdocs build --strict` reaches the Git revision plugin, which cannot resolve the server-side CLB worktree gitdir from Windows; the failure occurs before documentation rendering.

## Non-goals

- No RasControl/COM bridge.
- No direct ad hoc `Ras.exe` invocation outside ras-commander.
- No container or application-specific orchestration changes in this PR.
- No claim that the two-phase unsteady lane is production-qualified yet.
