### PR TITLE
fix: validate and guard example project links

### DIFF
--- a/docs/assets/javascripts/ras-example-library.js
+++ b/docs/assets/javascripts/ras-example-library.js
@@ -5,6 +5,7 @@
   }
 
   const DEFAULT_BOUNDS = [-125, 24, -66, 50];
+  const MANIFEST_REQUEST_TIMEOUT_MS = 10000;
   const PIN_REPLACEMENT_PIXEL_SIZE = 44;
   const PROJECT_PIN_IMAGE_ID = "ras-project-pin";
   const PROFILE_CONFIG = window.RAS_EXAMPLE_PROJECT_PROFILES || { projects: {}, groups: {} };
@@ -46,8 +47,16 @@
       .replace(/'/g, "&#39;");
   }
 
-  function resolveHref(href) {
-    return new URL(href, window.location.href).toString();
+  function resolveHttpHref(href, base = window.location.href) {
+    if (typeof href !== "string" || !href.trim()) {
+      return "";
+    }
+    try {
+      const url = new URL(href.trim(), base);
+      return ["http:", "https:"].includes(url.protocol) ? url.toString() : "";
+    } catch (_error) {
+      return "";
+    }
   }
 
   function normalizeBounds(bounds) {
@@ -259,13 +268,11 @@
     };
   }
 
