### PR TITLE
Make rasmap_df parse outcomes observable

### DIFF
--- a/.claude/agents/ebfe-organizer/SUBAGENT.md
+++ b/.claude/agents/ebfe-organizer/SUBAGENT.md
@@ -241,25 +241,25 @@ if hasattr(ras, 'boundary_df') and ras.boundary_df is not None:
 
 # VALIDATION 3: Check rasmap_df (terrain files)
 print("\nValidating Terrain Files (.rasmap)...")
-if hasattr(ras, 'rasmap_df') and ras.rasmap_df is not None:
-    for idx, row in ras.rasmap_df.iterrows():
-        if 'terrain_file' in row and pd.notna(row['terrain_file']):
-            terrain_path = Path(row['terrain_file'])
-
-            # Check if path is relative
-            if terrain_path.is_absolute():
-                print(f"  ✗ ABSOLUTE PATH: {terrain_path}")
-                print(f"    This will cause errors - FIX REQUIRED")
-            # Check if file exists
-            elif not terrain_path.exists():
-                # Try relative to project
-                terrain_resolved = ras.prj_file.parent / terrain_path
-                if terrain_resolved.exists():
-                    print(f"  ✓ Terrain found (relative): {terrain_path}")
-                else:
-                    print(f"  ✗ TERRAIN NOT FOUND: {terrain_path}")
-            else:
-                print(f"  ✓ Terrain found: {terrain_path}")
+summary = ras.rasmap_df.iloc[0]
+status = summary.get('rasmap_status', 'parsed')  # legacy frames default to usable
+if status == 'absent':
+    print(f"  ⚠️ No .rasmap found at {summary.get('rasmap_path')}")
+elif status == 'failed':
+    print(f"  ✗ RASMAP PARSE FAILED: {summary.get('rasmap_error')}")
+else:
+    field_errors = summary.get('rasmap_field_errors', {})
+    if 'terrain_hdf_path' in field_errors:
+        print(f"  ✗ TERRAIN FIELD FAILED: {field_errors['terrain_hdf_path']}")
+    terrain_paths = summary.get('terrain_hdf_path', [])
+    if not terrain_paths:
+        print("  ⚠️ No terrain layer configured")
+    for raw_path in terrain_paths:
+        terrain_path = Path(raw_path)
+        if terrain_path.is_file():
+            print(f"  ✓ Terrain found: {terrain_path}")
+        else:
+            print(f"  ✗ TERRAIN NOT FOUND: {terrain_path}")
 
 # VALIDATION 4: Check land cover HDF if 2D model
 print("\nValidating Land Cover (if 2D)...")
@@ -450,31 +450,26 @@ if hasattr(ras, 'boundary_df'):
 
 ```python
 # Check terrain file references
-if hasattr(ras, 'rasmap_df'):
-    for idx, row in ras.rasmap_df.iterrows():
-        if 'terrain_file' in row and pd.notna(row['terrain_file']):
-            terrain_file = Path(row['terrain_file'])
+summary = ras.rasmap_df.iloc[0]
+status = summary.get('rasmap_status', 'parsed')  # legacy frames default to usable
+if status == 'absent':
+    print(f"WARN: No .rasmap found at {summary.get('rasmap_path')}")
+elif status == 'failed':
+    print(f"FAIL: RASMapper parse failed: {summary.get('rasmap_error')}")
+else:
+    field_errors = summary.get('rasmap_field_errors', {})
+    if 'terrain_hdf_path' in field_errors:
+        print(f"FAIL: Terrain field failed: {field_errors['terrain_hdf_path']}")
 
-            # CRITICAL CHECKS:
-            is_absolute = terrain_file.is_absolute()
-            exists = terrain_file.exists()
-
-            if is_absolute:
-                print(f"FAIL: Absolute terrain path")
-            elif not exists:
-                # Try relative to project
-                terrain_resolved = ras.prj_file.parent / terrain_file
-                if terrain_resolved.exists():
-                    print(f"PASS: Terrain found (relative)")
-                else:
-                    print(f"FAIL: Terrain not found")
-
-                    # Search for terrain file
-                    terrain_name = terrain_file.name
-                    found = list(ras.prj_file.parent.glob(f'**/{terrain_name}'))
-                    if found:
-                        print(f"  Found at: {found[0]}")
-                        print(f"  Should correct .rasmap to: {found[0].relative_to(ras.prj_file.parent)}")
+    terrain_paths = summary.get('terrain_hdf_path', [])
+    if not terrain_paths:
+        print("WARN: No terrain layer configured")
+    for raw_path in terrain_paths:
+        terrain_file = Path(raw_path)
+        if terrain_file.is_file():
+            print(f"PASS: Terrain found: {terrain_file}")
+        else:
+            print(f"FAIL: Terrain not found: {terrain_file}")
 ```
 
 **Goal**: Zero failures - all paths relative, all files exist, model runnable

--- a/.claude/skills/ebfe_validate_models/SKILL.md
+++ b/.claude/skills/ebfe_validate_models/SKILL.md
@@ -139,28 +139,33 @@ if hasattr(ras, 'boundary_df') and ras.boundary_df is not None:
 ```python
 print("\nValidating Terrain (rasmap_df)...")
 
-if hasattr(ras, 'rasmap_df') and ras.rasmap_df is not None:
-    for idx, row in ras.rasmap_df.iterrows():
-        if 'terrain_file' in row and pd.notna(row['terrain_file']):
-            terrain_path = Path(row['terrain_file'])
+summary = ras.rasmap_df.iloc[0]
+status = summary.get('rasmap_status', 'parsed')  # legacy frames default to usable
+if status == 'absent':
+    print(f"  ⚠️ No .rasmap found at {summary.get('rasmap_path')}")
+elif status == 'failed':
+    print(f"  ✗ FAIL: RASMapper parse failed: {summary.get('rasmap_error')}")
+else:
+    field_errors = summary.get('rasmap_field_errors', {})
+    if 'terrain_hdf_path' in field_errors:
+        print(f"  ✗ FAIL: Terrain field failed: {field_errors['terrain_hdf_path']}")
 
-            # CRITICAL: Check if absolute
-            if terrain_path.is_absolute():
-                print(f"  ✗ FAIL: Absolute terrain path: {terrain_path}")
-                print(f"    Will cause errors in RAS Mapper")
-                continue
+    terrain_paths = summary.get('terrain_hdf_path', [])
+    if not terrain_paths:
+        print("  ⚠️ No terrain layer configured")
+    for raw_path in terrain_paths:
+        terrain_path = Path(raw_path)
+        if not terrain_path.is_file():
+            print(f"  ✗ FAIL: Terrain not found: {terrain_path}")
+            continue
 
-            # Check if file exists
-            if terrain_path.exists():
-                print(f"  ✓ PASS: Terrain found: {terrain_path}")
-
-                # Validate using RasMap
-                from ras_commander import RasMap
-                is_valid = RasMap.is_valid_layer(terrain_path, layer_type='terrain')
-                if is_valid:
-                    print(f"    ✓ Terrain layer valid")
-                else:
-                    print(f"    ⚠️ Terrain layer validation failed")
+        print(f"  ✓ PASS: Terrain found: {terrain_path}")
+        from ras_commander import RasMap
+        is_valid = RasMap.is_valid_layer(terrain_path, layer_type='terrain')
+        if is_valid:
+            print("    ✓ Terrain layer valid")
+        else:
+            print("    ⚠️ Terrain layer validation failed")
             else:
                 # Try relative to project
                 terrain_resolved = ras.prj_file.parent / terrain_path

--- a/agent_tasks/2026-09-07_rasmap_df_fable_qaqc.md
+++ b/agent_tasks/2026-09-07_rasmap_df_fable_qaqc.md
@@ -1,0 +1,134 @@
+# Claude Code Fable QA/QC: `rasmap_df` provenance PR
+
+**Date:** 2026-09-07
+
+**Reviewer:** Claude Code 2.1.263, `--model fable --effort max`
+
+**Mode:** Read-only (`Read`, `Glob`, `Grep`, and `Bash`; no edit/write tools)
+
+## Fable verdict
+
+**READY WITH NON-BLOCKING FOLLOW-UPS**
+
+Fable reported no blockers and no high-severity findings. It also noted that the
+read-only permission harness denied Python execution, so it independently reviewed
+the implementation and diffs but did not independently reproduce the test counts
+already recorded in the worklog.
+
+## Fable findings (captured before maintainer verification)
+
+### Medium
+
+1. A malformed declaration can prevent valid entries in the same field group from
+   being returned. Fable recommended recording the declaration error and continuing
+   so valid sibling entries survive, or documenting an all-or-nothing rule.
+2. `ras_commander/AGENTS.md` contains a required `rasmap_df` contract bullet but was
+   omitted from the PR description's file inventory. The file also has unrelated
+   changes and must be staged by hunk.
+3. The `RasPrj.initialize()` logging diff includes an unrelated geometry-HDF count
+   logging change and must be split during staging or described as part of the PR.
+4. The tracked regression fixture checks only part of the 11-column legacy row;
+   Fable recommended a stronger equivalence regression and per-case lifecycle
+   status assertions.
+
+### Low
+
+1. A well-formed XML document with a non-`RASMapper` root is accepted as `parsed`.
+2. `map_layers` and the map-layer helper are initialized in one extraction block
+   and reused by later blocks, creating cross-block coupling after an earlier error.
+3. `RasPrj.initialize()` logging calls `.iloc[0]` without independently guarding a
+   zero-row DataFrame returned by a monkeypatch/subclass.
+4. `Path.exists()` is outside the parser's resilience boundary.
+5. The fallback expected path in notebook 122 uses the project folder name instead
+   of the `.prj` stem.
+6. Top-level layer traversal and canonical expected-path construction remain
+   duplicated internally.
+7. `ras_object` is retained for compatibility but is now unused by `parse_rasmap()`.
+
+## Compatibility observations from Fable
+
+- The frame grows from 11 to 15 columns while preserving the original column order.
+- Well-formed files retain the legacy path-resolution and field-value semantics.
+- UTF-8 BOM documents move from silent defaults to a real parse, which is a
+  corrective legacy-value change worth mentioning.
+- `get_infiltration_parameters()` changes from an accidentally broken decorated
+  attribute to a working API; explicit missing paths can now fail in the decorator
+  with `FileNotFoundError`.
+- Implicit missing infiltration lookup changes from accidental `IndexError` to the
+  documented contextual `ValueError`.
+
+## Missing tests suggested by Fable
+
+- Pin every lifecycle case to its expected status rather than comparing only the
+  set of statuses.
+- Cover the remaining per-field error groups and a mixed-validity group.
+- Cover empty XML and a non-`RASMapper` root.
+- Prove an unrelated partial field error does not block infiltration resolution,
+  and prove explicit missing-path behavior.
+- Add direct status-gating coverage for `scripts/ebfe_delivery_audit.py`.
+- When the external example archive is available, compare pinned legacy values for
+  a real extracted 2D project.
+
+## Dirty-worktree warning from Fable
+
+- Stage `RasPrj.py`, `docs/reference/dataframe-reference.md`, and
+  `ras_commander/AGENTS.md` interactively by hunk.
+- Do not add the untracked qualification subsystem.
+- Review the cached diff for LF/CRLF whole-file rewrites before committing.
+- Add the new schema module, both focused test modules, and the compact fixture
+  explicitly.
+
+## Commands Fable reported running
+
+- `git status --porcelain`, `git diff --stat`, and per-file `git diff`
+- `git diff --check`
+- `git grep` at `HEAD` for the infiltration decorator
+- `git ls-files` / `git grep` to establish qualification-subsystem tracked status
+
+Python tests, archive comparison, and notebook compilation were attempted but
+denied by the Claude read-only harness before execution. The primary agent's
+verification and resolution record follows in the PR worklog.
+
+## Maintainer verification and resolution
+
+The primary agent checked every finding against the working tree after Fable
+returned:
+
+- **Resolved:** malformed top-level land-classification, terrain, reference, and
+  basemap declarations now record field errors per declaration and continue.
+  Valid siblings are retained. Reference/basemap names remain usable when only
+  their corresponding filename/path is malformed.
+- **Resolved:** all 11 legacy columns are pinned by the representative fixture;
+  lifecycle expectations are asserted per input; mixed-validity siblings have a
+  dedicated regression.
+- **Resolved:** `MapLayers` lookup and the map-layer helper import no longer depend
+  on an earlier extraction block succeeding.
+- **Resolved:** the unrelated geometry-HDF logging change was removed from the
+  `RasPrj.initialize()` hunk, and status logging now guards an anomalous zero-row
+  monkeypatch/subclass result.
+- **Resolved:** filesystem existence probing is inside the parser resilience
+  boundary, and the compatibility-only `ras_object` parameter is documented.
+- **Resolved:** notebook 122 derives the absent fallback from the discovered `.prj`
+  stem when possible.
+- **Resolved:** `ras_commander/AGENTS.md` is named explicitly in the PR scope notes,
+  with hunk-only staging instructions.
+- **Resolved after corpus confirmation:** all 326 `.rasmap` files currently under
+  this repository have a `RASMapper` root. A well-formed document with another root
+  is now a document-level `failed` result and has regression coverage.
+- **Resolved:** direct eBFE delivery-audit tests prove that `failed` gates both
+  legacy values and raw XML fallback, while `parsed_with_errors` retains unaffected
+  delivery fields.
+- **Resolved before merge:** shared internal top-level traversal and canonical
+  expected-path construction are now centralized and their tracked callers are
+  migrated.
+- **Resolved before merge:** an archive-available integration test now sweeps every
+  `.rasmap` in the locally installed `RasExamples` archive, while skipping cleanly
+  in CI environments where that external archive is unavailable.
+
+Post-resolution verification was subsequently expanded after Fable's recheck: 39
+targeted review-driven tests passed; the final focused RASMapper/infiltration group
+passed 114 tests with 7 intentional skips;
+all 326 repository `.rasmap` files returned `parsed` with zero field-error rows;
+changed Python files compiled; changed notebook JSON/code cells compiled; Ruff was
+clean on every new focused Python module/test; and `git diff --check` passed with
+only line-ending normalization warnings.

--- a/agent_tasks/2026-09-07_rasmap_df_fable_recheck.md
+++ b/agent_tasks/2026-09-07_rasmap_df_fable_recheck.md
@@ -1,0 +1,52 @@
+# Claude Code Fable recheck: `rasmap_df` provenance PR
+
+**Date:** 2026-09-07
+
+**Reviewer:** Claude Code 2.1.263, Fable, maximum effort
+
+## Verdict
+
+**READY WITH NON-BLOCKING FOLLOW-UPS**
+
+Fable found no regression in the parser, `RasPrj` fallback, infiltration resolver,
+or eBFE audit. It marked all four original medium findings resolved and six of the
+seven original low findings resolved. Its remaining internal-deduplication follow-up
+was subsequently completed before merge.
+
+## Recheck findings and final disposition
+
+- **Medium — eBFE test import portability:** The new test imported
+  `scripts.ebfe_delivery_audit`, but `scripts/` is not a package and the import can
+  depend on how pytest is launched. **Resolved:** the test now loads the standalone
+  script with `importlib.util.spec_from_file_location`.
+- **Low — possibly unbound `land_columns`:** The error-key list was inside the
+  `try` whose `except` referenced it. **Resolved:** it is initialized before the
+  `try`.
+- **Low — value plus field error / last-writer-wins:** A malformed unknown
+  land-classification declaration conservatively marks all three classification
+  path columns, even if a valid sibling populated one. Repeated errors also
+  overwrote earlier details. **Resolved:** infiltration resolution is value-first,
+  so valid sibling candidates remain usable, and repeated messages for a column
+  are accumulated rather than overwritten. A two-method regression pins the
+  value-first behavior.
+- **Low — notebook `.prj` ambiguity:** A root-level projection `.prj` could win a
+  simple glob. **Resolved:** notebook 122 now uses `RasPrj.find_ras_prj()`, the
+  library's content-aware project-file discovery.
+- **Low — duplicated traversal/path construction:** **Resolved after this recheck.**
+  Shared helpers now own canonical expected-path construction and top-level
+  `MapLayers/Layer` traversal, and tracked call sites use them.
+
+Fable could not execute Python under its read-only harness. It statically confirmed
+that the then-current counts were internally consistent. After the final recheck
+fixes, the primary agent ran the expanded review-focused modules (**39 passed**)
+and the complete focused group (**114 passed, 7 skipped**), plus compilation,
+notebook, Ruff, corpus, and diff checks recorded in the worklog.
+
+## Dirty-tree reminder
+
+`ras_commander/AGENTS.md` requires splitting the combined hunk so the unrelated
+model-sources bullet is not staged. `RasPrj.py` and the DataFrame reference also
+contain extensive unrelated worktree changes. Use `python -m pytest` from this
+checkout: the checkout's `.venv` editable metadata points at another repository
+path, and the global `pytest` console launcher does not import this checkout's
+`ras_commander` package reliably.

--- a/agent_tasks/2026-09-07_rasmap_df_pr_description.md
+++ b/agent_tasks/2026-09-07_rasmap_df_pr_description.md
@@ -1,0 +1,50 @@
+# Make `rasmap_df` parse outcomes observable
+
+## Summary
+
+- preserve the existing single-row frame and first 11 columns
+- append explicit file, lifecycle, document-error, and per-field-error provenance
+- keep partial parsing non-raising while preserving valid sibling layers
+- normalize exceptional initialization fallbacks to the same one-row shape
+- centralize expected-path, top-level-layer, status-health, and HDF lookup logic
+- migrate tracked downstream consumers and all six infiltration/statistics APIs
+- document the contract and show provenance-first use in the two QA/QC notebooks
+
+## Compatibility
+
+Normal named-column access is unchanged. The additive frame width changes from
+11 to 15 columns, and the rare zero-row initialization fallback is corrected to
+one row. Exact-schema/positional consumers must account for those changes.
+
+## User-facing example
+
+```python
+summary = ras.rasmap_df.iloc[0]
+
+if summary["rasmap_status"] == "failed":
+    raise RuntimeError(summary["rasmap_error"])
+if summary["rasmap_status"] == "absent":
+    print("No map:", summary["rasmap_path"])
+else:
+    print(summary["terrain_hdf_path"])
+```
+
+`len`, `.empty`, and non-`None` are shape/existence observations, not parser
+health checks.
+
+## Validation
+
+- 216 focused tests passed with 5 mapped-drive skips across parser, consumers,
+  HDF lookup, map-layer, geometry-association, archive compatibility, and
+  ScienceBase promotion behavior
+- 327 repository `.rasmap` files replayed with no failed or partial parses
+- 32 files from the installed RasExamples archive parsed across terrain, basemap,
+  results, and modern land-cover forms
+- both modified notebooks compile as JSON and Python
+- parser/resolver/cross-section changes and new tests pass Ruff
+- two Claude Code Fable reviews found no blocker or high-severity issue
+- the API consistency auditor's final pass found no blocker, high, or medium issue
+
+The full suite produced 2676 passed, 61 skipped, and 13 unrelated baseline or
+environment failures. See `2026-09-07_rasmap_df_pr_worklog.md` for categorization,
+the documentation build result, and the independent review record.

--- a/agent_tasks/2026-09-07_rasmap_df_pr_worklog.md
+++ b/agent_tasks/2026-09-07_rasmap_df_pr_worklog.md
@@ -1,0 +1,127 @@
+# `rasmap_df` provenance PR worklog
+
+**Date:** 2026-09-07
+
+**Branch:** `codex/rasmap-df-provenance`
+
+**Base:** `origin/main` at `49f1b0f18660ca04d7266e215cda907dcf19a8ef`
+
+## Contract decisions
+
+- `rasmap_df` remains a pandas DataFrame with exactly one row and index `0` in
+  every lifecycle state.
+- The original 11 columns retain their names, order, value shapes, and path
+  normalization behavior.
+- Four columns are appended: `rasmap_path`, `rasmap_status`, `rasmap_error`, and
+  `rasmap_field_errors`.
+- The public statuses are `absent`, `parsed`, `parsed_with_errors`, and `failed`.
+- Document-level errors go in `rasmap_error`; declaration/field-level errors are
+  accumulated by affected legacy column in `rasmap_field_errors`.
+- Missing optional sections and missing referenced assets are not parse errors.
+- Parsing remains non-raising and preserves valid sibling declarations after a
+  malformed declaration.
+- Legacy frames without provenance columns remain usable to internal consumers.
+
+## Follow-ups completed before merge
+
+1. Centralized canonical `<project-name>.rasmap` construction in
+   `_rasmap_schema.expected_rasmap_path()` and migrated tracked call sites.
+2. Centralized direct `MapLayers/Layer` traversal and made legacy `LandCover`
+   and modern `LandCoverLayer` classification consistent.
+3. Added `_rasmap_schema.rasmap_dataframe_is_usable()` and migrated tracked
+   health checks in `RasPrj`, `RasProject`, `HdfResultsMesh`, ScienceBase
+   validation, and the eBFE delivery audit.
+4. Migrated all six implicit HDF classification/infiltration lookups to
+   `HdfInfiltration._resolve_rasmap_hdf_path()`.
+   - `get_infiltration_map()` and `get_infiltration_parameters()` now raise a
+     contextual `ValueError` rather than an accidental `IndexError`.
+   - The four statistics APIs retain their documented log-and-empty-DataFrame
+     recovery behavior.
+5. Added an opt-in/archive-available `RasExamples` compatibility sweep over all
+   `.rasmap` members plus a compact tracked fixture for deterministic CI.
+6. Updated the untracked local `RasQualificationActions` subsystem separately to
+   use the shared health/path helpers. The subsystem is intentionally not copied
+   wholesale into this PR because it is not present on `main`.
+7. Migrated `RasCrossSections` to the shared path/health contract. While doing so,
+   restored the pre-existing misplaced body of `_crs_units()` so that its CRS
+   fallback remains functional and the touched module is lint-clean.
+8. Closed the final API-audit gaps: parser-helper imports now remain inside the
+   one-row resilience boundary; `RasPrj` distinguishes module-import failure from
+   initialization failure; ScienceBase promotion reports document and field parse
+   failures; and `RasProject` inventories each failed field without dropping valid
+   sibling assets.
+9. Replaced obsolete `.empty`/non-`None` health checks and the nonexistent
+   `terrain_file` column in both tracked eBFE validation guides. The spatial-data
+   guide now gates explicit infiltration sidecar indexing on `rasmap_status`.
+
+## Consumer behavior
+
+| Consumer | Behavior after this PR |
+|---|---|
+| `RasPrj.initialize()` | All paths, including import/unexpected failure, produce one provenance row. |
+| `RasPrj` path accessors | Return values only from parsed/partially parsed rows; legacy frames remain accepted. |
+| `RasProject.inspect_project_assets()` | Does not invent an absent RASMapper asset and reports unusable structured parsing explicitly. |
+| `HdfResultsMesh` | Ignores profile paths from absent/failed rows. |
+| `RasCrossSections` | Uses the canonical map path and ignores projection defaults from absent/failed rows. |
+| ScienceBase validation | Ignores projection defaults from absent/failed rows. |
+| eBFE delivery audit | Records parse provenance, gates failed maps, and still handles noncanonical discovered filenames. |
+| Infiltration map/parameter readers | Explicit paths bypass project lookup; implicit unusable/missing values raise contextual `ValueError`. |
+| Four raster-statistics helpers | Use the same resolver but continue returning an empty DataFrame after a logged lookup problem. |
+
+## Compatibility
+
+This is source-compatible for normal named-column callers. It has two narrow
+compatibility effects worth release-note coverage:
+
+- exact 11-column schemas/fixed-width serializers must accept four appended
+  columns;
+- the rare exceptional `RasPrj.initialize()` fallback changes from zero rows to
+  the intended one-row invariant.
+
+Successful legacy access such as
+`ras.rasmap_df.iloc[0]["terrain_hdf_path"]` remains unchanged after a caller has
+established that the project fixture is valid.
+
+## Review and validation record
+
+- Claude Code 2.1.263, Fable model, maximum effort: two read-only passes; both
+  concluded **READY WITH NON-BLOCKING FOLLOW-UPS**, with no blocker or high
+  finding. The original reports are preserved beside this worklog.
+- The first pass drove sibling-preservation, wrong-root, consumer-gating, and
+  stronger test fixes. The second pass confirmed those findings resolved.
+- API consistency auditor: the initial infiltration decorator finding and four
+  final consumer/resilience/guidance findings were resolved. Its final exact-scope
+  re-audit concluded **READY**, with no blocker, high, or medium issues; the five
+  directly relevant regressions passed independently.
+- Final consolidated consumer suite: **216 passed, 5 skipped**. The skips require
+  an unavailable mapped network drive. This covers parser/resolver provenance,
+  infiltration APIs, ScienceBase and eBFE audits, project assets, cross sections,
+  geometry association, land classification, map layers, terrain display, the
+  installed example archive, and the tracked network-path tests.
+- Broader relevant suite: **207 passed, 12 skipped, 3 failed**. The three failures
+  are pre-existing Windows/Pandas timezone dtype assertions in
+  `tests/test_ras_project.py` and reproduce outside this change.
+- Full suite: **2676 passed, 61 skipped, 13 failed**. The failures are unrelated
+  repository/environment baselines: citation-version drift, two strict HDF test
+  fixtures, a RasBenefits direct-writer issue, the same three timezone assertions,
+  five process-global CLR version-rebind failures, and one RasPlan sediment
+  expectation.
+- Parser replay: **327 `.rasmap` files**, with **0 failed** and **0 partial**.
+- Installed RasExamples archive compatibility: **32 `.rasmap` files**, all parsed;
+  the corpus includes terrain, basemap, results, and modern land-cover forms. The
+  tracked compact fixture covers legacy `LandCover` deterministically in CI.
+- Notebook JSON and every code cell compile successfully. Modified code-cell
+  outputs were cleared; all unrelated stored outputs and execution counts were
+  preserved.
+- GitHub's first documentation run correctly caught stale generated notebook
+  inventory metadata. `examples/notebooks.yml` was regenerated; both the
+  generator's `--check` mode and `validate_notebooks_yml.py` now pass locally
+  (the validator retains 62 existing warnings and reports 0 errors).
+- Ruff passed for all new files and the changed parser/resolver/cross-section,
+  geometry-association, and layer-helper modules. `git diff --check` passed (Git
+  emitted only configured LF-to-CRLF conversion warnings).
+- `mkdocs build --strict` was attempted and stopped on 146 existing warnings from
+  absent generated docs/notebooks and the no-history worktree; no documentation
+  structure changed in this PR.
+- The separate local qualification tests produced **53 passed, 1 failed**; the
+  failure is the existing inaccessible `R:/` drive check (`WinError 1272`).

--- a/agent_tasks/2026-09-07_rasmap_df_silent_failure.md
+++ b/agent_tasks/2026-09-07_rasmap_df_silent_failure.md
@@ -1,0 +1,161 @@
+# `rasmap_df` reports success and failure identically
+
+**Type:** correctness / observability defect
+**Files:** `ras_commander/RasMap.py`, `ras_commander/RasPrj.py`, `ras_commander/_land_classification_helper.py`
+**Found:** 2026-09-07, auditing FEMA eBFE HUC 12090301 (2,378 projects)
+**Wanted:** a PR
+
+---
+
+## Summary
+
+`ras.rasmap_df` cannot distinguish a project with **no** `.rasmap`, a project with a
+**malformed** `.rasmap`, and a project with a **valid** `.rasmap`. All three produce a
+DataFrame of exactly one row with the same columns. Every failure is downgraded to a log
+line and an empty default value. A caller holding only the DataFrame has no way to tell
+"this model has no terrain configured" from "this model's terrain block failed to parse."
+
+This was proven empirically by planting corruption in a copy of a real project and loading
+all three states: identical shape, identical row count, indistinguishable content.
+
+## Why it matters
+
+RASMapper configuration is where terrain, land cover, infiltration and soil layers are
+declared. In the FEMA eBFE corpus those layers ship *separately* from the RAS project and are
+frequently missing — measured presence is 30–53% depending on layer. Quantifying that gap is
+the entire point of the audit consuming this API.
+
+With the current behavior, a study whose `.rasmap` files are all unparseable reports
+**exactly the same numbers** as a study that legitimately ships no RASMapper configuration:
+0% terrain, 0% land cover, 0% infiltration. One is a data gap in the delivery. The other is a
+gap in our parsing. They are not the same finding and must not be reported as the same
+number.
+
+---
+
+## Root cause
+
+### 1. `rasmap_df` is a single-row-by-design schema, so row count discriminates nothing
+
+`_land_classification_helper.empty_rasmap_dataframe()` (`:291`) returns one row:
+
+```python
+pd.DataFrame({
+    "projection_path": [None],
+    "profile_lines_path": [[]],
+    ...
+    "current_settings": [{}],
+})
+```
+
+`RasMap.parse_rasmap()` builds its working dict from that same helper
+(`data = _lch.empty_rasmap_dataframe().to_dict(orient="list")`) and mutates `data[field][0]`
+in place. **A fully successful parse also returns exactly one row.** Any check of the form
+`len(rasmap_df)`, `rasmap_df.empty`, or `if rasmap_df is not None` is therefore meaningless —
+it is `1`, `False`, and `True` in every state including total failure.
+
+### 2. Five distinct outcomes collapse to the same value
+
+| Condition | Site | Logged at | Returns |
+|---|---|---|---|
+| No `.rasmap` found for project | `RasMap.initialize_rasmap_df` `:995` | `warning` | 1-row empty |
+| `.rasmap` path does not exist | `RasMap.parse_rasmap` `:286` | `error` | 1-row empty |
+| Content is not XML (no leading `<`) | `parse_rasmap` `:298` | `error` | 1-row empty |
+| `ET.ParseError` | `parse_rasmap` `:304` | `error` | 1-row empty |
+| Any other exception | `RasPrj.initialize` `:207` | `error` | **0-row** empty |
+
+### 3. Per-field failures are silent and partial
+
+`parse_rasmap` wraps **eight** independent extraction blocks in `except Exception` (lines
+319, 332, 354, 368, 384, 400, and the settings block), each logging `warning` and leaving
+that one field at its empty default. So a `.rasmap` that parses as XML but has a malformed
+terrain block yields `terrain_hdf_path == []` — byte-identical to a project that genuinely
+declares no terrain. This is the most damaging case because it is *partial*: the row looks
+populated and healthy, and one field is quietly empty.
+
+### 4. Bonus inconsistency
+
+The `RasPrj.initialize` fallbacks (`:202` and `:207`) build
+`pd.DataFrame(columns=[...])` — **zero rows**, while every other path returns **one row**.
+The column names match, the shape does not. Any downstream `rasmap_df.iloc[0]` raises
+`IndexError` in that one branch and works everywhere else. These should route through
+`empty_rasmap_dataframe()`.
+
+---
+
+## What the fix should achieve
+
+The DataFrame must carry enough provenance to answer, per project, without consulting logs:
+
+1. Was a `.rasmap` file found? Where?
+2. Did it parse?
+3. If it parsed, did every field extract cleanly, or did some fail?
+
+Suggested shape — **additive columns only**, so the existing 11 columns and all current
+callers keep working unchanged:
+
+| Column | Type | Meaning |
+|---|---|---|
+| `rasmap_path` | `str \| None` | The file actually read, or `None` if none found |
+| `rasmap_status` | `str` | `absent` · `not_found` · `not_xml` · `parse_error` · `parsed` · `parsed_with_errors` |
+| `rasmap_field_errors` | `dict` | `{field_name: error_message}` for the per-field `except` blocks; empty when clean |
+
+With those, `absent` versus `parse_error` versus `parsed` is a column lookup, and
+`parsed_with_errors` surfaces the partial case that is currently invisible.
+
+Also fix the zero-row/one-row inconsistency in `RasPrj.initialize` by returning
+`_lch.empty_rasmap_dataframe()` in both fallback branches.
+
+Design latitude is fine — an enum instead of strings, a separate accessor, a
+`ValidationReport` (the repo has `ras_commander/RasValidation.py` with
+`ValidationSeverity`/`ValidationResult`/`ValidationReport` and this is arguably a natural fit).
+What is not negotiable is that **success and failure must be distinguishable from the
+returned object alone.**
+
+## Constraints
+
+- **Backward compatible.** The 11 existing columns keep their names, order and semantics.
+  Callers doing `rasmap_df['terrain_hdf_path'][0]` must not break.
+- **Do not make parsing stricter.** The goal is to *report* failure, not to start raising on
+  models that load today. A malformed `.rasmap` should still yield a usable row.
+- Follow the repo's static-class and `@log_call` conventions; `pathlib.Path` for paths.
+
+## Tests to include
+
+Build a real project via `RasExamples.extract_project()`, then copy it and plant each state:
+
+1. **Absent** — delete the `.rasmap`. Expect `rasmap_status == "absent"`.
+2. **Not XML** — write `not xml at all` into the `.rasmap`. Expect `not_xml`.
+3. **Malformed XML** — truncate mid-tag. Expect `parse_error`.
+4. **Valid** — untouched. Expect `parsed`, `rasmap_field_errors == {}`, and the same field
+   values the current code produces (regression guard).
+5. **Partial** — valid XML with a corrupted terrain block only. Expect `parsed_with_errors`
+   with `terrain_hdf_path` in `rasmap_field_errors`, and the *other* fields still populated.
+
+Assert in every case that the three states are **mutually distinguishable from the returned
+DataFrame alone**, with no reference to log output. That assertion is the point of the PR.
+
+Per `.claude/rules/commit-policy.md`: this touches existing functions rather than adding new
+public API, so a notebook is not required — but `ras_commander/AGENTS.md` should note the new
+columns if they are added to the public `rasmap_df` contract.
+
+## Reproduction
+
+```python
+from ras_commander import init_ras_project, RasExamples
+import shutil, pathlib
+
+src = RasExamples.extract_project("BaldEagleCrkMulti2D", suffix="rasmap_probe")
+
+for state in ("absent", "not_xml", "parse_error", "valid"):
+    dst = pathlib.Path(f"{src}_{state}")
+    shutil.rmtree(dst, ignore_errors=True); shutil.copytree(src, dst)
+    rmap = next(dst.glob("*.rasmap"), None)
+    if state == "absent":       rmap.unlink()
+    elif state == "not_xml":    rmap.write_text("not xml at all")
+    elif state == "parse_error":rmap.write_text("<RASMapper><Terr")
+
+    ras = init_ras_project(dst, "6.6")
+    print(state, len(ras.rasmap_df), ras.rasmap_df['terrain_hdf_path'][0])
+    # today: every state prints the same row count and the same empty terrain list
+```

--- a/docs/api/hdf.md
+++ b/docs/api/hdf.md
@@ -305,8 +305,16 @@ Native infiltration authoring and read-only inspection.
 - `set_infiltration_sidecar_parameters(hdf_path, data, hecras_version=...)` - Set sidecar parameters through native RASMapper serialization
 - `scale_infiltration_sidecar_parameters(hdf_path, data, scale_factors, hecras_version=...)` - Scale and save sidecar parameters natively
 - `get_classification_polygons(hdf_path)` - Read infiltration sidecar classification polygon overrides
-- `get_infiltration_map(hdf_path)` - Read infiltration raster map
+- `get_infiltration_map(hdf_path=None, ras_object=None)` - Read the
+  infiltration raster map; without an explicit path, resolve the first usable
+  `rasmap_df["infiltration_hdf_path"]`
 - `calculate_soil_statistics(hdf_path)` - Process zonal statistics for soil analysis
+- `get_soils_raster_stats(geom_hdf_path, soil_hdf_path=None, ras_object=None)` -
+  Resolve the soil sidecar consistently; lookup failures retain the empty-frame
+  recovery contract
+- `get_soil_raster_stats(...)`, `get_infiltration_stats(...)`, and
+  `get_landcover_raster_stats(...)` - Use the same status-aware sidecar resolver
+  and empty-frame recovery contract
 
 The compatibility names `create_infiltration_group()`,
 `set_infiltration_baseoverrides()`, `set_infiltration_layer_data()`, and
@@ -323,7 +331,8 @@ Ras Commander never hand-authors or selectively deletes
 
 - `get_significant_mukeys(hdf_path, threshold)` - Identify mukeys above percentage threshold
 - `calculate_total_significant_percentage(hdf_path)` - Compute total coverage
-- `get_infiltration_parameters(hdf_path, mukey)` - Get parameters for specific mukey
+- `get_infiltration_parameters(hdf_path=None, mukey=None, ras_object=None)` - Get
+  parameters for a specific mukey, with the same optional `rasmap_df` lookup
 - `calculate_weighted_parameters(hdf_path)` - Compute weighted average parameters
 
 **Data Export:**

--- a/docs/reference/dataframe-reference.md
+++ b/docs/reference/dataframe-reference.md
@@ -350,9 +350,10 @@ this window. Pass canonical inventory values explicitly, for example
 
 ## `rasmap_df`
 
-`rasmap_df` is a **single-row compact summary** of the project `.rasmap`.
-Several columns contain lists because the dataframe is optimized for project
-overview, not one-row-per-layer discovery.
+`rasmap_df` is a **single-row compact summary** of the project `.rasmap`. It has
+one row for every outcome, including a missing or unreadable file. Several
+columns contain lists because the dataframe is optimized for project overview,
+not one-row-per-layer discovery.
 
 Current default columns (each cell is one element because the DataFrame is a
 single row; "Dtype" describes the value inside that cell):
@@ -370,12 +371,31 @@ single row; "Dtype" describes the value inside that cell):
 | `basemap_layer_names` | list[str] | basemap layer names |
 | `basemap_layer_path` | list[str] | basemap layer paths |
 | `current_settings` | dict | compact `.rasmap` settings summary |
+| `rasmap_path` | str / None | requested or expected `.rasmap` path, including when absent |
+| `rasmap_status` | str | `absent`, `parsed`, `parsed_with_errors`, or `failed` |
+| `rasmap_error` | str / None | document-level read, parse, or initialization error |
+| `rasmap_field_errors` | dict | extraction errors keyed by affected data column |
 
 ```python
 summary = ras.rasmap_df.iloc[0]
