### PR TITLE
Standardize the HdfXsec cross-section reader API

### DIFF
--- a/docs/api/hdf.md
+++ b/docs/api/hdf.md
@@ -193,13 +193,17 @@ Plan-level results.
 
 Cross-section and river geometry extraction from HDF.
 
-- `get_cross_sections(hdf_path)` - Extract cross-section geometries as GeoDataFrame
+- `get_cross_sections(hdf_path, ras_object=None)` - Extract cross-section
+  geometries as a GeoDataFrame. Accepts a geometry HDF path or a plan selector;
+  multipart cut lines are returned as `MultiLineString` without synthetic connectors.
 - `get_xs_coords(hdf_path, river=None, reach=None, rs=None)` - Extract native
   station/elevation points as XYZ with point/station order, cut-line distance,
   Manning's n, bank classification, coordinate metadata, and source provenance
-- `get_river_centerlines(hdf_path)` - Extract river centerlines
+- `get_river_centerlines(hdf_path)` - Extract river centerlines as `LineString`
+  or `MultiLineString` geometries
 - `get_river_stationing(hdf_path)` - Calculate river stationing along centerlines
-- `get_river_reaches(hdf_path)` - Return model 1D river reach lines
+- `get_river_reaches(hdf_path)` - Return model 1D river reach lines with stable
+  `river_id` and computed `length` columns
 - `get_river_edge_lines(hdf_path)` - Return river edge lines
 - `get_river_bank_lines(hdf_path)` - Extract river bank lines
 

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -211,9 +211,9 @@ See [Example Projects](example-projects.md) for the CRS-valid source catalog and
 | [954 - Using eBFE Models: Lake Maurepas Validation](../notebooks/954_ebfe_lake_maurepas_validation.md) | [.ipynb](https://github.com/gpt-cmdr/ras-commander/blob/main/examples/954_ebfe_lake_maurepas_validation.ipynb) | 3 s |
 | [955 - Using eBFE Models: Tickfaw Results-Ready Validation](../notebooks/955_ebfe_tickfaw_validation.md) | [.ipynb](https://github.com/gpt-cmdr/ras-commander/blob/main/examples/955_ebfe_tickfaw_validation.ipynb) | 3 s |
 | [956 - NextGen Hydrofabric Conflation Visual QA — Texas eBFE Shiloh Branch](../notebooks/956_hydrofabric_conflation_visual_qa.md) | [.ipynb](https://github.com/gpt-cmdr/ras-commander/blob/main/examples/956_hydrofabric_conflation_visual_qa.ipynb) | 5 s |
-| [959 - eBFE 2D Breakout Geometry Preparation](../notebooks/959_ebfe_2d_breakout_geometry_preparation.md) | [.ipynb](https://github.com/gpt-cmdr/ras-commander/blob/main/examples/959_ebfe_2d_breakout_geometry_preparation.ipynb) | N/A |
 | [957 - Using eBFE Models: Spring River Validation](../notebooks/957_ebfe_spring_river_validation.md) | [.ipynb](https://github.com/gpt-cmdr/ras-commander/blob/main/examples/957_ebfe_spring_river_validation.ipynb) | N/A |
 | [958 - Model Sources: Unified Discovery, Download & Visualization](../notebooks/958_model_sources_showcase.md) | [.ipynb](https://github.com/gpt-cmdr/ras-commander/blob/main/examples/958_model_sources_showcase.ipynb) | N/A |
+| [959 - eBFE 2D Breakout Geometry Preparation](../notebooks/959_ebfe_2d_breakout_geometry_preparation.md) | [.ipynb](https://github.com/gpt-cmdr/ras-commander/blob/main/examples/959_ebfe_2d_breakout_geometry_preparation.ipynb) | N/A |
 
 ## 960s - Cloud-Native Export
 

--- a/examples/notebooks.yml
+++ b/examples/notebooks.yml
@@ -4031,35 +4031,6 @@ notebooks:
   excluded: false
   code_cells: 13
   executed_cells: 13
-- id: 959_ebfe_2d_breakout_geometry_preparation
-  filename: 959_ebfe_2d_breakout_geometry_preparation.ipynb
-  title: eBFE 2D Breakout Geometry Preparation
-  series: 950
-  series_name: eBFE Delivery Validation
-  summary: Qualify and prepare a contained pure-2D HUC12 breakout from Upper Guadalupe 3 plan 08, with
-    byte-identical unsteady cloning, geometry trimming/remeshing, parent terrain and inundation context,
-    and unassigned parent-face flux review.
-  tags:
-  - 2d
-  - breakout
-  - ebfe
-  - geometry
-  - mesh
-  difficulty: advanced
-  est_runtime: null
-  data_project: null
-  functions_used:
-  - HdfMesh.get_mesh_sloped_topology
-  - HdfResultsMesh.get_mesh_max_ws
-  - RasBreakout2D.clone_plan_components
-  - RasBreakout2D.preflight
-  - RasBreakout2D.prepare_cloned_geometry
-  - RasBreakout2D.review_parent_boundary_flux
-  hec_refs: []
-  learning_paths: []
-  excluded: false
-  code_cells: 9
-  executed_cells: 9
 - id: 957_ebfe_spring_river_validation
   filename: 957_ebfe_spring_river_validation.ipynb
   title: 'Using eBFE Models: Spring River Validation'
@@ -4100,6 +4071,35 @@ notebooks:
   excluded: false
   code_cells: 23
   executed_cells: 23
+- id: 959_ebfe_2d_breakout_geometry_preparation
+  filename: 959_ebfe_2d_breakout_geometry_preparation.ipynb
+  title: eBFE 2D Breakout Geometry Preparation
+  series: 950
+  series_name: eBFE Delivery Validation
+  summary: Qualify and prepare a contained pure-2D HUC12 breakout from Upper Guadalupe 3 plan 08, with
+    byte-identical unsteady cloning, geometry trimming/remeshing, parent terrain and inundation context,
+    and unassigned parent-face flux review.
+  tags:
+  - 2d
+  - breakout
+  - ebfe
+  - geometry
+  - mesh
+  difficulty: advanced
+  est_runtime: null
+  data_project: null
+  functions_used:
+  - HdfMesh.get_mesh_sloped_topology
+  - HdfResultsMesh.get_mesh_max_ws
+  - RasBreakout2D.clone_plan_components
+  - RasBreakout2D.preflight
+  - RasBreakout2D.prepare_cloned_geometry
+  - RasBreakout2D.review_parent_boundary_flux
+  hec_refs: []
+  learning_paths: []
+  excluded: false
+  code_cells: 9
+  executed_cells: 9
 - id: 960_cloud_native_geometry_export
   filename: 960_cloud_native_geometry_export.ipynb
   title: Cloud-Native Geometry Export with ras2cng

--- a/ras_commander/hdf/HdfXsec.py
+++ b/ras_commander/hdf/HdfXsec.py
@@ -34,7 +34,7 @@ handling and logging.
 """
 
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 import h5py
 import numpy as np
@@ -729,24 +729,32 @@ class HdfXsec:
 
     @staticmethod
     @log_call
-    def get_cross_sections(hdf_path: str, datetime_to_str: bool = True, ras_object=None) -> gpd.GeoDataFrame:
+    @standardize_input(file_type='geom_hdf')
+    def get_cross_sections(
+        hdf_path: Union[str, Path],
+        datetime_to_str: bool = True,
+        *,
+        ras_object=None,
+    ) -> gpd.GeoDataFrame:
         """
         Extracts cross-section geometries and attributes from a HEC-RAS geometry HDF file.
 
         Parameters
         ----------
-        hdf_path : str
-            Path to the HEC-RAS geometry HDF file
+        hdf_path : str or Path
+            HEC-RAS geometry HDF path or supported geometry selector. String
+            and numeric selectors are resolved against ``ras_object``.
         datetime_to_str : bool, optional
             Convert datetime objects to strings, defaults to True
         ras_object : RasPrj, optional
-            RAS project object for additional context, defaults to None
+            Project used to resolve plan/geometry selectors. When omitted, the
+            initialized global project is used. Must be passed by keyword.
 
         Returns
         -------
         gpd.GeoDataFrame
             Cross-section data with columns:
-            - geometry: LineString - Cross-section polyline geometry
+            - geometry: LineString or MultiLineString - Cross-section polyline geometry
             - station_elevation: ndarray - Station-elevation profile (Nx2 array: [station, elevation])
             - mannings_n: dict - Raw Manning's n data with keys 'Station' and 'Mann n' (lists)
             - n_lob: float - Left overbank Manning's n (computed from bank stations)
@@ -785,6 +793,12 @@ class HdfXsec:
         -----
         The returned GeoDataFrame includes the coordinate system from the HDF file
         when available. All byte strings are converted to regular strings.
+
+        Raises
+        ------
+        FileNotFoundError
+            If the path or project selector cannot be resolved to an existing
+            geometry HDF file.
         """
         try:
             with h5py.File(hdf_path, 'r') as hdf:
@@ -1052,7 +1066,7 @@ class HdfXsec:
         -------
         GeoDataFrame
             River centerline data with columns:
-            - geometry: LineString - River centerline geometry
+            - geometry: LineString or MultiLineString - River centerline geometry
             - River Name: str - Name of the river
             - Reach Name: str - Name of the reach
             - US Type: str - Upstream connection type (e.g., 'Junction', 'External')
@@ -1297,7 +1311,7 @@ class HdfXsec:
         -------
         GeoDataFrame
             River reach data with columns:
-            - geometry: LineString - River reach line geometry
+            - geometry: LineString or MultiLineString - River reach line geometry
             - river_id: int - Unique identifier for each reach (0-indexed)
             - River Name: str - Name of the river
             - Reach Name: str - Name of the reach
@@ -1306,6 +1320,7 @@ class HdfXsec:
             - DS Type: str - Downstream connection type
             - DS Name: str - Downstream connection name
             - Last Edited: datetime or str - Last edit timestamp (str if datetime_to_str=True)
+            - length: float - Reach length in project coordinate units (computed)
 
             Note: Additional HDF attributes may be included depending on HEC-RAS version.
         """

--- a/tests/test_hdf_xsec_legacy_schema.py
+++ b/tests/test_hdf_xsec_legacy_schema.py
@@ -5,7 +5,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from ras_commander import HdfXsec
+from ras_commander import HdfXsec, RasPlan
 from ras_commander.RasPrj import RasPrj
 from ras_commander.geom.GeomMetadata import GeomMetadata
 from ras_commander.hdf.HdfBase import HdfBase
@@ -289,6 +289,103 @@ def test_reads_hec_ras_5_separated_cross_section_schema(tmp_path, monkeypatch):
     assert cross_sections.iloc[1]["ineffective_blocks"] == []
 
 
+@pytest.mark.parametrize("selector", [1, "01", "p01"])
+def test_get_cross_sections_resolves_selector_with_ras_object(
+    tmp_path,
+    monkeypatch,
+    selector,
+):
+    hdf_path = tmp_path / "Legacy.g01.hdf"
+    _write_legacy_geometry_hdf(hdf_path)
+
+    class FakeRasProject:
+        plan_df = pd.DataFrame(
+            [{"plan_number": "01", "geometry_number": "01"}]
+        )
+
+        @staticmethod
+        def check_initialized():
+            return None
+
+    monkeypatch.setattr(
+        RasPlan,
+        "get_geom_path",
+        staticmethod(lambda *_args, **_kwargs: hdf_path.with_suffix("")),
+    )
+
+    cross_sections = HdfXsec.get_cross_sections(
+        selector,
+        ras_object=FakeRasProject(),
+    )
+
+    assert len(cross_sections) == 2
+    assert cross_sections["RS"].tolist() == ["200", "100"]
+
+
+def test_get_cross_sections_accepts_path_string_and_open_hdf(tmp_path, monkeypatch):
+    hdf_path = tmp_path / "Legacy.g01.hdf"
+    _write_legacy_geometry_hdf(hdf_path)
+    monkeypatch.setattr(HdfBase, "get_projection", lambda *_args, **_kwargs: None)
+
+    from_path = HdfXsec.get_cross_sections(hdf_path)
+    from_string = HdfXsec.get_cross_sections(str(hdf_path))
+    with h5py.File(hdf_path, "r") as hdf:
+        from_open_hdf = HdfXsec.get_cross_sections(hdf)
+
+    expected_stations = ["200", "100"]
+    assert from_path["RS"].tolist() == expected_stations
+    assert from_string["RS"].tolist() == expected_stations
+    assert from_open_hdf["RS"].tolist() == expected_stations
+
+
+def test_get_cross_sections_unresolved_input_raises_file_not_found(tmp_path):
+    missing = tmp_path / "missing.g01.hdf"
+
+    with pytest.raises(FileNotFoundError, match="HDF file not found"):
+        HdfXsec.get_cross_sections(missing)
+
+
+def test_multipart_cross_section_preserves_disjoint_parts(tmp_path, monkeypatch):
+    hdf_path = tmp_path / "Legacy.g01.hdf"
+    _write_legacy_geometry_hdf(hdf_path)
+    monkeypatch.setattr(HdfBase, "get_projection", lambda *_args, **_kwargs: None)
+    with h5py.File(hdf_path, "a") as hdf:
+        xs = hdf["Geometry/Cross Sections"]
+        del xs["Polyline Info"]
+        del xs["Polyline Parts"]
+        del xs["Polyline Points"]
+        xs.create_dataset(
+            "Polyline Info",
+            data=np.array([[0, 4, 0, 2], [4, 3, 2, 1]], dtype=np.int32),
+        )
+        xs.create_dataset(
+            "Polyline Parts",
+            data=np.array([[0, 2], [2, 2], [0, 3]], dtype=np.int32),
+        )
+        xs.create_dataset(
+            "Polyline Points",
+            data=np.array(
+                [
+                    [0.0, 10.0],
+                    [4.0, 10.0],
+                    [6.0, 10.0],
+                    [10.0, 10.0],
+                    [0.0, 0.0],
+                    [5.0, 1.0],
+                    [10.0, 0.0],
+                ],
+                dtype=np.float64,
+            ),
+        )
+
+    cross_sections = HdfXsec.get_cross_sections(hdf_path)
+
+    assert len(cross_sections) == 2
+    assert cross_sections.geometry.iloc[0].geom_type == "MultiLineString"
+    assert len(cross_sections.geometry.iloc[0].geoms) == 2
+    assert cross_sections.geometry.iloc[1].geom_type == "LineString"
+
+
 def test_legacy_schema_count_classifies_as_1d(tmp_path):
     hdf_path = tmp_path / "Legacy.g01.hdf"
     _write_legacy_geometry_hdf(hdf_path)
@@ -369,6 +466,7 @@ def test_reads_legacy_centerline_and_bank_line_schemas(tmp_path, monkeypatch):
     assert len(centerlines.geometry.iloc[0].coords) == 3
     assert reaches["river_id"].tolist() == [0]
     assert reaches["River Name"].tolist() == ["River A"]
+    assert reaches["length"].tolist() == pytest.approx([14.0])
     assert len(bank_lines) == 2
     assert bank_lines["bank_side"].tolist() == ["Left", "Right"]
     assert bank_lines.geometry.apply(lambda geometry: len(geometry.coords)).tolist() == [2, 2]


### PR DESCRIPTION
## Summary

- Apply the standard geometry-HDF input decorator to `HdfXsec.get_cross_sections()` so direct paths, open HDF handles, and plan selectors resolve consistently through an explicit `ras_object` or the initialized global project.
- Accept `str | Path` in the public signature and make `ras_object` keyword-only, matching the decorator contract and all repository callers.
- Document `LineString | MultiLineString` returns for cross sections, centerlines, and reaches, plus the delegated reach `length` column.
- Add regression coverage for `Path`, string path, open-HDF, `1`/`"01"`/`"p01"` selectors, unresolved-input errors, multipart cross sections, and reach length.
- Update the concise HDF API reference.
- Refresh `examples/notebooks.yml` and its generated `docs/examples/index.md` row order to correct a pre-existing deterministic drift that blocked documentation CI; metadata values and notebook content are unchanged.

## Type of Change

- [x] Bug fix (non-breaking behavior for supported keyword-style calls; see compatibility note)
- [ ] New feature
- [x] Documentation update
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)
- [ ] Example notebook

---

## LLM Self-Review

### Style Compliance

- [x] Static class pattern followed
- [x] `@staticmethod` → `@log_call` → `@standardize_input` decorator order followed
- [x] Naming conventions followed
- [x] `pathlib.Path` used while accepting string paths
- [x] DataFrame-backed project metadata used by selector resolution

### Code Quality

- [x] Existing module docstring style retained and public behavior documented
- [x] Tested with the real Olustee Creek Trib 6.1 HEC-RAS 5.x geometry HDF
- [x] No hardcoded library paths
- [x] Uses logging, not `print()`
- [x] Proper error handling with informative messages

### API Changes

- [x] `ras_object=None` retained for multi-project support and made keyword-only
- [x] API consistency auditor five-rule review passed
- [x] GeoDataFrame return contract retained

### Notebooks

No notebook content changes are required. A read-only audit found 13 call cells across eight examples; all pass existing `Path` objects. No example calls `get_river_reaches()`, and the bundled Bald Eagle/Muncie HDFs used by direct-coordinate examples contain only single-part cross sections. The generated notebook metadata was reordered canonically only to repair the existing CI baseline.

---

## Compatibility Note

- Repository callers already pass `ras_object=` by keyword. A third positional `ras_object` now raises `TypeError`, enforcing the existing decorator convention.
- Invalid or unresolved inputs now raise the decorator's documented `FileNotFoundError` instead of being caught inside the reader and returned as an empty GeoDataFrame.

## Test Plan

- `python -m ruff check ras_commander/hdf/HdfXsec.py tests/test_hdf_xsec_legacy_schema.py`
- `python -m pytest -q tests/test_hdf_xsec_legacy_schema.py tests/test_hdf_xsec_logging.py tests/test_project_extent_fill_holes.py tests/test_ras_geometry_compute.py tests/test_river_edge_lines.py` — 42 passed
- `python .claude/scripts/generate_notebooks_metadata.py --check` — passed
- `python .claude/scripts/validate_notebooks_yml.py` — 139 entries, 139 notebooks, 0 errors (existing curation/symbol warnings remain)
- `python .claude/scripts/generate_examples_index.py` — generated index synchronized
- `mkdocs build --site-dir working/mkdocs-hdf-xsec-followup` — passed with existing non-strict documentation warnings
- Real Olustee HEC-RAS 5.x read-only qualification — 7 cross sections, 1 reach, and the expected reach length (`1705.680420072429`)
- Independent final API consistency audit — PASS, no release-blocking findings

## LLM Attribution

**Model/Tool used**: OpenAI Codex