-    function projectPopupSection(feature) {
-      const props = feature.properties || {};
-      const webmap = props.webmap ? resolveHref(props.webmap) : "";
-      const details = props.details ? resolveHref(props.details) : "";
-      const rod = props.recordOfDeficiencies
-        ? resolveHref(props.recordOfDeficiencies)
-        : "";
+  function projectPopupSection(feature) {
+    const props = feature.properties || {};
+    const webmap = resolveHttpHref(props.webmap);
+    const details = resolveHttpHref(props.details);
+    const rod = resolveHttpHref(props.recordOfDeficiencies);
     return [
       '<section class="ras-library-popup__project">',
       `<h3>${escapeHtml(props.title || feature.id || "Example Project")}</h3>`,
@@ -345,27 +352,34 @@
       links.className = "ras-library-project-links";
       for (const child of entry.features) {
         const childProfile = projectProfile(child);
-        const webmap = child.properties?.webmap;
-        const projectHref = webmap || child.properties?.details;
+        const webmap = resolveHttpHref(child.properties?.webmap);
+        const projectHref = webmap || resolveHttpHref(child.properties?.details);
         const label = document.createElement(projectHref ? "a" : "span");
         if (projectHref) {
-          label.href = resolveHref(projectHref);
+          label.href = projectHref;
           label.title = webmap ? "Open project map" : "Open project details";
         } else {
           label.className = "ras-library-project-link--disabled";
+          if (child.properties?.linkUnavailableReason) {
+            label.title = child.properties.linkUnavailableReason;
+          }
         }
         label.textContent = childProfile.variantLabel || child.properties?.title || child.id;
         links.append(label);
       }
       project.append(links);
     } else {
-      const projectHref = props.webmap || props.details;
+      const webmap = resolveHttpHref(props.webmap);
+      const projectHref = webmap || resolveHttpHref(props.details);
       const link = document.createElement(projectHref ? "a" : "span");
       if (projectHref) {
-        link.href = resolveHref(projectHref);
-        link.title = props.webmap ? "Open project map" : "Open project details";
+        link.href = projectHref;
+        link.title = webmap ? "Open project map" : "Open project details";
       } else {
         link.className = "ras-library-project-link--disabled";
+        if (props.linkUnavailableReason) {
+          link.title = props.linkUnavailableReason;
+        }
       }
       link.textContent = props.title || feature.id || "Example Project";
       project.append(link);
@@ -381,10 +395,12 @@
     const information = document.createElement("td");
     information.className = "ras-library-project-information";
     information.textContent = profile.summary || props.summary || props.notes || "";
-    const recordOfDeficiencies = profile.recordOfDeficiencies || props.recordOfDeficiencies;
+    const recordOfDeficiencies = resolveHttpHref(
+      profile.recordOfDeficiencies || props.recordOfDeficiencies
+    );
     if (recordOfDeficiencies) {
       const details = document.createElement("a");
-      details.href = resolveHref(recordOfDeficiencies);
+      details.href = recordOfDeficiencies;
       details.textContent = "Record of Deficiencies";
       information.append(document.createElement("br"), details);
     }
@@ -422,16 +438,89 @@
     };
   }
 
+  function disableViewerLink(feature, reason) {
+    return {
+      ...feature,
+      properties: {
+        ...(feature.properties || {}),
+        webmap: "",
+        manifest: "",
+        projectManifest: "",
+        linkUnavailableReason: reason,
+      },
+    };
+  }
+
+  async function qualifyViewerLinks(collection) {
+    const checks = (collection.features || []).map(async (feature) => {
+      const properties = feature.properties || {};
+      if (!properties.webmap) {
+        return { feature, unavailable: false };
+      }
+      const manifestUrl = resolveHttpHref(properties.manifest);
+      if (!manifestUrl) {
+        return {
+          feature: disableViewerLink(feature, "Published project map manifest is unavailable."),
+          unavailable: true,
+        };
+      }
+      const controller = new AbortController();
+      const timeout = window.setTimeout(
+        () => controller.abort(),
+        MANIFEST_REQUEST_TIMEOUT_MS
+      );
+      try {
+        const response = await fetch(manifestUrl, {
+          cache: "no-store",
+          signal: controller.signal,
+        });
+        if (!response.ok) {
+          throw new Error(`status ${response.status}`);
+        }
+        const manifest = await response.json();
+        if (!manifest || typeof manifest !== "object" || Array.isArray(manifest)) {
+          throw new Error("invalid manifest");
+        }
+        return { feature, unavailable: false };
+      } catch (_error) {
+        return {
+          feature: disableViewerLink(
+            feature,
+            "Published project map is temporarily unavailable because its manifest could not be loaded."
+          ),
+          unavailable: true,
+        };
+      } finally {
+        window.clearTimeout(timeout);
+      }
+    });
+    const results = await Promise.all(checks);
+    return {
+      collection: {
+        ...collection,
+        features: results.map((result) => result.feature),
+      },
+      unavailableCount: results.filter((result) => result.unavailable).length,
+    };
+  }
+
   async function loadProjectIndex(dataUrl) {
     try {
       const response = await fetch(dataUrl, { cache: "no-store" });
       if (!response.ok) {
         throw new Error(`Example project index request failed: ${response.status}`);
       }
-      return mergeProjectCollections(await response.json());
+      return {
+        collection: mergeProjectCollections(await response.json()),
+        usedFallback: false,
+      };
     } catch (error) {
       if (window.RAS_EXAMPLE_PROJECTS) {
-        return mergeProjectCollections(window.RAS_EXAMPLE_PROJECTS);
+        return {
+          collection: mergeProjectCollections(window.RAS_EXAMPLE_PROJECTS),
+          usedFallback: true,
+          error,
+        };
       }
       throw error;
     }
@@ -446,10 +535,15 @@
     registerPmtilesProtocol();
     const dataUrl = root.dataset.index ||
       "https://rascommander.info/data/rasexamples/hec-ras-7.0/current/example-projects.geojson";
-    const sourceCollection = await loadProjectIndex(dataUrl);
+    const indexResult = await loadProjectIndex(dataUrl);
+    const enrichedCollection = {
+      ...indexResult.collection,
+      features: (indexResult.collection.features || []).map(enrichFeature),
+    };
+    const linkResult = await qualifyViewerLinks(enrichedCollection);
+    const sourceCollection = linkResult.collection;
     const features = (sourceCollection.features || [])
-      .filter((feature) => feature.geometry)
-      .map(enrichFeature);
+      .filter((feature) => feature.geometry);
     const emptyCollection = { type: "FeatureCollection", features: [] };
     const initialPins = {
       type: "FeatureCollection",
@@ -464,7 +558,16 @@
     renderProjectTable(root, features);
     const status = root.querySelector("[data-library-status]");
     if (status) {
-      status.textContent = "Select a project pin or model extent.";
+      if (linkResult.unavailableCount) {
+        status.textContent = (
+          `${linkResult.unavailableCount} published project maps are temporarily unavailable; ` +
+          "source-candidate details remain available."
+        );
+      } else if (indexResult.usedFallback) {
+        status.textContent = "Using the bundled project catalog. Select a project pin or model extent.";
+      } else {
+        status.textContent = "Select a project pin or model extent.";
+      }
     }
 
     const bounds = mergeBounds(features);
@@ -626,7 +729,10 @@
       if (!map.isStyleLoaded()) {
         await new Promise((resolve) => map.once("load", resolve));
       }
-      const manifestUrl = resolveHref(manifestHref);
+      const manifestUrl = resolveHttpHref(manifestHref);
+      if (!manifestUrl) {
+        return;
+      }
       const response = await fetch(manifestUrl, { cache: "no-store" });
       if (!response.ok) {
         throw new Error(`Project manifest request failed: ${response.status}`);
@@ -653,7 +759,10 @@
           continue;
         }
         const sourceId = `selected-model-${projectId}-${safeId(tileset.id)}`;
-        const tileUrl = new URL(tileset.href, manifestUrl).toString();
+        const tileUrl = resolveHttpHref(tileset.href, manifestUrl);
+        if (!tileUrl) {
+          continue;
+        }
         map.addSource(sourceId, {
           type: "vector",
           url: `pmtiles://${tileUrl}`,

--- a/docs/examples/example-projects.md
+++ b/docs/examples/example-projects.md
@@ -36,7 +36,7 @@ available geometry, terrain, and results.
 <script src="../../assets/javascripts/ras-example-project-profiles.js?v=20260911Tdmfb-candidate02"></script>
 <script src="../../assets/javascripts/ras-example-projects-data.js?v=20260906Texact-extents01"></script>
 <script src="../../assets/javascripts/ras-example-project-supplements.js?v=20260911Tdmfb-candidate02"></script>
-<script src="../../assets/javascripts/ras-example-library.js?v=20260909Tcandidate-detail-links01"></script>
+<script src="../../assets/javascripts/ras-example-library.js?v=20260912Tcatalog-outage-guard01"></script>
 
 ## Dashboard Qualification Status
 

--- a/scripts/example_library/validate_public_example_library.py
+++ b/scripts/example_library/validate_public_example_library.py
@@ -1,0 +1,696 @@
+#!/usr/bin/env python
+"""Validate the public RAS Commander Example Project Library link graph.
+
+The landing page is only the outer shell.  This validator follows the catalog
+through each project viewer to the viewer and project manifests so that a
+successful HTML response cannot hide missing project data.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import socket
+import sys
+import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import dataclass
+from html.parser import HTMLParser
+from pathlib import Path
+from typing import Any, Iterable, Mapping, Sequence
+from urllib.error import HTTPError, URLError
+from urllib.parse import (
+    parse_qs,
+    parse_qsl,
+    urlencode,
+    urldefrag,
+    urljoin,
+    unquote,
+    urlsplit,
+    urlunsplit,
+)
+from urllib.request import Request, urlopen
+
+
+DEFAULT_LIBRARY_URL = "https://rascommander.info/ras/examples/example-projects/"
+DEFAULT_CATALOG_URL = (
+    "https://rascommander.info/data/rasexamples/hec-ras-7.0/current/"
+    "example-projects.geojson"
+)
+USER_AGENT = "rascommander-example-library-validator/1.0"
+MAX_CATALOG_BYTES = 20 * 1024 * 1024
+JSON_ENDPOINT_TARGETS = {"manifest", "projectManifest", "webmap-manifest"}
+REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_FALLBACK_CATALOG = (
+    REPOSITORY_ROOT
+    / "docs"
+    / "assets"
+    / "javascripts"
+    / "ras-example-projects-data.js"
+)
+DEFAULT_SUPPLEMENTS_CATALOG = (
+    REPOSITORY_ROOT
+    / "docs"
+    / "assets"
+    / "javascripts"
+    / "ras-example-project-supplements.js"
+)
+
+
+@dataclass(frozen=True)
+class Finding:
+    """One independently reportable validation result."""
+
+    project_id: str
+    target: str
+    ok: bool
+    url: str = ""
+    status: int | None = None
+    message: str = ""
+
+
+@dataclass(frozen=True)
+class ValidationReport:
+    """Complete link-graph validation result."""
+
+    findings: tuple[Finding, ...]
+    project_count: int
+
+    @property
+    def ok(self) -> bool:
+        return bool(self.findings) and all(finding.ok for finding in self.findings)
+
+    @property
+    def failure_count(self) -> int:
+        return sum(not finding.ok for finding in self.findings)
+
+
+@dataclass(frozen=True)
+class _Endpoint:
+    project_id: str
+    target: str
+    url: str
+
+
+@dataclass(frozen=True)
+class _HttpResult:
+    ok: bool
+    status: int | None
+    message: str
+    body: bytes = b""
+
+
+class _IdCollector(HTMLParser):
+    """Collect HTML element IDs for fragment validation."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.ids: set[str] = set()
+
+    def handle_starttag(
+        self, _tag: str, attrs: list[tuple[str, str | None]]
+    ) -> None:
+        for name, value in attrs:
+            if name.casefold() == "id" and value:
+                self.ids.add(value)
+
+
+def _cache_control_has_no_store(value: str) -> bool:
+    directives = [item.strip().split("=", 1)[0].lower() for item in value.split(",")]
+    return "no-store" in directives
+
+
+def _request(
+    url: str,
+    *,
+    timeout: float,
+    retries: int,
+    read_body: bool,
+) -> _HttpResult:
+    headers = {
+        "Accept": "application/geo+json, application/json, text/html;q=0.9, */*;q=0.8",
+        "User-Agent": USER_AGENT,
+    }
+    if not read_body:
+        # A GET is more representative than HEAD for static hosting and reverse
+        # proxies, while the range keeps accidental artifact downloads bounded.
+        headers["Range"] = "bytes=0-65535"
+
+    last_result: _HttpResult | None = None
+    for attempt in range(retries + 1):
+        try:
+            request = Request(url, headers=headers)
+            with urlopen(request, timeout=timeout) as response:  # noqa: S310
+                status = response.getcode()
+                if read_body:
+                    body = response.read(MAX_CATALOG_BYTES + 1)
+                    if len(body) > MAX_CATALOG_BYTES:
+                        return _HttpResult(
+                            False,
+                            status,
+                            f"response exceeds {MAX_CATALOG_BYTES} bytes",
+                        )
+                else:
+                    # Force at least one response byte through the connection,
+                    # then close without consuming a server that ignored Range.
+                    response.read(1)
+                    body = b""
+                return _HttpResult(True, status, "", body)
+        except HTTPError as exc:
+            cache_control = exc.headers.get("Cache-Control", "")
+            cache_note = ""
+            if not _cache_control_has_no_store(cache_control):
+                shown = cache_control or "<missing>"
+                cache_note = f"; Cache-Control lacks no-store ({shown})"
+            last_result = _HttpResult(
+                False,
+                exc.code,
+                f"HTTP {exc.code}{cache_note}",
+            )
+            if exc.code < 500 or attempt == retries:
+                return last_result
+        except (TimeoutError, socket.timeout, URLError, OSError) as exc:
+            reason = getattr(exc, "reason", exc)
+            last_result = _HttpResult(False, None, f"request failed: {reason}")
+            if attempt == retries:
+                return last_result
+
+        time.sleep(min(0.25 * (2**attempt), 2.0))
+
+    return last_result or _HttpResult(False, None, "request failed")
+
+
+def _resolved_url(base_url: str, value: object) -> str:
+    if not isinstance(value, str) or not value.strip():
+        return ""
+    resolved = urljoin(base_url, value.strip())
+    scheme = urlsplit(resolved).scheme.lower()
+    if scheme not in {"http", "https"}:
+        return ""
+    return resolved
+
+
+def _canonical_url(url: str) -> str:
+    """Return a comparison form that ignores query ordering and fragments."""
+
+    resolved, _fragment = urldefrag(url)
+    parts = urlsplit(resolved)
+    host = (parts.hostname or "").lower()
+    port = parts.port
+    if port is not None and not (
+        (parts.scheme.lower() == "http" and port == 80)
+        or (parts.scheme.lower() == "https" and port == 443)
+    ):
+        host = f"{host}:{port}"
+    query = urlencode(sorted(parse_qsl(parts.query, keep_blank_values=True)), doseq=True)
+    return urlunsplit((parts.scheme.lower(), host, parts.path or "/", query, ""))
+
+
+def _is_candidate(properties: Mapping[str, Any]) -> bool:
+    labels = (properties.get("status"), properties.get("viewerType"))
+    return any("candidate" in str(value).casefold() for value in labels if value)
+
+
+def _read_catalog_assignment(path: Path, variable: str) -> Mapping[str, Any]:
+    """Read one exact ``window.NAME = <JSON>;`` data assignment without eval."""
+
+    prefix = f"window.{variable} = "
+    source = path.read_text(encoding="utf-8")
+    if not source.startswith(prefix):
+        raise ValueError(f"expected assignment prefix {prefix!r}")
+    payload = source[len(prefix) :].rstrip()
+    if not payload.endswith(";"):
+        raise ValueError("assignment must end with a semicolon")
+    payload = payload[:-1]
+    try:
+        collection = json.loads(payload)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"assignment payload is not JSON: {exc}") from exc
+    if not isinstance(collection, Mapping) or not isinstance(
+        collection.get("features"), list
+    ):
+        raise ValueError("assignment must contain an object with a features array")
+    return collection
+
+
+def _project_id(feature: object) -> str:
+    if not isinstance(feature, Mapping):
+        return ""
+    properties = feature.get("properties")
+    property_id = properties.get("projectId") if isinstance(properties, Mapping) else ""
+    return str(feature.get("id") or property_id or "")
+
+
+def _merge_project_collections(
+    primary: Mapping[str, Any], supplements: Mapping[str, Any] | None
+) -> Mapping[str, Any]:
+    """Mirror the landing page's primary-first, project-ID deduplication."""
+
+    features = list(primary.get("features", []))
+    existing_ids = {_project_id(feature) for feature in features}
+    if supplements:
+        for feature in supplements.get("features", []):
+            identifier = _project_id(feature)
+            if identifier and identifier not in existing_ids:
+                features.append(feature)
+                existing_ids.add(identifier)
+    return {**primary, "features": features}
+
+
+def _load_local_collection(
+    path: Path | str | None,
+    *,
+    variable: str,
+    target: str,
+) -> tuple[Mapping[str, Any] | None, Finding | None]:
+    if path is None:
+        return None, None
+    resolved_path = Path(path).resolve()
+    try:
+        collection = _read_catalog_assignment(resolved_path, variable)
+    except (OSError, ValueError) as exc:
+        return None, Finding(
+            "library",
+            target,
+            False,
+            url=str(resolved_path),
+            message=str(exc),
+        )
+    return collection, Finding(
+        "library",
+        target,
+        True,
+        url=str(resolved_path),
+        message=f"loaded {len(collection['features'])} features",
+    )
+
+
+def _local_finding(project_id: str, target: str, message: str) -> Finding:
+    return Finding(project_id, target, False, message=message)
+
+
+def _project_endpoints(
+    feature: Mapping[str, Any],
+    *,
+    library_url: str,
+    ordinal: int,
+) -> tuple[list[_Endpoint], list[Finding]]:
+    properties_value = feature.get("properties")
+    if not isinstance(properties_value, Mapping):
+        project_id = str(feature.get("id") or f"feature-{ordinal}")
+        return [], [_local_finding(project_id, "catalog", "properties is not an object")]
+
+    properties = properties_value
+    project_id = str(
+        feature.get("id")
+        or properties.get("projectId")
+        or properties.get("title")
+        or f"feature-{ordinal}"
+    )
+    candidate = _is_candidate(properties)
+    endpoints: list[_Endpoint] = []
+    findings: list[Finding] = []
+
+    webmap = _resolved_url(library_url, properties.get("webmap"))
+    manifest = _resolved_url(library_url, properties.get("manifest"))
+    project_manifest = _resolved_url(library_url, properties.get("projectManifest"))
+
+    if webmap:
+        endpoints.append(_Endpoint(project_id, "webmap", webmap))
+        manifest_parameters = parse_qs(urlsplit(webmap).query).get("manifest", [])
+        if len(manifest_parameters) != 1 or not manifest_parameters[0].strip():
+            findings.append(
+                _local_finding(
+                    project_id,
+                    "webmap-manifest",
+                    "viewer URL must contain exactly one non-empty manifest parameter",
+                )
+            )
+        else:
+            nested_manifest = _resolved_url(webmap, manifest_parameters[0])
+            if not nested_manifest:
+                findings.append(
+                    _local_finding(
+                        project_id,
+                        "webmap-manifest",
+                        "viewer manifest parameter is not an HTTP(S) URL",
+                    )
+                )
+            else:
+                endpoints.append(
+                    _Endpoint(project_id, "webmap-manifest", nested_manifest)
+                )
+                if manifest and _canonical_url(nested_manifest) != _canonical_url(manifest):
+                    findings.append(
+                        _local_finding(
+                            project_id,
+                            "webmap-manifest-match",
+                            "viewer manifest parameter does not match catalog manifest: "
+                            f"{nested_manifest!r} != {manifest!r}",
+                        )
+                    )
+    elif not candidate:
+        findings.append(
+            _local_finding(project_id, "webmap", "published project has no webmap URL")
+        )
+
+    if manifest:
+        endpoints.append(_Endpoint(project_id, "manifest", manifest))
+    elif not candidate:
+        findings.append(
+            _local_finding(project_id, "manifest", "published project has no manifest URL")
+        )
+
+    if project_manifest:
+        endpoints.append(_Endpoint(project_id, "projectManifest", project_manifest))
+    elif not candidate:
+        findings.append(
+            _local_finding(
+                project_id,
+                "projectManifest",
+                "published project has no projectManifest URL",
+            )
+        )
+
+    for field, target in (
+        ("details", "details"),
+        ("recordOfDeficiencies", "recordOfDeficiencies"),
+    ):
+        url = _resolved_url(library_url, properties.get(field))
+        if url:
+            endpoints.append(_Endpoint(project_id, target, url))
+        elif candidate:
+            findings.append(
+                _local_finding(
+                    project_id,
+                    target,
+                    f"source qualification candidate has no {field} URL",
+                )
+            )
+
+    return endpoints, findings
+
+
+def _check_endpoints(
+    endpoints: Iterable[_Endpoint],
+    *,
+    timeout: float,
+    retries: int,
+    workers: int,
+) -> list[Finding]:
+    endpoint_list = list(endpoints)
+    request_urls = {
+        endpoint.url: urldefrag(endpoint.url)[0] for endpoint in endpoint_list
+    }
+    unique_urls = sorted(set(request_urls.values()))
+    json_urls = {
+        request_urls[endpoint.url]
+        for endpoint in endpoint_list
+        if endpoint.target in JSON_ENDPOINT_TARGETS
+    }
+    html_urls = {
+        request_urls[endpoint.url]
+        for endpoint in endpoint_list
+        if urlsplit(endpoint.url).fragment
+    }
+    results: dict[str, _HttpResult] = {}
+    with ThreadPoolExecutor(max_workers=max(1, workers)) as executor:
+        futures = {
+            executor.submit(
+                _request,
+                url,
+                timeout=timeout,
+                retries=retries,
+                read_body=url in json_urls or url in html_urls,
+            ): url
+            for url in unique_urls
+        }
+        for future in as_completed(futures):
+            results[futures[future]] = future.result()
+
+    for url in json_urls:
+        result = results[url]
+        if not result.ok:
+            continue
+        try:
+            payload = json.loads(result.body)
+        except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+            results[url] = _HttpResult(
+                False,
+                result.status,
+                f"response is not valid JSON: {exc}",
+                result.body,
+            )
+        else:
+            if not isinstance(payload, Mapping):
+                results[url] = _HttpResult(
+                    False,
+                    result.status,
+                    "JSON response is not an object",
+                    result.body,
+                )
+
+    html_ids: dict[str, set[str]] = {}
+    for url in html_urls:
+        result = results[url]
+        if not result.ok:
+            continue
+        collector = _IdCollector()
+        collector.feed(result.body.decode("utf-8", errors="replace"))
+        html_ids[url] = collector.ids
+
+    findings: list[Finding] = []
+    for endpoint in endpoint_list:
+        request_url = request_urls[endpoint.url]
+        result = results[request_url]
+        fragment = unquote(urlsplit(endpoint.url).fragment)
+        accepted_ids = {fragment, f"user-content-{fragment}"}
+        if result.ok and fragment and accepted_ids.isdisjoint(
+            html_ids.get(request_url, set())
+        ):
+            result = _HttpResult(
+                False,
+                result.status,
+                f"HTML response has no element with id {fragment!r}",
+                result.body,
+            )
+        findings.append(
+            Finding(
+                endpoint.project_id,
+                endpoint.target,
+                result.ok,
+                url=endpoint.url,
+                status=result.status,
+                message=result.message,
+            )
+        )
+    return findings
+
+
+def validate_public_example_library(
+    *,
+    library_url: str = DEFAULT_LIBRARY_URL,
+    catalog_url: str = DEFAULT_CATALOG_URL,
+    timeout: float = 15.0,
+    retries: int = 2,
+    workers: int = 8,
+    fallback_catalog: Path | str | None = DEFAULT_FALLBACK_CATALOG,
+    supplements_catalog: Path | str | None = DEFAULT_SUPPLEMENTS_CATALOG,
+) -> ValidationReport:
+    """Validate the landing page and every project-level catalog link."""
+
+    findings: list[Finding] = []
+    library_url = _resolved_url(library_url, library_url)
+    catalog_url = _resolved_url(library_url, catalog_url)
+    if not library_url:
+        return ValidationReport(
+            (_local_finding("library", "landing", "invalid library HTTP(S) URL"),),
+            0,
+        )
+    if not catalog_url:
+        return ValidationReport(
+            (_local_finding("library", "catalog", "invalid catalog HTTP(S) URL"),),
+            0,
+        )
+
+    landing_result = _request(
+        library_url,
+        timeout=timeout,
+        retries=retries,
+        read_body=False,
+    )
+    findings.append(
+        Finding(
+            "library",
+            "landing",
+            landing_result.ok,
+            url=library_url,
+            status=landing_result.status,
+            message=landing_result.message,
+        )
+    )
+
+    catalog_result = _request(
+        catalog_url,
+        timeout=timeout,
+        retries=retries,
+        read_body=True,
+    )
+    findings.append(
+        Finding(
+            "library",
+            "catalog",
+            catalog_result.ok,
+            url=catalog_url,
+            status=catalog_result.status,
+            message=catalog_result.message,
+        )
+    )
+    catalog: Mapping[str, Any] | None = None
+    if catalog_result.ok:
+        try:
+            parsed_catalog = json.loads(catalog_result.body)
+        except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+            findings.append(
+                _local_finding("library", "catalog-json", f"invalid JSON: {exc}")
+            )
+        else:
+            if isinstance(parsed_catalog, Mapping) and isinstance(
+                parsed_catalog.get("features"), list
+            ):
+                catalog = parsed_catalog
+            else:
+                findings.append(
+                    _local_finding(
+                        "library",
+                        "catalog-json",
+                        "catalog must be an object with a features array",
+                    )
+                )
+
+    if catalog is None:
+        catalog, fallback_finding = _load_local_collection(
+            fallback_catalog,
+            variable="RAS_EXAMPLE_PROJECTS",
+            target="fallback-catalog",
+        )
+        if fallback_finding:
+            findings.append(fallback_finding)
+        if catalog is None:
+            return ValidationReport(tuple(findings), 0)
+
+    supplements, supplements_finding = _load_local_collection(
+        supplements_catalog,
+        variable="RAS_EXAMPLE_PROJECT_SUPPLEMENTS",
+        target="supplements-catalog",
+    )
+    if supplements_finding:
+        findings.append(supplements_finding)
+    catalog = _merge_project_collections(catalog, supplements)
+
+    features = catalog["features"]
+    endpoints: list[_Endpoint] = []
+    for ordinal, feature in enumerate(features, start=1):
+        if not isinstance(feature, Mapping):
+            findings.append(
+                _local_finding(
+                    f"feature-{ordinal}", "catalog", "feature is not an object"
+                )
+            )
+            continue
+        project_endpoints, project_findings = _project_endpoints(
+            feature,
+            library_url=library_url,
+            ordinal=ordinal,
+        )
+        endpoints.extend(project_endpoints)
+        findings.extend(project_findings)
+
+    findings.extend(
+        _check_endpoints(
+            endpoints,
+            timeout=timeout,
+            retries=retries,
+            workers=workers,
+        )
+    )
+    findings.sort(key=lambda item: (item.project_id, item.target, item.url))
+    return ValidationReport(tuple(findings), len(features))
+
+
+def format_report(report: ValidationReport) -> str:
+    """Render concise, stable diagnostics for terminal and scheduled runs."""
+
+    lines: list[str] = []
+    current_project = ""
+    for finding in report.findings:
+        if finding.project_id != current_project:
+            if lines:
+                lines.append("")
+            current_project = finding.project_id
+            lines.append(f"{current_project}:")
+        state = "OK" if finding.ok else "FAIL"
+        status = f" [{finding.status}]" if finding.status is not None else ""
+        message = f" - {finding.message}" if finding.message else ""
+        lines.append(f"  {state} {finding.target}{status}{message}")
+        if finding.url:
+            lines.append(f"    {finding.url}")
+
+    lines.extend(
+        [
+            "",
+            (
+                f"Summary: {report.project_count} projects; "
+                f"{len(report.findings)} checks; {report.failure_count} failures"
+            ),
+        ]
+    )
+    return "\n".join(lines)
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--library-url", default=DEFAULT_LIBRARY_URL)
+    parser.add_argument("--catalog-url", default=DEFAULT_CATALOG_URL)
+    parser.add_argument("--timeout", type=float, default=15.0)
+    parser.add_argument("--retries", type=int, default=2)
+    parser.add_argument("--workers", type=int, default=8)
+    parser.add_argument(
+        "--fallback-catalog",
+        type=Path,
+        default=DEFAULT_FALLBACK_CATALOG,
+        help="strict window.RAS_EXAMPLE_PROJECTS JSON assignment used if the public catalog fails",
+    )
+    parser.add_argument(
+        "--supplements-catalog",
+        type=Path,
+        default=DEFAULT_SUPPLEMENTS_CATALOG,
+        help="strict window.RAS_EXAMPLE_PROJECT_SUPPLEMENTS JSON assignment merged by project ID",
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    if args.timeout <= 0:
+        raise SystemExit("--timeout must be greater than zero")
+    if args.retries < 0:
+        raise SystemExit("--retries must be zero or greater")
+    if args.workers <= 0:
+        raise SystemExit("--workers must be greater than zero")
+
+    report = validate_public_example_library(
+        library_url=args.library_url,
+        catalog_url=args.catalog_url,
+        timeout=args.timeout,
+        retries=args.retries,
+        workers=args.workers,
+        fallback_catalog=args.fallback_catalog,
+        supplements_catalog=args.supplements_catalog,
+    )
+    print(format_report(report))
+    return 0 if report.ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_example_library_page.py
+++ b/tests/test_example_library_page.py
@@ -66,6 +66,35 @@ def test_example_library_consumes_only_the_atomic_current_release() -> None:
     assert expected in javascript
 
 
+def test_example_library_does_not_expose_stale_viewer_links_during_catalog_outage() -> None:
+    javascript = (
+        ROOT / "docs" / "assets" / "javascripts" / "ras-example-library.js"
+    ).read_text(encoding="utf-8")
+
+    assert "qualifyViewerLinks" in javascript
+    assert "MANIFEST_REQUEST_TIMEOUT_MS" in javascript
+    assert "controller.abort()" in javascript
+    assert "await response.json()" in javascript
+    assert 'webmap: ""' in javascript
+    assert 'manifest: ""' in javascript
+    assert 'projectManifest: ""' in javascript
+    assert "props.linkUnavailableReason" in javascript
+    assert "published project maps are temporarily unavailable" in javascript
+    assert "source-candidate details remain available" in javascript
+
+
+def test_example_library_only_makes_http_links_clickable() -> None:
+    javascript = (
+        ROOT / "docs" / "assets" / "javascripts" / "ras-example-library.js"
+    ).read_text(encoding="utf-8")
+
+    assert "function resolveHttpHref" in javascript
+    assert 'typeof href !== "string" || !href.trim()' in javascript
+    assert '["http:", "https:"].includes(url.protocol)' in javascript
+    assert 'catch (_error)' in javascript
+    assert "resolveHref" not in javascript
+
+
 def test_san_gabriel_submodels_are_grouped_in_the_dashboard() -> None:
     page = (ROOT / "docs" / "examples" / "example-projects.md").read_text(
         encoding="utf-8"
@@ -135,10 +164,10 @@ def test_san_gabriel_submodels_are_grouped_in_the_dashboard() -> None:
     assert 'title: "San Gabriel Model Suite"' in profiles
     assert 'variantLabel: "LBSG_503 (Florence)"' in profiles
     assert 'variantLabel: "LBSG_504 (Round Rock)"' in profiles
-    assert "webmap || child.properties?.details" in library
+    assert "webmap || resolveHttpHref(child.properties?.details)" in library
     assert 'document.createElement(projectHref ? "a" : "span")' in library
     assert 'webmap ? "Open project map" : "Open project details"' in library
-    assert 'props.details ? resolveHref(props.details) : ""' in library
+    assert "const details = resolveHttpHref(props.details)" in library
     assert "!webmap && details" in library
 
 

--- a/tests/test_validate_public_example_library.py
+++ b/tests/test_validate_public_example_library.py
@@ -1,0 +1,493 @@
+from __future__ import annotations
+
+import json
+import threading
+from contextlib import contextmanager
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import Iterator
+from urllib.parse import quote
+
+from scripts.example_library.validate_public_example_library import (
+    format_report,
+    main,
+    validate_public_example_library,
+)
+
+
+class _FixtureHandler(BaseHTTPRequestHandler):
+    routes: dict[str, tuple[int, dict[str, str], bytes]] = {}
+    requests: list[tuple[str, str | None]] = []
+
+    def do_GET(self) -> None:  # noqa: N802 - BaseHTTPRequestHandler API
+        path = self.path.split("?", 1)[0]
+        type(self).requests.append((path, self.headers.get("Range")))
+        status, headers, body = type(self).routes.get(
+            path,
+            (404, {"Cache-Control": "no-store"}, b"not found"),
+        )
+        self.send_response(status)
+        for name, value in headers.items():
+            self.send_header(name, value)
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, _format: str, *_args: object) -> None:
+        return
+
+
+@contextmanager
+def _server(
+    routes: dict[str, tuple[int, dict[str, str], bytes]],
+) -> Iterator[tuple[str, type[_FixtureHandler]]]:
+    handler = type("FixtureHandler", (_FixtureHandler,), {})
+    handler.routes = routes
+    handler.requests = []
+    server = ThreadingHTTPServer(("127.0.0.1", 0), handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        host, port = server.server_address
+        yield f"http://{host}:{port}", handler
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=2)
+
+
+def _response(
+    body: bytes = b"ok",
+    *,
+    content_type: str = "text/plain",
+) -> tuple[int, dict[str, str], bytes]:
+    return 200, {"Content-Type": content_type}, body
+
+
+def _catalog(base_url: str, *, nested_manifest: str | None = None) -> bytes:
+    manifest = f"{base_url}/data/published/viewer/manifest.json?v=1"
+    nested = nested_manifest or manifest
+    viewer = f"{base_url}/viewer/?manifest={quote(nested, safe='')}"
+    payload = {
+        "type": "FeatureCollection",
+        "features": [
+            {
+                "type": "Feature",
+                "id": "published",
+                "properties": {
+                    "status": "Published",
+                    "webmap": viewer,
+                    "manifest": manifest,
+                    "projectManifest": f"{base_url}/data/published/project.json",
+                    "details": f"{base_url}/published-details/",
+                },
+            },
+            {
+                "type": "Feature",
+                "id": "candidate",
+                "properties": {
+                    "status": "Source qualification candidate",
+                    "webmap": "",
+                    "manifest": "",
+                    "projectManifest": "",
+                    "details": f"{base_url}/rod.md#candidate",
+                    "recordOfDeficiencies": f"{base_url}/rod.md",
+                },
+            },
+        ],
+    }
+    return json.dumps(payload).encode()
+
+
+def _healthy_routes(base_url: str) -> dict[str, tuple[int, dict[str, str], bytes]]:
+    return {
+        "/library/": _response(b"<html>library</html>", content_type="text/html"),
+        "/catalog.json": _response(
+            _catalog(base_url), content_type="application/geo+json"
+        ),
+        "/viewer/": _response(b"<html>viewer</html>", content_type="text/html"),
+        "/data/published/viewer/manifest.json": _response(
+            b"{}", content_type="application/json"
+        ),
+        "/data/published/project.json": _response(
+            b"{}", content_type="application/json"
+        ),
+        "/published-details/": _response(b"details"),
+        "/rod.md": _response(b'<h3 id="user-content-candidate">Candidate</h3>'),
+    }
+
+
+def _write_assignment(path, variable: str, collection: object) -> None:
+    path.write_text(
+        f"window.{variable} = {json.dumps(collection, separators=(',', ':'))};\n",
+        encoding="utf-8",
+    )
+
+
+def test_validates_complete_link_graph_and_uses_range_gets() -> None:
+    with _server({}) as (base_url, handler):
+        handler.routes = _healthy_routes(base_url)
+        report = validate_public_example_library(
+            library_url=f"{base_url}/library/",
+            catalog_url=f"{base_url}/catalog.json",
+            timeout=2,
+            retries=0,
+            workers=4,
+            supplements_catalog=None,
+        )
+
+    assert report.ok
+    assert report.project_count == 2
+    assert report.failure_count == 0
+    assert {finding.target for finding in report.findings} >= {
+        "landing",
+        "catalog",
+        "webmap",
+        "webmap-manifest",
+        "manifest",
+        "projectManifest",
+        "details",
+        "recordOfDeficiencies",
+    }
+    requests = dict(handler.requests)
+    assert requests["/catalog.json"] is None
+    assert requests["/data/published/viewer/manifest.json"] is None
+    assert requests["/data/published/project.json"] is None
+    assert requests["/rod.md"] is None
+    assert requests["/library/"] == "bytes=0-65535"
+    assert requests["/viewer/"] == "bytes=0-65535"
+    assert requests["/published-details/"] == "bytes=0-65535"
+
+
+def test_viewer_200_does_not_hide_nested_manifest_404() -> None:
+    with _server({}) as (base_url, handler):
+        handler.routes = _healthy_routes(base_url)
+        handler.routes["/catalog.json"] = _response(
+            _catalog(base_url), content_type="application/geo+json"
+        )
+        handler.routes["/data/published/viewer/manifest.json"] = (
+            404,
+            {"Cache-Control": "no-store"},
+            b"missing",
+        )
+        report = validate_public_example_library(
+            library_url=f"{base_url}/library/",
+            catalog_url=f"{base_url}/catalog.json",
+            timeout=2,
+            retries=0,
+            supplements_catalog=None,
+        )
+
+    assert not report.ok
+    assert any(
+        finding.target == "webmap" and finding.ok and finding.status == 200
+        for finding in report.findings
+    )
+    nested = [
+        finding
+        for finding in report.findings
+        if finding.project_id == "published"
+        and finding.target == "webmap-manifest"
+    ]
+    assert len(nested) == 1
+    assert nested[0].status == 404
+    assert not nested[0].ok
+    assert "Cache-Control lacks" not in nested[0].message
+
+
+def test_manifest_html_error_shell_with_200_is_not_healthy() -> None:
+    with _server({}) as (base_url, handler):
+        handler.routes = _healthy_routes(base_url)
+        handler.routes["/data/published/viewer/manifest.json"] = _response(
+            b"<html>not a manifest</html>", content_type="text/html"
+        )
+        report = validate_public_example_library(
+            library_url=f"{base_url}/library/",
+            catalog_url=f"{base_url}/catalog.json",
+            timeout=2,
+            retries=0,
+            supplements_catalog=None,
+        )
+
+    failures = [
+        finding
+        for finding in report.findings
+        if finding.project_id == "published"
+        and finding.target in {"manifest", "webmap-manifest"}
+    ]
+    assert len(failures) == 2
+    assert all(not finding.ok and finding.status == 200 for finding in failures)
+    assert all("not valid JSON" in finding.message for finding in failures)
+
+
+def test_detects_manifest_mismatch_and_bad_error_cache_policy() -> None:
+    with _server({}) as (base_url, handler):
+        mismatched = f"{base_url}/data/other/manifest.json"
+        handler.routes = _healthy_routes(base_url)
+        handler.routes["/catalog.json"] = _response(
+            _catalog(base_url, nested_manifest=mismatched),
+            content_type="application/geo+json",
+        )
+        handler.routes["/data/other/manifest.json"] = (
+            404,
+            {"Cache-Control": "public, max-age=60"},
+            b"missing",
+        )
+        report = validate_public_example_library(
+            library_url=f"{base_url}/library/",
+            catalog_url=f"{base_url}/catalog.json",
+            timeout=2,
+            retries=0,
+            supplements_catalog=None,
+        )
+
+    assert not report.ok
+    assert any(
+        finding.target == "webmap-manifest-match" and not finding.ok
+        for finding in report.findings
+    )
+    failed_nested = next(
+        finding
+        for finding in report.findings
+        if finding.target == "webmap-manifest" and finding.status == 404
+    )
+    assert "Cache-Control lacks no-store" in failed_nested.message
+
+
+def test_candidate_requires_both_details_and_record_of_deficiencies() -> None:
+    with _server({}) as (base_url, handler):
+        payload = json.loads(_catalog(base_url))
+        candidate = payload["features"][1]["properties"]
+        candidate["details"] = ""
+        candidate["recordOfDeficiencies"] = ""
+        handler.routes = _healthy_routes(base_url)
+        handler.routes["/catalog.json"] = _response(
+            json.dumps(payload).encode(), content_type="application/geo+json"
+        )
+        report = validate_public_example_library(
+            library_url=f"{base_url}/library/",
+            catalog_url=f"{base_url}/catalog.json",
+            timeout=2,
+            retries=0,
+            supplements_catalog=None,
+        )
+
+    failures = {
+        finding.target
+        for finding in report.findings
+        if finding.project_id == "candidate" and not finding.ok
+    }
+    assert failures == {"details", "recordOfDeficiencies"}
+
+
+def test_candidate_detail_fragment_must_exist() -> None:
+    with _server({}) as (base_url, handler):
+        handler.routes = _healthy_routes(base_url)
+        handler.routes["/catalog.json"] = _response(
+            _catalog(base_url), content_type="application/geo+json"
+        )
+        handler.routes["/rod.md"] = _response(b'<h3 id="another-model">Other</h3>')
+        report = validate_public_example_library(
+            library_url=f"{base_url}/library/",
+            catalog_url=f"{base_url}/catalog.json",
+            timeout=2,
+            retries=0,
+            supplements_catalog=None,
+        )
+
+    details = next(
+        finding
+        for finding in report.findings
+        if finding.project_id == "candidate" and finding.target == "details"
+    )
+    rod = next(
+        finding
+        for finding in report.findings
+        if finding.project_id == "candidate"
+        and finding.target == "recordOfDeficiencies"
+    )
+    assert not details.ok
+    assert details.status == 200
+    assert "no element with id 'candidate'" in details.message
+    assert rod.ok
+
+
+def test_cli_returns_nonzero_and_prints_project_diagnostics(capsys, tmp_path) -> None:
+    supplements_path = tmp_path / "supplements.js"
+    _write_assignment(
+        supplements_path,
+        "RAS_EXAMPLE_PROJECT_SUPPLEMENTS",
+        {"type": "FeatureCollection", "features": []},
+    )
+    with _server({}) as (base_url, handler):
+        handler.routes = _healthy_routes(base_url)
+        handler.routes["/data/published/project.json"] = (
+            404,
+            {"Cache-Control": "no-store"},
+            b"missing",
+        )
+        exit_code = main(
+            [
+                "--library-url",
+                f"{base_url}/library/",
+                "--catalog-url",
+                f"{base_url}/catalog.json",
+                "--timeout",
+                "2",
+                "--retries",
+                "0",
+                "--workers",
+                "2",
+                "--supplements-catalog",
+                str(supplements_path),
+            ]
+        )
+
+    output = capsys.readouterr().out
+    assert exit_code == 1
+    assert "published:" in output
+    assert "FAIL projectManifest [404]" in output
+    assert "2 projects" in output
+    assert "failures" in output
+
+
+def test_format_report_does_not_claim_success_for_404() -> None:
+    with _server({}) as (base_url, handler):
+        handler.routes = _healthy_routes(base_url)
+        handler.routes["/data/published/viewer/manifest.json"] = (
+            404,
+            {"Cache-Control": "no-store"},
+            b"missing",
+        )
+        report = validate_public_example_library(
+            library_url=f"{base_url}/library/",
+            catalog_url=f"{base_url}/catalog.json",
+            timeout=2,
+            retries=0,
+            supplements_catalog=None,
+        )
+
+    text = format_report(report)
+    assert "FAIL manifest [404]" in text
+    assert report.failure_count == 2
+
+
+def test_catalog_404_still_audits_fallback_and_supplement_links(tmp_path) -> None:
+    fallback_path = tmp_path / "fallback.js"
+    supplements_path = tmp_path / "supplements.js"
+    with _server({}) as (base_url, handler):
+        fallback = json.loads(_catalog(base_url))
+        # Keep one published fallback entry and make its nested manifest fail.
+        fallback["features"] = fallback["features"][:1]
+        supplement = {
+            "type": "FeatureCollection",
+            "features": [
+                {
+                    "type": "Feature",
+                    "id": "candidate-from-supplement",
+                    "properties": {
+                        "status": "Source qualification candidate",
+                        "details": f"{base_url}/candidate-details.md#model",
+                        "recordOfDeficiencies": f"{base_url}/candidate-rod.md",
+                    },
+                }
+            ],
+        }
+        _write_assignment(fallback_path, "RAS_EXAMPLE_PROJECTS", fallback)
+        _write_assignment(
+            supplements_path,
+            "RAS_EXAMPLE_PROJECT_SUPPLEMENTS",
+            supplement,
+        )
+        handler.routes = _healthy_routes(base_url)
+        handler.routes["/catalog.json"] = (
+            404,
+            {"Cache-Control": "no-store"},
+            b"missing catalog",
+        )
+        handler.routes["/data/published/viewer/manifest.json"] = (
+            404,
+            {"Cache-Control": "no-store"},
+            b"missing manifest",
+        )
+        handler.routes["/candidate-details.md"] = _response(
+            b'<h3 id="model">Candidate</h3>'
+        )
+        handler.routes["/candidate-rod.md"] = _response(b"rod")
+
+        report = validate_public_example_library(
+            library_url=f"{base_url}/library/",
+            catalog_url=f"{base_url}/catalog.json",
+            fallback_catalog=fallback_path,
+            supplements_catalog=supplements_path,
+            timeout=2,
+            retries=0,
+        )
+
+    assert not report.ok
+    assert report.project_count == 2
+    assert any(
+        finding.project_id == "library"
+        and finding.target == "catalog"
+        and finding.status == 404
+        for finding in report.findings
+    )
+    assert any(
+        finding.project_id == "published"
+        and finding.target == "webmap-manifest"
+        and finding.status == 404
+        for finding in report.findings
+    )
+    assert all(
+        finding.ok
+        for finding in report.findings
+        if finding.project_id == "candidate-from-supplement"
+    )
+    requested_paths = {path for path, _range in handler.requests}
+    assert "/candidate-details.md" in requested_paths
+    assert "/candidate-rod.md" in requested_paths
+
+
+def test_supplement_ids_are_deduplicated_with_primary_precedence(tmp_path) -> None:
+    fallback_path = tmp_path / "fallback.js"
+    supplements_path = tmp_path / "supplements.js"
+    with _server({}) as (base_url, handler):
+        fallback = json.loads(_catalog(base_url))
+        supplement = {
+            "type": "FeatureCollection",
+            "features": [
+                {
+                    "type": "Feature",
+                    "id": "candidate",
+                    "properties": {
+                        "status": "Source qualification candidate",
+                        "details": f"{base_url}/should-not-be-requested",
+                        "recordOfDeficiencies": f"{base_url}/should-not-be-requested",
+                    },
+                }
+            ],
+        }
+        _write_assignment(fallback_path, "RAS_EXAMPLE_PROJECTS", fallback)
+        _write_assignment(
+            supplements_path,
+            "RAS_EXAMPLE_PROJECT_SUPPLEMENTS",
+            supplement,
+        )
+        handler.routes = _healthy_routes(base_url)
+        handler.routes["/catalog.json"] = (
+            404,
+            {"Cache-Control": "no-store"},
+            b"missing catalog",
+        )
+        report = validate_public_example_library(
+            library_url=f"{base_url}/library/",
+            catalog_url=f"{base_url}/catalog.json",
+            fallback_catalog=fallback_path,
+            supplements_catalog=supplements_path,
+            timeout=2,
+            retries=0,
+        )
+
+    assert report.project_count == 2
+    assert not any(
+        path == "/should-not-be-requested" for path, _range in handler.requests
+    )


### PR DESCRIPTION
## Summary

- deep-QA the Example Projects landing page, every published viewer edge, and every source-candidate evidence link
- validate each published viewer manifest as JSON before making its project link clickable
- disable only unavailable published maps, retain valid candidate detail links, and show the failure count on the dashboard
- restrict catalog-controlled browser links and PMTiles targets to HTTP(S)
- bound browser manifest checks with a ten-second timeout
- add a reusable standard-library validator for the landing page, authoritative and fallback catalogs, viewer shells, encoded/direct manifests, project manifests, candidate details, Records of Deficiencies, and heading anchors

## Live audit findings

`python scripts/example_library/validate_public_example_library.py` audited 27 branch-intended projects through 94 checks. The post-merge rerun reports 55 failures, all in the public data route.

- the public landing page and all 18 outer viewer shells return `200`
- the authoritative current catalog returns `404`
- every published project has three failed public data edges: encoded viewer manifest, direct manifest, and project manifest (`54` failures)
- those public `/data/*` `404` responses are cached for one hour instead of using `no-store`
- all underlying release artifacts are present at the artifact origin; this is a public proxy/routing outage, not 18 independent stale slugs
- all nine San Gabriel and Double Mountain Fork project-detail anchors and both ROD destinations are healthy; there are zero candidate-link failures

The production routing repair belongs to the separate documentation-host deployment. This PR prevents users from entering a viewer whose manifest is known to be broken and supplies a repeatable check for restoring the route safely.

## Validation

- `66 passed` across the eBFE source, resume, extent-catalog, example-page, plan-helper, and new link-validator suites
- all new and modified Python QA files pass Ruff and `py_compile`
- dashboard JavaScript passes `node --check`
- notebook inventory `--check` passes
- production-equivalent MkDocs build passes; the known missing-notebook warnings remain pre-existing
- local browser QA: 18 unavailable published map labels disabled, zero broken map links exposed, and all nine San Gabriel/Double Mountain Fork detail links retained
