### PR TITLE
Read legacy HEC-RAS 5.x 1D geometry HDFs

### DIFF
--- a/ras_commander/geom/GeomMetadata.py
+++ b/ras_commander/geom/GeomMetadata.py
@@ -225,14 +225,12 @@ class GeomMetadata:
 
     @staticmethod
     def _get_xs_count_hdf(hdf: h5py.File) -> int:
-        """Get 1D cross section count from geometry HDF."""
-        path = '/Geometry/Cross Sections/Attributes'
-        if path not in hdf:
-            return 0
-        dataset = hdf[path]
-        if not isinstance(dataset, h5py.Dataset) or not dataset.shape:
-            raise ValueError(f"Unreadable cross-section attributes dataset: {path}")
-        return int(dataset.shape[0])
+        """Get the validated 1D cross-section count for modern or legacy HDF."""
+        # Lazy import keeps the geometry metadata module independent during
+        # package initialization while sharing one schema-recognition contract.
+        from ..hdf.HdfXsec import HdfXsec
+
+        return HdfXsec._get_cross_section_count(hdf)
 
     @staticmethod
     def _get_structure_counts_hdf(hdf: h5py.File) -> Dict[str, int]:

--- a/ras_commander/hdf/HdfXsec.py
+++ b/ras_commander/hdf/HdfXsec.py
@@ -34,7 +34,7 @@ handling and logging.
 """
 
 from pathlib import Path
-from typing import Any, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 import h5py
 import numpy as np
@@ -85,6 +85,324 @@ class HdfXsec:
         f"{CROSS_SECTION_GROUP}/Polyline Parts",
         f"{CROSS_SECTION_GROUP}/Polyline Points",
     )
+
+    @staticmethod
+    def _cross_section_group(hdf: h5py.File) -> h5py.Group:
+        """Return the cross-section group or fail with a schema-specific error."""
+        path = "/Geometry/Cross Sections"
+        if path not in hdf or not isinstance(hdf[path], h5py.Group):
+            raise ValueError(f"Missing cross-section group: {path}")
+        return hdf[path]
+
+    @staticmethod
+    def _dataset(group: h5py.Group, name: str, *, columns: int = 0) -> np.ndarray:
+        """Read one required cross-section dataset and validate its shape."""
+        if name not in group or not isinstance(group[name], h5py.Dataset):
+            raise ValueError(f"Missing cross-section dataset: {group.name}/{name}")
+        values = group[name][()]
+        if values.ndim == 0:
+            raise ValueError(f"Cross-section dataset is scalar: {group.name}/{name}")
+        if columns and (values.ndim != 2 or values.shape[1] < columns):
+            raise ValueError(
+                f"Cross-section dataset {group.name}/{name} must have at least "
+                f"{columns} columns; found shape {values.shape}"
+            )
+        return values
+
+    @staticmethod
+    def _get_cross_section_count(hdf: h5py.File) -> int:
+        """Return the XS row count for compound or legacy separated schemas.
+
+        HEC-RAS 5.x geometry HDF files store cross-section identity and
+        hydraulic attributes in separate datasets instead of the compound
+        ``Attributes`` dataset used by newer releases. A legacy schema is
+        recognized only when its three independent row anchors are present.
+        All feature-row datasets that are present must agree on row count.
+        This establishes dimensional evidence; full reader methods separately
+        validate the datasets needed to extract hydraulic content.
+        """
+        path = "/Geometry/Cross Sections"
+        if path not in hdf:
+            return 0
+        group = HdfXsec._cross_section_group(hdf)
+
+        if "Attributes" in group:
+            attributes = group["Attributes"]
+            if not isinstance(attributes, h5py.Dataset) or len(attributes.shape) != 1:
+                raise ValueError(
+                    "Cross-section Attributes must be a one-dimensional dataset; "
+                    f"found {getattr(attributes, 'shape', None)}"
+                )
+            row_count = int(attributes.shape[0])
+        else:
+            legacy_anchors = ("Node Names", "River Stations", "Polyline Info")
+            present = [name for name in legacy_anchors if name in group]
+            if not present:
+                return 0
+            if len(present) != len(legacy_anchors):
+                missing = sorted(set(legacy_anchors) - set(present))
+                raise ValueError(
+                    "Incomplete legacy cross-section schema; missing row anchors: "
+                    + ", ".join(missing)
+                )
+            row_count = int(group["Polyline Info"].shape[0])
+
+        row_datasets = (
+            "Polyline Info",
+            "Station Elevation Info",
+            "Manning's n Info",
+            "Station Manning's n Info",
+            "Ineffective Info",
+            "Blocked Ineffective Info",
+            "River Names",
+            "Reach Names",
+            "River Stations",
+            "Node Names",
+            "Node Descriptions",
+            "Lengths",
+            "Bank Stations",
+            "Contr Expan Coef",
+            "Hydraulic Tables Starting Elevation and Increment Size",
+            "Hydraulic Tables Vertical and Horizontal Slices",
+        )
+        inconsistent = []
+        for name in row_datasets:
+            if name not in group:
+                continue
+            dataset = group[name]
+            if not isinstance(dataset, h5py.Dataset) or not dataset.shape:
+                raise ValueError(f"Unreadable cross-section dataset: {group.name}/{name}")
+            rows = int(dataset.shape[0])
+            if rows != row_count:
+                inconsistent.append(f"{name}={rows}")
+
+        if inconsistent:
+            raise ValueError(
+                f"Cross-section row count mismatch (expected {row_count}): "
+                + ", ".join(inconsistent)
+            )
+        return row_count
+
+    @staticmethod
+    def _info_values_pair(
+        group: h5py.Group,
+        info_names: Tuple[str, ...],
+        value_names: Tuple[str, ...],
+        row_count: int,
+        *,
+        value_columns: int,
+    ) -> Tuple[np.ndarray, np.ndarray]:
+        """Select and validate a matching info/value dataset pair."""
+        info_name = value_name = None
+        for candidate_info, candidate_values in zip(info_names, value_names):
+            if candidate_info in group or candidate_values in group:
+                if candidate_info not in group or candidate_values not in group:
+                    raise ValueError(
+                        "Incomplete cross-section info/value dataset pair: "
+                        f"{candidate_info!r} / {candidate_values!r}"
+                    )
+                info_name, value_name = candidate_info, candidate_values
+                break
+        if info_name is None:
+            raise ValueError(
+                "Missing cross-section info/value dataset pair: "
+                f"{info_names!r} / {value_names!r}"
+            )
+
+        info = HdfXsec._dataset(group, info_name, columns=2)
+        values = HdfXsec._dataset(group, value_name, columns=value_columns)
+        if len(info) != row_count:
+            raise ValueError(
+                f"Cross-section row count mismatch (expected {row_count}): "
+                f"{info_name}={len(info)}"
+            )
+
+        for row_index, (raw_start, raw_count, *_) in enumerate(info):
+            start = int(raw_start)
+            count = int(raw_count)
+            if (
+                not np.isfinite(float(raw_start))
+                or not np.isfinite(float(raw_count))
+                or float(raw_start) != start
+                or float(raw_count) != count
+            ):
+                raise ValueError(
+                    f"Non-integer {info_name} slice at cross-section row "
+                    f"{row_index}: start={raw_start}, count={raw_count}"
+                )
+            if start < 0 or count < 0 or start + count > len(values):
+                raise ValueError(
+                    f"Invalid {info_name} slice at cross-section row {row_index}: "
+                    f"start={start}, count={count}, values={len(values)}"
+                )
+        return info, values
+
+    @staticmethod
+    def _legacy_cross_section_attributes(
+        group: h5py.Group,
+        row_count: int,
+    ) -> Dict[str, np.ndarray]:
+        """Normalize HEC-RAS 5.x separated XS attributes by public field name."""
+        column_specs = {
+            "River": ("River Names", None),
+            "Reach": ("Reach Names", None),
+            "RS": ("River Stations", None),
+            "Name": ("Node Names", None),
+            "Description": ("Node Descriptions", None),
+            "Len Left": ("Lengths", 0),
+            "Len Channel": ("Lengths", 1),
+            "Len Right": ("Lengths", 2),
+            "Left Bank": ("Bank Stations", 0),
+            "Right Bank": ("Bank Stations", 1),
+            "Contr": ("Contr Expan Coef", 0),
+            "Expan": ("Contr Expan Coef", 1),
+            "HP Start Elev": (
+                "Hydraulic Tables Starting Elevation and Increment Size",
+                0,
+            ),
+            "HP Vert Incr": (
+                "Hydraulic Tables Starting Elevation and Increment Size",
+                1,
+            ),
+            "HP Count": ("Hydraulic Tables Vertical and Horizontal Slices", 0),
+            "HP LOB Slices": (
+                "Hydraulic Tables Vertical and Horizontal Slices",
+                1,
+            ),
+            "HP Chan Slices": (
+                "Hydraulic Tables Vertical and Horizontal Slices",
+                2,
+            ),
+            "HP ROB Slices": (
+                "Hydraulic Tables Vertical and Horizontal Slices",
+                3,
+            ),
+        }
+        attributes = {}
+        for field_name, (dataset_name, column) in column_specs.items():
+            values = HdfXsec._dataset(
+                group,
+                dataset_name,
+                columns=column + 1 if column is not None else 0,
+            )
+            if len(values) != row_count:
+                raise ValueError(
+                    f"Cross-section row count mismatch (expected {row_count}): "
+                    f"{dataset_name}={len(values)}"
+                )
+            column_values = values if column is None else values[:, column]
+            if field_name.startswith("Len "):
+                column_values = np.asarray(column_values, dtype=float).copy()
+                column_values[column_values >= np.finfo(np.float32).max * 0.99] = np.nan
+            attributes[field_name] = column_values
+        return attributes
+
+    @staticmethod
+    def _attribute_columns(
+        group: h5py.Group,
+        row_count: int,
+    ) -> Dict[str, np.ndarray]:
+        """Return normalized attribute columns for either supported XS schema."""
+        if "Attributes" not in group:
+            return HdfXsec._legacy_cross_section_attributes(group, row_count)
+        attributes = HdfXsec._dataset(group, "Attributes")
+        if len(attributes) != row_count or not attributes.dtype.names:
+            raise ValueError(
+                "Cross-section Attributes must be a compound dataset with one row "
+                "per cross section"
+            )
+        return {name: attributes[name] for name in attributes.dtype.names}
+
+    @staticmethod
+    def _string_values(values: np.ndarray) -> List[str]:
+        """Decode fixed-width HDF strings without interpreting their contents."""
+        decoded = []
+        for value in values:
+            if isinstance(value, (bytes, np.bytes_)):
+                value = bytes(value).decode("utf-8", errors="replace")
+            decoded.append(str(value).strip())
+        return decoded
+
+    @staticmethod
+    def _polyline_geometries(
+        group: h5py.Group,
+        info_name: str,
+        parts_name: str,
+        points_name: str,
+        *,
+        expected_rows: Optional[int] = None,
+    ) -> List:
+        """Build validated polylines from one HEC-RAS info/parts/points trio."""
+        info = HdfXsec._dataset(group, info_name, columns=4)
+        parts = HdfXsec._dataset(group, parts_name, columns=2)
+        points = HdfXsec._dataset(group, points_name, columns=2)
+        if expected_rows is not None and len(info) != expected_rows:
+            raise ValueError(
+                f"Polyline row count mismatch (expected {expected_rows}): "
+                f"{info_name}={len(info)}"
+            )
+
+        geometries = []
+        for row_index, row in enumerate(info):
+            raw_indices = row[:4]
+            point_start, point_count, part_start, part_count = (
+                int(value) for value in raw_indices
+            )
+            if any(
+                not np.isfinite(float(value)) or float(value) != int(value)
+                for value in raw_indices
+            ):
+                raise ValueError(f"Non-integer polyline index/count at row {row_index}")
+            if min(point_start, point_count, part_start, part_count) < 0:
+                raise ValueError(f"Negative polyline index/count at row {row_index}")
+            if point_count < 2 or point_start + point_count > len(points):
+                raise ValueError(
+                    f"Invalid {points_name} slice at row {row_index}: "
+                    f"start={point_start}, count={point_count}, points={len(points)}"
+                )
+            if part_count == 0 or part_start + part_count > len(parts):
+                raise ValueError(
+                    f"Invalid {parts_name} slice at row {row_index}: "
+                    f"start={part_start}, count={part_count}, parts={len(parts)}"
+                )
+
+            feature_parts = []
+            expected_offset = 0
+            for part in parts[part_start : part_start + part_count]:
+                raw_offset, raw_points = part[:2]
+                part_offset, part_points = int(raw_offset), int(raw_points)
+                if (
+                    not np.isfinite(float(raw_offset))
+                    or not np.isfinite(float(raw_points))
+                    or float(raw_offset) != part_offset
+                    or float(raw_points) != part_points
+                    or part_offset != expected_offset
+                    or part_points < 2
+                    or part_offset + part_points > point_count
+                ):
+                    raise ValueError(
+                        f"Invalid {parts_name} point span at row {row_index}: "
+                        f"offset={part_offset}, count={part_points}"
+                    )
+                start = point_start + part_offset
+                part_coordinates = points[start : start + part_points]
+                if not np.isfinite(part_coordinates).all():
+                    raise ValueError(
+                        f"Polyline part at row {row_index} contains non-finite points"
+                    )
+                feature_parts.append(LineString(part_coordinates))
+                expected_offset += part_points
+            if expected_offset != point_count:
+                raise ValueError(
+                    f"Polyline parts account for {expected_offset} points at row "
+                    f"{row_index}; declared point count is {point_count}"
+                )
+            geometries.append(
+                feature_parts[0]
+                if len(feature_parts) == 1
+                else MultiLineString(feature_parts)
+            )
+        return geometries
 
     @staticmethod
     def _filename(hdf_path) -> str:
@@ -477,172 +795,178 @@ class HdfXsec:
                     )
                     return gpd.GeoDataFrame()
 
-                missing_datasets = [
+                missing_core = [
                     dataset
-                    for dataset in HdfXsec.CROSS_SECTION_REQUIRED_DATASETS
+                    for dataset in HdfXsec.CROSS_SECTION_CORE_GEOMETRY_DATASETS
                     if dataset not in hdf
                 ]
-                if missing_datasets:
-                    if all(
-                        dataset in missing_datasets
-                        for dataset in HdfXsec.CROSS_SECTION_CORE_GEOMETRY_DATASETS
+                if missing_core:
+                    if len(missing_core) == len(
+                        HdfXsec.CROSS_SECTION_CORE_GEOMETRY_DATASETS
                     ):
                         logger.debug(
-                            "No cross-section geometry datasets found in %s; missing %s; returning empty GeoDataFrame.",
+                            "No cross-section geometry datasets found in %s; missing %s; "
+                            "returning empty GeoDataFrame.",
                             HdfXsec._filename(hdf_path),
-                            ", ".join(missing_datasets),
+                            ", ".join(missing_core),
                         )
                     else:
                         logger.warning(
-                            "Cross-section geometry in %s is missing required dataset(s): %s; returning empty GeoDataFrame.",
+                            "Cross-section geometry in %s is missing required dataset(s): "
+                            "%s; returning empty GeoDataFrame.",
                             HdfXsec._filename(hdf_path),
-                            ", ".join(missing_datasets),
+                            ", ".join(missing_core),
                         )
                     return gpd.GeoDataFrame()
 
-                # Extract required datasets
-                poly_info = hdf['/Geometry/Cross Sections/Polyline Info'][:]
-                poly_parts = hdf['/Geometry/Cross Sections/Polyline Parts'][:]
-                poly_points = hdf['/Geometry/Cross Sections/Polyline Points'][:]
-                
-                station_info = hdf['/Geometry/Cross Sections/Station Elevation Info'][:]
-                station_values = hdf['/Geometry/Cross Sections/Station Elevation Values'][:]
-                
-                # Get attributes for cross sections
-                xs_attrs = hdf['/Geometry/Cross Sections/Attributes'][:]
-                
-                # Get Manning's n data
-                mann_info = hdf["/Geometry/Cross Sections/Manning's n Info"][:]
-                mann_values = hdf["/Geometry/Cross Sections/Manning's n Values"][:]
-                
-                # Get ineffective blocks data if they exist
-                if '/Geometry/Cross Sections/Ineffective Blocks' in hdf:
-                    ineff_blocks = hdf['/Geometry/Cross Sections/Ineffective Blocks'][:]
-                    ineff_info = hdf['/Geometry/Cross Sections/Ineffective Info'][:]
-                else:
-                    ineff_blocks = None
-                    ineff_info = None
-                
-                # Initialize lists to store data
-                geometries = []
+                group = HdfXsec._cross_section_group(hdf)
+                row_count = HdfXsec._get_cross_section_count(hdf)
+                if row_count == 0:
+                    return gpd.GeoDataFrame()
+
+                geometries = HdfXsec._polyline_geometries(
+                    group,
+                    "Polyline Info",
+                    "Polyline Parts",
+                    "Polyline Points",
+                    expected_rows=row_count,
+                )
+                station_info, station_values = HdfXsec._info_values_pair(
+                    group,
+                    ("Station Elevation Info",),
+                    ("Station Elevation Values",),
+                    row_count,
+                    value_columns=2,
+                )
+                mann_info, mann_values = HdfXsec._info_values_pair(
+                    group,
+                    ("Manning's n Info", "Station Manning's n Info"),
+                    ("Manning's n Values", "Station Manning's n Values"),
+                    row_count,
+                    value_columns=2,
+                )
+                attributes = HdfXsec._attribute_columns(group, row_count)
+
+                modern_ineff = ("Ineffective Info", "Ineffective Blocks")
+                legacy_ineff = (
+                    "Blocked Ineffective Info",
+                    "Blocked Ineffective Values",
+                )
+                ineff_info = ineff_values = None
+                for info_name, value_name in (modern_ineff, legacy_ineff):
+                    if info_name in group or value_name in group:
+                        ineff_info, ineff_values = HdfXsec._info_values_pair(
+                            group,
+                            (info_name,),
+                            (value_name,),
+                            row_count,
+                            value_columns=0,
+                        )
+                        break
+
                 station_elevations = []
                 mannings_n = []
                 ineffective_blocks = []
                 n_lob_list = []
                 n_channel_list = []
                 n_rob_list = []
-                
-                # Process each cross section
-                for i in range(len(poly_info)):
-                    # Extract polyline info
-                    point_start_idx = poly_info[i][0]
-                    part_start_idx = poly_info[i][2]
-                    part_count = poly_info[i][3]
-                    
-                    # Extract parts for current polyline
-                    parts = poly_parts[part_start_idx:part_start_idx + part_count]
-                    
-                    # Collect all points for this cross section
-                    xs_points = []
-                    for part in parts:
-                        part_point_start = point_start_idx + part[0]
-                        part_point_count = part[1]
-                        points = poly_points[part_point_start:part_point_start + part_point_count]
-                        xs_points.extend(points)
-                    
-                    # Create LineString geometry
-                    if len(xs_points) >= 2:
-                        geometry = LineString(xs_points)
-                        geometries.append(geometry)
-                        
-                        # Extract station-elevation data
-                        start_idx = station_info[i][0]
-                        count = station_info[i][1]
-                        station_elev = station_values[start_idx:start_idx + count]
-                        station_elevations.append(station_elev)
-                        
-                        # Extract Manning's n data
-                        mann_start_idx = mann_info[i][0]
-                        mann_count = mann_info[i][1]
-                        mann_n_section = mann_values[mann_start_idx:mann_start_idx + mann_count]
-                        mann_n_dict = {
-                            'Station': mann_n_section[:, 0].tolist(),
-                            'Mann n': mann_n_section[:, 1].tolist()
+
+                for i in range(row_count):
+                    station_start, station_count = (
+                        int(value) for value in station_info[i, :2]
+                    )
+                    station_elevations.append(
+                        station_values[station_start : station_start + station_count]
+                    )
+
+                    mann_start, mann_count = (
+                        int(value) for value in mann_info[i, :2]
+                    )
+                    mann_section = mann_values[mann_start : mann_start + mann_count]
+                    mannings_n.append(
+                        {
+                            "Station": mann_section[:, 0].tolist(),
+                            "Mann n": mann_section[:, 1].tolist(),
                         }
-                        mannings_n.append(mann_n_dict)
+                    )
 
-                        # Compute LOB/Channel/ROB Manning's n values
-                        # Get bank stations for this XS
-                        left_bank = float(xs_attrs[i]['Left Bank'])
-                        right_bank = float(xs_attrs[i]['Right Bank'])
-
-                        # Map n values to LOB/Channel/ROB based on stations
-                        if mann_count == 0:
-                            n_lob_val = n_channel_val = n_rob_val = np.nan
-                        elif mann_count == 3:
-                            # Simple LOB/Channel/ROB model (most common)
-                            n_lob_val = float(mann_n_section[0, 1])
-                            n_channel_val = float(mann_n_section[1, 1])
-                            n_rob_val = float(mann_n_section[2, 1])
-                        elif mann_count == 2:
-                            # Two regions
-                            sta1, n1 = float(mann_n_section[0, 0]), float(mann_n_section[0, 1])
-                            sta2, n2 = float(mann_n_section[1, 0]), float(mann_n_section[1, 1])
-                            if sta1 < left_bank and sta2 >= left_bank:
-                                n_lob_val, n_channel_val, n_rob_val = n1, n2, n2
-                            else:
-                                n_lob_val, n_channel_val, n_rob_val = n1, n1, n2
-                        elif mann_count >= 4:
-                            # Variable n - map by station regions
-                            n_lob_val = n_channel_val = n_rob_val = None
-                            for j in range(mann_count):
-                                sta, n_val = float(mann_n_section[j, 0]), float(mann_n_section[j, 1])
-                                if sta < left_bank:
-                                    n_lob_val = n_val
-                                elif sta < right_bank:
-                                    if n_channel_val is None:
-                                        n_channel_val = n_val
-                                else:
-                                    if n_rob_val is None:
-                                        n_rob_val = n_val
-                            # Fill missing
-                            if n_lob_val is None:
-                                n_lob_val = float(mann_n_section[0, 1])
-                            if n_channel_val is None:
-                                n_channel_val = n_lob_val
-                            if n_rob_val is None:
-                                n_rob_val = n_channel_val
+                    left_bank = float(attributes["Left Bank"][i])
+                    right_bank = float(attributes["Right Bank"][i])
+                    if mann_count == 0:
+                        n_lob_val = n_channel_val = n_rob_val = np.nan
+                    elif mann_count == 3:
+                        n_lob_val = float(mann_section[0, 1])
+                        n_channel_val = float(mann_section[1, 1])
+                        n_rob_val = float(mann_section[2, 1])
+                    elif mann_count == 2:
+                        sta1, n1 = (float(value) for value in mann_section[0, :2])
+                        sta2, n2 = (float(value) for value in mann_section[1, :2])
+                        if sta1 < left_bank and sta2 >= left_bank:
+                            n_lob_val, n_channel_val, n_rob_val = n1, n2, n2
                         else:
-                            # Single value
-                            n_lob_val = n_channel_val = n_rob_val = float(mann_n_section[0, 1])
+                            n_lob_val, n_channel_val, n_rob_val = n1, n1, n2
+                    elif mann_count >= 4:
+                        n_lob_val = n_channel_val = n_rob_val = None
+                        for station, n_value in mann_section[:, :2]:
+                            station, n_value = float(station), float(n_value)
+                            if station < left_bank:
+                                n_lob_val = n_value
+                            elif station < right_bank and n_channel_val is None:
+                                n_channel_val = n_value
+                            elif station >= right_bank and n_rob_val is None:
+                                n_rob_val = n_value
+                        if n_lob_val is None:
+                            n_lob_val = float(mann_section[0, 1])
+                        if n_channel_val is None:
+                            n_channel_val = n_lob_val
+                        if n_rob_val is None:
+                            n_rob_val = n_channel_val
+                    else:
+                        n_lob_val = n_channel_val = n_rob_val = float(
+                            mann_section[0, 1]
+                        )
+                    n_lob_list.append(n_lob_val)
+                    n_channel_list.append(n_channel_val)
+                    n_rob_list.append(n_rob_val)
 
-                        # Append computed Manning's n values
-                        n_lob_list.append(n_lob_val)
-                        n_channel_list.append(n_channel_val)
-                        n_rob_list.append(n_rob_val)
-
-                        # Extract ineffective blocks data
-                        if ineff_info is not None and ineff_blocks is not None:
-                            ineff_start_idx = ineff_info[i][0]
-                            ineff_count = ineff_info[i][1]
-                            if ineff_count > 0:
-                                blocks = ineff_blocks[ineff_start_idx:ineff_start_idx + ineff_count]
-                                blocks_list = []
-                                for block in blocks:
-                                    block_dict = {
-                                        'Left Sta': float(block['Left Sta']),
-                                        'Right Sta': float(block['Right Sta']), 
-                                        'Elevation': float(block['Elevation']),
-                                        'Permanent': bool(block['Permanent'])
-                                    }
-                                    blocks_list.append(block_dict)
-                                ineffective_blocks.append(blocks_list)
+                    blocks_list = []
+                    if ineff_info is not None and ineff_values is not None:
+                        ineff_start, ineff_count = (
+                            int(value) for value in ineff_info[i, :2]
+                        )
+                        blocks = ineff_values[ineff_start : ineff_start + ineff_count]
+                        for block in blocks:
+                            if blocks.dtype.names:
+                                required = {"Left Sta", "Right Sta", "Elevation"}
+                                if not required.issubset(blocks.dtype.names):
+                                    raise ValueError(
+                                        "Ineffective Blocks dataset is missing required fields"
+                                    )
+                                permanent = (
+                                    bool(block["Permanent"])
+                                    if "Permanent" in blocks.dtype.names
+                                    else False
+                                )
+                                left_sta = block["Left Sta"]
+                                right_sta = block["Right Sta"]
+                                elevation = block["Elevation"]
                             else:
-                                ineffective_blocks.append([])
-                        else:
-                            ineffective_blocks.append([])
-                
-                # Create base dictionary with required fields
+                                if blocks.ndim != 2 or blocks.shape[1] < 3:
+                                    raise ValueError(
+                                        "Blocked Ineffective Values must have at least three columns"
+                                    )
+                                left_sta, right_sta, elevation = block[:3]
+                                permanent = False
+                            blocks_list.append(
+                                {
+                                    "Left Sta": float(left_sta),
+                                    "Right Sta": float(right_sta),
+                                    "Elevation": float(elevation),
+                                    "Permanent": permanent,
+                                }
+                            )
+                    ineffective_blocks.append(blocks_list)
+
                 data = {
                     'geometry': geometries,
                     'station_elevation': station_elevations,
@@ -653,7 +977,6 @@ class HdfXsec:
                     'ineffective_blocks': ineffective_blocks,
                 }
                 
-                # Define field mappings with default values
                 field_mappings = {
                     'River': ('River', ''),
                     'Reach': ('Reach', ''),
@@ -684,34 +1007,28 @@ class HdfXsec:
                     'Last Edited': ('Last Edited', '')
                 }
                 
-                # Add fields that exist in xs_attrs
                 for field_name, (attr_name, default_value) in field_mappings.items():
-                    if attr_name in xs_attrs.dtype.names:
-                        if xs_attrs[attr_name].dtype.kind == 'S':
-                            # Handle string fields
-                            data[field_name] = [x[attr_name].decode('utf-8').strip() 
-                                              for x in xs_attrs]
+                    if attr_name in attributes:
+                        values = np.asarray(attributes[attr_name])
+                        if values.dtype.kind in {'S', 'U', 'O'}:
+                            data[field_name] = HdfXsec._string_values(values)
                         else:
-                            # Handle numeric fields
-                            data[field_name] = xs_attrs[attr_name]
+                            data[field_name] = values
                     else:
-                        # Use default value if field doesn't exist
                         data[field_name] = [default_value] * len(geometries)
                         logger.debug(f"Field {attr_name} not found in attributes, using default value")
-                
-                if geometries:
-                    gdf = gpd.GeoDataFrame(data)
-                    
-                    # Set CRS if available
-                    if 'Projection' in hdf['/Geometry'].attrs:
-                        proj = hdf['/Geometry'].attrs['Projection']
-                        if isinstance(proj, bytes):
-                            proj = proj.decode('utf-8')
-                        gdf = gdf.set_crs(proj, allow_override=True)
-                    
-                    return gdf
-                
-                return gpd.GeoDataFrame()
+
+                projection = None
+                if "Geometry" in hdf and "Projection" in hdf["Geometry"].attrs:
+                    projection = HdfXsec._convert_hdf_value(
+                        hdf["Geometry"].attrs["Projection"]
+                    )
+                if not projection:
+                    projection = HdfBase.get_projection(Path(hdf_path))
+                result = gpd.GeoDataFrame(data, crs=projection)
+                if datetime_to_str:
+                    result = HdfUtils.convert_df_datetimes_to_str(result)
+                return result
                 
         except Exception as e:
             logger.error(f"Error processing cross-section data from {hdf_path}: {str(e)}")
@@ -762,23 +1079,74 @@ class HdfXsec:
                     return GeoDataFrame()
 
                 centerline_data = hdf_file["Geometry/River Centerlines"]
-                
-                # Get attributes directly from HDF dataset
-                attrs = centerline_data["Attributes"][()]
-                
-                # Create initial dictionary for DataFrame
-                centerline_dict = HdfXsec._structured_array_to_dict(attrs)
-
-                # Get polylines using utility function
-                geoms = HdfBase.get_polylines_from_parts(
-                    hdf_path, 
-                    "Geometry/River Centerlines",
-                    info_name="Polyline Info",
-                    parts_name="Polyline Parts",
-                    points_name="Polyline Points"
+                geoms = HdfXsec._polyline_geometries(
+                    centerline_data,
+                    "Polyline Info",
+                    "Polyline Parts",
+                    "Polyline Points",
                 )
+                row_count = len(geoms)
 
-                # Create GeoDataFrame
+                if "Attributes" in centerline_data:
+                    attrs = HdfXsec._dataset(centerline_data, "Attributes")
+                    if len(attrs) != row_count or not attrs.dtype.names:
+                        raise ValueError(
+                            "River centerline Attributes must be a compound dataset "
+                            "with one row per centerline"
+                        )
+                    centerline_dict = {}
+                    for name in attrs.dtype.names:
+                        values = attrs[name]
+                        centerline_dict[name] = (
+                            HdfXsec._string_values(values)
+                            if values.dtype.kind in {"S", "U", "O"}
+                            else values.tolist()
+                        )
+                else:
+                    legacy_names = (
+                        "River Names",
+                        "Reach Names",
+                        "US Junction",
+                        "US SA-2D",
+                        "DS Junction",
+                        "DS SA-2D",
+                    )
+                    legacy_values = {}
+                    for name in legacy_names:
+                        values = HdfXsec._dataset(centerline_data, name)
+                        if values.ndim != 1 or len(values) != row_count:
+                            raise ValueError(
+                                "River centerline row count mismatch "
+                                f"(expected {row_count}): {name}={len(values)}"
+                            )
+                        legacy_values[name] = HdfXsec._string_values(values)
+
+                    centerline_dict = {
+                        "River Name": legacy_values["River Names"],
+                        "Reach Name": legacy_values["Reach Names"],
+                        "US Type": [],
+                        "US Name": [],
+                        "DS Type": [],
+                        "DS Name": [],
+                    }
+                    for row_index in range(row_count):
+                        for prefix in ("US", "DS"):
+                            junction = legacy_values[f"{prefix} Junction"][row_index]
+                            sa_2d = legacy_values[f"{prefix} SA-2D"][row_index]
+                            if junction and sa_2d:
+                                raise ValueError(
+                                    f"River centerline row {row_index} has both "
+                                    f"{prefix} Junction and {prefix} SA-2D connections"
+                                )
+                            if junction:
+                                connection_type, connection_name = "Junction", junction
+                            elif sa_2d:
+                                connection_type, connection_name = "SA-2D", sa_2d
+                            else:
+                                connection_type, connection_name = "External", ""
+                            centerline_dict[f"{prefix} Type"].append(connection_type)
+                            centerline_dict[f"{prefix} Name"].append(connection_name)
+
                 centerline_gdf = GeoDataFrame(
                     centerline_dict,
                     geometry=geoms,
@@ -796,13 +1164,10 @@ class HdfXsec:
                 if not centerline_gdf.empty:
                     centerline_gdf['length'] = centerline_gdf.geometry.length
                     
-                    # Convert datetime columns if requested
                     if datetime_to_str:
-                        datetime_cols = centerline_gdf.select_dtypes(
-                            include=['datetime64']).columns
-                        for col in datetime_cols:
-                            centerline_gdf[col] = centerline_gdf[col].dt.strftime(
-                                '%Y-%m-%d %H:%M:%S')
+                        centerline_gdf = HdfUtils.convert_df_datetimes_to_str(
+                            centerline_gdf
+                        )
 
                 logger.debug(f"Extracted {len(centerline_gdf)} river centerlines")
                 return centerline_gdf
@@ -945,34 +1310,15 @@ class HdfXsec:
             Note: Additional HDF attributes may be included depending on HEC-RAS version.
         """
         try:
-            with h5py.File(hdf_path, 'r') as hdf_file:
-                if "Geometry/River Centerlines" not in hdf_file:
-                    logger.debug(
-                        "No Geometry/River Centerlines group in %s; returning empty GeoDataFrame.",
-                        HdfXsec._filename(hdf_path),
-                    )
-                    return GeoDataFrame()
-
-                river_data = hdf_file["Geometry/River Centerlines"]
-                river_attrs = river_data["Attributes"][()]
-                river_dict = {"river_id": list(range(river_attrs.shape[0]))}
-                river_dict.update(HdfXsec._structured_array_to_dict(river_attrs))
-                
-                # Get polylines for river reaches
-                geoms = HdfBase.get_polylines_from_parts(
-                    hdf_path, "Geometry/River Centerlines"
-                )
-
-                river_gdf = GeoDataFrame(
-                    river_dict,
-                    geometry=geoms,
-                    crs=HdfBase.get_projection(hdf_path),
-                )
-                if datetime_to_str and "Last Edited" in river_gdf.columns:
-                    river_gdf["Last Edited"] = river_gdf["Last Edited"].apply(
-                        HdfXsec._datetime_value_to_str
-                    )
+            river_gdf = HdfXsec.get_river_centerlines(
+                hdf_path,
+                datetime_to_str=datetime_to_str,
+            )
+            if river_gdf.empty:
                 return river_gdf