-print(summary["terrain_hdf_path"])
-print(summary["landcover_hdf_path"])
+
+if summary["rasmap_status"] == "failed":
+    raise RuntimeError(summary["rasmap_error"])
+if summary["rasmap_status"] == "absent":
+    print(f"No RASMapper file at {summary['rasmap_path']}")
+else:
+    if summary["rasmap_field_errors"]:
+        print("Incomplete RASMapper fields:", summary["rasmap_field_errors"])
+    print(summary["terrain_hdf_path"])
+    print(summary["landcover_hdf_path"])
 ```
+
+Do not use `len(rasmap_df)`, `rasmap_df.empty`, or `rasmap_df is not None` as a
+parse-success check. Those values are deliberately constant so callers can
+safely use `.iloc[0]`; inspect `rasmap_status` instead. Missing optional
+sections and an empty projection filename are valid parsed states. Missing
+files referenced by otherwise valid XML are asset-validation findings, not
+parser failures.
 
 Use `rasmap_df` for quick project-level path inspection. When you need
 discoverable layer names and per-layer metadata, prefer:

--- a/docs/user-guide/spatial-data.md
+++ b/docs/user-guide/spatial-data.md
@@ -4,7 +4,10 @@ RAS Commander provides comprehensive tools for working with HEC-RAS spatial data
 
 ## Overview
 
-When you initialize a RAS project, the library automatically parses the RASMapper file (`.rasmap`) and populates the `rasmap_df` DataFrame with paths to all spatial datasets. This provides programmatic access to terrain models, land cover layers, soil data, and more.
+When you initialize a RAS project, the library looks for the RASMapper file
+(`.rasmap`) and populates the single-row `rasmap_df` DataFrame. The row contains
+spatial paths when parsing succeeds and explicit provenance when the file is
+missing, malformed, or only partly readable.
 
 ## Authoritative Extents for Raster Inputs
 
@@ -115,8 +118,15 @@ The `rasmap_df` typically contains paths to:
 ### Accessing Specific Data Paths
 
 ```python
-# rasmap_df is a compact project summary. Several columns contain lists.
+# rasmap_df is always one row. Check provenance before reading path values.
 summary = ras.rasmap_df.iloc[0]
+
+if summary["rasmap_status"] == "failed":
+    raise RuntimeError(summary["rasmap_error"])
+if summary["rasmap_status"] == "absent":
+    raise FileNotFoundError(summary["rasmap_path"])
+if summary["rasmap_field_errors"]:
+    print("Some fields could not be extracted:", summary["rasmap_field_errors"])
 
 terrain_paths = summary["terrain_hdf_path"]
 landcover_paths = summary["landcover_hdf_path"]
@@ -1119,10 +1129,42 @@ hole-free polygons instead.
 
 ### Infiltration Sidecar
 
