### PR TITLE
Quote Ras.exe preprocessing paths exactly

### DIFF
--- a/ras_commander/RasPreprocess.py
+++ b/ras_commander/RasPreprocess.py
@@ -74,6 +74,25 @@ class RasPreprocess:
     )
 
     @staticmethod
+    def _ras_compute_command_line(
+        ras_exe: Union[str, Path],
+        project_file: Union[str, Path],
+        plan_file: Union[str, Path],
+    ) -> str:
+        """Build the fully quoted command line required by ``Ras.exe -c``.
+
+        HEC-RAS parses the optional plan path from the raw Windows command
+        line and requires it to be quoted even when the path has no spaces.
+        Passing an argument vector through ``subprocess`` is therefore not
+        equivalent to the documented command-line contract.
+        """
+        values = tuple(str(value) for value in (ras_exe, project_file, plan_file))
+        if any('"' in value for value in values):
+            raise ValueError("HEC-RAS command paths cannot contain a double quote")
+        executable, project, plan = values
+        return f'"{executable}" -c "{project}" "{plan}"'
+
+    @staticmethod
     @log_call
     def preprocess_plan(
         plan_number: Union[str, Number],
@@ -224,16 +243,30 @@ class RasPreprocess:
         # Windows Python hosted by Wine.
         launcher = (
             "import subprocess,sys; "
-            "raise SystemExit(subprocess.call(sys.argv[1:], shell=False))"
+            "ras_exe,command_line=sys.argv[1:3]; "
+            "raise SystemExit(subprocess.call(command_line, "
+            "executable=ras_exe, shell=False))"
         )
+        try:
+            compute_command_line = RasPreprocess._ras_compute_command_line(
+                ras_exe,
+                prj_file,
+                plan_file,
+            )
+        except ValueError as e:
+            return PreprocessResult(
+                success=False,
+                plan_number=plan_num,
+                geometry_number=geometry_number,
+                error=f"Could not launch HEC-RAS preprocessing: {e}",
+                elapsed_seconds=time.time() - start_time,
+            )
         cmd = [
             sys.executable,
             "-c",
             launcher,
             str(ras_exe),
-            "-c",
-            str(prj_file),
-            str(plan_file),
+            compute_command_line,
         ]
         logger.info("Starting HEC-RAS preprocessing for plan %s", plan_num)
         logger.debug(f"Command: {cmd}")

--- a/tests/test_raspreprocess_linux_hosted.py
+++ b/tests/test_raspreprocess_linux_hosted.py
@@ -55,6 +55,30 @@ def _write_preprocess_outputs(folder: Path):
     (folder / "fixture.x03").write_bytes(b"ready")
 
 
+def test_compute_command_line_quotes_every_hec_ras_path():
+    assert RasPreprocess._ras_compute_command_line(
+        r"C:\HEC-RAS\6.6\Ras.exe",
+        r"Q:\fixture\model.prj",
+        r"Q:\fixture\model.p01",
+    ) == (
+        r'"C:\HEC-RAS\6.6\Ras.exe" -c '
+        r'"Q:\fixture\model.prj" "Q:\fixture\model.p01"'
+    )
+
+
+def test_compute_command_line_rejects_quote_in_path():
+    try:
+        RasPreprocess._ras_compute_command_line(
+            r"C:\HEC-RAS\6.6\Ras.exe",
+            'Q:\\bad"folder\\model.prj',
+            r"Q:\fixture\model.p01",
+        )
+    except ValueError as error:
+        assert "cannot contain a double quote" in str(error)
+    else:
+        raise AssertionError("a quoted path must be rejected")
+
+
 def test_preprocess_uses_owned_launcher_and_records_alternate_signal(
     tmp_path,
     monkeypatch,
@@ -112,11 +136,15 @@ def test_preprocess_uses_owned_launcher_and_records_alternate_signal(
         sys.executable,
         "-c",
         "import subprocess,sys; "
-        "raise SystemExit(subprocess.call(sys.argv[1:], shell=False))",
+        "ras_exe,command_line=sys.argv[1:3]; "
+        "raise SystemExit(subprocess.call(command_line, "
+        "executable=ras_exe, shell=False))",
         str(ras_obj.ras_exe_path),
-        "-c",
-        str(tmp_path / "fixture.prj"),
-        str(tmp_path / "fixture.p01"),
+        (
+            f'"{ras_obj.ras_exe_path}" -c '
+            f'"{tmp_path / "fixture.prj"}" '
+            f'"{tmp_path / "fixture.p01"}"'
+        ),
     ]
     assert launched["kwargs"]["shell"] is False
     assert callable(launched["monitor"]["alternate_signal_condition"])


### PR DESCRIPTION
## Summary

- construct the documented raw `Ras.exe -c` command line with the executable, project, and plan paths always quoted
- retain the Python-owned supervisor process and `shell=False` cleanup boundary
- reject impossible Windows paths containing a double quote before launch
- cover quoted paths, rejection, owned launch, timeout cleanup, geometry preprocessing, and the compute-only facade

## Validation

- `python -m pytest tests/test_compute_extra.py tests/test_raspreprocess_linux_hosted.py tests/test_raspreprocess_logging.py tests/test_remote_docker_worker_logging.py -q` (22 passed)
- `python -m ruff check ras_commander/RasPreprocess.py tests/test_raspreprocess_linux_hosted.py`
- real HEC-RAS 6.6 Wine preprocessing of Bald Eagle plan 06 completed in 19.7 seconds, reported `owned_process_artifacts`, completed standalone geometry preprocessing, and left no supervised-process survivors