### PR TITLE
Release ras-commander 0.99.2

### DIFF
--- a/docs/development/release-notes.md
+++ b/docs/development/release-notes.md
@@ -2,7 +2,7 @@
 
 ## Version History
 
-### Unreleased
+### v0.99.2 (Current published release — August 2026)
 
 **Native Registered-Terrain Export**
 
@@ -81,7 +81,7 @@
 - Normalize relative components in mapped-drive fallbacks without converting
   HEC-RAS-compatible drive-letter paths to UNC paths.
 
-### v0.99.1 (Current published release — July 2026)
+### v0.99.1 (July 2026)
 
 **Qualified Raster Processing on Linux/Wine**
 

--- a/ras_commander/__init__.py
+++ b/ras_commander/__init__.py
@@ -17,7 +17,7 @@ try:
     __version__ = version("ras-commander")
 except PackageNotFoundError:
     # package is not installed
-    __version__ = "0.99.1"
+    __version__ = "0.99.2"
 
 # Canonical machine-readable agent index (see docs() helper below)
 __llms_txt__ = "https://rascommander.info/ras/llms.txt"

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ class CustomBuildPy(build_py):
 
 setup(
     name="ras-commander",
-    version="0.99.1",
+    version="0.99.2",
     packages=find_packages(include=['ras_commander', 'ras_commander.*']),
     include_package_data=True,
     package_data={


### PR DESCRIPTION
## Summary

- bump ras-commander package metadata to 0.99.2
- publish the merged August 2026 release notes
- retain the 0.99.2 deprecation marker for the row-sampled terrain compatibility API

## Validation

- focused terrain and native-export regression suites: **143 passed**
- source distribution and wheel built successfully
- `twine check dist/*`: passed
- wheel metadata reports version 0.99.2
- packaged native terrain helper executable, source, build recipe, and host module are present
- `git diff --check`: passed