+The map and parameter readers accept an explicit sidecar path or resolve the
+first configured infiltration sidecar from an initialized project:
+
+```python
+raster_map = HdfInfiltration.get_infiltration_map(ras_object=ras)
+parameters = HdfInfiltration.get_infiltration_parameters(
+    mukey="100",
+    ras_object=ras,
+)
+```
+
+The implicit lookup checks `rasmap_status` and `rasmap_field_errors`. It raises
+`ValueError` with map/path context when the map is absent or failed, the target
+field could not be extracted, or no matching layer is configured. A valid
+sibling path remains usable after another declaration fails. Supplying the HDF
+path explicitly bypasses the project lookup.
+
+The four raster-statistics helpers use the same resolver but retain their
+legacy recovery contract: a lookup problem is logged and returned as an empty
+DataFrame. This applies to `get_soils_raster_stats()`,
+`get_soil_raster_stats()`, `get_infiltration_stats()`, and
+`get_landcover_raster_stats()`.
+
 Edit a sidecar explicitly when the geometry has no active Base Overrides:
 
 ```python
-infiltration_path = ras.rasmap_df['infiltration_hdf_path'][0][0]
+summary = ras.rasmap_df.iloc[0]
+if summary["rasmap_status"] not in {"parsed", "parsed_with_errors"}:
+    raise ValueError(
+        f"Cannot select infiltration sidecar: {summary['rasmap_status']} - "
+        f"{summary['rasmap_error']}"
+    )
+infiltration_paths = summary["infiltration_hdf_path"]
+if not infiltration_paths:
+    raise ValueError("No infiltration layer is configured in RASMapper")
+infiltration_path = infiltration_paths[0]
 sidecar_df = HdfInfiltration.get_infiltration_layer_data(infiltration_path)
 
 updated_sidecar = HdfInfiltration.scale_infiltration_sidecar_parameters(

--- a/examples/122_rasmapper_spatial_review.ipynb
+++ b/examples/122_rasmapper_spatial_review.ipynb
@@ -10,7 +10,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "bb6a8ffa",
    "metadata": {
     "execution": {
@@ -20,17 +20,7 @@
      "shell.execute_reply": "2026-06-26T23:38:39.877449Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "ras-commander: 0.98.0\n",
-      "Run folder: <workspace>\\examples\\working\\notebook_runs\\122_rasmapper_spatial_review\n",
-      "Capture snapshots: True\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "from pathlib import Path\n",
     "import json\n",
@@ -40,7 +30,7 @@
     "import pandas as pd\n",
     "from IPython.display import Image, Markdown, display\n",
     "\n",
-    "from ras_commander import RasExamples, RasMap\n",
+    "from ras_commander import RasExamples, RasMap, RasPrj\n",
     "import ras_commander\n",
     "\n",
     "pd.set_option(\"display.max_columns\", 80)\n",
@@ -408,12 +398,12 @@
    "source": [
     "## Project Inventory\n",
     "\n",
-    "Start by reading the `.rasmap` files into DataFrames. This gives a model-by-model catalog of terrain, map layers, land-cover/infiltration/soils layers, geometry elements, result layers, and current view state."
+    "Start by reading the `.rasmap` files into DataFrames. The inventory carries each file's parse status and field-error count alongside its layer counts, so an unreadable file cannot look like a valid project with zero layers."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "id": "564527e3",
    "metadata": {
     "execution": {
@@ -423,234 +413,40 @@
      "shell.execute_reply": "2026-06-26T23:38:52.862980Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-06-26 19:38:52 - ras_commander.RasMap - INFO - Successfully parsed RASMapper file: <workspace>\\examples\\working\\notebook_runs\\122_rasmapper_spatial_review\\Balde Eagle Creek_rasmapper_demo\\BaldEagle.rasmap\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-06-26 19:38:52 - ras_commander.RasMap - INFO - Found 0 map layers in .rasmap\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-06-26 19:38:52 - ras_commander.RasMap - INFO - Successfully parsed RASMapper file: <workspace>\\examples\\working\\notebook_runs\\122_rasmapper_spatial_review\\Muncie_rasmapper_demo\\Muncie.rasmap\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-06-26 19:38:52 - ras_commander.RasMap - INFO - Found 3 map layers in .rasmap\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-06-26 19:38:52 - ras_commander.RasMap - INFO - Successfully parsed RASMapper file: <workspace>\\examples\\working\\notebook_runs\\122_rasmapper_spatial_review\\BaldEagleCrkMulti2D_rasmapper_demo\\BaldEagleDamBrk.rasmap\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-06-26 19:38:52 - ras_commander.RasMap - INFO - Found 4 map layers in .rasmap\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-06-26 19:38:52 - ras_commander.RasMap - INFO - Successfully parsed RASMapper file: <workspace>\\examples\\working\\notebook_runs\\122_rasmapper_spatial_review\\Davis_rasmapper_demo\\DavisStormSystem.rasmap\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-06-26 19:38:52 - ras_commander.RasMap - INFO - Found 0 map layers in .rasmap\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-06-26 19:38:52 - ras_commander.RasMap - INFO - Successfully parsed RASMapper file: <workspace>\\examples\\working\\notebook_runs\\122_rasmapper_spatial_review\\NewOrleansMetro_rasmapper_demo\\NewOrleansMetro.rasmap\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-06-26 19:38:52 - ras_commander.RasMap - INFO - Found 2 map layers in .rasmap\n"
-     ]
-    },
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>project</th>\n",
-       "      <th>terrains</th>\n",
-       "      <th>map_layers</th>\n",
-       "      <th>reference_layers</th>\n",
-       "      <th>basemaps</th>\n",
-       "      <th>landcover_layers</th>\n",
-       "      <th>soils_layers</th>\n",
-       "      <th>infiltration_layers</th>\n",
-       "      <th>geometry_tree_rows</th>\n",
-       "      <th>result_tree_rows</th>\n",
-       "      <th>current_view_min_x</th>\n",
-       "      <th>current_view_max_x</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>Balde Eagle Creek</td>\n",
-       "      <td>0</td>\n",
-       "      <td>0</td>\n",
-       "      <td>0</td>\n",
-       "      <td>0</td>\n",
-       "      <td>0</td>\n",
-       "      <td>0</td>\n",
-       "      <td>0</td>\n",
-       "      <td>27</td>\n",
-       "      <td>0</td>\n",
-       "      <td>1.967609e+06</td>\n",
-       "      <td>2.065322e+06</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>Muncie</td>\n",
-       "      <td>2</td>\n",
-       "      <td>3</td>\n",
-       "      <td>0</td>\n",
-       "      <td>0</td>\n",
-       "      <td>3</td>\n",
-       "      <td>0</td>\n",
-       "      <td>0</td>\n",
-       "      <td>96</td>\n",
-       "      <td>0</td>\n",
-       "      <td>4.028388e+05</td>\n",
-       "      <td>4.130636e+05</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>BaldEagleCrkMulti2D</td>\n",
-       "      <td>1</td>\n",
-       "      <td>4</td>\n",
-       "      <td>0</td>\n",
-       "      <td>1</td>\n",
-       "      <td>1</td>\n",
-       "      <td>1</td>\n",
-       "      <td>1</td>\n",
-       "      <td>305</td>\n",
-       "      <td>0</td>\n",
-       "      <td>1.944200e+06</td>\n",
-       "      <td>2.139981e+06</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>3</th>\n",
-       "      <td>Davis</td>\n",
-       "      <td>1</td>\n",
-       "      <td>0</td>\n",
-       "      <td>0</td>\n",
-       "      <td>0</td>\n",
-       "      <td>0</td>\n",
-       "      <td>0</td>\n",
-       "      <td>0</td>\n",
-       "      <td>41</td>\n",
-       "      <td>43</td>\n",
-       "      <td>6.627354e+06</td>\n",
-       "      <td>6.645854e+06</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>4</th>\n",
-       "      <td>NewOrleansMetro</td>\n",
-       "      <td>1</td>\n",
-       "      <td>2</td>\n",
-       "      <td>0</td>\n",
-       "      <td>1</td>\n",
-       "      <td>1</td>\n",
-       "      <td>0</td>\n",
-       "      <td>0</td>\n",
-       "      <td>40</td>\n",
-       "      <td>49</td>\n",
-       "      <td>3.658821e+06</td>\n",
-       "      <td>3.685485e+06</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "               project  terrains  map_layers  reference_layers  basemaps  \\\n",
-       "0    Balde Eagle Creek         0           0                 0         0   \n",
-       "1               Muncie         2           3                 0         0   \n",
-       "2  BaldEagleCrkMulti2D         1           4                 0         1   \n",
-       "3                Davis         1           0                 0         0   \n",
-       "4      NewOrleansMetro         1           2                 0         1   \n",
-       "\n",
-       "   landcover_layers  soils_layers  infiltration_layers  geometry_tree_rows  \\\n",
-       "0                 0             0                    0                  27   \n",
-       "1                 3             0                    0                  96   \n",
-       "2                 1             1                    1                 305   \n",
-       "3                 0             0                    0                  41   \n",
-       "4                 1             0                    0                  40   \n",
-       "\n",
-       "   result_tree_rows  current_view_min_x  current_view_max_x  \n",
-       "0                 0        1.967609e+06        2.065322e+06  \n",
-       "1                 0        4.028388e+05        4.130636e+05  \n",
-       "2                 0        1.944200e+06        2.139981e+06  \n",
-       "3                43        6.627354e+06        6.645854e+06  \n",
-       "4                49        3.658821e+06        3.685485e+06  "
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "inventory_rows = []\n",
     "catalogs = {}\n",
     "\n",
     "for name, project_path in projects.items():\n",
     "    project_path = Path(project_path)\n",
-    "    rasmap_df = RasMap.parse_rasmap(project_path / next(project_path.glob(\"*.rasmap\")).name)\n",
-    "    map_layers = RasMap.list_map_layers(project_path)\n",
-    "    terrain_layers = RasMap.list_terrain_layers(project_path)\n",
-    "    landcover_layers = RasMap.list_landcover_layers(project_path)\n",
-    "    soils_layers = RasMap.list_soils_layers(project_path)\n",
-    "    infiltration_layers = RasMap.list_infiltration_layers(project_path)\n",
-    "    geometry_layers = RasMap.list_geometry_layers(project_path)\n",
-    "    result_layers = RasMap.list_result_layers(project_path)\n",
-    "    current_view = RasMap.get_current_view(project_path)\n",
+    "    project_file = RasPrj.find_ras_prj(project_path)\n",
+    "    expected_rasmap = (\n",
+    "        project_file.with_suffix(\".rasmap\")\n",
+    "        if project_file is not None\n",
+    "        else project_path / f\"{project_path.name}.rasmap\"\n",
+    "    )\n",
+    "    rasmap_file = next(project_path.glob(\"*.rasmap\"), expected_rasmap)\n",
+    "    rasmap_df = RasMap.parse_rasmap(rasmap_file)\n",
+    "    rasmap_summary = rasmap_df.iloc[0]\n",
+    "    if rasmap_summary[\"rasmap_status\"] in {\"parsed\", \"parsed_with_errors\"}:\n",
+    "        map_layers = RasMap.list_map_layers(rasmap_file)\n",
+    "        terrain_layers = RasMap.list_terrain_layers(rasmap_file)\n",
+    "        landcover_layers = RasMap.list_landcover_layers(rasmap_file)\n",
+    "        soils_layers = RasMap.list_soils_layers(rasmap_file)\n",
+    "        infiltration_layers = RasMap.list_infiltration_layers(rasmap_file)\n",
+    "        geometry_layers = RasMap.list_geometry_layers(rasmap_file)\n",
+    "        result_layers = RasMap.list_result_layers(rasmap_file)\n",
+    "        current_view = RasMap.get_current_view(rasmap_file)\n",
+    "    else:\n",
+    "        map_layers = pd.DataFrame(columns=[\"category\"])\n",
+    "        terrain_layers = pd.DataFrame()\n",
+    "        landcover_layers = pd.DataFrame()\n",
+    "        soils_layers = pd.DataFrame()\n",
+    "        infiltration_layers = pd.DataFrame()\n",
+    "        geometry_layers = pd.DataFrame(columns=[\"category\"])\n",
+    "        result_layers = pd.DataFrame()\n",
+    "        current_view = {}\n",
     "\n",
     "    catalogs[name] = {\n",
     "        \"rasmap_df\": rasmap_df,\n",
@@ -667,6 +463,8 @@
     "    inventory_rows.append(\n",
     "        {\n",
     "            \"project\": name,\n",
+    "            \"rasmap_status\": rasmap_summary[\"rasmap_status\"],\n",
+    "            \"rasmap_field_error_count\": len(rasmap_summary[\"rasmap_field_errors\"]),\n",
     "            \"terrains\": len(terrain_layers),\n",
     "            \"map_layers\": len(map_layers),\n",
     "            \"reference_layers\": int((map_layers.get(\"category\", pd.Series(dtype=str)) == \"reference\").sum()) if not map_layers.empty else 0,\n",

--- a/examples/611_validating_map_layers.ipynb
+++ b/examples/611_validating_map_layers.ipynb
@@ -392,12 +392,12 @@
    "source": [
     "## 3. Discover Registered RASMapper Layers\n",
     "\n",
-    "`rasmap_df` is a compact project summary: it keeps terrain, land-cover, soils, and infiltration paths in list-valued columns so a whole project fits on one row. The layer-list methods below are more discoverable for QA/QC workflows because they return one row per registered `.rasmap` layer, including the layer name users see in RAS Mapper, the source filename, the resolved path, and available display/selection metadata.\n"
+    "`rasmap_df` is always a one-row project summary, including when the `.rasmap` is absent or cannot be parsed. Check `rasmap_status` before interpreting its list-valued terrain, land-cover, soils, and infiltration columns. After that gate, known-valid project notebooks can keep the concise `ras.rasmap_df.iloc[0][\"terrain_hdf_path\"]` access pattern. The layer-list methods below are more discoverable for QA/QC workflows because they return one row per registered `.rasmap` layer, including the layer name users see in RAS Mapper, the source filename, the resolved path, and available display/selection metadata.\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "id": "03f01429",
    "metadata": {
     "execution": {
@@ -407,252 +407,7 @@
      "shell.execute_reply": "2026-06-11T21:30:36.701879Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-06-11 17:30:36 - ras_commander.RasMap - INFO - Successfully parsed RASMapper file: <workspace>\\examples\\example_projects\\BaldEagleCrkMulti2D\\BaldEagleDamBrk.rasmap\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Reading layer catalog from: BaldEagleDamBrk.rasmap\n",
-      "\n",
-      "Compact project summary columns:\n"
-     ]
-    },
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>terrain_hdf_path</th>\n",
-       "      <th>landcover_hdf_path</th>\n",
-       "      <th>soil_layer_path</th>\n",
-       "      <th>infiltration_hdf_path</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>[<repo_root>\\symphony-workspaces\\ras-commander\\CLB-7...</td>\n",
-       "      <td>[<repo_root>\\symphony-workspaces\\ras-commander\\CLB-7...</td>\n",
-       "      <td>[<repo_root>\\symphony-workspaces\\ras-commander\\CLB-7...</td>\n",
-       "      <td>[<repo_root>\\symphony-workspaces\\ras-commander\\CLB-7...</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "                                    terrain_hdf_path  \\\n",
-       "0  [<repo_root>\\symphony-workspaces\\ras-commander\\CLB-7...   \n",
-       "\n",
-       "                                  landcover_hdf_path  \\\n",
-       "0  [<repo_root>\\symphony-workspaces\\ras-commander\\CLB-7...   \n",
-       "\n",
-       "                                     soil_layer_path  \\\n",
-       "0  [<repo_root>\\symphony-workspaces\\ras-commander\\CLB-7...   \n",
-       "\n",
-       "                               infiltration_hdf_path  \n",
-       "0  [<repo_root>\\symphony-workspaces\\ras-commander\\CLB-7...  "
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "Terrain layers registered in RASMapper:\n"
-     ]
-    },
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>name</th>\n",
-       "      <th>filename</th>\n",
-       "      <th>resolved_path</th>\n",
-       "      <th>checked</th>\n",
-       "      <th>type</th>\n",
-       "      <th>resample_method</th>\n",
-       "      <th>surface_on</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>Terrain50</td>\n",
-       "      <td>.\\Terrain\\Terrain50.hdf</td>\n",
-       "      <td><repo_root>\\symphony-workspaces\\ras-commander\\CLB-70...</td>\n",
-       "      <td>True</td>\n",
-       "      <td>TerrainLayer</td>\n",
-       "      <td>near</td>\n",
-       "      <td>True</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "        name                 filename  \\\n",
-       "0  Terrain50  .\\Terrain\\Terrain50.hdf   \n",
-       "\n",
-       "                                       resolved_path  checked          type  \\\n",
-       "0  <repo_root>\\symphony-workspaces\\ras-commander\\CLB-70...     True  TerrainLayer   \n",
-       "\n",
-       "  resample_method  surface_on  \n",
-       "0            near        True  "
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "All land-classification layers registered in RASMapper:\n"
-     ]
-    },
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>name</th>\n",
-       "      <th>classification_kind</th>\n",
-       "      <th>filename</th>\n",
-       "      <th>resolved_path</th>\n",
-       "      <th>checked</th>\n",
-       "      <th>selected_parameter</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>LandCover</td>\n",
-       "      <td>landcover</td>\n",
-       "      <td>.\\Land Classification\\LandCover.hdf</td>\n",
-       "      <td><repo_root>\\symphony-workspaces\\ras-commander\\CLB-70...</td>\n",
-       "      <td>True</td>\n",
-       "      <td>ManningsN</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>Hydrologic Soil Groups</td>\n",
-       "      <td>soils</td>\n",
-       "      <td>.\\Soils Data\\Hydrologic Soil Groups.hdf</td>\n",
-       "      <td><repo_root>\\symphony-workspaces\\ras-commander\\CLB-70...</td>\n",
-       "      <td>True</td>\n",
-       "      <td>ID</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>Infiltration</td>\n",
-       "      <td>infiltration</td>\n",
-       "      <td>.\\Soils Data\\Infiltration.hdf</td>\n",
-       "      <td><repo_root>\\symphony-workspaces\\ras-commander\\CLB-70...</td>\n",
-       "      <td>True</td>\n",
-       "      <td>ID</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "                     name classification_kind  \\\n",
-       "0               LandCover           landcover   \n",
-       "1  Hydrologic Soil Groups               soils   \n",
-       "2            Infiltration        infiltration   \n",
-       "\n",
-       "                                  filename  \\\n",
-       "0      .\\Land Classification\\LandCover.hdf   \n",
-       "1  .\\Soils Data\\Hydrologic Soil Groups.hdf   \n",
-       "2            .\\Soils Data\\Infiltration.hdf   \n",
-       "\n",
-       "                                       resolved_path  checked  \\\n",
-       "0  <repo_root>\\symphony-workspaces\\ras-commander\\CLB-70...     True   \n",
-       "1  <repo_root>\\symphony-workspaces\\ras-commander\\CLB-70...     True   \n",
-       "2  <repo_root>\\symphony-workspaces\\ras-commander\\CLB-70...     True   \n",
-       "\n",
-       "  selected_parameter  \n",
-       "0          ManningsN  \n",
-       "1                 ID  \n",
-       "2                 ID  "
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "Filtered wrappers for workflow-specific discovery:\n",
-      "  land cover:   1 layer(s)\n",
-      "  soils:        1 layer(s)\n",
-      "  infiltration: 1 layer(s)\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "rasmap_files = list(project_path.glob(\"*.rasmap\"))\n",
     "rasmap_file = rasmap_files[0] if rasmap_files else None\n",
@@ -660,6 +415,19 @@
     "if rasmap_file:\n",
     "    print(f\"Reading layer catalog from: {rasmap_file.name}\")\n",
     "    compact_rasmap_df = RasMap.parse_rasmap(rasmap_file)\n",
+    "    summary = compact_rasmap_df.iloc[0]\n",
+    "\n",
+    "    print(\"\\nParse provenance:\")\n",
+    "    display(compact_rasmap_df[[\n",
+    "        \"rasmap_path\",\n",
+    "        \"rasmap_status\",\n",
+    "        \"rasmap_error\",\n",
+    "        \"rasmap_field_errors\",\n",
+    "    ]])\n",
+    "    if summary[\"rasmap_status\"] == \"failed\":\n",
+    "        raise RuntimeError(summary[\"rasmap_error\"])\n",
+    "    if summary[\"rasmap_field_errors\"]:\n",
+    "        print(\"Fields requiring review:\", summary[\"rasmap_field_errors\"])\n",
     "\n",
     "    terrain_layers = RasMap.list_terrain_layers(project_path)\n",
     "    land_classification_layers = RasMap.list_land_classification_layers(project_path)\n",

--- a/examples/notebooks.yml
+++ b/examples/notebooks.yml
@@ -478,11 +478,12 @@ notebooks:
   - RasMap.set_terrain_layer_visibility
   - RasMap.set_update_legend_with_view
   - RasMap.zoom_to_geometry_layer
+  - RasPrj.find_ras_prj
   hec_refs: []
   learning_paths: []
   excluded: false
   code_cells: 18
-  executed_cells: 17
+  executed_cells: 15
 - id: 123_rasmapper_geometry_layer_updates
   filename: 123_rasmapper_geometry_layer_updates.ipynb
   title: RASMapper Geometry Layer Updates
@@ -2769,7 +2770,7 @@ notebooks:
   learning_paths: []
   excluded: false
   code_cells: 25
-  executed_cells: 24
+  executed_cells: 23
 - id: 612_benefit_area_analysis
   filename: 612_benefit_area_analysis.ipynb
   title: Benefit-area mapping for storm-system alternatives

--- a/ras_commander/AGENTS.md
+++ b/ras_commander/AGENTS.md
@@ -33,6 +33,9 @@ This file is the canonical local instruction file for the `ras_commander/` packa
 
 - Prefer the existing static-class pattern. Most `Ras*` and `Hdf*` classes should be called directly, not instantiated.
 - Use DataFrame-backed project metadata first. Prefer `ras.plan_df`, `ras.geom_df`, `ras.flow_df`, `ras.unsteady_df`, `ras.boundaries_df`, and related helpers over ad hoc filesystem scanning.
+- `rasmap_df` is always one row; use `rasmap_status` (or the shared schema
+  health helper), never row count, `.empty`, or non-`None`, to decide whether
+  parsed values are usable.
 - Use `pathlib.Path` consistently for file paths.
 - Keep imports ordered `stdlib -> third-party -> local`.
 - Public functions should use the repo logging pattern with `get_logger()` and `@log_call`.

--- a/ras_commander/RasCrossSections.py
+++ b/ras_commander/RasCrossSections.py
@@ -13,6 +13,7 @@ import pandas as pd
 
 from .Decorators import log_call
 from .LoggingConfig import get_logger
+from ._rasmap_schema import expected_rasmap_path, rasmap_dataframe_is_usable
 
 logger = get_logger(__name__)
 
@@ -346,6 +347,14 @@ class RasCrossSections:
     def _crs_units(crs: Any) -> str | None:
         if crs is None:
             return None
+        try:
+            from pyproj import CRS
+
+            parsed = CRS.from_user_input(crs)
+            return parsed.axis_info[0].unit_name if parsed.axis_info else None
+        except (TypeError, ValueError) as exc:
+            logger.debug("Could not determine CRS units from %r: %s", crs, exc)
+            return None
 
     @staticmethod
     def _project_mapper_crs(context: _ProjectContext) -> str | None:
@@ -353,7 +362,7 @@ class RasCrossSections:
         from .RasMap import RasMap
         from .hdf.HdfBase import HdfBase
 
-        preferred = context.folder / f"{context.model_id}.rasmap"
+        preferred = expected_rasmap_path(context.folder, context.model_id)
         if preferred.is_file():
             rasmap_path = preferred
         else:
@@ -366,7 +375,7 @@ class RasCrossSections:
             rasmap_path,
             ras_object=context.ras_object,
         )
-        if rasmap.empty or "projection_path" not in rasmap:
+        if not rasmap_dataframe_is_usable(rasmap) or "projection_path" not in rasmap:
             return None
         raw_path = rasmap.iloc[0]["projection_path"]
         if pd.isna(raw_path) or not str(raw_path).strip():
@@ -375,14 +384,6 @@ class RasCrossSections:
         if not projection_path.is_file():
             return None
         return HdfBase._get_projection_from_prj_file(projection_path)
-        try:
-            from pyproj import CRS
-
-            parsed = CRS.from_user_input(crs)
-            return parsed.axis_info[0].unit_name if parsed.axis_info else None
-        except (TypeError, ValueError) as exc:
-            logger.debug("Could not determine CRS units from %r: %s", crs, exc)
-            return None
 
     @staticmethod
     def _point_mannings(stations: np.ndarray, breakpoints: pd.DataFrame) -> np.ndarray:

--- a/ras_commander/RasMap.py
+++ b/ras_commander/RasMap.py
@@ -100,6 +100,7 @@ from ._native_helper import (
     run_store_all_maps_helper,
 )
 from ._execution_types import BenefitAreaConfig, StoreMapPerformanceOptions
+from ._rasmap_schema import create_rasmap_dataframe, expected_rasmap_path
 
 if TYPE_CHECKING:
     from geopandas import GeoDataFrame
@@ -299,37 +300,69 @@ class RasMap:
 
         Args:
             rasmap_path (Union[str, Path]): Path to the .rasmap file.
-            ras_object: Optional RAS object instance.
+            ras_object: Optional RAS object instance. Retained for API
+                compatibility; parsing does not require project state.
 
         Returns:
-            pd.DataFrame: DataFrame containing extracted information from the .rasmap file.
+            pd.DataFrame: A single-row frame containing extracted information
+                and explicit parse provenance.
         """
         rasmap_path = Path(rasmap_path)
-        from . import _land_classification_helper as _lch
-
-        if not rasmap_path.exists():
-            logger.error(f"RASMapper file not found: {rasmap_path}")
-            return _lch.empty_rasmap_dataframe()
 
         try:
-            data = _lch.empty_rasmap_dataframe().to_dict(orient="list")
+            if not rasmap_path.exists():
+                logger.error(f"RASMapper file not found: {rasmap_path}")
+                return create_rasmap_dataframe(
+                    rasmap_path=rasmap_path,
+                    rasmap_status="absent",
+                )
 
-            # Read the file content
-            with open(rasmap_path, "r", encoding="utf-8") as f:
-                xml_content = f.read()
-
-            # Check if it's a valid XML file
-            if not xml_content.strip().startswith("<"):
-                logger.error(f"File does not appear to be valid XML: {rasmap_path}")
-                return pd.DataFrame(data)
-
-            # Parse the XML file
             try:
-                tree = ET.parse(rasmap_path)
-                root = tree.getroot()
+                root = ET.fromstring(rasmap_path.read_bytes())
             except ET.ParseError as e:
                 logger.error(f"Error parsing XML in {rasmap_path}: {e}")
-                return _lch.empty_rasmap_dataframe()
+                return create_rasmap_dataframe(
+                    rasmap_path=rasmap_path,
+                    rasmap_status="failed",
+                    rasmap_error=f"ParseError: {e}",
+                )
+
+            root_name = root.tag.rsplit("}", 1)[-1]
+            if root_name != "RASMapper":
+                message = (
+                    "ValueError: Expected RASMapper root element, "
+                    f"found {root.tag!r}"
+                )
+                logger.error("Invalid RASMapper document %s: %s", rasmap_path, message)
+                return create_rasmap_dataframe(
+                    rasmap_path=rasmap_path,
+                    rasmap_status="failed",
+                    rasmap_error=message,
+                )
+
+            from . import _land_classification_helper as _lch
+            from . import _rasmap_layer_helper as _mlh
+
+            map_layers = _mlh.top_level_map_layers(root)
+            data = create_rasmap_dataframe(
+                rasmap_path=rasmap_path,
+                rasmap_status="parsed",
+            ).to_dict(orient="list")
+            field_errors: Dict[str, str] = {}
+
+            def record_field_error(
+                columns: Union[str, Sequence[str]],
+                description: str,
+                exc: Exception,
+            ) -> None:
+                affected_columns = [columns] if isinstance(columns, str) else columns
+                message = f"{type(exc).__name__}: {exc}"
+                for column in affected_columns:
+                    previous = field_errors.get(column)
+                    field_errors[column] = (
+                        f"{previous}; {message}" if previous else message
+                    )
+                logger.warning("Error extracting %s: %s", description, message)
 
             # Extract projection path
             try:
@@ -343,7 +376,7 @@ class RasMap:
                         str(projection_path) if projection_path is not None else None
                     )
             except Exception as e:
-                logger.warning(f"Error extracting projection path: {e}")
+                record_field_error("projection_path", "projection path", e)
 
             # Extract profile lines path
             try:
@@ -361,14 +394,38 @@ class RasMap:
                     if profile_lines_path is not None:
                         data["profile_lines_path"][0].append(str(profile_lines_path))
             except Exception as e:
-                logger.warning(f"Error extracting profile lines path: {e}")
+                record_field_error("profile_lines_path", "profile lines path", e)
 
+            land_columns = (
+                "soil_layer_path",
+                "infiltration_hdf_path",
+                "landcover_hdf_path",
+            )
             try:
-                land_layers = RasMap.list_land_classification_layers(
-                    rasmap_path,
-                    ras_object=ras_object,
-                )
-                if not land_layers.empty:
+                land_records = []
+                for layer in map_layers:
+                    if layer.attrib.get("Type") not in _mlh.LAND_CLASSIFICATION_LAYER_TYPES:
+                        continue
+                    try:
+                        if not layer.attrib.get("Filename", "").strip():
+                            raise ValueError(
+                                "Land-classification declaration is missing Filename"
+                            )
+                        land_records.append(
+                            _lch.build_land_classification_record(
+                                layer,
+                                rasmap_path.parent,
+                            )
+                        )
+                    except Exception as e:
+                        record_field_error(
+                            land_columns,
+                            "land-classification layer declaration",
+                            e,
+                        )
+
+                if land_records:
+                    land_layers = pd.DataFrame(land_records)
                     for kind, target_column in (
                         ("soils", "soil_layer_path"),
                         ("infiltration", "infiltration_hdf_path"),
@@ -385,53 +442,114 @@ class RasMap:
                         ]
                         data[target_column][0] = paths
             except Exception as e:
-                logger.warning(f"Error extracting land-classification layer paths: {e}")
+                record_field_error(
+                    land_columns,
+                    "land-classification layer paths",
+                    e,
+                )
 
             # Extract terrain HDF paths
             try:
                 terrain_layers = root.findall(".//Terrains/Layer")
+                terrain_paths = []
                 for layer in terrain_layers:
-                    if "Filename" in layer.attrib:
+                    try:
+                        filename = layer.attrib.get("Filename", "")
+                        if not filename.strip():
+                            raise ValueError(
+                                "Terrain layer declaration is missing Filename"
+                            )
                         terrain_path = _lch.resolve_rasmap_relative_path(
                             rasmap_path.parent,
-                            layer.attrib["Filename"],
+                            filename,
                         )
                         if terrain_path is not None:
-                            data["terrain_hdf_path"][0].append(str(terrain_path))
+                            terrain_paths.append(str(terrain_path))
+                    except Exception as e:
+                        record_field_error(
+                            "terrain_hdf_path",
+                            "terrain layer declaration",
+                            e,
+                        )
+                data["terrain_hdf_path"][0] = terrain_paths
             except Exception as e:
-                logger.warning(f"Error extracting terrain HDF paths: {e}")
+                record_field_error("terrain_hdf_path", "terrain HDF paths", e)
 
             try:
-                reference_layers = RasMap.list_reference_map_layers(
-                    rasmap_path,
-                    ras_object=ras_object,
-                )
-                if not reference_layers.empty:
-                    data["reference_map_layer_names"][0] = (
-                        reference_layers["name"].dropna().tolist()
-                    )
-                    data["reference_map_layer_path"][0] = [
-                        str(path)
-                        for path in reference_layers["resolved_path"].dropna().tolist()
-                    ]
+                reference_names = []
+                reference_paths = []
+                for layer in map_layers:
+                    if layer.attrib.get("Type") not in _mlh.REFERENCE_MAP_LAYER_TYPES:
+                        continue
+                    reference_names.append(layer.attrib.get("Name", ""))
+                    filename = layer.attrib.get("Filename", "")
+                    if not filename.strip():
+                        record_field_error(
+                            "reference_map_layer_path",
+                            "reference map layer declaration",
+                            ValueError(
+                                "Reference map layer declaration is missing Filename"
+                            ),
+                        )
+                        continue
+                    try:
+                        resolved_path = _lch.resolve_rasmap_relative_path(
+                            rasmap_path.parent,
+                            filename,
+                        )
+                        if resolved_path is not None:
+                            reference_paths.append(str(resolved_path))
+                    except Exception as e:
+                        record_field_error(
+                            "reference_map_layer_path",
+                            "reference map layer declaration",
+                            e,
+                        )
+                data["reference_map_layer_names"][0] = reference_names
+                data["reference_map_layer_path"][0] = reference_paths
             except Exception as e:
-                logger.warning(f"Error extracting reference map layers: {e}")
+                record_field_error(
+                    ("reference_map_layer_names", "reference_map_layer_path"),
+                    "reference map layers",
+                    e,
+                )
 
             try:
-                basemap_layers = RasMap.list_basemap_layers(
-                    rasmap_path,
-                    ras_object=ras_object,
-                )
-                if not basemap_layers.empty:
-                    data["basemap_layer_names"][0] = (
-                        basemap_layers["name"].dropna().tolist()
-                    )
-                    data["basemap_layer_path"][0] = [
-                        str(path)
-                        for path in basemap_layers["resolved_path"].dropna().tolist()
-                    ]
+                basemap_names = []
+                basemap_paths = []
+                for layer in map_layers:
+                    if layer.attrib.get("Type") != _mlh.BASEMAP_LAYER_TYPE:
+                        continue
+                    basemap_names.append(layer.attrib.get("Name", ""))
+                    filename = layer.attrib.get("Filename", "")
+                    if not filename.strip():
+                        record_field_error(
+                            "basemap_layer_path",
+                            "basemap layer declaration",
+                            ValueError("Basemap layer declaration is missing Filename"),
+                        )
+                        continue
+                    try:
+                        resolved_path = _lch.resolve_rasmap_relative_path(
+                            rasmap_path.parent,
+                            filename,
+                        )
+                        if resolved_path is not None:
+                            basemap_paths.append(str(resolved_path))
+                    except Exception as e:
+                        record_field_error(
+                            "basemap_layer_path",
+                            "basemap layer declaration",
+                            e,
+                        )
+                data["basemap_layer_names"][0] = basemap_names
+                data["basemap_layer_path"][0] = basemap_paths
             except Exception as e:
-                logger.warning(f"Error extracting basemap layers: {e}")
+                record_field_error(
+                    ("basemap_layer_names", "basemap_layer_path"),
+                    "basemap layers",
+                    e,
+                )
 
             # Extract current settings
             current_settings = {}
@@ -452,13 +570,18 @@ class RasMap:
 
                 data["current_settings"][0] = current_settings
             except Exception as e:
-                logger.warning(f"Error extracting current settings: {e}")
+                record_field_error("current_settings", "current settings", e)
 
-            # Create DataFrame
+            data["rasmap_field_errors"][0] = field_errors
+            data["rasmap_status"][0] = (
+                "parsed_with_errors" if field_errors else "parsed"
+            )
             df = pd.DataFrame(data)
             logger.debug(
-                "Parsed RASMapper file: %s (terrains=%d, reference_layers=%d, basemaps=%d)",
+                "Parsed RASMapper file: %s (status=%s, terrains=%d, "
+                "reference_layers=%d, basemaps=%d)",
                 rasmap_path.name,
+                data["rasmap_status"][0],
                 len(data.get("terrain_hdf_path", [[]])[0] or []),
                 len(data.get("reference_map_layer_names", [[]])[0] or []),
                 len(data.get("basemap_layer_names", [[]])[0] or []),
@@ -469,7 +592,11 @@ class RasMap:
             logger.error(
                 f"Unexpected error processing RASMapper file {rasmap_path}: {e}"
             )
-            return _lch.empty_rasmap_dataframe()
+            return create_rasmap_dataframe(
+                rasmap_path=rasmap_path,
+                rasmap_status="failed",
+                rasmap_error=f"{type(e).__name__}: {e}",
+            )
 
     @staticmethod
     @log_call
@@ -521,13 +648,11 @@ class RasMap:
             logger.error(f"Error parsing .rasmap XML: {e}")
             return pd.DataFrame(columns=columns)
 
-        map_layers = root.find("MapLayers")
-        if map_layers is None:
-            return pd.DataFrame(columns=columns)
+        from . import _rasmap_layer_helper as _mlh
 
         records = []
-        for layer in map_layers.findall("Layer"):
-            if layer.attrib.get("Type") not in {"LandCover", "LandCoverLayer"}:
+        for layer in _mlh.top_level_map_layers(root):
+            if layer.attrib.get("Type") not in _mlh.LAND_CLASSIFICATION_LAYER_TYPES:
                 continue
             records.append(
                 _lch.build_land_classification_record(
@@ -1076,7 +1201,7 @@ class RasMap:
 
         project_name = ras_obj.project_name
         project_folder = ras_obj.project_folder
-        rasmap_path = project_folder / f"{project_name}.rasmap"
+        rasmap_path = expected_rasmap_path(project_folder, project_name)
 
         if not rasmap_path.exists():
             logger.warning(f"RASMapper file not found: {rasmap_path}")
@@ -1098,14 +1223,19 @@ class RasMap:
         """
         ras_obj = ras_object or ras
         ras_obj.check_initialized()
-        from . import _land_classification_helper as _lch
 
         rasmap_path = RasMap.get_rasmap_path(ras_obj)
         if rasmap_path is None:
             logger.debug(
                 "No .rasmap file found for this project. Creating empty rasmap_df."
             )
-            return _lch.empty_rasmap_dataframe()
+            return create_rasmap_dataframe(
+                rasmap_path=expected_rasmap_path(
+                    ras_obj.project_folder,
+                    ras_obj.project_name,
+                ),
+                rasmap_status="absent",
+            )
 
         return RasMap.parse_rasmap(rasmap_path, ras_obj)
 
@@ -1497,7 +1627,7 @@ class RasMap:
         ras_obj = ras_object or ras
         ras_obj.check_initialized()
 
-        rasmap_path = ras_obj.project_folder / f"{ras_obj.project_name}.rasmap"
+        rasmap_path = expected_rasmap_path(ras_obj.project_folder, ras_obj.project_name)
         if not rasmap_path.exists():
             logger.warning(f"RASMapper file not found: {rasmap_path}")
             return False
@@ -1509,13 +1639,15 @@ class RasMap:
             logger.error(f"Error parsing .rasmap XML: {e}")
             return False
 
-        map_layers = root.find("MapLayers")
+        from . import _rasmap_layer_helper as _mlh
+
+        map_layers = _mlh.map_layers_element(root)
         if map_layers is None:
             logger.warning("No MapLayers section found in .rasmap")
             return False
 
         # Find and remove layer by name
-        for layer in map_layers.findall("Layer"):
+        for layer in _mlh.top_level_map_layers(root):
             if layer.get("Name") == layer_name:
                 map_layers.remove(layer)
                 tree.write(rasmap_path, encoding="utf-8", xml_declaration=True)
@@ -1549,7 +1681,7 @@ class RasMap:
         ras_obj = ras_object or ras
         ras_obj.check_initialized()
 
-        rasmap_path = ras_obj.project_folder / f"{ras_obj.project_name}.rasmap"
+        rasmap_path = expected_rasmap_path(ras_obj.project_folder, ras_obj.project_name)
         if not rasmap_path.exists():
             logger.warning(f"RASMapper file not found: {rasmap_path}")
             return []
@@ -1617,7 +1749,7 @@ class RasMap:
         ras_obj = ras_object or ras
         ras_obj.check_initialized()
 
-        rasmap_path = ras_obj.project_folder / f"{ras_obj.project_name}.rasmap"
+        rasmap_path = expected_rasmap_path(ras_obj.project_folder, ras_obj.project_name)
         if not rasmap_path.exists():
             logger.warning(f"RASMapper file not found: {rasmap_path}")
             return False
@@ -1696,7 +1828,7 @@ class RasMap:
         ras_obj = ras_object or ras
         ras_obj.check_initialized()
 
-        rasmap_path = ras_obj.project_folder / f"{ras_obj.project_name}.rasmap"
+        rasmap_path = expected_rasmap_path(ras_obj.project_folder, ras_obj.project_name)
         if not rasmap_path.exists():
             logger.warning(f"RASMapper file not found: {rasmap_path}")
             return 0
@@ -2381,7 +2513,7 @@ class RasMap:
         prj_path = Path(ras_project_path)
         project_folder = prj_path.parent
         project_name = prj_path.stem
-        rasmap_path = project_folder / f"{project_name}.rasmap"
+        rasmap_path = expected_rasmap_path(project_folder, project_name)
 
         # Backup .rasmap
         rasmap_backup = None
@@ -2692,7 +2824,7 @@ class RasMap:
         ras_obj.check_initialized()
 
         # Get .rasmap path
-        rasmap_path = ras_obj.project_folder / f"{ras_obj.project_name}.rasmap"
+        rasmap_path = expected_rasmap_path(ras_obj.project_folder, ras_obj.project_name)
 
         if not rasmap_path.exists():
             logger.warning(f"No .rasmap file found: {rasmap_path}")
@@ -3080,7 +3212,7 @@ class RasMap:
             [plan_number] if isinstance(plan_number, str) else plan_number
         )
 