+            river_gdf = river_gdf.copy()
+            river_gdf.insert(0, "river_id", range(len(river_gdf)))
+            return river_gdf
         except Exception as e:
             logger.error(f"Error reading river reaches from {hdf_path}: {str(e)}")
             return GeoDataFrame()
@@ -1094,16 +1440,32 @@ class HdfXsec:
                     )
                     return GeoDataFrame()
 
-                # Get polyline geometries using existing helper method
-                geoms = HdfBase.get_polylines_from_parts(
-                    hdf_path, 
-                    "Geometry/River Bank Lines",
-                    info_name="Polyline Info",
-                    parts_name="Polyline Parts",
-                    points_name="Polyline Points"
+                bank_data = hdf_file["Geometry/River Bank Lines"]
+                dataset_trios = (
+                    ("Polyline Info", "Polyline Parts", "Polyline Points"),
+                    ("Bank Lines Info", "Bank Lines Parts", "Bank Lines Points"),
                 )
+                selected = None
+                for trio in dataset_trios:
+                    present = [name in bank_data for name in trio]
+                    if any(present):
+                        if not all(present):
+                            missing = [
+                                name for name, exists in zip(trio, present) if not exists
+                            ]
+                            raise ValueError(
+                                "Incomplete river bank-line polyline datasets; missing: "
+                                + ", ".join(missing)
+                            )
+                        selected = trio
+                        break
+                if selected is None:
+                    raise ValueError(
+                        "River bank-line group contains no polyline datasets"
+                    )
 
-                # Create basic attributes
+                geoms = HdfXsec._polyline_geometries(bank_data, *selected)
+
                 bank_dict = {
                     "bank_id": list(range(len(geoms))),
                     "bank_side": HdfXsec._alternating_bank_sides(len(geoms)),

--- a/tests/test_hdf_xsec_legacy_schema.py
+++ b/tests/test_hdf_xsec_legacy_schema.py
@@ -1,0 +1,432 @@
+from pathlib import Path
+
+import h5py
+import numpy as np
+import pandas as pd
+import pytest
+
+from ras_commander import HdfXsec
+from ras_commander.RasPrj import RasPrj
+from ras_commander.geom.GeomMetadata import GeomMetadata
+from ras_commander.hdf.HdfBase import HdfBase
+
+
+def _write_legacy_geometry_hdf(path: Path) -> None:
+    float32_missing = np.finfo(np.float32).max
+    with h5py.File(path, "w") as hdf:
+        xs = hdf.create_group("Geometry/Cross Sections")
+        xs.create_dataset(
+            "Polyline Info",
+            data=np.array([[0, 2, 0, 1], [2, 3, 1, 1]], dtype=np.int32),
+        )
+        xs.create_dataset(
+            "Polyline Parts",
+            data=np.array([[0, 2], [0, 3]], dtype=np.int32),
+        )
+        xs.create_dataset(
+            "Polyline Points",
+            data=np.array(
+                [[0.0, 10.0], [10.0, 10.0], [0.0, 0.0], [5.0, 1.0], [10.0, 0.0]],
+                dtype=np.float64,
+            ),
+        )
+        xs.create_dataset(
+            "Station Elevation Info",
+            data=np.array([[0, 3], [3, 3]], dtype=np.int32),
+        )
+        xs.create_dataset(
+            "Station Elevation Values",
+            data=np.array(
+                [
+                    [0.0, 101.0],
+                    [5.0, 99.0],
+                    [10.0, 101.0],
+                    [0.0, 98.0],
+                    [5.0, 96.0],
+                    [10.0, 98.0],
+                ],
+                dtype=np.float32,
+            ),
+        )
+        xs.create_dataset(
+            "Station Manning's n Info",
+            data=np.array([[0, 3], [3, 4]], dtype=np.int32),
+        )
+        xs.create_dataset(
+            "Station Manning's n Values",
+            data=np.array(
+                [
+                    [0.0, 0.04],
+                    [2.0, 0.03],
+                    [8.0, 0.05],
+                    [0.0, 0.045],
+                    [2.0, 0.035],
+                    [8.0, 0.04],
+                    [10.0, 0.05],
+                ],
+                dtype=np.float32,
+            ),
+        )
+        xs.create_dataset("River Names", data=np.array([b"River A", b"River A"], dtype="S16"))
+        xs.create_dataset("Reach Names", data=np.array([b"Reach 1", b"Reach 1"], dtype="S16"))
+        xs.create_dataset("River Stations", data=np.array([b"200", b"100"], dtype="S8"))
+        xs.create_dataset("Node Names", data=np.array([b"Upper", b"Lower"], dtype="S16"))
+        xs.create_dataset(
+            "Node Descriptions",
+            data=np.array([b"Upstream section", b"Downstream section"], dtype="S64"),
+        )
+        xs.create_dataset(
+            "Lengths",
+            data=np.array(
+                [[100.0, 110.0, 120.0], [float32_missing] * 3],
+                dtype=np.float32,
+            ),
+        )
+        xs.create_dataset(
+            "Bank Stations",
+            data=np.array([[2.0, 8.0], [2.0, 8.0]], dtype=np.float32),
+        )
+        xs.create_dataset(
+            "Contr Expan Coef",
+            data=np.array([[0.1, 0.3], [0.2, 0.4]], dtype=np.float32),
+        )
+        xs.create_dataset(
+            "Hydraulic Tables Starting Elevation and Increment Size",
+            data=np.array([[95.0, 1.0], [94.0, 0.5]], dtype=np.float32),
+        )
+        xs.create_dataset(
+            "Hydraulic Tables Vertical and Horizontal Slices",
+            data=np.array([[20, 5, 6, 7], [30, 8, 9, 10]], dtype=np.int32),
+        )
+        xs.create_dataset(
+            "Blocked Ineffective Info",
+            data=np.array([[0, 1], [1, 0]], dtype=np.int32),
+        )
+        xs.create_dataset(
+            "Blocked Ineffective Values",
+            data=np.array([[0.0, 1.5, 100.0]], dtype=np.float32),
+        )
+
+        centerline = hdf.create_group("Geometry/River Centerlines")
+        centerline.create_dataset(
+            "Polyline Info", data=np.array([[0, 3, 0, 1]], dtype=np.int32)
+        )
+        centerline.create_dataset(
+            "Polyline Parts", data=np.array([[0, 3]], dtype=np.int32)
+        )
+        centerline.create_dataset(
+            "Polyline Points",
+            data=np.array([[5.0, 12.0], [5.0, 5.0], [5.0, -2.0]], dtype=np.float64),
+        )
+        centerline.create_dataset("River Names", data=np.array([b"River A"], dtype="S16"))
+        centerline.create_dataset("Reach Names", data=np.array([b"Reach 1"], dtype="S16"))
+        for name in ("US Junction", "US SA-2D", "DS Junction", "DS SA-2D"):
+            centerline.create_dataset(name, data=np.array([b""], dtype="S16"))
+
+        bank_lines = hdf.create_group("Geometry/River Bank Lines")
+        bank_lines.create_dataset(
+            "Bank Lines Info",
+            data=np.array([[0, 2, 0, 1], [2, 2, 1, 1]], dtype=np.int32),
+        )
+        bank_lines.create_dataset(
+            "Bank Lines Parts", data=np.array([[0, 2], [0, 2]], dtype=np.int32)
+        )
+        bank_lines.create_dataset(
+            "Bank Lines Points",
+            data=np.array(
+                [[2.0, 12.0], [2.0, -2.0], [8.0, 12.0], [8.0, -2.0]],
+                dtype=np.float64,
+            ),
+        )
+
+
+def _convert_fixture_to_modern_schema(path: Path) -> None:
+    attributes_dtype = np.dtype(
+        [
+            ("River", "S16"),
+            ("Reach", "S16"),
+            ("RS", "S8"),
+            ("Name", "S16"),
+            ("Description", "S64"),
+            ("Len Left", "f4"),
+            ("Len Channel", "f4"),
+            ("Len Right", "f4"),
+            ("Left Bank", "f4"),
+            ("Right Bank", "f4"),
+            ("Contr", "f4"),
+            ("Expan", "f4"),
+        ]
+    )
+    attributes = np.array(
+        [
+            (
+                b"River A",
+                b"Reach 1",
+                b"200",
+                b"Upper",
+                b"Upstream section",
+                100.0,
+                110.0,
+                120.0,
+                2.0,
+                8.0,
+                0.1,
+                0.3,
+            ),
+            (
+                b"River A",
+                b"Reach 1",
+                b"100",
+                b"Lower",
+                b"Downstream section",
+                0.0,
+                0.0,
+                0.0,
+                2.0,
+                8.0,
+                0.2,
+                0.4,
+            ),
+        ],
+        dtype=attributes_dtype,
+    )
+    ineffective_dtype = np.dtype(
+        [
+            ("Left Sta", "f4"),
+            ("Right Sta", "f4"),
+            ("Elevation", "f4"),
+            ("Permanent", "?"),
+        ]
+    )
+
+    with h5py.File(path, "a") as hdf:
+        xs = hdf["Geometry/Cross Sections"]
+        xs.create_dataset("Attributes", data=attributes)
+        xs.move("Station Manning's n Info", "Manning's n Info")
+        xs.move("Station Manning's n Values", "Manning's n Values")
+        xs.create_dataset("Ineffective Info", data=xs["Blocked Ineffective Info"][()])
+        xs.create_dataset(
+            "Ineffective Blocks",
+            data=np.array([(0.0, 1.5, 100.0, True)], dtype=ineffective_dtype),
+        )
+        legacy_only = (
+            "River Names",
+            "Reach Names",
+            "River Stations",
+            "Node Names",
+            "Node Descriptions",
+            "Lengths",
+            "Bank Stations",
+            "Contr Expan Coef",
+            "Hydraulic Tables Starting Elevation and Increment Size",
+            "Hydraulic Tables Vertical and Horizontal Slices",
+            "Blocked Ineffective Info",
+            "Blocked Ineffective Values",
+        )
+        for name in legacy_only:
+            del xs[name]
+
+        centerline = hdf["Geometry/River Centerlines"]
+        centerline_dtype = np.dtype(
+            [
+                ("River Name", "S16"),
+                ("Reach Name", "S16"),
+                ("US Type", "S16"),
+                ("US Name", "S16"),
+                ("DS Type", "S16"),
+                ("DS Name", "S16"),
+            ]
+        )
+        centerline.create_dataset(
+            "Attributes",
+            data=np.array(
+                [(b"River A", b"Reach 1", b"External", b"", b"External", b"")],
+                dtype=centerline_dtype,
+            ),
+        )
+
+        bank_lines = hdf["Geometry/River Bank Lines"]
+        bank_lines.move("Bank Lines Info", "Polyline Info")
+        bank_lines.move("Bank Lines Parts", "Polyline Parts")
+        bank_lines.move("Bank Lines Points", "Polyline Points")
+
+
+def test_reads_hec_ras_5_separated_cross_section_schema(tmp_path, monkeypatch):
+    hdf_path = tmp_path / "Legacy.g01.hdf"
+    _write_legacy_geometry_hdf(hdf_path)
+    monkeypatch.setattr(HdfBase, "get_projection", lambda *_args, **_kwargs: "EPSG:26916")
+
+    cross_sections = HdfXsec.get_cross_sections(hdf_path)
+
+    assert len(cross_sections) == 2
+    assert cross_sections.crs.to_epsg() == 26916
+    assert cross_sections["River"].tolist() == ["River A", "River A"]
+    assert cross_sections["Reach"].tolist() == ["Reach 1", "Reach 1"]
+    assert cross_sections["RS"].tolist() == ["200", "100"]
+    assert cross_sections["Name"].tolist() == ["Upper", "Lower"]
+    assert cross_sections.geometry.apply(lambda geometry: len(geometry.coords)).tolist() == [2, 3]
+    assert cross_sections.iloc[0]["station_elevation"].shape == (3, 2)
+    assert cross_sections.iloc[1]["mannings_n"]["Mann n"] == pytest.approx(
+        [0.045, 0.035, 0.04, 0.05]
+    )
+    assert cross_sections["n_lob"].tolist() == pytest.approx([0.04, 0.045])
+    assert cross_sections["n_channel"].tolist() == pytest.approx([0.03, 0.035])
+    assert cross_sections["n_rob"].tolist() == pytest.approx([0.05, 0.04])
+    assert cross_sections["Len Channel"].iloc[0] == pytest.approx(110.0)
+    assert np.isnan(cross_sections["Len Channel"].iloc[1])
+    assert cross_sections["Contr"].tolist() == pytest.approx([0.1, 0.2])
+    assert cross_sections["Expan"].tolist() == pytest.approx([0.3, 0.4])
+    assert cross_sections["HP Count"].tolist() == [20, 30]
+    assert cross_sections["HP Chan Slices"].tolist() == [6, 9]
+    assert cross_sections.iloc[0]["ineffective_blocks"] == [
+        {
+            "Left Sta": 0.0,
+            "Right Sta": 1.5,
+            "Elevation": 100.0,
+            "Permanent": False,
+        }
+    ]
+    assert cross_sections.iloc[1]["ineffective_blocks"] == []
+
+
+def test_legacy_schema_count_classifies_as_1d(tmp_path):
+    hdf_path = tmp_path / "Legacy.g01.hdf"
+    _write_legacy_geometry_hdf(hdf_path)
+
+    metadata = GeomMetadata.get_geometry_counts(None, hdf_path)
+
+    assert metadata["geometry_metadata_source"] == "hdf"
+    assert metadata["geometry_metadata_valid"] is True
+    assert metadata["num_cross_sections"] == 2
+    assert metadata["has_1d_xs"] is True
+    assert metadata["has_2d_mesh"] is False
+    assert RasPrj._classify_geometry(pd.Series(metadata)) == "1D"
+
+
+def test_legacy_schema_row_mismatch_fails_closed(tmp_path):
+    hdf_path = tmp_path / "Legacy.g01.hdf"
+    _write_legacy_geometry_hdf(hdf_path)
+    with h5py.File(hdf_path, "a") as hdf:
+        del hdf["Geometry/Cross Sections/Node Names"]
+        hdf["Geometry/Cross Sections"].create_dataset(
+            "Node Names", data=np.array([b"Only one"], dtype="S16")
+        )
+
+    metadata = GeomMetadata.get_geometry_counts(None, hdf_path)
+
+    assert metadata["geometry_metadata_valid"] is False
+    assert metadata["has_1d_xs"] is None
+    assert "row count mismatch" in metadata["geometry_metadata_error"]
+    assert HdfXsec.get_cross_sections(hdf_path).empty
+
+
+def test_legacy_schema_out_of_bounds_profile_slice_fails_closed(tmp_path):
+    hdf_path = tmp_path / "Legacy.g01.hdf"
+    _write_legacy_geometry_hdf(hdf_path)
+    with h5py.File(hdf_path, "a") as hdf:
+        hdf["Geometry/Cross Sections/Station Elevation Info"][1] = [5, 2]
+
+    assert HdfXsec.get_cross_sections(hdf_path).empty
+
+
+def test_legacy_schema_fractional_profile_slice_fails_closed(tmp_path):
+    hdf_path = tmp_path / "Legacy.g01.hdf"
+    _write_legacy_geometry_hdf(hdf_path)
+    with h5py.File(hdf_path, "a") as hdf:
+        xs = hdf["Geometry/Cross Sections"]
+        del xs["Station Elevation Info"]
+        xs.create_dataset(
+            "Station Elevation Info",
+            data=np.array([[0.0, 3.0], [3.5, 2.0]], dtype=np.float64),
+        )
+
+    assert HdfXsec.get_cross_sections(hdf_path).empty
+
+
+def test_legacy_schema_out_of_bounds_declared_polyline_fails_closed(tmp_path):
+    hdf_path = tmp_path / "Legacy.g01.hdf"
+    _write_legacy_geometry_hdf(hdf_path)
+    with h5py.File(hdf_path, "a") as hdf:
+        hdf["Geometry/Cross Sections/Polyline Info"][0] = [0, 99, 0, 1]
+
+    assert HdfXsec.get_cross_sections(hdf_path).empty
+
+
+def test_reads_legacy_centerline_and_bank_line_schemas(tmp_path, monkeypatch):
+    hdf_path = tmp_path / "Legacy.g01.hdf"
+    _write_legacy_geometry_hdf(hdf_path)
+    monkeypatch.setattr(HdfBase, "get_projection", lambda *_args, **_kwargs: None)
+
+    centerlines = HdfXsec.get_river_centerlines(hdf_path)
+    reaches = HdfXsec.get_river_reaches(hdf_path)
+    bank_lines = HdfXsec.get_river_bank_lines(hdf_path)
+
+    assert len(centerlines) == 1
+    assert centerlines.loc[0, "River Name"] == "River A"
+    assert centerlines.loc[0, "Reach Name"] == "Reach 1"
+    assert centerlines.loc[0, "US Type"] == "External"
+    assert centerlines.loc[0, "DS Type"] == "External"
+    assert len(centerlines.geometry.iloc[0].coords) == 3
+    assert reaches["river_id"].tolist() == [0]
+    assert reaches["River Name"].tolist() == ["River A"]
+    assert len(bank_lines) == 2
+    assert bank_lines["bank_side"].tolist() == ["Left", "Right"]
+    assert bank_lines.geometry.apply(lambda geometry: len(geometry.coords)).tolist() == [2, 2]
+
+
+def test_multipart_legacy_centerline_preserves_disjoint_parts(tmp_path, monkeypatch):
+    hdf_path = tmp_path / "Legacy.g01.hdf"
+    _write_legacy_geometry_hdf(hdf_path)
+    monkeypatch.setattr(HdfBase, "get_projection", lambda *_args, **_kwargs: None)
+    with h5py.File(hdf_path, "a") as hdf:
+        centerline = hdf["Geometry/River Centerlines"]
+        del centerline["Polyline Info"]
+        del centerline["Polyline Parts"]
+        del centerline["Polyline Points"]
+        centerline.create_dataset(
+            "Polyline Info", data=np.array([[0, 4, 0, 2]], dtype=np.int32)
+        )
+        centerline.create_dataset(
+            "Polyline Parts", data=np.array([[0, 2], [2, 2]], dtype=np.int32)
+        )
+        centerline.create_dataset(
+            "Polyline Points",
+            data=np.array(
+                [[5.0, 12.0], [5.0, 8.0], [6.0, 2.0], [6.0, -2.0]],
+                dtype=np.float64,
+            ),
+        )
+
+    centerlines = HdfXsec.get_river_centerlines(hdf_path)
+
+    assert len(centerlines) == 1
+    assert centerlines.geometry.iloc[0].geom_type == "MultiLineString"
+    assert len(centerlines.geometry.iloc[0].geoms) == 2
+
+    with h5py.File(hdf_path, "a") as hdf:
+        hdf["Geometry/River Centerlines/Polyline Parts"][:] = [[0, 2], [1, 2]]
+
+    assert HdfXsec.get_river_centerlines(hdf_path).empty
+
+
+def test_modern_compound_schema_remains_supported(tmp_path, monkeypatch):
+    hdf_path = tmp_path / "Modern.g01.hdf"
+    _write_legacy_geometry_hdf(hdf_path)
+    _convert_fixture_to_modern_schema(hdf_path)
+    monkeypatch.setattr(HdfBase, "get_projection", lambda *_args, **_kwargs: None)
+
+    cross_sections = HdfXsec.get_cross_sections(hdf_path)
+
+    assert len(cross_sections) == 2
+    assert cross_sections["RS"].tolist() == ["200", "100"]
+    assert cross_sections["Len Channel"].tolist() == pytest.approx([110.0, 0.0])
+    assert cross_sections.iloc[0]["mannings_n"]["Mann n"] == pytest.approx(
+        [0.04, 0.03, 0.05]
+    )
+    assert cross_sections.iloc[0]["ineffective_blocks"][0]["Permanent"] is True
+
+    centerlines = HdfXsec.get_river_centerlines(hdf_path)
+    bank_lines = HdfXsec.get_river_bank_lines(hdf_path)
+    assert centerlines["River Name"].tolist() == ["River A"]
+    assert centerlines["US Type"].tolist() == ["External"]
+    assert bank_lines["bank_side"].tolist() == ["Left", "Right"]


### PR DESCRIPTION
## Summary

- Read HEC-RAS 5.x geometry HDFs that store cross-section identity, hydraulic attributes, and Manning values in separated datasets instead of the newer compound `Attributes` schema.
- Support legacy river-centerline and bank-line dataset names while preserving multipart polylines as `MultiLineString` geometries.
- Share schema-aware cross-section counts with `GeomMetadata`, so legacy 1D projects are classified from affirmative cross-section evidence rather than appearing to have zero cross sections.
- Fail closed on mismatched feature rows, incomplete info/value pairs, non-integral or out-of-bounds slices, non-finite geometry, and overlapping/gapped polyline parts.
- Retain modern compound-schema behavior and existing logging/CRS compatibility.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)
- [ ] Example notebook

---

## LLM Self-Review

### Style Compliance

- [x] Static class pattern followed (`.claude/rules/python/static-classes.md`)
- [x] `@staticmethod` + `@log_call` retained on public methods (`.claude/rules/python/decorators.md`)
- [x] Naming conventions followed (`.claude/rules/python/naming-conventions.md`)
- [x] `pathlib.Path` used, accepts both `str` and `Path` (`.claude/rules/python/path-handling.md`)
- [x] DataFrames used for project metadata, not glob (`.claude/rules/python/dataframe-first-principle.md`)

### Code Quality

- [x] Focused docstrings added for private schema helpers
- [x] Tested with a real HEC-RAS 5.x project (Olustee Creek Trib 6.1; external campaign fixture, read-only)
- [x] No hardcoded file paths
- [x] Uses logging, not `print()`
- [x] Proper error handling with informative messages

### API Changes (if applicable)

No public signature or return-shape changes.

### Notebooks (if applicable)

Not applicable.

---

## Test Plan

- `python -m ruff check ras_commander/hdf/HdfXsec.py ras_commander/geom/GeomMetadata.py tests/test_hdf_xsec_legacy_schema.py`
- `python -m pytest -q tests/test_hdf_xsec_legacy_schema.py tests/test_hdf_xsec_logging.py tests/test_cross_section_points.py tests/test_geom_metadata_2d.py tests/test_geom_metadata_provenance.py tests/test_river_edge_lines.py tests/test_project_extent_fill_holes.py` — 59 passed
- Real-model read-only qualification against Olustee Creek Trib 6.1 (HEC-RAS 5.x): 7 cross sections, 1 centerline/reach, 2 bank lines, 2 edge lines, and 1 valid footprint; metadata source `hdf`, classified as 1D with no 2D mesh.
- No HEC-RAS execution, source-model mutation, or publication was performed. The raw model package does not include its referenced projection file, so CRS remains unset during the archive-only qualification.

## Follow-up

The eBFE campaign worker's separate `HDF exists => 2D` fallback should be removed in a fresh campaign-runtime change after this library fix is adopted. Missing dimensional evidence should remain unknown; preserved campaign results are not relabeled by this PR.

## LLM Attribution

**Model/Tool used**: OpenAI Codex