### PR TITLE
Add ras2fim-ready steady profile map primitives

### DIFF
--- a/agent_tasks/2026-09-01_ras2fim_upstream_primitives_plan.md
+++ b/agent_tasks/2026-09-01_ras2fim_upstream_primitives_plan.md
@@ -104,3 +104,26 @@ Required behavior:
 - Real HEC-RAS qualification on Windows and Wine when a suitable steady model
   and installed runtime are available; do not substitute direct executable
   calls for ras-commander APIs.
+
+## Implementation status
+
+- PR #327 (unified cross-section points) was corrected per the API audit,
+  passed its focused suite and CI, and merged to `main` as `4a0cef6a1`.
+- `HdfBase.get_result_unit_metadata()` is implemented as a strict,
+  standalone plan-result-HDF fallback. Documentation and docstrings state that
+  `RasPrj.get_project_units()` is authoritative when the project is available.
+- `RasProcess.store_maps_at_steady_profiles()` and
+  `RasMap.store_all_maps(mode="steady_profiles")` are implemented with one
+  bulk stored-layer XML transaction and one aggregate helper launch per plan.
+- Public DataFrame schema version 1.8 includes both `cross_section_points` and
+  `steady_profile_stored_maps`.
+- Integrated focused verification: 155 passed, 16 skipped.
+- Broad repository verification reached 2,455 passed and 121 skipped; its 41
+  failures and two setup errors were in environment/package-artifact cases
+  outside the changed paths (notably missing `netCDF4`/`pythonnet`, installed
+  package-metadata expectations, and local native validation fixtures).
+- Python compilation and `git diff --check`: passed.
+- Documentation CI-equivalent generation and MkDocs build: passed; only the
+  repository's pre-existing non-strict notebook link/date warnings remain.
+- Real HEC-RAS and Windows/Wine performance qualification remains a downstream
+  qualification task requiring a suitable computed steady project/runtime.

--- a/agent_tasks/2026-09-01_ras2fim_upstream_primitives_plan.md
+++ b/agent_tasks/2026-09-01_ras2fim_upstream_primitives_plan.md
@@ -1,0 +1,106 @@
+# ras2fim upstream primitives implementation plan
+
+Date: 2026-09-01
+
+## Goal
+
+Add only the generic ras-commander APIs that the private ras2fim fork needs,
+without moving ras2fim inventory, hydrofabric, scenario, rating-curve, or
+release-policy concerns upstream.
+
+## Confirmed existing capabilities
+
+- Exact 1D and 2D footprints already exist in `HdfProject` and `HdfXsec`.
+- Project discovery, plan/geometry metadata, terrain discovery, cloning,
+  steady-flow authoring, execution, steady-result extraction, and compute-message
+  QA already exist.
+- Text-project units are available through `RasPrj.get_project_units()` in PR
+  #327 and are authoritative whenever the project `.prj` is available.
+
+## Upstream implementation scope
+
+### 1. Unified cross-section points
+
+- Land PR #327 after changing project-backed HDF extraction to pass the unit
+  value parsed from the project `.prj` as an explicit override.
+- Preserve HDF unit discovery only for direct, lower-level HDF calls that do not
+  have project context.
+
+### 2. Batched steady-profile stored maps
+
+Public contracts:
+
+- `RasProcess.store_maps_at_steady_profiles(...)` is the execution engine.
+- `RasMap.store_all_maps(mode="steady_profiles", ...)` is the canonical,
+  JSON-serializable facade.
+
+Required behavior:
+
+- Resolve profile names and zero-based indexes from
+  `HdfResultsPlan.get_steady_profile_names()`.
+- Accept all profiles, exact profile names, or zero-based profile indexes.
+- Reject missing names, duplicate names in the result HDF, duplicate requests,
+  and filenames that collide after RASMapper-safe normalization.
+- Add every requested profile/map combination to the `.rasmap` in one XML
+  parse/write transaction.
+- Optionally add one inundation-boundary polygon for the highest selected
+  profile or an explicitly selected profile.
+- Invoke aggregate `StoreAllMaps` exactly once per plan. Do not loop through
+  `RasProcess.store_maps()`.
+- Restore the original `.rasmap` even on failure.
+- Return deterministic profile-to-asset records from `RasProcess`; serialize
+  those records into the existing `RasMap.store_all_maps()` summary shape.
+- Use the existing Windows/Wine helper and mapper-compatible HDF context.
+
+Performance qualification:
+
+- Record profile count, configured map count, XML-configuration wall time,
+  helper wall time, total wall time, and generated file count in result metadata.
+- Keep execution aggregate/serial by design: the optimization is avoiding one
+  helper startup and one XML rewrite per profile.
+- Later compare this single-launch path with the legacy repeated-launch ras2fim
+  worker on the Iowa/RRASSLER sample and a larger BLE model.
+
+### 3. Standalone result-HDF unit metadata
+
+Public contract:
+
+- `HdfBase.get_result_unit_metadata(hdf_path)` returns normalized metadata from
+  an HEC-RAS plan-result HDF.
+
+Required behavior:
+
+- Name and documentation must state that this is for a standalone result HDF
+  when the full project `.prj` is unavailable.
+- A full-project workflow must use `RasPrj.get_project_units()` instead.
+- Promote the strict evidence and contradiction handling already implemented by
+  `HdfResultsProducts._unit_metadata()`.
+- Return JSON-serializable unit system, horizontal/length units,
+  vertical/depth units, velocity units, source, and evidence.
+- Raise on missing, unrecognized, or contradictory embedded metadata.
+- Refactor `HdfResultsProducts` to call the public reader so the logic has one
+  source of truth.
+
+## Explicitly out of upstream scope
+
+- Persistent model inventory/registry and supersession policy.
+- Hydrofabric conflation and confidence policy.
+- HUC8 catalog identifiers and overrides.
+- Discharge ladders, two-pass refinement, rating curves, and ras2fim QA policy.
+- ras2fim checkpoints, worker/container supervision, DEM clipping,
+  simplification, geocurves, and release packaging.
+- New footprint APIs.
+- Terrain-agreement work, which is generic but optional and not required for
+  this integration slice.
+
+## Verification
+
+- Focused unit tests for bulk XML configuration, profile selection and
+  validation, one-helper invocation, result grouping, rasmap restoration,
+  facade dispatch, and unit evidence/contradictions.
+- Existing stored-map, RasMap mode, HDF result-product, cross-section, project,
+  and schema tests.
+- Documentation build if API pages change.
+- Real HEC-RAS qualification on Windows and Wine when a suitable steady model
+  and installed runtime are available; do not substitute direct executable
+  calls for ras-commander APIs.