-        rasmap_path = ras_obj.project_folder / f"{ras_obj.project_name}.rasmap"
+        rasmap_path = expected_rasmap_path(ras_obj.project_folder, ras_obj.project_name)
         rasmap_backup_path = rasmap_path.with_suffix(
             f"{rasmap_path.suffix}.storedmap.bak"
         )
@@ -4017,7 +4149,7 @@ class RasMap:
             [plan_number] if isinstance(plan_number, str) else list(plan_number)
         )
 
-        rasmap_path = ras_obj.project_folder / f"{ras_obj.project_name}.rasmap"
+        rasmap_path = expected_rasmap_path(ras_obj.project_folder, ras_obj.project_name)
         if not rasmap_path.exists():
             raise FileNotFoundError(f".rasmap file not found: {rasmap_path}")
 
@@ -4403,7 +4535,7 @@ class RasMap:
             )
 
         # Get rasmap path
-        rasmap_path = ras_obj.project_folder / f"{ras_obj.project_name}.rasmap"
+        rasmap_path = expected_rasmap_path(ras_obj.project_folder, ras_obj.project_name)
         if not rasmap_path.exists():
             raise FileNotFoundError(f"RASMapper file not found: {rasmap_path}")
 
@@ -4528,7 +4660,7 @@ class RasMap:
         ras_obj = ras_object or ras
         ras_obj.check_initialized()
 
-        rasmap_path = ras_obj.project_folder / f"{ras_obj.project_name}.rasmap"
+        rasmap_path = expected_rasmap_path(ras_obj.project_folder, ras_obj.project_name)
         if not rasmap_path.exists():
             logger.warning(f"RASMapper file not found: {rasmap_path}")
             return None
@@ -5111,7 +5243,7 @@ class RasMap:
         ras_obj = ras_object or ras
         ras_obj.check_initialized()
 
-        rasmap_path = ras_obj.project_folder / f"{ras_obj.project_name}.rasmap"
+        rasmap_path = expected_rasmap_path(ras_obj.project_folder, ras_obj.project_name)
         if not rasmap_path.exists():
             logger.warning(f"RASMapper file not found: {rasmap_path}")
             return []
@@ -5165,7 +5297,7 @@ class RasMap:
         )
         project_folder = plan_path.parent
         project_name = _project_name_from_plan_path(plan_path)
-        rasmap_path = project_folder / f"{project_name}.rasmap"
+        rasmap_path = expected_rasmap_path(project_folder, project_name)
         hdf_path = Path(str(plan_path) + ".hdf")
 
         if not hdf_path.exists():
@@ -5243,7 +5375,7 @@ class RasMap:
         )
         project_folder = plan_path.parent
         project_name = _project_name_from_plan_path(plan_path)
-        rasmap_path = project_folder / f"{project_name}.rasmap"
+        rasmap_path = expected_rasmap_path(project_folder, project_name)
 
         if rasmap_path.exists():
             try:
@@ -5329,7 +5461,7 @@ class RasMap:
         ras_obj = ras_object or ras
         ras_obj.check_initialized()
 
-        rasmap_path = ras_obj.project_folder / f"{ras_obj.project_name}.rasmap"
+        rasmap_path = expected_rasmap_path(ras_obj.project_folder, ras_obj.project_name)
         if not rasmap_path.exists():
             logger.warning(f"RASMapper file not found: {rasmap_path}")
             return []
@@ -5393,7 +5525,7 @@ class RasMap:
         ras_obj = ras_object or ras
         ras_obj.check_initialized()
 
-        rasmap_path = ras_obj.project_folder / f"{ras_obj.project_name}.rasmap"
+        rasmap_path = expected_rasmap_path(ras_obj.project_folder, ras_obj.project_name)
         if not rasmap_path.exists():
             raise FileNotFoundError(f"RASMapper file not found: {rasmap_path}")
 
@@ -5492,7 +5624,7 @@ class RasMap:
         ras_obj = ras_object or ras
         ras_obj.check_initialized()
 
-        rasmap_path = ras_obj.project_folder / f"{ras_obj.project_name}.rasmap"
+        rasmap_path = expected_rasmap_path(ras_obj.project_folder, ras_obj.project_name)
         if not rasmap_path.exists():
             logger.warning(f"RASMapper file not found: {rasmap_path}")
             return []
@@ -5616,7 +5748,7 @@ class RasMap:
         ras_obj = ras_object or ras
         ras_obj.check_initialized()
 
-        rasmap_path = ras_obj.project_folder / f"{ras_obj.project_name}.rasmap"
+        rasmap_path = expected_rasmap_path(ras_obj.project_folder, ras_obj.project_name)
         if not rasmap_path.exists():
             raise FileNotFoundError(f"RASMapper file not found: {rasmap_path}")
 
@@ -5741,7 +5873,7 @@ class RasMap:
         ras_obj = ras_object or ras
         ras_obj.check_initialized()
 
-        rasmap_path = ras_obj.project_folder / f"{ras_obj.project_name}.rasmap"
+        rasmap_path = expected_rasmap_path(ras_obj.project_folder, ras_obj.project_name)
         if not rasmap_path.exists():
             logger.warning(f"RASMapper file not found: {rasmap_path}")
             return False
@@ -5882,7 +6014,7 @@ class RasMap:
                 )
 
         # Validate terrain names exist
-        rasmap_path = ras_obj.project_folder / f"{ras_obj.project_name}.rasmap"
+        rasmap_path = expected_rasmap_path(ras_obj.project_folder, ras_obj.project_name)
         terrain_names = RasMap.get_terrain_names(rasmap_path)
         for t_name in (exist_terrain, prop_terrain):
             if t_name not in terrain_names:

--- a/ras_commander/RasPrj.py
+++ b/ras_commander/RasPrj.py
@@ -75,15 +75,18 @@ Functions in RasPrj that are not part of the class:
         
         
 """
-import os
 import re
 from dataclasses import dataclass
 from pathlib import Path
 import pandas as pd
 from typing import Union, Any, List, Dict, Tuple, Optional
-import logging
 from ras_commander.LoggingConfig import get_logger
 from ras_commander.Decorators import log_call
+from ras_commander._rasmap_schema import (
+    create_rasmap_dataframe,
+    expected_rasmap_path,
+    rasmap_dataframe_is_usable,
+)
 
 logger = get_logger(__name__)
 
@@ -235,24 +238,37 @@ class RasPrj:
         self.boundaries_df = self.get_boundary_conditions()
         
         # Load RASMapper data if available
+        # Import here to avoid circular imports. Keep import failure distinct
+        # from an ImportError raised while initializing a successfully imported
+        # RasMap implementation.
         try:
-            # Import here to avoid circular imports
             from .RasMap import RasMap
-            self.rasmap_df = RasMap.initialize_rasmap_df(self)
-        except ImportError:
-            logger.warning("RasMap module not available. RASMapper data will not be loaded.")
-            self.rasmap_df = pd.DataFrame(columns=['projection_path', 'profile_lines_path', 'soil_layer_path', 
-                                                'infiltration_hdf_path', 'landcover_hdf_path', 'terrain_hdf_path', 
-                                                'reference_map_layer_names', 'reference_map_layer_path',
-                                                'basemap_layer_names', 'basemap_layer_path',
-                                                'current_settings'])
-        except Exception as e:
-            logger.error(f"Error initializing RASMapper data: {e}")
-            self.rasmap_df = pd.DataFrame(columns=['projection_path', 'profile_lines_path', 'soil_layer_path',
-                                                'infiltration_hdf_path', 'landcover_hdf_path', 'terrain_hdf_path',
-                                                'reference_map_layer_names', 'reference_map_layer_path',
-                                                'basemap_layer_names', 'basemap_layer_path',
-                                                'current_settings'])
+        except ImportError as e:
+            logger.warning(
+                "RasMap module not available. RASMapper data will not be loaded: %s",
+                e,
+            )
+            self.rasmap_df = create_rasmap_dataframe(
+                rasmap_path=expected_rasmap_path(
+                    self.project_folder,
+                    self.project_name,
+                ),
+                rasmap_status="failed",
+                rasmap_error=f"ImportError: {e}",
+            )
+        else:
+            try:
+                self.rasmap_df = RasMap.initialize_rasmap_df(self)
+            except Exception as e:
+                logger.error(f"Error initializing RASMapper data: {e}")
+                self.rasmap_df = create_rasmap_dataframe(
+                    rasmap_path=expected_rasmap_path(
+                        self.project_folder,
+                        self.project_name,
+                    ),
+                    rasmap_status="failed",
+                    rasmap_error=f"{type(e).__name__}: {e}",
+                )
 
         if load_hdf_metadata:
             self.refresh_project_crs()
@@ -283,7 +299,10 @@ class RasPrj:
                 ).dropna()
             )
             logger.info(f"Geometry HDF files found: {geometry_hdf_count}")
-            logger.info(f"RASMapper data loaded: {not self.rasmap_df.empty}")
+            logger.info(
+                "RASMapper data loaded: %s",
+                rasmap_dataframe_is_usable(self.rasmap_df),
+            )
             logger.info(f"Results summaries loaded: {len(self.results_df)} plans with HDF results")
 
     @log_call
@@ -1257,7 +1276,7 @@ class RasPrj:
         return (self.project_folder / path_value).resolve(strict=False)
 
     def _get_rasmap_scalar_path(self, column: str) -> Optional[Path]:
-        if getattr(self, 'rasmap_df', None) is None or self.rasmap_df.empty:
+        if not rasmap_dataframe_is_usable(getattr(self, 'rasmap_df', None)):
             return None
 
         if column not in self.rasmap_df.columns:
@@ -1270,7 +1289,7 @@ class RasPrj:
         return self._resolve_candidate_path(paths[0])
 
     def _get_rasmap_list_paths(self, column: str) -> List[Path]:
-        if getattr(self, 'rasmap_df', None) is None or self.rasmap_df.empty:
+        if not rasmap_dataframe_is_usable(getattr(self, 'rasmap_df', None)):
             return []
 
         if column not in self.rasmap_df.columns:
@@ -2539,7 +2558,7 @@ def init_ras_project(
                 error_msg = f"The file does not appear to be a valid HEC-RAS project file (missing 'Proj Title='): {input_path}"
                 logger.error(error_msg)
                 raise ValueError(f"{error_msg}. Please provide a valid HEC-RAS .prj file.")
-            logger.debug(f"Validated .prj file contains 'Proj Title=' marker")
+            logger.debug("Validated .prj file contains 'Proj Title=' marker")
         except Exception as e:
             error_msg = f"Error validating .prj file: {e}"
             logger.error(error_msg)
@@ -2825,8 +2844,8 @@ def get_ras_exe(ras_version=None):
             return ras.ras_exe_path
         else:
             default_path = "Ras.exe"
-            logger.debug(f"No HEC-RAS version specified and global 'ras' object not initialized or missing ras_exe_path.")
-            logger.warning(f"HEC-RAS is not installed or version not specified. Running HEC-RAS will fail unless a valid installed version is specified.")
+            logger.debug("No HEC-RAS version specified and global 'ras' object not initialized or missing ras_exe_path.")
+            logger.warning("HEC-RAS is not installed or version not specified. Running HEC-RAS will fail unless a valid installed version is specified.")
             return default_path
 
     discovered_versions = "not checked"

--- a/ras_commander/RasProject.py
+++ b/ras_commander/RasProject.py
@@ -30,6 +30,7 @@ from .LoggingConfig import get_logger
 from .RasPrj import RasPrj, init_ras_project
 from .RasUnsteady import RasUnsteady
 from .RasUtils import RasUtils
+from ._rasmap_schema import expected_rasmap_path, rasmap_dataframe_is_usable
 from .schemas import DATAFRAME_SCHEMAS
 
 logger = get_logger(__name__)
@@ -1179,13 +1180,9 @@ def _inspect_project_assets_impl(
                     occurrence=occurrence * max(len(plan_numbers), 1) + scope_index,
                 )
 
-    rasmap_path = project_root / f"{project_file.stem}.rasmap"
+    rasmap_path = expected_rasmap_path(project_root, project_file.stem)
     rasmap_id: Optional[str] = None
-    if _path_exists(rasmap_path) or getattr(
-        ras_obj,
-        "rasmap_df",
-        pd.DataFrame(),
-    ).shape[0]:
+    if _path_exists(rasmap_path):
         rasmap_id = _add_asset(
             rows,
             inventory_id=inventory_id,
@@ -1203,8 +1200,12 @@ def _inspect_project_assets_impl(
         )
 
     rasmap_df = getattr(ras_obj, "rasmap_df", pd.DataFrame())
+    rasmap_usable = rasmap_dataframe_is_usable(rasmap_df)
     seen_map_paths: set[str] = set()
-    if _path_is_file(rasmap_path) and rasmap_df.empty:
+    if _path_is_file(rasmap_path) and not rasmap_usable:
+        summary = rasmap_df.iloc[0] if not rasmap_df.empty else {}
+        status = summary.get("rasmap_status") if hasattr(summary, "get") else None
+        error = summary.get("rasmap_error") if hasattr(summary, "get") else None
         _add_asset(
             rows,
             inventory_id=inventory_id,
@@ -1223,16 +1224,44 @@ def _inspect_project_assets_impl(
             readiness="unknown",
             reason_code="rasmap_structured_inventory_empty",
             detail=(
-                "RASMapper exists but the structured parser returned no rows; "
-                "raw XML references are inventoried separately"
+                "RASMapper exists but its structured summary is unusable "
+                f"(status={status!r}, error={error!r}); raw XML references "
+                "are inventoried separately"
             ),
             id_discriminator="rasmap_structured_inventory_empty",
         )
-    if not rasmap_df.empty:
+    if rasmap_usable:
+        summary = rasmap_df.iloc[0]
+        field_errors = summary.get("rasmap_field_errors", {})
+        if isinstance(field_errors, dict):
+            for occurrence, (column, error) in enumerate(
+                sorted(field_errors.items())
+            ):
+                _add_asset(
+                    rows,
+                    inventory_id=inventory_id,
+                    depth=depth,
+                    project_root=project_root,
+                    kind="unknown_reference",
+                    role="unknown",
+                    owner=rasmap_path,
+                    raw=None,
+                    path=None,
+                    required=None,
+                    source_api=f"RasPrj.rasmap_df.{column}",
+                    hash_files=hash_files,
+                    parent_asset_id=rasmap_id,
+                    state="not_inspected",
+                    readiness="unknown",
+                    reason_code="rasmap_field_parse_failed",
+                    detail=f"{column}: {error}"[:500],
+                    occurrence=occurrence,
+                    id_discriminator=f"rasmap_field_parse_failed:{column}",
+                )
         for column, kind in _RASMAP_KINDS.items():
             if column not in rasmap_df.columns:
                 continue
-            for occurrence, raw_path in enumerate(_as_values(rasmap_df.iloc[0].get(column))):
+            for occurrence, raw_path in enumerate(_as_values(summary.get(column))):
                 path = RasUtils.safe_resolve(Path(raw_path))
                 seen_map_paths.add(os.path.normcase(str(path)))
                 map_required = False if kind in {"stored_map", "projection"} else None

--- a/ras_commander/_geometry_association.py
+++ b/ras_commander/_geometry_association.py
@@ -353,6 +353,8 @@ def list_registered_rasmap_layers(
     rasmap_path: Optional[PathLike] = None,
 ) -> list[dict[str, Any]]:
     """List terrain and land-classification layer names registered in .rasmap."""
+    from . import _rasmap_layer_helper as _mlh
+
     project_folder = safe_resolve_path(project_folder)
     rasmap_path = Path(rasmap_path) if rasmap_path is not None else None
     if rasmap_path is None:
@@ -377,25 +379,23 @@ def list_registered_rasmap_layers(
             }
         )
 
-    map_layers = root.find("MapLayers")
-    if map_layers is not None:
-        for layer in map_layers.findall("Layer"):
-            if layer.attrib.get("Type") != "LandCoverLayer":
-                continue
-            filename = layer.attrib.get("Filename")
-            resolved_path = _resolve_rasmap_filename(project_folder, filename)
-            records.append(
-                {
-                    "name": layer.attrib.get("Name", ""),
-                    "type": layer.attrib.get("Type", ""),
-                    "filename": filename,
-                    "resolved_path": str(resolved_path) if resolved_path else None,
-                    "layer_kind": _infer_land_classification_kind(
-                        filename,
-                        _get_selected_parameter(layer),
-                    ),
-                }
-            )
+    for layer in _mlh.top_level_map_layers(root):
+        if layer.attrib.get("Type") not in _mlh.LAND_CLASSIFICATION_LAYER_TYPES:
+            continue
+        filename = layer.attrib.get("Filename")
+        resolved_path = _resolve_rasmap_filename(project_folder, filename)
+        records.append(
+            {
+                "name": layer.attrib.get("Name", ""),
+                "type": layer.attrib.get("Type", ""),
+                "filename": filename,
+                "resolved_path": str(resolved_path) if resolved_path else None,
+                "layer_kind": _infer_land_classification_kind(
+                    filename,
+                    _get_selected_parameter(layer),
+                ),
+            }
+        )
 
     return records
 

--- a/ras_commander/_land_classification_helper.py
+++ b/ras_commander/_land_classification_helper.py
@@ -25,6 +25,7 @@ import pandas as pd
 
 from .LoggingConfig import get_logger
 from .RasUtils import RasUtils
+from ._rasmap_schema import create_rasmap_dataframe, expected_rasmap_path
 from ._spatial_extent import _normalize_extent_bounds
 
 logger = get_logger(__name__)
@@ -282,22 +283,8 @@ class LandClassificationProjectPaths:
 
 
 def empty_rasmap_dataframe() -> pd.DataFrame:
-    """Return the default single-row RasMap dataframe shape."""
-    return pd.DataFrame(
-        {
-            "projection_path": [None],
-            "profile_lines_path": [[]],
-            "soil_layer_path": [[]],
-            "infiltration_hdf_path": [[]],
-            "landcover_hdf_path": [[]],
-            "terrain_hdf_path": [[]],
-            "reference_map_layer_names": [[]],
-            "reference_map_layer_path": [[]],
-            "basemap_layer_names": [[]],
-            "basemap_layer_path": [[]],
-            "current_settings": [{}],
-        }
-    )
+    """Return a fresh absent-state ``rasmap_df`` summary row."""
+    return create_rasmap_dataframe()
 
 
 def _find_hecras_dir() -> Path:
@@ -492,12 +479,12 @@ def resolve_project_paths(
                 f"No HEC-RAS .prj file found in project folder: {project_folder}"
             )
         project_name = prj_path.stem
-        rasmap_path = project_folder / f"{project_name}.rasmap"
+        rasmap_path = expected_rasmap_path(project_folder, project_name)
     elif project_path.suffix.lower() == ".prj":
         prj_path = RasUtils.safe_resolve(project_path)
         project_folder = prj_path.parent
         project_name = prj_path.stem
-        rasmap_path = project_folder / f"{project_name}.rasmap"
+        rasmap_path = expected_rasmap_path(project_folder, project_name)
     elif project_path.suffix.lower() == ".rasmap":
         rasmap_path = RasUtils.safe_resolve(project_path)
         project_folder = rasmap_path.parent
@@ -1345,7 +1332,9 @@ def _load_rasmap_tree(
 
 
 def _ensure_map_layers(root: ET.Element) -> ET.Element:
-    map_layers = root.find("MapLayers")
+    from . import _rasmap_layer_helper as _mlh
+
+    map_layers = _mlh.map_layers_element(root)
     if map_layers is None:
         map_layers = ET.SubElement(root, "MapLayers")
     return map_layers
@@ -1356,9 +1345,11 @@ def _remove_existing_landcover_layers(
     project_folder: Path,
     target_path: Path,
 ) -> None:
+    from . import _rasmap_layer_helper as _mlh
+
     target_path = RasUtils.safe_resolve(target_path)
-    for layer in list(map_layers.findall("Layer")):
-        if layer.attrib.get("Type") not in {"LandCover", "LandCoverLayer"}:
+    for layer in _mlh.map_layer_children(map_layers):
+        if layer.attrib.get("Type") not in _mlh.LAND_CLASSIFICATION_LAYER_TYPES:
             continue
         resolved = resolve_rasmap_relative_path(
             project_folder,
@@ -1462,6 +1453,8 @@ def upsert_land_classification_layer(
 def _list_land_classification_records(
     project_paths: LandClassificationProjectPaths,
 ) -> pd.DataFrame:
+    from . import _rasmap_layer_helper as _mlh
+
     columns = [
         "name",
         "type",
@@ -1478,13 +1471,9 @@ def _list_land_classification_records(
         return pd.DataFrame(columns=columns)
 
     root = ET.parse(project_paths.rasmap_path).getroot()
-    map_layers = root.find("MapLayers")
-    if map_layers is None:
-        return pd.DataFrame(columns=columns)
-
     records = []
-    for layer in map_layers.findall("Layer"):
-        if layer.attrib.get("Type") not in {"LandCover", "LandCoverLayer"}:
+    for layer in _mlh.top_level_map_layers(root):
+        if layer.attrib.get("Type") not in _mlh.LAND_CLASSIFICATION_LAYER_TYPES:
             continue
         records.append(
             build_land_classification_record(

--- a/ras_commander/_rasmap_layer_helper.py
+++ b/ras_commander/_rasmap_layer_helper.py
@@ -24,6 +24,7 @@ REFERENCE_MAP_LAYER_TYPES = frozenset(
     }
 )
 BASEMAP_LAYER_TYPE = "WMSLayer"
+LAND_CLASSIFICATION_LAYER_TYPES = frozenset({"LandCover", "LandCoverLayer"})
 
 STANDARD_BASEMAP_LAYERS: dict[str, str] = {
     "Google Hybrid": r"%LocalAppData%\HEC\Mapping\5.1\XML\Google Hybrid.xml",
@@ -59,6 +60,34 @@ MAP_LAYER_COLUMNS = [
 ]
 
 
+def _local_name(tag: str) -> str:
+    """Return an XML tag without an optional namespace."""
+    return tag.rsplit("}", 1)[-1]
+
+
+def map_layers_element(root: ET.Element) -> Optional[ET.Element]:
+    """Return the direct ``MapLayers`` container from a parsed root."""
+    return next(
+        (child for child in root if _local_name(child.tag) == "MapLayers"),
+        None,
+    )
+
+
+def map_layer_children(map_layers: ET.Element) -> tuple[ET.Element, ...]:
+    """Return direct ``Layer`` children from a ``MapLayers`` container."""
+    return tuple(
+        child for child in map_layers if _local_name(child.tag) == "Layer"
+    )
+
+
+def top_level_map_layers(root: ET.Element) -> tuple[ET.Element, ...]:
+    """Return direct ``MapLayers/Layer`` declarations from a parsed root."""
+    map_layers = map_layers_element(root)
+    if map_layers is None:
+        return ()
+    return map_layer_children(map_layers)
+
+
 def list_available_basemaps() -> pd.DataFrame:
     """Return the standard HEC-RAS 6.x basemap entries observed in .rasmap XML."""
     return pd.DataFrame(
@@ -81,12 +110,12 @@ def list_map_layers(ras_project_path: Union[str, Path]) -> pd.DataFrame:
         return pd.DataFrame(columns=MAP_LAYER_COLUMNS)
 
     root = ET.parse(project_paths.rasmap_path).getroot()
-    map_layers = root.find("MapLayers")
-    if map_layers is None:
+    layers = top_level_map_layers(root)
+    if not layers:
         return pd.DataFrame(columns=MAP_LAYER_COLUMNS)
 
     records = []
-    for position, layer in enumerate(map_layers.findall("Layer")):
+    for position, layer in enumerate(layers):
         records.append(_build_map_layer_record(project_paths, layer, position))
 
     return pd.DataFrame(records, columns=MAP_LAYER_COLUMNS)
@@ -127,7 +156,7 @@ def set_map_layer_visibility(
     """
     project_paths = _lch.resolve_project_paths(ras_project_path)
     tree, root = _load_rasmap_tree(project_paths.rasmap_path)
-    map_layers = root.find("MapLayers")
+    map_layers = map_layers_element(root)
     if map_layers is None:
         return 0
 