--- a/docs/api/core.md
+++ b/docs/api/core.md
@@ -855,7 +855,9 @@ results = RasProcess.store_maps(
 products in one `.rasmap` update and invokes aggregate `StoreAllMaps` exactly
 once. `profiles=None` selects all HDF profiles; exact names and zero-based
 indexes can be mixed. One inundation boundary for the final selected profile is
-included by default.
+included by default. Supported profile rasters are `wse`, `depth`, `velocity`,
+`froude`, `shear_stress`, `depth_x_velocity`, `depth_x_velocity_sq`, and
+`flow`.
 
 ```python
 frame = RasProcess.store_maps_at_steady_profiles(

--- a/docs/api/core.md
+++ b/docs/api/core.md
@@ -849,6 +849,26 @@ results = RasProcess.store_maps(
 )
 ```
 
+##### Steady Profile Batch
+
+`RasProcess.store_maps_at_steady_profiles()` configures all requested profile
+products in one `.rasmap` update and invokes aggregate `StoreAllMaps` exactly
+once. `profiles=None` selects all HDF profiles; exact names and zero-based
+indexes can be mixed. One inundation boundary for the final selected profile is
+included by default.
+
+```python
+frame = RasProcess.store_maps_at_steady_profiles(
+    "01",
+    profiles=None,
+    map_types=("depth",),
+    output_path="steady_maps",
+)
+```
+
+Use `RasMap.store_all_maps(mode="steady_profiles", ...)` when a directly
+JSON-serializable project summary is preferred.
+
 !!! warning "Georeferencing Fix"
     RasProcess.exe has a known bug where generated TIFs may lack proper CRS information.
     Set `fix_georef=True` (default) to automatically apply the CRS from the project's

--- a/docs/api/hdf.md
+++ b/docs/api/hdf.md
@@ -11,8 +11,17 @@ Base functionality for HDF file operations.
 - `get_dataset_info(hdf_path, group_path=None)` - Print HDF structure
 - `get_attrs(hdf_path, path)` - Get attributes at path
 - `get_projection(hdf_path)` - Get coordinate system
+- `get_result_unit_metadata(hdf_path, strict=True)` - Read normalized unit
+  metadata and source evidence from a standalone plan-result HDF
 - `parse_ras_datetime(datetime_str)` - Parse HEC-RAS datetime string
 - `parse_ras_datetime_ms(datetime_bytes)` - Parse datetime with milliseconds
+
+`get_result_unit_metadata()` is deliberately a result-HDF fallback. When the
+full project is available, use `RasPrj.get_project_units()` and treat the text
+`.prj` marker as authoritative. The HDF reader never defaults missing metadata
+to English units. It raises on missing, unrecognized, geometry-only, or
+contradictory metadata unless `strict=False`, which returns the raw evidence
+and an unresolved status for audit workflows.
 
 ### HdfPlan
 

--- a/docs/user-guide/spatial-data.md
+++ b/docs/user-guide/spatial-data.md
@@ -642,7 +642,10 @@ HEC-RAS can generate stored maps (raster outputs like depth and water surface el
 
 ### Headless Generation with RasProcess (Recommended)
 
-The `RasProcess` class uses the undocumented RasProcess.exe CLI tool bundled with HEC-RAS to generate stored maps without opening the GUI. This is faster and more reliable for batch processing.
+The canonical `RasMap.store_all_maps()` facade and its `RasProcess` engine use
+ras-commander's packaged RAS Mapper helper and the mapping libraries installed
+with HEC-RAS. They generate stored maps without opening the GUI and support the
+same aggregate path on Windows and Wine.
 
 ```python
 from ras_commander import RasCmdr, RasProcess
@@ -691,6 +694,38 @@ results = RasProcess.store_maps(plan_number="01", profile="Min")
 timestamps = RasProcess.get_plan_timestamps("01")
 results = RasProcess.store_maps(plan_number="01", profile=timestamps[10])
 ```
+
+#### All Steady Profiles in One Launch
+
+For a steady plan, use the canonical `steady_profiles` mode. It resolves names
+and zero-based indexes from the result HDF, writes every selected layer to the
+temporary `.rasmap` in one transaction, and launches aggregate `StoreAllMaps`
+once for the plan.
+
+```python
+from ras_commander import RasMap
+
+summary = RasMap.store_all_maps(
+    "01",
+    mode="steady_profiles",
+    profiles=None,                 # every HDF profile, in HDF order
+    map_types=("depth",),
+    inundation_boundary=True,      # one polygon for the final selected profile
+    output_path="steady_maps",
+)
+```
+
+The final selected profile is not assumed to be hydraulically highest for an
+arbitrary model. ras2fim constructs ascending discharge ladders, so its final
+profile is the highest ladder step. Exact names and zero-based indexes can be
+mixed when a subset or custom order is needed.
+
+The lower-level
+`RasProcess.store_maps_at_steady_profiles()` returns one DataFrame row per
+logical profile/product. It records the VRT or SHP primary path, all TIFF tiles
+or shapefile sidecars, and performance metadata including configuration time,
+helper time, and helper launch count. The original `.rasmap` is restored after
+success or failure.
 
 #### Batch Processing All Plans
 

--- a/docs/user-guide/spatial-data.md
+++ b/docs/user-guide/spatial-data.md
@@ -700,7 +700,8 @@ results = RasProcess.store_maps(plan_number="01", profile=timestamps[10])
 For a steady plan, use the canonical `steady_profiles` mode. It resolves names
 and zero-based indexes from the result HDF, writes every selected layer to the
 temporary `.rasmap` in one transaction, and launches aggregate `StoreAllMaps`
-once for the plan.
+once for the plan. `map_types` accepts `wse`, `depth`, `velocity`, `froude`,
+`shear_stress`, `depth_x_velocity`, `depth_x_velocity_sq`, and `flow`.
 
 ```python
 from ras_commander import RasMap
@@ -724,8 +725,8 @@ The lower-level
 `RasProcess.store_maps_at_steady_profiles()` returns one DataFrame row per
 logical profile/product. It records the VRT or SHP primary path, all TIFF tiles
 or shapefile sidecars, and performance metadata including configuration time,
-helper time, and helper launch count. The original `.rasmap` is restored after
-success or failure.
+helper time, helper launch count, and generated file count. The original
+`.rasmap` is restored after success or failure.
 
 #### Batch Processing All Plans
 

--- a/ras_commander/RasMap.py
+++ b/ras_commander/RasMap.py
@@ -69,6 +69,7 @@ List of Functions in RasMap:
 - add_wse_comparison_layers(): Batch add WSE comparison layers for existing/proposed plan pairs
 """
 
+import json
 import re
 import subprocess
 import warnings
@@ -3376,6 +3377,9 @@ class RasMap:
         output_folder: Optional[str] = None,
         output_path: Optional[Union[str, Path]] = None,
         profile: str = "Max",
+        profiles: Optional[
+            Union[str, int, Sequence[Union[str, int]]]
+        ] = None,
         timesteps: Optional[
             Union[int, str, datetime, Sequence[Union[int, str, datetime]]]
         ] = None,
@@ -3418,6 +3422,9 @@ class RasMap:
           enables memory-admitted map-level parallelism.
         - ``"timesteps"`` generates selected products for requested output
           timesteps.
+        - ``"steady_profiles"`` configures every selected steady profile in
+          one XML transaction and invokes aggregate ``StoreAllMaps`` once per
+          plan.
         - ``"all_plans"`` applies the selected-map configuration to every
           project plan with an HDF result.
         - ``"auto"`` preserves a plain historic call as ``"configured"``,
@@ -3437,15 +3444,18 @@ class RasMap:
             render_mode: Optional water-surface rendering override.
             ras_object: Initialized project object; defaults to the active project.
             timeout: Per-helper timeout in seconds.
-            mode: ``auto``, ``configured``, ``selected``, ``timesteps``, or
-                ``all_plans``. ``native`` remains a deprecated compatibility
-                alias for ``configured``.
+            mode: ``auto``, ``configured``, ``selected``, ``timesteps``,
+                ``steady_profiles``, or ``all_plans``. ``native`` remains a
+                deprecated compatibility alias for ``configured``.
             output_folder: Relative ``.rasmap`` StoredFilename folder name for
                 configured non-timestep modes. It is not an output destination.
             output_path: Destination directory to which generated products are
                 moved. Multi-plan modes create ``plan_XX`` children.
             profile: ``Max``, ``Min``, or a timestamp for configured
                 non-timestep modes.
+            profiles: Steady-profile selectors for ``steady_profiles`` mode.
+                ``None`` selects all profiles; exact names and zero-based
+                indexes may be mixed in a sequence.
             timesteps, max_timesteps: Timestep selectors for ``timesteps`` mode.
             map_types: One product name or a sequence of names. Do not combine
                 with individual product flags. Defaults are WSE/Depth/Velocity
@@ -3490,10 +3500,18 @@ class RasMap:
             "all": "all_plans",
         }
         resolved_mode = mode_aliases.get(requested_mode, requested_mode)
-        valid_modes = {"auto", "configured", "selected", "timesteps", "all_plans"}
+        valid_modes = {
+            "auto",
+            "configured",
+            "selected",
+            "timesteps",
+            "steady_profiles",
+            "all_plans",
+        }
         if resolved_mode not in valid_modes:
             raise ValueError(
-                "mode must be auto, configured, selected, timesteps, or all_plans"
+                "mode must be auto, configured, selected, timesteps, "
+                "steady_profiles, or all_plans"
             )
 
         requested_flags = {
@@ -3514,6 +3532,7 @@ class RasMap:
                 output_folder is not None,
                 output_path is not None,
                 profile != "Max",
+                profiles is not None,
                 timesteps is not None,
                 max_timesteps is not None,
                 map_types is not None,
@@ -3529,7 +3548,9 @@ class RasMap:
             )
         )
         if resolved_mode == "auto":
-            if timesteps is not None or max_timesteps is not None:
+            if profiles is not None:
+                resolved_mode = "steady_profiles"
+            elif timesteps is not None or max_timesteps is not None:
                 resolved_mode = "timesteps"
             elif plan_number is None:
                 resolved_mode = "all_plans"
@@ -3569,12 +3590,20 @@ class RasMap:
 
         if resolved_mode == "all_plans" and plan_number is not None:
             raise ValueError("plan_number must be omitted for mode='all_plans'")
-        if resolved_mode in {"selected", "timesteps"} and plan_number is None:
+        if resolved_mode in {
+            "selected",
+            "timesteps",
+            "steady_profiles",
+        } and plan_number is None:
             raise ValueError(f"plan_number is required for mode='{resolved_mode}'")
         if resolved_mode != "timesteps" and timesteps is not None:
             raise ValueError("timesteps are only valid with mode='timesteps'")
         if resolved_mode != "timesteps" and max_timesteps is not None:
             raise ValueError("max_timesteps is only valid with mode='timesteps'")
+        if resolved_mode != "steady_profiles" and profiles is not None:
+            raise ValueError(
+                "profiles are only valid with mode='steady_profiles'"
+            )
         if resolved_mode == "timesteps":
             unsupported_timestep_options = []
             if output_folder is not None:
@@ -3591,6 +3620,31 @@ class RasMap:
                 raise ValueError(
                     "mode='timesteps' does not support: "
                     + ", ".join(unsupported_timestep_options)
+                )
+
+        if resolved_mode == "steady_profiles":
+            unsupported_steady_options = []
+            if output_folder is not None:
+                unsupported_steady_options.append("output_folder (use output_path)")
+            if profile != "Max":
+                unsupported_steady_options.append("profile (use profiles)")
+            if timesteps is not None or max_timesteps is not None:
+                unsupported_steady_options.append("timesteps")
+            if arrival_depth != 0.0:
+                unsupported_steady_options.append("arrival_depth")
+            if benefit_area is not None:
+                unsupported_steady_options.append("benefit_area")
+            if performance is not None:
+                unsupported_steady_options.append(
+                    "performance (steady batches use one aggregate helper)"
+                )
+            for product in ("arrival_time", "duration", "percent_inundated"):
+                if requested_flags.get(product):
+                    unsupported_steady_options.append(product)
+            if unsupported_steady_options:
+                raise ValueError(
+                    "mode='steady_profiles' does not support: "
+                    + ", ".join(unsupported_steady_options)
                 )
 
         supported_map_types = tuple(requested_flags)
@@ -3617,7 +3671,7 @@ class RasMap:
         elif benefit_area is not None:
             # BenefitArea has configuration-dependent defaults in RasProcess.
             map_flags = dict(requested_flags)
-        elif resolved_mode == "timesteps":
+        elif resolved_mode in {"timesteps", "steady_profiles"}:
             map_flags = {name: name == "depth" for name in supported_map_types}
         else:
             map_flags = {
@@ -3643,6 +3697,18 @@ class RasMap:
                 raise ValueError(
                     "mode='timesteps' does not support: "
                     + ", ".join(unsupported_timestep_products)
+                )
+
+        if resolved_mode == "steady_profiles":
+            unsupported_steady_products = sorted(
+                name
+                for name in ("arrival_time", "duration", "percent_inundated")
+                if map_flags.get(name)
+            )
+            if unsupported_steady_products:
+                raise ValueError(
+                    "mode='steady_profiles' does not support: "
+                    + ", ".join(unsupported_steady_products)
                 )
 
         if resolved_mode == "all_plans":
@@ -3752,6 +3818,82 @@ class RasMap:
                         "success": True,
                         "timesteps": timestep_summary,
                         "files": flat_files,
+                    }
+                elif resolved_mode == "steady_profiles":
+                    steady_map_types = [
+                        name
+                        for name in (
+                            "wse",
+                            "depth",
+                            "velocity",
+                            "froude",
+                            "shear_stress",
+                            "depth_x_velocity",
+                            "depth_x_velocity_sq",
+                            "flow",
+                        )
+                        if map_flags.get(name)
+                    ]
+                    if not steady_map_types:
+                        raise ValueError(
+                            "At least one steady profile raster product is required"
+                        )
+                    frame = RasProcess.store_maps_at_steady_profiles(
+                        plan_number=plan_num,
+                        profiles=profiles,
+                        output_path=plan_output_path,
+                        map_types=steady_map_types,
+                        render_mode=render_mode,
+                        clear_existing=clear_existing,
+                        fix_georef=fix_georef,
+                        ras_object=ras_obj,
+                        ras_version=ras_version,
+                        timeout=timeout,
+                        terrain_name=terrain_name,
+                        inundation_boundary=(
+                            True
+                            if inundation_boundary is None
+                            else bool(inundation_boundary)
+                        ),
+                    )
+                    records = frame.to_dict(orient="records")
+                    grouped_profiles = []
+                    for profile_index in frame["profile_index"].drop_duplicates():
+                        profile_rows = frame[
+                            frame["profile_index"] == profile_index
+                        ]
+                        grouped_profiles.append(
+                            {
+                                "profile_index": int(profile_index),
+                                "profile_name": str(
+                                    profile_rows.iloc[0]["profile_name"]
+                                ),
+                                "products": profile_rows.to_dict(orient="records"),
+                            }
+                        )
+                    flat_files = list(
+                        dict.fromkeys(
+                            path
+                            for record in records
+                            for path in record["files"]
+                        )
+                    )
+                    output_directories = sorted(
+                        {str(Path(path).parent) for path in flat_files}
+                    )
+                    summary["plans"][plan_num] = {
+                        "success": True,
+                        "output_dir": (
+                            output_directories[0]
+                            if len(output_directories) == 1
+                            else None
+                        ),
+                        "files": flat_files,
+                        "stored_maps": records,
+                        "profiles": grouped_profiles,
+                        "performance": json.loads(
+                            json.dumps(frame.attrs, default=str)
+                        ),
                     }
                 else:
                     generated = RasProcess.store_maps(**shared_arguments)

--- a/ras_commander/RasMap.py
+++ b/ras_commander/RasMap.py
@@ -3648,6 +3648,11 @@ class RasMap:
                 )
 
         supported_map_types = tuple(requested_flags)
+        if resolved_mode == "steady_profiles":
+            # Flow is a profile-dependent RASMapper product supported by the
+            # steady batch engine, but it has no legacy individual boolean
+            # flag on this facade. It is therefore selected through map_types.
+            supported_map_types += ("flow",)
         supported_map_type_set = set(supported_map_types)
         explicit_map_selection = map_types is not None or any(
             value is not None for value in requested_flags.values()

--- a/ras_commander/RasProcess.py
+++ b/ras_commander/RasProcess.py
@@ -4404,6 +4404,8 @@ Step 5: Configure (optional — auto-detection usually works)
                 are invalid or ambiguous.
             RuntimeError: If StoreAllMaps fails or a requested product is
                 missing from the fresh outputs.
+            subprocess.TimeoutExpired: If the aggregate StoreAllMaps helper
+                exceeds ``timeout``.
         """
         from .hdf.HdfResultsPlan import HdfResultsPlan
 
@@ -4744,6 +4746,7 @@ Step 5: Configure (optional — auto-detection usually works)
             frame.attrs["helper_elapsed_seconds"] = helper_elapsed
             frame.attrs["profile_count"] = len(selected_profiles)
             frame.attrs["configured_map_count"] = len(configured_specs)
+            frame.attrs["generated_file_count"] = len(produced_paths)
             frame.attrs["runtime_provenance"] = runtime_provenance
             logger.info(
                 "Steady-profile StoreAllMaps complete: plan=%s; profiles=%d; "

--- a/ras_commander/RasProcess.py
+++ b/ras_commander/RasProcess.py
@@ -2517,6 +2517,164 @@ Step 5: Configure (optional — auto-detection usually works)
         return None
 
     @staticmethod
+    def _stored_map_display_name(map_type: str) -> str:
+        """Return the canonical display name for one RASMapper map type."""
+        for xml_name, display_name, _ in RasProcess.MAP_TYPES.values():
+            if xml_name == map_type:
+                return display_name
+        return str(map_type).title()
+
+    @staticmethod
+    def _safe_stored_map_profile(profile_name: str) -> str:
+        """Normalize a profile label exactly once for a Windows-safe filename."""
+        return re.sub(r'[<>:"/\\|?*]', "_", str(profile_name)).rstrip(". ")
+
+    @staticmethod
+    def _stored_map_output_filename(
+        *,
+        output_folder: str,
+        display_name: str,
+        profile_name: str,
+        output_mode: str,
+    ) -> str:
+        safe_profile = RasProcess._safe_stored_map_profile(profile_name)
+        extension = ".shp" if "Polygon" in output_mode else ".vrt"
+        return f".\\{output_folder}\\{display_name} ({safe_profile}){extension}"
+
+    @staticmethod
+    def _add_stored_maps_to_rasmap(
+        rasmap_path: Path,
+        plan_hdf_filename: str,
+        output_folder: str,
+        map_specs: Sequence[Dict[str, Any]],
+        *,
+        clear_existing: bool,
+    ) -> List[Dict[str, Any]]:
+        """Configure a stored-map batch in one XML parse/write transaction."""
+        rasmap_path = Path(rasmap_path)
+        tree = ET.parse(_windows_extended_length_path(rasmap_path))
+        root = tree.getroot()
+
+        results_elem = root.find(".//Results")
+        if results_elem is None:
+            results_elem = ET.Element("Results")
+            results_elem.set("Checked", "True")
+            results_elem.set("Expanded", "True")
+            geom_elem = root.find(".//Geometries")
+            if geom_elem is not None and geom_elem in list(root):
+                root.insert(list(root).index(geom_elem) + 1, results_elem)
+            else:
+                root.append(results_elem)
+            logger.debug("Created Results element in rasmap")
+
+        plan_layer = None
+        plan_basename = Path(plan_hdf_filename).name.casefold()
+        for layer in results_elem.findall("Layer"):
+            filename = layer.get("Filename", "")
+            if PureWindowsPath(filename).name.casefold() == plan_basename:
+                plan_layer = layer
+                break
+        if plan_layer is None:
+            plan_layer = ET.SubElement(results_elem, "Layer")
+            plan_layer.set("Name", output_folder)
+            plan_layer.set("Filename", f".\\{plan_hdf_filename}")
+            logger.debug(
+                "Created plan layer '%s' in rasmap for %s",
+                output_folder,
+                plan_hdf_filename,
+            )
+        plan_layer.set("Type", "RASResults")
+        plan_layer.set("Checked", "True")
+        plan_layer.set("Expanded", "True")
+
+        existing_filenames = set()
+        for layer in list(plan_layer.findall("Layer")):
+            if layer.get("Type") != "RASResultsMap":
+                continue
+            parameters = layer.find("MapParameters")
+            if parameters is None or "Stored" not in parameters.get(
+                "OutputMode", ""
+            ):
+                continue
+            if clear_existing:
+                plan_layer.remove(layer)
+            else:
+                stored_filename = parameters.get("StoredFilename", "")
+                if stored_filename:
+                    existing_filenames.add(stored_filename.casefold())
+
+        configured = []
+        batch_filenames = set()
+        for raw_spec in map_specs:
+            spec = dict(raw_spec)
+            map_type = str(spec["map_type"])
+            profile_name = str(spec["profile_name"])
+            profile_index = int(spec["profile_index"])
+            output_mode = str(
+                spec.get("output_mode", "Stored Current Terrain")
+            )
+            display_name = str(
+                spec.get("display_name")
+                or RasProcess._stored_map_display_name(map_type)
+            )
+            output_filename = RasProcess._stored_map_output_filename(
+                output_folder=output_folder,
+                display_name=display_name,
+                profile_name=profile_name,
+                output_mode=output_mode,
+            )
+            filename_key = output_filename.casefold()
+            if filename_key in batch_filenames or filename_key in existing_filenames:
+                raise ValueError(
+                    "Stored-map output filename collision: " + output_filename
+                )
+            batch_filenames.add(filename_key)
+
+            layer_elem = ET.SubElement(plan_layer, "Layer")
+            layer_elem.set("Name", display_name)
+            layer_elem.set("Type", "RASResultsMap")
+            layer_elem.set("Checked", "True")
+            layer_elem.set("Filename", output_filename)
+
+            map_params = ET.SubElement(layer_elem, "MapParameters")
+            map_params.set("MapType", map_type)
+            map_params.set("OutputMode", output_mode)
+            map_params.set("StoredFilename", output_filename)
+            map_params.set("ProfileIndex", str(profile_index))
+            map_params.set("ProfileName", profile_name)
+            for attr_name, attr_value in spec.get("extra_attrs", {}).items():
+                map_params.set(str(attr_name), str(attr_value))
+
+            spec["display_name"] = display_name
+            spec["output_filename"] = output_filename
+            configured.append(spec)
+
+        temporary_path = rasmap_path.with_name(
+            f".{rasmap_path.name}.{os.getpid()}.{uuid.uuid4().hex}.tmp"
+        )
+        try:
+            tree.write(
+                _windows_extended_length_path(temporary_path),
+                encoding="utf-8",
+                xml_declaration=True,
+            )
+            os.replace(
+                _windows_extended_length_path(temporary_path),
+                _windows_extended_length_path(rasmap_path),
+            )
+        finally:
+            temporary_io = _windows_extended_length_path(temporary_path)
+            if os.path.exists(temporary_io):
+                os.remove(temporary_io)
+
+        logger.debug(
+            "Configured %d stored maps in one rasmap update for %s",
+            len(configured),
+            plan_hdf_filename,
+        )
+        return configured
+
+    @staticmethod
     @log_call
     def _add_stored_map_to_rasmap(
         rasmap_path: Path,
@@ -4082,6 +4240,528 @@ Step 5: Configure (optional — auto-detection usually works)
                     _windows_extended_length_path(rasmap_path),
                 )
                 os.remove(rasmap_backup_path)
+
+    @staticmethod
+    def _resolve_steady_profile_selectors(
+        profile_names: Sequence[str],
+        profiles: Optional[
+            Union[str, int, Sequence[Union[str, int]]]
+        ] = None,
+    ) -> List[Tuple[int, str]]:
+        """Resolve exact steady profile names/indexes without fallback."""
+        available = [str(name) for name in profile_names]
+        if not available:
+            raise ValueError("Steady result HDF contains no profiles")
+
+        if profiles is None:
+            requested: List[Union[str, int]] = list(range(len(available)))
+        elif isinstance(profiles, bool):
+            raise ValueError("Boolean values are not valid steady profile indexes")
+        elif isinstance(profiles, (str, int, np.integer)):
+            requested = [profiles]
+        else:
+            requested = list(profiles)
+        if not requested:
+            raise ValueError("At least one steady profile must be selected")
+
+        resolved: List[Tuple[int, str]] = []
+        seen_indexes = set()
+        for selector in requested:
+            if isinstance(selector, bool):
+                raise ValueError(
+                    "Boolean values are not valid steady profile indexes"
+                )
+            if isinstance(selector, (int, np.integer)):
+                selector = int(selector)
+                if selector < 0 or selector >= len(available):
+                    raise ValueError(
+                        f"Steady profile index {selector} is out of range for "
+                        f"{len(available)} profiles"
+                    )
+                index = selector
+            elif isinstance(selector, str):
+                matches = [
+                    index
+                    for index, name in enumerate(available)
+                    if name == selector
+                ]
+                if not matches:
+                    raise ValueError(
+                        f"Steady profile {selector!r} was not found. "
+                        f"Available profiles: {available}"
+                    )
+                if len(matches) > 1:
+                    raise ValueError(
+                        f"Steady profile name {selector!r} is ambiguous at "
+                        f"indexes {matches}; select by zero-based index"
+                    )
+                index = matches[0]
+            else:
+                raise TypeError(
+                    "Steady profile selectors must be exact names or "
+                    f"zero-based integer indexes, got {type(selector).__name__}"
+                )
+            if index in seen_indexes:
+                raise ValueError(
+                    f"Steady profile {available[index]!r} (index {index}) "
+                    "was selected more than once"
+                )
+            seen_indexes.add(index)
+            resolved.append((index, available[index]))
+        return resolved
+
+    @staticmethod
+    def _normalize_steady_map_types(
+        map_types: Union[str, Sequence[str]],
+    ) -> List[str]:
+        """Normalize and validate profile-dependent stored-map products."""
+        supported = {
+            "wse",
+            "depth",
+            "velocity",
+            "froude",
+            "shear_stress",
+            "depth_x_velocity",
+            "depth_x_velocity_sq",
+            "flow",
+        }
+        raw_values = [map_types] if isinstance(map_types, str) else list(map_types)
+        normalized = [
+            str(value).strip().casefold().replace(" ", "_")
+            for value in raw_values
+        ]
+        if not normalized or any(not value for value in normalized):
+            raise ValueError("At least one steady stored-map product is required")
+        unknown = sorted(set(normalized) - supported)
+        if unknown:
+            raise ValueError(
+                "Unsupported steady stored-map products: " + ", ".join(unknown)
+            )
+        if len(set(normalized)) != len(normalized):
+            raise ValueError("Steady stored-map products contain duplicates")
+        return normalized
+
+    @staticmethod
+    @_serialize_store_maps
+    @log_call
+    def store_maps_at_steady_profiles(
+        plan_number: str,
+        profiles: Optional[
+            Union[str, int, Sequence[Union[str, int]]]
+        ] = None,
+        output_path: Union[str, Path] = None,
+        map_types: Union[str, Sequence[str]] = ("depth",),
+        render_mode: str = None,
+        clear_existing: bool = True,
+        fix_georef: bool = True,
+        ras_object=None,
+        ras_version: str = None,
+        timeout: int = 1800,
+        *,
+        terrain_name: Optional[str] = None,
+        inundation_boundary: bool = True,
+    ) -> pd.DataFrame:
+        """Generate all selected steady-profile maps with one helper launch.
+
+        Profiles are resolved from the result HDF in exact HDF order. ``None``
+        selects every profile; exact names and zero-based indexes may be mixed
+        in a sequence. The request order is preserved and no selector falls
+        back to ``Max``.
+
+        Every profile/product layer is configured in one ``.rasmap`` XML
+        transaction, then aggregate ``StoreAllMaps`` is invoked exactly once.
+        By default, one inundation boundary is also generated for the final
+        selected profile. This means the highest profile for ras2fim's
+        ascending ladders, but no hydraulic ordering is inferred here.
+
+        Args:
+            plan_number: Steady plan number.
+            profiles: ``None``, an exact profile name, zero-based index, or a
+                sequence mixing names and indexes.
+            output_path: Optional destination for all newly generated files.
+            map_types: Profile-dependent product key(s). Defaults to Depth.
+            render_mode: Optional water-surface render-mode override.
+            clear_existing: Remove existing stored-map layers for this plan in
+                the temporary configuration.
+            fix_georef: Apply the existing terrain georeferencing repair to
+                generated TIFF tiles.
+            ras_object: Optional initialized project object.
+            ras_version: Optional installed HEC-RAS mapping-runtime version.
+            timeout: Aggregate helper timeout in seconds.
+            terrain_name: Optional registered RASMapper terrain to select.
+            inundation_boundary: Generate one polygon for the final selected
+                profile. Defaults to True.
+
+        Returns:
+            DataFrame with one row per logical profile/product and stable
+            columns registered as ``steady_profile_stored_maps`` in
+            :mod:`ras_commander.schemas`.
+
+        Raises:
+            FileNotFoundError: If required project, HDF, mapper, runtime, or
+                terrain files are missing.
+            ValueError: If the plan, selectors, products, or output filenames
+                are invalid or ambiguous.
+            RuntimeError: If StoreAllMaps fails or a requested product is
+                missing from the fresh outputs.
+        """
+        from .hdf.HdfResultsPlan import HdfResultsPlan
+
+        started = time.perf_counter()
+        ras_obj = ras_object or ras
+        ras_obj.check_initialized()
+        plan_num = RasUtils.normalize_ras_number(plan_number)
+
+        hecras_dir = Path(str(ras_obj.ras_exe_path)).parent
+        if not hecras_dir.is_dir():
+            raise FileNotFoundError(f"HEC-RAS directory not found: {hecras_dir}")
+        rasmap_path = RasMap.get_rasmap_path(ras_obj)
+        if rasmap_path is None or not Path(rasmap_path).is_file():
+            raise FileNotFoundError("No .rasmap file found in project folder")
+        rasmap_path = Path(rasmap_path)
+
+        plan_hdf_name = f"{ras_obj.project_name}.p{plan_num}.hdf"
+        plan_hdf_path = ras_obj.project_folder / plan_hdf_name
+        if not plan_hdf_path.is_file():
+            raise FileNotFoundError(f"Plan HDF not found: {plan_hdf_path}")
+        if not HdfResultsPlan.is_steady_plan(plan_hdf_path):
+            raise ValueError(
+                f"Plan {plan_num} does not contain steady results: {plan_hdf_path}"
+            )
+
+        available_profiles = HdfResultsPlan.get_steady_profile_names(plan_hdf_path)
+        selected_profiles = RasProcess._resolve_steady_profile_selectors(
+            available_profiles,
+            profiles,
+        )
+        selected_map_types = RasProcess._normalize_steady_map_types(map_types)
+
+        plan_short_id = RasProcess._get_plan_short_id(plan_hdf_path)
+        if not plan_short_id:
+            plan_rows = ras_obj.plan_df[
+                ras_obj.plan_df["plan_number"].astype(str).eq(plan_num)
+            ]
+            plan_short_id = (
+                str(plan_rows.iloc[0].get("Short Identifier", "")).strip()
+                if not plan_rows.empty
+                else ""
+            )
+        output_folder = plan_short_id or f"Plan_{plan_num}"
+        output_dir = ras_obj.project_folder / output_folder
+
+        extra_attrs = {"Terrain": terrain_name} if terrain_name is not None else {}
+        map_specs: List[Dict[str, Any]] = []
+        for profile_index, profile_name in selected_profiles:
+            for map_key in selected_map_types:
+                xml_name, display_name, _ = RasProcess.MAP_TYPES[map_key]
+                map_specs.append(
+                    {
+                        "map_key": map_key,
+                        "map_type": xml_name,
+                        "display_name": display_name,
+                        "profile_index": profile_index,
+                        "profile_name": profile_name,
+                        "output_mode": "Stored Current Terrain",
+                        "extra_attrs": dict(extra_attrs),
+                    }
+                )
+        if inundation_boundary:
+            boundary_index, boundary_name = selected_profiles[-1]
+            boundary_attrs = {**extra_attrs, "ArrivalDepth": "0"}
+            map_specs.append(
+                {
+                    "map_key": "inundation_boundary",
+                    "map_type": "depth",
+                    "display_name": "Inundation Boundary",
+                    "profile_index": boundary_index,
+                    "profile_name": boundary_name,
+                    "output_mode": "Stored Polygon Specified Depth",
+                    "extra_attrs": boundary_attrs,
+                }
+            )
+
+        # Fail before mutating the rasmap when two selected labels normalize to
+        # the same StoredFilename.
+        requested_filenames = []
+        for spec in map_specs:
+            requested_filenames.append(
+                RasProcess._stored_map_output_filename(
+                    output_folder=output_folder,
+                    display_name=spec["display_name"],
+                    profile_name=spec["profile_name"],
+                    output_mode=spec["output_mode"],
+                )
+            )
+        collision_keys = [name.casefold() for name in requested_filenames]
+        if len(set(collision_keys)) != len(collision_keys):
+            duplicates = sorted(
+                {
+                    name
+                    for name in requested_filenames
+                    if collision_keys.count(name.casefold()) > 1
+                }
+            )
+            raise ValueError(
+                "Steady stored-map output filename collision: "
+                + ", ".join(duplicates)
+            )
+
+        resolved_output_path = None
+        if output_path is not None:
+            resolved_output_path = Path(output_path)
+            if not resolved_output_path.is_absolute():
+                resolved_output_path = RasUtils.safe_resolve(
+                    ras_obj.project_folder / resolved_output_path
+                )
+
+        rasmap_backup = rasmap_path.with_name(
+            f"{rasmap_path.name}.{os.getpid()}.{uuid.uuid4().hex}.bak"
+        )
+        shutil.copy2(
+            _windows_extended_length_path(rasmap_path),
+            _windows_extended_length_path(rasmap_backup),
+        )
+
+        helper_elapsed = 0.0
+        configuration_elapsed = 0.0
+        try:
+            configuration_started = time.perf_counter()
+            configured_specs = RasProcess._add_stored_maps_to_rasmap(
+                rasmap_path,
+                plan_hdf_name,
+                output_folder,
+                map_specs,
+                clear_existing=clear_existing,
+            )
+            configuration_elapsed = time.perf_counter() - configuration_started
+
+            if terrain_name is not None:
+                RasProcess._select_terrain_for_mapping(
+                    rasmap_path,
+                    terrain_name,
+                    ras_object=ras_obj,
+                )
+            if render_mode is not None:
+                RasMap.set_water_surface_render_mode(
+                    mode=render_mode,
+                    ras_object=ras_obj,
+                )
+
+            os.makedirs(_windows_extended_length_path(output_dir), exist_ok=True)
+            if resolved_output_path is not None:
+                os.makedirs(
+                    _windows_extended_length_path(resolved_output_path),
+                    exist_ok=True,
+                )
+
+            before = {}
+            for item in _iterdir_paths(output_dir):
+                if not os.path.isfile(_windows_extended_length_path(item)):
+                    continue
+                stat = os.stat(_windows_extended_length_path(item))
+                before[item.name] = (stat.st_mtime_ns, stat.st_size)
+
+            current_mode = render_mode or RasMap.get_water_surface_render_mode(
+                ras_object=ras_obj
+            )
+            helper_mode = normalize_store_map_render_mode(current_mode)
+            effective_ras_version = ras_version or getattr(
+                ras_obj,
+                "ras_version",
+                None,
+            )
+            runtime_provenance = store_maps_runtime_provenance(hecras_dir)
+
+            with RasProcess._mapper_compatible_result_hdf(
+                plan_hdf_path,
+                effective_ras_version,
+            ) as mapper_hdf_path:
+                helper_started = time.perf_counter()
+                result = run_store_all_maps_helper(
+                    hecras_dir=hecras_dir,
+                    render_mode=helper_mode,
+                    rasmap_path=rasmap_path,
+                    result_hdf_path=mapper_hdf_path,
+                    timeout=timeout,
+                    working_dir=ras_obj.project_folder,
+                )
+                helper_elapsed = time.perf_counter() - helper_started
+
+            logger.debug("Steady StoreAllMaps stdout: %s", result.stdout)
+            if result.stderr:
+                logger.debug("Steady StoreAllMaps stderr: %s", result.stderr)
+            if result.returncode != 0:
+                detail = next(
+                    (line.strip() for line in result.stderr.splitlines() if line.strip()),
+                    "",
+                )
+                raise RuntimeError(
+                    f"StoreAllMaps failed for steady plan {plan_num} "
+                    f"(exit code {result.returncode})"
+                    + (f": {detail[:500]}" if detail else "")
+                )
+
+            produced_paths = []
+            for item in _iterdir_paths(output_dir):
+                if not os.path.isfile(_windows_extended_length_path(item)):
+                    continue
+                stat = os.stat(_windows_extended_length_path(item))
+                signature = (stat.st_mtime_ns, stat.st_size)
+                if before.get(item.name) != signature:
+                    produced_paths.append(item)
+
+            if resolved_output_path is not None and os.path.normcase(
+                os.path.abspath(resolved_output_path)
+            ) != os.path.normcase(os.path.abspath(output_dir)):
+                moved_paths = []
+                for item in produced_paths:
+                    if item.name == "PostProcessing.hdf":
+                        continue
+                    destination = resolved_output_path / item.name
+                    destination_io = _windows_extended_length_path(destination)
+                    if os.path.exists(destination_io):
+                        os.remove(destination_io)
+                    shutil.move(
+                        _windows_extended_length_path(item),
+                        destination_io,
+                    )
+                    moved_paths.append(destination)
+                produced_paths = moved_paths
+
+            if fix_georef:
+                tif_paths = [
+                    path
+                    for path in produced_paths
+                    if path.suffix.casefold() in {".tif", ".tiff"}
+                ]
+                if tif_paths:
+                    projection = RasProcess._get_projection_info(rasmap_path)
+                    terrain_paths = projection.terrain_paths
+                    if not terrain_paths and projection.terrain_path is not None:
+                        terrain_paths = (projection.terrain_path,)
+                    for tif_path in tif_paths:
+                        terrain_path = RasProcess._terrain_for_stored_map(
+                            tif_path,
+                            terrain_paths,
+                        )
+                        if terrain_path is None:
+                            logger.warning(
+                                "Could not match steady stored-map TIFF to a "
+                                "terrain; georeferencing was not changed: %s",
+                                tif_path,
+                            )
+                            continue
+                        RasProcess._fix_georeferencing(
+                            tif_path,
+                            projection.prj_path,
+                            terrain_path,
+                        )
+                    readable = {"batch": list(tif_paths)}
+                    RasProcess._drop_unreadable_tifs(readable)
+                    readable_keys = {
+                        os.path.normcase(os.path.abspath(path))
+                        for path in readable["batch"]
+                    }
+                    produced_paths = [
+                        path
+                        for path in produced_paths
+                        if path.suffix.casefold() not in {".tif", ".tiff"}
+                        or os.path.normcase(os.path.abspath(path)) in readable_keys
+                    ]
+
+            produced_paths = sorted(
+                produced_paths,
+                key=lambda path: path.name.casefold(),
+            )
+            rows = []
+            for spec in configured_specs:
+                safe_profile = RasProcess._safe_stored_map_profile(
+                    spec["profile_name"]
+                )
+                filename_base = (
+                    f"{spec['display_name']} ({safe_profile})"
+                ).casefold()
+                associated = [
+                    path
+                    for path in produced_paths
+                    if path.name.casefold().startswith(filename_base)
+                ]
+                is_polygon = "Polygon" in spec["output_mode"]
+                primary_suffix = ".shp" if is_polygon else ".vrt"
+                primary = next(
+                    (
+                        path
+                        for path in associated
+                        if path.suffix.casefold() == primary_suffix
+                    ),
+                    None,
+                )
+                raster_tiles = [
+                    path
+                    for path in associated
+                    if path.suffix.casefold() in {".tif", ".tiff"}
+                ]
+                if primary is None or (not is_polygon and not raster_tiles):
+                    expected = "SHP" if is_polygon else "VRT and TIFF tile(s)"
+                    raise RuntimeError(
+                        f"StoreAllMaps did not produce requested {expected} for "
+                        f"{spec['map_key']} profile {spec['profile_name']!r}"
+                    )
+                rows.append(
+                    {
+                        "plan_number": plan_num,
+                        "result_hdf_path": str(plan_hdf_path.resolve()),
+                        "profile_index": int(spec["profile_index"]),
+                        "profile_name": str(spec["profile_name"]),
+                        "map_type": str(spec["map_key"]),
+                        "output_mode": "polygon" if is_polygon else "raster",
+                        "primary_path": str(primary.resolve()),
+                        "files": [str(path.resolve()) for path in associated],
+                        "file_count": len(associated),
+                    }
+                )
+
+            frame = pd.DataFrame(
+                rows,
+                columns=[
+                    "plan_number",
+                    "result_hdf_path",
+                    "profile_index",
+                    "profile_name",
+                    "map_type",
+                    "output_mode",
+                    "primary_path",
+                    "files",
+                    "file_count",
+                ],
+            )
+            frame.attrs["schema"] = (
+                "ras_commander.steady_profile_stored_maps.v1"
+            )
+            frame.attrs["helper_launch_count"] = 1
+            frame.attrs["elapsed_seconds"] = time.perf_counter() - started
+            frame.attrs["configuration_elapsed_seconds"] = configuration_elapsed
+            frame.attrs["helper_elapsed_seconds"] = helper_elapsed
+            frame.attrs["profile_count"] = len(selected_profiles)
+            frame.attrs["configured_map_count"] = len(configured_specs)
+            frame.attrs["runtime_provenance"] = runtime_provenance
+            logger.info(
+                "Steady-profile StoreAllMaps complete: plan=%s; profiles=%d; "
+                "configured_maps=%d; helper_launches=1; files=%d",
+                plan_num,
+                len(selected_profiles),
+                len(configured_specs),
+                len(produced_paths),
+            )
+            return frame
+        finally:
+            backup_io = _windows_extended_length_path(rasmap_backup)
+            if os.path.exists(backup_io):
+                shutil.copy2(
+                    backup_io,
+                    _windows_extended_length_path(rasmap_path),
+                )
+                os.remove(backup_io)
 
     @staticmethod
     @log_call

--- a/ras_commander/RasProject.py
+++ b/ras_commander/RasProject.py
@@ -710,7 +710,11 @@ def _to_arrow_frame(rows: list[dict[str, Any]]) -> pd.DataFrame:
         elif column not in timestamp_columns:
             frame[column] = pd.array(frame[column], dtype="string[pyarrow]")
     for column in ("expected_start", "expected_end", "available_start", "available_end"):
-        frame[column] = pd.to_datetime(frame[column], errors="coerce", utc=True)
+        timestamps = pd.to_datetime(frame[column], errors="coerce", utc=True)
+        frame[column] = pd.array(
+            timestamps,
+            dtype="timestamp[ns, tz=UTC][pyarrow]",
+        )
     return frame.convert_dtypes(dtype_backend="pyarrow")
 
 

--- a/ras_commander/hdf/HdfBase.py
+++ b/ras_commander/hdf/HdfBase.py
@@ -393,6 +393,214 @@ class HdfBase:
         return None
 
     @staticmethod
+    def _decode_unit_attribute(value: Any) -> str:
+        """Return one stable text representation for an HDF attribute."""
+        if isinstance(value, bytes):
+            return value.decode("utf-8", errors="replace").strip()
+        if isinstance(value, np.ndarray):
+            if value.size == 1:
+                return HdfBase._decode_unit_attribute(value.reshape(-1)[0])
+            return str(value.tolist())
+        if isinstance(value, np.generic):
+            value = value.item()
+        return str(value).strip()
+
+    @staticmethod
+    def _parse_si_units_attribute(value: Any) -> Optional[bool]:
+        """Parse the HEC-RAS ``Geometry/@SI Units`` attribute."""
+        if isinstance(value, np.ndarray) and value.size == 1:
+            value = value.reshape(-1)[0]
+        if isinstance(value, np.generic):
+            value = value.item()
+        if isinstance(value, bool):
+            return value
+        if isinstance(value, (int, float)) and value in {0, 1}:
+            return bool(value)
+        text = HdfBase._decode_unit_attribute(value).casefold()
+        if text in {"1", "true", "yes", "on"}:
+            return True
+        if text in {"0", "false", "no", "off"}:
+            return False
+        return None
+
+    @staticmethod
+    def _parse_unit_system_attribute(value: Any) -> Optional[bool]:
+        """Return True for SI and False for US Customary root metadata."""
+        text = HdfBase._decode_unit_attribute(value).casefold()
+        if text.startswith("si") or text == "metric":
+            return True
+        if text.startswith("us") or text in {"english", "imperial"}:
+            return False
+        return None
+
+    @staticmethod
+    def _result_unit_metadata_from_file(
+        hdf_file: h5py.File,
+        *,
+        source_file: Union[str, Path],
+        strict: bool,
+    ) -> Dict[str, Any]:
+        """Build normalized result-HDF unit metadata from an open file."""
+        source_path = Path(source_file)
+        try:
+            source_text = str(source_path.resolve())
+        except OSError:
+            source_text = str(source_path.absolute())
+
+        evidence: List[Dict[str, Optional[str]]] = []
+        recognized: List[Tuple[str, bool]] = []
+        problems: List[str] = []
+
+        if "Results" not in hdf_file:
+            problems.append("HDF file does not contain a /Results group")
+
+        geometry = hdf_file.get("Geometry")
+        if geometry is not None and "SI Units" in geometry.attrs:
+            raw_value = geometry.attrs["SI Units"]
+            si_units = HdfBase._parse_si_units_attribute(raw_value)
+            evidence.append(
+                {
+                    "attribute": "/Geometry/@SI Units",
+                    "raw_value": HdfBase._decode_unit_attribute(raw_value),
+                    "unit_system": (
+                        "SI"
+                        if si_units is True
+                        else "US Customary"
+                        if si_units is False
+                        else None
+                    ),
+                }
+            )
+            if si_units is None:
+                problems.append(
+                    "Unrecognized /Geometry/@SI Units value "
+                    f"{HdfBase._decode_unit_attribute(raw_value)!r}"
+                )
+            else:
+                recognized.append(("/Geometry/@SI Units", si_units))
+
+        if "Units System" in hdf_file.attrs:
+            raw_value = hdf_file.attrs["Units System"]
+            si_units = HdfBase._parse_unit_system_attribute(raw_value)
+            evidence.append(
+                {
+                    "attribute": "/@Units System",
+                    "raw_value": HdfBase._decode_unit_attribute(raw_value),
+                    "unit_system": (
+                        "SI"
+                        if si_units is True
+                        else "US Customary"
+                        if si_units is False
+                        else None
+                    ),
+                }
+            )
+            if si_units is None:
+                problems.append(
+                    "Unrecognized /@Units System value "
+                    f"{HdfBase._decode_unit_attribute(raw_value)!r}"
+                )
+            else:
+                recognized.append(("/@Units System", si_units))
+
+        states = {state for _, state in recognized}
+        if len(states) > 1:
+            detail = ", ".join(
+                f"{attribute}={'SI' if state else 'US Customary'}"
+                for attribute, state in recognized
+            )
+            problems.append(
+                "Result HDF unit-system metadata is contradictory: " + detail
+            )
+        if not evidence:
+            problems.append(
+                "Result HDF contains no recognized embedded unit-system metadata"
+            )
+
+        resolved = not problems and len(states) == 1
+        si_units = states.pop() if resolved else None
+        if resolved:
+            unit_system = "SI" if si_units else "US Customary"
+            length_units = "m" if si_units else "ft"
+            result = {
+                "status": "resolved",
+                "unit_system": unit_system,
+                "length_units": length_units,
+                "depth_units": length_units,
+                "velocity_units": "m/s" if si_units else "ft/s",
+                "flow_units": "m3/s" if si_units else "ft3/s",
+                "source": "plan_hdf",
+                "source_file": source_text,
+                "evidence": evidence,
+                "contradictions": [],
+            }
+            return result
+
+        if len(states) > 1:
+            status = "contradictory"
+        elif evidence and any(item["unit_system"] is None for item in evidence):
+            status = "unrecognized"
+        elif "Results" not in hdf_file:
+            status = "unrecognized"
+        else:
+            status = "missing"
+        result = {
+            "status": status,
+            "unit_system": None,
+            "length_units": None,
+            "depth_units": None,
+            "velocity_units": None,
+            "flow_units": None,
+            "source": "plan_hdf",
+            "source_file": source_text,
+            "evidence": evidence,
+            "contradictions": problems,
+        }
+        if strict:
+            raise ValueError(
+                f"Could not resolve result-HDF units for {source_path.name}: "
+                + "; ".join(problems)
+            )
+        return result
+
+    @staticmethod
+    @log_call
+    @standardize_input(file_type="plan_hdf")
+    def get_result_unit_metadata(
+        hdf_path: Path,
+        *,
+        strict: bool = True,
+    ) -> Dict[str, Any]:
+        """Read normalized units from a standalone HEC-RAS result HDF.
+
+        This is a fallback for workflows that have only a plan-result HDF. If
+        the full HEC-RAS project is available, use
+        :meth:`RasPrj.get_project_units` instead; the text project marker is
+        authoritative and embedded HDF attributes must not override it.
+
+        The reader checks both ``/Geometry/@SI Units`` and
+        ``/@Units System``. With ``strict=True`` (default), missing,
+        unrecognized, non-result, or contradictory metadata raises
+        :class:`ValueError`. With ``strict=False``, the same condition returns
+        a JSON-serializable unresolved record with evidence and contradictions.
+
+        Args:
+            hdf_path: Standalone HEC-RAS plan-result HDF path or plan selector.
+            strict: Raise when the embedded metadata cannot be resolved.
+
+        Returns:
+            Dict containing status, normalized unit labels, provenance,
+            source evidence, and contradictions.
+        """
+        source = Path(hdf_path)
+        with h5py.File(source, "r") as hdf_file:
+            return HdfBase._result_unit_metadata_from_file(
+                hdf_file,
+                source_file=source,
+                strict=strict,
+            )
+
+    @staticmethod
     @standardize_input(file_type='plan_hdf')
     def get_attrs(hdf_file: h5py.File, attr_path: str) -> Dict[str, Any]:
         """

--- a/ras_commander/hdf/HdfResultsProducts.py
+++ b/ras_commander/hdf/HdfResultsProducts.py
@@ -1150,56 +1150,19 @@ class HdfResultsProducts:
 
     @staticmethod
     def _unit_metadata(hdf_file: h5py.File) -> dict[str, str]:
-        candidates: list[tuple[str, bool]] = []
-        geometry = hdf_file.get("Geometry")
-        if geometry is not None and "SI Units" in geometry.attrs:
-            candidates.append(
-                (
-                    "Geometry/SI Units",
-                    HdfResultsProducts._required_bool(
-                        geometry.attrs["SI Units"],
-                        label="Geometry/SI Units",
-                    ),
-                )
-            )
-
-        if "Units System" in hdf_file.attrs:
-            units_text = HdfResultsProducts._decode(
-                hdf_file.attrs["Units System"]
-            ).strip().casefold()
-            if units_text.startswith("si") or units_text in {"metric"}:
-                candidates.append(("Units System", True))
-            elif units_text.startswith("us") or units_text in {
-                "english",
-                "imperial",
-            }:
-                candidates.append(("Units System", False))
-            else:
-                raise ValueError(
-                    "Result HDF has an unrecognized Units System attribute: "
-                    f"{units_text!r}"
-                )
-
-        if not candidates:
-            raise ValueError(
-                "Result HDF contains no recognized embedded unit-system metadata"
-            )
-        states = {state for _, state in candidates}
-        if len(states) != 1:
-            evidence = ", ".join(
-                f"{label}={'SI' if state else 'US Customary'}"
-                for label, state in candidates
-            )
-            raise ValueError(
-                f"Result HDF unit-system metadata is contradictory: {evidence}"
-            )
-        si_units = states.pop()
-        length = "m" if si_units else "ft"
+        metadata = HdfBase._result_unit_metadata_from_file(
+            hdf_file,
+            source_file=Path(hdf_file.filename),
+            strict=True,
+        )
         return {
-            "unit_system": "SI" if si_units else "US Customary",
-            "length_units": length,
-            "depth_units": length,
-            "velocity_units": "m/s" if si_units else "ft/s",
+            key: metadata[key]
+            for key in (
+                "unit_system",
+                "length_units",
+                "depth_units",
+                "velocity_units",
+            )
         }
 
     @staticmethod

--- a/ras_commander/hdf/HdfResultsProducts.py
+++ b/ras_commander/hdf/HdfResultsProducts.py
@@ -176,7 +176,10 @@ class HdfResultsProducts:
                 timestamp_count=len(timestamp_index),
             )
 
-        intervals = np.diff(timestamp_index.asi8).astype(float) / 1e9
+        timestamp_ns = timestamp_index.to_numpy(
+            dtype="datetime64[ns]"
+        ).astype("int64")
+        intervals = np.diff(timestamp_ns).astype(float) / 1e9
         regular = bool(
             intervals.size > 0
             and np.allclose(intervals, intervals[0], rtol=0.0, atol=1e-6)
@@ -1109,9 +1112,17 @@ class HdfResultsProducts:
         primary = axes[paths[0]]
         for path in paths[1:]:
             candidate = axes[path]
+            candidate_seconds = (
+                candidate.to_numpy(dtype="datetime64[ns]").astype("int64")
+                // 1_000_000_000
+            )
+            primary_seconds = (
+                primary.to_numpy(dtype="datetime64[ns]").astype("int64")
+                // 1_000_000_000
+            )
             if len(candidate) != len(primary) or not np.array_equal(
-                candidate.asi8 // 1_000_000_000,
-                primary.asi8 // 1_000_000_000,
+                candidate_seconds,
+                primary_seconds,
             ):
                 raise ValueError(
                     "Result HDF timestamp datasets disagree: "

--- a/ras_commander/hdf/HdfResultsQuery.py
+++ b/ras_commander/hdf/HdfResultsQuery.py
@@ -18,6 +18,7 @@ import numpy as np
 import pandas as pd
 from scipy.spatial import KDTree
 
+from .HdfBase import HdfBase
 from .HdfMesh import HdfMesh
 from .HdfPlan import HdfPlan
 from .HdfResultsMesh import HdfResultsMesh
@@ -1170,30 +1171,17 @@ def _decode_hdf_attr(value: Any) -> Any:
     return value
 
 
-def _read_unit_metadata(geom_hdf_path: Path) -> Dict[str, str]:
-    """Read project unit metadata from a geometry HDF."""
-    raw_si_units = None
-    raw_unit_system = None
-    with h5py.File(geom_hdf_path, "r") as hdf_file:
-        geometry_group = hdf_file.get("Geometry")
-        if geometry_group is not None:
-            raw_si_units = _decode_hdf_attr(geometry_group.attrs.get("SI Units"))
-        raw_unit_system = _decode_hdf_attr(hdf_file.attrs.get("Units System"))
-
-    unit_text = str(raw_unit_system or "").strip().lower()
-    si_units = str(raw_si_units).strip().lower() in {
-        "true",
-        "1",
-        "yes",
-        "si",
-    } or unit_text.startswith("si")
-
-    length_units = "m" if si_units else "ft"
+def _read_unit_metadata(plan_hdf_path: Path) -> Dict[str, str]:
+    """Read strict unit metadata from a standalone plan-result HDF."""
+    metadata = HdfBase.get_result_unit_metadata(plan_hdf_path)
     return {
-        "unit_system": "SI" if si_units else "US Customary",
-        "length_units": length_units,
-        "velocity_units": "m/s" if si_units else "ft/s",
-        "depth_units": length_units,
+        key: str(metadata[key])
+        for key in (
+            "unit_system",
+            "length_units",
+            "velocity_units",
+            "depth_units",
+        )
     }
 
 
@@ -1322,7 +1310,7 @@ def _profile_dataframe(
 ) -> pd.DataFrame:
     """Build a profile DataFrame with standard RAS metadata attrs."""
     result_df = pd.DataFrame({column: profile_data[column] for column in columns})
-    result_df.attrs.update(_read_unit_metadata(geom_hdf_path))
+    result_df.attrs.update(_read_unit_metadata(hdf_path))
     result_df.attrs["sample_spacing"] = float(sample_spacing)
     result_df.attrs[source_key] = [source_value]
     result_df.attrs["ras_version"] = _read_ras_version(hdf_path)

--- a/ras_commander/hdf/HdfResultsSediment.py
+++ b/ras_commander/hdf/HdfResultsSediment.py
@@ -56,22 +56,13 @@ class HdfResultsSediment:
 
     @staticmethod
     def _length_unit(f: h5py.File) -> str:
-        """Return 'm' (SI) or 'ft' (US Customary) for the model, from HDF attrs.
-
-        Mirrors the unit detection in HdfResultsQuery: SI when the geometry
-        'SI Units' attr is truthy OR the root 'Units System' starts with 'si'.
-        """
-        def _dec(v):
-            return v.decode("utf-8", "ignore") if isinstance(v, (bytes, np.bytes_)) else v
-        raw_unit_system = _dec(f.attrs.get("Units System"))
-        raw_si = None
-        g = f.get("Geometry")
-        if g is not None:
-            raw_si = _dec(g.attrs.get("SI Units"))
-        unit_text = str(raw_unit_system or "").strip().lower()
-        si = (str(raw_si).strip().lower() in {"true", "1", "yes", "si"}
-              or unit_text.startswith("si"))
-        return "m" if si else "ft"
+        """Return the strictly resolved result-HDF model length unit."""
+        metadata = HdfBase._result_unit_metadata_from_file(
+            f,
+            source_file=Path(f.filename),
+            strict=True,
+        )
+        return str(metadata["length_units"])
 
     # ------------------------------------------------------------------ #
     # Discovery

--- a/ras_commander/schemas.py
+++ b/ras_commander/schemas.py
@@ -29,7 +29,7 @@ Each entry of :data:`DATAFRAME_SCHEMAS`:
 """
 
 # Schema contract version -- bump when the documented column surface changes meaningfully.
-SCHEMA_VERSION = "1.7"
+SCHEMA_VERSION = "1.8"
 
 DATAFRAME_SCHEMAS = {
     "cross_section_points": {
@@ -67,7 +67,7 @@ DATAFRAME_SCHEMAS = {
             {"name": "left_bank_station", "dtype": "float", "description": "Stored left-bank station for the cross section."},
             {"name": "right_bank_station", "dtype": "float", "description": "Stored right-bank station for the cross section."},
             {"name": "horizontal_crs", "dtype": "str | None", "description": "Horizontal or compound CRS definition/code associated with XYZ."},
-            {"name": "horizontal_units", "dtype": "str | None", "description": "Horizontal CRS axis units, falling back to declared model units when CRS is unavailable."},
+            {"name": "horizontal_units", "dtype": "str | None", "description": "Horizontal CRS axis units or project text units for text extraction when CRS is unavailable."},
             {"name": "vertical_units", "dtype": "str | None", "description": "Native or target vertical units."},
             {"name": "vertical_units_source", "dtype": "str", "description": "Unit provenance: explicit, project_text, geometry_hdf_explicit, or unknown."},
             {"name": "vertical_datum", "dtype": "str | None", "description": "Explicit native or target vertical datum; never inferred from horizontal location."},
@@ -75,6 +75,27 @@ DATAFRAME_SCHEMAS = {
             {"name": "extraction_method", "dtype": "str", "description": "text_geometry or geometry_hdf."},
             {"name": "vertical_transform_applied", "dtype": "bool", "description": "Whether an explicit per-point XYZ transform changed coordinates."},
             {"name": "vertical_transform_provenance", "dtype": "str", "description": "Deterministic JSON operation provenance, including explicit no-transform state."},
+        ],
+    },
+    "steady_profile_stored_maps": {
+        "description": (
+            "One row per logical steady-profile stored-map product generated "
+            "by one aggregate StoreAllMaps launch."
+        ),
+        "accessor": "RasProcess.store_maps_at_steady_profiles(plan_number, ...)",
+        "source": "RasProcess.store_maps_at_steady_profiles()",
+        "extra_columns": False,
+        "dynamic": False,
+        "columns": [
+            {"name": "plan_number", "dtype": "str", "description": "Normalized two-digit plan number."},
+            {"name": "result_hdf_path", "dtype": "str", "description": "Absolute source plan-result HDF path."},
+            {"name": "profile_index", "dtype": "int64", "description": "Zero-based profile index in the steady result HDF."},
+            {"name": "profile_name", "dtype": "str", "description": "Exact steady profile name stored in the result HDF."},
+            {"name": "map_type", "dtype": "str", "description": "Canonical ras-commander product key."},
+            {"name": "output_mode", "dtype": "str", "description": "Logical raster or polygon output mode."},
+            {"name": "primary_path", "dtype": "str", "description": "VRT for rasters or SHP for polygons."},
+            {"name": "files", "dtype": "list[str]", "description": "All physical product files, including tiles or sidecars."},
+            {"name": "file_count", "dtype": "int64", "description": "Number of physical files in files."},
         ],
     },
     "project_asset_inventory": {

--- a/tests/test_hdf_result_unit_metadata.py
+++ b/tests/test_hdf_result_unit_metadata.py
@@ -1,0 +1,132 @@
+from pathlib import Path
+
+import h5py
+import numpy as np
+import pytest
+
+from ras_commander import HdfBase
+
+
+def _write_result_hdf(
+    path: Path,
+    *,
+    si_units=None,
+    unit_system=None,
+    include_results: bool = True,
+) -> Path:
+    with h5py.File(path, "w") as hdf_file:
+        if include_results:
+            hdf_file.require_group("Results/Steady")
+        geometry = hdf_file.require_group("Geometry")
+        if si_units is not None:
+            geometry.attrs["SI Units"] = si_units
+        if unit_system is not None:
+            hdf_file.attrs["Units System"] = unit_system
+    return path
+
+
+@pytest.mark.parametrize(
+    ("si_units", "unit_system", "expected"),
+    [
+        (False, np.bytes_("US Customary"), ("US Customary", "ft", "ft3/s")),
+        (1, np.bytes_("SI Units"), ("SI", "m", "m3/s")),
+    ],
+)
+def test_result_unit_metadata_resolves_agreeing_evidence(
+    tmp_path,
+    si_units,
+    unit_system,
+    expected,
+):
+    hdf_path = _write_result_hdf(
+        tmp_path / "Model.p01.hdf",
+        si_units=si_units,
+        unit_system=unit_system,
+    )
+
+    metadata = HdfBase.get_result_unit_metadata(hdf_path)
+
+    expected_system, expected_length, expected_flow = expected
+    assert metadata["status"] == "resolved"
+    assert metadata["unit_system"] == expected_system
+    assert metadata["length_units"] == expected_length
+    assert metadata["depth_units"] == expected_length
+    assert metadata["velocity_units"] == f"{expected_length}/s"
+    assert metadata["flow_units"] == expected_flow
+    assert metadata["source"] == "plan_hdf"
+    assert metadata["source_file"] == str(hdf_path.resolve())
+    assert metadata["contradictions"] == []
+    assert [item["attribute"] for item in metadata["evidence"]] == [
+        "/Geometry/@SI Units",
+        "/@Units System",
+    ]
+
+
+def test_result_unit_metadata_reports_missing_without_english_default(tmp_path):
+    hdf_path = _write_result_hdf(tmp_path / "missing.p01.hdf")
+
+    with pytest.raises(ValueError, match="no recognized embedded"):
+        HdfBase.get_result_unit_metadata(hdf_path)
+
+    metadata = HdfBase.get_result_unit_metadata(hdf_path, strict=False)
+    assert metadata["status"] == "missing"
+    assert metadata["unit_system"] is None
+    assert metadata["length_units"] is None
+    assert metadata["flow_units"] is None
+    assert metadata["evidence"] == []
+
+
+def test_result_unit_metadata_reports_unrecognized_value(tmp_path):
+    hdf_path = _write_result_hdf(
+        tmp_path / "unrecognized.p01.hdf",
+        unit_system=np.bytes_("Martian"),
+    )
+
+    with pytest.raises(ValueError, match="Unrecognized /@Units System"):
+        HdfBase.get_result_unit_metadata(hdf_path)
+
+    metadata = HdfBase.get_result_unit_metadata(hdf_path, strict=False)
+    assert metadata["status"] == "unrecognized"
+    assert metadata["evidence"] == [
+        {
+            "attribute": "/@Units System",
+            "raw_value": "Martian",
+            "unit_system": None,
+        }
+    ]
+    assert metadata["contradictions"]
+
+
+def test_result_unit_metadata_reports_contradictory_evidence(tmp_path):
+    hdf_path = _write_result_hdf(
+        tmp_path / "contradictory.p01.hdf",
+        si_units=True,
+        unit_system=np.bytes_("US Customary"),
+    )
+
+    with pytest.raises(ValueError, match="unit-system metadata is contradictory"):
+        HdfBase.get_result_unit_metadata(hdf_path)
+
+    metadata = HdfBase.get_result_unit_metadata(hdf_path, strict=False)
+    assert metadata["status"] == "contradictory"
+    assert metadata["unit_system"] is None
+    assert {item["unit_system"] for item in metadata["evidence"]} == {
+        "SI",
+        "US Customary",
+    }
+
+
+def test_result_unit_metadata_rejects_geometry_only_hdf(tmp_path):
+    hdf_path = _write_result_hdf(
+        tmp_path / "Model.g01.hdf",
+        si_units=False,
+        unit_system=np.bytes_("US Customary"),
+        include_results=False,
+    )
+
+    with pytest.raises(ValueError, match="does not contain a /Results group"):
+        HdfBase.get_result_unit_metadata(hdf_path)
+
+    metadata = HdfBase.get_result_unit_metadata(hdf_path, strict=False)
+    assert metadata["status"] == "unrecognized"
+    assert metadata["length_units"] is None

--- a/tests/test_rasprj_plan_classification.py
+++ b/tests/test_rasprj_plan_classification.py
@@ -111,7 +111,7 @@ def test_classification_and_provenance_columns_are_canonical_schema() -> None:
         "geometry_metadata_error": "str | None",
     }
 
-    assert SCHEMA_VERSION == "1.7"
+    assert SCHEMA_VERSION == "1.8"
     for dataframe, expected in (
         ("plan_df", expected_plan_columns),
         ("geom_df", expected_geom_columns),

--- a/tests/test_steady_profile_stored_maps.py
+++ b/tests/test_steady_profile_stored_maps.py
@@ -189,6 +189,7 @@ def test_steady_profile_engine_bulk_configures_and_launches_once(
     assert frame.attrs["helper_launch_count"] == 1
     assert frame.attrs["profile_count"] == 2
     assert frame.attrs["configured_map_count"] == 5
+    assert frame.attrs["generated_file_count"] == 11
     assert frame.attrs["runtime_provenance"] == {"helper": "test-double"}
     schema_columns = [
         column["name"]
@@ -369,3 +370,44 @@ def test_rasmap_steady_profiles_mode_serializes_dataframe(monkeypatch, tmp_path)
     assert summary["plans"]["01"]["profiles"][0]["profile_name"] == "P1"
     assert len(summary["plans"]["01"]["stored_maps"]) == 2
     json.dumps(summary)
+
+
+def test_rasmap_steady_profiles_mode_dispatches_flow_product(
+    monkeypatch,
+    tmp_path,
+):
+    ras_obj, _, _ = _write_steady_project(tmp_path)
+    calls = []
+
+    def fake_engine(**kwargs):
+        calls.append(kwargs)
+        return pd.DataFrame(
+            columns=[
+                "plan_number",
+                "result_hdf_path",
+                "profile_index",
+                "profile_name",
+                "map_type",
+                "output_mode",
+                "primary_path",
+                "files",
+                "file_count",
+            ]
+        )
+
+    monkeypatch.setattr(
+        RasProcess,
+        "store_maps_at_steady_profiles",
+        staticmethod(fake_engine),
+    )
+
+    summary = RasMap.store_all_maps(
+        "01",
+        mode="steady_profiles",
+        profiles=[0],
+        map_types=("flow",),
+        ras_object=ras_obj,
+    )
+
+    assert calls[0]["map_types"] == ["flow"]
+    assert summary["success"] is True

--- a/tests/test_steady_profile_stored_maps.py
+++ b/tests/test_steady_profile_stored_maps.py
@@ -1,0 +1,371 @@
+from contextlib import contextmanager
+from importlib import import_module
+from pathlib import Path, PureWindowsPath
+from types import SimpleNamespace
+import json
+import subprocess
+import xml.etree.ElementTree as ET
+
+import h5py
+import numpy as np
+import pandas as pd
+import pytest
+
+from ras_commander import RasMap, RasProcess
+from ras_commander.schemas import DATAFRAME_SCHEMAS
+
+
+ras_process_module = import_module("ras_commander.RasProcess")
+
+
+class _DummyRas:
+    def __init__(self, project_folder: Path):
+        self.project_folder = project_folder
+        self.project_name = "Demo"
+        self.ras_exe_path = project_folder / "HEC-RAS" / "Ras.exe"
+        self.ras_version = "6.6"
+        self.plan_df = pd.DataFrame(
+            [{"plan_number": "01", "Short Identifier": "PlanShort"}]
+        )
+
+    def check_initialized(self):
+        return None
+
+
+def _write_steady_project(tmp_path: Path, profile_names=("P1", "P2", "P3")):
+    rasmap_path = tmp_path / "Demo.rasmap"
+    rasmap_path.write_text(
+        """<?xml version="1.0" encoding="utf-8"?>
+<RASMapper>
+  <Geometries />
+  <Results>
+    <Layer Name="PlanShort" Type="RASResults" Filename=".\\Demo.p01.hdf">
+      <Layer Name="Old" Type="RASResultsMap" Filename=".\\PlanShort\\Old.vrt">
+        <MapParameters MapType="depth" OutputMode="Stored Current Terrain"
+          StoredFilename=".\\PlanShort\\Old.vrt" ProfileIndex="0" ProfileName="Old" />
+      </Layer>
+    </Layer>
+  </Results>
+</RASMapper>
+""",
+        encoding="utf-8",
+    )
+    hdf_path = tmp_path / "Demo.p01.hdf"
+    with h5py.File(hdf_path, "w") as hdf_file:
+        plan_info = hdf_file.require_group("Plan Data/Plan Information")
+        plan_info.attrs["Plan ShortID"] = np.bytes_("PlanShort")
+        profile_group = hdf_file.require_group(
+            "Results/Steady/Output/Output Blocks/Base Output/"
+            "Steady Profiles"
+        )
+        profile_group.create_dataset(
+            "Profile Names",
+            data=np.asarray([name.encode("utf-8") for name in profile_names]),
+        )
+    (tmp_path / "HEC-RAS").mkdir()
+    return _DummyRas(tmp_path), rasmap_path, hdf_path
+
+
+def _configure_engine(monkeypatch, tmp_path, profile_names=("P1", "P2", "P3")):
+    ras_obj, rasmap_path, hdf_path = _write_steady_project(
+        tmp_path,
+        profile_names=profile_names,
+    )
+    monkeypatch.setattr(
+        ras_process_module.RasMap,
+        "get_rasmap_path",
+        staticmethod(lambda _ras_object=None: rasmap_path),
+    )
+    monkeypatch.setattr(
+        ras_process_module.RasMap,
+        "get_water_surface_render_mode",
+        staticmethod(lambda ras_object=None: "horizontal"),
+    )
+    monkeypatch.setattr(
+        ras_process_module,
+        "store_maps_runtime_provenance",
+        lambda _hecras_dir: {"helper": "test-double"},
+    )
+
+    @contextmanager
+    def compatible_hdf(path, _version):
+        yield path
+
+    monkeypatch.setattr(
+        RasProcess,
+        "_mapper_compatible_result_hdf",
+        staticmethod(compatible_hdf),
+    )
+    return ras_obj, rasmap_path, hdf_path
+
+
+def _write_configured_outputs(rasmap_path: Path, output_dir: Path) -> None:
+    tree = ET.parse(rasmap_path)
+    for parameters in tree.findall(".//MapParameters"):
+        stored_filename = parameters.get("StoredFilename", "")
+        filename = PureWindowsPath(stored_filename).name
+        if not filename or filename == "Old.vrt":
+            continue
+        target = output_dir / filename
+        target.write_text("primary", encoding="utf-8")
+        if "Polygon" in parameters.get("OutputMode", ""):
+            target.with_suffix(".dbf").write_text("dbf", encoding="utf-8")
+            target.with_suffix(".shx").write_text("shx", encoding="utf-8")
+        else:
+            (output_dir / f"{target.stem}.Terrain.tif").write_text(
+                "tile",
+                encoding="utf-8",
+            )
+
+
+def test_steady_profile_engine_bulk_configures_and_launches_once(
+    monkeypatch,
+    tmp_path,
+):
+    ras_obj, rasmap_path, hdf_path = _configure_engine(monkeypatch, tmp_path)
+    original_rasmap = rasmap_path.read_bytes()
+    output_dir = tmp_path / "PlanShort"
+    helper_calls = []
+    xml_writes = []
+    original_write = ET.ElementTree.write
+
+    def counted_write(self, *args, **kwargs):
+        xml_writes.append(args[0])
+        return original_write(self, *args, **kwargs)
+
+    monkeypatch.setattr(ET.ElementTree, "write", counted_write)
+
+    def fake_helper(**kwargs):
+        helper_calls.append(kwargs)
+        _write_configured_outputs(rasmap_path, output_dir)
+        return subprocess.CompletedProcess(
+            args=["RasStoreMapHelper.exe"],
+            returncode=0,
+            stdout="Maps generated: 5",
+            stderr="",
+        )
+
+    monkeypatch.setattr(
+        ras_process_module,
+        "run_store_all_maps_helper",
+        fake_helper,
+    )
+    destination = tmp_path / "published"
+
+    frame = RasProcess.store_maps_at_steady_profiles(
+        "01",
+        profiles=[2, "P1"],
+        output_path=destination,
+        map_types=("depth", "velocity"),
+        fix_georef=False,
+        ras_object=ras_obj,
+    )
+
+    assert len(helper_calls) == 1
+    assert len(xml_writes) == 1
+    assert rasmap_path.read_bytes() == original_rasmap
+    assert frame[["profile_index", "profile_name", "map_type"]].to_records(
+        index=False
+    ).tolist() == [
+        (2, "P3", "depth"),
+        (2, "P3", "velocity"),
+        (0, "P1", "depth"),
+        (0, "P1", "velocity"),
+        (0, "P1", "inundation_boundary"),
+    ]
+    assert frame["output_mode"].tolist() == [
+        "raster",
+        "raster",
+        "raster",
+        "raster",
+        "polygon",
+    ]
+    assert all(Path(path).parent == destination for path in frame["primary_path"])
+    assert frame.loc[frame["output_mode"] == "raster", "file_count"].eq(2).all()
+    assert frame.loc[frame["output_mode"] == "polygon", "file_count"].eq(3).all()
+    assert frame.attrs["schema"] == (
+        "ras_commander.steady_profile_stored_maps.v1"
+    )
+    assert frame.attrs["helper_launch_count"] == 1
+    assert frame.attrs["profile_count"] == 2
+    assert frame.attrs["configured_map_count"] == 5
+    assert frame.attrs["runtime_provenance"] == {"helper": "test-double"}
+    schema_columns = [
+        column["name"]
+        for column in DATAFRAME_SCHEMAS["steady_profile_stored_maps"]["columns"]
+    ]
+    assert schema_columns == frame.columns.tolist()
+    assert frame["result_hdf_path"].unique().tolist() == [str(hdf_path.resolve())]
+
+
+@pytest.mark.parametrize("failure_mode", ["exit", "missing", "timeout"])
+def test_steady_profile_engine_restores_rasmap_on_failure(
+    monkeypatch,
+    tmp_path,
+    failure_mode,
+):
+    ras_obj, rasmap_path, _ = _configure_engine(monkeypatch, tmp_path)
+    original_rasmap = rasmap_path.read_bytes()
+    calls = []
+
+    def fake_helper(**_kwargs):
+        calls.append(failure_mode)
+        if failure_mode == "timeout":
+            raise subprocess.TimeoutExpired("RasStoreMapHelper.exe", 1)
+        return subprocess.CompletedProcess(
+            args=["RasStoreMapHelper.exe"],
+            returncode=1 if failure_mode == "exit" else 0,
+            stdout="",
+            stderr="forced failure" if failure_mode == "exit" else "",
+        )
+
+    monkeypatch.setattr(
+        ras_process_module,
+        "run_store_all_maps_helper",
+        fake_helper,
+    )
+
+    expected_exception = (
+        subprocess.TimeoutExpired if failure_mode == "timeout" else RuntimeError
+    )
+    with pytest.raises(expected_exception):
+        RasProcess.store_maps_at_steady_profiles(
+            "01",
+            fix_georef=False,
+            ras_object=ras_obj,
+        )
+
+    assert calls == [failure_mode]
+    assert rasmap_path.read_bytes() == original_rasmap
+
+
+@pytest.mark.parametrize(
+    "profiles",
+    [True, -1, 99, "Missing", [0, "P1"]],
+)
+def test_steady_profile_engine_rejects_invalid_selectors_before_mutation(
+    monkeypatch,
+    tmp_path,
+    profiles,
+):
+    ras_obj, rasmap_path, _ = _configure_engine(monkeypatch, tmp_path)
+    original_rasmap = rasmap_path.read_bytes()
+    helper_calls = []
+    monkeypatch.setattr(
+        ras_process_module,
+        "run_store_all_maps_helper",
+        lambda **kwargs: helper_calls.append(kwargs),
+    )
+
+    with pytest.raises((TypeError, ValueError)):
+        RasProcess.store_maps_at_steady_profiles(
+            "01",
+            profiles=profiles,
+            fix_georef=False,
+            ras_object=ras_obj,
+        )
+
+    assert helper_calls == []
+    assert rasmap_path.read_bytes() == original_rasmap
+
+
+def test_steady_profile_engine_rejects_ambiguous_names_and_filename_collisions(
+    monkeypatch,
+    tmp_path,
+):
+    ambiguous_dir = tmp_path / "ambiguous"
+    ambiguous_dir.mkdir()
+    ras_obj, rasmap_path, _ = _configure_engine(
+        monkeypatch,
+        ambiguous_dir,
+        profile_names=("Same", "Same"),
+    )
+    original = rasmap_path.read_bytes()
+    with pytest.raises(ValueError, match="ambiguous"):
+        RasProcess.store_maps_at_steady_profiles(
+            "01",
+            profiles="Same",
+            fix_georef=False,
+            ras_object=ras_obj,
+        )
+    assert rasmap_path.read_bytes() == original
+
+    collision_dir = tmp_path / "collision"
+    collision_dir.mkdir()
+    ras_obj, rasmap_path, _ = _configure_engine(
+        monkeypatch,
+        collision_dir,
+        profile_names=("A:B", "A/B"),
+    )
+    original = rasmap_path.read_bytes()
+    with pytest.raises(ValueError, match="filename collision"):
+        RasProcess.store_maps_at_steady_profiles(
+            "01",
+            fix_georef=False,
+            ras_object=ras_obj,
+        )
+    assert rasmap_path.read_bytes() == original
+
+
+def test_rasmap_steady_profiles_mode_serializes_dataframe(monkeypatch, tmp_path):
+    ras_obj, _, hdf_path = _write_steady_project(tmp_path)
+    calls = []
+    frame = pd.DataFrame(
+        [
+            {
+                "plan_number": "01",
+                "result_hdf_path": str(hdf_path),
+                "profile_index": 0,
+                "profile_name": "P1",
+                "map_type": "depth",
+                "output_mode": "raster",
+                "primary_path": str(tmp_path / "Depth (P1).vrt"),
+                "files": [
+                    str(tmp_path / "Depth (P1).vrt"),
+                    str(tmp_path / "Depth (P1).Terrain.tif"),
+                ],
+                "file_count": 2,
+            },
+            {
+                "plan_number": "01",
+                "result_hdf_path": str(hdf_path),
+                "profile_index": 0,
+                "profile_name": "P1",
+                "map_type": "inundation_boundary",
+                "output_mode": "polygon",
+                "primary_path": str(tmp_path / "Inundation Boundary (P1).shp"),
+                "files": [str(tmp_path / "Inundation Boundary (P1).shp")],
+                "file_count": 1,
+            },
+        ]
+    )
+    frame.attrs["schema"] = "ras_commander.steady_profile_stored_maps.v1"
+    frame.attrs["helper_launch_count"] = 1
+
+    def fake_engine(**kwargs):
+        calls.append(kwargs)
+        return frame
+
+    monkeypatch.setattr(
+        RasProcess,
+        "store_maps_at_steady_profiles",
+        staticmethod(fake_engine),
+    )
+
+    summary = RasMap.store_all_maps(
+        "01",
+        mode="steady_profiles",
+        profiles=[0],
+        map_types=("depth",),
+        ras_object=ras_obj,
+    )
+
+    assert len(calls) == 1
+    assert calls[0]["profiles"] == [0]
+    assert calls[0]["map_types"] == ["depth"]
+    assert calls[0]["inundation_boundary"] is True
+    assert summary["success"] is True
+    assert summary["mode"] == "steady_profiles"
+    assert summary["plans"]["01"]["profiles"][0]["profile_name"] == "P1"
+    assert len(summary["plans"]["01"]["stored_maps"]) == 2
+    json.dumps(summary)


### PR DESCRIPTION
## Summary

Adds the narrow generic ras-commander primitives needed by the private ras2fim integration without upstreaming ras2fim-specific inventory, hydrofabric, scenario, or rating-curve policy.

- batch all selected steady profiles through one temporary `.rasmap` transaction and one aggregate `StoreAllMaps` helper launch per plan
- expose strict unit metadata for standalone plan-result HDFs only, while keeping `.prj` text units authoritative for full projects
- refactor result-product/query/sediment unit consumers onto the shared HDF reader
- expose stable DataFrame records and JSON-serializable `RasMap.store_all_maps(mode="steady_profiles")` summaries
- record configuration/helper/total timing, runtime provenance, launch count, and generated-file count
- include pandas 3 timestamp-resolution compatibility fixes found during baseline qualification

## API boundaries

- `RasProcess.store_maps_at_steady_profiles(...) -> DataFrame`
- `RasMap.store_all_maps(mode="steady_profiles", ...) -> dict`
- `HdfBase.get_result_unit_metadata(hdf_path, strict=True) -> dict`
- HDF units are a standalone result-HDF fallback; `RasPrj.get_project_units()` remains authoritative when a project `.prj` is available.

## Verification

- 155 passed, 16 skipped in the integrated cross-section/map/HDF regression suite
- independent API consistency audit: all blockers resolved
- Python compilation and `git diff --check` passed
- notebook metadata/validation and MkDocs documentation build passed
- broad repository run: 2,455 passed, 121 skipped; unrelated optional-runtime/package-artifact cases remained (notably missing `netCDF4`/`pythonnet` and local native fixtures)

## Follow-up

Real Windows/Wine HEC-RAS performance qualification will use a computed steady BLE/RRASSLER sample. It is intentionally not replaced by direct executable calls or synthetic timing claims in this PR.