@@ -135,7 +164,7 @@ def set_map_layer_visibility(
     types = _normalize_string_filter(layer_type)
     categories = _normalize_string_filter(category)
     has_selector = any((names, types, categories))
-    layers = list(map_layers.findall("Layer"))
+    layers = list(map_layer_children(map_layers))
     matches = [
         layer
         for layer in layers
@@ -396,7 +425,7 @@ def _classify_map_layer(layer: ET.Element) -> str:
         return "basemap"
     if layer_type in REFERENCE_MAP_LAYER_TYPES:
         return "reference"
-    if layer_type == "LandCoverLayer":
+    if layer_type in LAND_CLASSIFICATION_LAYER_TYPES:
         return "land_classification"
     return "other"
 
@@ -428,7 +457,7 @@ def _load_rasmap_tree(rasmap_path: Path) -> tuple[ET.ElementTree, ET.Element]:
 
 
 def _ensure_map_layers(root: ET.Element) -> ET.Element:
-    map_layers = root.find("MapLayers")
+    map_layers = map_layers_element(root)
     if map_layers is not None:
         return map_layers
 
@@ -471,7 +500,7 @@ def _remove_existing_layers(
     layer_types: Iterable[str],
 ) -> None:
     layer_type_set = set(layer_types)
-    for layer in list(map_layers.findall("Layer")):
+    for layer in map_layer_children(map_layers):
         if layer.attrib.get("Name") == name and layer.attrib.get("Type") in layer_type_set:
             map_layers.remove(layer)
 

--- a/ras_commander/_rasmap_schema.py
+++ b/ras_commander/_rasmap_schema.py
@@ -1,0 +1,91 @@
+"""Lightweight schema helpers for the single-row ``rasmap_df`` contract."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Mapping, Optional, Union
+
+import pandas as pd
+
+
+RASMAP_LEGACY_COLUMNS = (
+    "projection_path",
+    "profile_lines_path",
+    "soil_layer_path",
+    "infiltration_hdf_path",
+    "landcover_hdf_path",
+    "terrain_hdf_path",
+    "reference_map_layer_names",
+    "reference_map_layer_path",
+    "basemap_layer_names",
+    "basemap_layer_path",
+    "current_settings",
+)
+
+RASMAP_PROVENANCE_COLUMNS = (
+    "rasmap_path",
+    "rasmap_status",
+    "rasmap_error",
+    "rasmap_field_errors",
+)
+
+RASMAP_COLUMNS = RASMAP_LEGACY_COLUMNS + RASMAP_PROVENANCE_COLUMNS
+RASMAP_STATUSES = frozenset({"absent", "parsed", "parsed_with_errors", "failed"})
+RASMAP_USABLE_STATUSES = frozenset({"parsed", "parsed_with_errors"})
+
+
+def expected_rasmap_path(
+    project_folder: Union[str, Path],
+    project_name: str,
+) -> Path:
+    """Return the canonical project ``.rasmap`` path."""
+    return Path(project_folder) / f"{project_name}.rasmap"
+
+
+def create_rasmap_dataframe(
+    *,
+    rasmap_path: Optional[Union[str, Path]] = None,
+    rasmap_status: str = "absent",
+    rasmap_error: Optional[str] = None,
+    rasmap_field_errors: Optional[Mapping[str, str]] = None,
+) -> pd.DataFrame:
+    """Return a fresh, single-row ``rasmap_df`` with explicit parse provenance."""
+    if rasmap_status not in RASMAP_STATUSES:
+        raise ValueError(
+            f"Unsupported rasmap_status {rasmap_status!r}; "
+            f"expected one of {sorted(RASMAP_STATUSES)}"
+        )
+
+    return pd.DataFrame(
+        {
+            "projection_path": [None],
+            "profile_lines_path": [[]],
+            "soil_layer_path": [[]],
+            "infiltration_hdf_path": [[]],
+            "landcover_hdf_path": [[]],
+            "terrain_hdf_path": [[]],
+            "reference_map_layer_names": [[]],
+            "reference_map_layer_path": [[]],
+            "basemap_layer_names": [[]],
+            "basemap_layer_path": [[]],
+            "current_settings": [{}],
+            "rasmap_path": [str(rasmap_path) if rasmap_path is not None else None],
+            "rasmap_status": [rasmap_status],
+            "rasmap_error": [rasmap_error],
+            "rasmap_field_errors": [dict(rasmap_field_errors or {})],
+        },
+        columns=RASMAP_COLUMNS,
+    )
+
+
+def rasmap_dataframe_is_usable(rasmap_df: Any) -> bool:
+    """Return whether a frame contains a usable RASMapper summary row.
+
+    Frames created before provenance columns were introduced remain usable when
+    they contain a row. New frames are usable only after a full or partial parse.
+    """
+    if not isinstance(rasmap_df, pd.DataFrame) or rasmap_df.empty:
+        return False
+    if "rasmap_status" not in rasmap_df.columns:
+        return True
+    return rasmap_df.iloc[0].get("rasmap_status") in RASMAP_USABLE_STATUSES

--- a/ras_commander/hdf/HdfInfiltration.py
+++ b/ras_commander/hdf/HdfInfiltration.py
@@ -68,6 +68,7 @@ from .HdfBase import HdfBase
 from .HdfUtils import HdfUtils
 from ..Decorators import standardize_input, log_call
 from ..LoggingConfig import get_logger
+from .._rasmap_schema import rasmap_dataframe_is_usable
 
 if TYPE_CHECKING:
     import geopandas as gpd
@@ -127,6 +128,70 @@ class HdfInfiltration:
         'Wetting Front Suction', 'Saturated Hydraulic Conductivity',
         'Initial Soil Water Content', 'Saturated Soil Water Content',
     ]
+
+    @staticmethod
+    def _resolve_rasmap_hdf_path(
+        explicit_path: Optional[Union[str, Path]],
+        column: str,
+        ras_object: Any = None,
+    ) -> Path:
+        """Resolve an explicit path or the first usable ``rasmap_df`` value."""
+        layer_label = {
+            "infiltration_hdf_path": "infiltration",
+            "soil_layer_path": "soil",
+            "landcover_hdf_path": "land cover",
+        }.get(column, column)
+        if explicit_path is not None:
+            return Path(explicit_path)
+
+        if ras_object is None:
+            from ..RasPrj import ras
+
+            ras_object = ras
+
+        rasmap_df = getattr(ras_object, "rasmap_df", None)
+        if rasmap_df is None or rasmap_df.empty:
+            raise ValueError(
+                f"No {column} was provided and rasmap_df has no summary row. "
+                "Pass the HDF path explicitly or initialize a project with a "
+                "usable RASMapper layer."
+            )
+
+        summary = rasmap_df.iloc[0]
+        status = summary.get("rasmap_status")
+        rasmap_path = summary.get("rasmap_path")
+        context = f"rasmap_status={status!r}"
+        if rasmap_path:
+            context += f", rasmap_path={rasmap_path!r}"
+
+        if not rasmap_dataframe_is_usable(rasmap_df):
+            detail = summary.get("rasmap_error")
+            if detail:
+                context += f", rasmap_error={detail!r}"
+            raise ValueError(
+                f"Cannot resolve {column} from rasmap_df ({context}). Pass "
+                "the HDF path explicitly or correct the RASMapper configuration."
+            )
+
+        candidates = summary.get(column)
+        if isinstance(candidates, (list, tuple, np.ndarray)) and len(candidates):
+            candidate = candidates[0]
+            if candidate not in (None, ""):
+                return Path(candidate)
+        elif isinstance(candidates, (str, Path)) and str(candidates):
+            return Path(candidates)
+
+        field_errors = summary.get("rasmap_field_errors", {})
+        if isinstance(field_errors, dict) and column in field_errors:
+            raise ValueError(
+                f"Cannot resolve {column} because that RASMapper field failed "
+                f"to parse ({context}): {field_errors[column]}"
+            )
+
+        raise ValueError(
+            f"No {layer_label} layer is configured in rasmap_df ({context}). Pass "
+            "the HDF path explicitly or add the corresponding layer in RASMapper."
+        )
 
     @staticmethod
     def _is_nodata_value(value: Any, no_data: Any) -> bool:
@@ -1134,21 +1199,21 @@ class HdfInfiltration:
         # Import here to avoid circular imports
         from .HdfMesh import HdfMesh
         
-        # Get the soil HDF path
-        if soil_hdf_path is None:
-            if ras_object is None:
-                from ..RasPrj import ras
-                ras_object = ras
-            
-            # Try to get soil_layer_path from rasmap_df
-            try:
-                soil_hdf_path = Path(ras_object.rasmap_df.loc[0, 'soil_layer_path'][0])
-                if not soil_hdf_path.exists():
-                    logger.warning(f"Soil HDF path from rasmap_df does not exist: {soil_hdf_path}")
-                    return pd.DataFrame()
-            except (KeyError, IndexError, AttributeError, TypeError) as e:
-                logger.error(f"Error retrieving soil_layer_path from rasmap_df: {str(e)}")
+        try:
+            soil_hdf_path = HdfInfiltration._resolve_rasmap_hdf_path(
+                soil_hdf_path,
+                "soil_layer_path",
+                ras_object,
+            )
+            if not soil_hdf_path.exists():
+                logger.warning(
+                    "Soil HDF path does not exist: %s",
+                    soil_hdf_path,
+                )
                 return pd.DataFrame()
+        except (ValueError, KeyError, IndexError, AttributeError, TypeError) as e:
+            logger.error("Error resolving soil_layer_path: %s", e)
+            return pd.DataFrame()
         
         # Get infiltration map - pass as hdf_path to ensure standardize_input works correctly
         try:
@@ -1336,27 +1401,27 @@ class HdfInfiltration:
             from ..RasPrj import ras
             ras_object = ras
         
-        # Get the landcover HDF path
-        if landcover_hdf_path is None:
-            try:
-                landcover_hdf_path = Path(ras_object.rasmap_df.loc[0, 'landcover_hdf_path'][0])
-                if not landcover_hdf_path.exists():
-                    logger.warning(f"Land cover HDF path from rasmap_df does not exist: {landcover_hdf_path}")
+        try:
+            landcover_hdf_path = HdfInfiltration._resolve_rasmap_hdf_path(
+                landcover_hdf_path,
+                "landcover_hdf_path",
+                ras_object,
+            )
+            soil_hdf_path = HdfInfiltration._resolve_rasmap_hdf_path(
+                soil_hdf_path,
+                "soil_layer_path",
+                ras_object,
+            )
+            for label, path in (
+                ("Land cover", landcover_hdf_path),
+                ("Soil", soil_hdf_path),
+            ):
+                if not path.exists():
+                    logger.warning("%s HDF path does not exist: %s", label, path)
                     return pd.DataFrame()
-            except (KeyError, IndexError, AttributeError, TypeError) as e:
-                logger.error(f"Error retrieving landcover_hdf_path from rasmap_df: {str(e)}")
-                return pd.DataFrame()
-        
-        # Get the soil HDF path
-        if soil_hdf_path is None:
-            try:
-                soil_hdf_path = Path(ras_object.rasmap_df.loc[0, 'soil_layer_path'][0])
-                if not soil_hdf_path.exists():
-                    logger.warning(f"Soil HDF path from rasmap_df does not exist: {soil_hdf_path}")
-                    return pd.DataFrame()
-            except (KeyError, IndexError, AttributeError, TypeError) as e:
-                logger.error(f"Error retrieving soil_layer_path from rasmap_df: {str(e)}")
-                return pd.DataFrame()
+        except (ValueError, KeyError, IndexError, AttributeError, TypeError) as e:
+            logger.error("Error resolving RASMapper classification HDF paths: %s", e)
+            return pd.DataFrame()
         
         # Get land cover map (raster to ID mapping)
         try:
@@ -1604,27 +1669,27 @@ class HdfInfiltration:
             from ..RasPrj import ras
             ras_object = ras
         
-        # Get the landcover HDF path
-        if landcover_hdf_path is None:
-            try:
-                landcover_hdf_path = Path(ras_object.rasmap_df.loc[0, 'landcover_hdf_path'][0])
-                if not landcover_hdf_path.exists():
-                    logger.warning(f"Land cover HDF path from rasmap_df does not exist: {landcover_hdf_path}")
+        try:
+            landcover_hdf_path = HdfInfiltration._resolve_rasmap_hdf_path(
+                landcover_hdf_path,
+                "landcover_hdf_path",
+                ras_object,
+            )
+            soil_hdf_path = HdfInfiltration._resolve_rasmap_hdf_path(
+                soil_hdf_path,
+                "soil_layer_path",
+                ras_object,
+            )
+            for label, path in (
+                ("Land cover", landcover_hdf_path),
+                ("Soil", soil_hdf_path),
+            ):
+                if not path.exists():
+                    logger.warning("%s HDF path does not exist: %s", label, path)
                     return pd.DataFrame()
-            except (KeyError, IndexError, AttributeError, TypeError) as e:
-                logger.error(f"Error retrieving landcover_hdf_path from rasmap_df: {str(e)}")
-                return pd.DataFrame()
-        
-        # Get the soil HDF path
-        if soil_hdf_path is None:
-            try:
-                soil_hdf_path = Path(ras_object.rasmap_df.loc[0, 'soil_layer_path'][0])
-                if not soil_hdf_path.exists():
-                    logger.warning(f"Soil HDF path from rasmap_df does not exist: {soil_hdf_path}")
-                    return pd.DataFrame()
-            except (KeyError, IndexError, AttributeError, TypeError) as e:
-                logger.error(f"Error retrieving soil_layer_path from rasmap_df: {str(e)}")
-                return pd.DataFrame()
+        except (ValueError, KeyError, IndexError, AttributeError, TypeError) as e:
+            logger.error("Error resolving RASMapper classification HDF paths: %s", e)
+            return pd.DataFrame()
         
         # Get land cover map (raster to ID mapping)
         try:
@@ -1832,12 +1897,16 @@ class HdfInfiltration:
             
         Returns:
             Dictionary mapping raster values to mukeys
+
+        Raises:
+            ValueError: If ``hdf_path`` is omitted and no usable infiltration
+                layer can be resolved from ``rasmap_df``.
         """
-        if hdf_path is None:
-            if ras_object is None:
-                from ..RasPrj import ras
-                ras_object = ras
-            hdf_path = Path(ras_object.rasmap_df.iloc[0]['infiltration_hdf_path'][0])
+        hdf_path = HdfInfiltration._resolve_rasmap_hdf_path(
+            hdf_path,
+            "infiltration_hdf_path",
+            ras_object,
+        )
             
         with h5py.File(hdf_path, 'r') as hdf:
             raster_map_data = hdf['Raster Map'][:]
@@ -1952,7 +2021,7 @@ class HdfInfiltration:
 
     @staticmethod
     @log_call
-    @standardize_input
+    @standardize_input(file_type='geom_hdf')
     def get_infiltration_parameters(hdf_path: Path = None, mukey: str = None, ras_object: Any = None) -> Optional[Dict[str, float]]:
         """Get infiltration parameters for a specific mukey from HDF file
 
@@ -1963,12 +2032,16 @@ class HdfInfiltration:
 
         Returns:
             Optional[Dict[str, float]]: Dictionary of infiltration parameters, or None if mukey not found
+
+        Raises:
+            ValueError: If ``hdf_path`` is omitted and no usable infiltration
+                layer can be resolved from ``rasmap_df``.
         """
-        if hdf_path is None:
-            if ras_object is None:
-                from ..RasPrj import ras
-                ras_object = ras
-            hdf_path = Path(ras_object.rasmap_df.iloc[0]['infiltration_hdf_path'][0])
+        hdf_path = HdfInfiltration._resolve_rasmap_hdf_path(
+            hdf_path,
+            "infiltration_hdf_path",
+            ras_object,
+        )
             
         with h5py.File(hdf_path, 'r') as hdf:
             if 'Infiltration Parameters' not in hdf:
@@ -2101,21 +2174,21 @@ class HdfInfiltration:
         # Import here to avoid circular imports
         from .HdfMesh import HdfMesh
         
-        # Get the landcover HDF path
-        if landcover_hdf_path is None:
-            if ras_object is None:
-                from ..RasPrj import ras
-                ras_object = ras
-            
-            # Try to get landcover_hdf_path from rasmap_df
-            try:
-                landcover_hdf_path = Path(ras_object.rasmap_df.loc[0, 'landcover_hdf_path'][0])
-                if not landcover_hdf_path.exists():
-                    logger.warning(f"Land cover HDF path from rasmap_df does not exist: {landcover_hdf_path}")
-                    return pd.DataFrame()
-            except (KeyError, IndexError, AttributeError, TypeError) as e:
-                logger.error(f"Error retrieving landcover_hdf_path from rasmap_df: {str(e)}")
+        try:
+            landcover_hdf_path = HdfInfiltration._resolve_rasmap_hdf_path(
+                landcover_hdf_path,
+                "landcover_hdf_path",
+                ras_object,
+            )
+            if not landcover_hdf_path.exists():
+                logger.warning(
+                    "Land cover HDF path does not exist: %s",
+                    landcover_hdf_path,
+                )
                 return pd.DataFrame()
+        except (ValueError, KeyError, IndexError, AttributeError, TypeError) as e:
+            logger.error("Error resolving landcover_hdf_path: %s", e)
+            return pd.DataFrame()
         
         # Get land cover map (raster to ID mapping)
         try:

--- a/ras_commander/hdf/HdfResultsMesh.py
+++ b/ras_commander/hdf/HdfResultsMesh.py
@@ -79,6 +79,8 @@ HdfUtils for common operations. Methods use @log_call decorator for logging and
 
 import numpy as np
 import pandas as pd
+
+from .._rasmap_schema import rasmap_dataframe_is_usable
 import xarray as xr
 from pathlib import Path
 import h5py
@@ -982,7 +984,7 @@ class HdfResultsMesh:
                     ras_obj = None
 
             rasmap_df = getattr(ras_obj, "rasmap_df", None)
-            if rasmap_df is not None and not rasmap_df.empty and "profile_lines_path" in rasmap_df.columns:
+            if rasmap_dataframe_is_usable(rasmap_df) and "profile_lines_path" in rasmap_df.columns:
                 for value in rasmap_df["profile_lines_path"].tolist():
                     if isinstance(value, (list, tuple, set)):
                         candidate_paths.extend(value)

--- a/ras_commander/schemas.py
+++ b/ras_commander/schemas.py
@@ -13,7 +13,7 @@ resolve "what columns does ``plan_df`` have?" without scraping rendered HTML).
 
 Why a declarative file rather than re-deriving columns from construction code: the construction
 methods (``RasPrj.get_plan_entries`` / ``get_geom_entries`` / ``get_boundary_conditions``, and
-``_land_classification_helper.empty_rasmap_dataframe``) remain the **runtime authority** and may
+``_rasmap_schema.create_rasmap_dataframe``) remain the **runtime authority** and may
 add extra, project-specific columns beyond this stable core. Pinning the documented contract here
 gives agents a stable, reviewable schema and one place to update when a frame's columns change.
 Where a frame is built from a static shape (``rasmap_df``), the generator cross-checks this
@@ -329,12 +329,12 @@ DATAFRAME_SCHEMAS = {
         ],
     },
     "rasmap_df": {
-        "description": "Single-row frame of RASMapper layer/terrain/land-cover/infiltration paths and settings.",
+        "description": "Single-row frame of RASMapper paths, settings, and parse provenance.",
         "accessor": "ras.rasmap_df  (built by RasMap.initialize_rasmap_df())",
-        "source": "_land_classification_helper.empty_rasmap_dataframe() (shape) + RasMap.parse_rasmap() (.rasmap XML)",
+        "source": "_rasmap_schema.create_rasmap_dataframe() (shape) + RasMap.parse_rasmap() (.rasmap XML)",
         # shape_fn: zero-arg callable returning this frame's empty shape; the docs build's schema
         # validator (validate_api_schemas.py) calls it and fails the build if these columns drift.
-        "shape_fn": "ras_commander._land_classification_helper.empty_rasmap_dataframe",
+        "shape_fn": "ras_commander._rasmap_schema.create_rasmap_dataframe",
         "extra_columns": False,
         "dynamic": False,
         "columns": [
@@ -349,6 +349,10 @@ DATAFRAME_SCHEMAS = {
             {"name": "basemap_layer_names", "dtype": "list", "description": "Names of basemap layers."},
             {"name": "basemap_layer_path", "dtype": "list", "description": "Paths of basemap layers."},
             {"name": "current_settings", "dtype": "dict", "description": "RASMapper current-settings map (rendering/units/etc.)."},
+            {"name": "rasmap_path", "dtype": "str | None", "description": "Expected or parsed .rasmap path."},
+            {"name": "rasmap_status", "dtype": "str", "description": "absent, parsed, parsed_with_errors, or failed."},
+            {"name": "rasmap_error", "dtype": "str | None", "description": "Document-level parse failure, when status is failed."},
+            {"name": "rasmap_field_errors", "dtype": "dict", "description": "Per-field extraction errors retained after partial parsing."},
         ],
     },
     "network_edge_coverage": {

--- a/ras_commander/sources/federal/sciencebase_validation.py
+++ b/ras_commander/sources/federal/sciencebase_validation.py
@@ -17,6 +17,8 @@ from typing import Any, Optional, Union
 
 import pandas as pd
 
+from ..._rasmap_schema import rasmap_dataframe_is_usable
+
 from ras_commander import get_logger, log_call
 from ras_commander.RasCmdr import RasCmdr
 from ras_commander.RasMap import RasMap
@@ -534,6 +536,44 @@ class ScienceBaseValidation:
         project_root: Path,
     ) -> None:
         """Inspect terrain and land-classification references via RasMap APIs."""
+        rasmap_df = ras_obj.rasmap_df
+        summary = (
+            rasmap_df.iloc[0]
+            if isinstance(rasmap_df, pd.DataFrame) and not rasmap_df.empty
+            else {}
+        )
+        status = summary.get("rasmap_status") if hasattr(summary, "get") else None
+        rasmap_path = summary.get("rasmap_path") if hasattr(summary, "get") else None
+        owner = str(ras_obj.prj_file)
+
+        if status == "failed":
+            issues.append(
+                {
+                    "code": "rasmap_parse_failed",
+                    "kind": "rasmap",
+                    "owner": owner,
+                    "path": str(rasmap_path or ras_obj.prj_file),
+                    "detail": str(summary.get("rasmap_error") or "unknown parse error"),
+                }
+            )
+            return
+        if not rasmap_dataframe_is_usable(rasmap_df):
+            return
+
+        field_errors = summary.get("rasmap_field_errors", {})
+        if isinstance(field_errors, dict):
+            for field, error in sorted(field_errors.items()):
+                issues.append(
+                    {
+                        "code": "rasmap_field_parse_failed",
+                        "kind": "rasmap",
+                        "owner": owner,
+                        "path": str(rasmap_path or ras_obj.prj_file),
+                        "field": str(field),
+                        "detail": str(error),
+                    }
+                )
+
         for kind, layers in (
             (
                 "terrain",
@@ -559,10 +599,7 @@ class ScienceBaseValidation:
                     project_root=project_root,
                 )
 
-        rasmap_df = ras_obj.rasmap_df
-        if rasmap_df is None or rasmap_df.empty:
-            return
-        projection_path = rasmap_df.iloc[0].get("projection_path")
+        projection_path = summary.get("projection_path")
         if ScienceBaseValidation._has_value(projection_path):
             resolved = ScienceBaseValidation._lexical_absolute(projection_path)
             if not resolved.exists():

--- a/scripts/ebfe_delivery_audit.py
+++ b/scripts/ebfe_delivery_audit.py
@@ -16,7 +16,8 @@ from typing import Any, Optional
 
 from pyproj import CRS
 
-from ras_commander import RasPrj, RasUtils, init_ras_project
+from ras_commander import RasMap, RasPrj, RasUtils, init_ras_project
+from ras_commander._rasmap_schema import rasmap_dataframe_is_usable
 from ras_commander.hdf import HdfBase
 
 
@@ -69,6 +70,9 @@ class ProjectAudit:
     plan_count: int
     flow_types: list[str] = field(default_factory=list)
     has_rasmap: bool = False
+    rasmap_status: Optional[str] = None
+    rasmap_error: Optional[str] = None
+    rasmap_field_errors: dict[str, str] = field(default_factory=dict)
     project_crs: Optional[str] = None
     projection_file: Optional[str] = None
     output_hdf_count: int = 0
@@ -637,35 +641,53 @@ def audit_loaded_project(project_folder: Path, ras_obj: RasPrj) -> ProjectAudit:
                 audit.dss_missing_references.append(ref)
 
     rasmap_df = getattr(ras_obj, "rasmap_df", None)
+    rasmap_can_supply_fields = True
     if rasmap_df is not None and not rasmap_df.empty:
         row = rasmap_df.iloc[0]
-        projection_path = scalar_from_rasmap(row.get("projection_path"))
-        if projection_path:
-            audit.projection_file = rel_path(Path(projection_path))
+        if row.get("rasmap_status") == "absent" and rasmap_path is not None:
+            # Delivery discovery accepts a differently named map, while RasPrj
+            # initializes only the canonical <project-name>.rasmap path.
+            rasmap_df = RasMap.parse_rasmap(rasmap_path)
+            row = rasmap_df.iloc[0]
+        audit.rasmap_status = row.get("rasmap_status")
+        audit.rasmap_error = row.get("rasmap_error")
+        raw_field_errors = row.get("rasmap_field_errors", {})
+        if isinstance(raw_field_errors, dict):
+            audit.rasmap_field_errors = raw_field_errors
 
-        terrain_paths = string_list(row.get("terrain_hdf_path"))
-        land_cover_paths = string_list(row.get("landcover_hdf_path"))
-        audit.terrain_layers = [rel_path(Path(path)) for path in terrain_paths]
-        audit.land_cover_layers = [rel_path(Path(path)) for path in land_cover_paths]
+        rasmap_can_supply_fields = rasmap_dataframe_is_usable(rasmap_df)
+        if rasmap_can_supply_fields:
+            projection_path = scalar_from_rasmap(row.get("projection_path"))
+            if projection_path:
+                audit.projection_file = rel_path(Path(projection_path))
 
-        for terrain_path in terrain_paths:
-            actual = get_asset_crs(Path(terrain_path))
-            if not compare_crs(project_crs, actual):
-                audit.terrain_crs_mismatches.append(f"{rel_path(Path(terrain_path))}: {actual}")
+            terrain_paths = string_list(row.get("terrain_hdf_path"))
+            land_cover_paths = string_list(row.get("landcover_hdf_path"))
+            audit.terrain_layers = [rel_path(Path(path)) for path in terrain_paths]
+            audit.land_cover_layers = [rel_path(Path(path)) for path in land_cover_paths]
 
-        for land_cover_path in land_cover_paths:
-            actual = get_asset_crs(Path(land_cover_path))
-            if not compare_crs(project_crs, actual):
-                audit.land_cover_crs_mismatches.append(f"{rel_path(Path(land_cover_path))}: {actual}")
+            for terrain_path in terrain_paths:
+                actual = get_asset_crs(Path(terrain_path))
+                if not compare_crs(project_crs, actual):
+                    audit.terrain_crs_mismatches.append(
+                        f"{rel_path(Path(terrain_path))}: {actual}"
+                    )
 
-    if rasmap_path is not None and not audit.terrain_layers:
+            for land_cover_path in land_cover_paths:
+                actual = get_asset_crs(Path(land_cover_path))
+                if not compare_crs(project_crs, actual):
+                    audit.land_cover_crs_mismatches.append(
+                        f"{rel_path(Path(land_cover_path))}: {actual}"
+                    )
+
+    if rasmap_path is not None and rasmap_can_supply_fields and not audit.terrain_layers:
         for terrain_path in rasmap_layer_paths(project_folder, rasmap_path, "TerrainLayer"):
             audit.terrain_layers.append(rel_path(terrain_path))
             actual = get_asset_crs(terrain_path)
             if not compare_crs(project_crs, actual):
                 audit.terrain_crs_mismatches.append(f"{rel_path(terrain_path)}: {actual}")
 
-    if rasmap_path is not None and not audit.land_cover_layers:
+    if rasmap_path is not None and rasmap_can_supply_fields and not audit.land_cover_layers:
         for land_cover_path in rasmap_layer_paths(project_folder, rasmap_path, "LandCoverLayer"):
             audit.land_cover_layers.append(rel_path(land_cover_path))
             actual = get_asset_crs(land_cover_path)
@@ -676,7 +698,12 @@ def audit_loaded_project(project_folder: Path, ras_obj: RasPrj) -> ProjectAudit:
         audit.issues.append("Pre-computed HDF results are not fully inside the project folder.")
     if audit.dss_missing_references:
         audit.issues.append("One or more DSS references are broken.")
-    if audit.has_rasmap and not audit.projection_file:
+    if audit.rasmap_status == "failed":
+        audit.issues.append(f"RAS Mapper parse failed: {audit.rasmap_error}")
+    elif audit.rasmap_status == "parsed_with_errors":
+        failed_fields = ", ".join(sorted(audit.rasmap_field_errors))
+        audit.issues.append(f"RAS Mapper field extraction failed: {failed_fields}")
+    if audit.has_rasmap and audit.rasmap_status != "failed" and not audit.projection_file:
         audit.issues.append("RAS Mapper projection file is missing.")
     if audit.terrain_crs_mismatches:
         audit.issues.append("Terrain CRS mismatch detected.")

--- a/tests/data/rasmap/bald_eagle_representative.rasmap
+++ b/tests/data/rasmap/bald_eagle_representative.rasmap
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RASMapper Version="2.0.0.0">
+  <RASProjectionFilename Filename=".\Terrain\Projection.prj" />
+  <Features>
+    <Layer Name="Profile Lines" Type="PolylineFeatureLayer" Filename=".\GISData\Profile Lines.shp" />
+  </Features>
+  <MapLayers Expanded="True">
+    <Layer Name="LandCover" Type="LandCoverLayer" Filename=".\Land Classification\LandCover.hdf" SelectedParameterForSurfaceFillLabel="ManningsN">
+      <Layer Name="Classification Polygons" Type="LandCoverClassificationLayer" Checked="True" Filename=".\Land Classification\LandCover.hdf" />
+    </Layer>
+    <Layer Name="Hydrologic Soil Groups" Type="LandCoverLayer" Filename=".\Soils Data\Hydrologic Soil Groups.hdf" SelectedParameterForSurfaceFillLabel="ID">
+      <Layer Name="Classification Polygons" Type="LandCoverClassificationLayer" Checked="True" Filename=".\Soils Data\Hydrologic Soil Groups.hdf" />
+    </Layer>
+    <Layer Name="Infiltration" Type="LandCoverLayer" Filename=".\Soils Data\Infiltration.hdf" SelectedParameterForSurfaceFillLabel="ID">
+      <Layer Name="Classification Polygons" Type="LandCoverClassificationLayer" Checked="True" Filename=".\Soils Data\Infiltration.hdf" />
+    </Layer>
+    <Layer Name="USGS Topo" Type="WMSLayer" Checked="True" Filename="%LocalAppData%\HEC\Mapping\5.1\XML\USGS Topo.xml" />
+    <Layer Name="Inspection Line" Type="PolylineFeatureLayer" Checked="True" Filename=".\GISData\Inspection Line.shp" />
+  </MapLayers>
+  <Terrains Checked="True" Expanded="True">
+    <Layer Name="Terrain50" Type="TerrainLayer" Checked="True" Filename=".\Terrain\Terrain50.hdf">
+      <ResampleMethod>near</ResampleMethod>
+      <Surface On="True" />
+    </Layer>
+  </Terrains>
+  <CurrentSettings>
+    <ProjectSettings>
+      <ProjectIsMetric>False</ProjectIsMetric>
+    </ProjectSettings>
+    <Folders>
+      <TerrainFolder>Terrain</TerrainFolder>
+    </Folders>
+  </CurrentSettings>
+</RASMapper>

--- a/tests/test_ebfe_delivery_audit_rasmap_status.py
+++ b/tests/test_ebfe_delivery_audit_rasmap_status.py
@@ -1,0 +1,100 @@
+"""Regression tests for status-aware eBFE delivery audit consumption."""
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pandas as pd
+
+from ras_commander._rasmap_schema import create_rasmap_dataframe
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPT_PATH = REPO_ROOT / "scripts" / "ebfe_delivery_audit.py"
+SCRIPT_SPEC = importlib.util.spec_from_file_location(
+    "_ebfe_delivery_audit_under_test",
+    SCRIPT_PATH,
+)
+assert SCRIPT_SPEC is not None and SCRIPT_SPEC.loader is not None
+delivery_audit = importlib.util.module_from_spec(SCRIPT_SPEC)
+sys.modules[SCRIPT_SPEC.name] = delivery_audit
+SCRIPT_SPEC.loader.exec_module(delivery_audit)
+
+
+def _project(rasmap_df):
+    return SimpleNamespace(
+        plan_df=pd.DataFrame(columns=["flow_type", "HDF_Results_Path"]),
+        boundaries_df=pd.DataFrame(),
+        rasmap_df=rasmap_df,
+    )
+
+
+def _isolate_project_probes(monkeypatch, rasmap_path: Path):
+    monkeypatch.setattr(delivery_audit, "extract_project_crs", lambda *args: None)
+    monkeypatch.setattr(delivery_audit, "find_rasmap", lambda *args: rasmap_path)
+    monkeypatch.setattr(delivery_audit, "get_asset_crs", lambda *args: None)
+    monkeypatch.setattr(delivery_audit, "compare_crs", lambda *args: True)
+
+
+def test_failed_rasmap_status_gates_legacy_and_raw_layer_fallbacks(
+    monkeypatch,
+    tmp_path: Path,
+):
+    rasmap_path = tmp_path / "Broken.rasmap"
+    rasmap_path.write_text("<RASMapper>", encoding="utf-8")
+    rasmap_df = create_rasmap_dataframe(
+        rasmap_path=rasmap_path,
+        rasmap_status="failed",
+        rasmap_error="ParseError: invalid XML",
+    )
+    rasmap_df.at[0, "terrain_hdf_path"] = [str(tmp_path / "stale-terrain.hdf")]
+    _isolate_project_probes(monkeypatch, rasmap_path)
+
+    def unexpected_raw_fallback(*args, **kwargs):
+        raise AssertionError("failed documents must not be reparsed as raw layers")
+
+    monkeypatch.setattr(
+        delivery_audit,
+        "rasmap_layer_paths",
+        unexpected_raw_fallback,
+    )
+
+    audit = delivery_audit.audit_loaded_project(tmp_path, _project(rasmap_df))
+
+    assert audit.rasmap_status == "failed"
+    assert audit.terrain_layers == []
+    assert audit.land_cover_layers == []
+    assert "RAS Mapper parse failed: ParseError: invalid XML" in audit.issues
+
+
+def test_partial_status_keeps_unaffected_delivery_fields(
+    monkeypatch,
+    tmp_path: Path,
+):
+    rasmap_path = tmp_path / "Partial.rasmap"
+    rasmap_path.write_text("<RASMapper />", encoding="utf-8")
+    terrain_path = tmp_path / "Terrain.hdf"
+    landcover_path = tmp_path / "LandCover.hdf"
+    rasmap_df = create_rasmap_dataframe(
+        rasmap_path=rasmap_path,
+        rasmap_status="parsed_with_errors",
+        rasmap_field_errors={
+            "infiltration_hdf_path": "ValueError: missing Filename"
+        },
+    )
+    rasmap_df.at[0, "terrain_hdf_path"] = [str(terrain_path)]
+    rasmap_df.at[0, "landcover_hdf_path"] = [str(landcover_path)]
+    _isolate_project_probes(monkeypatch, rasmap_path)
+
+    audit = delivery_audit.audit_loaded_project(tmp_path, _project(rasmap_df))
+
+    assert audit.rasmap_status == "parsed_with_errors"
+    assert audit.rasmap_field_errors == {
+        "infiltration_hdf_path": "ValueError: missing Filename"
+    }
+    assert audit.terrain_layers == [str(terrain_path)]
+    assert audit.land_cover_layers == [str(landcover_path)]
+    assert (
+        "RAS Mapper field extraction failed: infiltration_hdf_path" in audit.issues
+    )

--- a/tests/test_geometry_association.py
+++ b/tests/test_geometry_association.py
@@ -10,6 +10,7 @@ if str(REPO_ROOT) not in sys.path:
 
 from ras_commander import RasMap  # noqa: E402
 from ras_commander._geometry_association import (  # noqa: E402
+    list_registered_rasmap_layers,
     validate_geometry_extents_for_2d_classification,
 )
 
@@ -34,6 +35,29 @@ def _make_geometry_hdf(path: Path) -> Path:
     with h5py.File(path, "w") as hdf_file:
         hdf_file.create_group("Geometry")
     return path
+
+
+def test_registered_rasmap_layers_include_legacy_landcover(tmp_path):
+    project_dir = _make_project(tmp_path)
+    legacy_landcover = _touch(project_dir / "Land" / "LegacyLandCover.tif")
+    (project_dir / "AssocProject.rasmap").write_text(
+        (
+            "<RASMapper>\n"
+            "  <MapLayers>\n"
+            '    <Layer Name="Legacy Land" Type="LandCover" '
+            'Filename=".\\Land\\LegacyLandCover.tif" />\n'
+            "  </MapLayers>\n"
+            "</RASMapper>\n"
+        ),
+        encoding="utf-8",
+    )
+
+    layers = list_registered_rasmap_layers(project_dir)
+
+    assert len(layers) == 1
+    assert layers[0]["type"] == "LandCover"
+    assert layers[0]["layer_kind"] == "landcover"
+    assert Path(layers[0]["resolved_path"]) == legacy_landcover
 
 
 def test_rasmap_associate_geometry_layers_writes_hdf_attrs_with_layer_names(tmp_path):

--- a/tests/test_hdf_infiltration_rasmap_lookup.py
+++ b/tests/test_hdf_infiltration_rasmap_lookup.py
@@ -1,0 +1,285 @@
+"""Tests for status-aware implicit infiltration HDF path resolution."""
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import h5py
+import numpy as np
+import pandas as pd
+import pytest
+
+from ras_commander._rasmap_schema import create_rasmap_dataframe
+from ras_commander.hdf import HdfInfiltration
+
+
+def _write_infiltration_hdf(path: Path) -> Path:
+    with h5py.File(path, "w") as hdf:
+        hdf.create_dataset(
+            "Raster Map",
+            data=np.array(
+                [(1, b"100"), (2, b"200")],
+                dtype=[("raster_value", "i4"), ("mukey", "S16")],
+            ),
+        )
+        hdf.create_dataset(
+            "Infiltration Parameters",
+            data=np.array(
+                [(b"100", 0.25, 0.10, 12.0)],
+                dtype=[
+                    ("mukey", "S16"),
+                    ("initial_loss", "f8"),
+                    ("constant_loss_rate", "f8"),
+                    ("impervious_area", "f8"),
+                ],
+            ),
+        )
+    return path
+
+
+def _call(method_name: str, ras_object, hdf_path: Path | None = None):
+    method = getattr(HdfInfiltration, method_name)
+    kwargs = {"hdf_path": hdf_path, "ras_object": ras_object}
+    if method_name == "get_infiltration_parameters":
+        kwargs["mukey"] = "100"
+    return method(**kwargs)
+
+
+@pytest.mark.parametrize(
+    "method_name",
+    ["get_infiltration_map", "get_infiltration_parameters"],
+)
+@pytest.mark.parametrize(
+    ("rasmap_df", "message"),
+    [
+        (
+            pd.DataFrame(),
+            "rasmap_df has no summary row",
+        ),
+        (
+            create_rasmap_dataframe(
+                rasmap_path="Missing.rasmap",
+                rasmap_status="absent",
+            ),
+            "rasmap_status='absent'",
+        ),
+        (
+            create_rasmap_dataframe(
+                rasmap_path="Broken.rasmap",
+                rasmap_status="failed",
+                rasmap_error="ParseError: invalid XML",
+            ),
+            "rasmap_status='failed'",
+        ),
+        (
+            create_rasmap_dataframe(
+                rasmap_path="Partial.rasmap",
+                rasmap_status="parsed_with_errors",
+                rasmap_field_errors={
+                    "infiltration_hdf_path": "ValueError: missing Filename"
+                },
+            ),
+            "field failed to parse",
+        ),
+        (
+            create_rasmap_dataframe(
+                rasmap_path="NoLayer.rasmap",
+                rasmap_status="parsed",
+            ),
+            "No infiltration layer is configured",
+        ),
+    ],
+)
+def test_implicit_lookup_has_clear_status_aware_errors(
+    method_name: str,
+    rasmap_df: pd.DataFrame,
+    message: str,
+):
+    ras_object = SimpleNamespace(rasmap_df=rasmap_df)
+
+    with pytest.raises(ValueError, match=message):
+        _call(method_name, ras_object)
+
+
+@pytest.mark.parametrize(
+    "method_name",
+    ["get_infiltration_map", "get_infiltration_parameters"],
+)
+def test_implicit_lookup_reads_configured_path(
+    method_name: str,
+    tmp_path: Path,
+):
+    hdf_path = _write_infiltration_hdf(tmp_path / "Infiltration.hdf")
+    rasmap_df = create_rasmap_dataframe(
+        rasmap_path=tmp_path / "Project.rasmap",
+        rasmap_status="parsed",
+    )
+    rasmap_df.at[0, "infiltration_hdf_path"] = [str(hdf_path)]
+    ras_object = SimpleNamespace(rasmap_df=rasmap_df)
+
+    result = _call(method_name, ras_object)
+
+    if method_name == "get_infiltration_map":
+        assert result == {1: "100", 2: "200"}
+    else:
+        assert result == {
+            "Initial Loss (in)": 0.25,
+            "Constant Loss Rate (in/hr)": 0.10,
+            "Impervious Area (%)": 12.0,
+        }
+
+
+@pytest.mark.parametrize(
+    "method_name",
+    ["get_infiltration_map", "get_infiltration_parameters"],
+)
+def test_legacy_rasmap_df_without_status_remains_usable(
+    method_name: str,
+    tmp_path: Path,
+):
+    hdf_path = _write_infiltration_hdf(tmp_path / "LegacyInfiltration.hdf")
+    ras_object = SimpleNamespace(
+        rasmap_df=pd.DataFrame({"infiltration_hdf_path": [[str(hdf_path)]]})
+    )
+
+    result = _call(method_name, ras_object)
+
+    assert result is not None
+
+
+@pytest.mark.parametrize(
+    "method_name",
+    ["get_infiltration_map", "get_infiltration_parameters"],
+)
+def test_explicit_path_bypasses_failed_rasmap_status(
+    method_name: str,
+    tmp_path: Path,
+):
+    hdf_path = _write_infiltration_hdf(tmp_path / "ExplicitInfiltration.hdf")
+    ras_object = SimpleNamespace(
+        rasmap_df=create_rasmap_dataframe(
+            rasmap_path="Broken.rasmap",
+            rasmap_status="failed",
+            rasmap_error="ParseError: invalid XML",
+        )
+    )
+
+    result = _call(method_name, ras_object, hdf_path=hdf_path)
+
+    assert result is not None
+
+
+@pytest.mark.parametrize(
+    "method_name",
+    ["get_infiltration_map", "get_infiltration_parameters"],
+)
+def test_unrelated_partial_field_error_does_not_block_lookup(
+    method_name: str,
+    tmp_path: Path,
+):
+    hdf_path = _write_infiltration_hdf(tmp_path / "PartialInfiltration.hdf")
+    rasmap_df = create_rasmap_dataframe(
+        rasmap_path=tmp_path / "Project.rasmap",
+        rasmap_status="parsed_with_errors",
+        rasmap_field_errors={"terrain_hdf_path": "ValueError: malformed terrain"},
+    )
+    rasmap_df.at[0, "infiltration_hdf_path"] = [str(hdf_path)]
+    ras_object = SimpleNamespace(rasmap_df=rasmap_df)
+
+    result = _call(method_name, ras_object)
+
+    assert result is not None
+
+
+@pytest.mark.parametrize(
+    "method_name",
+    ["get_infiltration_map", "get_infiltration_parameters"],
+)
+def test_field_error_does_not_hide_valid_sibling_candidate(
+    method_name: str,
+    tmp_path: Path,
+):
+    hdf_path = _write_infiltration_hdf(tmp_path / "ValidSibling.hdf")
+    rasmap_df = create_rasmap_dataframe(
+        rasmap_path=tmp_path / "Project.rasmap",
+        rasmap_status="parsed_with_errors",
+        rasmap_field_errors={
+            "infiltration_hdf_path": "ValueError: another layer is malformed"
+        },
+    )
+    rasmap_df.at[0, "infiltration_hdf_path"] = [str(hdf_path)]
+    ras_object = SimpleNamespace(rasmap_df=rasmap_df)
+
+    result = _call(method_name, ras_object)
+
+    assert result is not None
+
+
+@pytest.mark.parametrize(
+    "method_name",
+    ["get_infiltration_map", "get_infiltration_parameters"],
+)
+def test_explicit_missing_path_uses_decorator_file_error(
+    method_name: str,
+    tmp_path: Path,
+):
+    ras_object = SimpleNamespace(rasmap_df=pd.DataFrame())
+
+    with pytest.raises(FileNotFoundError, match="HDF file not found"):
+        _call(method_name, ras_object, hdf_path=tmp_path / "Missing.hdf")
+
+
+@pytest.mark.parametrize(
+    ("method_name", "path_kwargs"),
+    [
+        ("get_soils_raster_stats", {}),
+        ("get_soil_raster_stats", {}),
+        ("get_infiltration_stats", {}),
+        ("get_landcover_raster_stats", {}),
+    ],
+)
+def test_statistics_lookups_keep_empty_frame_contract_on_unusable_rasmap(
+    method_name: str,
+    path_kwargs: dict,
+    tmp_path: Path,
+):
+    geom_hdf_path = tmp_path / "Geometry.hdf"
+    geom_hdf_path.touch()
+    ras_object = SimpleNamespace(
+        rasmap_df=create_rasmap_dataframe(
+            rasmap_path="Broken.rasmap",
+            rasmap_status="failed",
+            rasmap_error="ParseError: invalid XML",
+        )
+    )
+
+    result = getattr(HdfInfiltration, method_name)(
+        geom_hdf_path=geom_hdf_path,
+        ras_object=ras_object,
+        **path_kwargs,
+    )
+
+    assert result.empty
+
+
+@pytest.mark.parametrize(
+    "column",
+    ["soil_layer_path", "landcover_hdf_path", "infiltration_hdf_path"],
+)
+def test_shared_resolver_prefers_a_valid_sibling_before_field_error(
+    column: str,
+    tmp_path: Path,
+):
+    configured = tmp_path / f"{column}.hdf"
+    rasmap_df = create_rasmap_dataframe(
+        rasmap_status="parsed_with_errors",
+        rasmap_field_errors={column: "ValueError: another declaration is malformed"},
+    )
+    rasmap_df.at[0, column] = [str(configured)]
+
+    resolved = HdfInfiltration._resolve_rasmap_hdf_path(
+        None,
+        column,
+        SimpleNamespace(rasmap_df=rasmap_df),
+    )
+
+    assert resolved == configured

--- a/tests/test_ras_project.py
+++ b/tests/test_ras_project.py
@@ -14,6 +14,7 @@ import pandas as pd
 import pytest
 
 import ras_commander.RasProject as project_module
+from ras_commander._rasmap_schema import create_rasmap_dataframe
 from ras_commander.schemas import DATAFRAME_SCHEMAS
 from ras_commander import (
     ProjectPathAmbiguityError,
@@ -517,6 +518,57 @@ def test_empty_structured_rasmap_inventory_remains_explicit(
     ].iloc[0]
     assert row["inspection_state"] == "not_inspected"
     assert row["readiness"] == "unknown"
+
+
+def test_absent_single_row_rasmap_summary_does_not_create_phantom_asset(
+    tmp_path: Path,
+) -> None:
+    project = _write_project(tmp_path / "source")
+
+    assets = inspect_project_assets(project, depth="project")
+
+    assert not (assets["asset_kind"] == "rasmap").any()
+    assert not (
+        assets["reason_code"] == "rasmap_structured_inventory_empty"
+    ).any()
+
+
+def test_partial_rasmap_inventory_reports_errors_and_keeps_valid_siblings(
+    tmp_path: Path,
+) -> None:
+    project = _write_project(tmp_path / "source")
+    rasmap_path = project.parent / "Model.rasmap"
+    rasmap_path.write_text("<RASMapper />", encoding="utf-8")
+    terrain_path = project.parent / "Terrain" / "Terrain.hdf"
+    terrain_path.parent.mkdir()
+    terrain_path.write_bytes(b"terrain")
+    ras_object = project_module._explicit_ras(project, None)
+    ras_object.rasmap_df = create_rasmap_dataframe(
+        rasmap_path=rasmap_path,
+        rasmap_status="parsed_with_errors",
+        rasmap_field_errors={
+            "infiltration_hdf_path": "ValueError: malformed declaration"
+        },
+    )
+    ras_object.rasmap_df.at[0, "terrain_hdf_path"] = [str(terrain_path)]
+
+    assets = inspect_project_assets(
+        project,
+        ras_object=ras_object,
+        depth="project",
+    )
+
+    error_row = assets.loc[
+        assets["reason_code"] == "rasmap_field_parse_failed"
+    ].iloc[0]
+    assert error_row["inspection_state"] == "not_inspected"
+    assert error_row["readiness"] == "unknown"
+    assert error_row["source_api"] == (
+        "RasPrj.rasmap_df.infiltration_hdf_path"
+    )
+    assert "malformed declaration" in error_row["detail"]
+    terrain_rows = assets.loc[assets["asset_kind"] == "terrain"]
+    assert terrain_rows["resolved_path"].tolist() == [str(terrain_path)]
 
 
 def test_stage_project_publishes_verified_copy_without_source_drift(tmp_path: Path) -> None:

--- a/tests/test_rasexamples_archive_rasmap_compatibility.py
+++ b/tests/test_rasexamples_archive_rasmap_compatibility.py
@@ -1,0 +1,59 @@
+"""Optional compatibility sweep over an installed RasExamples archive."""
+
+from __future__ import annotations
+
+import zipfile
+from pathlib import Path
+
+import pytest
+
+from ras_commander import RasExamples, RasMap
+
+
+@pytest.mark.integration
+def test_installed_rasexamples_archive_parses_diverse_rasmap_corpus(
+    tmp_path: Path,
+):
+    archives = sorted(
+        RasExamples._user_data_dir.glob("Example_Projects_*.zip")
+    )
+    if not archives:
+        pytest.skip("No locally installed RasExamples archive")
+
+    archive = archives[-1]
+    failed = []
+    statuses = []
+    feature_counts = {
+        "modern_landcover": 0,
+        "terrain": 0,
+        "basemap": 0,
+        "results": 0,
+    }
+
+    with zipfile.ZipFile(archive) as source:
+        members = sorted(
+            name for name in source.namelist() if name.lower().endswith(".rasmap")
+        )
+        if not members:
+            pytest.skip(f"No .rasmap members in {archive.name}")
+
+        for index, member in enumerate(members):
+            contents = source.read(member)
+            feature_counts["modern_landcover"] += b'Type="LandCoverLayer"' in contents
+            feature_counts["terrain"] += b'Type="TerrainLayer"' in contents
+            feature_counts["basemap"] += b'Type="WMSLayer"' in contents
+            feature_counts["results"] += b"<Results" in contents
+
+            rasmap_path = tmp_path / str(index) / Path(member).name
+            rasmap_path.parent.mkdir()
+            rasmap_path.write_bytes(contents)
+            rasmap_df = RasMap.parse_rasmap(rasmap_path)
+            status = rasmap_df.at[0, "rasmap_status"]
+            statuses.append(status)
+            if status == "failed":
+                failed.append((member, rasmap_df.at[0, "rasmap_error"]))
+
+    assert len(members) >= 20
+    assert failed == []
+    assert set(statuses) <= {"parsed", "parsed_with_errors"}
+    assert all(count > 0 for count in feature_counts.values())

--- a/tests/test_rasmap_parse_status.py
+++ b/tests/test_rasmap_parse_status.py
@@ -1,0 +1,411 @@
+"""Regression tests for explicit ``rasmap_df`` parse provenance."""
+
+import builtins
+import sys
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+import pytest
+
+from ras_commander import RasMap
+from ras_commander.RasPrj import RasPrj
+from ras_commander._rasmap_schema import (
+    RASMAP_COLUMNS,
+    RASMAP_LEGACY_COLUMNS,
+    create_rasmap_dataframe,
+    expected_rasmap_path,
+    rasmap_dataframe_is_usable,
+)
+from ras_commander._rasmap_layer_helper import top_level_map_layers
+from ras_commander.schemas import DATAFRAME_SCHEMAS
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+BALD_EAGLE_RASMAP_FIXTURE = (
+    REPO_ROOT
+    / "tests"
+    / "data"
+    / "rasmap"
+    / "bald_eagle_representative.rasmap"
+)
+
+
+def _path_names(value):
+    """Return platform-neutral basenames for one path or a path collection."""
+    values = value if isinstance(value, list) else [value]
+    return [str(item).replace("\\", "/").rsplit("/", 1)[-1] for item in values]
+
+
+def test_schema_is_always_one_row_and_preserves_legacy_column_order():
+    rasmap_df = create_rasmap_dataframe()
+
+    assert rasmap_df.shape == (1, len(RASMAP_COLUMNS))
+    assert list(rasmap_df.columns[: len(RASMAP_LEGACY_COLUMNS)]) == list(
+        RASMAP_LEGACY_COLUMNS
+    )
+    assert rasmap_df.index.tolist() == [0]
+    assert [
+        column["name"]
+        for column in DATAFRAME_SCHEMAS["rasmap_df"]["columns"]
+    ] == list(rasmap_df.columns)
+
+
+def test_schema_uses_fresh_mutable_defaults():
+    first = create_rasmap_dataframe()
+    second = create_rasmap_dataframe()
+
+    first.at[0, "terrain_hdf_path"].append("terrain.hdf")
+    first.at[0, "rasmap_field_errors"]["terrain_hdf_path"] = "broken"
+
+    assert second.at[0, "terrain_hdf_path"] == []
+    assert second.at[0, "rasmap_field_errors"] == {}
+
+
+def test_shared_path_and_health_helpers_preserve_legacy_frames(tmp_path: Path):
+    assert expected_rasmap_path(tmp_path, "Project") == tmp_path / "Project.rasmap"
+    assert not rasmap_dataframe_is_usable(create_rasmap_dataframe())
+    assert rasmap_dataframe_is_usable(
+        create_rasmap_dataframe(rasmap_status="parsed")
+    )
+    assert rasmap_dataframe_is_usable(
+        create_rasmap_dataframe(rasmap_status="parsed_with_errors")
+    )
+    assert rasmap_dataframe_is_usable(
+        create_rasmap_dataframe().drop(columns=["rasmap_status"])
+    )
+
+
+def test_top_level_layer_traversal_excludes_nested_layers():
+    root = ET.fromstring(
+        "<RASMapper><MapLayers><Layer Name='top'><Layer Name='nested' />"
+        "</Layer><Layer Name='sibling' /></MapLayers></RASMapper>"
+    )
+
+    assert [layer.attrib["Name"] for layer in top_level_map_layers(root)] == [
+        "top",
+        "sibling",
+    ]
+
+
+@pytest.mark.parametrize(
+    ("contents", "expected_error_prefix"),
+    [
+        (b"", "ParseError:"),
+        (b"not xml", "ParseError:"),
+        (b"<RASMapper>", "ParseError:"),
+        (b"<NotRASMapper />", "ValueError:"),
+    ],
+)
+def test_document_parse_failures_are_explicit(
+    tmp_path: Path,
+    contents: bytes,
+    expected_error_prefix: str,
+):
+    rasmap_path = tmp_path / "Broken.rasmap"
+    rasmap_path.write_bytes(contents)
+
+    rasmap_df = RasMap.parse_rasmap(rasmap_path)
+
+    assert len(rasmap_df) == 1
+    assert rasmap_df.at[0, "rasmap_status"] == "failed"
+    assert rasmap_df.at[0, "rasmap_error"].startswith(expected_error_prefix)
+    assert rasmap_df.at[0, "rasmap_field_errors"] == {}
+
+
+def test_missing_file_is_absent_and_retains_requested_path(tmp_path: Path):
+    rasmap_path = tmp_path / "Missing.rasmap"
+
+    rasmap_df = RasMap.parse_rasmap(rasmap_path)
+
+    assert len(rasmap_df) == 1
+    assert rasmap_df.at[0, "rasmap_status"] == "absent"
+    assert rasmap_df.at[0, "rasmap_path"] == str(rasmap_path)
+    assert rasmap_df.at[0, "rasmap_error"] is None
+
+
+def test_valid_minimal_and_utf8_bom_files_are_parsed(tmp_path: Path):
+    rasmap_path = tmp_path / "Minimal.rasmap"
+    rasmap_path.write_bytes(b"\xef\xbb\xbf<RASMapper />")
+
+    rasmap_df = RasMap.parse_rasmap(rasmap_path)
+
+    assert rasmap_df.at[0, "rasmap_status"] == "parsed"
+    assert rasmap_df.at[0, "rasmap_error"] is None
+    assert rasmap_df.at[0, "rasmap_field_errors"] == {}
+
+
+def test_helper_import_failure_returns_failed_summary(monkeypatch, tmp_path: Path):
+    rasmap_path = tmp_path / "ImportFailure.rasmap"
+    rasmap_path.write_text("<RASMapper />", encoding="utf-8")
+    original_import = builtins.__import__
+
+    def fail_land_helper(name, globals=None, locals=None, fromlist=(), level=0):
+        if "_land_classification_helper" in fromlist:
+            raise ImportError("injected helper import failure")
+        return original_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", fail_land_helper)
+
+    rasmap_df = RasMap.parse_rasmap(rasmap_path)
+
+    assert len(rasmap_df) == 1
+    assert rasmap_df.at[0, "rasmap_status"] == "failed"
+    assert rasmap_df.at[0, "rasmap_error"] == (
+        "ImportError: injected helper import failure"
+    )
+    assert rasmap_df.at[0, "terrain_hdf_path"] == []
+
+
+def test_four_public_lifecycle_states_are_mutually_distinguishable(
+    tmp_path: Path,
+):
+    paths = {
+        "absent": tmp_path / "Absent.rasmap",
+        "failed": tmp_path / "Failed.rasmap",
+        "valid": tmp_path / "Valid.rasmap",
+        "partial": tmp_path / "Partial.rasmap",
+    }
+    paths["failed"].write_text("<RASMapper>", encoding="utf-8")
+    paths["valid"].write_text("<RASMapper />", encoding="utf-8")
+    paths["partial"].write_text(
+        '<RASMapper><Terrains><Layer Type="TerrainLayer" /></Terrains></RASMapper>',
+        encoding="utf-8",
+    )
+
+    statuses = {
+        name: RasMap.parse_rasmap(path).at[0, "rasmap_status"]
+        for name, path in paths.items()
+    }
+
+    assert statuses == {
+        "absent": "absent",
+        "failed": "failed",
+        "valid": "parsed",
+        "partial": "parsed_with_errors",
+    }
+
+
+def test_bald_eagle_fixture_preserves_happy_path_values():
+    rasmap_df = RasMap.parse_rasmap(BALD_EAGLE_RASMAP_FIXTURE)
+
+    assert rasmap_df.at[0, "rasmap_status"] == "parsed"
+    assert rasmap_df.at[0, "rasmap_field_errors"] == {}
+    assert _path_names(rasmap_df.at[0, "projection_path"]) == ["Projection.prj"]
+    assert _path_names(rasmap_df.at[0, "profile_lines_path"]) == [
+        "Profile Lines.shp"
+    ]
+    assert _path_names(rasmap_df.at[0, "soil_layer_path"]) == [
+        "Hydrologic Soil Groups.hdf"
+    ]
+    assert _path_names(rasmap_df.at[0, "infiltration_hdf_path"]) == [
+        "Infiltration.hdf"
+    ]
+    assert _path_names(rasmap_df.at[0, "landcover_hdf_path"]) == ["LandCover.hdf"]
+    assert _path_names(rasmap_df.at[0, "terrain_hdf_path"]) == ["Terrain50.hdf"]
+    assert rasmap_df.at[0, "reference_map_layer_names"] == ["Inspection Line"]
+    assert _path_names(rasmap_df.at[0, "reference_map_layer_path"]) == [
+        "Inspection Line.shp"
+    ]
+    assert rasmap_df.at[0, "basemap_layer_names"] == ["USGS Topo"]
+    assert _path_names(rasmap_df.at[0, "basemap_layer_path"]) == ["USGS Topo.xml"]
+    assert rasmap_df.at[0, "current_settings"] == {
+        "ProjectIsMetric": "False",
+        "TerrainFolder": "Terrain",
+    }
+
+
+def test_malformed_terrain_is_partial_failure_without_hiding_other_fields(
+    tmp_path: Path,
+):
+    rasmap_path = tmp_path / "Partial.rasmap"
+    contents = BALD_EAGLE_RASMAP_FIXTURE.read_text(encoding="utf-8")
+    contents = contents.replace(
+        ' Filename=".\\Terrain\\Terrain50.hdf"',
+        "",
+        1,
+    )
+    rasmap_path.write_text(contents, encoding="utf-8")
+
+    rasmap_df = RasMap.parse_rasmap(rasmap_path)
+
+    assert rasmap_df.at[0, "rasmap_status"] == "parsed_with_errors"
+    assert rasmap_df.at[0, "rasmap_error"] is None
+    assert rasmap_df.at[0, "terrain_hdf_path"] == []
+    assert "terrain_hdf_path" in rasmap_df.at[0, "rasmap_field_errors"]
+    assert Path(rasmap_df.at[0, "projection_path"]).name == "Projection.prj"
+    assert len(rasmap_df.at[0, "landcover_hdf_path"]) == 1
+
+
+def test_malformed_layer_declarations_preserve_valid_siblings(tmp_path: Path):
+    rasmap_path = tmp_path / "Mixed.rasmap"
+    contents = BALD_EAGLE_RASMAP_FIXTURE.read_text(encoding="utf-8")
+    contents = contents.replace(
+        "  </MapLayers>",
+        """    <Layer Name="Broken Land" Type="LandCoverLayer" />
+    <Layer Name="Broken Reference" Type="PolylineFeatureLayer" />
+    <Layer Name="Broken Basemap" Type="WMSLayer" />
+  </MapLayers>""",
+    )
+    contents = contents.replace(
+        "  </Terrains>",
+        """    <Layer Name="Broken Terrain" Type="TerrainLayer" />
+  </Terrains>""",
+    )
+    rasmap_path.write_text(contents, encoding="utf-8")
+
+    rasmap_df = RasMap.parse_rasmap(rasmap_path)
+    errors = rasmap_df.at[0, "rasmap_field_errors"]
+
+    assert rasmap_df.at[0, "rasmap_status"] == "parsed_with_errors"
+    assert _path_names(rasmap_df.at[0, "landcover_hdf_path"]) == ["LandCover.hdf"]
+    assert _path_names(rasmap_df.at[0, "soil_layer_path"]) == [
+        "Hydrologic Soil Groups.hdf"
+    ]
+    assert _path_names(rasmap_df.at[0, "infiltration_hdf_path"]) == [
+        "Infiltration.hdf"
+    ]
+    assert _path_names(rasmap_df.at[0, "terrain_hdf_path"]) == ["Terrain50.hdf"]
+    assert "Inspection Line" in rasmap_df.at[0, "reference_map_layer_names"]
+    assert _path_names(rasmap_df.at[0, "reference_map_layer_path"]) == [
+        "Inspection Line.shp"
+    ]
+    assert "USGS Topo" in rasmap_df.at[0, "basemap_layer_names"]
+    assert _path_names(rasmap_df.at[0, "basemap_layer_path"]) == ["USGS Topo.xml"]
+    assert {
+        "soil_layer_path",
+        "infiltration_hdf_path",
+        "landcover_hdf_path",
+        "terrain_hdf_path",
+        "reference_map_layer_path",
+        "basemap_layer_path",
+    }.issubset(errors)
+
+
+def test_legacy_and_modern_landcover_layers_share_one_parse_path(tmp_path: Path):
+    rasmap_path = tmp_path / "LegacyAndModern.rasmap"
+    contents = BALD_EAGLE_RASMAP_FIXTURE.read_text(encoding="utf-8")
+    contents = contents.replace(
+        'Type="LandCoverLayer"',
+        'Type="LandCover"',
+        1,
+    )
+    rasmap_path.write_text(contents, encoding="utf-8")
+
+    rasmap_df = RasMap.parse_rasmap(rasmap_path)
+
+    assert rasmap_df.at[0, "rasmap_status"] == "parsed"
+    assert _path_names(rasmap_df.at[0, "landcover_hdf_path"]) == [
+        "LandCover.hdf"
+    ]
+    (tmp_path / "LegacyAndModern.prj").write_text(
+        "Proj Title=Legacy and Modern\n",
+        encoding="utf-8",
+    )
+    layers = RasMap.list_map_layers(rasmap_path)
+    assert "land_classification" in layers["category"].tolist()
+
+
+def test_initialize_without_rasmap_returns_expected_path(tmp_path: Path):
+    class ProjectStub:
+        project_folder = tmp_path
+        project_name = "NoMap"
+
+        @staticmethod
+        def check_initialized():
+            return None
+
+    rasmap_df = RasMap.initialize_rasmap_df(ProjectStub())
+
+    assert len(rasmap_df) == 1
+    assert rasmap_df.at[0, "rasmap_status"] == "absent"
+    assert rasmap_df.at[0, "rasmap_path"] == str(tmp_path / "NoMap.rasmap")
+
+
+def test_rasprj_initialization_fallback_is_one_row(monkeypatch, tmp_path: Path):
+    prj_path = tmp_path / "Fallback.prj"
+    prj_path.write_text("Proj Title=Fallback\nCurrent Plan=\n", encoding="utf-8")
+    project = RasPrj()
+
+    monkeypatch.setattr(project, "_load_project_data", lambda: None)
+    monkeypatch.setattr(project, "get_boundary_conditions", lambda: None)
+    monkeypatch.setattr(project, "refresh_project_crs", lambda: None)
+
+    def fail_initialization(*args, **kwargs):
+        raise RuntimeError("injected initialization failure")
+
+    monkeypatch.setattr(RasMap, "initialize_rasmap_df", fail_initialization)
+
+    project.initialize(
+        tmp_path,
+        ras_exe_path="Ras.exe",
+        suppress_logging=True,
+        prj_file=prj_path,
+        load_results_summary=False,
+    )
+
+    assert len(project.rasmap_df) == 1
+    assert project.rasmap_df.at[0, "rasmap_status"] == "failed"
+    assert project.rasmap_df.at[0, "rasmap_error"] == (
+        "RuntimeError: injected initialization failure"
+    )
+
+
+def test_rasprj_import_fallback_is_one_row(monkeypatch, tmp_path: Path):
+    prj_path = tmp_path / "ImportFallback.prj"
+    prj_path.write_text(
+        "Proj Title=Import Fallback\nCurrent Plan=\n",
+        encoding="utf-8",
+    )
+    project = RasPrj()
+
+    monkeypatch.setattr(project, "_load_project_data", lambda: None)
+    monkeypatch.setattr(project, "get_boundary_conditions", lambda: None)
+    monkeypatch.setattr(project, "refresh_project_crs", lambda: None)
+    monkeypatch.setitem(sys.modules, "ras_commander.RasMap", None)
+
+    project.initialize(
+        tmp_path,
+        ras_exe_path="Ras.exe",
+        suppress_logging=True,
+        prj_file=prj_path,
+        load_results_summary=False,
+    )
+
+    assert len(project.rasmap_df) == 1
+    assert project.rasmap_df.at[0, "rasmap_status"] == "failed"
+    assert project.rasmap_df.at[0, "rasmap_error"].startswith("ImportError:")
+
+
+def test_rasprj_initialization_importerror_preserves_real_error(
+    monkeypatch,
+    tmp_path: Path,
+):
+    prj_path = tmp_path / "DependencyFailure.prj"
+    prj_path.write_text(
+        "Proj Title=Dependency Failure\nCurrent Plan=\n",
+        encoding="utf-8",
+    )
+    project = RasPrj()
+
+    monkeypatch.setattr(project, "_load_project_data", lambda: None)
+    monkeypatch.setattr(project, "get_boundary_conditions", lambda: None)
+    monkeypatch.setattr(project, "refresh_project_crs", lambda: None)
+
+    def fail_initialization(*args, **kwargs):
+        raise ImportError("optional parser dependency is unavailable")
+
+    monkeypatch.setattr(RasMap, "initialize_rasmap_df", fail_initialization)
+
+    project.initialize(
+        tmp_path,
+        ras_exe_path="Ras.exe",
+        suppress_logging=True,
+        prj_file=prj_path,
+        load_results_summary=False,
+    )
+
+    assert len(project.rasmap_df) == 1
+    assert project.rasmap_df.at[0, "rasmap_status"] == "failed"
+    assert project.rasmap_df.at[0, "rasmap_error"] == (
+        "ImportError: optional parser dependency is unavailable"
+    )

--- a/tests/test_unc_rasmap_dss.py
+++ b/tests/test_unc_rasmap_dss.py
@@ -7,7 +7,6 @@ These tests verify that:
 3. Projects with DSS boundary conditions work correctly
 """
 
-import os
 import sys
 import shutil
 from pathlib import Path
@@ -51,8 +50,6 @@ class TestRasMapOnNetworkDrive:
     @pytest.mark.skipif(not is_network_drive_available(), reason="Network drive not available")
     def test_rasmap_paths_preserve_drive_letter(self, setup_network_test_dir):
         """RasMap should preserve drive letters in terrain layer paths."""
-        from ras_commander import RasMap
-
         output_path = setup_network_test_dir / "rasmap_test"
 
         # Extract project with terrain
@@ -64,14 +61,17 @@ class TestRasMapOnNetworkDrive:
         init_ras_project(project_path, "6.6")
 
         # Check that rasmap_df paths don't have UNC
-        if hasattr(ras, 'rasmap_df') and ras.rasmap_df is not None and not ras.rasmap_df.empty:
+        if ras.rasmap_df.iloc[0].get("rasmap_status") in {
+            "parsed",
+            "parsed_with_errors",
+        }:
             for col in ras.rasmap_df.columns:
                 if 'path' in col.lower() or 'file' in col.lower():
                     for idx, val in ras.rasmap_df[col].items():
                         if val and str(val).startswith("\\\\"):
                             pytest.fail(f"UNC path found in rasmap_df[{col}]: {val}")
 
-        print(f"[PASS] RasMap paths use drive letters")
+        print("[PASS] RasMap paths use drive letters")
 
 
 class TestDamBreachProjectOnNetworkDrive:
@@ -121,7 +121,7 @@ class TestDamBreachProjectOnNetworkDrive:
         if issues:
             pytest.fail(f"UNC paths found: {issues}")
 
-        print(f"[PASS] All Dam Breaching paths use drive letters")
+        print("[PASS] All Dam Breaching paths use drive letters")
 
 
 class TestMultipleProjectsOnNetworkDrive:
@@ -152,7 +152,7 @@ class TestMultipleProjectsOnNetworkDrive:
 
             print(f"[OK] {proj_name}: {prj_str}")
 
-        print(f"[PASS] Project switching maintains drive letters")
+        print("[PASS] Project switching maintains drive letters")
 
 
 class TestDSSOperationsOnNetworkDrive:

--- a/tests/test_usgs_sciencebase_catalog.py
+++ b/tests/test_usgs_sciencebase_catalog.py
@@ -7,6 +7,7 @@ import pytest
 
 from ras_commander import RasDss
 from ras_commander.RasExamples import RasExamples
+from ras_commander._rasmap_schema import create_rasmap_dataframe
 from ras_commander.sources.federal.sciencebase_validation import (
     ScienceBaseValidation,
 )
@@ -1046,6 +1047,97 @@ def test_dependency_inspection_rejects_absolute_and_external_paths(tmp_path):
         "absolute_reference",
         "external_reference",
     }
+
+
+def test_rasmap_dependency_inspection_reports_document_failure(
+    monkeypatch,
+    tmp_path,
+):
+    rasmap_path = tmp_path / "Model.rasmap"
+    ras_object = SimpleNamespace(
+        prj_file=tmp_path / "Model.prj",
+        rasmap_df=create_rasmap_dataframe(
+            rasmap_path=rasmap_path,
+            rasmap_status="failed",
+            rasmap_error="ParseError: malformed XML",
+        ),
+    )
+
+    def fail_layer_lookup(*args, **kwargs):
+        raise AssertionError("failed rasmap must be gated before layer lookup")
+
+    monkeypatch.setattr(
+        "ras_commander.sources.federal.sciencebase_validation."
+        "RasMap.list_terrain_layers",
+        fail_layer_lookup,
+    )
+    monkeypatch.setattr(
+        "ras_commander.sources.federal.sciencebase_validation."
+        "RasMap.list_land_classification_layers",
+        fail_layer_lookup,
+    )
+    issues = []
+
+    ScienceBaseValidation._inspect_rasmap_dependencies(
+        ras_object,
+        issues,
+        tmp_path,
+    )
+
+    assert issues == [
+        {
+            "code": "rasmap_parse_failed",
+            "kind": "rasmap",
+            "owner": str(ras_object.prj_file),
+            "path": str(rasmap_path),
+            "detail": "ParseError: malformed XML",
+        }
+    ]
+
+
+def test_rasmap_dependency_inspection_reports_partial_field_errors(
+    monkeypatch,
+    tmp_path,
+):
+    rasmap_path = tmp_path / "Model.rasmap"
+    ras_object = SimpleNamespace(
+        prj_file=tmp_path / "Model.prj",
+        rasmap_df=create_rasmap_dataframe(
+            rasmap_path=rasmap_path,
+            rasmap_status="parsed_with_errors",
+            rasmap_field_errors={
+                "terrain_hdf_path": "ValueError: malformed terrain"
+            },
+        ),
+    )
+    monkeypatch.setattr(
+        "ras_commander.sources.federal.sciencebase_validation."
+        "RasMap.list_terrain_layers",
+        lambda *args, **kwargs: pd.DataFrame(),
+    )
+    monkeypatch.setattr(
+        "ras_commander.sources.federal.sciencebase_validation."
+        "RasMap.list_land_classification_layers",
+        lambda *args, **kwargs: pd.DataFrame(),
+    )
+    issues = []
+
+    ScienceBaseValidation._inspect_rasmap_dependencies(
+        ras_object,
+        issues,
+        tmp_path,
+    )
+
+    assert issues == [
+        {
+            "code": "rasmap_field_parse_failed",
+            "kind": "rasmap",
+            "owner": str(ras_object.prj_file),
+            "path": str(rasmap_path),
+            "field": "terrain_hdf_path",
+            "detail": "ValueError: malformed terrain",
+        }
+    ]
 
 
 def test_validation_containment_does_not_resolve_mapped_paths(monkeypatch, tmp_path):


### PR DESCRIPTION
# Make `rasmap_df` parse outcomes observable

## Summary

- preserve the existing single-row frame and first 11 columns
- append explicit file, lifecycle, document-error, and per-field-error provenance
- keep partial parsing non-raising while preserving valid sibling layers
- normalize exceptional initialization fallbacks to the same one-row shape
- centralize expected-path, top-level-layer, status-health, and HDF lookup logic
- migrate tracked downstream consumers and all six infiltration/statistics APIs
- document the contract and show provenance-first use in the two QA/QC notebooks

## Compatibility

Normal named-column access is unchanged. The additive frame width changes from
11 to 15 columns, and the rare zero-row initialization fallback is corrected to
one row. Exact-schema/positional consumers must account for those changes.

## User-facing example

```python
summary = ras.rasmap_df.iloc[0]

if summary["rasmap_status"] == "failed":
    raise RuntimeError(summary["rasmap_error"])
if summary["rasmap_status"] == "absent":
    print("No map:", summary["rasmap_path"])
else:
    print(summary["terrain_hdf_path"])
```

`len`, `.empty`, and non-`None` are shape/existence observations, not parser
health checks.

## Validation

- 216 focused tests passed with 5 mapped-drive skips across parser, consumers,
  HDF lookup, map-layer, geometry-association, archive compatibility, and
  ScienceBase promotion behavior
- 327 repository `.rasmap` files replayed with no failed or partial parses
- 32 files from the installed RasExamples archive parsed across terrain, basemap,
  results, and modern land-cover forms
- both modified notebooks compile as JSON and Python
- parser/resolver/cross-section changes and new tests pass Ruff
- two Claude Code Fable reviews found no blocker or high-severity issue
- the API consistency auditor's final pass found no blocker, high, or medium issue

The full suite produced 2676 passed, 61 skipped, and 13 unrelated baseline or
environment failures. See `2026-09-07_rasmap_df_pr_worklog.md` for categorization,
the documentation build result, and the independent review record.
